### PR TITLE
Include more add-on data

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -1,3 +1,10 @@
 export function gettext(str) {
   return str;
 }
+
+export function ngettext(singular, plural, n) {
+  if (n === 1) {
+    return singular;
+  }
+  return plural;
+}

--- a/src/search/components/SearchResult/index.js
+++ b/src/search/components/SearchResult/index.js
@@ -1,0 +1,31 @@
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+
+import './style.scss';
+
+function fileCount(version) {
+  if (version && version.files) {
+    return version.files.length;
+  }
+  return 0;
+}
+
+export default class SearchResult extends React.Component {
+  static propTypes = {
+    result: PropTypes.object.isRequired,
+  }
+
+  render() {
+    const { result } = this.props;
+    return (
+      <Link to={`/search/addons/${result.slug}`} className="search-result">
+        <div className="search-result--name">
+          {result.name}
+        </div>
+        <span className="search-result--info">{result.type}</span>
+        <span className="search-result--info">{result.status}</span>
+        <span className="search-result--info">{fileCount(result.current_version)} files</span>
+      </Link>
+    );
+  }
+}

--- a/src/search/components/SearchResult/index.js
+++ b/src/search/components/SearchResult/index.js
@@ -18,13 +18,15 @@ export default class SearchResult extends React.Component {
   render() {
     const { result } = this.props;
     return (
-      <Link to={`/search/addons/${result.slug}`} className="search-result">
-        <div className="search-result--name">
+      <Link to={`/search/addons/${result.slug}`} className="search-result" ref="container">
+        <div className="search-result--name" ref="name">
           {result.name}
         </div>
-        <span className="search-result--info">{result.type}</span>
-        <span className="search-result--info">{result.status}</span>
-        <span className="search-result--info">{fileCount(result.current_version)} files</span>
+        <span className="search-result--info" ref="type">{result.type}</span>
+        <span className="search-result--info" ref="status">{result.status}</span>
+        <span className="search-result--info" ref="fileCount">
+          {fileCount(result.current_version)} files
+        </span>
       </Link>
     );
   }

--- a/src/search/components/SearchResult/index.js
+++ b/src/search/components/SearchResult/index.js
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 
+import { ngettext } from 'core/utils';
+
 import './style.scss';
 
 function fileCount(version) {
@@ -8,6 +10,11 @@ function fileCount(version) {
     return version.files.length;
   }
   return 0;
+}
+
+function fileCountText(version) {
+  const count = fileCount(version);
+  return ngettext('{count} file', '{count} files', count).replace('{count}', count);
 }
 
 export default class SearchResult extends React.Component {
@@ -25,7 +32,7 @@ export default class SearchResult extends React.Component {
         <span className="search-result--info" ref="type">{result.type}</span>
         <span className="search-result--info" ref="status">{result.status}</span>
         <span className="search-result--info" ref="fileCount">
-          {fileCount(result.current_version)} files
+          {fileCountText(result.current_version)}
         </span>
       </Link>
     );

--- a/src/search/components/SearchResult/style.scss
+++ b/src/search/components/SearchResult/style.scss
@@ -1,0 +1,22 @@
+.search-result {
+  border-bottom: 1px solid #cfcfcf;
+  color: #333;
+  display: block;
+  margin: 0;
+  padding: 1em 0;
+  text-decoration: none;
+
+  &:hover .search-result--name {
+    text-decoration: underline;
+  }
+}
+
+.search-result--name {
+  font-size: 1.25em;
+  margin-bottom: 0.25em;
+}
+
+.search-result--info {
+  font-size: 0.8em;
+  margin-right: 1em;
+}

--- a/src/search/components/SearchResults.js
+++ b/src/search/components/SearchResults.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
-import { Link } from 'react-router';
 
 import { gettext as _ } from 'core/utils';
+import SearchResult from 'search/components/SearchResult';
 
 import 'search/css/SearchResults.scss';
 
@@ -29,12 +29,8 @@ export default class SearchResults extends React.Component {
     if (query && count > 0) {
       messageText = _(`Your search for "${query}" returned ${count} results.`);
       searchResults = (
-        <ul ref="results">
-          {results.map((result) => (
-            <li key={result.slug}>
-              <Link to={`/search/addons/${result.slug}`}>{result.name}</Link>
-            </li>
-          ))}
+        <ul ref="results" className="search-results">
+          {results.map((result) => <li key={result.slug}><SearchResult result={result} /></li>)}
         </ul>
       );
     } else if (query && loading) {
@@ -48,7 +44,7 @@ export default class SearchResults extends React.Component {
     const message = messageText ? <p ref="message">{messageText}</p> : null;
 
     return (
-      <div ref="container" className="search-results">
+      <div ref="container" className="search-page">
         {message}
         {searchResults}
       </div>

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';
 import { fetchAddon } from 'core/api';
 import { loadEntities } from 'search/actions';
+import { gettext as _ } from 'core/utils';
 
 import './style.scss';
 
@@ -26,21 +27,24 @@ class AddonPage extends React.Component {
     const items = [
       [addon.type, 'type'],
       [addon.status, 'status'],
-      [<a href={addon.url} target="_blank">View on site</a>, 'url'],
-      [<a href={editUrl(addon.url)} target="_blank">Edit on site</a>, 'edit'],
+      [<a href={addon.url} target="_blank">{_('View on site')}</a>, 'url'],
+      [<a href={editUrl(addon.url)} target="_blank">{_('Edit on site')}</a>, 'edit'],
     ];
     if (addon.homepage) {
       items.push([
-        <a href={addon.homepage} rel="external" target="_blank">View homepage</a>,
+        <a href={addon.homepage} rel="external" target="_blank">{_('View homepage')}</a>,
         'homepage',
       ]);
     }
     if (addon.support_email) {
-      items.push([<a href={`mailto:${addon.support_email}`}>Support email</a>, 'support_email']);
+      items.push([
+        <a href={`mailto:${addon.support_email}`}>{_('Support email')}</a>,
+        'support_email',
+      ]);
     }
     if (addon.support_url) {
       items.push([
-        <a href={addon.support_url} rel="external" target="_blank">View support site</a>,
+        <a href={addon.support_url} rel="external" target="_blank">{_('View support site')}</a>,
         'support_url',
       ]);
     }
@@ -62,9 +66,9 @@ class AddonPage extends React.Component {
     if (version) {
       return (
         <div className="addon--current-version">
-          <h2>Current version</h2>
+          <h2>{_('Current version')}</h2>
           {this.dataBar([[version.version, 'version']])}
-          <h3>Files</h3>
+          <h3>{_('Files')}</h3>
           <ul>
             {version.files.map((file) => (
               <li>
@@ -73,7 +77,7 @@ class AddonPage extends React.Component {
                   [file.status, 'status'],
                   [`${file.size} bytes`, 'size'],
                   [file.created, 'created'],
-                  [<a href={file.url}>Download</a>, 'download'],
+                  [<a href={file.url}>{_('Download')}</a>, 'download'],
                 ])}
               </li>
             ))}
@@ -83,7 +87,7 @@ class AddonPage extends React.Component {
     }
     return (
       <div className="addon--current-version">
-        <h2>No current version</h2>
+        <h2>{_('No current version')}</h2>
       </div>
     );
   }
@@ -96,9 +100,9 @@ class AddonPage extends React.Component {
     return (
       <div className="addon">
         <h1>{addon.name}</h1>
-        <p>Attributes</p>
+        <p>{_('Attributes')}</p>
         {this.dataBar(this.dataItems())}
-        <p>Tags</p>
+        <p>{_('Tags')}</p>
         {this.dataBar(addon.tags.map((tag, i) => [tag, i]))}
         <p className="addon--summary">{addon.summary}</p>
         <p className="addon--description">{addon.description}</p>

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -38,7 +38,7 @@ class AddonPage extends React.Component {
     }
     if (addon.support_email) {
       items.push([
-        <a href={`mailto:${addon.support_email}`}>{_('Support email')}</a>,
+        <a href={`mailto:${addon.support_email}`}>{_('Email support')}</a>,
         'support_email',
       ]);
     }
@@ -51,23 +51,24 @@ class AddonPage extends React.Component {
     return items;
   }
 
-  dataBar(items) {
-    if (!items) {
+  dataBar(items, dataType) {
+    if (items.length === 0) {
       return [];
     }
     return (
-      <ul className="addon--data-bar">
+      <ul className={`addon--data-bar addon--${dataType}`}>
         {items.map(
           ([item, key]) => <li key={key} className="addon--data-bar--item">{item}</li>)}
       </ul>
     );
   }
+
   renderVersion(version) {
     if (version) {
       return (
         <div className="addon--current-version">
           <h2>{_('Current version')}</h2>
-          {this.dataBar([[version.version, 'version']])}
+          {this.dataBar([[version.version, 'version']], 'version-info')}
           <h3>{_('Files')}</h3>
           <ul>
             {version.files.map((file) => (
@@ -78,7 +79,7 @@ class AddonPage extends React.Component {
                   [`${file.size} bytes`, 'size'],
                   [file.created, 'created'],
                   [<a href={file.url}>{_('Download')}</a>, 'download'],
-                ])}
+                ], 'file-info')}
               </li>
             ))}
           </ul>
@@ -101,9 +102,9 @@ class AddonPage extends React.Component {
       <div className="addon">
         <h1>{addon.name}</h1>
         <p>{_('Attributes')}</p>
-        {this.dataBar(this.dataItems())}
+        {this.dataBar(this.dataItems(), 'info')}
         <p>{_('Tags')}</p>
-        {this.dataBar(addon.tags.map((tag, i) => [tag, i]))}
+        {this.dataBar(addon.tags.map((tag, i) => [tag, i]), 'tags')}
         <p className="addon--summary">{addon.summary}</p>
         <p className="addon--description">{addon.description}</p>
         {addon.type !== 'Theme' ? this.renderVersion(addon.current_version) : []}

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -96,7 +96,7 @@ class AddonPage extends React.Component {
   render() {
     const { addon } = this.props;
     if (!addon) {
-      return <div className="addon--loading"><h1>Loading...</h1></div>;
+      return <div className="addon--loading"><h1>{_('Loading...')}</h1></div>;
     }
     return (
       <div className="addon">

--- a/src/search/containers/AddonPage/style.scss
+++ b/src/search/containers/AddonPage/style.scss
@@ -1,0 +1,23 @@
+.addon--data-bar {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    &:first-of-type {
+      margin-left: 0;
+    }
+    &:last-of-type {
+      margin-right: 0;
+    }
+    background: #cfcfcf;
+    display: inline-block;
+    font-size: 0.8em;
+    margin: 0.5em;
+    padding: 0.5em;
+  }
+}
+
+.addon p {
+  line-height: 1.3333333;
+}

--- a/src/search/css/SearchResults.scss
+++ b/src/search/css/SearchResults.scss
@@ -1,3 +1,14 @@
+.serach-page {
+  margin-top: 1em 0 0;
+}
+
 .search-results {
-  margin-top: 1em;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    margin: 0;
+    padding: 0;
+  }
 }

--- a/tests/karma/search/components/TestSearchResult.js
+++ b/tests/karma/search/components/TestSearchResult.js
@@ -33,4 +33,10 @@ describe('<SearchResult />', () => {
   it('links to the detail page', () => {
     assert.equal(root.refs.container.props.to, '/search/addons/a-search-result');
   });
+
+  it('renders the number of files singularly', () => {
+    const thisResult = {...result, current_version: {files: [{}]}};
+    const thisRoot = renderIntoDocument(<SearchResult result={thisResult} />);
+    assert.equal(thisRoot.refs.fileCount.textContent, '1 file');
+  });
 });

--- a/tests/karma/search/components/TestSearchResult.js
+++ b/tests/karma/search/components/TestSearchResult.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
+import SearchResult from 'search/components/SearchResult';
+
+describe('<SearchResult />', () => {
+  const result = {
+    name: 'A search result',
+    type: 'Extension',
+    slug: 'a-search-result',
+    status: 'Fully Reviewed',
+    current_version: {
+      files: [{}, {}],
+    },
+  };
+  const root = renderIntoDocument(<SearchResult result={result} />);
+
+  it('renders the name', () => {
+    assert.equal(root.refs.name.textContent, 'A search result');
+  });
+
+  it('renders the type', () => {
+    assert.equal(root.refs.type.textContent, 'Extension');
+  });
+
+  it('renders the status', () => {
+    assert.equal(root.refs.status.textContent, 'Fully Reviewed');
+  });
+
+  it('renders the number of files', () => {
+    assert.equal(root.refs.fileCount.textContent, '2 files');
+  });
+
+  it('links to the detail page', () => {
+    assert.equal(root.refs.container.props.to, '/search/addons/a-search-result');
+  });
+});

--- a/tests/karma/search/containers/TestAddonPage.js
+++ b/tests/karma/search/containers/TestAddonPage.js
@@ -8,7 +8,11 @@ import * as api from 'core/api';
 import * as actions from 'search/actions';
 
 describe('AddonPage', () => {
-  const initialState = {addons: {'my-addon': {name: 'Addon!', slug: 'my-addon'}}};
+  const initialState = {
+    addons: {
+      'my-addon': {name: 'Addon!', slug: 'my-addon', url: 'http://example.com/my-addon', tags: []},
+    },
+  };
 
   function render({props, state}) {
     const store = createStore(state);
@@ -24,15 +28,9 @@ describe('AddonPage', () => {
     assert.equal(root.querySelector('h1').textContent, 'Addon!');
   });
 
-  it('renders the slug', () => {
-    const root = render({state: initialState, props: {params: {slug: 'my-addon'}}});
-    assert.equal(root.querySelector('p').textContent, 'This is the page for my-addon.');
-  });
-
   it('loads the add-on if not found', () => {
     const root = render({state: initialState, props: {params: {slug: 'other-addon'}}});
     assert.equal(root.querySelector('h1').textContent, 'Loading...');
-    assert.equal(root.querySelector('p').textContent, 'This is the page for other-addon.');
   });
 
   describe('findAddon', () => {

--- a/tests/karma/search/containers/TestAddonPage.js
+++ b/tests/karma/search/containers/TestAddonPage.js
@@ -22,6 +22,18 @@ describe('AddonPage', () => {
         tags: ['foo-tag', 'bar-tag'],
         type: 'Extension',
         url: 'https://addons.mozilla.org/firefox/addon/my-addon/',
+        current_version: {
+          version: '2.5-beta.1',
+          files: [
+            {
+              platform: 'Linux',
+              status: 'Fully Reviewed',
+              size: 556677,
+              created: '2016-04-01T12:11:10',
+              url: 'https://addons.mozilla.org/files/54321',
+            },
+          ],
+        },
       },
     },
   };
@@ -100,12 +112,34 @@ describe('AddonPage', () => {
       assert.equal(url.tagName, 'A');
       assert.equal(url.getAttribute('href'), 'https://example.com/my-addon');
     });
+
+    it('renders the current version header', () => {
+      assert.equal(
+        root.querySelector('.addon--current-version h2').textContent,
+        'Current version');
+    });
+
+    it('renders the current version', () => {
+      const version = Array
+        .from(root.querySelector('.addon--version-info').childNodes)
+        .map((infum) => infum.textContent);
+      assert.deepEqual(version, ['2.5-beta.1']);
+    });
+
+    it('renders the file info', () => {
+      const file = Array
+        .from(root.querySelector('.addon--file-info').childNodes)
+        .map((infum) => infum.textContent);
+      assert.deepEqual(
+        file, ['Linux', 'Fully Reviewed', '556677 bytes', '2016-04-01T12:11:10', 'Download']);
+    });
   });
 
   describe('optional fields', () => {
     const updatedState = {
       addons: {
         'my-addon': Object.assign({}, initialState.addons['my-addon'], {
+          current_version: undefined,
           homepage: undefined,
           support_email: undefined,
           support_url: undefined,
@@ -126,6 +160,31 @@ describe('AddonPage', () => {
     it('does not render the tags', () => {
       const tags = root.querySelector('.addon--tags');
       assert.strictEqual(tags, null);
+    });
+
+    it('notes that there is no current version', () => {
+      assert.equal(
+        root.querySelector('.addon--current-version h2').textContent, 'No current version');
+    });
+  });
+
+  describe('themes', () => {
+    const updatedState = {
+      addons: {
+        'my-addon': Object.assign({}, initialState.addons['my-addon'], {
+          current_version: {},
+          homepage: undefined,
+          support_email: undefined,
+          support_url: undefined,
+          tags: [],
+          type: 'Theme',
+        }),
+      },
+    };
+    const root = render({state: updatedState, props: {params: {slug: 'my-addon'}}});
+
+    it('does not render the version', () => {
+      assert.strictEqual(root.querySelector('.addon--current-version'), null);
     });
   });
 

--- a/tests/karma/search/containers/TestAddonPage.js
+++ b/tests/karma/search/containers/TestAddonPage.js
@@ -8,34 +8,15 @@ import * as api from 'core/api';
 import * as actions from 'search/actions';
 
 describe('AddonPage', () => {
-  const initialState = {
-    addons: {
-      'my-addon': {
-        description: 'An add-on that adds on.',
-        homepage: 'https://example.com/my-addon',
-        name: 'Addon!',
-        slug: 'my-addon',
-        summary: 'My add-on',
-        support_email: 'my-addon@example.com',
-        support_url: 'https://example.com/my-addon/support',
-        status: 'Fully Reviewed',
-        tags: ['foo-tag', 'bar-tag'],
-        type: 'Extension',
-        url: 'https://addons.mozilla.org/firefox/addon/my-addon/',
-        current_version: {
-          version: '2.5-beta.1',
-          files: [
-            {
-              platform: 'Linux',
-              status: 'Fully Reviewed',
-              size: 556677,
-              created: '2016-04-01T12:11:10',
-              url: 'https://addons.mozilla.org/files/54321',
-            },
-          ],
-        },
-      },
-    },
+  const basicAddon = {
+    description: 'An add-on that adds on.',
+    name: 'Addon!',
+    slug: 'my-addon',
+    summary: 'My add-on',
+    status: 'Fully Reviewed',
+    tags: [],
+    type: 'Extension',
+    url: 'https://addons.mozilla.org/firefox/addon/my-addon/',
   };
 
   function render({props, state}) {
@@ -48,6 +29,30 @@ describe('AddonPage', () => {
   }
 
   describe('rendered fields', () => {
+    const initialState = {
+      addons: {
+        'my-addon': {
+          ...basicAddon,
+          homepage: 'https://example.com/my-addon',
+          support_email: 'my-addon@example.com',
+          support_url: 'https://example.com/my-addon/support',
+          tags: ['foo-tag', 'bar-tag'],
+          current_version: {
+            version: '2.5-beta.1',
+            files: [
+              {
+                platform: 'Linux',
+                status: 'Fully Reviewed',
+                size: 556677,
+                created: '2016-04-01T12:11:10',
+                url: 'https://addons.mozilla.org/files/54321',
+              },
+            ],
+          },
+        },
+      },
+    };
+
     const root = render({state: initialState, props: {params: {slug: 'my-addon'}}});
 
     it('renders the name', () => {
@@ -64,8 +69,8 @@ describe('AddonPage', () => {
     });
 
     it('renders the tags', () => {
-      const tags = root.querySelector('.addon--tags').childNodes;
-      const tagText = Array.prototype.map.call(tags, (tag) => tag.textContent);
+      const tags = Array.from(root.querySelector('.addon--tags').childNodes);
+      const tagText = tags.map((tag) => tag.textContent);
       assert.deepEqual(tagText, ['foo-tag', 'bar-tag']);
     });
 
@@ -136,18 +141,8 @@ describe('AddonPage', () => {
   });
 
   describe('optional fields', () => {
-    const updatedState = {
-      addons: {
-        'my-addon': Object.assign({}, initialState.addons['my-addon'], {
-          current_version: undefined,
-          homepage: undefined,
-          support_email: undefined,
-          support_url: undefined,
-          tags: [],
-        }),
-      },
-    };
-    const root = render({state: updatedState, props: {params: {slug: 'my-addon'}}});
+    const initialState = {addons: {'my-addon': basicAddon}};
+    const root = render({state: initialState, props: {params: {slug: 'my-addon'}}});
 
     it('does not render the info', () => {
       const info = Array.from(root.querySelector('.addon--info').childNodes);
@@ -169,19 +164,15 @@ describe('AddonPage', () => {
   });
 
   describe('themes', () => {
-    const updatedState = {
+    const initialState = {
       addons: {
-        'my-addon': Object.assign({}, initialState.addons['my-addon'], {
-          current_version: {},
-          homepage: undefined,
-          support_email: undefined,
-          support_url: undefined,
-          tags: [],
+        'my-addon': {
+          ...basicAddon,
           type: 'Theme',
-        }),
+        },
       },
     };
-    const root = render({state: updatedState, props: {params: {slug: 'my-addon'}}});
+    const root = render({state: initialState, props: {params: {slug: 'my-addon'}}});
 
     it('does not render the version', () => {
       assert.strictEqual(root.querySelector('.addon--current-version'), null);
@@ -189,6 +180,7 @@ describe('AddonPage', () => {
   });
 
   it('loads the add-on if not found', () => {
+    const initialState = {addons: {'my-addon': basicAddon}};
     const root = render({state: initialState, props: {params: {slug: 'other-addon'}}});
     assert.equal(root.querySelector('h1').textContent, 'Loading...');
   });

--- a/tests/karma/search/containers/TestAddonPage.js
+++ b/tests/karma/search/containers/TestAddonPage.js
@@ -10,7 +10,19 @@ import * as actions from 'search/actions';
 describe('AddonPage', () => {
   const initialState = {
     addons: {
-      'my-addon': {name: 'Addon!', slug: 'my-addon', url: 'http://example.com/my-addon', tags: []},
+      'my-addon': {
+        description: 'An add-on that adds on.',
+        homepage: 'https://example.com/my-addon',
+        name: 'Addon!',
+        slug: 'my-addon',
+        summary: 'My add-on',
+        support_email: 'my-addon@example.com',
+        support_url: 'https://example.com/my-addon/support',
+        status: 'Fully Reviewed',
+        tags: ['foo-tag', 'bar-tag'],
+        type: 'Extension',
+        url: 'https://addons.mozilla.org/firefox/addon/my-addon/',
+      },
     },
   };
 
@@ -23,9 +35,98 @@ describe('AddonPage', () => {
     ));
   }
 
-  it('renders the name', () => {
+  describe('rendered fields', () => {
     const root = render({state: initialState, props: {params: {slug: 'my-addon'}}});
-    assert.equal(root.querySelector('h1').textContent, 'Addon!');
+
+    it('renders the name', () => {
+      assert.equal(root.querySelector('h1').textContent, 'Addon!');
+    });
+
+    it('renders the summary', () => {
+      assert.equal(root.querySelector('.addon--summary').textContent, 'My add-on');
+    });
+
+    it('renders the description', () => {
+      assert.equal(
+        root.querySelector('.addon--description').textContent, 'An add-on that adds on.');
+    });
+
+    it('renders the tags', () => {
+      const tags = root.querySelector('.addon--tags').childNodes;
+      const tagText = Array.prototype.map.call(tags, (tag) => tag.textContent);
+      assert.deepEqual(tagText, ['foo-tag', 'bar-tag']);
+    });
+
+    const info = Array.from(root.querySelector('.addon--info').childNodes);
+    it('renders the addon info', () => {
+      const infoText = info.map((infum) => infum.textContent);
+      assert.deepEqual(
+        infoText,
+        ['Extension', 'Fully Reviewed', 'View on site', 'Edit on site', 'View homepage',
+         'Email support', 'View support site']);
+    });
+
+    it('renders the AMO page as a link', () => {
+      const url = info.find(
+        (infum) => infum.textContent === 'View on site').firstChild;
+      assert.equal(url.tagName, 'A');
+      assert.equal(url.getAttribute('href'), 'https://addons.mozilla.org/firefox/addon/my-addon/');
+    });
+
+    it('renders the manage page as a link', () => {
+      const url = info.find(
+        (infum) => infum.textContent === 'Edit on site').firstChild;
+      assert.equal(url.tagName, 'A');
+      assert.equal(
+        url.getAttribute('href'), 'https://addons.mozilla.org/developers/addon/my-addon/edit');
+    });
+
+    it('renders the support email as a mailto', () => {
+      const email = info.find((infum) => infum.textContent === 'Email support').firstChild;
+      assert.equal(email.tagName, 'A');
+      assert.equal(email.getAttribute('href'), 'mailto:my-addon@example.com');
+    });
+
+    it('renders the support url as a link', () => {
+      const url = info.find(
+        (infum) => infum.textContent === 'View support site').firstChild;
+      assert.equal(url.tagName, 'A');
+      assert.equal(url.getAttribute('href'), 'https://example.com/my-addon/support');
+    });
+
+    it('renders the homepage as a link', () => {
+      const url = info.find(
+        (infum) => infum.textContent === 'View homepage').firstChild;
+      assert.equal(url.tagName, 'A');
+      assert.equal(url.getAttribute('href'), 'https://example.com/my-addon');
+    });
+  });
+
+  describe('optional fields', () => {
+    const updatedState = {
+      addons: {
+        'my-addon': Object.assign({}, initialState.addons['my-addon'], {
+          homepage: undefined,
+          support_email: undefined,
+          support_url: undefined,
+          tags: [],
+        }),
+      },
+    };
+    const root = render({state: updatedState, props: {params: {slug: 'my-addon'}}});
+
+    it('does not render the info', () => {
+      const info = Array.from(root.querySelector('.addon--info').childNodes);
+      const infoText = info.map((infum) => infum.textContent);
+      assert.deepEqual(
+        infoText,
+        ['Extension', 'Fully Reviewed', 'View on site', 'Edit on site']);
+    });
+
+    it('does not render the tags', () => {
+      const tags = root.querySelector('.addon--tags');
+      assert.strictEqual(tags, null);
+    });
   });
 
   it('loads the add-on if not found', () => {


### PR DESCRIPTION
Show more info about add-ons on the search results and detail pages.

<img width="874" alt="screenshot 2016-04-01 15 57 11" src="https://cloud.githubusercontent.com/assets/211578/14219900/744e2278-f822-11e5-8d55-107fbaaec64d.png">
> Search results

<img width="874" alt="screenshot 2016-04-01 15 57 17" src="https://cloud.githubusercontent.com/assets/211578/14219901/74635efe-f822-11e5-9a58-03972938d061.png">
> Add-on detail

Fixes #166.