### PR TITLE
Use theme instead of persona for theme type

### DIFF
--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -1,4 +1,13 @@
+import { API_THEME_TYPE, THEME_TYPE } from 'disco/constants';
+
 const initialState = {};
+
+export function getGuid(result) {
+  if (result.type === API_THEME_TYPE) {
+    return `${result.id}@personas.mozilla.org`;
+  }
+  return result.guid;
+}
 
 export default function addon(state = initialState, action) {
   const { payload } = action;
@@ -10,7 +19,8 @@ export default function addon(state = initialState, action) {
         newState[key] = {
           ...thisAddon,
           ...thisAddon.theme_data,
-          guid: `${thisAddon.id}@personas.mozilla.org`,
+          guid: getGuid(thisAddon),
+          type: THEME_TYPE,
         };
         delete newState[key].theme_data;
       } else {

--- a/src/disco/api.js
+++ b/src/disco/api.js
@@ -1,13 +1,7 @@
 import { Schema, arrayOf } from 'normalizr';
 
 import { callApi } from 'core/api';
-
-export function getGuid(result) {
-  if (result.type === 'persona') {
-    return `${result.id}@personas.mozilla.org`;
-  }
-  return result.guid;
-}
+import { getGuid } from 'core/reducers/addons';
 
 export const discoResult =
   new Schema('discoResults', {idAttribute: (result) => getGuid(result.addon)});

--- a/src/disco/constants.js
+++ b/src/disco/constants.js
@@ -17,8 +17,9 @@ export const validInstallStates = [
 ];
 
 // Add-on types.
+export const API_THEME_TYPE = 'persona';
 export const EXTENSION_TYPE = 'extension';
-export const THEME_TYPE = 'persona';
+export const THEME_TYPE = 'theme';
 // These types are not used.
 // export const DICT_TYPE = 'dictionary';
 // export const SEARCH_TYPE = 'search';

--- a/tests/client/core/reducers/test_addons.js
+++ b/tests/client/core/reducers/test_addons.js
@@ -1,4 +1,5 @@
 import addons from 'core/reducers/addons';
+import { API_THEME_TYPE, THEME_TYPE } from 'disco/constants';
 
 describe('addon reducer', () => {
   let originalState;
@@ -44,11 +45,12 @@ describe('addon reducer', () => {
   });
 
   it('flattens theme data', () => {
+    const type = API_THEME_TYPE;
     const state = addons(originalState, {
       payload: {
         entities: {
           addons: {
-            baz: {slug: 'baz', id: 42, theme_data: {theme_thing: 'some-data'}},
+            baz: {slug: 'baz', id: 42, theme_data: {theme_thing: 'some-data'}, type},
           },
         },
       },
@@ -63,6 +65,7 @@ describe('addon reducer', () => {
           slug: 'baz',
           theme_thing: 'some-data',
           guid: '42@personas.mozilla.org',
+          type: THEME_TYPE,
         },
       });
   });

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -371,13 +371,12 @@ describe('<Addon />', () => {
       const fakeAddonManager = stubAddonManager();
       const dispatch = sinon.spy();
       const name = 'whatevs';
-      const type = 'persona';
       const fakeTracking = {
         sendEvent: sinon.spy(),
       };
       const { uninstall } = mapDispatchToProps(dispatch,
         {_tracking: fakeTracking, _addonManager: fakeAddonManager});
-      return uninstall({guid, installURL, name, type})
+      return uninstall({guid, installURL, name, type: THEME_TYPE})
         .then(() => {
           assert(fakeTracking.sendEvent.calledWith({
             action: 'theme',

--- a/tests/client/disco/test_api.js
+++ b/tests/client/disco/test_api.js
@@ -1,6 +1,6 @@
 import { arrayOf, normalize } from 'normalizr';
 
-import { discoResult, getDiscoveryAddons, getGuid } from 'disco/api';
+import { discoResult, getDiscoveryAddons } from 'disco/api';
 import * as coreApi from 'core/api';
 
 describe('disco api', () => {
@@ -30,16 +30,6 @@ describe('disco api', () => {
           result: '{foo}',
         },
         sinon.format(normalized.entities));
-    });
-  });
-
-  describe('getGuid', () => {
-    it('provides a theme guid for a theme', () => {
-      const fakeResult = {
-        type: 'persona',
-        id: 'awooga',
-      };
-      assert.equal(getGuid(fakeResult), 'awooga@personas.mozilla.org');
     });
   });
 });


### PR DESCRIPTION
Fixes a bug where the theme install state would stay installed when it is disabled. Refreshing the page will update theme buttons to the correct state.

The reducer now normalizes `persona` to `theme` since that's what Firefox uses.