### PR TITLE
Add a uitests specific config

### DIFF
--- a/config/uitests-disco.js
+++ b/config/uitests-disco.js
@@ -1,0 +1,25 @@
+const amoCDN = 'https://addons.cdn.mozilla.net';
+
+module.exports = {
+  staticHost: '',
+
+  CSP: {
+    directives: {
+      scriptSrc: [
+        "'self'",
+        'https://www.google-analytics.com',
+      ],
+      styleSrc: ["'self'"],
+      imgSrc: [
+        "'self'",
+        'data:',
+        amoCDN,
+        'https://www.google-analytics.com',
+      ],
+      mediaSrc: ["'self'"],
+    },
+  },
+
+  enableNodeStatics: true,
+  enableTracking: false,
+};


### PR DESCRIPTION
Fixes #795

@davehunt can you check this PR out and verify it works for you. The config ensures the statics are served locally and allowed with CSP and that the tracking is off.

```
docker build .
...snip
Successfully built 9bfec4e5af1c
...snip
docker run -p 4000:4000 -e NODE_APP_INSTANCE=disco -e NODE_ENV=uitests 9bfec4e5af1c /bin/sh -c "npm run build && npm run start"
```

Results in this:

<img width="478" alt="discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/16988539/a6a6cab0-4e88-11e6-883c-6ce332671b42.png">
