### PR TITLE
Render a not found page when add-on isn't loaded

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -17,7 +17,12 @@ function makeQueryString(opts) {
 function callApi(endpoint, schema, params) {
   const queryString = makeQueryString(params);
   return fetch(`${API_BASE}/${endpoint}/?${queryString}`)
-    .then((response) => response.json())
+    .then((response) => {
+      if (response.ok) {
+        return response.json();
+      }
+      throw new Error('Error calling API');
+    })
     .then((response) => normalize(response, schema));
 }
 

--- a/src/core/components/NotFound.js
+++ b/src/core/components/NotFound.js
@@ -5,7 +5,7 @@ export default class NotFound extends React.Component {
   render() {
     return (
       <div className="not-found">
-        <h1 ref="header">{_("We're sorry, but we can't find what you're looking for.")}</h1>
+        <h1 ref="heading">{_("We're sorry, but we can't find what you're looking for.")}</h1>
         <p>{_("The page or file you requested wasn't found on our site. It's possible that you " +
               "clicked a link that's out of date, or typed in the address incorrectly.")}</p>
       </div>

--- a/src/core/components/NotFound.js
+++ b/src/core/components/NotFound.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { gettext as _ } from 'core/utils';
+
+export default class NotFound extends React.Component {
+  render() {
+    return (
+      <div className="not-found">
+        <h1 ref="header">{_("We're sorry, but we can't find what you're looking for.")}</h1>
+        <p>{_("The page or file you requested wasn't found on our site. It's possible that you " +
+              "clicked a link that's out of date, or typed in the address incorrectly.")}</p>
+      </div>
+    );
+  }
+}

--- a/src/search/actions/index.js
+++ b/src/search/actions/index.js
@@ -12,6 +12,13 @@ export function searchLoad({ query, entities, result }) {
   };
 }
 
+export function searchFail({ page, query }) {
+  return {
+    type: 'SEARCH_FAILED',
+    payload: { page, query },
+  };
+}
+
 export function loadEntities(entities) {
   return {
     type: 'ENTITIES_LOADED',

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -4,6 +4,7 @@ import { asyncConnect } from 'redux-async-connect';
 import { fetchAddon } from 'core/api';
 import { loadEntities } from 'search/actions';
 import { gettext as _ } from 'core/utils';
+import NotFound from 'core/components/NotFound';
 
 import './style.scss';
 
@@ -96,7 +97,7 @@ class AddonPage extends React.Component {
   render() {
     const { addon } = this.props;
     if (!addon) {
-      return <div className="addon--loading"><h1>{_('Loading...')}</h1></div>;
+      return <NotFound />;
     }
     return (
       <div className="addon">

--- a/src/search/containers/CurrentSearchPage.js
+++ b/src/search/containers/CurrentSearchPage.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';
 import SearchPage from '../components/SearchPage';
-import { searchStart, searchLoad } from '../actions';
+import { searchStart, searchLoad, searchFail } from '../actions';
 import { search } from 'core/api';
 
 export function mapStateToProps(state) {
@@ -11,7 +11,8 @@ export function mapStateToProps(state) {
 function performSearch({dispatch, page, query}) {
   dispatch(searchStart(query, page));
   return search({ page, query })
-    .then((response) => dispatch(searchLoad({ page, query, ...response })));
+    .then((response) => dispatch(searchLoad({ page, query, ...response })))
+    .catch(() => dispatch(searchFail({ page, query })));
 }
 
 export function isLoaded({page, query, state}) {

--- a/src/search/reducers/search.js
+++ b/src/search/reducers/search.js
@@ -1,6 +1,7 @@
 const initialState = {
   count: 0,
   loading: false,
+  page: 1,
   query: null,
   results: [],
 };
@@ -9,16 +10,23 @@ export default function search(state = initialState, action) {
   const { payload } = action;
   switch (action.type) {
     case 'SET_QUERY':
-      return Object.assign({}, state, {query: payload.query});
+      return {...state, query: payload.query};
     case 'SEARCH_STARTED':
-      return Object.assign({}, state, {...payload, loading: true, results: []});
+      return {...state, ...payload, count: 0, loading: true, results: []};
     case 'SEARCH_LOADED':
-      return Object.assign({}, state, {
+      return {
+        ...state,
         count: payload.result.count,
         loading: false,
         query: payload.query,
         results: payload.result.results.map((slug) => payload.entities.addons[slug]),
-      });
+      };
+    case 'SEARCH_FAILED':
+      return {
+        ...initialState,
+        page: payload.page,
+        query: payload.query,
+      };
     default:
       return state;
   }

--- a/tests/karma/core/api/test_api.js
+++ b/tests/karma/core/api/test_api.js
@@ -13,6 +13,7 @@ describe('search api', () => {
 
   function mockResponse() {
     return Promise.resolve({
+      ok: true,
       json() {
         return Promise.resolve({
           results: [
@@ -62,6 +63,7 @@ describe('add-on api', () => {
 
   function mockResponse() {
     return Promise.resolve({
+      ok: true,
       json() {
         return Promise.resolve({
           name: 'Foo!',
@@ -86,5 +88,16 @@ describe('add-on api', () => {
       assert.deepEqual(results.result, 'foo');
       assert.deepEqual(results.entities, {addons: {foo}});
     });
+  });
+
+  it('fails when the add-on is not found', () => {
+    mockWindow
+      .expects('fetch')
+      .withArgs('https://addons.mozilla.org/api/v3/addons/addon/foo/?lang=en-US')
+      .once()
+      .returns(Promise.resolve({ok: false}));
+    return api.fetchAddon('foo').then(
+      () => assert.fail(null, null, 'expected API call to fail'),
+      (error) => assert.equal(error.message, 'Error calling API'));
   });
 });

--- a/tests/karma/core/components/TestNotFound.js
+++ b/tests/karma/core/components/TestNotFound.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
+import NotFound from 'core/components/NotFound';
+
+describe('<NotFound />', () => {
+  const root = renderIntoDocument(<NotFound />);
+
+  it('sets a header', () => {
+    assert.equal(
+      root.refs.header.textContent, "We're sorry, but we can't find what you're looking for.");
+  });
+});

--- a/tests/karma/core/components/TestNotFound.js
+++ b/tests/karma/core/components/TestNotFound.js
@@ -5,8 +5,8 @@ import NotFound from 'core/components/NotFound';
 describe('<NotFound />', () => {
   const root = renderIntoDocument(<NotFound />);
 
-  it('sets a header', () => {
+  it('sets a heading', () => {
     assert.equal(
-      root.refs.header.textContent, "We're sorry, but we can't find what you're looking for.");
+      root.refs.heading.textContent, "We're sorry, but we can't find what you're looking for.");
   });
 });

--- a/tests/karma/search/actions/test_index.js
+++ b/tests/karma/search/actions/test_index.js
@@ -26,6 +26,18 @@ describe('SEARCH_LOADED', () => {
   });
 });
 
+describe('SEARCH_FAILED', () => {
+  const action = actions.searchFail({query: 'foo', page: 25});
+
+  it('sets the type', () => {
+    assert.equal(action.type, 'SEARCH_FAILED');
+  });
+
+  it('sets the payload', () => {
+    assert.deepEqual(action.payload, {page: 25, query: 'foo'});
+  });
+});
+
 describe('ENTITIES_LOADED', () => {
   const entities = sinon.stub();
   const action = actions.loadEntities(entities);

--- a/tests/karma/search/containers/TestAddonPage.js
+++ b/tests/karma/search/containers/TestAddonPage.js
@@ -179,10 +179,10 @@ describe('AddonPage', () => {
     });
   });
 
-  it('loads the add-on if not found', () => {
+  it('renders NotFound when the add-on is not loaded', () => {
     const initialState = {addons: {'my-addon': basicAddon}};
     const root = render({state: initialState, props: {params: {slug: 'other-addon'}}});
-    assert.equal(root.querySelector('h1').textContent, 'Loading...');
+    assert(root.querySelector('h1').textContent.includes("we can't find what you're looking for"));
   });
 
   describe('findAddon', () => {
@@ -261,6 +261,27 @@ describe('AddonPage', () => {
         .returns(action);
       return loadAddonIfNeeded(makeProps(slug)).then(() => {
         assert(dispatch.calledWith(action), 'dispatch not called');
+        mockApi.verify();
+        mockActions.verify();
+      });
+    });
+
+    it('handles 404s when loading the add-on', () => {
+      const slug = 'other-addon';
+      const mockApi = makeMock(api);
+      mockApi
+        .expects('fetchAddon')
+        .once()
+        .withArgs(slug)
+        .returns(Promise.reject(new Error('Error accessing API')));
+      const mockActions = makeMock(actions);
+      mockActions
+        .expects('loadEntities')
+        .never();
+      return loadAddonIfNeeded(makeProps(slug)).then(() => {
+        assert(false, 'expected promise to fail');
+      }, () => {
+        assert(!dispatch.called, 'dispatch called');
         mockApi.verify();
         mockActions.verify();
       });

--- a/tests/karma/search/containers/TestCurrentSearchPage.js
+++ b/tests/karma/search/containers/TestCurrentSearchPage.js
@@ -114,4 +114,30 @@ describe('CurrentSearchPage.loadSearchResultsIfNeeded()', () => {
         'searchLoad not called');
     });
   });
+
+  it('triggers searchFail when it fails', () => {
+    const page = 11;
+    const query = 'no ads';
+    const state = {loading: false, page, query: 'old query'};
+    const dispatch = sinon.spy();
+    const store = {dispatch, getState: () => ({search: state})};
+    const location = {query: {page, q: query}};
+    const mockApi = sinon.mock(api);
+    const entities = sinon.stub();
+    const result = sinon.stub();
+    mockApi
+      .expects('search')
+      .once()
+      .withArgs({page, query})
+      .returns(Promise.reject());
+    return loadSearchResultsIfNeeded({store, location}).then(() => {
+      mockApi.verify();
+      assert(
+        dispatch.firstCall.calledWith(actions.searchStart(query, page)),
+        'searchStart not called');
+      assert(
+        dispatch.secondCall.calledWith(actions.searchFail({page, query})),
+        'searchFail not called');
+    });
+  });
 });

--- a/tests/karma/search/containers/TestCurrentSearchPage.js
+++ b/tests/karma/search/containers/TestCurrentSearchPage.js
@@ -123,8 +123,6 @@ describe('CurrentSearchPage.loadSearchResultsIfNeeded()', () => {
     const store = {dispatch, getState: () => ({search: state})};
     const location = {query: {page, q: query}};
     const mockApi = sinon.mock(api);
-    const entities = sinon.stub();
-    const result = sinon.stub();
     mockApi
       .expects('search')
       .once()

--- a/tests/karma/search/reducers/test_search.js
+++ b/tests/karma/search/reducers/test_search.js
@@ -89,4 +89,14 @@ describe('search reducer', () => {
       assert.deepEqual(results, [{slug: 'food'}, {slug: 'foo'}]);
     });
   });
+
+  describe('SEARCH_FAILED', () => {
+    it('resets the initialState with page and query', () => {
+      const page = 5;
+      const query = 'add-ons';
+      const initialState = {foo: 'bar', query: 'hi', page: 100, results: [1, 2, 3]};
+      const state = search(initialState, {type: 'SEARCH_FAILED', payload: {page, query}});
+      assert.deepEqual(state, {count: 0, loading: false, page, query, results: []});
+    });
+  });
 });


### PR DESCRIPTION
Renders a not found page for add-ons and just shows "no results" when you ask for a page that is past the result set. The search endpoint should probably still return the count though and then we'd be able to figure out that they've gone too far, currently it 404s though.

<img alt="screenshot 2016-04-11 16 02 49" src="https://cloud.githubusercontent.com/assets/211578/14442754/18c55d72-0001-11e6-8fc0-9d76131f6329.png" width="300" />
>  Add-on detail not found

<img alt="screenshot 2016-04-11 16 18 35" src="https://cloud.githubusercontent.com/assets/211578/14442753/18c3f2fc-0001-11e6-8e7e-728f26571092.png" width="300" /> <img alt="screenshot 2016-04-11 16 18 41" src="https://cloud.githubusercontent.com/assets/211578/14442752/18c32fb6-0001-11e6-8463-cd59e1325833.png" width="300" />
> Search last page and last page + 1 (ignore the pagination bug, see #200)

Fixes #165.