### PR TITLE
Prevent build and start without NODE_APP_INSTANCE

### DIFF
--- a/bin/build-checks.js
+++ b/bin/build-checks.js
@@ -8,19 +8,9 @@ const config = require('config');
 
 const appName = config.get('appName');
 
-if (!appName) {
+// Bail if appName isn't set unless explicitly enabled.
+if (!appName && process.env.ADDONS_FRONTEND_BUILD_ALL !== '1') {
   console.log(
     chalk.red('Please specify the appName with NODE_APP_INSTANCE'));
   process.exit(1);
 }
-
-if (config.util.getEnv('NODE_ENV') === 'development') {
-  if (!require('piping')({
-    hook: true,
-    ignore: /(\/\.|~$|\.json|\.scss$)/i,
-  })) {
-    return;
-  }
-}
-
-require('core/server/base').runServer();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "build": "better-npm-run build",
+    "build": "bin/build-checks.js && better-npm-run build",
     "extract-locales": "better-npm-run extract-locales",
     "build:disco": "better-npm-run build:disco",
     "build:search": "better-npm-run build:search",
@@ -15,7 +15,7 @@
     "eslint": "eslint .",
     "stylelint": "stylelint --syntax scss **/*.scss",
     "lint": "npm run eslint && npm run stylelint",
-    "servertest": "npm run build && better-npm-run servertest",
+    "servertest": "ADDONS_FRONTEND_BUILD_ALL=1 npm run build && better-npm-run servertest",
     "start": "npm run version-check && NODE_PATH='./:./src' node bin/server.js",
     "start:disco": "NODE_APP_INSTANCE=disco npm start",
     "start:search": "NODE_APP_INSTANCE=search npm start",


### PR DESCRIPTION
This prevents `npm run build` and `npm run start` from running without setting the name of the app via `NODE_APP_INSTANCE`.

Building all the apps is allowed with a special env var, this is because server tests still currently need to build all apps.