### PR TITLE
Remove focus outline for theme image hover

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -39,7 +39,6 @@ $addon-padding: 20px;
       display: block;
     }
 
-    &:hover,
     &:focus {
       @include focus();
     }


### PR DESCRIPTION
Fixes #614