### PR TITLE
Add tracking to disco pane

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -18,15 +18,21 @@ module.exports = {
       // about:addons can iframe the disco pane.
       frameAncestors: ['about:'],
       // Script is limited to the discovery specific CDN.
-      scriptSrc: [staticHost],
+      scriptSrc: [
+        staticHost,
+        'https://www.google-analytics.com',
+      ],
       styleSrc: [staticHost],
       imgSrc: [
         "'self'",
         'data:',
         amoCDN,
         staticHost,
+        'https://www.google-analytics.com',
       ],
       mediaSrc: [staticHost],
     },
   },
+  trackingEnabled: true,
+  trackingId: 'UA-36116321-7',
 };

--- a/config/default.js
+++ b/config/default.js
@@ -70,6 +70,8 @@ module.exports = {
     'langs',
     'langMap',
     'rtlLangs',
+    'trackingEnabled',
+    'trackingId',
   ],
 
   // Content Security Policy.
@@ -133,4 +135,9 @@ module.exports = {
   rtlLangs: ['ar', 'dbr', 'fa', 'he'],
   defaultLang: 'en-US',
   localeDir: path.resolve(path.join(__dirname, '../locale')),
+
+  // This is off by default
+  // and enabled on a per-app basis.
+  trackingEnabled: false,
+  trackingId: null,
 };

