### PR TITLE
UITour doorhanger on add-on install

### DIFF
--- a/src/disco/addonManager.js
+++ b/src/disco/addonManager.js
@@ -28,8 +28,18 @@ export function install(url, eventCallback,
         log.info(`[install] Adding listener for ${event}`);
         installObj.addEventListener(event, callback);
       }
-      log.info('Events to handle the installation initialized.');
-      return installObj.install();
+      return new Promise((resolve, reject) => {
+        installObj.addEventListener('onInstallEnded', () => {
+          console.log('resolving');
+          resolve();
+        });
+        installObj.addEventListener('onInstallFailed', () => {
+          console.log('rejecting');
+          reject();
+        });
+        log.info('Events to handle the installation initialized.');
+        installObj.install();
+      });
     });
 }
 

--- a/src/disco/addonManager.js
+++ b/src/disco/addonManager.js
@@ -29,14 +29,8 @@ export function install(url, eventCallback,
         installObj.addEventListener(event, callback);
       }
       return new Promise((resolve, reject) => {
-        installObj.addEventListener('onInstallEnded', () => {
-          console.log('resolving');
-          resolve();
-        });
-        installObj.addEventListener('onInstallFailed', () => {
-          console.log('rejecting');
-          reject();
-        });
+        installObj.addEventListener('onInstallEnded', () => resolve());
+        installObj.addEventListener('onInstallFailed', () => reject());
         log.info('Events to handle the installation initialized.');
         installObj.install();
       });

--- a/src/disco/components/InstallButton.js
+++ b/src/disco/components/InstallButton.js
@@ -44,7 +44,7 @@ export class InstallButton extends React.Component {
     if (type === THEME_TYPE && status === UNINSTALLED) {
       installTheme(this.refs.themeData, guid, name);
     } else if (status === UNINSTALLED) {
-      install({ guid, installURL, name });
+      install();
     } else if (status === INSTALLED) {
       uninstall({ guid, installURL, name, type });
     }

--- a/tests/client/disco/TestAddonManager.js
+++ b/tests/client/disco/TestAddonManager.js
@@ -82,7 +82,7 @@ describe('addonManager', () => {
       return addonManager.install(
         fakeInstallUrl, fakeCallback, { _mozAddonManager: fakeMozAddonManager })
         .then(
-          () => assert.ok(false, 'expected promise to reject'),
+          unexpectedSuccess,
           () => assert.ok(fakeInstallObj.install.called));
     });
 

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -445,7 +445,10 @@ describe('<Addon />', () => {
     it('calls addonManager.install()', () => {
       const fakeAddonManager = getFakeAddonManagerWrapper();
       const dispatch = sinon.spy();
-      const { install } = mapDispatchToProps(dispatch, { _addonManager: fakeAddonManager });
+      const i18n = getFakeI18nInst();
+      const { install } = mapDispatchToProps(
+        dispatch,
+        { _addonManager: fakeAddonManager, i18n, installURL });
       return install({ guid, installURL })
         .then(() => {
           assert(fakeAddonManager.install.calledWith(installURL, sinon.match.func));
@@ -456,12 +459,14 @@ describe('<Addon />', () => {
       const fakeAddonManager = getFakeAddonManagerWrapper();
       const name = 'hai-addon';
       const type = 'extension';
+      const i18n = getFakeI18nInst();
       const dispatch = sinon.spy();
       const fakeTracking = {
         sendEvent: sinon.spy(),
       };
-      const { install } = mapDispatchToProps(dispatch,
-        { _tracking: fakeTracking, _addonManager: fakeAddonManager });
+      const { install } = mapDispatchToProps(
+        dispatch,
+        { _tracking: fakeTracking, _addonManager: fakeAddonManager, i18n, name });
       return install({ guid, installURL, name, type })
         .then(() => {
           assert(fakeTracking.sendEvent.calledWith({
@@ -472,11 +477,13 @@ describe('<Addon />', () => {
         });
     });
 
-
     it('should dispatch START_DOWNLOAD', () => {
       const fakeAddonManager = getFakeAddonManagerWrapper();
+      const i18n = getFakeI18nInst();
       const dispatch = sinon.spy();
-      const { install } = mapDispatchToProps(dispatch, { _addonManager: fakeAddonManager });
+      const { install } = mapDispatchToProps(
+        dispatch,
+        { _addonManager: fakeAddonManager, guid, i18n });
       return install({ guid, installURL })
         .then(() => assert(dispatch.calledWith({
           type: START_DOWNLOAD,

--- a/tests/client/disco/components/TestInstallButton.js
+++ b/tests/client/disco/components/TestInstallButton.js
@@ -136,7 +136,7 @@ describe('<InstallButton />', () => {
     const button = renderButton({ guid, i18n, install, installURL, name, status: UNINSTALLED });
     const root = findDOMNode(button);
     Simulate.click(root);
-    assert(install.calledWith({ guid, installURL, name }));
+    assert(install.calledWith());
   });
 
   it('should call uninstall function on click when installed', () => {

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -46,6 +46,7 @@ export function getFakeI18nInst() {
     dpgettext: sinon.stub(),
     npgettext: sinon.stub(),
     dnpgettext: sinon.stub(),
+    sprintf: sinon.stub(),
   };
 }
 


### PR DESCRIPTION
Extra button states are missing since I don't have the latest uplift for that to work.

![install-doorhanger mov](https://cloud.githubusercontent.com/assets/211578/16156786/b70e0052-34ad-11e6-82ad-e3435c18d0a1.gif)

Fixes #565.