### PR TITLE
Revert "Use includes in place of indexOf"

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -69,7 +69,7 @@ const config = new Map();
 
   // Create a list of apps to build targets for.
   const appName = process.env.APP_NAME;
-  if (validAppNames.includes(appName)) {
+  if (validAppNames.indexOf(appName) > -1) {
     config.set('appsBuildList', [appName]);
     config.set('currentApp', appName);
   } else {


### PR DESCRIPTION
Reverts mozilla/addons-frontend#261

Need to revert this since it's not in node. We should be able to workaround it with a polyfill but to un-break things I'll revert for now.