### PR TITLE
Temporary fix for cdn images

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -37,6 +37,11 @@ const config = new Map();
     directives: {
       connectSrc: ["'self'", config.get('apiHost')],
       defaultSrc: ["'self'"],
+      imgSrc: [
+        "'self'",
+        // FIXME: This should be added via a separate config for -dev once #272 is fixed.
+        'https://addons-dev-cdn.allizom.org/',
+      ],
       scriptSrc: ["'self'"],
       styleSrc: ["'self'"],
       reportUri: '/__cspreport__',


### PR DESCRIPTION
This should make https://discovery.addons-dev.allizom.org/ look a bit nicer since CSP is currently blocking the images. 