### PR TITLE
Add link to page

### DIFF
--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -67,6 +67,7 @@ class DiscoPane extends React.Component {
           </div>
         </header>
         {results.map((item, i) => <Addon {...camelCaseProps(item)} key={i} />)}
+        <a className="cta" href="https://addons.mozilla.org/">{i18n.gettext('See more add-ons!')}</a>
       </div>
     );
   }

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -10,6 +10,7 @@ $addon-padding: 20px;
   flex-direction: row;
   line-height: 1.5;
   margin-top: 20px;
+  width: 100%;
 
   &.theme {
     display: block;

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -59,7 +59,7 @@ header {
   color: #fff;
   text-decoration: none;
   font-size: 13px;
-  transition: background .2s;
+  transition: background 200ms;
 
   &:hover {
     background: lighten($cta-background-color, 7);

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -1,5 +1,6 @@
 @import "~normalize.css";
 @import "~core/css/inc/lib";
+@import "~core/css/inc/mixins";
 @import "~disco/css/inc/vars";
 
 
@@ -28,6 +29,13 @@ img {
   padding: 50px 20px;
 }
 
+#app-view {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+}
+
+
 header {
   border-bottom: 1px solid $header-border-color;
   margin-bottom: 40px;
@@ -40,6 +48,25 @@ header {
     font-weight: 400;
     line-height: 1.5;
     margin: 0 0 20px;
+  }
+}
+
+.cta {
+  align-self: center;
+  padding: 1em 1.5em;
+  margin: 30px 0;
+  background: $cta-background-color;
+  color: #fff;
+  text-decoration: none;
+  font-size: 13px;
+  transition: background .2s;
+
+  &:hover {
+    background: lighten($cta-background-color, 7);
+  }
+
+  &:focus {
+    @include focus();
   }
 }
 

--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -6,3 +6,5 @@ $secondary-font-color: #6a6a6a;
 
 $header-copy-font-color: #414141;
 $header-border-color: #b1b1b1;
+
+$cta-background-color: #0083FA;


### PR DESCRIPTION
Add the link to amo as per #407

<img width="413" alt="discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/15684122/8dcc39aa-275d-11e6-9559-c297035357f2.png">

* There was no detailed spec for this but I'm happy to tweak this PR to whatever the details need to be.

@pwalm Currently the hover is a lightened version of the background color I grabbed from the docs. Let me know what the exact colours + paddings etc should be and I can update this PR or we can do that separately if you need more time since we need to get this string in to be localized.