### PR TITLE
Add customizable env vars

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,0 +1,4 @@
+{
+  "serverHost": "SERVER_HOST",
+  "serverPort": "SERVER_PORT"
+}

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,4 +1,5 @@
 {
+  "apiHost": "API_HOST",
   "serverHost": "SERVER_HOST",
   "serverPort": "SERVER_PORT"
 }

--- a/config/development.js
+++ b/config/development.js
@@ -5,7 +5,7 @@ const defer = require('config/defer').deferConfig;
 module.exports = {
   serverPort: 3000,
 
-  apiHost: process.env.API_HOST || 'https://addons-dev.allizom.org',
+  apiHost: 'https://addons-dev.allizom.org',
   amoCDN: 'https://addons-dev-cdn.allizom.org',
 
   webpackServerHost: '127.0.0.1',

--- a/tests/server/TestConfig.js
+++ b/tests/server/TestConfig.js
@@ -44,3 +44,27 @@ describe('Config', () => {
     assert.equal(config.util.getEnv('NODE_ENV'), 'development');
   });
 });
+
+
+describe('Config Environment Variables', () => {
+  afterEach(() => {
+    delete process.env.SERVER_HOST;
+    delete process.env.SERVER_PORT;
+  });
+
+  it('should allow host overrides', () => {
+    let config = requireUncached('config');
+    assert.equal(config.get('serverHost'), '127.0.0.1', 'initial host is set');
+    process.env.SERVER_HOST = '0.0.0.0';
+    config = requireUncached('config');
+    assert.equal(config.get('serverHost'), '0.0.0.0', 'host is overidden');
+  });
+
+  it('should allow port overrides', () => {
+    let config = requireUncached('config');
+    assert.equal(config.get('serverPort'), '4000', 'Initial port is set');
+    process.env.SERVER_PORT = '5000';
+    config = requireUncached('config');
+    assert.equal(config.get('serverPort'), '5000', 'Port is overidden');
+  });
+});


### PR DESCRIPTION
Fixes #297

This config explicitly say what config options can be overriden with env vars. I've set-up `SERVER_HOST` and `SERVER_PORT` envvars to override the config values `serverHost` and `serverPort`.

_Note: that the way node-config works the envvars setup this way will override all other config._

@jasonthomas r?  Let me know if there's any other env vars you need.