### PR TITLE
Support the disco pane URL format

### DIFF
--- a/src/disco/routes.js
+++ b/src/disco/routes.js
@@ -7,5 +7,9 @@ import DiscoPane from './containers/DiscoPane';
 export default (
   <Route path="/" component={App}>
     <IndexRoute component={DiscoPane} />
+    <Route
+      path="/:locale/firefox/discovery/pane/:version/:platform/:compatibilityMode"
+      component={DiscoPane}
+    />
   </Route>
 );


### PR DESCRIPTION
This just adds a route that matches the disco pane format. We'll actually use the locale in #147.

Fixes #306.