### PR TITLE
Remove frame-ancestors since x-frame-options DENY will suffice

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -11,12 +11,6 @@ module.exports = {
 
   CSP: {
     directives: {
-      // The location object in about:addons has '' for hostname and
-      // a value of `about:addons` for `frame-ancestors` is still blocked.
-      // However, the protocol in the location object is `about:`
-      // and with just `about:` as the value for frame-ancestors
-      // about:addons can iframe the disco pane.
-      frameAncestors: ['about:'],
       // Script is limited to the discovery specific CDN.
       scriptSrc: [
         staticHost,

--- a/config/default.js
+++ b/config/default.js
@@ -90,7 +90,6 @@ module.exports = {
       connectSrc: [apiHost],
       formAction: ["'none'"],
       frameSrc: ["'none'"],
-      frameAncestors: ["'none'"],
       imgSrc: [
         // Favicons are normally served
         // from the document host.

--- a/tests/server/TestCSPConfig.js
+++ b/tests/server/TestCSPConfig.js
@@ -61,12 +61,6 @@ describe('CSP Config', () => {
     assert.deepEqual(cspConfig.formAction, ["'none'"]);
   });
 
-  it('should default frame-ancestors to "\'none\'"', () => {
-    const config = requireUncached('config');
-    const cspConfig = config.get('CSP').directives;
-    assert.deepEqual(cspConfig.frameAncestors, ["'none'"]);
-  });
-
   it('should default frame-src to "\'none\'"', () => {
     const config = requireUncached('config');
     const cspConfig = config.get('CSP').directives;
@@ -132,18 +126,5 @@ describe('App Specific CSP Config', () => {
       'https://addons-discovery.cdn.mozilla.net',
       'https://www.google-analytics.com',
     ]);
-  });
-
-  it('should default frame-ancestors to "\'none\'"', () => {
-    const config = requireUncached('config');
-    const cspConfig = config.get('CSP').directives;
-    assert.deepEqual(cspConfig.frameAncestors, ["'none'"]);
-  });
-
-  it('should set frame-ancestors to about: to allow framing of disco pane', () => {
-    process.env.NODE_APP_INSTANCE = 'disco';
-    const config = requireUncached('config');
-    const cspConfig = config.get('CSP').directives;
-    assert.deepEqual(cspConfig.frameAncestors, ['about:']);
   });
 });


### PR DESCRIPTION
about:blank can be injected so frame-ancestors set to about: isn't useful. However, the x-frame-options DENY is still preventing framing (this works because about:addons seems to ignore that header but if you then try and iframe the page elsewhere that header prevents framing since it's set to DENY.

Since the the CSP 2 spec states frame-ancestors should take precedence over x-frame-options it seems to make sense to remove frame-ancestors for now in-case FF behaviour changes and follows the spec more closely. [1]

> The frame-ancestors directive obsoletes the X-Frame-Options header. If a resource has both policies, the frame-ancestors policy SHOULD be enforced and the X-Frame-Options policy SHOULD be ignored.

[1] https://www.w3.org/TR/CSP/#frame-ancestors-and-frame-options

Other apps will need to set frame-ancestors explicitly in an app specific config as needed. This is because falsey values won't remove that directive.



