### PR TITLE
Add arrow-parens eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
   },
   "parser": "babel-eslint",
   "rules": {
+    "arrow-parens": ["error", "always"],
     "import/no-unresolved": "off",
     "space-before-function-paren": ["error", "never"],
     "react/prefer-stateless-function": "off",


### PR DESCRIPTION
So far, we've consistently used braces for arrow functions - adding this rule enforces it.