### PR TITLE
Reflect state of add-on/theme in label

### DIFF
--- a/src/disco/components/InstallButton.js
+++ b/src/disco/components/InstallButton.js
@@ -10,6 +10,7 @@ import {
   INSTALLED,
   THEME_TYPE,
   UNINSTALLED,
+  UNINSTALLING,
   UNKNOWN,
   validAddonTypes,
   validInstallStates as validStates,
@@ -41,6 +42,36 @@ export class InstallButton extends React.Component {
     downloadProgress: 0,
   }
 
+  getLabel() {
+    const { i18n, name, status } = this.props;
+    let label;
+    switch (status) {
+      case DOWNLOADING:
+        label = i18n.gettext('Downloading %(name)s.');
+        break;
+      case INSTALLING:
+        label = i18n.gettext('Installing %(name)s.');
+        break;
+      case ENABLED:
+      case INSTALLED:
+        label = i18n.gettext('%(name)s is installed and enabled. Click to uninstall.');
+        break;
+      case DISABLED:
+        label = i18n.gettext('%(name)s is disabled. Click to enable.');
+        break;
+      case UNINSTALLING:
+        label = i18n.gettext('Uninstalling %(name)s.');
+        break;
+      case UNINSTALLED:
+        label = i18n.gettext('%(name)s is uninstalled. Click to install.');
+        break;
+      default:
+        label = i18n.gettext('Install state for %(name)s is unknown.');
+        break;
+    }
+    return i18n.sprintf(label, { name });
+  }
+
   handleClick = (e) => {
     e.preventDefault();
     const {
@@ -58,7 +89,7 @@ export class InstallButton extends React.Component {
   }
 
   render() {
-    const { downloadProgress, i18n, slug, status } = this.props;
+    const { downloadProgress, slug, status } = this.props;
 
     if (!validStates.includes(status)) {
       throw new Error('Invalid add-on status');
@@ -84,7 +115,7 @@ export class InstallButton extends React.Component {
           type="checkbox" />
         <label htmlFor={identifier}>
           {isDownloading ? <div className="progress"></div> : null}
-          <span className="visually-hidden">{i18n.gettext('Install')}</span>
+          <span className="visually-hidden">{this.getLabel()}</span>
         </label>
       </div>
     );

--- a/tests/client/disco/components/TestInstallButton.js
+++ b/tests/client/disco/components/TestInstallButton.js
@@ -6,8 +6,9 @@ import {
   InstallButton,
 } from 'disco/components/InstallButton';
 import {
-  DOWNLOADING,
+  DISABLED,
   DISABLING,
+  DOWNLOADING,
   ENABLED,
   ENABLING,
   INSTALLED,
@@ -28,6 +29,8 @@ describe('<InstallButton />', () => {
       installTheme: sinon.spy(),
       uninstall: sinon.spy(),
       i18n: getFakeI18nInst(),
+      slug: 'foo',
+      name: 'test-addon',
       ...props,
     };
 
@@ -43,12 +46,26 @@ describe('<InstallButton />', () => {
     assert.ok(root.classList.contains('unknown'));
   });
 
+  it('should reflect DISABLED status', () => {
+    const button = renderButton({ status: DISABLED });
+    const root = findDOMNode(button);
+    const checkbox = root.querySelector('input[type=checkbox]');
+    assert.equal(checkbox.hasAttribute('disabled'), false);
+    assert.ok(root.classList.contains('disabled'));
+    const label = root.querySelector('label');
+    assert.include(label.textContent, 'test-addon is disabled');
+    assert.include(label.textContent, 'Click to enable');
+  });
+
   it('should reflect UNINSTALLED status', () => {
     const button = renderButton({ status: UNINSTALLED });
     const root = findDOMNode(button);
     const checkbox = root.querySelector('input[type=checkbox]');
     assert.equal(checkbox.hasAttribute('disabled'), false);
     assert.ok(root.classList.contains('uninstalled'));
+    const label = root.querySelector('label');
+    assert.include(label.textContent, 'test-addon is uninstalled');
+    assert.include(label.textContent, 'Click to install');
   });
 
   it('should reflect INSTALLED status', () => {
@@ -65,6 +82,9 @@ describe('<InstallButton />', () => {
     const checkbox = root.querySelector('input[type=checkbox]');
     assert.equal(checkbox.checked, true, 'checked is true');
     assert.ok(root.classList.contains('enabled'));
+    const label = root.querySelector('label');
+    assert.include(label.textContent, 'test-addon is installed and enabled');
+    assert.include(label.textContent, 'Click to uninstall');
   });
 
   it('should reflect download downloadProgress', () => {
@@ -72,6 +92,8 @@ describe('<InstallButton />', () => {
     const root = findDOMNode(button);
     assert.ok(root.classList.contains('downloading'));
     assert.equal(root.getAttribute('data-download-progress'), 50);
+    const label = root.querySelector('label');
+    assert.include(label.textContent, 'Downloading test-addon');
   });
 
   it('should reflect installation', () => {
@@ -80,6 +102,8 @@ describe('<InstallButton />', () => {
     assert.ok(root.classList.contains('installing'));
     const checkbox = root.querySelector('input[type=checkbox]');
     assert.equal(checkbox.checked, true, 'checked is true');
+    const label = root.querySelector('label');
+    assert.include(label.textContent, 'Installing test-addon');
   });
 
   it('should reflect ENABLING status', () => {
@@ -94,6 +118,8 @@ describe('<InstallButton />', () => {
     const button = renderButton({ status: UNINSTALLING });
     const root = findDOMNode(button);
     assert.ok(root.classList.contains('uninstalling'));
+    const label = root.querySelector('label');
+    assert.include(label.textContent, 'Uninstalling test-addon');
   });
 
   it('should not call anything on click when neither installed or uninstalled', () => {

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRenderer } from 'react-addons-test-utils';
 import { EXTENSION_TYPE } from 'disco/constants';
+import { sprintf } from 'jed';
 
 export function shallowRender(stuff) {
   const renderer = createRenderer();
@@ -47,7 +48,7 @@ export function getFakeI18nInst() {
     dpgettext: sinon.stub(),
     npgettext: sinon.stub(),
     dnpgettext: sinon.stub(),
-    sprintf: sinon.stub(),
+    sprintf: sinon.spy(sprintf),
   };
 }
 


### PR DESCRIPTION
Fixes #385 

This text content isn't visible but should mean that if a user is focused on the button the label is what should be read out by a screenreader. 