### PR TITLE
Rename lint + style scripts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 server.babel.js
+dist

--- a/.jscsignore
+++ b/.jscsignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,4 @@
 {
-  "preset": "airbnb"
+  "preset": "airbnb",
+  "excludeFiles": ['dist']
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
     - "4"
 env:
-  - TASK=test:lint
-  - TASK=test:style
+  - TASK=lint
+  - TASK=jscs
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -12,10 +12,23 @@ nvm. See https://github.com/creationix/nvm for more info.
 
 ## Get started
 
-Run:
-
 * npm install
 * npm run dev
+
+
+## NPM scripts
+
+| Script                 | Description                                       |
+|------------------------|---------------------------------------------------|
+| npm start              |  Starts the express server                        |
+| npm test               |  Runs the tests                                   |
+| npm run build          |  Builds the lib                                   |
+| npm run dev            |  Starts the dev server (Express + webpack)        |
+| npm run dev:search     |  As above but just the search code                |
+| npm run dev:disco      |  As above but just the discovery pane code        |
+| npm run lint           |  Lints the files with `eslint` (Run in `npm test`)|
+| npm run eslint         |  An alias for `npm run lint`                      |
+| npm run jscs           |  Checks for style issues (Run in `npm test`)      |
 
 ## Overview and rationale
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "dev": "npm run start & webpack-dev-server --progress --color --port 3000",
     "dev:search": "APP_NAME=search npm run dev",
     "dev:disco": "APP_NAME=disco npm run dev",
-    "test": "npm run test:lint && npm run test:style",
-    "test:lint": "eslint .",
-    "test:style": "jscs .",
+    "test": "npm run lint && npm run jscs",
+    "lint": "eslint .",
+    "eslint": "npm run lint",
+    "jscs": "jscs .",
     "build": "webpack --progress --color -p --config webpack.prod.config.js"
   },
   "repository": {


### PR DESCRIPTION
I changed the tasks for lint + jscs because I think it makes sense to only use the `command:foo` format when we're specifying a sub-target. E.g. I think that's more undertandable particularly when coming from something like the grunt world.

Also I've added a table showing the command list to the README.