### PR TITLE
Universal add-on detail page

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-redux": "4.4.0",
     "react-router": "2.0.1",
     "redux": "3.3.1",
-    "redux-async-connect": "1.0.0-rc4"
+    "redux-async-connect": "1.0.0-rc4",
+    "redux-logger": "2.6.1"
   },
   "devDependencies": {
     "autoprefixer-loader": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react": "0.14.7",
     "react-redux": "4.4.0",
     "react-router": "2.0.1",
-    "redux": "3.3.1"
+    "redux": "3.3.1",
+    "redux-async-connect": "1.0.0-rc4"
   },
   "devDependencies": {
     "autoprefixer-loader": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "react-router": "2.0.1",
     "redux": "3.3.1",
     "redux-async-connect": "1.0.0-rc4",
-    "redux-logger": "2.6.1"
+    "redux-logger": "2.6.1",
+    "serialize-javascript": "1.2.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "3.2.0",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,6 +24,9 @@ config.set('apiHost',
     NODE_ENV === 'development' ?
       'https://addons-dev.allizom.org' : 'https://addons.mozilla.org');
 
+config.set('apiPath', process.env.API_PATH || '/api/v3');
+config.set('apiBase', config.get('apiHost') + config.get('apiPath'));
+
 const CSP = {
   directives: {
     connectSrc: ["'self'", config.get('apiHost')],

--- a/src/config/webpack.dev.config.babel.js
+++ b/src/config/webpack.dev.config.babel.js
@@ -10,6 +10,8 @@ import config from './index';
 import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 import webpackIsomorphicToolsConfig from './webpack-isomorphic-tools';
 
+const development = config.get('env') === 'development';
+
 const webpackIsomorphicToolsPlugin =
   new WebpackIsomorphicToolsPlugin(webpackIsomorphicToolsConfig);
 const APP_NAME = config.get('currentApp');
@@ -27,7 +29,7 @@ const babelDevPlugins = [['react-transform', {
 }]];
 
 const BABEL_QUERY = Object.assign({}, babelrcObject, {
-  plugins: babelPlugins.concat(babelDevPlugins),
+  plugins: development ? babelPlugins.concat(babelDevPlugins) : babelPlugins,
 });
 
 const webpackHost = config.get('webpackServerHost');

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -2,6 +2,8 @@ import { Schema, arrayOf, normalize } from 'normalizr';
 
 import config from 'config';
 
+import 'isomorphic-fetch';
+
 
 const API_HOST = config.get('apiHost');
 const API_BASE = `${API_HOST}/api/v3`;
@@ -19,4 +21,10 @@ export function search({ query }) {
   return fetch(`${API_BASE}/addons/search/?${queryString}`)
     .then((response) => response.json())
     .then((response) => normalize(response, {results: arrayOf(addon)}));
+}
+
+export function loadAddon(slug) {
+  return fetch(`${API_BASE}/addons/addon/${slug}/?lang=en-US`)
+    .then((response) => response.json())
+    .then((response) => normalize(response, addon));
 }

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -15,16 +15,22 @@ function makeQueryString(opts) {
   return Object.keys(opts).map((k) => `${k}=${opts[k]}`).join('&');
 }
 
+function callApi(endpoint, schema, params = {}) {
+  const queryString = makeQueryString(params);
+  let fullUrl = `${API_BASE}/${endpoint}/`;
+  if (queryString) {
+    fullUrl += `?${queryString}`;
+  }
+  return fetch(fullUrl)
+    .then((response) => response.json())
+    .then((response) => normalize(response, schema));
+}
+
 export function search({ query }) {
   // TODO: Get the language from the server.
-  const queryString = makeQueryString({q: query, lang: 'en-US'});
-  return fetch(`${API_BASE}/addons/search/?${queryString}`)
-    .then((response) => response.json())
-    .then((response) => normalize(response, {results: arrayOf(addon)}));
+  return callApi('addons/search', {results: arrayOf(addon)}, {q: query, lang: 'en-US'});
 }
 
 export function loadAddon(slug) {
-  return fetch(`${API_BASE}/addons/addon/${slug}/?lang=en-US`)
-    .then((response) => response.json())
-    .then((response) => normalize(response, addon));
+  return callApi(`addons/addon/${slug}`, addon, {lang: 'en-US'});
 }

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -30,6 +30,6 @@ export function search({ query }) {
   return callApi('addons/search', {results: arrayOf(addon)}, {q: query, lang: 'en-US'});
 }
 
-export function loadAddon(slug) {
+export function fetchAddon(slug) {
   return callApi(`addons/addon/${slug}`, addon, {lang: 'en-US'});
 }

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -5,8 +5,7 @@ import config from 'config';
 import 'isomorphic-fetch';
 
 
-const API_HOST = config.get('apiHost');
-const API_BASE = `${API_HOST}/api/v3`;
+const API_BASE = config.get('apiBase');
 
 const addon = new Schema('addons', {idAttribute: 'slug'});
 

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from 'react-dom';
-import { Router, browserHistory } from 'react-router';
-import routes from './routes';
-
-render(
-  <Router children={routes} history={browserHistory} />,
-  document.getElementById('react-view')
-);

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -1,0 +1,31 @@
+import 'babel-polyfill';
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider } from 'react-redux';
+import { Router, browserHistory } from 'react-router';
+import { ReduxAsyncConnect } from 'redux-async-connect';
+
+export default function makeClient(routes, createStore) {
+  const initialStateContainer = document.getElementById('redux-store-state');
+  let initialState;
+
+  if (initialStateContainer) {
+    try {
+      initialState = JSON.parse(initialStateContainer.textContent);
+    } catch (error) {
+      console.error('Could not load initial redux data'); // eslint-disable-line no-console
+    }
+  }
+  const store = createStore(initialState);
+
+  function reduxAsyncConnectRender(props) {
+    return <ReduxAsyncConnect {...props} />;
+  }
+
+  render(
+    <Provider store={store} key="provider">
+      <Router render={reduxAsyncConnectRender} children={routes} history={browserHistory} />
+    </Provider>,
+    document.getElementById('react-view')
+  );
+}

--- a/src/core/client/index.js
+++ b/src/core/client/index.js
@@ -1,0 +1,5 @@
+import makeClient from './base';
+import routes from './routes';
+import createStore from 'search/store';
+
+makeClient(routes, createStore);

--- a/src/core/containers/App.js
+++ b/src/core/containers/App.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+export default class App extends React.Component {
+  render() {
+    return (
+      <ul>
+        <li><Link to="/search">Search</Link></li>
+        <li><Link to="/disco">Discovery Pane</Link></li>
+      </ul>
+    );
+  }
+}
+

--- a/src/core/routes.js
+++ b/src/core/routes.js
@@ -1,9 +1,14 @@
 import React from 'react';
-import { Route } from 'react-router';
+import { IndexRoute, Route } from 'react-router';
 
+import App from './containers/App';
 import discoRoutes from '../disco/routes';
 import searchRoutes from '../search/routes';
 
 export default (
-  <Route children={[discoRoutes, searchRoutes]} />
+  <Route path="/">
+    <IndexRoute component={App} />
+    {searchRoutes}
+    {discoRoutes}
+  </Route>
 );

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import Express from 'express';
 import helmet from 'helmet';
 import path from 'path';
@@ -7,14 +5,17 @@ import React from 'react';
 
 import { stripIndent } from 'common-tags';
 import { renderToString } from 'react-dom/server';
-import { RouterContext, match } from 'react-router';
+import { match } from 'react-router';
+import { Provider } from 'react-redux';
+import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
+
 
 import config from 'config';
 
 
 const ENV = config.get('env');
 
-export default function(routes) {
+export default function(routes, createStore) {
   const app = new Express();
   app.disable('x-powered-by');
 
@@ -31,7 +32,7 @@ export default function(routes) {
   app.use(helmet.csp(config.get('CSP')));
 
   if (ENV === 'development') {
-    console.log('Running in Development Mode');
+    console.log('Running in Development Mode'); // eslint-disable-line no-console
 
     // clear require() cache if in development mode
     // webpackIsomorphicTools.refresh();
@@ -71,33 +72,40 @@ export default function(routes) {
         return res.status(404).end('Not found.');
       }
 
-      const InitialComponent = (
-        <RouterContext {...renderProps} />
-      );
+      const store = createStore();
 
-      const componentHTML = renderToString(InitialComponent);
-      const assets = webpackIsomorphicTools.assets();
-      const styles = Object.keys(assets.styles).map((style) =>
-       `<link href=${assets.styles[style]} rel="stylesheet" type="text/css" />`
-      ).join('\n');
+      return loadOnServer({...renderProps, store}).then(() => {
+        const InitialComponent = (
+          <Provider store={store} key="provider">
+            <ReduxAsyncConnect {...renderProps} />
+          </Provider>
+        );
 
-      const HTML = stripIndent`
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta charset="utf-8">
-          <title>Isomorphic Redux Demo</title>
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
-          ${styles}
-        </head>
-        <body>
-          <div id="react-view">${componentHTML}</div>
-          <script src="${assets.javascript.main}"></script>
-        </body>
-      </html>`;
+        const componentHTML = renderToString(InitialComponent);
+        const assets = webpackIsomorphicTools.assets();
+        const styles = Object.keys(assets.styles).map((style) =>
+        `<link href=${assets.styles[style]} rel="stylesheet" type="text/css" />`
+        ).join('\n');
 
-      res.header('Content-Type', 'text/html');
-      return res.end(HTML);
+        const HTML = stripIndent`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <title>Isomorphic Redux Demo</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            ${styles}
+          </head>
+          <body>
+            <div id="react-view">${componentHTML}</div>
+            <script>window.__data = ${JSON.stringify(store.getState())}</script>
+            <script src="${assets.javascript.main}"></script>
+          </body>
+        </html>`;
+
+        res.header('Content-Type', 'text/html');
+        return res.end(HTML);
+      });
     });
   });
 

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -35,24 +35,6 @@ export default function(routes, createStore) {
 
     // clear require() cache if in development mode
     // webpackIsomorphicTools.refresh();
-
-    app.get('/', (req, res) => {
-      res.header('Content-Type', 'text/html');
-      res.end(stripIndent`
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta charset="utf-8">
-          <title>Nav</title>
-        </head>
-        <body>
-          <ul>
-            <li><a href="/search">Search</a></li>
-            <li><a href="/disco">Discovery Pane</a></li>
-          </ul>
-        </body>
-      </html>`);
-    });
   }
 
   app.use(Express.static(path.join(__dirname, '../../../dist')));

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -1,14 +1,13 @@
+import { stripIndent } from 'common-tags';
 import Express from 'express';
 import helmet from 'helmet';
 import path from 'path';
 import React from 'react';
-
-import { stripIndent } from 'common-tags';
 import { renderToString } from 'react-dom/server';
-import { match } from 'react-router';
 import { Provider } from 'react-redux';
+import { match } from 'react-router';
 import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
-
+import serialize from 'serialize-javascript';
 
 import config from 'config';
 
@@ -98,7 +97,9 @@ export default function(routes, createStore) {
           </head>
           <body>
             <div id="react-view">${componentHTML}</div>
-            <script>window.__data = ${JSON.stringify(store.getState())}</script>
+            <script type="application/json" id="redux-store-state">
+              ${serialize(store.getState())}
+            </script>
             <script src="${assets.javascript.main}"></script>
           </body>
         </html>`;

--- a/src/core/server/index.js
+++ b/src/core/server/index.js
@@ -1,6 +1,7 @@
 import baseServer from './base';
 import routes from '../routes';
+import createStore from 'search/store';
 
-const app = baseServer(routes);
+const app = baseServer(routes, createStore);
 
 export default app;

--- a/src/search/actions/index.js
+++ b/src/search/actions/index.js
@@ -12,13 +12,6 @@ export function searchLoad({ query, entities, result }) {
   };
 }
 
-export function addonLoad(addon) {
-  return {
-    type: 'ADDON_LOADED',
-    payload: {entities: [addon]},
-  };
-}
-
 export function loadEntities(entities) {
   return {
     type: 'ENTITIES_LOADED',

--- a/src/search/actions/index.js
+++ b/src/search/actions/index.js
@@ -12,3 +12,17 @@ export function searchLoad({ query, entities, result }) {
   };
 }
 
+export function addonLoad(addon) {
+  return {
+    type: 'ADDON_LOADED',
+    payload: {entities: [addon]},
+  };
+}
+
+export function loadEntities(entities) {
+  return {
+    type: 'ENTITIES_LOADED',
+    payload: {entities},
+  };
+}
+

--- a/src/search/actions/index.js
+++ b/src/search/actions/index.js
@@ -18,4 +18,3 @@ export function loadEntities(entities) {
     payload: {entities},
   };
 }
-

--- a/src/search/client.js
+++ b/src/search/client.js
@@ -1,10 +1,21 @@
 import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
+import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
+import { ReduxAsyncConnect } from 'redux-async-connect';
 import routes from './routes';
+import createStore from './store';
+
+const store = createStore(window.__data);
+
+function reduxAsyncConnectRender(props) {
+  return <ReduxAsyncConnect {...props} />;
+}
 
 render(
-  <Router children={routes} history={browserHistory} />,
+  <Provider store={store} key="provider">
+    <Router render={reduxAsyncConnectRender} children={routes} history={browserHistory} />
+  </Provider>,
   document.getElementById('react-view')
 );

--- a/src/search/client.js
+++ b/src/search/client.js
@@ -1,31 +1,5 @@
-import 'babel-polyfill';
-import React from 'react';
-import { render } from 'react-dom';
-import { Provider } from 'react-redux';
-import { Router, browserHistory } from 'react-router';
-import { ReduxAsyncConnect } from 'redux-async-connect';
+import makeClient from 'core/client/base';
 import routes from './routes';
 import createStore from './store';
 
-const initialStateContainer = document.getElementById('redux-store-state');
-let initialState;
-
-if (initialStateContainer) {
-  try {
-    initialState = JSON.parse(initialStateContainer.textContent);
-  } catch (error) {
-    console.error('Could not load initial redux data'); // eslint-disable-line no-console
-  }
-}
-const store = createStore(initialState);
-
-function reduxAsyncConnectRender(props) {
-  return <ReduxAsyncConnect {...props} />;
-}
-
-render(
-  <Provider store={store} key="provider">
-    <Router render={reduxAsyncConnectRender} children={routes} history={browserHistory} />
-  </Provider>,
-  document.getElementById('react-view')
-);
+makeClient(routes, createStore);

--- a/src/search/client.js
+++ b/src/search/client.js
@@ -7,7 +7,17 @@ import { ReduxAsyncConnect } from 'redux-async-connect';
 import routes from './routes';
 import createStore from './store';
 
-const store = createStore(window.__data);
+const initialStateContainer = document.getElementById('redux-store-state');
+let initialState;
+
+if (initialStateContainer) {
+  try {
+    initialState = JSON.parse(initialStateContainer.textContent);
+  } catch (error) {
+    console.error('Could not load initial redux data'); // eslint-disable-line no-console
+  }
+}
+const store = createStore(initialState);
 
 function reduxAsyncConnectRender(props) {
   return <ReduxAsyncConnect {...props} />;

--- a/src/search/components/App.js
+++ b/src/search/components/App.js
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Provider } from 'react-redux';
 import { createStore, combineReducers } from 'redux';
 
-import CurrentSearchPage from '../containers/CurrentSearchPage';
 import search from '../reducers/search';
 import addons from 'core/reducers/addons';
 
@@ -12,10 +11,15 @@ const store = createStore(combineReducers({addons, search}));
 
 
 export default class App extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
   render() {
+    const { children } = this.props;
     return (
       <Provider store={store}>
-        <CurrentSearchPage />
+        {children}
       </Provider>
     );
   }

--- a/src/search/components/App.js
+++ b/src/search/components/App.js
@@ -1,13 +1,6 @@
 import React, { PropTypes } from 'react';
-import { Provider } from 'react-redux';
-import { createStore, combineReducers } from 'redux';
-
-import search from '../reducers/search';
-import addons from 'core/reducers/addons';
 
 import 'search/css/App.scss';
-
-const store = createStore(combineReducers({addons, search}));
 
 
 export default class App extends React.Component {
@@ -17,10 +10,6 @@ export default class App extends React.Component {
 
   render() {
     const { children } = this.props;
-    return (
-      <Provider store={store}>
-        {children}
-      </Provider>
-    );
+    return children;
   }
 }

--- a/src/search/components/SearchResults.js
+++ b/src/search/components/SearchResults.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
 
 import { gettext as _ } from 'core/utils';
 
@@ -27,7 +28,11 @@ export default class SearchResults extends React.Component {
       messageText = _(`Your search for "${query}" returned ${results.length} results.`);
       searchResults = (
         <ul ref="results">
-          {results.map((result) => <li key={result.slug}>{result.name}</li>)}
+          {results.map((result) => (
+            <li key={result.slug}>
+              <Link to={`/search/addons/${result.slug}`}>{result.name}</Link>
+            </li>
+          ))}
         </ul>
       );
     } else if (query && loading) {

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -1,0 +1,58 @@
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { loadAddon } from 'core/api';
+import { loadEntities } from 'search/actions';
+
+class AddonPage extends React.Component {
+  static propTypes = {
+    addon: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      slug: PropTypes.string.isRequired,
+    }),
+    loadData: PropTypes.func.isRequired,
+    slug: PropTypes.string.isRequired,
+  }
+
+  componentWillMount() {
+    const { addon, slug } = this.props;
+    if (!addon || addon.slug !== slug) {
+      this.props.loadData(slug);
+    }
+  }
+
+  render() {
+    const { slug } = this.props;
+    let { addon } = this.props;
+    if (!addon) {
+      addon = {name: 'Loading...', slug};
+    }
+    return (
+      <div>
+        <h1>{addon.name}</h1>
+        <p>This is the page for {slug}</p>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state, ownProps) {
+  const { slug } = ownProps.params;
+  return {
+    addon: state.addons[slug],
+    slug,
+  };
+}
+
+function loadData(dispatch) {
+  return {
+    loadData: (slug) => {
+      loadAddon(slug).then((response) => {
+        dispatch(loadEntities(response.entities));
+      });
+    },
+  };
+}
+
+const CurrentAddonPage = connect(mapStateToProps, loadData)(AddonPage);
+
+export default CurrentAddonPage;

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';
-import { loadAddon } from 'core/api';
+import { fetchAddon } from 'core/api';
 import { loadEntities } from 'search/actions';
 
 class AddonPage extends React.Component {
@@ -36,19 +36,21 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function findAddon(state, slug) {
+export function findAddon(state, slug) {
   return state.addons[slug];
+}
+
+export function loadAddonIfNeeded({store: {dispatch, getState}, params: {slug}}) {
+  const addon = findAddon(getState(), slug);
+  if (addon) {
+    return addon;
+  }
+  return fetchAddon(slug).then(({entities}) => dispatch(loadEntities(entities)));
 }
 
 const CurrentAddonPage = asyncConnect([{
   deferred: true,
-  promise: ({store: {dispatch, getState}, params: {slug}}) => {
-    const addon = findAddon(getState(), slug);
-    if (addon) {
-      return addon;
-    }
-    return loadAddon(slug).then((response) => dispatch(loadEntities(response.entities)));
-  },
+  promise: loadAddonIfNeeded,
 }])(connect(mapStateToProps)(AddonPage));
 
 export default CurrentAddonPage;

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -9,7 +9,7 @@ class AddonPage extends React.Component {
     addon: PropTypes.shape({
       name: PropTypes.string.isRequired,
       slug: PropTypes.string.isRequired,
-    }),
+    }).isRequired,
     slug: PropTypes.string.isRequired,
   }
 
@@ -22,13 +22,13 @@ class AddonPage extends React.Component {
     return (
       <div>
         <h1>{addon.name}</h1>
-        <p>This is the page for {slug}</p>
+        <p>This is the page for {slug}.</p>
       </div>
     );
   }
 }
 
-function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state, ownProps) {
   const { slug } = ownProps.params;
   return {
     addon: state.addons[slug],
@@ -36,7 +36,7 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-function findAddon(state, slug) {
+export function findAddon(state, slug) {
   return state.addons[slug];
 }
 

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -9,7 +9,7 @@ class AddonPage extends React.Component {
     addon: PropTypes.shape({
       name: PropTypes.string.isRequired,
       slug: PropTypes.string.isRequired,
-    }).isRequired,
+    }),
     slug: PropTypes.string.isRequired,
   }
 
@@ -28,7 +28,7 @@ class AddonPage extends React.Component {
   }
 }
 
-export function mapStateToProps(state, ownProps) {
+function mapStateToProps(state, ownProps) {
   const { slug } = ownProps.params;
   return {
     addon: state.addons[slug],
@@ -36,7 +36,7 @@ export function mapStateToProps(state, ownProps) {
   };
 }
 
-export function findAddon(state, slug) {
+function findAddon(state, slug) {
   return state.addons[slug];
 }
 

--- a/src/search/containers/App.js
+++ b/src/search/containers/App.js
@@ -10,6 +10,10 @@ export default class App extends React.Component {
 
   render() {
     const { children } = this.props;
-    return children;
+    return (
+      <div className="search-page">
+        {children}
+      </div>
+    );
   }
 }

--- a/src/search/routes.js
+++ b/src/search/routes.js
@@ -1,8 +1,13 @@
 import React from 'react';
-import { Route } from 'react-router';
+import { IndexRoute, Route } from 'react-router';
 
 import App from './components/App';
+import CurrentSearchPage from './containers/CurrentSearchPage';
+import AddonPage from './containers/AddonPage';
 
 export default (
-  <Route name="search" component={App} path="/search" />
+  <Route path="/search" component={App}>
+    <IndexRoute component={CurrentSearchPage} />
+    <Route path="addons/:slug" component={AddonPage} />
+  </Route>
 );

--- a/src/search/routes.js
+++ b/src/search/routes.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IndexRoute, Route } from 'react-router';
 
-import App from './components/App';
+import App from './containers/App';
 import CurrentSearchPage from './containers/CurrentSearchPage';
 import AddonPage from './containers/AddonPage';
 

--- a/src/search/server.js
+++ b/src/search/server.js
@@ -1,6 +1,7 @@
 import baseServer from 'core/server/base';
 import routes from './routes';
+import createStore from './store';
 
-const app = baseServer(routes);
+const app = baseServer(routes, createStore);
 
 export default app;

--- a/src/search/store.js
+++ b/src/search/store.js
@@ -1,0 +1,14 @@
+import { applyMiddleware, createStore as _createStore, combineReducers } from 'redux';
+import { reducer as reduxAsyncConnect } from 'redux-async-connect';
+import createLogger from 'redux-logger';
+
+import search from 'search/reducers/search';
+import addons from 'core/reducers/addons';
+
+export default function createStore(initialData = {}) {
+  return _createStore(
+    combineReducers({addons, search, reduxAsyncConnect}),
+    initialData,
+    applyMiddleware(createLogger()),
+  );
+}

--- a/src/search/store.js
+++ b/src/search/store.js
@@ -5,10 +5,10 @@ import createLogger from 'redux-logger';
 import search from 'search/reducers/search';
 import addons from 'core/reducers/addons';
 
-export default function createStore(initialData = {}) {
+export default function createStore(initialState = {}) {
   return _createStore(
     combineReducers({addons, search, reduxAsyncConnect}),
-    initialData,
+    initialState,
     applyMiddleware(createLogger()),
   );
 }

--- a/tests/core/api/test_api.js
+++ b/tests/core/api/test_api.js
@@ -1,4 +1,4 @@
-import { search } from 'core/api';
+import * as api from 'core/api';
 
 describe('search api', () => {
   let mockWindow;
@@ -31,12 +31,12 @@ describe('search api', () => {
       .withArgs('https://addons.mozilla.org/api/v3/addons/search/?q=foo&lang=en-US')
       .once()
       .returns(mockResponse());
-    return search({query: 'foo'}).then(() => mockWindow.verify());
+    return api.search({query: 'foo'}).then(() => mockWindow.verify());
   });
 
   it('normalizes the response', () => {
     mockWindow.expects('fetch').once().returns(mockResponse());
-    return search({query: 'foo'}).then((results) => {
+    return api.search({query: 'foo'}).then((results) => {
       assert.deepEqual(results.result.results, ['foo', 'food', 'football']);
       assert.deepEqual(results.entities, {
         addons: {
@@ -45,6 +45,46 @@ describe('search api', () => {
           football: {slug: 'football'},
         },
       });
+    });
+  });
+});
+
+describe('add-on api', () => {
+  let mockWindow;
+
+  beforeEach(() => {
+    mockWindow = sinon.mock(window);
+  });
+
+  afterEach(() => {
+    mockWindow.restore();
+  });
+
+  function mockResponse() {
+    return Promise.resolve({
+      json() {
+        return Promise.resolve({
+          name: 'Foo!',
+          slug: 'foo',
+        });
+      },
+    });
+  }
+
+  it('sets the lang and slug', () => {
+    mockWindow.expects('fetch')
+      .withArgs('https://addons.mozilla.org/api/v3/addons/addon/foo/?lang=en-US')
+      .once()
+      .returns(mockResponse());
+    return api.loadAddon('foo').then(() => mockWindow.verify());
+  });
+
+  it('normalizes the response', () => {
+    mockWindow.expects('fetch').once().returns(mockResponse());
+    return api.loadAddon('foo').then((results) => {
+      const foo = {slug: 'foo', name: 'Foo!'};
+      assert.deepEqual(results.result, 'foo');
+      assert.deepEqual(results.entities, {addons: {foo}});
     });
   });
 });

--- a/tests/core/api/test_api.js
+++ b/tests/core/api/test_api.js
@@ -76,12 +76,12 @@ describe('add-on api', () => {
       .withArgs('https://addons.mozilla.org/api/v3/addons/addon/foo/?lang=en-US')
       .once()
       .returns(mockResponse());
-    return api.loadAddon('foo').then(() => mockWindow.verify());
+    return api.fetchAddon('foo').then(() => mockWindow.verify());
   });
 
   it('normalizes the response', () => {
     mockWindow.expects('fetch').once().returns(mockResponse());
-    return api.loadAddon('foo').then((results) => {
+    return api.fetchAddon('foo').then((results) => {
       const foo = {slug: 'foo', name: 'Foo!'};
       assert.deepEqual(results.result, 'foo');
       assert.deepEqual(results.entities, {addons: {foo}});

--- a/tests/search/actions/test_index.js
+++ b/tests/search/actions/test_index.js
@@ -1,0 +1,40 @@
+import * as actions from 'search/actions';
+
+describe('SEARCH_STARTED', () => {
+  const action = actions.searchStart('foo');
+
+  it('sets the type', () => {
+    assert.equal(action.type, 'SEARCH_STARTED');
+  });
+
+  it('sets the query', () => {
+    assert.deepEqual(action.payload, {query: 'foo'});
+  });
+});
+
+describe('SEARCH_LOADED', () => {
+  const entities = sinon.stub();
+  const result = sinon.stub();
+  const action = actions.searchLoad({query: 'foo', entities, result});
+
+  it('sets the type', () => {
+    assert.equal(action.type, 'SEARCH_LOADED');
+  });
+
+  it('sets the payload', () => {
+    assert.deepEqual(action.payload, {query: 'foo', entities, result});
+  });
+});
+
+describe('ENTITIES_LOADED', () => {
+  const entities = sinon.stub();
+  const action = actions.loadEntities(entities);
+
+  it('sets the type', () => {
+    assert.equal(action.type, 'ENTITIES_LOADED');
+  });
+
+  it('sets the payload', () => {
+    assert.deepEqual(action.payload, {entities});
+  });
+});

--- a/tests/search/components/TestSearchPage.js
+++ b/tests/search/components/TestSearchPage.js
@@ -1,15 +1,9 @@
 import React from 'react';
-import { createRenderer } from 'react-addons-test-utils';
 
 import SearchPage from 'search/components/SearchPage';
 import SearchResults from 'search/components/SearchResults';
 import SearchForm from 'search/components/SearchForm';
-
-function findByTag(root, tag) {
-  const matches = root.props.children.filter((child) => child.type === tag);
-  assert.equal(matches.length, 1, 'expected one match');
-  return matches[0];
-}
+import { findByTag, shallowRender } from '../../utils';
 
 describe('<SearchPage />', () => {
   let root;
@@ -22,10 +16,7 @@ describe('<SearchPage />', () => {
       results: [{name: 'Foo', slug: 'foo'}, {name: 'Bar', slug: 'bar'}],
       query: 'foo',
     };
-    // eslint-disable-next-line new-cap
-    const renderer = createRenderer();
-    renderer.render(<SearchPage {...state} />);
-    root = renderer.getRenderOutput();
+    root = shallowRender(<SearchPage {...state} />);
   });
 
   it('has a nice heading', () => {

--- a/tests/search/containers/TestAddonPage.js
+++ b/tests/search/containers/TestAddonPage.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 import { Provider } from 'react-redux';
-import AddonPage from 'search/containers/AddonPage';
+import AddonPage, { findAddon, loadAddonIfNeeded } from 'search/containers/AddonPage';
 import createStore from 'search/store';
+import * as api from 'core/api';
+import * as actions from 'search/actions';
 
 describe('AddonPage', () => {
   const initialState = {addons: {'my-addon': {name: 'Addon!', slug: 'my-addon'}}};
@@ -31,5 +33,87 @@ describe('AddonPage', () => {
     const root = render({state: initialState, props: {params: {slug: 'other-addon'}}});
     assert.equal(root.querySelector('h1').textContent, 'Loading...');
     assert.equal(root.querySelector('p').textContent, 'This is the page for other-addon.');
+  });
+
+  describe('findAddon', () => {
+    const addon = sinon.stub();
+    const state = {
+      addons: {
+        'the-addon': addon,
+      },
+    };
+
+    it('finds the add-on in the state', () => {
+      assert.strictEqual(findAddon(state, 'the-addon'), addon);
+    });
+
+    it('does not find the add-on in the state', () => {
+      assert.strictEqual(findAddon(state, 'different-addon'), undefined);
+    });
+  });
+
+  describe('loadAddonIfNeeded', () => {
+    const loadedSlug = 'my-addon';
+    let loadedAddon;
+    let dispatch;
+    let mocks;
+
+    beforeEach(() => {
+      loadedAddon = sinon.stub();
+      dispatch = sinon.spy();
+      mocks = [];
+    });
+
+    afterEach(() => {
+      mocks.forEach((mock) => mock.restore());
+    });
+
+    function makeMock(thing) {
+      const mock = sinon.mock(thing);
+      mocks.push(mock);
+      return mock;
+    }
+
+    function makeProps(slug) {
+      return {
+        store: {
+          getState: () => ({
+            addons: {
+              [loadedSlug]: loadedAddon,
+            },
+          }),
+          dispatch,
+        },
+        params: {slug},
+      };
+    }
+
+    it('returns the add-on if loaded', () => {
+      assert.strictEqual(loadAddonIfNeeded(makeProps(loadedSlug)), loadedAddon);
+    });
+
+    it('loads the add-on if it is not loaded', () => {
+      const slug = 'other-addon';
+      const addon = sinon.stub();
+      const entities = {[slug]: addon};
+      const mockApi = makeMock(api);
+      mockApi
+        .expects('fetchAddon')
+        .once()
+        .withArgs(slug)
+        .returns(Promise.resolve({entities}));
+      const action = sinon.stub();
+      const mockActions = makeMock(actions);
+      mockActions
+        .expects('loadEntities')
+        .once()
+        .withArgs(entities)
+        .returns(action);
+      return loadAddonIfNeeded(makeProps(slug)).then(() => {
+        assert(dispatch.calledWith(action), 'dispatch not called');
+        mockApi.verify();
+        mockActions.verify();
+      });
+    });
   });
 });

--- a/tests/search/containers/TestAddonPage.js
+++ b/tests/search/containers/TestAddonPage.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+import { Provider } from 'react-redux';
+import AddonPage from 'search/containers/AddonPage';
+import createStore from 'search/store';
+
+describe('AddonPage', () => {
+  const initialState = {addons: {'my-addon': {name: 'Addon!', slug: 'my-addon'}}};
+
+  function render({props, state}) {
+    const store = createStore(state);
+    return findDOMNode(renderIntoDocument(
+      <Provider store={store} key="provider">
+        <AddonPage {...props} />
+      </Provider>
+    ));
+  }
+
+  it('renders the name', () => {
+    const root = render({state: initialState, props: {params: {slug: 'my-addon'}}});
+    assert.equal(root.querySelector('h1').textContent, 'Addon!');
+  });
+
+  it('renders the slug', () => {
+    const root = render({state: initialState, props: {params: {slug: 'my-addon'}}});
+    assert.equal(root.querySelector('p').textContent, 'This is the page for my-addon.');
+  });
+
+  it('loads the add-on if not found', () => {
+    const root = render({state: initialState, props: {params: {slug: 'other-addon'}}});
+    assert.equal(root.querySelector('h1').textContent, 'Loading...');
+    assert.equal(root.querySelector('p').textContent, 'This is the page for other-addon.');
+  });
+});

--- a/tests/search/containers/TestApp.js
+++ b/tests/search/containers/TestApp.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import App from 'search/containers/App';
+import { shallowRender } from '../../utils';
+
+describe('App', () => {
+  it('renders its children', () => {
+    class MyComponent extends React.Component {
+      render() {
+        return <p>The component</p>;
+      }
+    }
+    const root = shallowRender(<App><MyComponent /></App>);
+    assert.equal(root.type, 'div');
+    assert.equal(root.props.children.type, MyComponent);
+  });
+});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,13 @@
+import { createRenderer } from 'react-addons-test-utils';
+
+export function shallowRender(stuff) {
+  const renderer = createRenderer();
+  renderer.render(stuff);
+  return renderer.getRenderOutput();
+}
+
+export function findByTag(root, tag) {
+  const matches = root.props.children.filter((child) => child.type === tag);
+  assert.equal(matches.length, 1, 'expected one match');
+  return matches[0];
+}


### PR DESCRIPTION
I wanted this to be for #104 but the add-on detail view is simpler so this actually fixes #22. It adds an add-on detail page that is universal but doesn't address the search page since that seemed like more work.

Mostly a redo of #128. Some stuff is copied over but I wanted to avoid using the middleware and see what happened when starting with `redux-async-connect` instead of `redux-thunk`. I think this is much better.

You need to start the server with `APP_NAME=search` or React will complain on the client about `Uncaught Invariant Violation: Could not find "store" in either the context or props of "Connect(Connect(AddonPage))". Either wrap the root component in a <Provider>, or explicitly pass "store" as a prop to "Connect(Connect(AddonPage))".` After putting some `throw`s in code that is (in my mind) *definitely* being executed and things still running I'm calling that a tomorrow problem (along with tests and more cleanup).

@muffinresearch still some cleanup to do and there aren't any tests but if you have comments let me know.