### PR TITLE
Add application redirects + vary headers

### DIFF
--- a/config/default-search.js
+++ b/config/default-search.js
@@ -19,5 +19,5 @@ module.exports = {
     },
   },
 
-  redirectLangPrefix: false,
+  enablePrefixMiddleware: false,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -140,7 +140,8 @@ module.exports = {
   },
   rtlLangs: ['ar', 'dbr', 'fa', 'he'],
   defaultLang: 'en-US',
-  redirectLangPrefix: true,
+
+  enablePrefixMiddleware: true,
 
   localeDir: path.resolve(path.join(__dirname, '../locale')),
 
@@ -150,4 +151,14 @@ module.exports = {
   trackingId: null,
 
   enablePostCssLoader: true,
+
+  // The list of valid client application names. These are derived from UA strings when
+  // not supplied in the URL.
+  validClientApplications: [
+    'firefox',
+    'android',
+  ],
+
+  // The default app used in the URL.
+  defaultClientApp: 'firefox',
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint": "eslint .",
     "stylelint": "stylelint --syntax scss **/*.scss",
     "lint": "npm run eslint && npm run stylelint",
-    "servertest": "ADDONS_FRONTEND_BUILD_ALL=1 npm run build && better-npm-run servertest && better-npm-run servertest:disco && better-npm-run servertest:search",
+    "servertest": "ADDONS_FRONTEND_BUILD_ALL=1 npm run build && better-npm-run servertest && better-npm-run servertest:amo && better-npm-run servertest:disco && better-npm-run servertest:search",
     "start": "npm run version-check && NODE_PATH='./:./src' node bin/server.js",
     "test": "better-npm-run test",
     "unittest": "better-npm-run unittest",
@@ -67,6 +67,15 @@
       "env": {
         "NODE_PATH": "./:./src",
         "NODE_ENV": "production",
+        "TRACKING_ENABLED": "false"
+      }
+    },
+    "servertest:amo": {
+      "command": "mocha --compilers js:babel-register --timeout 10000 tests/server/amo",
+      "env": {
+        "NODE_PATH": "./:./src",
+        "NODE_ENV": "production",
+        "NODE_APP_INSTANCE": "amo",
         "TRACKING_ENABLED": "false"
       }
     },

--- a/src/amo/containers/DetailPage.js
+++ b/src/amo/containers/DetailPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default class DetailPage extends React.Component {
+  render() {
+    return (
+      <div>
+        <h1>Detail Page</h1>
+      </div>
+    );
+  }
+}

--- a/src/amo/css/App.scss
+++ b/src/amo/css/App.scss
@@ -4,5 +4,5 @@
 
 html,
 body {
-  background: red;
+  background: #fff;
 }

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -3,9 +3,11 @@ import { IndexRoute, Route } from 'react-router';
 
 import App from './containers/App';
 import Home from './containers/Home';
+import DetailPage from './containers/DetailPage';
 
 export default (
-  <Route path="/(:lang/)" component={App}>
+  <Route path="/:lang/:application" component={App}>
     <IndexRoute component={Home} />
+    <Route path="addon/:slug/" component={DetailPage} />
   </Route>
 );

