### PR TITLE
Center play button text when wrapping

### DIFF
--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -170,7 +170,7 @@ header {
   background: rgba(0, 0, 0, 0.5);
   color: #fff;
   display: inline-block;
-  margin: 10px;
+  margin: 0 20px;
   padding: 10px;
   text-align: center;
   transition: background 300ms;

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -170,6 +170,7 @@ header {
   background: rgba(0, 0, 0, 0.5);
   color: #fff;
   display: inline-block;
+  margin: 10px;
   padding: 10px;
   text-align: center;
   transition: background 300ms;

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -171,6 +171,7 @@ header {
   color: #fff;
   display: inline-block;
   padding: 10px;
+  text-align: center;
   transition: background 300ms;
 
   &::before {


### PR DESCRIPTION
<img width="834" alt="screenshot 2016-06-14 14 25 26" src="https://cloud.githubusercontent.com/assets/211578/16044317/e030e522-323b-11e6-950d-03ce71a80466.png">

Fixes #517.