### PR TITLE
Relax frame-ancestors to just about: protocol for disco pane

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -1,13 +1,12 @@
 module.exports = {
   CSP: {
     directives: {
-      frameAncestors: ['about:addons'],
+      // The location object in about:addons has '' for hostname and
+      // a value of `about:addons` for `frame-ancestors` is still blocked.
+      // However, the protocol in the location object is `about:`
+      // and with just `about:` as the value for frame-ancestors
+      // about:addons can iframe the disco pane.
+      frameAncestors: ['about:'],
     },
-  },
-
-  // x-frame-options must match frame-ancestors CSP directive.
-  frameGuard: {
-    action: 'allow-from',
-    domain: 'about:addons',
   },
 };

--- a/tests/server/TestCSPConfig.js
+++ b/tests/server/TestCSPConfig.js
@@ -105,10 +105,10 @@ describe('App Specific CSP Config', () => {
     assert.deepEqual(cspConfig.frameAncestors, ["'none'"]);
   });
 
-  it('should default set frame-ancestors to about:addons for disco pane', () => {
+  it('should set frame-ancestors to about: to allow framing of disco pane', () => {
     process.env.NODE_APP_INSTANCE = 'disco';
     const config = requireUncached('config');
     const cspConfig = config.get('CSP').directives;
-    assert.deepEqual(cspConfig.frameAncestors, ['about:addons']);
+    assert.deepEqual(cspConfig.frameAncestors, ['about:']);
   });
 });

--- a/tests/server/TestFrameGuardConfig.js
+++ b/tests/server/TestFrameGuardConfig.js
@@ -13,12 +13,4 @@ describe('App Specific Frameguard Config', () => {
     assert.equal(frameGuardConfig.action, 'deny');
     assert.equal(frameGuardConfig.domain, undefined);
   });
-
-  it('should default set frameGuard to allow about:addons for disco pane', () => {
-    process.env.NODE_APP_INSTANCE = 'disco';
-    const config = requireUncached('config');
-    const frameGuardConfig = config.get('frameGuard');
-    assert.equal(frameGuardConfig.action, 'allow-from');
-    assert.equal(frameGuardConfig.domain, 'about:addons');
-  });
 });


### PR DESCRIPTION
Fixes #433

* x-frame-options *are* ignored (even if set to DENY) so there's no need to override them for the disco pane
* Setting just the protocol `about:` instead of `about:addons` appears to work modifying the directive via charles.
