### PR TITLE
Fix min-width

### DIFF
--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -42,8 +42,9 @@ img {
 .disco-pane {
   box-sizing: content-box;
   margin: 0 auto;
-  padding: 10px 20px 20px;
   max-width: 680px;
+  min-width: 260px; // 300 - (20px + 20px)
+  padding: 10px 20px 20px;
 }
 
 @include respond-to('large') {


### PR DESCRIPTION
Fixes #767 - forces scrollbars if discopane width drops below 300px

![discover_add-ons](https://cloud.githubusercontent.com/assets/1514/16872860/8e1301e4-4a87-11e6-8bab-01c73689be87.png)
