### PR TITLE
Fix chunkhash warning in dev webpack config

### DIFF
--- a/src/config/webpack.dev.config.babel.js
+++ b/src/config/webpack.dev.config.babel.js
@@ -47,8 +47,8 @@ export default Object.assign({}, webpackConfig, {
   },
   output: Object.assign({}, webpackConfig.output, {
     path: assetsPath,
-    filename: `${APP_NAME}-[name]-[chunkhash].js`,
-    chunkFilename: `${APP_NAME}-[name]-[chunkhash].js`,
+    filename: `${APP_NAME}-[name]-[hash].js`,
+    chunkFilename: `${APP_NAME}-[name]-[hash].js`,
     publicPath: `http://${webpackHost}:${webpackPort}/`,
   }),
   module: {


### PR DESCRIPTION
Fixes `Cannot use [chunkhash] for chunk in 'search-[name]-[chunkhash].js' (use [hash] instead)` error in dev server