### PR TITLE
First pass at improving RTL styles

### DIFF
--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -71,7 +71,9 @@ export class DiscoPane extends React.Component {
           </div>
         </header>
         {results.map((item, i) => <Addon {...camelCaseProps(item)} key={i} />)}
-        <a className="cta" href="https://addons.mozilla.org/">{i18n.gettext('See more add-ons!')}</a>
+        <div className="amo-link">
+          <a href="https://addons.mozilla.org/">{i18n.gettext('See more add-ons!')}</a>
+        </div>
       </div>
     );
   }

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -10,7 +10,6 @@ $addon-padding: 20px;
   flex-direction: row;
   line-height: 1.5;
   margin-top: 20px;
-  width: 100%;
 
   blockquote {
     margin: 0;

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -29,13 +29,6 @@ img {
   padding: 50px 20px;
 }
 
-#app-view {
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-}
-
-
 header {
   border-bottom: 1px solid $header-border-color;
   margin-bottom: 40px;
@@ -51,22 +44,26 @@ header {
   }
 }
 
-.cta {
-  align-self: center;
-  padding: 1em 1.5em;
-  margin: 30px 0;
-  background: $cta-background-color;
-  color: #fff;
-  text-decoration: none;
-  font-size: 13px;
-  transition: background 200ms;
+.amo-link {
+  text-align: center;
 
-  &:hover {
-    background: lighten($cta-background-color, 7);
-  }
+  a {
+    background: $amo-link-background-color;
+    color: #fff;
+    display: inline-block;
+    font-size: 13px;
+    margin: 30px 0;
+    padding: 1em 1.5em;
+    text-decoration: none;
+    transition: background 300ms;
 
-  &:focus {
-    @include focus();
+    &:hover {
+      background: lighten($amo-link-background-color, 7);
+    }
+
+    &:focus {
+      @include focus();
+    }
   }
 }
 
@@ -76,6 +73,11 @@ header {
   line-height: 1.28;
   margin-right: 50px;
   width: 415px;
+
+  [dir=rtl] & {
+    margin-left: 50px;
+    margin-right: 0;
+  }
 
   &:last-child {
     display: block;
@@ -106,6 +108,10 @@ header {
   .disco-header {
     transform: translateX(-465px);
     width: 1145px;
+
+    [dir=rtl] & {
+      transform: translateX(465px);
+    }
   }
   .disco-content {
     opacity: 0;

--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -7,4 +7,4 @@ $secondary-font-color: #6a6a6a;
 $header-copy-font-color: #414141;
 $header-border-color: #b1b1b1;
 
-$cta-background-color: #0083FA;
+$amo-link-background-color: #0083FA;


### PR DESCRIPTION
Will need to take another look when we have RTL editorial.

Also fixes a regression in the video display caused by the addition of the AMO link.

Before:
<img width="413" alt="before-header" src="https://cloud.githubusercontent.com/assets/1514/15713449/693e53aa-280e-11e6-9fdc-bc89b44413a7.png">
<img width="654" alt="before-video" src="https://cloud.githubusercontent.com/assets/1514/15713454/6dd2adc6-280e-11e6-93a2-2e7db7ebc3a6.png">

After: 

<img width="426" alt="after-header" src="https://cloud.githubusercontent.com/assets/1514/15713458/714c5506-280e-11e6-8738-6c4a85a98efe.png">
<img width="494" alt="after-video" src="https://cloud.githubusercontent.com/assets/1514/15713463/730e3d50-280e-11e6-8080-6635004b1587.png">

