### PR TITLE
Update amoCDN for disco stage config

### DIFF
--- a/config/stage-disco.js
+++ b/config/stage-disco.js
@@ -1,4 +1,4 @@
-const amoCDN = 'https://addons-cdn.allizom.org';
+const amoCDN = 'https://addons-stage-cdn.allizom.org';
 const staticHost = 'https://addons-discovery-cdn.allizom.org';
 
 module.exports = {


### PR DESCRIPTION
Updated to match https://github.com/mozilla/addons-server/blob/master/src/olympia/conf/stage/settings.py#L11. Currently CSP failures causing assets not to load on https://discovery.addons.allizom.org/.

r?