### PR TITLE
Define NODE_ENV=production in webpack's prod config

### DIFF
--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -53,6 +53,7 @@ export default {
       CLIENT: true,
       SERVER: false,
       CLIENT_CONFIG: JSON.stringify(clientConfig),
+      'process.env.NODE_ENV': JSON.stringify('production'),
     }),
     // Replaces server config module with the subset clientConfig object.
     new webpack.NormalModuleReplacementPlugin(/config$/, 'client-config.js'),


### PR DESCRIPTION
Fixes #328 

Also the built files are a bit smaller now. 233k vs 311k in disco pane for example.