### PR TITLE
Add alias for normalize.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "extract-text-webpack-plugin": "1.0.1",
     "helmet": "1.3.0",
     "isomorphic-fetch": "2.2.1",
-    "normalize.css": "3.0.3",
+    "normalize.css": "4.0.0",
     "normalizr": "2.0.0",
     "piping": "0.3.0",
     "react": "0.14.7",

--- a/src/config/webpack.prod.config.babel.js
+++ b/src/config/webpack.prod.config.babel.js
@@ -63,6 +63,9 @@ export default {
     new WebpackIsomorphicToolsPlugin(webpackIsomorphicToolsConfig),
   ],
   resolve: {
+    alias: {
+      'normalize.css': 'normalize.css/normalize.css',
+    },
     root: [
       path.resolve('../src'),
     ],


### PR DESCRIPTION
Changes in 4.0.0 (removal of the main entry) mean we now require aliasing.