### PR TITLE
Remove footgun from client-config module

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "bunyan": "1.8.1",
     "camelcase": "3.0.0",
     "classnames": "2.2.5",
+    "common-tags": "0.0.3",
     "config": "1.20.1",
     "express": "4.13.4",
     "extract-text-webpack-plugin": "1.0.1",

--- a/src/client-config.js
+++ b/src/client-config.js
@@ -4,11 +4,23 @@
  * When webpack builds the client-side code it exposes
  * the clientConfig config via the definePlugin as CLIENT_CONFIG.
  */
+import { oneLine } from 'common-tags';
 
-const clientConfig = new Map();
+export class ClientConfig {
+  constructor(objData) {
+    // This Object.assign keeps the config data private.
+    Object.assign(this, {
+      has: (key) => objData.hasOwnProperty(key),
 
-Object.keys(CLIENT_CONFIG).forEach((key) => {
-  clientConfig.set(key, CLIENT_CONFIG[key]);
-});
+      get: (key) => {
+        if (this.has(key)) {
+          return objData[key];
+        }
+        throw new Error(oneLine`Key was not found in clientConfig. Check the
+          key has been added to clientConfigKeys`);
+      },
+    });
+  }
+}
 
-module.exports = clientConfig;
+export default new ClientConfig(CLIENT_CONFIG);

--- a/tests/client/test_client_config.js
+++ b/tests/client/test_client_config.js
@@ -1,0 +1,42 @@
+import { ClientConfig } from 'client-config';
+
+describe('client-config module', () => {
+  let config;
+
+  beforeEach(() => {
+    config = new ClientConfig({
+      foo: 'test-value-1',
+      bar: 'test-value-2',
+    });
+  });
+
+  it('provides no access to the underlying data from outside', () => {
+    assert.equal(config.objData, undefined);
+  });
+
+  it('has the right methods', () => {
+    assert.sameMembers(Object.keys(new ClientConfig({})), ['get', 'has']);
+  });
+
+  describe('ClientConfig.get()', () => {
+    it('returns a key when present', () => {
+      assert.equal(config.get('foo'), 'test-value-1');
+    });
+
+    it('throws if key is missing', () => {
+      assert.throws(() => {
+        config.get('missing-key');
+      }, Error, /Key was not found in clientConfig/);
+    });
+  });
+
+  describe('ClientConfig.has()', () => {
+    it('returns true if key is present', () => {
+      assert.ok(config.has('foo'));
+    });
+
+    it('returns false if key is missing', () => {
+      assert.notOk(config.has('whatevs'));
+    });
+  });
+});


### PR DESCRIPTION
Fixes #356

This also means the API for client config now should match node-config.