### PR TITLE
Clean up assert.fail usage

### DIFF
--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -1,4 +1,5 @@
 import * as api from 'core/api';
+import * as helpers from 'tests/client/helpers';
 
 describe('api', () => {
   let mockWindow;
@@ -30,21 +31,23 @@ describe('api', () => {
           'https://addons.mozilla.org/api/v3/internal/addons/search/?q=foo&lang=en-US&page=3')
         .once()
         .returns(mockResponse());
-      return api.search({query: 'foo', page: 3}).then(() => mockWindow.verify());
+      return api.search({query: 'foo', page: 3})
+        .then(() => mockWindow.verify());
     });
 
     it('normalizes the response', () => {
       mockWindow.expects('fetch').once().returns(mockResponse());
-      return api.search({query: 'foo'}).then((results) => {
-        assert.deepEqual(results.result.results, ['foo', 'food', 'football']);
-        assert.deepEqual(results.entities, {
-          addons: {
-            foo: {slug: 'foo'},
-            food: {slug: 'food'},
-            football: {slug: 'football'},
-          },
+      return api.search({query: 'foo'})
+        .then((results) => {
+          assert.deepEqual(results.result.results, ['foo', 'food', 'football']);
+          assert.deepEqual(results.entities, {
+            addons: {
+              foo: {slug: 'foo'},
+              food: {slug: 'food'},
+              football: {slug: 'football'},
+            },
+          });
         });
-      });
     });
   });
 
@@ -68,16 +71,18 @@ describe('api', () => {
           {headers: {}, method: 'get'})
         .once()
         .returns(mockResponse());
-      return api.fetchAddon({slug: 'foo'}).then(() => mockWindow.verify());
+      return api.fetchAddon({slug: 'foo'})
+        .then(() => mockWindow.verify());
     });
 
     it('normalizes the response', () => {
       mockWindow.expects('fetch').once().returns(mockResponse());
-      return api.fetchAddon('foo').then((results) => {
-        const foo = {slug: 'foo', name: 'Foo!'};
-        assert.deepEqual(results.result, 'foo');
-        assert.deepEqual(results.entities, {addons: {foo}});
-      });
+      return api.fetchAddon('foo')
+        .then((results) => {
+          const foo = {slug: 'foo', name: 'Foo!'};
+          assert.deepEqual(results.result, 'foo');
+          assert.deepEqual(results.entities, {addons: {foo}});
+        });
     });
 
     it('fails when the add-on is not found', () => {
@@ -88,9 +93,9 @@ describe('api', () => {
           {headers: {}, method: 'get'})
         .once()
         .returns(Promise.resolve({ok: false}));
-      return api.fetchAddon({slug: 'foo'}).then(
-        () => assert.fail(null, null, 'expected API call to fail'),
-        (error) => assert.equal(error.message, 'Error calling API'));
+      return api.fetchAddon({slug: 'foo'})
+        .then(helpers.unexpectedSuccess,
+              (error) => assert.equal(error.message, 'Error calling API'));
     });
 
     it('includes the authorization token if available', () => {

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -1,5 +1,5 @@
 import * as api from 'core/api';
-import * as helpers from 'tests/client/helpers';
+import { unexpectedSuccess } from 'tests/client/helpers';
 
 describe('api', () => {
   let mockWindow;
@@ -94,8 +94,8 @@ describe('api', () => {
         .once()
         .returns(Promise.resolve({ok: false}));
       return api.fetchAddon({slug: 'foo'})
-        .then(helpers.unexpectedSuccess,
-              (error) => assert.equal(error.message, 'Error calling API'));
+        .then(unexpectedSuccess,
+          (error) => assert.equal(error.message, 'Error calling API'));
     });
 
     it('includes the authorization token if available', () => {

--- a/tests/client/disco/TestAddonManager.js
+++ b/tests/client/disco/TestAddonManager.js
@@ -1,5 +1,6 @@
 import { AddonManager } from 'disco/addonManager';
 import { installEventList } from 'disco/constants';
+import * as helpers from 'tests/client/helpers';
 
 
 describe('AddonManager', () => {
@@ -49,12 +50,8 @@ describe('AddonManager', () => {
                                             {mozAddonManager: fakeMozAddonManager});
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(false));
       return addonManager.getAddon()
-        .then(() => {
-          assert.fail('unexpected success');
-        })
-        .catch((err) => {
-          assert.equal(err.message, 'Addon not found');
-        });
+        .then(helpers.unexpectedSuccess,
+              (err) => assert.equal(err.message, 'Addon not found'));
     });
   });
 
@@ -105,12 +102,8 @@ describe('AddonManager', () => {
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(false));
       // If the code doesn't resolve this will blow up.
       return addonManager.uninstall()
-        .then(() => {
-          assert.fail('unexpected success');
-        })
-        .catch((err) => {
-          assert.equal(err.message, 'Addon not found');
-        });
+        .then(helpers.unexpectedSuccess,
+              (err) => assert.equal(err.message, 'Addon not found'));
     });
 
     it('should reject if addon.uninstall resolves with false', () => {
@@ -119,10 +112,8 @@ describe('AddonManager', () => {
       fakeAddon.uninstall.returns(Promise.resolve(false));
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
       return addonManager.uninstall()
-        .then(() => assert.fail('unexpected success'))
-        .catch((err) => {
-          assert.equal(err.message, 'Uninstall failed');
-        });
+        .then(helpers.unexpectedSuccess,
+              (err) => assert.equal(err.message, 'Uninstall failed'));
     });
 
     it('should resolve if addon.uninstall resolves with true', () => {

--- a/tests/client/disco/TestAddonManager.js
+++ b/tests/client/disco/TestAddonManager.js
@@ -1,6 +1,6 @@
 import { AddonManager } from 'disco/addonManager';
 import { installEventList } from 'disco/constants';
-import * as helpers from 'tests/client/helpers';
+import { unexpectedSuccess } from 'tests/client/helpers';
 
 
 describe('AddonManager', () => {
@@ -50,8 +50,8 @@ describe('AddonManager', () => {
                                             {mozAddonManager: fakeMozAddonManager});
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(false));
       return addonManager.getAddon()
-        .then(helpers.unexpectedSuccess,
-              (err) => assert.equal(err.message, 'Addon not found'));
+        .then(unexpectedSuccess,
+          (err) => assert.equal(err.message, 'Addon not found'));
     });
   });
 
@@ -102,8 +102,8 @@ describe('AddonManager', () => {
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(false));
       // If the code doesn't resolve this will blow up.
       return addonManager.uninstall()
-        .then(helpers.unexpectedSuccess,
-              (err) => assert.equal(err.message, 'Addon not found'));
+        .then(unexpectedSuccess,
+          (err) => assert.equal(err.message, 'Addon not found'));
     });
 
     it('should reject if addon.uninstall resolves with false', () => {
@@ -112,8 +112,8 @@ describe('AddonManager', () => {
       fakeAddon.uninstall.returns(Promise.resolve(false));
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
       return addonManager.uninstall()
-        .then(helpers.unexpectedSuccess,
-              (err) => assert.equal(err.message, 'Uninstall failed'));
+        .then(unexpectedSuccess,
+          (err) => assert.equal(err.message, 'Uninstall failed'));
     });
 
     it('should resolve if addon.uninstall resolves with true', () => {

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -29,3 +29,6 @@ export function stubAddonManager({ getAddon = Promise.resolve() } = {}) {
   return instance;
 }
 
+export function unexpectedSuccess() {
+  return assert.fail(null, null, 'Unexpected success');
+}

--- a/tests/client/search/containers/TestAddonPage.js
+++ b/tests/client/search/containers/TestAddonPage.js
@@ -6,7 +6,7 @@ import AddonPage, { findAddon, loadAddonIfNeeded } from 'search/containers/Addon
 import createStore from 'search/store';
 import * as api from 'core/api';
 import * as actions from 'search/actions';
-import { stubAddonManager } from 'tests/client/helpers';
+import { stubAddonManager, unexpectedSuccess } from 'tests/client/helpers';
 
 describe('AddonPage', () => {
   const basicAddon = {
@@ -288,13 +288,13 @@ describe('AddonPage', () => {
       mockActions
         .expects('loadEntities')
         .never();
-      return loadAddonIfNeeded(props).then(() => {
-        assert(false, 'expected promise to fail');
-      }, () => {
-        assert(!dispatch.called, 'dispatch called');
-        mockApi.verify();
-        mockActions.verify();
-      });
+      return loadAddonIfNeeded(props)
+        .then(unexpectedSuccess,
+          () => {
+            assert(!dispatch.called, 'dispatch called');
+            mockApi.verify();
+            mockActions.verify();
+          });
     });
   });
 });


### PR DESCRIPTION
If we check for unexpected success using the the resolve callback in the `then` when it throws the tests will catch it (bypassing the reject callback) as long as the test returns the promise. 

This seems more ideal than assuming the catch's assertion will fail because of the unexpected success.

What do you think?