--- a/src/core/client/logger.js
+++ b/src/core/client/logger.js
@@ -34,7 +34,7 @@ export function bindConsoleMethod(consoleMethodName, { _consoleObj = window.cons
 }
 
 const log = {};
-['log', 'info', 'error', 'warn'].forEach((logMethodName) => {
+['log', 'debug', 'info', 'error', 'warn'].forEach((logMethodName) => {
   log[logMethodName] = bindConsoleMethod(logMethodName);
 });
 

--- a/src/core/middleware.js
+++ b/src/core/middleware.js
@@ -1,0 +1,82 @@
+import { getClientApp, isValidClientApp } from 'core/utils';
+import { getLanguage, isValidLang } from 'core/i18n/utils';
+import config from 'config';
+import log from 'core/logger';
+
+
+export function prefixMiddleWare(req, res, next, { _config = config } = {}) {
+  // Split on slashes after removing the leading slash.
+  const URLParts = req.originalUrl.replace(/^\//, '').split('/');
+  log.debug(URLParts);
+
+  // Get lang and app parts from the URL. At this stage they may be incorrect
+  // or missing.
+  const [langFromURL, appFromURL] = URLParts;
+
+  // Get language from URL or fall-back to detecting it from accept-language header.
+  const acceptLanguage = req.headers['accept-language'];
+  const { lang, isLangFromHeader } = getLanguage({ lang: langFromURL, acceptLanguage });
+
+  const hasValidLang = isValidLang(langFromURL);
+  const hasValidClientApp = isValidClientApp(appFromURL, { _config });
+
+  let prependedLang = false;
+
+  if ((hasValidLang && langFromURL !== lang) ||
+      (!hasValidLang && hasValidClientApp)) {
+    // Replace the first part of the URL if:
+    // * It's valid and we've mapped it e.g: pt -> pt-PT.
+    // * The lang is invalid but we have a valid application
+    //   e.g. /bogus/firefox/.
+    log.info(`Replacing lang in URL ${URLParts[0]} -> ${lang}`);
+    URLParts[0] = lang;
+  } else if (!hasValidLang) {
+    // If lang wasn't valid or was missing prepend one.
+    log.info(`Prepending lang to URL: ${lang}`);
+    URLParts.splice(0, 0, lang);
+    prependedLang = true;
+  }
+
+  let isApplicationFromHeader = false;
+
+  if (!hasValidClientApp && prependedLang &&
+      isValidClientApp(URLParts[1], { _config })) {
+    // We skip prepending an app if we'd previously prepended a lang and the
+    // 2nd part of the URL is now a valid app.
+    log.info('Application in URL is valid following prepending a lang.');
+  } else if (!hasValidClientApp) {
+    // If the app supplied is not valid we need to prepend one.
+    const application = getClientApp(req.headers['user-agent']);
+    log.info(`Prepending application to URL: ${application}`);
+    URLParts.splice(1, 0, application);
+    isApplicationFromHeader = true;
+  }
+
+  // Redirect to the new URL.
+  // For safety we'll deny a redirect to a URL starting with '//' since
+  // that will be treated as a protocol-free URL.
+  const newURL = `/${URLParts.join('/')}`;
+  if (newURL !== req.originalUrl && !newURL.startsWith('//')) {
+    // Collect vary headers to apply to the redirect
+    // so we can make it cacheable.
+    // TODO: Make the redirects cacheable by adding expires headers.
+    const varyHeaders = [];
+    if (isLangFromHeader) {
+      varyHeaders.push('accept-language');
+    }
+    if (isApplicationFromHeader) {
+      varyHeaders.push('user-agent');
+    }
+    res.set('vary', varyHeaders);
+    return res.redirect(302, newURL);
+  }
+
+  // Add the data to res.locals to be utilised later.
+  /* eslint-disable no-param-reassign */
+  const [newLang, newApp] = URLParts;
+  res.locals.lang = newLang;
+  res.locals.clientApp = newApp;
+  /* eslint-enable no-param-reassign */
+
+  return next();
+}

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -11,6 +11,7 @@ import ReactDOM from 'react-dom/server';
 import { Provider } from 'react-redux';
 import { match } from 'react-router';
 import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
+import { prefixMiddleWare } from 'core/middleware';
 
 import WebpackIsomorphicTools from 'webpack-isomorphic-tools';
 import WebpackIsomorphicToolsConfig from 'webpack-isomorphic-tools-config';
@@ -20,7 +21,7 @@ import config from 'config';
 import { convertBoolean } from 'core/utils';
 import { setLang, setJWT } from 'core/actions';
 import log from 'core/logger';
-import { getDirection, getFilteredUserLanguage, langToLocale } from 'core/i18n/utils';
+import { getDirection, isValidLang, langToLocale } from 'core/i18n/utils';
 import I18nProvider from 'core/i18n/Provider';
 import Jed from 'jed';
 
@@ -91,9 +92,14 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
       res.redirect(302, '/en-US/firefox/discovery/pane/48.0/Darwin/normal'));
   }
 
+  // Handle application and lang redirections.
+  if (config.get('enablePrefixMiddleware')) {
+    app.use(prefixMiddleWare);
+  }
+
   app.use((req, res) => {
     if (isDevelopment) {
-      log.info('Running in Development Mode');
+      log.info('Clearing require cache for webpack isomorphic tools. [Development Mode]');
 
       // clear require() cache if in development mode
       webpackIsomorphicTools.refresh();
@@ -121,28 +127,9 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
         fs.readFileSync(path.join(config.get('basePath'), 'dist/sri.json'))
       ) : {};
 
-      const acceptLanguage = req.headers['accept-language'];
-      // Get language from URL or fall-back to accept-language.
-      const lang = getFilteredUserLanguage({ renderProps, acceptLanguage });
-
-      if (renderProps.params) {
-        const origLang = renderProps.params.lang;
-        if (lang !== origLang) {
-          // If a lang was provided but the lang looked up is different
-          // redirect to the looked-up lang (or default).
-          // eslint-disable-next-line no-unused-vars
-          const [_, firstPart, ...rest] = req.originalUrl.split('/');
-          if (origLang === decodeURIComponent(firstPart)) {
-            // The '' provides a leading /
-            return res.redirect(302, ['', lang, ...rest].join('/'));
-          } else if (!origLang && config.get('redirectLangPrefix')) {
-            // If there was no lang param. Redirect to the same URL with
-            // a lang prepended.
-            return res.redirect(302, `/${lang}${req.originalUrl}`);
-          }
-        }
-      }
-
+      // Check the lang supplied by res.locals.lang for validity
+      // or fall-back to the default.
+      const lang = isValidLang(res.locals.lang) ? res.locals.lang : config.get('defaultLang');
       const dir = getDirection(lang);
       const locale = langToLocale(lang);
       store.dispatch(setLang(lang));
@@ -181,8 +168,8 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
               jedData = require(`json!../../locale/${locale}/${appInstanceName}.json`);
             }
           } catch (e) {
-            log.info(dedent`Locale not found or required for locale: "${locale}".
-              Falling back to default lang: "${config.get('defaultLang')}"`);
+            log.info(`Locale JSON not found or required for locale: "${locale}"`);
+            log.info(`Falling back to default lang: "${config.get('defaultLang')}".`);
           }
           const i18n = new Jed(jedData);
           const InitialComponent = (

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -1,4 +1,5 @@
 import camelCase from 'camelcase';
+import config from 'config';
 
 export function gettext(str) {
   return str;
@@ -37,4 +38,13 @@ export function convertBoolean(value) {
     default:
       return false;
   }
+}
+
+export function getClientApp() {
+  // TODO: Look at user-agent header passed in.
+  return 'firefox';
+}
+
+export function isValidClientApp(value, { _config = config } = {}) {
+  return _config.get('validClientApplications').includes(value);
 }

--- a/src/disco/routes.js
+++ b/src/disco/routes.js
@@ -7,7 +7,7 @@ import DiscoPane from './containers/DiscoPane';
 export default (
   <Router component={App}>
     <Route
-      path="/(:lang/)firefox/discovery/pane/:version/:platform/:compatibilityMode"
+      path="/:lang/firefox/discovery/pane/:version/:platform/:compatibilityMode"
       component={DiscoPane}
     />
   </Router>

--- a/tests/client/amo/containers/TestDetail.js
+++ b/tests/client/amo/containers/TestDetail.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import {
+  renderIntoDocument,
+} from 'react-addons-test-utils';
+
+import DetailPage from 'amo/containers/DetailPage';
+
+
+describe('DetailPage', () => {
+  it('renders a heading', () => {
+    const root = renderIntoDocument(<DetailPage />);
+    const rootNode = findDOMNode(root);
+    assert.include(rootNode.querySelector('h1').textContent, 'Detail Page');
+  });
+});

--- a/tests/client/core/test_middleware.js
+++ b/tests/client/core/test_middleware.js
@@ -1,0 +1,121 @@
+import { prefixMiddleWare } from 'core/middleware';
+
+describe('Prefix Middleware', () => {
+  let fakeRes;
+  let fakeNext;
+  let fakeConfig;
+
+  beforeEach(() => {
+    fakeNext = sinon.stub();
+    fakeRes = {
+      locals: {},
+      redirect: sinon.stub(),
+      set: sinon.stub(),
+    };
+    fakeConfig = new Map();
+    fakeConfig.set('validClientApplications', ['firefox', 'android']);
+  });
+
+  it('should call res.redirect if changing the case', () => {
+    const fakeReq = {
+      originalUrl: '/en-us/firefox',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/en-US/firefox']);
+    assert.notOk(fakeNext.called);
+  });
+
+  it('should call res.redirect if handed a locale insted of a lang', () => {
+    const fakeReq = {
+      originalUrl: '/en_US/firefox',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/en-US/firefox']);
+    assert.notOk(fakeNext.called);
+  });
+
+  it('should add an application when missing', () => {
+    const fakeReq = {
+      originalUrl: '/en-US/whatever/',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/en-US/firefox/whatever/']);
+  });
+
+  it('should prepend a lang when missing but leave a valid app intact', () => {
+    const fakeReq = {
+      originalUrl: '/firefox/whatever',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/en-US/firefox/whatever']);
+    assert.deepEqual(fakeRes.set.firstCall.args, ['vary', []]);
+  });
+
+  it('should fallback to and vary on accept-language headers', () => {
+    const fakeReq = {
+      originalUrl: '/firefox/whatever',
+      headers: {
+        'accept-language': 'pt-br;q=0.5,en-us;q=0.3,en;q=0.2',
+      },
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/pt-BR/firefox/whatever']);
+    assert.sameMembers(fakeRes.set.firstCall.args[1], ['accept-language']);
+  });
+
+  it('should map aliased langs', () => {
+    const fakeReq = {
+      originalUrl: '/pt/firefox/whatever',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/pt-PT/firefox/whatever']);
+  });
+
+  it('should vary on accept-language and user-agent', () => {
+    const fakeReq = {
+      originalUrl: '/whatever',
+      headers: {
+        'accept-language': 'pt-br;q=0.5,en-us;q=0.3,en;q=0.2',
+      },
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/pt-BR/firefox/whatever']);
+    assert.sameMembers(fakeRes.set.firstCall.args[1], ['accept-language', 'user-agent']);
+  });
+
+  it('should populate res.locals for a sane request', () => {
+    const fakeReq = {
+      originalUrl: '/en-US/firefox/',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.equal(fakeRes.locals.lang, 'en-US');
+    assert.equal(fakeRes.locals.clientApp, 'firefox');
+    assert.notOk(fakeRes.redirect.called);
+  });
+
+  it('should not populate res.locals for a redirection', () => {
+    const fakeReq = {
+      originalUrl: '/foo/bar',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.equal(fakeRes.locals.lang, undefined);
+    assert.equal(fakeRes.locals.clientApp, undefined);
+    assert.ok(fakeRes.redirect.called);
+  });
+
+  it('should not mangle a query string for a redirect', () => {
+    const fakeReq = {
+      originalUrl: '/foo/bar?test=1&bar=2',
+      headers: {},
+    };
+    prefixMiddleWare(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    assert.deepEqual(fakeRes.redirect.firstCall.args, [302, '/en-US/firefox/foo/bar?test=1&bar=2']);
+  });
+});

--- a/tests/client/core/test_tracking.js
+++ b/tests/client/core/test_tracking.js
@@ -23,7 +23,6 @@ describe('Tracking', () => {
         info: sinon.stub(),
       },
     });
-    // eslint-disable-next-line no-underscore-dangle
     assert.ok(tracking._log.info.calledWith(sinon.match(/OFF/), 'Tracking init'));
   });
 
@@ -35,7 +34,6 @@ describe('Tracking', () => {
         info: sinon.stub(),
       },
     });
-    // eslint-disable-next-line no-underscore-dangle
     assert.ok(tracking._log.info.secondCall.calledWith(sinon.match(/OFF/), 'Missing tracking id'));
   });
 

--- a/tests/client/core/test_utils.js
+++ b/tests/client/core/test_utils.js
@@ -1,4 +1,10 @@
-import { camelCaseProps, convertBoolean, getClientConfig } from 'core/utils';
+import {
+  camelCaseProps,
+  convertBoolean,
+  getClientApp,
+  getClientConfig,
+  isValidClientApp,
+} from 'core/utils';
 
 describe('camelCaseProps', () => {
   const input = {
@@ -70,5 +76,30 @@ describe('convertBoolean', () => {
 
   it('should return false for random string value', () => {
     assert.equal(convertBoolean('whatevs'), false);
+  });
+});
+
+
+describe('getClientApplication', () => {
+  it('should return firefox', () => {
+    assert.equal(getClientApp(), 'firefox');
+  });
+});
+
+
+describe('isValidClientApp', () => {
+  const _config = new Map();
+  _config.set('validClientApplications', ['firefox', 'android']);
+
+  it('should be valid if passed "firefox"', () => {
+    assert.equal(isValidClientApp('firefox', { _config }), true);
+  });
+
+  it('should be valid if passed "android"', () => {
+    assert.equal(isValidClientApp('android', { _config }), true);
+  });
+
+  it('should be invalid if passed "whatever"', () => {
+    assert.equal(isValidClientApp('whatever', { _config }), false);
   });
 });

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-loop-func */
+
+import request from 'supertest-as-promised';
+import { assert } from 'chai';
+
+import { runServer } from 'core/server/base';
+import Policy from 'csp-parse';
+
+import { checkSRI } from '../helpers';
+
+const defaultURL = '/en-US/firefox/';
+
+describe('AMO GET Requests', () => {
+  let app;
+
+  before(() => runServer({ listen: false, app: 'amo' })
+    .then((server) => {
+      app = server;
+    }));
+
+  after(() => {
+    webpackIsomorphicTools.undo();
+  });
+
+  it('should have a CSP policy on the amo app homepage', () => request(app)
+    .get(defaultURL)
+    .expect(200)
+    .then((res) => {
+      const policy = new Policy(res.header['content-security-policy']);
+      assert.notInclude(policy.get('script-src'), "'self'");
+      assert.include(policy.get('script-src'), 'https://addons.cdn.mozilla.net');
+      assert.notInclude(policy.get('connect-src'), "'self'");
+      assert.include(policy.get('connect-src'), 'https://addons.mozilla.org');
+    }));
+
+  it('should be using SRI for script and style on the amo app homepage', () => request(app)
+    .get(defaultURL)
+    .expect(200)
+    .then((res) => checkSRI(res)));
+
+  it('should be a 200 for requests to the homepage directly', () => request(app)
+    .get('/en-US/firefox/')
+    .expect(200));
+
+  it('should redirect an invalid locale', () => request(app)
+    .get('/whatever/firefox/')
+    .expect(302)
+    .then((res) => {
+      assert.equal(res.header.location,
+        '/en-US/firefox/');
+    }));
+});

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -22,7 +22,7 @@ describe('Discovery Pane GET requests', () => {
     webpackIsomorphicTools.undo();
   });
 
-  it('should have a CSP policy for / on the disco app', () => request(app)
+  it('should have a CSP policy on the disco app', () => request(app)
     .get(defaultURL)
     .expect(200)
     .then((res) => {
@@ -33,69 +33,21 @@ describe('Discovery Pane GET requests', () => {
       assert.include(policy.get('connect-src'), 'https://addons.mozilla.org');
     }));
 
-  it('should be using SRI for script and style in /', () => request(app)
+  it('should be using SRI for script and style', () => request(app)
     .get(defaultURL)
     .expect(200)
     .then((res) => checkSRI(res)));
 
-  it('should be a 404 for requests to /', () => request(app)
-    .get('/')
+  it('should be a 404 for requests to /en-US/firefox', () => request(app)
+    .get('/en-US/firefox')
     .expect(404));
 
-  it('should be a 404 for requests to /en-US/', () => request(app)
-    .get('/en-US/')
+  it('should be a 404 for requests to /en-US/firefox/', () => request(app)
+    .get('/en-US/firefox/')
     .expect(404));
 
   it('should redirect an invalid locale', () => request(app)
     .get('/whatevs/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(302)
-    .then((res) => {
-      assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
-    }));
-
-  it('should redirect an invalid locale which will be encoded', () => request(app)
-    .get('/<script>/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(302)
-    .then((res) => {
-      assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
-    }));
-
-  it('should redirect an invalid locale which will be encoded', () => request(app)
-    .get('/AC%2fDC/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(302)
-    .then((res) => {
-      assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
-    }));
-
-  it('should redirect an aliased lang', () => request(app)
-    .get('/pt/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(302)
-    .then((res) => {
-      assert.equal(res.header.location,
-        '/pt-PT/firefox/discovery/pane/48.0/Darwin/normal');
-    }));
-
-  it('should redirect a missing lang to default', () => request(app)
-    .get('/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(302)
-    .then((res) => {
-      assert.equal(res.header.location,
-        '/en-US/firefox/discovery/pane/48.0/Darwin/normal');
-    }));
-
-  it('should correct incorrect case', () => request(app)
-    .get('/pt-br/firefox/discovery/pane/48.0/Darwin/normal')
-    .expect(302)
-    .then((res) => {
-      assert.equal(res.header.location,
-        '/pt-BR/firefox/discovery/pane/48.0/Darwin/normal');
-    }));
-
-  it('should not replace more than it should', () => request(app)
-    .get('/48.0/firefox/discovery/pane/48.0/Darwin/normal')
     .expect(302)
     .then((res) => {
       assert.equal(res.header.location,


### PR DESCRIPTION
Fixes #786 and  #785

 This PR:

* Adds a redirection for client application e.g. firefox/android
* Moves the lang and application redirects into an express middleware
* ~~slashes are appended unless configured not to be. This is off for the disco pane since the URL in the pref doesn't end with a slash. (If we are going to need more control over this we'll need to think again) FWIW: AMO currently seems to mostly favour always adding a slash.~~

_NOTE: I updated and removed the slash handling for now. I think this is potentially better added separately if we want it._

The reason for moving to a middleware is because redirections need to happen for URLS that may not match the routes. If it's all done in react-router the redirects can only happen for matching routes. This also means the router prefix for lang and application don't have to be optional which also looks a bit nicer.

Like AMO the reason for having this in one piece of code is that the result is a single redirect. I added logic so vary headers are set only when headers are used for introspection. E.g. if an accept-language fall-back isn't used there won't be a vary on accept-language.

The redirection behaviour should match up to what AMO currently does e.g:

```
/ -> /en-US/firefox/
/whatever -> /en-US/firefox/whatever
/en-US -> /en-US

/en-US/ -> /en-US/firefox
/pt/ -> /pt-PT/firefox
/pt -> /pt-PT/firefox

/addon/adblock-plus -> /en-US/firefox/addon/adblock-plus
/whatever/firefox/ -> /en-US/firefox/
```

I'm still not sure if we should take the leading locale and application off the url at this point? That would mean react-router routes wouldn't need to care about locale or app at all. Either way we can consider that separately.

Adding user-agent header introspection to work out the correct application is to follow.