### PR TITLE
Set up security headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/mozillla/addons-frontend#readme",
   "dependencies": {
     "express": "4.13.4",
+    "helmet": "1.1.0",
     "react": "0.14.7",
     "react-router": "2.0.0"
   },


### PR DESCRIPTION
Fixes #10

This adds CSP and other useful security headers. We'll need to tweak the config as we go.