### PR TITLE
Support ENABLED and DISABLED installation statuses

### DIFF
--- a/src/disco/addonManager.js
+++ b/src/disco/addonManager.js
@@ -14,6 +14,7 @@ export function getAddon(guid, {_mozAddonManager = window.navigator.mozAddonMana
       if (!addon) {
         throw new Error('Addon not found');
       }
+      log.info('Add-on found', addon);
       return addon;
     });
 }

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -12,8 +12,12 @@ import * as addonManager from 'disco/addonManager';
 
 import InstallButton from 'disco/components/InstallButton';
 import {
+  validAddonTypes,
+  validInstallStates,
+  DISABLED,
   DOWNLOAD_FAILED,
   DOWNLOAD_PROGRESS,
+  ENABLED,
   ERROR,
   EXTENSION_TYPE,
   INSTALLED,
@@ -32,8 +36,6 @@ import {
   UNINSTALLED,
   UNINSTALL_CATEGORY,
   UNINSTALL_COMPLETE,
-  validAddonTypes,
-  validInstallStates,
 } from 'disco/constants';
 
 import 'disco/css/Addon.scss';
@@ -228,7 +230,7 @@ export function mapDispatchToProps(dispatch, { _tracking = tracking,
       return _addonManager.getAddon(guid)
         .then(
           (addon) => {
-            const status = addon.type === THEME_TYPE && !addon.isEnabled ? UNINSTALLED : INSTALLED;
+            const status = addon.isEnabled ? ENABLED : DISABLED;
             dispatch({type: INSTALL_STATE, payload: {...payload, status}});
           },
           () => dispatch({type: INSTALL_STATE, payload: {...payload, status: UNINSTALLED}}));

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -20,22 +20,17 @@ import {
   ENABLED,
   ERROR,
   EXTENSION_TYPE,
-  INSTALLED,
   INSTALL_CATEGORY,
-  INSTALL_COMPLETE,
   INSTALL_ERROR,
   INSTALL_FAILED,
   INSTALL_STATE,
   START_DOWNLOAD,
-  START_INSTALL,
-  START_UNINSTALL,
   THEME_INSTALL,
   THEME_PREVIEW,
   THEME_RESET_PREVIEW,
   THEME_TYPE,
   UNINSTALLED,
   UNINSTALL_CATEGORY,
-  UNINSTALL_COMPLETE,
 } from 'disco/constants';
 
 import 'disco/css/Addon.scss';
@@ -195,10 +190,17 @@ export class Addon extends React.Component {
   }
 }
 
-export function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state, ownProps, { _tracking = tracking } = {}) {
   const installation = state.installations[ownProps.guid] || {};
   const addon = state.addons[ownProps.guid] || {};
-  return {...installation, ...addon};
+  return {
+    ...installation,
+    ...addon,
+    installTheme(node, guid, name, _themeAction = themeAction) {
+      _themeAction(node, THEME_INSTALL);
+      _tracking.sendEvent({action: 'theme', category: INSTALL_CATEGORY, label: name});
+    },
+  };
 }
 
 export function makeProgressHandler(dispatch, guid) {
@@ -207,10 +209,6 @@ export function makeProgressHandler(dispatch, guid) {
       const downloadProgress = parseInt(
         100 * addonInstall.progress / addonInstall.maxProgress, 10);
       dispatch({type: DOWNLOAD_PROGRESS, payload: {guid, downloadProgress}});
-    } else if (addonInstall.state === 'STATE_INSTALLING') {
-      dispatch({type: START_INSTALL, payload: {guid}});
-    } else if (addonInstall.state === 'STATE_INSTALLED') {
-      dispatch({type: INSTALL_COMPLETE, payload: {guid}});
     } else if (e.type === 'onDownloadFailed') {
       dispatch({type: INSTALL_ERROR, payload: {guid, error: DOWNLOAD_FAILED}});
     } else if (e.type === 'onInstallFailed') {
@@ -230,7 +228,7 @@ export function mapDispatchToProps(dispatch, { _tracking = tracking,
       return _addonManager.getAddon(guid)
         .then(
           (addon) => {
-            const status = addon.isEnabled ? ENABLED : DISABLED;
+            const status = addon.isActive && addon.isEnabled ? ENABLED : DISABLED;
             dispatch({type: INSTALL_STATE, payload: {...payload, status}});
           },
           () => dispatch({type: INSTALL_STATE, payload: {...payload, status: UNINSTALLED}}));
@@ -242,26 +240,13 @@ export function mapDispatchToProps(dispatch, { _tracking = tracking,
       return _addonManager.install(installURL, makeProgressHandler(dispatch, guid));
     },
 
-    installTheme(node, guid, name, _themeAction = themeAction) {
-      _themeAction(node, THEME_INSTALL);
-      _tracking.sendEvent({action: 'theme', category: INSTALL_CATEGORY, label: name});
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          dispatch({type: INSTALL_STATE, payload: {guid, status: INSTALLED}});
-          resolve();
-        }, 250);
-      });
-    },
-
     uninstall({ guid, name, type }) {
-      dispatch({type: START_UNINSTALL, payload: {guid}});
       const action = {
         [EXTENSION_TYPE]: 'addon',
         [THEME_TYPE]: 'theme',
       }[type] || 'invalid';
       _tracking.sendEvent({action, category: UNINSTALL_CATEGORY, label: name});
-      return _addonManager.uninstall(guid)
-        .then(() => dispatch({type: UNINSTALL_COMPLETE, payload: {guid}}));
+      return _addonManager.uninstall(guid);
     },
   };
 }