--- a/config/dev-disco.js
+++ b/config/dev-disco.js
@@ -6,13 +6,17 @@ module.exports = {
 
   CSP: {
     directives: {
-      scriptSrc: [staticHost],
+      scriptSrc: [
+        staticHost,
+        'https://www.google-analytics.com',
+      ],
       styleSrc: [staticHost],
       imgSrc: [
         "'self'",
         'data:',
         amoCDN,
         staticHost,
+        'https://www.google-analytics.com',
       ],
       mediaSrc: [staticHost],
     },

--- a/config/development-disco.js
+++ b/config/development-disco.js
@@ -1,0 +1,4 @@
+
+module.exports = {
+  trackingEnabled: false,
+};

--- a/config/stage-disco.js
+++ b/config/stage-disco.js
@@ -6,13 +6,17 @@ module.exports = {
 
   CSP: {
     directives: {
-      scriptSrc: [staticHost],
+      scriptSrc: [
+        staticHost,
+        'https://www.google-analytics.com',
+      ],
       styleSrc: [staticHost],
       imgSrc: [
         "'self'",
         'data:',
         amoCDN,
         staticHost,
+        'https://www.google-analytics.com',
       ],
       mediaSrc: [staticHost],
     },

--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -10,16 +10,18 @@ export default class ServerHtml extends Component {
     appName: PropTypes.string.isRequired,
     assets: PropTypes.object.isRequired,
     component: PropTypes.object.isRequired,
-    htmlDir: PropTypes.object,
-    htmlLang: PropTypes.object,
+    htmlDir: PropTypes.string,
+    htmlLang: PropTypes.string,
     includeSri: PropTypes.bool,
     sriData: PropTypes.object,
     store: PropTypes.object.isRequired,
+    trackingEnabled: PropTypes.bool,
   };
 
   static defaultProps = {
     htmlDir: 'ltr',
     htmlLang: 'en-US',
+    trackingEnabled: false,
   }
 
   getStatic({filePath, type, index}) {
@@ -50,6 +52,13 @@ export default class ServerHtml extends Component {
     } else {
       return null;
     }
+  }
+
+  getAnalytics() {
+    if (this.props.trackingEnabled) {
+      return <script async src="https://www.google-analytics.com/analytics.js"></script>;
+    }
+    return null;
   }
 
   getStyle() {
@@ -85,6 +94,7 @@ export default class ServerHtml extends Component {
           <div id="react-view" dangerouslySetInnerHTML={{__html: content}} />
           <script dangerouslySetInnerHTML={{__html: serialize(store.getState())}}
                   type="application/json" id="redux-store-state" />
+          {this.getAnalytics()}
           {this.getScript()}
         </body>
       </html>

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -125,6 +125,7 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
           includeSri: isDeployed,
           sriData,
           store,
+          trackingEnabled: config.get('trackingEnabled'),
           ...props,
         };
 

--- a/src/core/tracking.js
+++ b/src/core/tracking.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-underscore-dangle */
+
+import config from 'config';
+import log from 'core/logger';
+
+
+export class Tracking {
+
+  constructor({ trackingId, trackingEnabled, _log = log } = {}) {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    this._log = _log;
+    this.id = trackingId;
+    this.enabled = trackingEnabled && trackingId;
+    this.logPrefix = `[GA: ${this.enabled ? 'ON' : 'OFF'}]`;
+
+    if (this.enabled) {
+      /* eslint-disable */
+      // Snippet from Google UA docs: http://bit.ly/1O6Dsdh
+      window.ga = window.ga || function() {(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', trackingId, 'auto');
+      ga('send', 'pageview');
+      /* eslint-enable */
+    }
+
+    this.log('Tracking init');
+    if (!this.id) {
+      this.log('Missing tracking id');
+    }
+  }
+
+  log(...args) {
+    this._log.info(this.logPrefix, ...args);
+  }
+
+  _ga(...args) {
+    if (this.enabled) {
+      window.ga(...args);
+    }
+  }
+
+ /*
+  * Param          Type    Required  Description
+  * obj.category   String  Yes       Typically the object that
+  *                                  was interacted with (e.g. button)
+  * obj.action     String  Yes       The type of interaction (e.g. click)
+  * obj.label      String  No        Useful for categorizing events
+  *                                  (e.g. nav buttons)
+  * obj.value      Number  No        Values must be non-negative.
+  *                                  Useful to pass counts (e.g. 4 times)
+  */
+  sendEvent({ category, action, label, value } = {}) {
+    if (!category) {
+      throw new Error('sendEvent: category is required');
+    }
+    if (!action) {
+      throw new Error('sendEvent: action is required');
+    }
+    const data = {
+      hitType: 'event',
+      eventCategory: category,
+      eventAction: action,
+      eventLabel: label,
+      eventValue: value,
+    };
+    this._ga('send', data);
+    this.log('sendEvent', JSON.stringify(data));
+  }
+
+ /*
+  * Should be called when a view changes or a routing update.
+  */
+  setPage(page) {
+    if (!page) {
+      throw new Error('setPage: page is required');
+    }
+    this._ga('set', 'page', page);
+    this.log('setPage', page);
+  }
+}
+
+export default new Tracking({
+  trackingEnabled: config.get('trackingEnabled'),
+  trackingId: config.get('trackingId'),
+});

--- a/src/disco/client.js
+++ b/src/disco/client.js
@@ -2,4 +2,7 @@ import makeClient from 'core/client/base';
 import routes from './routes';
 import createStore from './store';
 
+// Initialize the tracking.
+import 'core/tracking';
+
 makeClient(routes, createStore);

--- a/src/disco/constants.js
+++ b/src/disco/constants.js
@@ -51,3 +51,6 @@ export const installEventList = [
   'onInstallCancelled',
   'onInstallFailed',
 ];
+
+export const INSTALL_CATEGORY = 'AMO Addon / Theme Installs';
+export const UNINSTALL_CATEGORY = 'AMO Addon / Theme Uninstalls';

--- a/tests/client/core/containers/TestServerHtml.js
+++ b/tests/client/core/containers/TestServerHtml.js
@@ -57,6 +57,7 @@ describe('<ServerHtml />', () => {
       assets: fakeAssets,
       includeSri: true,
       store: fakeStore,
+      trackingEnabled: false,
       sriData: fakeSRIData,
       ...opts,
     };
@@ -68,6 +69,21 @@ describe('<ServerHtml />', () => {
       render({htmlLang: 'ar', htmlDir: 'rtl'}), 'html');
     assert.equal(html.getAttribute('lang'), 'ar');
     assert.equal(html.getAttribute('dir'), 'rtl');
+  });
+
+  it('renders GA script when trackingEnabled is true', () => {
+    const html = findRenderedDOMComponentWithTag(
+      render({trackingEnabled: true}), 'html');
+    const ga = html.querySelectorAll('script[src="https://www.google-analytics.com/analytics.js"]');
+    assert.equal(ga.length, 1);
+    assert.equal(ga[0].hasAttribute('async'), true);
+  });
+
+  it("doesn't render GA script when trackingEnabled is false", () => {
+    const html = findRenderedDOMComponentWithTag(
+      render({trackingEnabled: false}), 'html');
+    const ga = html.querySelectorAll('script[src="https://www.google-analytics.com/analytics.js"]');
+    assert.equal(ga.length, 0);
   });
 
   it('renders css provided', () => {

--- a/tests/client/core/test_tracking.js
+++ b/tests/client/core/test_tracking.js
@@ -1,0 +1,75 @@
+import { Tracking } from 'core/tracking';
+
+
+describe('Tracking', () => {
+  let tracking;
+
+  beforeEach(() => {
+    tracking = new Tracking({
+      trackingId: 'whatever',
+      trackingEnabled: true,
+      _log: {
+        info: sinon.stub(),
+      },
+    });
+    window.ga = sinon.stub();
+  });
+
+  it('should log OFF when not enabled', () => {
+    tracking = new Tracking({
+      trackingId: 'whatever',
+      trackingEnabled: false,
+      _log: {
+        info: sinon.stub(),
+      },
+    });
+    // eslint-disable-next-line no-underscore-dangle
+    assert.ok(tracking._log.info.calledWith(sinon.match(/OFF/), 'Tracking init'));
+  });
+
+  it('should log OFF when not enabled due to missing id', () => {
+    tracking = new Tracking({
+      trackingId: undefined,
+      trackingEnabled: true,
+      _log: {
+        info: sinon.stub(),
+      },
+    });
+    // eslint-disable-next-line no-underscore-dangle
+    // eslint-disable-next-line no-underscore-dangle
+    assert.ok(tracking._log.info.secondCall.calledWith(sinon.match(/OFF/), 'Missing tracking id'));
+  });
+
+  it('should throw if page not set', () => {
+    assert.throws(() => {
+      tracking.setPage();
+    }, Error, /page is required/);
+  });
+
+  it('should call ga', () => {
+    tracking.setPage('whatever');
+    assert.ok(window.ga.called);
+  });
+
+  it('should throw if category not set', () => {
+    assert.throws(() => {
+      tracking.sendEvent();
+    }, Error, /category is required/);
+  });
+
+  it('should throw if action not set', () => {
+    assert.throws(() => {
+      tracking.sendEvent({
+        category: 'whatever',
+      });
+    }, Error, /action is required/);
+  });
+
+  it('should call _ga', () => {
+    tracking.sendEvent({
+      category: 'whatever',
+      action: 'some-action',
+    });
+    assert.ok(window.ga.called);
+  });
+});

--- a/tests/client/disco/containers/TestInstallButton.js
+++ b/tests/client/disco/containers/TestInstallButton.js
@@ -121,22 +121,25 @@ describe('<InstallButton />', () => {
     const guid = '@foo';
     const install = sinon.spy();
     const installURL = 'https://my.url/download';
+    const name = 'hai';
     const slug = 'foo';
-    const button = renderButton({guid, install, installURL, slug, status: UNINSTALLED});
+    const button = renderButton({guid, install, installURL, name, slug, status: UNINSTALLED});
     const root = findDOMNode(button);
     Simulate.click(root);
-    assert(install.calledWith({guid, installURL, slug}));
+    assert(install.calledWith({guid, installURL, slug, name}));
   });
 
   it('should call uninstall function on click when installed', () => {
     const guid = '@foo';
     const installURL = 'https://my.url/download';
+    const name = 'hai';
     const slug = 'foo';
+    const type = 'whatevs';
     const uninstall = sinon.spy();
-    const button = renderButton({guid, installURL, slug, status: INSTALLED, uninstall});
+    const button = renderButton({guid, installURL, name, slug, status: INSTALLED, type, uninstall});
     const root = findDOMNode(button);
     Simulate.click(root);
-    assert(uninstall.calledWith({guid, installURL, slug}));
+    assert(uninstall.calledWith({guid, installURL, slug, name, type}));
   });
 
   it('should call setInitialStatus in componentDidMount', () => {
@@ -322,12 +325,13 @@ describe('<InstallButton />', () => {
 
   describe('installTheme', () => {
     it('installs the theme', () => {
+      const name = 'hai-theme';
       const node = sinon.stub();
       const slug = 'install-theme';
       const spyThemeAction = sinon.spy();
       const dispatch = sinon.spy();
       const { installTheme } = mapDispatchToProps(dispatch);
-      return installTheme(node, slug, spyThemeAction)
+      return installTheme(node, slug, name, spyThemeAction)
         .then(() => {
           assert(spyThemeAction.calledWith(node, THEME_INSTALL));
           assert(dispatch.calledWith({

--- a/tests/server/TestCSPConfig.js
+++ b/tests/server/TestCSPConfig.js
@@ -110,7 +110,8 @@ describe('App Specific CSP Config', () => {
     process.env.NODE_APP_INSTANCE = 'disco';
     const config = requireUncached('config');
     const cspConfig = config.get('CSP').directives;
-    assert.deepEqual(cspConfig.scriptSrc, ['https://addons-discovery.cdn.mozilla.net']);
+    assert.deepEqual(cspConfig.scriptSrc, [
+      'https://addons-discovery.cdn.mozilla.net', 'https://www.google-analytics.com']);
   });
 
   it('should set media-src for disco', () => {
@@ -129,6 +130,7 @@ describe('App Specific CSP Config', () => {
       'data:',
       'https://addons.cdn.mozilla.net',
       'https://addons-discovery.cdn.mozilla.net',
+      'https://www.google-analytics.com',
     ]);
   });
 


### PR DESCRIPTION
Fixes #41 

* Adds tracking lib 
* Uses async setup as per GA docs
* Adds CSP config (we might need more than this if beacons go to other hosts).
* preventDefault added (I was seeing 2 beacons fired) this probably meant installs were kicked off twice too.
* adds the install and uninstall events.
