### PR TITLE
Remove build and run commands from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ WORKDIR /srv/code
 RUN rm -rf node_modules
 RUN ln -s /srv/node/node_modules
 
-RUN npm run build
-
 RUN GITREF=$(git rev-parse HEAD) \
 GITTAG=$(git name-rev --tags --name-only $GITREF) \
 SOURCE='https://github.com/mozilla/addons-frontend' && \


### PR DESCRIPTION
These commands currently fail to run since we require `NODE_APP_INSTANCE` and `NODE_ENV` to be set. Since we run these as part of the deployment process I don't think we need them here as part of the Docker image build process. 

r?