### PR TITLE
Enable disabled Add-ons

### DIFF
--- a/src/disco/addonManager.js
+++ b/src/disco/addonManager.js
@@ -4,6 +4,7 @@ import {
   globalEvents,
   globalEventStatusMap,
   installEventList,
+  SET_ENABLE_NOT_AVAILABLE,
 } from 'disco/constants';
 
 
@@ -73,4 +74,15 @@ export function addChangeListeners(callback, mozAddonManager) {
     log.info('mozAddonManager.addEventListener not available');
   }
   return handleChangeEvent;
+}
+
+export function enable(guid, { _mozAddonManager = window.navigator.mozAddonManager } = {}) {
+  return getAddon(guid, { _mozAddonManager })
+    .then((addon) => {
+      log.info(`Enable ${guid}`);
+      if (addon.setEnabled) {
+        return addon.setEnabled(true);
+      }
+      throw new Error(SET_ENABLE_NOT_AVAILABLE);
+    });
 }

--- a/src/disco/components/InstallButton.js
+++ b/src/disco/components/InstallButton.js
@@ -3,6 +3,8 @@ import translate from 'core/i18n/translate';
 
 import {
   DOWNLOADING,
+  DISABLED,
+  ENABLED,
   INSTALLED,
   THEME_TYPE,
   UNINSTALLED,
@@ -16,19 +18,20 @@ import 'disco/css/InstallButton.scss';
 
 export class InstallButton extends React.Component {
   static propTypes = {
-    handleChange: PropTypes.func,
+    downloadProgress: PropTypes.number,
+    enable: PropTypes.func,
     guid: PropTypes.string.isRequired,
+    handleChange: PropTypes.func,
+    i18n: PropTypes.object.isRequired,
     install: PropTypes.func.isRequired,
     installTheme: PropTypes.func.isRequired,
-    i18n: PropTypes.object.isRequired,
     installURL: PropTypes.string,
     name: PropTypes.string.isRequired,
-    uninstall: PropTypes.func.isRequired,
-    url: PropTypes.string,
-    downloadProgress: PropTypes.number,
     slug: PropTypes.string.isRequired,
     status: PropTypes.oneOf(validStates),
     type: PropTypes.oneOf(validAddonTypes),
+    uninstall: PropTypes.func.isRequired,
+    url: PropTypes.string,
   }
 
   static defaultProps = {
@@ -39,13 +42,15 @@ export class InstallButton extends React.Component {
   handleClick = (e) => {
     e.preventDefault();
     const {
-      guid, install, installURL, name, status, installTheme, type, uninstall,
+      guid, enable, install, installURL, name, status, installTheme, type, uninstall,
     } = this.props;
-    if (type === THEME_TYPE && status === UNINSTALLED) {
+    if (type === THEME_TYPE && [UNINSTALLED, DISABLED].includes(status)) {
       installTheme(this.refs.themeData, guid, name);
     } else if (status === UNINSTALLED) {
       install();
-    } else if (status === INSTALLED) {
+    } else if (status === DISABLED) {
+      enable();
+    } else if ([INSTALLED, ENABLED].includes(status)) {
       uninstall({ guid, installURL, name, type });
     }
   }
@@ -57,7 +62,7 @@ export class InstallButton extends React.Component {
       throw new Error('Invalid add-on status');
     }
 
-    const isInstalled = status === INSTALLED;
+    const isInstalled = [INSTALLED, ENABLED].includes(status);
     const isDisabled = status === UNKNOWN;
     const isDownloading = status === DOWNLOADING;
     const switchClasses = `switch ${status.toLowerCase()}`;

--- a/src/disco/constants.js
+++ b/src/disco/constants.js
@@ -111,3 +111,7 @@ export const globalEvents = Object.keys(globalEventStatusMap);
 
 export const SHOW_INFO = 'SHOW_INFO';
 export const CLOSE_INFO = 'CLOSE_INFO';
+
+// Error used to know that the setEnable method on addon is
+// not available.
+export const SET_ENABLE_NOT_AVAILABLE = 'SET_ENABLE_NOT_AVAILABLE';

--- a/src/disco/css/InstallButton.scss
+++ b/src/disco/css/InstallButton.scss
@@ -182,8 +182,12 @@ $installStripeColor2: #00c42e;
     }
   }
 
-  &.installed input + label::before {
-    background: $switchBackgroundOn url('../img/tick.svg') no-repeat 35% 50%;
+  // When add-on status is enabled installed is implied.
+  &.enabled,
+  &.installed {
+    input + label::before {
+      background: $switchBackgroundOn url('../img/tick.svg') no-repeat 35% 50%;
+    }
   }
 }
 

--- a/src/disco/reducers/installations.js
+++ b/src/disco/reducers/installations.js
@@ -1,8 +1,6 @@
 import {
-  DISABLED,
   DOWNLOAD_PROGRESS,
   DOWNLOADING,
-  ENABLED,
   ERROR,
   INSTALLED,
   INSTALL_COMPLETE,
@@ -14,17 +12,6 @@ import {
   acceptedInstallTypes,
 } from 'disco/constants';
 
-
-function normalizeStatus(status) {
-  switch (status) {
-    case DISABLED:
-      return UNINSTALLED;
-    case ENABLED:
-      return INSTALLED;
-    default:
-      return status;
-  }
-}
 
 export default function installations(state = {}, { type, payload }) {
   if (!acceptedInstallTypes.includes(type)) {
@@ -40,7 +27,7 @@ export default function installations(state = {}, { type, payload }) {
       url: payload.url,
       error: payload.error,
       downloadProgress: 0,
-      status: normalizeStatus(payload.status),
+      status: payload.status,
       needsRestart: payload.needsRestart || false,
     };
   } else if (type === START_DOWNLOAD) {

--- a/tests/client/disco/TestAddonManager.js
+++ b/tests/client/disco/TestAddonManager.js
@@ -3,6 +3,7 @@ import { unexpectedSuccess } from 'tests/client/helpers';
 import {
   globalEventStatusMap,
   installEventList,
+  SET_ENABLE_NOT_AVAILABLE,
 } from 'disco/constants';
 
 
@@ -152,5 +153,27 @@ describe('addonManager', () => {
     it('throws on unknown event', () => assert.throws(() => {
       handleChangeEvent({ type: 'whatevs' });
     }, Error, /Unknown global event/));
+  });
+
+  describe('enable()', () => {
+    it('should call addon.setEnable()', () => {
+      fakeAddon = {
+        setEnabled: sinon.stub(),
+      };
+      fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
+      return addonManager.enable('whatever', { _mozAddonManager: fakeMozAddonManager })
+        .then(() => {
+          assert.ok(fakeAddon.setEnabled.calledWith(true));
+        });
+    });
+
+    it('should throw if addon.setEnable does not exist', () => {
+      fakeAddon = {};
+      fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
+      return addonManager.enable('whatevs', { _mozAddonManager: fakeMozAddonManager })
+        .then(unexpectedSuccess, (err) => {
+          assert.equal(err.message, SET_ENABLE_NOT_AVAILABLE);
+        });
+    });
   });
 });

--- a/tests/client/disco/reducers/test_installations.js
+++ b/tests/client/disco/reducers/test_installations.js
@@ -71,7 +71,7 @@ describe('installations reducer', () => {
       });
   });
 
-  it('treats ENABLED as INSTALLED in INSTALL_STATE', () => {
+  it('handles ENABLED status in INSTALL_STATE', () => {
     assert.deepEqual(
       installations(undefined, {
         type: 'INSTALL_STATE',
@@ -86,13 +86,13 @@ describe('installations reducer', () => {
           error: undefined,
           guid: 'my-addon@me.com',
           needsRestart: false,
-          status: INSTALLED,
+          status: ENABLED,
           url: undefined,
         },
       });
   });
 
-  it('treats DISABLED as UNINSTALLED in INSTALL_STATE', () => {
+  it('handles DISABLED status in INSTALL_STATE', () => {
     assert.deepEqual(
       installations(undefined, {
         type: 'INSTALL_STATE',
@@ -107,7 +107,7 @@ describe('installations reducer', () => {
           error: undefined,
           guid: 'my-addon@me.com',
           needsRestart: false,
-          status: UNINSTALLED,
+          status: DISABLED,
           url: undefined,
         },
       });

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -22,10 +22,11 @@ const enabledExtension = Promise.resolve({ type: EXTENSION_TYPE, isActive: true,
 
 export function getFakeAddonManagerWrapper({ getAddon = enabledExtension } = {}) {
   return {
+    addChangeListeners: sinon.stub(),
+    enable: sinon.stub().returns(Promise.resolve()),
     getAddon: sinon.stub().returns(getAddon),
     install: sinon.stub().returns(Promise.resolve()),
     uninstall: sinon.stub().returns(Promise.resolve()),
-    addChangeListerners: sinon.stub(),
   };
 }
 


### PR DESCRIPTION
Fixes #547

* Makes `DISABLED` and `ENABLED` first-class states rather than being aliased.
* `ENABLED` shares the same styles as installed.
* Use the new browser API to enable an addon when it's been disabled
* Fallback to quietly logging an error (where logging is enabled e.g. -dev) if addon.setEnable is not present - this means landing this will work before and after the API is available.