### PR TITLE
Add box-shadow to addon blocks

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -6,6 +6,7 @@ $addon-padding: 20px;
 .addon {
   align-items: center;
   background: #fff;
+  box-shadow: 0 1px 2px 0 rgba(0,0,0,0.2);
   display: flex;
   flex-direction: row;
   line-height: 1.5;


### PR DESCRIPTION
Fixes:  #548

@pwalm @designakt I've prepared this with 0.2 - but let me know what you think and if you prefer something else based on the screenshots in #548.

Before:
<img alt="discover_add-ons_and_comparing_mozilla_master___muffinresearch_add-box-shadow-to-addon-blocks_ _mozilla_addons-frontend" src="https://cloud.githubusercontent.com/assets/1514/15892194/553c4bd4-2d70-11e6-9bf0-97858504c79d.png">


After:
<img  alt="discover_add-ons_and_discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/15892182/3ff5870e-2d70-11e6-8a81-c4c98041b56b.png">
