### PR TITLE
Mobile Styles

### DIFF
--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -5,3 +5,15 @@
   box-shadow:0 0 5px 0 $focus-outline-color;
   outline:none;
 }
+
+@mixin respond-to($breakpoint) {
+  @if map-has-key($breakpoints, $breakpoint) {
+    @media #{map-get($breakpoints, $breakpoint)} {
+      @content;
+    }
+  }
+  @else {
+    @warn 'Unfortunately, no value could be retrieved from `#{$breakpoint}`. '
+    + 'Please make sure it is defined in `$breakpoints` map.';
+  }
+}

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -6,7 +6,7 @@ $addon-padding: 20px;
 .addon {
   align-items: center;
   background: #fff;
-  box-shadow: 0 1px 2px 0 rgba(0,0,0,0.1);
+  box-shadow: 0 1px 2px 0 rgba(0,0,0,0.2);
   display: flex;
   flex-direction: row;
   line-height: 1.5;
@@ -19,7 +19,7 @@ $addon-padding: 20px;
   .editorial-description {
     color: $secondary-font-color;
     font-size: 12px;
-    margin: 0.5em 0;
+    margin: 0.75em 0;
   }
 
   &.theme {
@@ -32,8 +32,10 @@ $addon-padding: 20px;
 
   .theme-image {
     display: block;
+    overflow: hidden;
 
     img {
+      float: right;
       display: block;
     }
 
@@ -47,11 +49,31 @@ $addon-padding: 20px;
     margin: 0 20px 0 30px;
   }
 
+  &:not(.theme) .install-button {
+    align-self: stretch;
+    border-top: 1px solid rgba(0,0,0,0.1);;
+    margin: 0 0 15px 0px;
+    padding: 15px 20px 0 20px;
+
+    > .switch {
+      float: right;
+    }
+  }
+
+  @include respond-to('large') {
+    &:not(.theme) .install-button {
+      align-self: center;
+      border: 0;
+      margin: 0 20px 0 30px;
+      padding: 0;
+    }
+  }
+
   .logo {
     align-items: center;
     align-self: stretch;
     display: flex;
-    padding: 0 15px;
+    padding: 0 10px;
 
     img {
       display: block;
@@ -60,9 +82,16 @@ $addon-padding: 20px;
     }
   }
 
+  @include respond-to('large') {
+    .logo {
+      padding: 0 15px;
+    }
+  }
+
   .heading {
     color: $primary-font-color;
-    font-size: 18px;
+    font-size: 14px;
+    line-height: 1.2;
     font-weight: medium;
     margin: 0;
 
@@ -73,6 +102,12 @@ $addon-padding: 20px;
     }
   }
 
+  @include respond-to('large') {
+    .heading {
+      font-size: 18px;
+    }
+  }
+
   .content {
     display: flex;
     align-items: center;
@@ -80,15 +115,32 @@ $addon-padding: 20px;
     flex-grow: 1;
     position: relative;
 
-
     .copy {
-      padding: 30px 20px;
+      padding: 20px 20px 15px;
       flex-grow: 1;
 
       // Remove the bottom margin of the last element.
       & :last-child {
         margin-bottom: 0;
       }
+    }
+
+    @include respond-to('large') {
+      .copy {
+        padding: 30px 20px;
+      }
+    }
+  }
+
+  &:not(.theme) .content {
+    flex-direction: column;
+    align-items: left;
+  }
+
+  @include respond-to('large') {
+    &:not(.theme) .content {
+      flex-direction: row;
+      align-items: center;
     }
   }
 

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -6,7 +6,7 @@ $addon-padding: 20px;
 .addon {
   align-items: center;
   background: #fff;
-  box-shadow: 0 1px 2px 0 rgba(0,0,0,0.2);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: row;
   line-height: 1.5;
@@ -51,8 +51,8 @@ $addon-padding: 20px;
 
   &:not(.theme) .install-button {
     align-self: stretch;
-    border-top: 1px solid rgba(0,0,0,0.1);;
-    margin: 0 0 15px 0px;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    margin: 0 0 15px 0;
     padding: 15px 20px 0 20px;
 
     > .switch {
@@ -152,7 +152,7 @@ $addon-padding: 20px;
     display: flex;
     flex-direction: row;
     left: 0;
-    padding: 15px 20px;
+    padding: 15px 80px 15px 20px;
     position: absolute;
     right: 0;
     top: 0;

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -30,22 +30,41 @@ img {
 .disco-pane {
   box-sizing: content-box;
   margin: 0 auto;
-  padding: 50px 20px;
-  width: 680px;
+  padding: 10px 20px 20px;
+  max-width: 680px;
+}
+
+@include respond-to('large') {
+  .disco-pane {
+    padding: 50px 20px 20px;
+  }
 }
 
 header {
-  border-bottom: 1px solid $header-border-color;
-  margin-bottom: 40px;
-  padding-bottom: 40px;
+  margin: 0 0 20px;
+  padding: 20px 0 0;
 
   h1 {
     color: $primary-font-color;
     display: block;
-    font-size: 20px;
+    font-size: 30px;
     font-weight: 400;
-    line-height: 1.5;
+    line-height: 1.1;
     margin: 0 0 20px;
+  }
+}
+
+@include respond-to('large') {
+  header {
+    background: inherit;
+    border-bottom: 1px solid $header-border-color;
+    padding: 0 0 40px;
+    margin: 0 0 40px;
+
+    h1 {
+      font-size: 20px;
+      line-height: 1.5;
+    }
   }
 }
 
@@ -85,19 +104,26 @@ header {
 
 .disco-content {
   color: $header-copy-font-color;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1.28;
-  margin-right: 50px;
-  width: 415px;
-
-  [dir=rtl] & {
-    margin-left: 50px;
-    margin-right: 0;
-  }
+  width: 100%;
 
   &:last-child {
     display: block;
     margin-bottom: 0;
+  }
+}
+
+@include respond-to('large') {
+  .disco-content {
+    font-size: 14px;
+    margin-right: 50px;
+    max-width: 415px;
+
+    [dir=rtl] & {
+      margin-left: 50px;
+      margin-right: 0;
+    }
   }
 }
 
@@ -151,7 +177,14 @@ header {
 }
 
 .video-wrapper {
+  display: none;
   position: relative;
+}
+
+@include respond-to('large') {
+  .video-wrapper {
+    display: block;
+  }
 }
 
 .play-video {

--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -6,3 +6,8 @@ $secondary-font-color: #6a6a6a;
 
 $header-copy-font-color: #414141;
 $header-border-color: #b1b1b1;
+
+$breakpoints: (
+  small: '(max-width: 719px)',
+  large: '(min-width: 720px)'
+);


### PR DESCRIPTION
I've ignored the bits we don't have for now and I've avoided trying to do the material-style buttons since we'd need quite a lot of changes to get that working in terms of modifications to the existing styles.

The breakpoints need playing with and tuning.

The tricky parts are:

* ~~When to switch the background (and turn off the 48px padding adjustment), we might need a better cue for that - we should think about how we can provide those hooks from the server (e.g. via the URL).~~

~~I'm thinking we could remove the background change part and leave the 48px padding and at least we have some steps towards being mobile compliant when the android UI makes changes towards exposing this page.~~ DONE

It looks like this (albeit the 48px is re-instated and the background is now consistent through-out):

![screen shot 2016-06-10 at 20 04 42](https://cloud.githubusercontent.com/assets/1514/15975731/e52d1dea-2f46-11e6-8864-6c8d340b1772.png)
![screen shot 2016-06-10 at 20 07 56](https://cloud.githubusercontent.com/assets/1514/15975772/200158fa-2f47-11e6-8051-741abc9a8dea.png)
![screen shot 2016-06-10 at 20 08 22](https://cloud.githubusercontent.com/assets/1514/15975774/24b0400a-2f47-11e6-9d98-2b0e97a8488f.png)

