### PR TITLE
Support pagination (fixes #106)

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -21,9 +21,12 @@ function callApi(endpoint, schema, params) {
     .then((response) => normalize(response, schema));
 }
 
-export function search({ query }) {
+export function search({ page, query }) {
   // TODO: Get the language from the server.
-  return callApi('addons/search', {results: arrayOf(addon)}, {q: query, lang: 'en-US'});
+  return callApi(
+    'addons/search',
+    {results: arrayOf(addon)},
+    {q: query, lang: 'en-US', page});
 }
 
 export function fetchAddon(slug) {

--- a/src/core/components/Paginate/Paginate.scss
+++ b/src/core/components/Paginate/Paginate.scss
@@ -1,0 +1,13 @@
+.paginator {
+  display: flex;
+  justify-content: space-between;
+  margin: 1em;
+  padding: 0;
+}
+
+.paginator--item {
+  display: inline-block;
+  margin: 0 0.5em;
+  list-style-type: none;
+  text-align: center;
+}

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -1,0 +1,63 @@
+import React, { PropTypes } from 'react';
+
+import './Paginate.scss';
+
+export default class Paginate extends React.Component {
+  static propTypes = {
+    count: PropTypes.number.isRequired,
+    currentPage: PropTypes.number.isRequired,
+    pager: PropTypes.func.isRequired,
+    perPage: PropTypes.number,
+    showPages: PropTypes.number,
+  }
+
+  static defaultProps = {
+    perPage: 25,
+    showPages: 9,
+  }
+
+  pageCount() {
+    return Math.ceil(this.props.count / this.props.perPage);
+  }
+
+  visiblePages() {
+    const { currentPage, showPages } = this.props;
+    const pageCount = this.pageCount();
+    const pageLinkCount = Math.min(showPages, pageCount);
+    // Offset should be a number between 0 and showPages. When near the middle it will be
+    // `showPages / 2`, when near the begging it will be near 0, when near then end it will be near
+    // `showPages`.
+    const offset = Math.max(
+      // Limit the offset when near the start to `currentPage - 1`, otherwise use `showPages / 2`.
+      Math.min(Math.floor(showPages / 2), currentPage - 1),
+      // When near the end the offset should approach `showPages`, but not if we have fewer pages
+      // than `showPages`.
+      showPages < pageCount ? showPages - (pageCount - currentPage) - 1 : 0);
+    return new Array(pageLinkCount).fill(0).map((val, i) => i + currentPage - offset);
+  }
+
+  makeLink({ currentPage, page, pager, text }) {
+    const goToPage = (e) => {
+      e.preventDefault();
+      pager(page);
+    };
+    let child;
+    if (currentPage === page || page < 1 || page > this.pageCount()) {
+      child = text || page;
+    } else {
+      child = <a href="#" onClick={goToPage}>{text || page}</a>;
+    }
+    return <li key={page} className="paginator--item">{child}</li>;
+  }
+
+  render() {
+    const { currentPage, pager } = this.props;
+    return (
+      <ul className="paginator">
+        {this.makeLink({page: currentPage - 1, currentPage, pager, text: 'Prev'})}
+        {this.visiblePages().map((page) => this.makeLink({page, currentPage, pager}))}
+        {this.makeLink({page: currentPage + 1, currentPage, pager, text: 'Next'})}
+      </ul>
+    );
+  }
+}

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -25,15 +25,20 @@ export default class Paginate extends React.Component {
     const pageCount = this.pageCount();
     const pageLinkCount = Math.min(showPages, pageCount);
     // Offset should be a number between 0 and showPages. When near the middle it will be
-    // `showPages / 2`, when near the begging it will be near 0, when near then end it will be near
-    // `showPages`.
+    // `showPages / 2`, when near the beginning it will be near 0, when near then end it will be
+    // near `showPages`.
     const offset = Math.max(
       // Limit the offset when near the start to `currentPage - 1`, otherwise use `showPages / 2`.
       Math.min(Math.floor(showPages / 2), currentPage - 1),
       // When near the end the offset should approach `showPages`, but not if we have fewer pages
       // than `showPages`.
       showPages < pageCount ? showPages - (pageCount - currentPage) - 1 : 0);
-    return new Array(pageLinkCount).fill(0).map((val, i) => i + currentPage - offset);
+    // Construct an array of visible page numbers.
+    const pages = new Array(pageLinkCount);
+    for (let i = 0; i < pageLinkCount; i++) {
+      pages[i] = i + currentPage - offset;
+    }
+    return pages;
   }
 
   makeLink({ currentPage, page, pager, text }) {

--- a/src/search/actions/index.js
+++ b/src/search/actions/index.js
@@ -1,7 +1,7 @@
-export function searchStart(query) {
+export function searchStart(query, page) {
   return {
     type: 'SEARCH_STARTED',
-    payload: { query },
+    payload: { page, query },
   };
 }
 

--- a/src/search/components/SearchPage.js
+++ b/src/search/components/SearchPage.js
@@ -1,16 +1,18 @@
 import React, { PropTypes } from 'react';
 
+import Paginate from 'core/components/Paginate';
 import SearchForm from './SearchForm';
 import SearchResults from './SearchResults';
 import { gettext as _ } from 'core/utils';
 
 import 'search/css/SearchPage.scss';
 
-
 export default class SearchPage extends React.Component {
   static propTypes = {
+    count: PropTypes.number,
     handleSearch: PropTypes.func.isRequired,
     loading: PropTypes.bool.isRequired,
+    page: PropTypes.number,
     results: PropTypes.arrayOf(PropTypes.shape({
       slug: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
@@ -18,14 +20,20 @@ export default class SearchPage extends React.Component {
     query: PropTypes.string,
   }
 
-  render() {
-    const { handleSearch, loading, results, query } = this.props;
+  pager = (page) => {
+    this.props.handleSearch(this.props.query, page);
+  }
 
+  render() {
+    const { count, handleSearch, loading, page, query, results } = this.props;
+    const paginator = query && count > 0 ?
+      <Paginate count={count} pager={this.pager} currentPage={page} /> : [];
     return (
       <div className="search-page">
         <h1>{_('Add-on Search')}</h1>
         <SearchForm onSearch={handleSearch} />
-        <SearchResults results={results} query={query} loading={loading} />
+        {paginator}
+        <SearchResults results={results} query={query} loading={loading} count={count} />
       </div>
     );
   }

--- a/src/search/components/SearchResults.js
+++ b/src/search/components/SearchResults.js
@@ -8,24 +8,26 @@ import 'search/css/SearchResults.scss';
 
 export default class SearchResults extends React.Component {
   static propTypes = {
+    count: PropTypes.number,
     loading: PropTypes.bool,
     query: PropTypes.string,
     results: PropTypes.arrayOf(PropTypes.object),
   }
 
   static defaultProps = {
+    count: 0,
     query: null,
     results: [],
   }
 
   render() {
-    const { loading, query, results } = this.props;
+    const { count, loading, query, results } = this.props;
 
     let searchResults;
     let messageText;
 
-    if (query && results.length > 0) {
-      messageText = _(`Your search for "${query}" returned ${results.length} results.`);
+    if (query && count > 0) {
+      messageText = _(`Your search for "${query}" returned ${count} results.`);
       searchResults = (
         <ul ref="results">
           {results.map((result) => (

--- a/src/search/containers/CurrentSearchPage.js
+++ b/src/search/containers/CurrentSearchPage.js
@@ -9,10 +9,10 @@ export function mapStateToProps(state) {
 
 export function mapDispatchToProps(dispatch) {
   return {
-    handleSearch: (query) => {
-      dispatch(searchStart(query));
-      return search({ query })
-        .then((response) => dispatch(searchLoad({ query, ...response })));
+    handleSearch: (query, page = 1) => {
+      dispatch(searchStart(query, page));
+      return search({ page, query })
+        .then((response) => dispatch(searchLoad({ page, query, ...response })));
     },
   };
 }

--- a/src/search/reducers/search.js
+++ b/src/search/reducers/search.js
@@ -1,6 +1,7 @@
 const initialState = {
-  query: null,
+  count: 0,
   loading: false,
+  query: null,
   results: [],
 };
 
@@ -10,11 +11,12 @@ export default function search(state = initialState, action) {
     case 'SET_QUERY':
       return Object.assign({}, state, {query: payload.query});
     case 'SEARCH_STARTED':
-      return Object.assign({}, state, {query: payload.query, loading: true, results: []});
+      return Object.assign({}, state, {...payload, loading: true, results: []});
     case 'SEARCH_LOADED':
       return Object.assign({}, state, {
-        query: payload.query,
+        count: payload.result.count,
         loading: false,
+        query: payload.query,
         results: payload.result.results.map((slug) => payload.entities.addons[slug]),
       });
     default:

--- a/tests/core/api/test_api.js
+++ b/tests/core/api/test_api.js
@@ -25,13 +25,13 @@ describe('search api', () => {
     });
   }
 
-  it('sets the lang and query', () => {
+  it('sets the lang, limit, page and query', () => {
     // FIXME: This shouldn't fail if the args are in a different order.
     mockWindow.expects('fetch')
-      .withArgs('https://addons.mozilla.org/api/v3/addons/search/?q=foo&lang=en-US')
+      .withArgs('https://addons.mozilla.org/api/v3/addons/search/?q=foo&lang=en-US&page=3')
       .once()
       .returns(mockResponse());
-    return api.search({query: 'foo'}).then(() => mockWindow.verify());
+    return api.search({query: 'foo', page: 3}).then(() => mockWindow.verify());
   });
 
   it('normalizes the response', () => {

--- a/tests/core/components/TestPaginate.js
+++ b/tests/core/components/TestPaginate.js
@@ -1,0 +1,124 @@
+import React from 'react';
+import { renderIntoDocument, Simulate } from 'react-addons-test-utils';
+import Paginate from 'core/components/Paginate';
+
+describe('<Paginate />', () => {
+  function render({count = 20, currentPage = 1, pager = sinon.spy(), ...extra}) {
+    return renderIntoDocument(
+      <Paginate count={count} currentPage={currentPage} pager={pager} {...extra} />);
+  }
+
+  describe('pageCount()', () => {
+    it('is count / perPage', () => {
+      const root = render({count: 100, perPage: 5});
+      assert.equal(root.pageCount(), 20);
+    });
+
+    it('uses the ceiling of the result', () => {
+      const root = render({count: 101, perPage: 5});
+      assert.equal(root.pageCount(), 21);
+    });
+  });
+
+  describe('visiblePages()', () => {
+    describe('with lots of pages', () => {
+      const commonParams = {count: 30, perPage: 3, showPages: 5};
+
+      it('will not be less than 0', () => {
+        const root = render({ ...commonParams, currentPage: 1});
+        assert.deepEqual(root.visiblePages(), [1, 2, 3, 4, 5]);
+      });
+
+      it('will not offset near the start', () => {
+        const root = render({ ...commonParams, currentPage: 2});
+        assert.deepEqual(root.visiblePages(), [1, 2, 3, 4, 5]);
+      });
+
+      it('will offset near the middle', () => {
+        const root = render({ ...commonParams, currentPage: 5});
+        assert.deepEqual(root.visiblePages(), [3, 4, 5, 6, 7]);
+      });
+
+      it('will offset more near the end', () => {
+        const root = render({ ...commonParams, currentPage: 9});
+        assert.deepEqual(root.visiblePages(), [6, 7, 8, 9, 10]);
+      });
+
+      it('will not offset more than showPages', () => {
+        const root = render({ ...commonParams, currentPage: 10});
+        assert.deepEqual(root.visiblePages(), [6, 7, 8, 9, 10]);
+      });
+    });
+
+    describe('with few pages', () => {
+      const commonParams = {count: 30, perPage: 10, showPages: 5};
+
+      it('will not be less than 0', () => {
+        const root = render({ ...commonParams, currentPage: 1});
+        assert.deepEqual(root.visiblePages(), [1, 2, 3]);
+      });
+
+      it('will not offset near the middle', () => {
+        const root = render({ ...commonParams, currentPage: 2});
+        assert.deepEqual(root.visiblePages(), [1, 2, 3]);
+      });
+
+      it('will not offset more than showPages', () => {
+        const root = render({ ...commonParams, currentPage: 3});
+        assert.deepEqual(root.visiblePages(), [1, 2, 3]);
+      });
+    });
+  });
+
+  describe('makeLink()', () => {
+    let pager;
+    let root;
+
+    beforeEach(() => {
+      pager = sinon.spy();
+      root = new Paginate({count: 50, currentPage: 5, pager});
+    });
+
+    describe('when the link is to the current page', () => {
+      it('does not contain a link', () => {
+        const link = renderIntoDocument(root.makeLink({currentPage: 3, page: 3, pager}));
+        assert.equal(link.childNodes.length, 1);
+        assert.equal(link.childNodes[0].nodeType, Node.TEXT_NODE);
+        assert.equal(link.textContent, '3');
+      });
+
+      it('uses the provided text', () => {
+        const link = renderIntoDocument(
+          root.makeLink({currentPage: 3, page: 3, pager, text: 'hi'}));
+        assert.equal(link.childNodes.length, 1);
+        assert.equal(link.childNodes[0].nodeType, Node.TEXT_NODE);
+        assert.equal(link.textContent, 'hi');
+      });
+    });
+
+    describe('when the link is to a different page', () => {
+      it('has a link', () => {
+        const link = renderIntoDocument(root.makeLink({currentPage: 2, page: 3, pager}));
+        assert.equal(link.childNodes.length, 1);
+        assert.equal(link.childNodes[0].tagName, 'A');
+        assert.equal(link.textContent, '3');
+      });
+
+      it('uses the provided text', () => {
+        const link = renderIntoDocument(
+          root.makeLink({currentPage: 4, page: 3, pager, text: 'hi'}));
+        assert.equal(link.childNodes.length, 1);
+        assert.equal(link.childNodes[0].tagName, 'A');
+        assert.equal(link.textContent, 'hi');
+      });
+
+      it('calls the pager when clicked', () => {
+        assert(!pager.called, 'pager was called early');
+        const link = renderIntoDocument(
+          root.makeLink({currentPage: 4, page: 3, pager, text: 'hi'}));
+        Simulate.click(link.querySelector('a'));
+        assert(pager.calledWith(3));
+      });
+    });
+  });
+});

--- a/tests/search/actions/test_index.js
+++ b/tests/search/actions/test_index.js
@@ -1,14 +1,14 @@
 import * as actions from 'search/actions';
 
 describe('SEARCH_STARTED', () => {
-  const action = actions.searchStart('foo');
+  const action = actions.searchStart('foo', 5);
 
   it('sets the type', () => {
     assert.equal(action.type, 'SEARCH_STARTED');
   });
 
   it('sets the query', () => {
-    assert.deepEqual(action.payload, {query: 'foo'});
+    assert.deepEqual(action.payload, {query: 'foo', page: 5});
   });
 });
 

--- a/tests/search/components/TestSearchPage.js
+++ b/tests/search/components/TestSearchPage.js
@@ -3,40 +3,72 @@ import React from 'react';
 import SearchPage from 'search/components/SearchPage';
 import SearchResults from 'search/components/SearchResults';
 import SearchForm from 'search/components/SearchForm';
-import { findByTag, shallowRender } from '../../utils';
+import Paginate from 'core/components/Paginate';
+import { findAllByTag, findByTag, shallowRender } from '../../utils';
 
 describe('<SearchPage />', () => {
-  let root;
   let state;
+
+  function render(updateState = {}) {
+    return shallowRender(<SearchPage {...Object.assign({}, state, updateState)} />);
+  }
 
   beforeEach(() => {
     state = {
+      count: 80,
+      page: 3,
       handleSearch: sinon.spy(),
       loading: false,
       results: [{name: 'Foo', slug: 'foo'}, {name: 'Bar', slug: 'bar'}],
       query: 'foo',
     };
-    root = shallowRender(<SearchPage {...state} />);
   });
 
   it('has a nice heading', () => {
+    const root = render();
     const heading = findByTag(root, 'h1');
     assert.equal(heading.props.children, 'Add-on Search');
   });
 
   it('renders the results', () => {
+    const root = render();
     const results = findByTag(root, SearchResults);
+    assert.strictEqual(results.props.count, state.count);
     assert.strictEqual(results.props.results, state.results);
     assert.strictEqual(results.props.query, state.query);
     assert.strictEqual(results.props.loading, state.loading);
     assert.deepEqual(
       Object.keys(results.props).sort(),
-      ['loading', 'results', 'query'].sort());
+      ['count', 'loading', 'results', 'query'].sort());
   });
 
   it('renders the query', () => {
+    const root = render();
     const form = findByTag(root, SearchForm);
     assert.strictEqual(form.props.onSearch, state.handleSearch);
     assert.deepEqual(Object.keys(form.props), ['onSearch']);
+  });
+
+  it('renders a Paginate', () => {
+    const root = render();
+    const paginator = findByTag(root, Paginate);
+    assert.equal(paginator.props.count, 80);
+    assert.equal(paginator.props.currentPage, 3);
+    assert.equal(typeof paginator.props.pager, 'function');
+  });
+
+  it('does not render a Paginate when there is no serach term', () => {
+    const root = render({query: null, count: 0});
+    const paginators = findAllByTag(root, Paginate);
+    assert.deepEqual(paginators, []);
+  });
+});
+
+describe('<SearchPage /> pager()', () => {
+  it('calls handleSearch with the query and page', () => {
+    const handleSearch = sinon.spy();
+    const searchPage = new SearchPage({handleSearch, loading: false, query: 'Howdy'});
+    searchPage.pager(20);
+    assert(handleSearch.calledWith('Howdy', 20));
   });
 });

--- a/tests/search/components/TestSearchPage.js
+++ b/tests/search/components/TestSearchPage.js
@@ -57,7 +57,7 @@ describe('<SearchPage />', () => {
     assert.equal(typeof paginator.props.pager, 'function');
   });
 
-  it('does not render a Paginate when there is no serach term', () => {
+  it('does not render a Paginate when there is no search term', () => {
     const root = render({query: null, count: 0});
     const paginators = findAllByTag(root, Paginate);
     assert.deepEqual(paginators, []);

--- a/tests/search/components/TestSearchResults.js
+++ b/tests/search/components/TestSearchResults.js
@@ -41,6 +41,7 @@ describe('<SearchResults />', () => {
 
   it('renders search results when supplied', () => {
     const root = renderResults({
+      count: 5,
       query: 'test',
       results: [
         {name: 'result 1', slug: '1'},
@@ -48,7 +49,7 @@ describe('<SearchResults />', () => {
       ],
     });
     const searchResultsMsg = root.refs.message;
-    assert.include(searchResultsMsg.textContent, 'Your search for "test" returned 2');
+    assert.include(searchResultsMsg.textContent, 'Your search for "test" returned 5 results');
 
     const searchResultsList = root.refs.results;
     assert.include(searchResultsList.textContent, 'result 1');

--- a/tests/search/containers/TestCurrentSearchPage.js
+++ b/tests/search/containers/TestCurrentSearchPage.js
@@ -31,7 +31,7 @@ describe('CurrentSearchPage.mapDispatchToProps', () => {
     Object.keys(mocks).forEach((name) => mocks[name].restore());
   });
 
-  function handleSearch(query, page, response = Promise.resolve({}), expectedPage) {
+  function handleSearch({query, page, response = Promise.resolve({}), expectedPage}) {
     mocks.api.expects('search')
       .withArgs({ page: expectedPage || page, query })
       .once()
@@ -46,7 +46,7 @@ describe('CurrentSearchPage.mapDispatchToProps', () => {
       .withArgs('DuckDuckGo', 5)
       .once()
       .returns(searchAction);
-    return handleSearch('DuckDuckGo', 5).then(() => {
+    return handleSearch({query: 'DuckDuckGo', page: 5}).then(() => {
       assert(dispatch.calledWith(searchAction), 'expected action to be dispatched');
       mocks.actions.verify();
     });
@@ -59,7 +59,7 @@ describe('CurrentSearchPage.mapDispatchToProps', () => {
       .withArgs('DuckDuckGo', 1)
       .once()
       .returns(searchAction);
-    return handleSearch('DuckDuckGo', undefined, undefined, 1).then(() => {
+    return handleSearch({query: 'DuckDuckGo', expectedPage: 1}).then(() => {
       assert(dispatch.calledWith(searchAction), 'expected action to be dispatched');
       mocks.actions.verify();
     });
@@ -80,7 +80,7 @@ describe('CurrentSearchPage.mapDispatchToProps', () => {
         result: ['foo', 'bar']})
       .once()
       .returns(loadAction);
-    return handleSearch('Yahoo!', 3, response).then(() => {
+    return handleSearch({query: 'Yahoo!', page: 3, response}).then(() => {
       mocks.actions.verify();
       assert(dispatch.calledWith(loadAction), 'expected action to be dispatched');
     });

--- a/tests/search/containers/TestCurrentSearchPage.js
+++ b/tests/search/containers/TestCurrentSearchPage.js
@@ -31,19 +31,35 @@ describe('CurrentSearchPage.mapDispatchToProps', () => {
     Object.keys(mocks).forEach((name) => mocks[name].restore());
   });
 
-  function handleSearch(query, response = Promise.resolve({})) {
-    mocks.api.expects('search').withArgs({ query }).once().returns(response);
-    return mapDispatchToProps(dispatch).handleSearch(query);
+  function handleSearch(query, page, response = Promise.resolve({}), expectedPage) {
+    mocks.api.expects('search')
+      .withArgs({ page: expectedPage || page, query })
+      .once()
+      .returns(response);
+    return mapDispatchToProps(dispatch).handleSearch(query, page);
   }
 
   it('sets the query', () => {
     const searchAction = sinon.stub();
     mocks.actions
       .expects('searchStart')
-      .withArgs('DuckDuckGo')
+      .withArgs('DuckDuckGo', 5)
       .once()
       .returns(searchAction);
-    return handleSearch('DuckDuckGo').then(() => {
+    return handleSearch('DuckDuckGo', 5).then(() => {
+      assert(dispatch.calledWith(searchAction), 'expected action to be dispatched');
+      mocks.actions.verify();
+    });
+  });
+
+  it('sets defaults the page to 1', () => {
+    const searchAction = sinon.stub();
+    mocks.actions
+      .expects('searchStart')
+      .withArgs('DuckDuckGo', 1)
+      .once()
+      .returns(searchAction);
+    return handleSearch('DuckDuckGo', undefined, undefined, 1).then(() => {
       assert(dispatch.calledWith(searchAction), 'expected action to be dispatched');
       mocks.actions.verify();
     });
@@ -57,10 +73,14 @@ describe('CurrentSearchPage.mapDispatchToProps', () => {
     });
     mocks.actions
       .expects('searchLoad')
-      .withArgs({query: 'Yahoo!', entities: {addons: {foo: {}, bar: {}}}, result: ['foo', 'bar']})
+      .withArgs({
+        query: 'Yahoo!',
+        entities: {addons: {foo: {}, bar: {}}},
+        page: 3,
+        result: ['foo', 'bar']})
       .once()
       .returns(loadAction);
-    return handleSearch('Yahoo!', response).then(() => {
+    return handleSearch('Yahoo!', 3, response).then(() => {
       mocks.actions.verify();
       assert(dispatch.calledWith(loadAction), 'expected action to be dispatched');
     });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -6,8 +6,12 @@ export function shallowRender(stuff) {
   return renderer.getRenderOutput();
 }
 
+export function findAllByTag(root, tag) {
+  return root.props.children.filter((child) => child.type === tag);
+}
+
 export function findByTag(root, tag) {
-  const matches = root.props.children.filter((child) => child.type === tag);
+  const matches = findAllByTag(root, tag);
   assert.equal(matches.length, 1, 'expected one match');
   return matches[0];
 }


### PR DESCRIPTION
![pagination-long mov](https://cloud.githubusercontent.com/assets/211578/14099080/e2bd67d8-f547-11e5-8f63-b20bb8cd45b7.gif)
> A long paginator

![pagination-short mov](https://cloud.githubusercontent.com/assets/211578/14099081/e2becf92-f547-11e5-8775-78f48961eebc.gif)
> A short paginator

![screenshot 2016-03-29 00 48 18](https://cloud.githubusercontent.com/assets/211578/14099091/f87c436e-f547-11e5-84a5-369fc18253a1.png)
> Current appearance

This doesn't update the URL yet. I'll tackle that along with the query param/universal in a later patch.

Fixes #106.