--- a/src/disco/constants.js
+++ b/src/disco/constants.js
@@ -1,7 +1,9 @@
 // Addon States.
 export const DISABLED = 'DISABLED';
+export const DISABLING = 'DISABLING';
 export const DOWNLOADING = 'DOWNLOADING';
 export const ENABLED = 'ENABLED';
+export const ENABLING = 'ENABLING';
 export const ERROR = 'ERROR';
 export const INSTALLED = 'INSTALLED';
 export const INSTALLING = 'INSTALLING';
@@ -70,9 +72,7 @@ export const UNINSTALL_CATEGORY = 'AMO Addon / Theme Uninstalls';
 export const INSTALL_STATE = 'INSTALL_STATE';
 export const START_DOWNLOAD = 'START_DOWNLOAD';
 export const DOWNLOAD_PROGRESS = 'DOWNLOAD_PROGRESS';
-export const START_INSTALL = 'START_INSTALL';
 export const INSTALL_COMPLETE = 'INSTALL_COMPLETE';
-export const START_UNINSTALL = 'START_UNINSTALL';
 export const UNINSTALL_COMPLETE = 'UNINSTALL_COMPLETE';
 export const INSTALL_ERROR = 'INSTALL_ERROR';
 
@@ -80,9 +80,7 @@ export const acceptedInstallTypes = [
   INSTALL_STATE,
   START_DOWNLOAD,
   DOWNLOAD_PROGRESS,
-  START_INSTALL,
   INSTALL_COMPLETE,
-  START_UNINSTALL,
   UNINSTALL_COMPLETE,
   INSTALL_ERROR,
 ];
@@ -94,6 +92,8 @@ export const globalEventStatusMap = {
   onInstalled: INSTALLED,
   onUninstalling: UNINSTALLING,
   onUninstalled: UNINSTALLED,
+  onEnabling: ENABLING,
+  onDisabling: DISABLING,
 };
 
 // The events here are set directly on mozAddonManager

--- a/src/disco/constants.js
+++ b/src/disco/constants.js
@@ -1,15 +1,13 @@
 // Addon States.
+export const DISABLED = 'DISABLED';
 export const DOWNLOADING = 'DOWNLOADING';
+export const ENABLED = 'ENABLED';
 export const ERROR = 'ERROR';
 export const INSTALLED = 'INSTALLED';
 export const INSTALLING = 'INSTALLING';
 export const UNINSTALLED = 'UNINSTALLED';
 export const UNINSTALLING = 'UNINSTALLING';
 export const UNKNOWN = 'UNKNOWN';
