### PR TITLE
Make css prefixing configurable

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -29,4 +29,6 @@ module.exports = {
   },
   trackingEnabled: true,
   trackingId: 'UA-36116321-7',
+
+  enablePostCssLoader: false,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -142,4 +142,6 @@ module.exports = {
   // and enabled on a per-app basis.
   trackingEnabled: false,
   trackingId: null,
+
+  enablePostCssLoader: true,
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,7 +44,7 @@ const newWebpackConfig = Object.assign({}, webpackConfigProd, {
       query: babelQuery,
     }, {
       test: /\.scss$/,
-      loader: 'style!css?importLoaders=2!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded',
+      loader: 'style!css?importLoaders=2!postcss!sass?outputStyle=expanded',
     }, {
       test: /\.svg$/,
       loader: 'url?limit=10000&mimetype=image/svg+xml',

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "url-loader": "0.5.7"
   },
   "devDependencies": {
-    "autoprefixer-loader": "3.2.0",
+    "autoprefixer": "6.3.6",
     "babel-core": "6.10.4",
     "babel-eslint": "6.1.0",
     "babel-gettext-extractor": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#f0f00b2afb71cba5edfb43d377bde9e1b08cdb46",
@@ -192,6 +192,7 @@
     "mocha": "2.5.3",
     "node-sass": "3.8.0",
     "po2json": "0.4.2",
+    "postcss-loader": "0.9.1",
     "react-addons-test-utils": "15.1.0",
     "react-dom": "15.1.0",
     "react-hot-loader": "1.3.0",

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -50,7 +50,6 @@ for (const app of appsBuildList) {
   ];
 }
 
-
 export default Object.assign({}, webpackConfig, {
   devtool: 'inline-source-map',
   context: path.resolve(__dirname),
@@ -69,7 +68,7 @@ export default Object.assign({}, webpackConfig, {
       query: BABEL_QUERY,
     }, {
       test: /\.scss$/,
-      loader: 'style!css?importLoaders=2!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded',
+      loader: 'style!css?importLoaders=2!postcss!sass?outputStyle=expanded',
     }, {
       test: /\.svg$/,
       loader: 'svg-url?limit=10000',

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
 
+import autoprefixer from 'autoprefixer';
 import path from 'path';
 
 import config from 'config';
@@ -22,8 +23,7 @@ for (const app of appsBuildList) {
   entryPoints[app] = `src/${app}/client`;
 }
 
-
-export default {
+const settings = {
   devtool: 'source-map',
   context: path.resolve(__dirname),
   progress: true,
@@ -42,7 +42,7 @@ export default {
         loader: 'babel',
       }, {
         test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style', 'css?importLoaders=2&sourceMap!autoprefixer?browsers=last 2 version!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true'),
+        loader: ExtractTextPlugin.extract('style', 'css?importLoaders=2&sourceMap!postcss!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true'),
       }, {
         test: /\.svg$/,
         loader: 'svg-url?limit=10000',
@@ -102,3 +102,11 @@ export default {
     extensions: ['', '.js', '.jsx'],
   },
 };
+
+if (config.get('enablePostCssLoader')) {
+  settings.postcss = [
+    autoprefixer({ browsers: ['last 2 versions'] }),
+  ];
+}
+
+export default settings;


### PR DESCRIPTION
Fixes #662

* Use postcss-loader since autoprefixer-loader is now deprecated
* Don't provide prefixing for the disco app CSS, since it's FF only.

Before:

24K 28 Jun 19:45 dist/disco-7ac5aeceb3f4b1a1f7d19076b057f2e8.css

After:

18K 28 Jun 19:50 dist/disco-6d88730d5d44d891a6eaa83f61d0e97d.css