### PR TITLE
Add tick as svg

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -65,6 +65,7 @@ module.exports = {
       imgSrc: [
         "'self'",
         amoCDN,
+        'data:',
       ],
       scriptSrc: ["'self'"],
       styleSrc: ["'self'"],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -40,6 +40,9 @@ const newWebpackConfig = Object.assign({}, webpackConfigProd, {
     }, {
       test: /\.scss$/,
       loader: 'style!css?importLoaders=2!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded',
+    }, {
+      test: /\.svg$/,
+      loader: 'url?limit=10000&mimetype=image/svg+xml',
     }],
   },
   output: undefined,

--- a/package.json
+++ b/package.json
@@ -130,7 +130,8 @@
     "redux-async-connect": "1.0.0-rc4",
     "redux-logger": "2.6.1",
     "serialize-javascript": "1.2.0",
-    "url": "0.11.0"
+    "url": "0.11.0",
+    "url-loader": "0.5.7"
   },
   "devDependencies": {
     "autoprefixer-loader": "3.2.0",

--- a/src/disco/css/InstallButton.scss
+++ b/src/disco/css/InstallButton.scss
@@ -45,14 +45,18 @@ $installStripeColor2: #00C42E;
 .switch {
   position: relative;
 
-  &.success:after {
+  &.installed:after {
+    background: url('../img/tick.svg') no-repeat 50% 50%;
     color: #fff;
-    content: '\2713';
+    content: '';
+    display: block;
     font-family: sans-serif;
+    height: 16px;
     left: $size;
     position: absolute;
     top: $size/2;
     transform: translate(-50%, -50%);
+    width: 16px;
   }
 
   input + label {

--- a/src/disco/img/tick.svg
+++ b/src/disco/img/tick.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32">
+  <path fill="#fff" d="M30.057,9.752L15.9,23.909h0l-4.044,4.045-4.045-4.045h0l-6.068-6.067,4.045-4.045,6.068,6.067L26.012,5.707Z"/>
+</svg>

--- a/webpack-isomorphic-tools-config.js
+++ b/webpack-isomorphic-tools-config.js
@@ -24,7 +24,7 @@ module.exports = {
       parser: WebpackIsomorphicToolsPlugin.url_loader_parser,
     },
     svg: {
-      extension: 'svg',
+      extensions: ['svg'],
       parser: WebpackIsomorphicToolsPlugin.url_loader_parser,
     },
     style_modules: {

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -70,6 +70,9 @@ export default Object.assign({}, webpackConfig, {
     }, {
       test: /\.scss$/,
       loader: 'style!css?importLoaders=2!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded',
+    }, {
+      test: /\.svg$/,
+      loader: 'url?limit=10000&mimetype=image/svg+xml',
     }],
   },
   plugins: [

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -40,10 +40,12 @@ export default {
         test: /\.jsx?$/,
         exclude: /node_modules/,
         loaders: ['babel'],
-      },
-      {
+      }, {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract('style', 'css?importLoaders=2&sourceMap!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true'),
+      }, {
+        test: /\.svg$/,
+        loader: 'url?limit=10000&mimetype=image/svg+xml',
       },
     ],
   },


### PR DESCRIPTION
This results in the svg being inlined which I think is OK for something so small but we can always push it outside the CSS if we think mobile perf is negatively impacted.

Before:

<img alt="before" src="https://cloud.githubusercontent.com/assets/1514/15149945/675693b0-16c3-11e6-88b0-a565522ce72e.png">

After:

<img alt="after" src="https://cloud.githubusercontent.com/assets/1514/15149887/2ee1d620-16c3-11e6-899c-67d5512a1fbc.png">
