### PR TITLE
Don't go more narrow than 680px

### DIFF
--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -25,8 +25,8 @@ img {
 .disco-pane {
   box-sizing: content-box;
   margin: 0 auto;
-  max-width: 680px;
   padding: 50px 20px;
+  width: 680px;
 }
 
 header {
@@ -92,6 +92,7 @@ header {
 }
 
 .disco-header {
+  align-items: flex-start;
   display: flex;
   width: 100%;
 


### PR DESCRIPTION
<img width="685" alt="screenshot 2016-06-02 00 00 22" src="https://cloud.githubusercontent.com/assets/211578/15734430/33a4b526-2855-11e6-80ca-d680baa6a1ae.png">
> Before

<img width="685" alt="screenshot 2016-06-02 00 00 12" src="https://cloud.githubusercontent.com/assets/211578/15734429/33a3c5c6-2855-11e6-9708-2f6850091039.png">
> After

Fixes #484.