### PR TITLE
Interact with install buttons with keyboard only

### DIFF
--- a/src/disco/containers/InstallButton.js
+++ b/src/disco/containers/InstallButton.js
@@ -49,18 +49,19 @@ export class InstallButton extends React.Component {
     const isDisabled = status === UNKNOWN;
     const isDownloading = status === DOWNLOADING;
     const switchClasses = `switch ${status}`;
+    const identifier = `install-button-${slug}`;
 
     return (
       <div className={switchClasses} onClick={this.handleClick}
         data-download-progress={isDownloading ? downloadProgress : 0}>
         <input
-          id={slug}
+          id={identifier}
           className="visually-hidden"
           checked={isInstalled}
           disabled={isDisabled}
           onChange={this.props.handleChange}
           type="checkbox" />
-        <label htmlFor={slug}>
+        <label htmlFor={identifier}>
           {isDownloading ? <div className="progress"></div> : null}
           <span className="visually-hidden">{_('Install')}</span>
         </label>

--- a/src/disco/containers/InstallButton.js
+++ b/src/disco/containers/InstallButton.js
@@ -39,7 +39,7 @@ export class InstallButton extends React.Component {
   }
 
   render() {
-    const { status, downloadProgress } = this.props;
+    const { downloadProgress, slug, status } = this.props;
 
     if (!validStates.includes(status)) {
       throw new Error('Invalid add-on status');
@@ -54,12 +54,13 @@ export class InstallButton extends React.Component {
       <div className={switchClasses} onClick={this.handleClick}
         data-download-progress={isDownloading ? downloadProgress : 0}>
         <input
+          id={slug}
           className="visually-hidden"
           checked={isInstalled}
           disabled={isDisabled}
           onChange={this.props.handleChange}
           type="checkbox" />
-        <label>
+        <label htmlFor={slug}>
           {isDownloading ? <div className="progress"></div> : null}
           <span className="visually-hidden">{_('Install')}</span>
         </label>

--- a/src/disco/css/InstallButton.scss
+++ b/src/disco/css/InstallButton.scss
@@ -1,3 +1,6 @@
+@import "~disco/css/inc/vars";
+@import "~core/css/inc/mixins";
+
 $size: 26px;
 $borderSize: 1px;
 
@@ -57,6 +60,10 @@ $installStripeColor2: #00C42E;
     top: $size/2;
     transform: translate(-50%, -50%);
     width: 16px;
+  }
+
+  input:focus + label {
+    @include focus();
   }
 
   input + label {

--- a/tests/client/disco/containers/TestInstallButton.js
+++ b/tests/client/disco/containers/TestInstallButton.js
@@ -97,6 +97,15 @@ describe('<InstallButton />', () => {
     assert.ok(!uninstall.called);
   });
 
+  it('should associate the label and input with id and for attributes', () => {
+    const button = renderButton({status: UNINSTALLED, slug: 'foo'});
+    const root = findDOMNode(button);
+    assert.equal(root.querySelector('input').getAttribute('id'),
+                 'install-button-foo', 'id is set');
+    assert.equal(root.querySelector('label').getAttribute('for'),
+                 'install-button-foo', 'for attribute matches id');
+  });
+
   it('should throw on bogus status', () => {
     assert.throws(() => {
       renderButton({status: 'BOGUS'});


### PR DESCRIPTION
Fixes #355 Fixes #354

This makes it possible for a keyboard user to focus and interact with the install button checkboxes.

<img width="464" alt="discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/15331413/00ebd7ac-1c59-11e6-8930-3939095fdaad.png">

Notes: You can tab to the buttons and it should be focussed as per the styles above. Hitting spacebar interacts with it which is the same for a normal checkbox.

I'll file some separate bugs re: reflecting the state of the install better for AT users.