### PR TITLE
Fix notification orientation for RTL

### DIFF
--- a/src/disco/css/InfoDialog.scss
+++ b/src/disco/css/InfoDialog.scss
@@ -12,6 +12,11 @@
   top: 10px;
   z-index: 20;
 
+  [dir=rtl] & {
+    left: 10px;
+    right: auto;
+  }
+
   .info {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
Fixes: #726

LTR:
<img width="675" alt="ltr" src="https://cloud.githubusercontent.com/assets/1514/16658698/385db48e-445f-11e6-855b-cd8f08e52e3e.png">

RTL:

<img width="721" alt="rtl" src="https://cloud.githubusercontent.com/assets/1514/16658703/3bedd624-445f-11e6-8371-651292c852ad.png">

