### PR TITLE
Update button to spec

### DIFF
--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -53,21 +53,32 @@ header {
   text-align: center;
 
   a {
-    background: $amo-link-background-color;
+    background: #2EA3FF;
+    border: 1px solid #0675D3;
     color: #fff;
     display: inline-block;
-    font-size: 13px;
+    font-size: 14px;
     margin: 30px 0;
-    padding: 1em 1.5em;
+    min-width: 140px;
+    padding: 10px 1em 11px;
     text-decoration: none;
-    transition: background 300ms;
+    transition: background 200ms;
 
+    &:focus,
     &:hover {
-      background: lighten($amo-link-background-color, 7);
+      background: #0996F8;
+      border: 1px solid #0461AE;
     }
 
     &:focus {
       @include focus();
+      border: 1px solid #fff;
+    }
+
+    &:active {
+      background: #0675D3;
+      border: 1px solid #025295;
+      box-shadow: none;
     }
   }
 }

--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -6,5 +6,3 @@ $secondary-font-color: #6a6a6a;
 
 $header-copy-font-color: #414141;
 $header-border-color: #b1b1b1;
-
-$amo-link-background-color: #0083FA;


### PR DESCRIPTION
Fixes #489

Only real difference to the spec is that I used a larger L+R padding since the min-width is exceeded in this use-case. 

Setting to 1em looks balanced to me - but happy to update if needed.

This was the specced version with 8px.

<img alt="discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/15822031/41b56f4a-2beb-11e6-9311-63f284e1f049.png">

I went with 1em (14px):

<img alt="discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/15822083/8947d172-2beb-11e6-955f-defcba0a4ea6.png">
