### PR TITLE
Update LoginRequired and secure local cookies

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -27,7 +27,6 @@ module.exports = {
   cookieMaxAge: 2592000,
   cookieName: 'jwt_api_auth_token',
   cookieSecure: true,
-  cookie: 'hi!',
 
   isDeployed: true,
   isDevelopment: false,
@@ -52,6 +51,7 @@ module.exports = {
     'apiPath',
     'cookieName',
     'cookieMaxAge',
+    'cookieSecure',
     'isDeployed',
     'isDevelopment',
   ],

--- a/config/default.js
+++ b/config/default.js
@@ -26,6 +26,7 @@ module.exports = {
   // 2592000 is 30 days in seconds.
   cookieMaxAge: 2592000,
   cookieName: 'jwt_api_auth_token',
+  cookieSecure: true,
 
   isDeployed: true,
   isDevelopment: false,

--- a/config/default.js
+++ b/config/default.js
@@ -27,6 +27,7 @@ module.exports = {
   cookieMaxAge: 2592000,
   cookieName: 'jwt_api_auth_token',
   cookieSecure: true,
+  cookie: 'hi!',
 
   isDeployed: true,
   isDevelopment: false,

--- a/config/development.js
+++ b/config/development.js
@@ -14,7 +14,8 @@ module.exports = {
   isDeployed: false,
   isDevelopment: true,
 
-  cookieSecure: false,
+  cookieSecure: true,
+  cookie: 'wat',
 
   serverPort: 3000,
   webpackServerHost,

--- a/config/development.js
+++ b/config/development.js
@@ -14,8 +14,7 @@ module.exports = {
   isDeployed: false,
   isDevelopment: true,
 
-  cookieSecure: true,
-  cookie: 'wat',
+  cookieSecure: false,
 
   serverPort: 3000,
   webpackServerHost,

--- a/config/development.js
+++ b/config/development.js
@@ -14,6 +14,8 @@ module.exports = {
   isDeployed: false,
   isDevelopment: true,
 
+  cookieSecure: false,
+
   serverPort: 3000,
   webpackServerHost,
   webpackServerPort,

--- a/src/core/components/LoginPage/index.js
+++ b/src/core/components/LoginPage/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import Helmet from 'react-helmet';
 
 import { startLoginUrl } from 'core/api';
 import { gettext as _ } from 'core/utils';
@@ -9,10 +10,12 @@ export default class LoginPage extends React.Component {
   }
 
   render() {
+    const title = _('Login Required');
     const { message } = this.props;
     return (
       <div>
-        <h1>{_('Login Required')}</h1>
+        <Helmet title={title} />
+        <h1>{title}</h1>
         <p className="login-message">
           {message || _('You must be logged in to access this page.')}
         </p>

--- a/src/core/containers/HandleLogin/index.js
+++ b/src/core/containers/HandleLogin/index.js
@@ -55,7 +55,7 @@ function createLoadData(dispatch) {
           dispatch(setJWT(token));
           cookie.save(config.get('cookieName'), token, {
             path: '/',
-            secure: true,
+            secure: config.get('cookieSecure'),
             maxAge: config.get('cookieMaxAge'),
           });
           router.push('/search');

--- a/src/core/containers/HandleLogin/index.js
+++ b/src/core/containers/HandleLogin/index.js
@@ -53,12 +53,6 @@ function createLoadData(dispatch) {
       return login({api, code, state})
         .then(({token}) => {
           dispatch(setJWT(token));
-          console.log(JSON.stringify({
-            cookieName: config.get('cookieName'),
-            cookieSecure: config.get('cookieSecure'),
-            cookieMaxAge: config.get('cookieMaxAge'),
-            cookie: config.get('cookie'),
-          }));
           cookie.save(config.get('cookieName'), token, {
             path: '/',
             secure: config.get('cookieSecure'),

--- a/src/core/containers/HandleLogin/index.js
+++ b/src/core/containers/HandleLogin/index.js
@@ -53,6 +53,12 @@ function createLoadData(dispatch) {
       return login({api, code, state})
         .then(({token}) => {
           dispatch(setJWT(token));
+          console.log(JSON.stringify({
+            cookieName: config.get('cookieName'),
+            cookieSecure: config.get('cookieSecure'),
+            cookieMaxAge: config.get('cookieMaxAge'),
+            cookie: config.get('cookie'),
+          }));
           cookie.save(config.get('cookieName'), token, {
             path: '/',
             secure: config.get('cookieSecure'),

--- a/src/core/containers/LoginRequired/index.js
+++ b/src/core/containers/LoginRequired/index.js
@@ -8,7 +8,8 @@ export function mapStateToProps(state) {
   };
 }
 
-class LoginRequired extends React.Component {
+// This class is exported for testing outside of redux.
+export class LoginRequired extends React.Component {
   static propTypes = {
     authenticated: PropTypes.bool.isRequired,
     children: PropTypes.node,

--- a/src/core/containers/LoginRequired/index.js
+++ b/src/core/containers/LoginRequired/index.js
@@ -2,29 +2,25 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import LoginPage from 'core/components/LoginPage';
 
-export function mapStateToProps(Component) {
-  return (state) => ({
+export function mapStateToProps(state) {
+  return {
     authenticated: !!state.auth.token,
-    Component,
-  });
+  };
 }
 
-export class LoginRequired extends React.Component {
+class LoginRequired extends React.Component {
   static propTypes = {
     authenticated: PropTypes.bool.isRequired,
-    // This is really a react component class but I guess that's a function.
-    Component: PropTypes.func.isRequired,
+    children: PropTypes.node,
   }
 
   render() {
-    const { authenticated, Component, ...childProps } = this.props;
+    const { authenticated, children } = this.props;
     if (authenticated) {
-      return <Component {...childProps} />;
+      return children;
     }
     return <LoginPage />;
   }
 }
 
-export default function loginRequired(Component) {
-  return connect(mapStateToProps(Component))(LoginRequired);
-}
+export default connect(mapStateToProps)(LoginRequired);

--- a/src/search/routes.js
+++ b/src/search/routes.js
@@ -4,15 +4,15 @@ import { IndexRoute, Route } from 'react-router';
 import App from './containers/App';
 import CurrentSearchPage from './containers/CurrentSearchPage';
 import AddonPage from './containers/AddonPage';
-import loginRequired from 'core/containers/LoginRequired';
+import LoginRequired from 'core/containers/LoginRequired';
 import HandleLogin from 'core/containers/HandleLogin';
 
 export default (
-  <Route path="/">
-    <Route path="/search" component={loginRequired(App)}>
+  <Route path="/" component={App}>
+    <Route path="search" component={LoginRequired}>
       <IndexRoute component={CurrentSearchPage} />
       <Route path="addons/:slug" component={AddonPage} />
     </Route>
-    <Route path="/fxa-authenticate" component={HandleLogin} />
+    <Route path="fxa-authenticate" component={HandleLogin} />
   </Route>
 );

--- a/tests/client/core/containers/TestHandleLogin.js
+++ b/tests/client/core/containers/TestHandleLogin.js
@@ -7,6 +7,8 @@ import { createStore } from 'redux';
 import HandleLogin, { mapDispatchToProps } from 'core/containers/HandleLogin';
 import * as api from 'core/api';
 
+import config from 'config';
+
 describe('<HandleLogin />', () => {
   let sandbox;
 
@@ -139,6 +141,13 @@ describe('<HandleLogin />', () => {
       const { apiConfig, dispatch, location, payload: {token}, router } = setupData();
       const { loadData } = mapDispatchToProps(dispatch);
       const mockCookie = sandbox.mock(cookie);
+        console.log(JSON.stringify({
+          tests: true,
+          cookieName: config.get('cookieName'),
+          cookieSecure: config.get('cookieSecure'),
+          cookieMaxAge: config.get('cookieMaxAge'),
+          cookie: config.get('cookie'),
+        }));
       mockCookie.expects('save').once().withArgs(
         'jwt_api_auth_token', token, {path: '/', secure: true, maxAge: 2592000});
       return loadData({api: apiConfig, location, router}).then(() => {

--- a/tests/client/core/containers/TestHandleLogin.js
+++ b/tests/client/core/containers/TestHandleLogin.js
@@ -7,8 +7,6 @@ import { createStore } from 'redux';
 import HandleLogin, { mapDispatchToProps } from 'core/containers/HandleLogin';
 import * as api from 'core/api';
 
-import config from 'config';
-
 describe('<HandleLogin />', () => {
   let sandbox;
 
@@ -141,13 +139,6 @@ describe('<HandleLogin />', () => {
       const { apiConfig, dispatch, location, payload: {token}, router } = setupData();
       const { loadData } = mapDispatchToProps(dispatch);
       const mockCookie = sandbox.mock(cookie);
-        console.log(JSON.stringify({
-          tests: true,
-          cookieName: config.get('cookieName'),
-          cookieSecure: config.get('cookieSecure'),
-          cookieMaxAge: config.get('cookieMaxAge'),
-          cookie: config.get('cookie'),
-        }));
       mockCookie.expects('save').once().withArgs(
         'jwt_api_auth_token', token, {path: '/', secure: true, maxAge: 2592000});
       return loadData({api: apiConfig, location, router}).then(() => {

--- a/tests/client/core/containers/TestLoginRequired.js
+++ b/tests/client/core/containers/TestLoginRequired.js
@@ -4,44 +4,42 @@ import { shallowRender } from 'tests/client/helpers';
 import { mapStateToProps, LoginRequired } from 'core/containers/LoginRequired';
 import LoginPage from 'core/components/LoginPage';
 
-describe('LoginRequired helpers', () => {
+describe('<LoginRequired />', () => {
   class MyComponent extends React.Component {
     render() {
       return <p>Authenticated content.</p>;
     }
   }
 
-  describe('rendered component when not authenticated', () => {
-    it('renders <LoginPage />', () => {
-      const root = shallowRender(<LoginRequired Component={MyComponent} authenticated={false} />);
-      assert.equal(root.type, LoginPage);
-    });
+  it('renders <LoginPage /> when unauthenticated', () => {
+    const root = shallowRender(
+      <LoginRequired authenticated={false}>
+        <MyComponent />
+      </LoginRequired>
+    );
+    assert.equal(root.type, LoginPage);
   });
 
-  describe('rendered component when authenticated', () => {
-    it('renders the child component', () => {
-      const root = shallowRender(<LoginRequired Component={MyComponent} authenticated />);
-      assert.equal(root.type, MyComponent);
-    });
-
-    it('passes along its props', () => {
-      const root = shallowRender(
-        <LoginRequired Component={MyComponent} authenticated foo="bar" />);
-      assert.deepEqual(root.props, {foo: 'bar'});
-    });
+  it('renders the children when authenticated', () => {
+    const root = shallowRender(
+      <LoginRequired authenticated>
+        <MyComponent />
+      </LoginRequired>
+    );
+    assert.equal(root.type, MyComponent);
   });
 
   describe('mapStateToProps', () => {
-    it('sets authenticated and Component when authenticated', () => {
+    it('sets authenticated to true when there is a token', () => {
       assert.deepEqual(
-        mapStateToProps(MyComponent)({auth: {token: 'foo'}}),
-        {authenticated: true, Component: MyComponent});
+        mapStateToProps({auth: {token: 'foo'}}),
+        {authenticated: true});
     });
 
-    it('sets authenticated and Component when unauthenticated', () => {
+    it('sets authenticated to false when there is not a token', () => {
       assert.deepEqual(
-        mapStateToProps(MyComponent)({auth: {}}),
-        {authenticated: false, Component: MyComponent});
+        mapStateToProps({auth: {}}),
+        {authenticated: false});
     });
   });
 });


### PR DESCRIPTION
This updates how the `LoginRequired` component works so that it integrates with Helmet a bit better.

It also updates it to not use secure cookies in development since that was breaking login persisting.

This doesn't prevent API requests from happening on the server when the user it redirected to login but I will leave that bug open for now. If it needs authentication then it will fail, if it doesn't then the data is public anyway. It's just a performance issue.