### PR TITLE
Fix up buttons and messages for RTL

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -208,11 +208,19 @@ $addon-padding: 20px;
     &.error {
       background: #c33c32 url('../img/warning.svg') no-repeat calc(100% - 40px) 50%;
       z-index: 20;
+
+      [dir=rtl] & {
+        background-position: 40px 50%;
+      }
     }
 
     &.restart {
       background: #70cf5b url('../img/restart.svg') no-repeat calc(100% - 40px) 50%;
       z-index: 10;
+
+      [dir=rtl] & {
+        background-position: 40px 50%;
+      }
     }
 
     .message {

--- a/src/disco/css/InstallButton.scss
+++ b/src/disco/css/InstallButton.scss
@@ -51,6 +51,7 @@ $installStripeColor2: #00c42e;
 }
 
 .switch {
+  direction: ltr;
   position: relative;
 
   input:focus + label {


### PR DESCRIPTION
Fixes:  #669

I've kept the button transition movement the same as ltr as a quick fix. If we think the button should be inverted for RTL then that will take longer and we should take a look at doing that separately.

Before:

![add-ons_manager](https://cloud.githubusercontent.com/assets/1514/16485213/8cfa1cbc-3eb5-11e6-924b-f96cc8d6c025.png)

After: 

![add-ons_manager](https://cloud.githubusercontent.com/assets/1514/16485199/764eceea-3eb5-11e6-9e76-d9bcfe840313.png)
