### PR TITLE
Add height to theme to help initial layout

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -35,8 +35,9 @@ $addon-padding: 20px;
     overflow: hidden;
 
     img {
-      float: right;
       display: block;
+      float: right;
+      height: 100px;
     }
 
     &:focus {


### PR DESCRIPTION
Fixes #700

Defining the height of the theme image helps the layout be defined up-front without waiting for the images to be downloaded.