-// Theme states
-export const DISABLED = 'DISABLED';
-export const ENABLED = 'ENABLED';
-
 export const validInstallStates = [
   DISABLED,
   ENABLED,
@@ -23,6 +21,7 @@ export const validInstallStates = [
   UNKNOWN,
 ];
 
+// Add-on error states.
 export const DOWNLOAD_FAILED = 'DOWNLOAD_FAILED';
 export const INSTALL_FAILED = 'INSTALL_FAILED';
 

--- a/src/disco/reducers/installations.js
+++ b/src/disco/reducers/installations.js
@@ -5,15 +5,11 @@ import {
   ENABLED,
   ERROR,
   INSTALLED,
-  INSTALLING,
   INSTALL_COMPLETE,
   INSTALL_ERROR,
   INSTALL_STATE,
   START_DOWNLOAD,
-  START_INSTALL,
-  START_UNINSTALL,
   UNINSTALLED,
-  UNINSTALLING,
   UNINSTALL_COMPLETE,
   acceptedInstallTypes,
 } from 'disco/constants';
@@ -49,14 +45,8 @@ export default function installations(state = {}, { type, payload }) {
     addon.status = DOWNLOADING;
   } else if (type === DOWNLOAD_PROGRESS) {
     addon.downloadProgress = payload.downloadProgress;
-  } else if (type === START_INSTALL) {
-    addon.downloadProgress = 100;
-    addon.status = INSTALLING;
   } else if (type === INSTALL_COMPLETE) {
     addon.status = INSTALLED;
-  } else if (type === START_UNINSTALL) {
-    addon.downloadProgress = 0;
-    addon.status = UNINSTALLING;
   } else if (type === UNINSTALL_COMPLETE) {
     addon.status = UNINSTALLED;
   /* istanbul ignore else */

--- a/src/disco/reducers/installations.js
+++ b/src/disco/reducers/installations.js
@@ -1,6 +1,8 @@
 import {
-  DOWNLOADING,
+  DISABLED,
   DOWNLOAD_PROGRESS,
+  DOWNLOADING,
+  ENABLED,
   ERROR,
   INSTALLED,
   INSTALLING,
@@ -17,6 +19,17 @@ import {
 } from 'disco/constants';
 
 
+function normalizeStatus(status) {
+  switch (status) {
+    case DISABLED:
+      return UNINSTALLED;
+    case ENABLED:
+      return INSTALLED;
+    default:
+      return status;
+  }
+}
+
 export default function installations(state = {}, { type, payload }) {
   if (!acceptedInstallTypes.includes(type)) {
     return state;
@@ -30,7 +43,7 @@ export default function installations(state = {}, { type, payload }) {
       guid: payload.guid,
       url: payload.url,
       downloadProgress: 0,
-      status: payload.status,
+      status: normalizeStatus(payload.status),
     };
   } else if (type === START_DOWNLOAD) {
     addon.status = DOWNLOADING;

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -303,7 +303,7 @@ describe('<Addon />', () => {
       return setCurrentStatus({guid, installURL})
         .then(() => {
           assert(dispatch.calledWith({
-            type: 'INSTALL_STATE',
+            type: INSTALL_STATE,
             payload: {guid, status: ENABLED, url: installURL},
           }));
         });
@@ -321,7 +321,7 @@ describe('<Addon />', () => {
       return setCurrentStatus({guid, installURL})
         .then(() => {
           assert(dispatch.calledWith({
-            type: 'INSTALL_STATE',
+            type: INSTALL_STATE,
             payload: {guid, status: DISABLED, url: installURL},
           }));
         });
@@ -338,7 +338,7 @@ describe('<Addon />', () => {
       return setCurrentStatus({guid, installURL})
         .then(() => {
           assert(dispatch.calledWith({
-            type: 'INSTALL_STATE',
+            type: INSTALL_STATE,
             payload: {guid, status: ENABLED, url: installURL},
           }));
         });
@@ -355,7 +355,7 @@ describe('<Addon />', () => {
       return setCurrentStatus({guid, installURL})
         .then(() => {
           assert(dispatch.calledWith({
-            type: 'INSTALL_STATE',
+            type: INSTALL_STATE,
             payload: {guid, status: DISABLED, url: installURL},
           }));
         });

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -13,14 +13,17 @@ import {
   mapStateToProps,
 } from 'disco/components/Addon';
 import {
+  DISABLED,
   DOWNLOAD_FAILED,
   DOWNLOAD_PROGRESS,
+  ENABLED,
   ERROR,
-  INSTALLED,
+  EXTENSION_TYPE,
   INSTALL_CATEGORY,
   INSTALL_COMPLETE,
   INSTALL_FAILED,
   INSTALL_STATE,
+  INSTALLED,
   START_DOWNLOAD,
   START_INSTALL,
   START_UNINSTALL,
@@ -291,7 +294,7 @@ describe('<Addon />', () => {
   });
 
   describe('setCurrentStatus', () => {
-    it('sets the status to INSTALLED when add-on found', () => {
+    it('sets the status to ENABLED when an enabled add-on found', () => {
       const dispatch = sinon.spy();
       const guid = '@foo';
       const installURL = 'http://the.url';
@@ -300,15 +303,34 @@ describe('<Addon />', () => {
       return setCurrentStatus({guid, installURL})
         .then(() => {
           assert(dispatch.calledWith({
-            type: INSTALL_STATE,
-            payload: {guid, status: INSTALLED, url: installURL},
+            type: 'INSTALL_STATE',
+            payload: {guid, status: ENABLED, url: installURL},
           }));
         });
     });
 
-    it('sets the status to INSTALLED when an installed theme is found', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper(
-        {getAddon: Promise.resolve({type: THEME_TYPE, isEnabled: true})});
+    it('sets the status to DISABLED when a disabled add-on found', () => {
+      const dispatch = sinon.spy();
+      const guid = '@foo';
+      const installURL = 'http://the.url';
+      const { setCurrentStatus } = mapDispatchToProps(dispatch, {
+        _addonManager: getFakeAddonManagerWrapper({
+          getAddon: Promise.resolve({type: EXTENSION_TYPE, isEnabled: false}),
+        }),
+      });
+      return setCurrentStatus({guid, installURL})
+        .then(() => {
+          assert(dispatch.calledWith({
+            type: 'INSTALL_STATE',
+            payload: {guid, status: DISABLED, url: installURL},
+          }));
+        });
+    });
+
+    it('sets the status to ENABLED when an enabled theme is found', () => {
+      const fakeAddonManager = getFakeAddonManagerWrapper({
+        getAddon: Promise.resolve({type: THEME_TYPE, isEnabled: true}),
+      });
       const dispatch = sinon.spy();
       const guid = '@foo';
       const installURL = 'http://the.url';
@@ -316,15 +338,16 @@ describe('<Addon />', () => {
       return setCurrentStatus({guid, installURL})
         .then(() => {
           assert(dispatch.calledWith({
-            type: INSTALL_STATE,
-            payload: {guid, status: INSTALLED, url: installURL},
+            type: 'INSTALL_STATE',
+            payload: {guid, status: ENABLED, url: installURL},
           }));
         });
     });
 
-    it('sets the status to UNINSTALLED when an uninstalled theme is found', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper(
-        {getAddon: Promise.resolve({type: THEME_TYPE, isEnabled: false})});
+    it('sets the status to DISABLED when a disabled theme is found', () => {
+      const fakeAddonManager = getFakeAddonManagerWrapper({
+        getAddon: Promise.resolve({type: THEME_TYPE, isEnabled: false}),
+      });
       const dispatch = sinon.spy();
       const guid = '@foo';
       const installURL = 'http://the.url';
@@ -332,8 +355,8 @@ describe('<Addon />', () => {
       return setCurrentStatus({guid, installURL})
         .then(() => {
           assert(dispatch.calledWith({
-            type: INSTALL_STATE,
-            payload: {guid, status: UNINSTALLED, url: installURL},
+            type: 'INSTALL_STATE',
+            payload: {guid, status: DISABLED, url: installURL},
           }));
         });
     });

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -23,10 +23,8 @@ import {
   INSTALL_COMPLETE,
   INSTALL_FAILED,
   INSTALL_STATE,
-  INSTALLED,
   START_DOWNLOAD,
   START_INSTALL,
-  START_UNINSTALL,
   THEME_INSTALL,
   THEME_PREVIEW,
   THEME_RESET_PREVIEW,
@@ -216,21 +214,24 @@ describe('<Addon />', () => {
         guid: 'foo@addon',
         downloadProgress: 75,
       };
-      assert.deepEqual(
-        mapStateToProps({
-          installations: {foo: {some: 'data'}, 'foo@addon': addon},
-          addons: {'foo@addon': {addonProp: 'addonValue'}},
-        }, {guid: 'foo@addon'}),
-        {guid: 'foo@addon', downloadProgress: 75, addonProp: 'addonValue'});
+      const props = mapStateToProps({
+        installations: {foo: {some: 'data'}, 'foo@addon': addon},
+        addons: {'foo@addon': {addonProp: 'addonValue'}},
+      }, {guid: 'foo@addon'});
+      assert.deepEqual(props, {
+        guid: 'foo@addon',
+        downloadProgress: 75,
+        addonProp: 'addonValue',
+        installTheme: props.installTheme,
+      });
     });
 
     it('handles missing data', () => {
-      assert.deepEqual(
-        mapStateToProps({
-          installations: {},
-          addons: {},
-        }, {guid: 'nope@addon'}),
-        {});
+      const props = mapStateToProps({
+        installations: {},
+        addons: {},
+      }, {guid: 'nope@addon'});
+      assert.deepEqual(props, {installTheme: props.installTheme});
     });
   });
 
@@ -243,28 +244,6 @@ describe('<Addon />', () => {
       assert(dispatch.calledWith({
         type: DOWNLOAD_PROGRESS,
         payload: {downloadProgress: 30, guid},
-      }));
-    });
-
-    it('sets status to installing on STATE_INSTALLING', () => {
-      const dispatch = sinon.spy();
-      const guid = 'foo@my-addon';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({state: 'STATE_INSTALLING'});
-      assert(dispatch.calledWith({
-        type: START_INSTALL,
-        payload: {guid},
-      }));
-    });
-
-    it('sets status to installed on STATE_INSTALLED', () => {
-      const dispatch = sinon.spy();
-      const guid = '{my-addon}';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({state: 'STATE_INSTALLED'});
-      assert(dispatch.calledWith({
-        type: INSTALL_COMPLETE,
-        payload: {guid},
       }));
     });
 
@@ -315,7 +294,25 @@ describe('<Addon />', () => {
       const installURL = 'http://the.url';
       const { setCurrentStatus } = mapDispatchToProps(dispatch, {
         _addonManager: getFakeAddonManagerWrapper({
-          getAddon: Promise.resolve({type: EXTENSION_TYPE, isEnabled: false}),
+          getAddon: Promise.resolve({type: EXTENSION_TYPE, isActive: false, isEnabled: false}),
+        }),
+      });
+      return setCurrentStatus({guid, installURL})
+        .then(() => {
+          assert(dispatch.calledWith({
+            type: INSTALL_STATE,
+            payload: {guid, status: DISABLED, url: installURL},
+          }));
+        });
+    });
+
+    it('sets the status to DISABLED when an inactive add-on found', () => {
+      const dispatch = sinon.spy();
+      const guid = '@foo';
+      const installURL = 'http://the.url';
+      const { setCurrentStatus } = mapDispatchToProps(dispatch, {
+        _addonManager: getFakeAddonManagerWrapper({
+          getAddon: Promise.resolve({type: EXTENSION_TYPE, isActive: false, isEnabled: true}),
         }),
       });
       return setCurrentStatus({guid, installURL})
@@ -329,7 +326,7 @@ describe('<Addon />', () => {
 
     it('sets the status to ENABLED when an enabled theme is found', () => {
       const fakeAddonManager = getFakeAddonManagerWrapper({
-        getAddon: Promise.resolve({type: THEME_TYPE, isEnabled: true}),
+        getAddon: Promise.resolve({type: THEME_TYPE, isActive: true, isEnabled: true}),
       });
       const dispatch = sinon.spy();
       const guid = '@foo';
@@ -344,9 +341,26 @@ describe('<Addon />', () => {
         });
     });
 
+    it('sets the status to DISABLED when an inactive theme is found', () => {
+      const fakeAddonManager = getFakeAddonManagerWrapper({
+        getAddon: Promise.resolve({type: THEME_TYPE, isActive: false, isEnabled: true}),
+      });
+      const dispatch = sinon.spy();
+      const guid = '@foo';
+      const installURL = 'http://the.url';
+      const { setCurrentStatus } = mapDispatchToProps(dispatch, {_addonManager: fakeAddonManager});
+      return setCurrentStatus({guid, installURL})
+        .then(() => {
+          assert(dispatch.calledWith({
+            type: INSTALL_STATE,
+            payload: {guid, status: DISABLED, url: installURL},
+          }));
+        });
+    });
+
     it('sets the status to DISABLED when a disabled theme is found', () => {
       const fakeAddonManager = getFakeAddonManagerWrapper({
-        getAddon: Promise.resolve({type: THEME_TYPE, isEnabled: false}),
+        getAddon: Promise.resolve({type: THEME_TYPE, isActive: true, isEnabled: false}),
       });
       const dispatch = sinon.spy();
       const guid = '@foo';
@@ -496,17 +510,6 @@ describe('<Addon />', () => {
           }));
         });
     });
-
-    it('should dispatch START_UNINSTALL', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      const dispatch = sinon.spy();
-      const { uninstall } = mapDispatchToProps(dispatch, {_addonManager: fakeAddonManager});
-      return uninstall({guid, installURL})
-        .then(() => assert(dispatch.calledWith({
-          type: START_UNINSTALL,
-          payload: {guid},
-        })));
-    });
   });
 
   describe('installTheme', () => {
@@ -515,36 +518,28 @@ describe('<Addon />', () => {
       const guid = '{install-theme}';
       const node = sinon.stub();
       const spyThemeAction = sinon.spy();
-      const dispatch = sinon.spy();
-      const { installTheme } = mapDispatchToProps(dispatch);
-      return installTheme(node, guid, name, spyThemeAction)
-        .then(() => {
-          assert(spyThemeAction.calledWith(node, THEME_INSTALL));
-          assert(dispatch.calledWith({
-            type: INSTALL_STATE,
-            payload: {guid, status: INSTALLED},
-          }));
-        });
+      const props = mapStateToProps({installations: {}, addons: {}}, {});
+      props.installTheme(node, guid, name, spyThemeAction);
+      assert(spyThemeAction.calledWith(node, THEME_INSTALL));
     });
 
     it('tracks a theme install', () => {
       const name = 'hai-theme';
       const guid = '{install-theme}';
       const node = sinon.stub();
-      const dispatch = sinon.spy();
       const spyThemeAction = sinon.spy();
       const fakeTracking = {
         sendEvent: sinon.spy(),
       };
-      const { installTheme } = mapDispatchToProps(dispatch, {_tracking: fakeTracking});
-      return installTheme(node, guid, name, spyThemeAction)
-        .then(() => {
-          assert(fakeTracking.sendEvent.calledWith({
-            action: 'theme',
-            category: INSTALL_CATEGORY,
-            label: 'hai-theme',
-          }));
-        });
+      const { installTheme } = mapStateToProps({installations: {}, addons: {}}, {}, {
+        _tracking: fakeTracking,
+      });
+      installTheme(node, guid, name, spyThemeAction);
+      assert(fakeTracking.sendEvent.calledWith({
+        action: 'theme',
+        category: INSTALL_CATEGORY,
+        label: 'hai-theme',
+      }));
     });
   });
 

--- a/tests/client/disco/reducers/test_installations.js
+++ b/tests/client/disco/reducers/test_installations.js
@@ -4,16 +4,14 @@ import {
   DOWNLOAD_PROGRESS,
   ENABLED,
   ERROR,
-  INSTALLED,
   INSTALL_COMPLETE,
   INSTALL_ERROR,
   INSTALL_STATE,
+  INSTALLED,
   INSTALLING,
   START_DOWNLOAD,
-  START_INSTALL,
-  START_UNINSTALL,
-  UNINSTALLED,
   UNINSTALL_COMPLETE,
+  UNINSTALLED,
   UNINSTALLING,
 } from 'disco/constants';
 import installations from 'disco/reducers/installations';
@@ -159,32 +157,6 @@ describe('installations reducer', () => {
       });
   });
 
-  it('updates the status and downloadProgress on START_INSTALL', () => {
-    const state = {
-      'my-addon@me.com': {
-        guid: 'my-addon@me.com',
-        url: 'https://cdn.amo/download/my-addon.xpi',
-        downloadProgress: 75,
-        status: DOWNLOADING,
-      },
-    };
-    assert.deepEqual(
-      installations(state, {
-        type: START_INSTALL,
-        payload: {
-          guid: 'my-addon@me.com',
-        },
-      }),
-      {
-        'my-addon@me.com': {
-          guid: 'my-addon@me.com',
-          url: 'https://cdn.amo/download/my-addon.xpi',
-          downloadProgress: 100,
-          status: INSTALLING,
-        },
-      });
-  });
-
   it('updates the status on INSTALL_COMPLETE', () => {
     const state = {
       'my-addon@me.com': {
@@ -207,32 +179,6 @@ describe('installations reducer', () => {
           url: 'https://cdn.amo/download/my-addon.xpi',
           downloadProgress: 100,
           status: INSTALLED,
-        },
-      });
-  });
-
-  it('updates the status on START_UNINSTALL', () => {
-    const state = {
-      'my-addon@me.com': {
-        guid: 'my-addon@me.com',
-        url: 'https://cdn.amo/download/my-addon.xpi',
-        downloadProgress: 100,
-        status: INSTALLED,
-      },
-    };
-    assert.deepEqual(
-      installations(state, {
-        type: START_UNINSTALL,
-        payload: {
-          guid: 'my-addon@me.com',
-        },
-      }),
-      {
-        'my-addon@me.com': {
-          guid: 'my-addon@me.com',
-          url: 'https://cdn.amo/download/my-addon.xpi',
-          downloadProgress: 0,
-          status: UNINSTALLING,
         },
       });
   });

--- a/tests/client/disco/reducers/test_installations.js
+++ b/tests/client/disco/reducers/test_installations.js
@@ -1,6 +1,8 @@
 import {
+  DISABLED,
   DOWNLOADING,
   DOWNLOAD_PROGRESS,
+  ENABLED,
   ERROR,
   INSTALLED,
   INSTALL_COMPLETE,
@@ -40,6 +42,44 @@ describe('installations reducer', () => {
         'my-addon@me.com': {
           guid: 'my-addon@me.com',
           url: 'https://cdn.amo/download/my-addon.xpi',
+          downloadProgress: 0,
+          status: UNINSTALLED,
+        },
+      });
+  });
+
+  it('treats ENABLED as INSTALLED in INSTALL_STATE', () => {
+    assert.deepEqual(
+      installations(undefined, {
+        type: 'INSTALL_STATE',
+        payload: {
+          guid: 'my-addon@me.com',
+          status: ENABLED,
+        },
+      }),
+      {
+        'my-addon@me.com': {
+          guid: 'my-addon@me.com',
+          url: undefined,
+          downloadProgress: 0,
+          status: INSTALLED,
+        },
+      });
+  });
+
+  it('treats DISABLED as UNINSTALLED in INSTALL_STATE', () => {
+    assert.deepEqual(
+      installations(undefined, {
+        type: 'INSTALL_STATE',
+        payload: {
+          guid: 'my-addon@me.com',
+          status: DISABLED,
+        },
+      }),
+      {
+        'my-addon@me.com': {
+          guid: 'my-addon@me.com',
+          url: undefined,
           downloadProgress: 0,
           status: UNINSTALLED,
         },

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -18,7 +18,7 @@ export function findByTag(root, tag) {
   return matches[0];
 }
 
-const enabledExtension = Promise.resolve({type: EXTENSION_TYPE, isEnabled: true});
+const enabledExtension = Promise.resolve({type: EXTENSION_TYPE, isActive: true, isEnabled: true});
 
 export function getFakeAddonManagerWrapper({ getAddon = enabledExtension } = {}) {
   return {

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createRenderer } from 'react-addons-test-utils';
+import { EXTENSION_TYPE } from 'disco/constants';
 
 export function shallowRender(stuff) {
   const renderer = createRenderer();
@@ -17,7 +18,9 @@ export function findByTag(root, tag) {
   return matches[0];
 }
 
-export function getFakeAddonManagerWrapper({ getAddon = Promise.resolve({type: 'addon'}) } = {}) {
+const enabledExtension = Promise.resolve({type: EXTENSION_TYPE, isEnabled: true});
+
+export function getFakeAddonManagerWrapper({ getAddon = enabledExtension } = {}) {
   return {
     getAddon: sinon.stub().returns(getAddon),
     install: sinon.stub().returns(Promise.resolve()),


### PR DESCRIPTION
This just treats `ENABLED` and `DISABLED` as `INSTALLED` and `UNINSTALLED`. I suppose that since `ENABLED` and `DISABLED` imply that it is installed we could get rid of `INSTALLED` but I kept it for now.

Fixes #540.