### PR TITLE
Add accept-language support

### DIFF
--- a/config/default-search.js
+++ b/config/default-search.js
@@ -18,4 +18,6 @@ module.exports = {
       ],
     },
   },
+
+  redirectLangPrefix: false,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -137,6 +137,8 @@ module.exports = {
   },
   rtlLangs: ['ar', 'dbr', 'fa', 'he'],
   defaultLang: 'en-US',
+  redirectLangPrefix: true,
+
   localeDir: path.resolve(path.join(__dirname, '../locale')),
 
   // This is off by default

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint": "eslint .",
     "stylelint": "stylelint --syntax scss **/*.scss",
     "lint": "npm run eslint && npm run stylelint",
-    "servertest": "ADDONS_FRONTEND_BUILD_ALL=1 npm run build && better-npm-run servertest",
+    "servertest": "ADDONS_FRONTEND_BUILD_ALL=1 npm run build && better-npm-run servertest && better-npm-run servertest:disco && better-npm-run servertest:search",
     "start": "npm run version-check && NODE_PATH='./:./src' node bin/server.js",
     "test": "better-npm-run test",
     "unittest": "better-npm-run unittest",
@@ -63,10 +63,26 @@
       }
     },
     "servertest": {
-      "command": "mocha --compilers js:babel-register --timeout 10000 --recursive tests/server/",
+      "command": "mocha --compilers js:babel-register --timeout 10000 tests/server/",
       "env": {
         "NODE_PATH": "./:./src",
         "NODE_ENV": "production"
+      }
+    },
+    "servertest:disco": {
+      "command": "mocha --compilers js:babel-register --timeout 10000 tests/server/disco",
+      "env": {
+        "NODE_PATH": "./:./src",
+        "NODE_ENV": "production",
+        "NODE_APP_INSTANCE": "disco"
+      }
+    },
+    "servertest:search": {
+      "command": "mocha --compilers js:babel-register --timeout 10000 tests/server/search",
+      "env": {
+        "NODE_PATH": "./:./src",
+        "NODE_ENV": "production",
+        "NODE_APP_INSTANCE": "search"
       }
     },
     "test": {

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -5,8 +5,7 @@ import App from './containers/App';
 import Home from './containers/Home';
 
 export default (
-  <Route path="/" component={App}>
+  <Route path="/(:lang/)" component={App}>
     <IndexRoute component={Home} />
-    <Route path="/:lang/" component={Home} />
   </Route>
 );

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -6,7 +6,7 @@ import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 import { ReduxAsyncConnect } from 'redux-async-connect';
-import { langToLocale, getLanguage } from 'core/i18n/utils';
+import { langToLocale, sanitizeLanguage } from 'core/i18n/utils';
 import I18nProvider from 'core/i18n/Provider';
 import Jed from 'jed';
 
@@ -18,7 +18,7 @@ export default function makeClient(routes, createStore) {
   let initialState;
 
   const html = document.querySelector('html');
-  const lang = getLanguage(html.getAttribute('lang'));
+  const lang = sanitizeLanguage(html.getAttribute('lang'));
   const locale = langToLocale(lang);
   const appName = config.get('appName');
 

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -59,11 +59,11 @@ export function normalizeLocale(locale) {
   return langToLocale(localeToLang(locale));
 }
 
-export function isValidLang(lang) {
-  return validLangs.includes(lang);
+export function isValidLang(lang, { _validLangs = validLangs } = {}) {
+  return _validLangs.includes(normalizeLang(lang));
 }
 
-export function getLanguage(langOrLocale) {
+export function sanitizeLanguage(langOrLocale) {
   let language = normalizeLang(langOrLocale);
   // Only look in the un-mapped lang list.
   if (!langs.includes(language)) {
@@ -73,7 +73,7 @@ export function getLanguage(langOrLocale) {
 }
 
 export function isRtlLang(lang) {
-  const language = getLanguage(lang);
+  const language = sanitizeLanguage(lang);
   return rtlLangs.includes(language);
 }
 
@@ -81,16 +81,85 @@ export function getDirection(lang) {
   return isRtlLang(lang) ? 'rtl' : 'ltr';
 }
 
-export function getLangFromRouter(renderProps) {
-  if (renderProps) {
-    // Get the lang from the url param by default
-    // if it exists.
-    if (renderProps.params && renderProps.params.lang) {
-      return getLanguage(renderProps.params.lang);
-    } else if (renderProps.location && renderProps.location.query &&
-               renderProps.location.query.lang) {
-      return getLanguage(renderProps.location.query.lang);
+
+function qualityCmp(a, b) {
+  if (a.quality === b.quality) {
+    return 0;
+  } else if (a.quality < b.quality) {
+    return 1;
+  }
+  return -1;
+}
+
+/*
+ * Parses the HTTP accept-language header and returns a
+ * sorted array of objects. Example object:
+ * {
+ *   lang: 'pl', quality: 0.7
+ * }
+ */
+export function parseAcceptLanguage(header) {
+  // pl,fr-FR;q=0.3,en-US;q=0.1
+  if (!header || !header.split) {
+    return [];
+  }
+  const rawLangs = header.split(',');
+  const langList = rawLangs.map((rawLang) => {
+    const parts = rawLang.split(';');
+    let q = 1;
+    if (parts.length > 1 && parts[1].indexOf('q=') === 0) {
+      const qVal = parseFloat(parts[1].split('=')[1]);
+      if (isNaN(qVal) === false) {
+        q = qVal;
+      }
+    }
+    return {
+      lang: parts[0].trim(),
+      quality: q,
+    };
+  });
+  langList.sort(qualityCmp);
+  return langList;
+}
+
+
+/*
+ * Given an accept-language header and a list of currently
+ * supported languages, returns the best match with no normalization.
+ *
+ */
+export function getLangFromHeader(acceptLanguage, { _validLangs } = {}) {
+  let userLang;
+  if (acceptLanguage) {
+    const langList = parseAcceptLanguage(acceptLanguage);
+    for (const langPref of langList) {
+      if (isValidLang(langPref.lang, { _validLangs })) {
+        userLang = langPref.lang;
+        break;
+      // Match locale, even if region isn't supported
+      } else if (isValidLang(langPref.lang.split('-')[0], { _validLangs })) {
+        userLang = langPref.lang.split('-')[0];
+        break;
+      }
     }
   }
-  return defaultLang;
+  return userLang;
+}
+
+/*
+ * Looks up the language from the router renderProps.
+ * When that fails fall-back to accept-language.
+ *
+ */
+export function getFilteredUserLanguage({ renderProps, acceptLanguage } = {}) {
+  let userLang;
+  // Get the lang from the url param by default if it exists.
+  if (renderProps && renderProps.params && renderProps.params.lang) {
+    userLang = renderProps.params.lang;
+  }
+  // If we don't have a valid userLang set yet try accept-language.
+  if (!isValidLang(userLang) && acceptLanguage) {
+    userLang = getLangFromHeader(acceptLanguage);
+  }
+  return sanitizeLanguage(userLang);
 }

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -94,9 +94,7 @@ function qualityCmp(a, b) {
 /*
  * Parses the HTTP accept-language header and returns a
  * sorted array of objects. Example object:
- * {
- *   lang: 'pl', quality: 0.7
- * }
+ * { lang: 'pl', quality: 0.7 }
  */
 export function parseAcceptLanguage(header) {
   // pl,fr-FR;q=0.3,en-US;q=0.1
@@ -107,7 +105,7 @@ export function parseAcceptLanguage(header) {
   const langList = rawLangs.map((rawLang) => {
     const parts = rawLang.split(';');
     let q = 1;
-    if (parts.length > 1 && parts[1].indexOf('q=') === 0) {
+    if (parts.length > 1 && parts[1].trim().indexOf('q=') === 0) {
       const qVal = parseFloat(parts[1].split('=')[1]);
       if (isNaN(qVal) === false) {
         q = qVal;

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -83,6 +83,11 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
     app.get('/', (req, res) => res.redirect(302, '/search'));
   }
 
+  if (appInstanceName === 'disco' && isDevelopment) {
+    app.get('/', (req, res) =>
+      res.redirect(302, '/en-US/firefox/discovery/pane/48.0/Darwin/normal'));
+  }
+
   app.use((req, res) => {
     if (isDevelopment) {
       log.info('Running in Development Mode');
@@ -126,11 +131,11 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
           const [_, firstPart, ...rest] = req.originalUrl.split('/');
           if (origLang === decodeURIComponent(firstPart)) {
             // The '' provides a leading /
-            return res.redirect(301, ['', lang, ...rest].join('/'));
+            return res.redirect(302, ['', lang, ...rest].join('/'));
           } else if (!origLang && config.get('redirectLangPrefix')) {
             // If there was no lang param. Redirect to the same URL with
             // a lang prepended.
-            return res.redirect(301, `/${lang}${req.originalUrl}`);
+            return res.redirect(302, `/${lang}${req.originalUrl}`);
           }
         }
       }

--- a/src/disco/routes.js
+++ b/src/disco/routes.js
@@ -5,10 +5,10 @@ import App from './containers/App';
 import DiscoPane from './containers/DiscoPane';
 
 export default (
-  <Route path="/" component={App}>
+  <Route path="/(:lang/)" component={App}>
     <IndexRoute component={DiscoPane} />
     <Route
-      path="/:lang/firefox/discovery/pane/:version/:platform/:compatibilityMode"
+      path="/(:lang/)firefox/discovery/pane/:version/:platform/:compatibilityMode"
       component={DiscoPane}
     />
   </Route>

--- a/src/disco/routes.js
+++ b/src/disco/routes.js
@@ -1,15 +1,14 @@
 import React from 'react';
-import { IndexRoute, Route } from 'react-router';
+import { Router, Route } from 'react-router';
 
 import App from './containers/App';
 import DiscoPane from './containers/DiscoPane';
 
 export default (
-  <Route path="/(:lang/)" component={App}>
-    <IndexRoute component={DiscoPane} />
+  <Router component={App}>
     <Route
       path="/(:lang/)firefox/discovery/pane/:version/:platform/:compatibilityMode"
       component={DiscoPane}
     />
-  </Route>
+  </Router>
 );

--- a/tests/client/core/i18n/test_utils.js
+++ b/tests/client/core/i18n/test_utils.js
@@ -102,6 +102,14 @@ describe('i18n utils', () => {
     it('should return a lang if handed a locale', () => {
       assert.equal(utils.sanitizeLanguage('en_US'), 'en-US');
     });
+
+    it('should return the default if handed undefined', () => {
+      assert.equal(utils.sanitizeLanguage(undefined), 'en-US');
+    });
+
+    it('should return the default if handed an empty string', () => {
+      assert.equal(utils.sanitizeLanguage(''), 'en-US');
+    });
   });
 
   describe('getDirection()', () => {
@@ -228,18 +236,46 @@ describe('i18n utils', () => {
 
     it('orders an accept-language header', () => {
       const input = 'fil;q=0.5,en;q=0.7';
-      assert.deepEqual(utils.parseAcceptLanguage(input), [
+      const result = utils.parseAcceptLanguage(input);
+      assert.deepEqual(result, [
         { lang: 'en', quality: 0.7 },
         { lang: 'fil', quality: 0.5 },
-      ], JSON.stringify(utils.parseAcceptLanguage(input)));
+      ], sinon.format(result));
+    });
+
+    it('deals with whitespace around delimiters except "="', () => {
+      const input = 'fil ; q=0.5 , en ; q=0.7';
+      const result = utils.parseAcceptLanguage(input);
+      assert.deepEqual(result, [
+        { lang: 'en', quality: 0.7 },
+        { lang: 'fil', quality: 0.5 },
+      ], sinon.format(result));
     });
 
     it('orders non-quality items higher', () => {
       const input = 'fil,en;q=0.7';
-      assert.deepEqual(utils.parseAcceptLanguage(input), [
+      const result = utils.parseAcceptLanguage(input);
+      assert.deepEqual(result, [
         { lang: 'fil', quality: 1 },
         { lang: 'en', quality: 0.7 },
-      ], JSON.stringify(utils.parseAcceptLanguage(input)));
+      ], sinon.format(result));
+    });
+
+    it('parses header where all entries have a quality value', () => {
+      const input = 'de; q=1.0, en; q=0.5';
+      const result = utils.parseAcceptLanguage(input);
+      assert.deepEqual(result, [
+        { lang: 'de', quality: 1 },
+        { lang: 'en', quality: 0.5 },
+      ], sinon.format(result));
+    });
+
+    it('handles entries with the same quality value', () => {
+      const input = 'de; q=0.5, en; q=0.5';
+      assert.deepEqual(utils.parseAcceptLanguage(input), [
+        { lang: 'de', quality: 0.5 },
+        { lang: 'en', quality: 0.5 },
+      ], sinon.format(utils.parseAcceptLanguage(input)));
     });
   });
 

--- a/tests/client/core/i18n/test_utils.js
+++ b/tests/client/core/i18n/test_utils.js
@@ -82,25 +82,25 @@ describe('i18n utils', () => {
     });
   });
 
-  describe('getLanguage()', () => {
+  describe('sanitizeLanguage()', () => {
     it('should get a standard language ', () => {
-      assert.equal(utils.getLanguage('ar'), 'ar');
+      assert.equal(utils.sanitizeLanguage('ar'), 'ar');
     });
 
     it('should convert short form lang to longer', () => {
-      assert.equal(utils.getLanguage('en'), 'en-US');
+      assert.equal(utils.sanitizeLanguage('en'), 'en-US');
     });
 
     it('should return the default if lookup not present', () => {
-      assert.equal(utils.getLanguage('awooga'), 'en-US');
+      assert.equal(utils.sanitizeLanguage('awooga'), 'en-US');
     });
 
     it('should return the default if bad type', () => {
-      assert.equal(utils.getLanguage(1), 'en-US');
+      assert.equal(utils.sanitizeLanguage(1), 'en-US');
     });
 
     it('should return a lang if handed a locale', () => {
-      assert.equal(utils.getLanguage('en_US'), 'en-US');
+      assert.equal(utils.sanitizeLanguage('en_US'), 'en-US');
     });
   });
 
@@ -144,10 +144,35 @@ describe('i18n utils', () => {
     });
   });
 
-  describe('getLangFromRouter()', () => {
+  describe('getFilteredUserLanguage()', () => {
+    it('should return default lang if called without args', () => {
+      assert.equal(utils.getFilteredUserLanguage(), config.get('defaultLang'));
+    });
+
     it('should return default lang if no lang is provided', () => {
       const fakeRenderProps = {};
-      assert.equal(utils.getLangFromRouter(fakeRenderProps), config.get('defaultLang'));
+      const result = utils.getFilteredUserLanguage({ renderProps: fakeRenderProps });
+      assert.equal(result, config.get('defaultLang'));
+    });
+
+    it('should return default lang if bad lang is provided', () => {
+      const fakeRenderProps = {
+        params: {
+          lang: 'bogus',
+        },
+      };
+      const result = utils.getFilteredUserLanguage({ renderProps: fakeRenderProps });
+      assert.equal(result, config.get('defaultLang'));
+    });
+
+    it('should return default lang if bad lang type provided', () => {
+      const fakeRenderProps = {
+        params: {
+          lang: 1,
+        },
+      };
+      const result = utils.getFilteredUserLanguage({ renderProps: fakeRenderProps });
+      assert.equal(result, config.get('defaultLang'));
     });
 
     it('should return lang if provided via the URL', () => {
@@ -156,32 +181,146 @@ describe('i18n utils', () => {
           lang: 'fr',
         },
       };
-      assert.equal(utils.getLangFromRouter(fakeRenderProps), 'fr');
+      assert.equal(utils.getFilteredUserLanguage({ renderProps: fakeRenderProps }), 'fr');
     });
 
-    it('should return lang if provided via a query param', () => {
-      const fakeRenderProps = {
-        location: {
-          query: {
-            lang: 'pt-PT',
-          },
-        },
-      };
-      assert.equal(utils.getLangFromRouter(fakeRenderProps), 'pt-PT');
-    });
-
-    it('should use url param if both that and query string are present', () => {
+    it('should fall-back to accept-language', () => {
       const fakeRenderProps = {
         params: {
-          lang: 'fr',
-        },
-        location: {
-          query: {
-            lang: 'pt-PT',
-          },
+          lang: 'bogus',
         },
       };
-      assert.equal(utils.getLangFromRouter(fakeRenderProps), 'fr');
+      const acceptLanguage = 'pt-br;q=0.5,en-us;q=0.3,en;q=0.2';
+      const result = utils.getFilteredUserLanguage(
+        { renderProps: fakeRenderProps, acceptLanguage });
+      assert.equal(result, 'pt-BR');
+    });
+
+    it('should map lang from accept-language too', () => {
+      const fakeRenderProps = {
+        params: {
+          lang: 'wat',
+        },
+      };
+      const acceptLanguage = 'pt;q=0.5,en-us;q=0.3,en;q=0.2';
+      const result = utils.getFilteredUserLanguage(
+        { renderProps: fakeRenderProps, acceptLanguage });
+      assert.equal(result, 'pt-PT');
+    });
+
+    it('should fallback when nothing matches', () => {
+      const fakeRenderProps = {
+        params: {
+          lang: 'wat',
+        },
+      };
+      const acceptLanguage = 'awooga;q=0.5';
+      const result = utils.getFilteredUserLanguage(
+        { renderProps: fakeRenderProps, acceptLanguage });
+      assert.equal(result, 'en-US');
+    });
+  });
+
+  describe('utils.parseAcceptLanguage()', () => {
+    it('returns an empty list if no arg is passed', () => {
+      assert.deepEqual(utils.parseAcceptLanguage(), []);
+    });
+
+    it('orders an accept-language header', () => {
+      const input = 'fil;q=0.5,en;q=0.7';
+      assert.deepEqual(utils.parseAcceptLanguage(input), [
+        { lang: 'en', quality: 0.7 },
+        { lang: 'fil', quality: 0.5 },
+      ], JSON.stringify(utils.parseAcceptLanguage(input)));
+    });
+
+    it('orders non-quality items higher', () => {
+      const input = 'fil,en;q=0.7';
+      assert.deepEqual(utils.parseAcceptLanguage(input), [
+        { lang: 'fil', quality: 1 },
+        { lang: 'en', quality: 0.7 },
+      ], JSON.stringify(utils.parseAcceptLanguage(input)));
+    });
+  });
+
+  describe('utils.getLangFromHeader()', () => {
+    it('should find an exact language match for Punjabi', () => {
+      const acceptLanguage = 'pa,sv;q=0.8,fi;q=0.7,it-ch;q=0.5,en-us;q=0.3,en;q=0.2';
+      const supportedLangs = ['af', 'en-US', 'pa'];
+      const result = utils.getLangFromHeader(acceptLanguage, { _validLangs: supportedLangs });
+      assert.equal(result, 'pa');
+    });
+
+    it('should find an exact language match for Punjabi India', () => {
+      const acceptLanguage = 'pa-in,sv;q=0.8,fi;q=0.7,it-ch;q=0.5,en-us;q=0.3,en;q=0.2';
+      const supportedLangs = ['af', 'en-US', 'pa'];
+      const result = utils.getLangFromHeader(acceptLanguage, { _validLangs: supportedLangs });
+      assert.equal(result, 'pa');
+    });
+
+    it('should not extend into region unless exact match is found', () => {
+      const acceptLanguage = 'pa,sv;q=0.8,fi;q=0.7,it-ch;q=0.5,en-us;q=0.3,en;q=0.2';
+      const supportedLangs = ['af', 'en-US', 'pa-IN'];
+      const result = utils.getLangFromHeader(acceptLanguage, { _validLangs: supportedLangs });
+      assert.equal(result, 'en-us');
+    });
+
+    it('should not match Finnish to Filipino (Philiippines)', () => {
+      const acceptLanguage = dedent`fil-PH,fil;q=0.97,en-US;q=0.94,en;q=0.91,en-ph;
+        q=0.89,en-gb;q=0.86,hu-HU;q=0.83,hu;q=0.8,en-AU;q=0.77,en-nl;
+        q=0.74,nl-en;q=0.71,nl;q=0.69,en-HK;q=0.66,en-sg;q=0.63,en-th;
+        q=0.6,pl-PL;q=0.57,pl;q=0.54,fr-FR;q=0.51,fr;q=0.49,en-AE;
+        q=0.46,zh-CN;q=0.43,zh;q=0.4,ja-JP;q=0.37,ja;q=0.34,id-ID;
+        q=0.31,id;q=0.29,ru-RU;q=0.26,ru;q=0.23,de-DE;q=0.2,de;
+        q=0.17,ko-KR;q=0.14,ko;q=0.11,es-ES;q=0.09,es;q=0.06,en-AP;q=0.0`;
+      const supportedLangs = ['en-US', 'fi'];
+      const result = utils.getLangFromHeader(acceptLanguage, { _validLangs: supportedLangs });
+      assert.equal(result, 'en-US');
+    });
+
+    it('should support Filipino (Philippines)', () => {
+      const acceptLanguage = dedent`fil-PH,fil;q=0.97,en-US;q=0.94,en;q=0.91,en-ph;
+        q=0.89,en-gb;q=0.86,hu-HU;q=0.83,hu;q=0.8,en-AU;q=0.77,en-nl;
+        q=0.74,nl-en;q=0.71,nl;q=0.69,en-HK;q=0.66,en-sg;q=0.63,en-th;
+        q=0.6,pl-PL;q=0.57,pl;q=0.54,fr-FR;q=0.51,fr;q=0.49,en-AE;
+        q=0.46,zh-CN;q=0.43,zh;q=0.4,ja-JP;q=0.37,ja;q=0.34,id-ID;
+        q=0.31,id;q=0.29,ru-RU;q=0.26,ru;q=0.23,de-DE;q=0.2,de;
+        q=0.17,ko-KR;q=0.14,ko;q=0.11,es-ES;q=0.09,es;q=0.06,en-AP;q=0.0`;
+      const supportedLangs = ['en-US', 'fi', 'fil-PH'];
+      const result = utils.getLangFromHeader(acceptLanguage, { _validLangs: supportedLangs });
+      assert.equal(result, 'fil-PH');
+    });
+
+    it('should support Filipino without region', () => {
+      const acceptLanguage = dedent`fil-PH,fil;q=0.97,en-US;q=0.94,en;q=0.91,en-ph;
+        q=0.89,en-gb;q=0.86,hu-HU;q=0.83,hu;q=0.8,en-AU;q=0.77,en-nl;
+        q=0.74,nl-en;q=0.71,nl;q=0.69,en-HK;q=0.66,en-sg;q=0.63,en-th;
+        q=0.6,pl-PL;q=0.57,pl;q=0.54,fr-FR;q=0.51,fr;q=0.49,en-AE;
+        q=0.46,zh-CN;q=0.43,zh;q=0.4,ja-JP;q=0.37,ja;q=0.34,id-ID;
+        q=0.31,id;q=0.29,ru-RU;q=0.26,ru;q=0.23,de-DE;q=0.2,de;
+        q=0.17,ko-KR;q=0.14,ko;q=0.11,es-ES;q=0.09,es;q=0.06,en-AP;q=0.0`;
+      const supportedLangs = ['en-US', 'fi', 'fil'];
+      const result = utils.getLangFromHeader(acceptLanguage, { _validLangs: supportedLangs });
+      assert.equal(result, 'fil');
+    });
+
+    it('should return undefined language for no match', () => {
+      const acceptLanguage = 'whatever';
+      const supportedLangs = ['af', 'en-US', 'pa'];
+      const result = utils.getLangFromHeader(acceptLanguage, { _validLangs: supportedLangs });
+      assert.equal(result, undefined);
+    });
+
+    it('should return undefined for empty string', () => {
+      const acceptLanguage = '';
+      const result = utils.getLangFromHeader(acceptLanguage);
+      assert.equal(result, undefined);
+    });
+
+    it('should return undefined for bad type', () => {
+      const acceptLanguage = null;
+      const result = utils.getLangFromHeader(acceptLanguage);
+      assert.equal(result, undefined);
     });
   });
 });

--- a/tests/server/disco/TestCSPConfig.js
+++ b/tests/server/disco/TestCSPConfig.js
@@ -1,19 +1,7 @@
 import { assert } from 'chai';
-import requireUncached from 'require-uncached';
+import config from 'config';
 
 describe('Disco App Specific CSP Config', () => {
-  let config;
-
-  afterEach(() => {
-    process.env.NODE_ENV = 'production';
-    delete process.env.NODE_APP_INSTANCE;
-  });
-
-  beforeEach(() => {
-    process.env.NODE_APP_INSTANCE = 'disco';
-    config = requireUncached('config');
-  });
-
   it('should set style-src for disco', () => {
     const cspConfig = config.get('CSP').directives;
     assert.deepEqual(cspConfig.styleSrc, ['https://addons-discovery.cdn.mozilla.net']);

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -8,6 +8,7 @@ import Policy from 'csp-parse';
 
 import { checkSRI } from '../helpers';
 
+const defaultURL = '/en-US/firefox/discovery/pane/48.0/Darwin/normal';
 
 describe('Discovery Pane GET requests', () => {
   let app;
@@ -22,7 +23,7 @@ describe('Discovery Pane GET requests', () => {
   });
 
   it('should have a CSP policy for / on the disco app', () => request(app)
-    .get('/en-US/')
+    .get(defaultURL)
     .expect(200)
     .then((res) => {
       const policy = new Policy(res.header['content-security-policy']);
@@ -33,13 +34,21 @@ describe('Discovery Pane GET requests', () => {
     }));
 
   it('should be using SRI for script and style in /', () => request(app)
-    .get('/en-US/')
+    .get(defaultURL)
     .expect(200)
     .then((res) => checkSRI(res)));
 
+  it('should be a 404 for requests to /', () => request(app)
+    .get('/')
+    .expect(404));
+
+  it('should be a 404 for requests to /en-US/', () => request(app)
+    .get('/en-US/')
+    .expect(404));
+
   it('should redirect an invalid locale', () => request(app)
     .get('/whatevs/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(301)
+    .expect(302)
     .then((res) => {
       assert.equal(res.header.location,
         '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
@@ -47,7 +56,7 @@ describe('Discovery Pane GET requests', () => {
 
   it('should redirect an invalid locale which will be encoded', () => request(app)
     .get('/<script>/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(301)
+    .expect(302)
     .then((res) => {
       assert.equal(res.header.location,
         '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
@@ -55,7 +64,7 @@ describe('Discovery Pane GET requests', () => {
 
   it('should redirect an invalid locale which will be encoded', () => request(app)
     .get('/AC%2fDC/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(301)
+    .expect(302)
     .then((res) => {
       assert.equal(res.header.location,
         '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
@@ -63,7 +72,7 @@ describe('Discovery Pane GET requests', () => {
 
   it('should redirect an aliased lang', () => request(app)
     .get('/pt/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(301)
+    .expect(302)
     .then((res) => {
       assert.equal(res.header.location,
         '/pt-PT/firefox/discovery/pane/48.0/Darwin/normal');
@@ -71,7 +80,7 @@ describe('Discovery Pane GET requests', () => {
 
   it('should redirect a missing lang to default', () => request(app)
     .get('/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(301)
+    .expect(302)
     .then((res) => {
       assert.equal(res.header.location,
         '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
@@ -79,7 +88,7 @@ describe('Discovery Pane GET requests', () => {
 
   it('should correct incorrect case', () => request(app)
     .get('/pt-br/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(301)
+    .expect(302)
     .then((res) => {
       assert.equal(res.header.location,
         '/pt-BR/firefox/discovery/pane/48.0/Darwin/normal');
@@ -87,14 +96,14 @@ describe('Discovery Pane GET requests', () => {
 
   it('should not replace more than it should', () => request(app)
     .get('/48.0/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(301)
+    .expect(302)
     .then((res) => {
       assert.equal(res.header.location,
         '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
     }));
 
   it('should set an HSTS header', () => request(app)
-    .get('/48.0/firefox/discovery/pane/48.0/Darwin/normal')
+    .get('/en-US/firefox/discovery/pane/48.0/Darwin/normal')
     .then((res) => {
       assert.equal(res.header['strict-transport-security'], 'max-age=31536000');
     }));

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -22,67 +22,75 @@ describe('Discovery Pane GET requests', () => {
   });
 
   it('should have a CSP policy for / on the disco app', () => request(app)
-    .get('/')
+    .get('/en-US/')
     .expect(200)
     .then((res) => {
       const policy = new Policy(res.header['content-security-policy']);
       assert.notInclude(policy.get('script-src'), "'self'");
-      assert.include(policy.get('script-src'), 'https://addons.cdn.mozilla.net');
+      assert.include(policy.get('script-src'), 'https://addons-discovery.cdn.mozilla.net');
       assert.notInclude(policy.get('connect-src'), "'self'");
       assert.include(policy.get('connect-src'), 'https://addons.mozilla.org');
     }));
 
   it('should be using SRI for script and style in /', () => request(app)
-    .get('/')
+    .get('/en-US/')
     .expect(200)
     .then((res) => checkSRI(res)));
 
   it('should redirect an invalid locale', () => request(app)
-    .get('/whatevs/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl')
+    .get('/whatevs/firefox/discovery/pane/48.0/Darwin/normal')
     .expect(301)
     .then((res) => {
       assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl');
+        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
     }));
 
   it('should redirect an invalid locale which will be encoded', () => request(app)
-    .get('/<script>/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl')
+    .get('/<script>/firefox/discovery/pane/48.0/Darwin/normal')
     .expect(301)
     .then((res) => {
       assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl');
+        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
     }));
 
   it('should redirect an invalid locale which will be encoded', () => request(app)
-    .get('/AC%2fDC/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl')
+    .get('/AC%2fDC/firefox/discovery/pane/48.0/Darwin/normal')
     .expect(301)
     .then((res) => {
       assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl');
+        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
     }));
 
   it('should redirect an aliased lang', () => request(app)
-    .get('/pt/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl')
+    .get('/pt/firefox/discovery/pane/48.0/Darwin/normal')
     .expect(301)
     .then((res) => {
       assert.equal(res.header.location,
-        '/pt-PT/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl');
+        '/pt-PT/firefox/discovery/pane/48.0/Darwin/normal');
+    }));
+
+  it('should redirect a missing lang to default', () => request(app)
+    .get('/firefox/discovery/pane/48.0/Darwin/normal')
+    .expect(301)
+    .then((res) => {
+      assert.equal(res.header.location,
+        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
     }));
 
   it('should correct incorrect case', () => request(app)
-    .get('/pt-br/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl')
+    .get('/pt-br/firefox/discovery/pane/48.0/Darwin/normal')
     .expect(301)
     .then((res) => {
       assert.equal(res.header.location,
-        '/pt-BR/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl');
+        '/pt-BR/firefox/discovery/pane/48.0/Darwin/normal');
     }));
 
   it('should not replace more than it should', () => request(app)
-    .get('/48.0/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl')
+    .get('/48.0/firefox/discovery/pane/48.0/Darwin/normal')
     .expect(301)
     .then((res) => {
       assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal?lang=dbl');
+        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
     }));
 
   it('should set an HSTS header', () => request(app)

--- a/tests/server/helpers.js
+++ b/tests/server/helpers.js
@@ -13,9 +13,11 @@ export function checkSRI(res) {
   const $script = $('script[src]');
   assert.ok($script.length > 0, 'must be at least 1 script');
   $script.each((i, elem) => {
-    assert.include($(elem).attr('integrity'),
-      'sha512', 'script should have integrity attr');
-    assert.equal($(elem).attr('crossorigin'),
-      'anonymous', 'script should have crossorigin attr');
+    if (!$(elem).attr('src').includes('analytics.js')) {
+      assert.include($(elem).attr('integrity'),
+        'sha512', 'script should have integrity attr');
+      assert.equal($(elem).attr('crossorigin'),
+        'anonymous', 'script should have crossorigin attr');
+    }
   });
 }

--- a/tests/server/search/TestViews.js
+++ b/tests/server/search/TestViews.js
@@ -8,7 +8,7 @@ import Policy from 'csp-parse';
 
 import { checkSRI } from '../helpers';
 
-describe('Seach App GET requests', () => {
+describe('Search App GET requests', () => {
   let app;
 
   before(() => runServer({ listen: false, app: 'search' })

--- a/tests/server/search/TestViews.js
+++ b/tests/server/search/TestViews.js
@@ -26,7 +26,7 @@ describe('Seach App GET requests', () => {
     .then((res) => {
       const policy = new Policy(res.header['content-security-policy']);
       assert.notInclude(policy.get('script-src'), "'self'");
-      assert.include(policy.get('script-src'), 'https://addons.cdn.mozilla.net');
+      assert.include(policy.get('script-src'), 'https://addons-admin.cdn.mozilla.net');
       assert.notInclude(policy.get('connect-src'), "'self'");
       assert.include(policy.get('connect-src'), 'https://addons.mozilla.org');
     }));


### PR DESCRIPTION
* Add accept-language fallback to lang lookup (this is derived from mozilla/i18n-abide code + tests).
* remove lang query-string support since it's superfluous.
* Make routes with lang (optional) makes it possible to redirect if lang isn't supplied.
* Improve server tests, splits them up so that passing NODE_APP_INSTANCE is done correctly - which required some test fixes since not passing the NODE_APP_INSTANCE meant some of the older tests were wrong.