### PR TITLE
Centre the content in about:addons

### DIFF
--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -12,6 +12,9 @@ body {
     "Ubuntu", "Cantarell", "Fira Sans",
     "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
+  // Firefox adds this margin to the left side, for some reason we only need to add half of it.
+  $firefox-margin: 48px;
+  margin-right: $firefox-margin / 2;
 }
 
 * {

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -12,9 +12,11 @@ body {
     "Ubuntu", "Cantarell", "Fira Sans",
     "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 14px;
-  // Firefox adds this margin to the left side, for some reason we only need to add half of it.
-  $firefox-margin: 48px;
-  margin-right: $firefox-margin / 2;
+}
+
+body {
+  // Match firefox's left margin to keep the content centered.
+  margin-right: 48px;
 }
 
 * {


### PR DESCRIPTION
I don't know why only half of the margin is required, but it is.

<img width="1178" alt="screenshot 2016-06-01 23 37 22" src="https://cloud.githubusercontent.com/assets/211578/15734126/d1a20656-2851-11e6-8f25-c99eafada1a0.png">
> Before

<img width="1329" alt="screenshot 2016-06-01 23 43 20" src="https://cloud.githubusercontent.com/assets/211578/15734199/abb083e0-2852-11e6-9a94-15508f1c02e3.png">
> After

Fixes #493.