### PR TITLE
Use full path to analytics for CSP

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -37,7 +37,7 @@ module.exports = {
       // Script is limited to the discovery specific CDN.
       scriptSrc: [
         staticHost,
-        'https://www.google-analytics.com',
+        'https://www.google-analytics.com/analytics.js',
       ],
       styleSrc: [staticHost],
       imgSrc: [

--- a/config/dev-disco.js
+++ b/config/dev-disco.js
@@ -8,7 +8,7 @@ module.exports = {
     directives: {
       scriptSrc: [
         staticHost,
-        'https://www.google-analytics.com',
+        'https://www.google-analytics.com/analytics.js',
       ],
       styleSrc: [staticHost],
       imgSrc: [

--- a/config/stage-disco.js
+++ b/config/stage-disco.js
@@ -8,7 +8,7 @@ module.exports = {
     directives: {
       scriptSrc: [
         staticHost,
-        'https://www.google-analytics.com',
+        'https://www.google-analytics.com/analytics.js',
       ],
       styleSrc: [staticHost],
       imgSrc: [

--- a/tests/server/disco/TestCSPConfig.js
+++ b/tests/server/disco/TestCSPConfig.js
@@ -22,7 +22,8 @@ describe('Disco App Specific CSP Config', () => {
   it('should set script-src for disco', () => {
     const cspConfig = config.get('CSP').directives;
     assert.deepEqual(cspConfig.scriptSrc, [
-      'https://addons-discovery.cdn.mozilla.net', 'https://www.google-analytics.com']);
+      'https://addons-discovery.cdn.mozilla.net',
+      'https://www.google-analytics.com/analytics.js']);
   });
 
   it('should set media-src for disco', () => {


### PR DESCRIPTION
Fixes #784

This sets an explicit path for script-src for google-analytics as opposed to just the host.