### PR TITLE
Use error overlay for errors (fixes #395)

### DIFF
--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -14,9 +14,11 @@ import InstallButton from 'disco/components/InstallButton';
 import {
   validAddonTypes,
   validInstallStates,
+  DOWNLOAD_FAILED,
   ERROR,
   EXTENSION_TYPE,
   INSTALL_CATEGORY,
+  INSTALL_FAILED,
   INSTALLED,
   THEME_INSTALL,
   THEME_TYPE,
@@ -40,7 +42,7 @@ export class Addon extends React.Component {
     accentcolor: PropTypes.string,
     description: PropTypes.string,
     editorialDescription: PropTypes.string.isRequired,
-    errorMessage: PropTypes.string,
+    error: PropTypes.string,
     footerURL: PropTypes.string,
     guid: PropTypes.string.isRequired,
     headerURL: PropTypes.string,
@@ -77,10 +79,8 @@ export class Addon extends React.Component {
   }
 
   getError() {
-    const { status, i18n } = this.props;
-    const errorMessage = this.props.errorMessage || i18n.gettext('An unexpected error occurred');
-    return status === ERROR ? (<div className="error">
-      <p className="message">{errorMessage}</p>
+    return this.props.status === ERROR ? (<div className="error">
+      <p className="message">{this.errorMessage()}</p>
       <a className="close" href="#" onClick={this.closeError}>Close</a>
     </div>) : null;
   }
@@ -121,6 +121,18 @@ export class Addon extends React.Component {
         className="editorial-description"
         dangerouslySetInnerHTML={sanitizeHTML(description, ['blockquote', 'cite'])} />
     );
+  }
+
+  errorMessage() {
+    const { error, i18n } = this.props;
+    switch (error) {
+      case INSTALL_FAILED:
+        return i18n.gettext('Installation failed. Please try again.');
+      case DOWNLOAD_FAILED:
+        return i18n.gettext('Download failed. Please check your connection.');
+      default:
+        return i18n.gettext('An unexpected error occurred.');
+    }
   }
 
   closeError = (e) => {
@@ -179,7 +191,7 @@ export function mapStateToProps(state, ownProps) {
   return {...installation, ...addon};
 }
 
-export function makeProgressHandler(dispatch, guid, i18n) {
+export function makeProgressHandler(dispatch, guid) {
   return (addonInstall, e) => {
     if (addonInstall.state === 'STATE_DOWNLOADING') {
       const downloadProgress = parseInt(
@@ -190,21 +202,9 @@ export function makeProgressHandler(dispatch, guid, i18n) {
     } else if (addonInstall.state === 'STATE_INSTALLED') {
       dispatch({type: 'INSTALL_COMPLETE', payload: {guid}});
     } else if (e.type === 'onDownloadFailed') {
-      dispatch({
-        type: 'INSTALL_ERROR',
-        payload: {
-          guid,
-          errorMessage: i18n.gettext('Download failed. Please check your connection.'),
-        },
-      });
+      dispatch({type: 'INSTALL_ERROR', payload: {guid, error: DOWNLOAD_FAILED}});
     } else if (e.type === 'onInstallFailed') {
-      dispatch({
-        type: 'INSTALL_ERROR',
-        payload: {
-          guid,
-          errorMessage: i18n.gettext('Installation failed. Please try again.'),
-        },
-      });
+      dispatch({type: 'INSTALL_ERROR', payload: {guid, error: INSTALL_FAILED}});
     }
   };
 }

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -38,7 +38,6 @@ function sanitizeHTML(text, allowTags = []) {
 export class Addon extends React.Component {
   static propTypes = {
     accentcolor: PropTypes.string,
-    closeErrorAction: PropTypes.func,
     description: PropTypes.string,
     editorialDescription: PropTypes.string.isRequired,
     errorMessage: PropTypes.string,
@@ -52,7 +51,7 @@ export class Addon extends React.Component {
     installURL: PropTypes.string,
     previewURL: PropTypes.string,
     name: PropTypes.string.isRequired,
-    setInitialStatus: PropTypes.func.isRequired,
+    setCurrentStatus: PropTypes.func.isRequired,
     status: PropTypes.oneOf(validInstallStates).isRequired,
     textcolor: PropTypes.string,
     themeAction: PropTypes.func,
@@ -65,8 +64,12 @@ export class Addon extends React.Component {
   }
 
   componentDidMount() {
-    const { guid, installURL, setInitialStatus } = this.props;
-    setInitialStatus({guid, installURL});
+    this.setCurrentStatus();
+  }
+
+  setCurrentStatus() {
+    const { guid, installURL, setCurrentStatus } = this.props;
+    setCurrentStatus({guid, installURL});
   }
 
   getBrowserThemeData() {
@@ -78,7 +81,7 @@ export class Addon extends React.Component {
     const errorMessage = this.props.errorMessage || i18n.gettext('An unexpected error occurred');
     return status === ERROR ? (<div className="error">
       <p className="message">{errorMessage}</p>
-      <a className="close" href="#" onClick={this.props.closeErrorAction}>Close</a>
+      <a className="close" href="#" onClick={this.closeError}>Close</a>
     </div>) : null;
   }
 
@@ -118,6 +121,11 @@ export class Addon extends React.Component {
         className="editorial-description"
         dangerouslySetInnerHTML={sanitizeHTML(description, ['blockquote', 'cite'])} />
     );
+  }
+
+  closeError = (e) => {
+    e.preventDefault();
+    this.setCurrentStatus();
   }
 
   handleClick = (e) => {
@@ -171,8 +179,8 @@ export function mapStateToProps(state, ownProps) {
   return {...installation, ...addon};
 }
 
-export function makeProgressHandler(dispatch, guid) {
-  return (addonInstall) => {
+export function makeProgressHandler(dispatch, guid, i18n) {
+  return (addonInstall, e) => {
     if (addonInstall.state === 'STATE_DOWNLOADING') {
       const downloadProgress = parseInt(
         100 * addonInstall.progress / addonInstall.maxProgress, 10);
@@ -181,6 +189,22 @@ export function makeProgressHandler(dispatch, guid) {
       dispatch({type: 'START_INSTALL', payload: {guid}});
     } else if (addonInstall.state === 'STATE_INSTALLED') {
       dispatch({type: 'INSTALL_COMPLETE', payload: {guid}});
+    } else if (e.type === 'onDownloadFailed') {
+      dispatch({
+        type: 'INSTALL_ERROR',
+        payload: {
+          guid,
+          errorMessage: i18n.gettext('Download failed. Please check your connection.'),
+        },
+      });
+    } else if (e.type === 'onInstallFailed') {
+      dispatch({
+        type: 'INSTALL_ERROR',
+        payload: {
+          guid,
+          errorMessage: i18n.gettext('Installation failed. Please try again.'),
+        },
+      });
     }
   };
 }
@@ -191,7 +215,7 @@ export function mapDispatchToProps(dispatch, { _tracking = tracking,
     return {};
   }
   return {
-    setInitialStatus({ guid, installURL }) {
+    setCurrentStatus({ guid, installURL }) {
       const payload = {guid, url: installURL};
       return _addonManager.getAddon(guid)
         .then(
@@ -202,10 +226,10 @@ export function mapDispatchToProps(dispatch, { _tracking = tracking,
           () => dispatch({type: 'INSTALL_STATE', payload: {...payload, status: UNINSTALLED}}));
     },
 
-    install({ guid, installURL, name }) {
+    install({ guid, i18n, installURL, name }) {
       dispatch({type: 'START_DOWNLOAD', payload: {guid}});
       _tracking.sendEvent({action: 'addon', category: INSTALL_CATEGORY, label: name});
-      return _addonManager.install(installURL, makeProgressHandler(dispatch, guid));
+      return _addonManager.install(installURL, makeProgressHandler(dispatch, guid, i18n));
     },
 
     installTheme(node, guid, name, _themeAction = themeAction) {

--- a/src/disco/components/InstallButton.js
+++ b/src/disco/components/InstallButton.js
@@ -39,12 +39,12 @@ export class InstallButton extends React.Component {
   handleClick = (e) => {
     e.preventDefault();
     const {
-      guid, i18n, install, installURL, name, status, installTheme, type, uninstall,
+      guid, install, installURL, name, status, installTheme, type, uninstall,
     } = this.props;
     if (type === THEME_TYPE && status === UNINSTALLED) {
       installTheme(this.refs.themeData, guid, name);
     } else if (status === UNINSTALLED) {
-      install({ guid, i18n, installURL, name });
+      install({ guid, installURL, name });
     } else if (status === INSTALLED) {
       uninstall({ guid, installURL, name, type });
     }

--- a/src/disco/components/InstallButton.js
+++ b/src/disco/components/InstallButton.js
@@ -38,11 +38,13 @@ export class InstallButton extends React.Component {
 
   handleClick = (e) => {
     e.preventDefault();
-    const { guid, install, installURL, name, status, installTheme, type, uninstall } = this.props;
+    const {
+      guid, i18n, install, installURL, name, status, installTheme, type, uninstall,
+    } = this.props;
     if (type === THEME_TYPE && status === UNINSTALLED) {
       installTheme(this.refs.themeData, guid, name);
     } else if (status === UNINSTALLED) {
-      install({ guid, installURL, name });
+      install({ guid, i18n, installURL, name });
     } else if (status === INSTALLED) {
       uninstall({ guid, installURL, name, type });
     }

--- a/src/disco/constants.js
+++ b/src/disco/constants.js
@@ -16,6 +16,9 @@ export const validInstallStates = [
   UNKNOWN,
 ];
 
+export const DOWNLOAD_FAILED = 'download-failed';
+export const INSTALL_FAILED = 'install-failed';
+
 // Add-on types.
 export const API_THEME_TYPE = 'persona';
 export const EXTENSION_TYPE = 'extension';

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -79,7 +79,7 @@ $addon-padding: 20px;
     flex-grow: 1;
     position: relative;
 
-    .error {
+    > .error {
       align-content: stretch;
       align-items: center;
       background: #c33c32 url('../img/warning.svg') no-repeat calc(100% - 40px) 50%;

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -99,11 +99,12 @@ $addon-padding: 20px;
       }
 
       .close {
+        bottom: 10px;
         color: #fff;
         display: block;
+        left: 15px;
+        padding: 5px;
         position: absolute;
-        left: 20px;
-        bottom: 15px;
       }
     }
 

--- a/src/disco/reducers/installations.js
+++ b/src/disco/reducers/installations.js
@@ -51,7 +51,7 @@ export default function installations(state = {}, { type, payload }) {
   } else if (type === 'INSTALL_ERROR') {
     addon.downloadProgress = 0;
     addon.status = ERROR;
-    addon.error = payload.error;
+    addon.errorMessage = payload.errorMessage;
   }
   return {
     ...state,

--- a/src/disco/reducers/installations.js
+++ b/src/disco/reducers/installations.js
@@ -51,7 +51,7 @@ export default function installations(state = {}, { type, payload }) {
   } else if (type === 'INSTALL_ERROR') {
     addon.downloadProgress = 0;
     addon.status = ERROR;
-    addon.errorMessage = payload.errorMessage;
+    addon.error = payload.error;
   }
   return {
     ...state,

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -14,7 +14,9 @@ import {
 } from 'disco/components/Addon';
 import {
   ERROR,
+  DOWNLOAD_FAILED,
   INSTALL_CATEGORY,
+  INSTALL_FAILED,
   INSTALLED,
   THEME_INSTALL,
   THEME_PREVIEW,
@@ -53,13 +55,42 @@ describe('<Addon />', () => {
       root = renderAddon(result);
     });
 
-    it('renders an error overlay', () => {
-      const data = {...result, status: ERROR,
-        errorMessage: 'this is an error', setCurrentStatus: sinon.stub()};
+    it('renders a default error overlay', () => {
+      const data = {...result, status: ERROR, setCurrentStatus: sinon.stub()};
       root = renderAddon(data);
       const error = findDOMNode(root).querySelector('.error');
-      assert.equal(error.querySelector('p').textContent, 'this is an error',
-                  'error message should be present');
+      assert.equal(
+        error.querySelector('p').textContent,
+        'An unexpected error occurred.',
+        'error message should be present');
+      Simulate.click(error.querySelector('.close'));
+      assert.ok(data.setCurrentStatus.called, 'setCurrentStatus should be called');
+    });
+
+    it('renders an install error overlay', () => {
+      const data = {
+        ...result, status: ERROR, error: INSTALL_FAILED, setCurrentStatus: sinon.stub(),
+      };
+      root = renderAddon(data);
+      const error = findDOMNode(root).querySelector('.error');
+      assert.equal(
+        error.querySelector('p').textContent,
+        'Installation failed. Please try again.',
+        'error message should be present');
+      Simulate.click(error.querySelector('.close'));
+      assert.ok(data.setCurrentStatus.called, 'setCurrentStatus should be called');
+    });
+
+    it('renders an error overlay', () => {
+      const data = {
+        ...result, status: ERROR, error: DOWNLOAD_FAILED, setCurrentStatus: sinon.stub(),
+      };
+      root = renderAddon(data);
+      const error = findDOMNode(root).querySelector('.error');
+      assert.equal(
+        error.querySelector('p').textContent,
+        'Download failed. Please check your connection.',
+        'error message should be present');
       Simulate.click(error.querySelector('.close'));
       assert.ok(data.setCurrentStatus.called, 'setCurrentStatus should be called');
     });
@@ -236,7 +267,7 @@ describe('<Addon />', () => {
       handler({state: 'STATE_SOMETHING'}, {type: 'onDownloadFailed'});
       assert(dispatch.calledWith({
         type: 'INSTALL_ERROR',
-        payload: {guid, errorMessage: 'Download failed. Please check your connection.'},
+        payload: {guid, error: DOWNLOAD_FAILED},
       }));
     });
 
@@ -248,7 +279,7 @@ describe('<Addon />', () => {
       handler({state: 'STATE_SOMETHING'}, {type: 'onInstallFailed'});
       assert(dispatch.calledWith({
         type: 'INSTALL_ERROR',
-        payload: {guid, errorMessage: 'Installation failed. Please try again.'},
+        payload: {guid, error: INSTALL_FAILED},
       }));
     });
   });

--- a/tests/client/disco/components/TestInstallButton.js
+++ b/tests/client/disco/components/TestInstallButton.js
@@ -115,11 +115,12 @@ describe('<InstallButton />', () => {
     const guid = '@foo';
     const name = 'hai';
     const install = sinon.spy();
+    const i18n = getFakeI18nInst();
     const installURL = 'https://my.url/download';
-    const button = renderButton({guid, install, installURL, name, status: UNINSTALLED});
+    const button = renderButton({guid, i18n, install, installURL, name, status: UNINSTALLED});
     const root = findDOMNode(button);
     Simulate.click(root);
-    assert(install.calledWith({guid, installURL, name}));
+    assert(install.calledWith({guid, i18n, installURL, name}));
   });
 
   it('should call uninstall function on click when installed', () => {

--- a/tests/client/disco/components/TestInstallButton.js
+++ b/tests/client/disco/components/TestInstallButton.js
@@ -120,7 +120,7 @@ describe('<InstallButton />', () => {
     const button = renderButton({guid, i18n, install, installURL, name, status: UNINSTALLED});
     const root = findDOMNode(button);
     Simulate.click(root);
-    assert(install.calledWith({guid, i18n, installURL, name}));
+    assert(install.calledWith({guid, installURL, name}));
   });
 
   it('should call uninstall function on click when installed', () => {

--- a/tests/client/disco/reducers/test_installations.js
+++ b/tests/client/disco/reducers/test_installations.js
@@ -229,7 +229,7 @@ describe('installations reducer', () => {
         type: 'INSTALL_ERROR',
         payload: {
           guid: 'my-addon@me.com',
-          errorMessage: 'Download interrupted, check your network connection.',
+          error: 'an-error',
         },
       }),
       {
@@ -238,7 +238,7 @@ describe('installations reducer', () => {
           url: 'https://cdn.amo/download/my-addon.xpi',
           downloadProgress: 0,
           status: ERROR,
-          errorMessage: 'Download interrupted, check your network connection.',
+          error: 'an-error',
         },
       });
   });

--- a/tests/client/disco/reducers/test_installations.js
+++ b/tests/client/disco/reducers/test_installations.js
@@ -229,7 +229,7 @@ describe('installations reducer', () => {
         type: 'INSTALL_ERROR',
         payload: {
           guid: 'my-addon@me.com',
-          error: 'Download interrupted, check your network connection.',
+          errorMessage: 'Download interrupted, check your network connection.',
         },
       }),
       {
@@ -238,7 +238,7 @@ describe('installations reducer', () => {
           url: 'https://cdn.amo/download/my-addon.xpi',
           downloadProgress: 0,
           status: ERROR,
-          error: 'Download interrupted, check your network connection.',
+          errorMessage: 'Download interrupted, check your network connection.',
         },
       });
   });

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -34,7 +34,7 @@ export function unexpectedSuccess() {
  */
 export function getFakeI18nInst() {
   return {
-    gettext: sinon.stub(),
+    gettext: sinon.spy((str) => str),
     dgettext: sinon.stub(),
     ngettext: sinon.stub(),
     dngettext: sinon.stub(),


### PR DESCRIPTION
I had a little animation on the overlay at first but getting it to animate out was tricky so I removed it. It appears quite abruptly so we should probably add something but I'll let @pwalm say what. Maybe worth noting that I barely missed the close button there and it didn't register my click. I guess we should make that clickier.

![error-overlay-nicer mov](https://cloud.githubusercontent.com/assets/211578/15863373/5e2a2046-2c98-11e6-83eb-5dda49138eed.gif)
> No animation

![error-overlay-animate-in mov](https://cloud.githubusercontent.com/assets/211578/15863239/c7ad28a2-2c97-11e6-8289-216d29d3c892.gif)
> In animation

Fixes #395.