### PR TITLE
Revert "Always send an STS header on secure requests"

### DIFF
--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -46,9 +46,6 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
 
   app.use(logRequests);
 
-  // Set HSTS, note: helmet uses ms not seconds.
-  app.use(helmet.hsts({ maxAge: 31536000000 }));
-
   // Sets X-Frame-Options
   app.use(helmet.frameguard(config.get('frameGuard')));
 


### PR DESCRIPTION
Reverts mozilla/addons-frontend#720 

It's not working since the ssl looks to be terminating above the node service. Going to use force instead since we can be sure that aside from local development we'll always be using SSL.

I'll do a new PR for that which should make tracking it for a cherry-pick a bit easier.