### PR TITLE
Revert "Update karma to version 1.1.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "file-loader": "0.9.0",
     "glob": "7.0.5",
     "json-loader": "0.5.4",
-    "karma": "1.1.0",
+    "karma": "1.0.0",
     "karma-chai": "0.1.0",
     "karma-coverage": "1.0.0",
     "karma-coveralls": "1.1.2",


### PR DESCRIPTION
Reverts mozilla/addons-frontend#651

Due to `https://github.com/karma-runner/karma/issues/2210`