### PR TITLE
Get URLs from search API

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -17,8 +17,6 @@ if (appName && validAppNames.indexOf(appName) === -1) {
 
 const amoCDN = 'https://addons.cdn.mozilla.net';
 const apiHost = 'https://addons.mozilla.org';
-const apiBase = `${apiHost}/api/v3`;
-const startLoginUrl = `${apiBase}/internal/accounts/login/start/`;
 
 
 module.exports = {
@@ -42,19 +40,18 @@ module.exports = {
   // The CDN host for AMO.
   amoCDN,
   apiHost,
-  apiBase,
-  startLoginUrl,
+  apiPath: '/api/v3',
 
   // The keys listed here will be exposed on the client.
   // Since by definition client-side code is public these config keys
   // must not contain sensitive data.
   clientConfigKeys: [
-    'apiBase',
+    'apiHost',
+    'apiPath',
     'cookieName',
     'cookieMaxAge',
     'isDeployed',
     'isDevelopment',
-    'startLoginUrl',
   ],
 
   // Content security policy.

--- a/config/dev.js
+++ b/config/dev.js
@@ -2,15 +2,11 @@
 
 const amoCDN = 'https://addons-dev-cdn.allizom.org';
 const apiHost = 'https://addons-dev.allizom.org';
-const apiBase = `${apiHost}/api/v3`;
-const startLoginUrl = `${apiBase}/internal/accounts/login/start/`;
 
 
 module.exports = {
   apiHost,
-  apiBase,
   amoCDN,
-  startLoginUrl,
 
   // Content security policy.
   CSP: {

--- a/config/development.js
+++ b/config/development.js
@@ -5,12 +5,9 @@ const webpackServerPort = 3001;
 const webpackHost = `${webpackServerHost}:${webpackServerPort}`;
 const apiHost = 'https://addons-dev.allizom.org';
 const amoCDN = 'https://addons-dev-cdn.allizom.org';
-const apiBase = `${apiHost}/api/v3`;
-const startLoginUrl = `${apiBase}/internal/accounts/login/start/`;
 
 
 module.exports = {
-
   apiHost,
   amoCDN,
 
@@ -18,7 +15,6 @@ module.exports = {
   isDevelopment: true,
 
   serverPort: 3000,
-  startLoginUrl,
   webpackServerHost,
   webpackServerPort,
   webpackHost,

--- a/config/stage.js
+++ b/config/stage.js
@@ -2,15 +2,11 @@
 
 const amoCDN = 'https://addons-stage-cdn.allizom.org';
 const apiHost = 'https://addons.allizom.org';
-const apiBase = `${apiHost}/api/v3`;
-const startLoginUrl = `${apiBase}/internal/accounts/login/start/`;
 
 
 module.exports = {
   apiHost,
-  apiBase,
   amoCDN,
-  startLoginUrl,
 
   // Content security policy.
   CSP: {

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -5,7 +5,7 @@ import config from 'config';
 
 import 'isomorphic-fetch';
 
-const API_BASE = config.get('apiBase');
+const API_BASE = `${config.get('apiHost')}${config.get('apiPath')}`;
 
 const addon = new Schema('addons', {idAttribute: 'slug'});
 
@@ -45,10 +45,11 @@ function callApi({endpoint, schema, params, auth = false, state = {}, method = '
 export function search({ api, page, query }) {
   // TODO: Get the language from the server.
   return callApi({
-    endpoint: 'addons/search',
+    endpoint: 'internal/addons/search',
     schema: {results: arrayOf(addon)},
     params: {q: query, lang: 'en-US', page},
     state: api,
+    auth: true,
   });
 }
 
@@ -71,4 +72,8 @@ export function login({ api, code, state }) {
     state: api,
     credentials: true,
   });
+}
+
+export function startLoginUrl() {
+  return `${API_BASE}/internal/accounts/login/start/`;
 }

--- a/src/core/components/LoginPage/index.js
+++ b/src/core/components/LoginPage/index.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 
-import config from 'config';
+import { startLoginUrl } from 'core/api';
 import { gettext as _ } from 'core/utils';
 
 export default class LoginPage extends React.Component {
@@ -17,7 +17,7 @@ export default class LoginPage extends React.Component {
           {message || _('You must be logged in to access this page.')}
         </p>
         <p>
-          <a className="button" href={config.get('startLoginUrl')}>
+          <a className="button" href={startLoginUrl()}>
             {_('Login')}
           </a>
         </p>

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -165,7 +165,8 @@ export function runServer({listen = true, app = appName} = {}) {
               reject(err);
             }
             log.info(`🔥  Addons-frontend server is running [ENV:${env}] [APP:${app}] ` +
-                     `[isDevelopment:${isDevelopment}] [isDeployed:${isDeployed}]`);
+                     `[isDevelopment:${isDevelopment}] [isDeployed:${isDeployed}] ` +
+                     `[apiHost:${config.get('apiHost')}] [apiPath:${config.get('apiPath')}]`);
             log.info(`👁  Open your browser at http://${host}:${port} to view it.`);
             resolve(server);
           });

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -9,7 +9,7 @@ import NotFound from 'core/components/NotFound';
 import './style.scss';
 
 function siteLink(url, text) {
-  return <a href={url} target="_blank">{text}</a>
+  return <a href={url} target="_blank">{text}</a>;
 }
 
 class AddonPage extends React.Component {

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -8,10 +8,8 @@ import NotFound from 'core/components/NotFound';
 
 import './style.scss';
 
-const editRegExpHelper = new RegExp('/firefox/addon/');
-const editRegExpPath = '/developers/addon/';
-function editUrl(viewUrl) {
-  return `${viewUrl.replace(editRegExpHelper, editRegExpPath)}edit`;
+function siteLink(url, text) {
+  return <a href={url} target="_blank">{text}</a>
 }
 
 class AddonPage extends React.Component {
@@ -28,8 +26,9 @@ class AddonPage extends React.Component {
     const items = [
       [addon.type, 'type'],
       [addon.status, 'status'],
-      [<a href={addon.url} target="_blank">{_('View on site')}</a>, 'url'],
-      [<a href={editUrl(addon.url)} target="_blank">{_('Edit on site')}</a>, 'edit'],
+      [siteLink(addon.url, _('View on site')), 'url'],
+      [siteLink(addon.edit_url, _('Edit on site')), 'edit'],
+      [siteLink(addon.review_url, _('View on editors')), 'editors'],
     ];
     if (addon.homepage) {
       items.push([
@@ -69,7 +68,11 @@ class AddonPage extends React.Component {
       return (
         <div className="addon--current-version">
           <h2>{_('Current version')}</h2>
-          {this.dataBar([[version.version, 'version']], 'version-info')}
+          {this.dataBar([
+            [version.version, 'version'],
+            [siteLink(version.url, _('View on site')), 'view'],
+            [siteLink(version.edit_url, _('Edit on site')), 'edit'],
+          ], 'version-info')}
           <h3>{_('Files')}</h3>
           <ul>
             {version.files.map((file) => (

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -30,7 +30,8 @@ describe('api', () => {
     it('sets the lang, limit, page and query', () => {
       // FIXME: This shouldn't fail if the args are in a different order.
       mockWindow.expects('fetch')
-        .withArgs('https://addons.mozilla.org/api/v3/addons/search/?q=foo&lang=en-US&page=3')
+        .withArgs(
+          'https://addons.mozilla.org/api/v3/internal/addons/search/?q=foo&lang=en-US&page=3')
         .once()
         .returns(mockResponse());
       return api.search({query: 'foo', page: 3}).then(() => mockWindow.verify());

--- a/tests/client/core/components/TestLoginPage.js
+++ b/tests/client/core/components/TestLoginPage.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 
-import config from 'config';
 import LoginPage from 'core/components/LoginPage';
 
 describe('<LoginPage />', () => {
@@ -32,7 +31,9 @@ describe('<LoginPage />', () => {
   it('has a button to the login URL', () => {
     const root = render();
     const loginLink = root.querySelector('a');
-    assert.equal(loginLink.href, config.get('startLoginUrl'));
+    assert.equal(
+      loginLink.href,
+      'https://addons.mozilla.org/api/v3/internal/accounts/login/start/');
     assert.equal(loginLink.textContent, 'Login');
   });
 });

--- a/tests/client/search/containers/TestAddonPage.js
+++ b/tests/client/search/containers/TestAddonPage.js
@@ -17,6 +17,8 @@ describe('AddonPage', () => {
     tags: [],
     type: 'Extension',
     url: 'https://addons.mozilla.org/firefox/addon/my-addon/',
+    edit_url: 'https://addons.mozilla.org/developers/addon/my-addon/edit',
+    review_url: 'https://addons.mozilla.org/en-US/editors/review/1865',
   };
 
   function render({props, state}) {
@@ -39,6 +41,8 @@ describe('AddonPage', () => {
           tags: ['foo-tag', 'bar-tag'],
           current_version: {
             version: '2.5-beta.1',
+            url: 'https://a.m.org/versions/2.5-beta.1',
+            edit_url: 'https://a.m.org/versions/2.5-beta.1/edit',
             files: [
               {
                 id: 54321,
@@ -80,8 +84,8 @@ describe('AddonPage', () => {
       const infoText = info.map((infum) => infum.textContent);
       assert.deepEqual(
         infoText,
-        ['Extension', 'Fully Reviewed', 'View on site', 'Edit on site', 'View homepage',
-         'Email support', 'View support site']);
+        ['Extension', 'Fully Reviewed', 'View on site', 'Edit on site', 'View on editors',
+         'View homepage', 'Email support', 'View support site']);
     });
 
     it('renders the AMO page as a link', () => {
@@ -129,7 +133,7 @@ describe('AddonPage', () => {
       const version = Array
         .from(root.querySelector('.addon--version-info').childNodes)
         .map((infum) => infum.textContent);
-      assert.deepEqual(version, ['2.5-beta.1']);
+      assert.deepEqual(version, ['2.5-beta.1', 'View on site', 'Edit on site']);
     });
 
     it('renders the file info', () => {
@@ -150,7 +154,7 @@ describe('AddonPage', () => {
       const infoText = info.map((infum) => infum.textContent);
       assert.deepEqual(
         infoText,
-        ['Extension', 'Fully Reviewed', 'View on site', 'Edit on site']);
+        ['Extension', 'Fully Reviewed', 'View on site', 'Edit on site', 'View on editors']);
     });
 
     it('does not render the tags', () => {


### PR DESCRIPTION
This uses the new internal search endpoint and pulls the URLs from its response.

This fixes a regression from removing the deferred config that caused `API_HOST` to not be able to change the value of `apiBase`.

Fixes #184.