### PR TITLE
Tweak disco pane styles

### DIFF
--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -216,6 +216,7 @@ export class Addon extends React.Component {
 
     const addonClasses = classNames('addon', {
       theme: type === THEME_TYPE,
+      extension: type === EXTENSION_TYPE,
     });
 
     return (

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -31,8 +31,8 @@ $addon-padding: 20px;
   }
 
   &.extension span {
-      display: block;
-      padding-top: 3px;
+    display: block;
+    padding-top: 3px;
   }
 
   .theme-image {

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -30,6 +30,11 @@ $addon-padding: 20px;
     }
   }
 
+  &.extension span {
+      display: block;
+      padding-top: 3px;
+  }
+
   .theme-image {
     display: block;
     overflow: hidden;
@@ -124,7 +129,6 @@ $addon-padding: 20px;
     // This only corresponds to the link for add-ons not themes which is all a link.
     span {
       color: $secondary-font-color;
-      display: block;
       font-size: 10px;
       font-weight: normal;
 

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -17,7 +17,7 @@ $addon-padding: 20px;
   }
 
   .editorial-description {
-    color: $secondary-font-color;
+    color: $header-copy-font-color;
     font-size: 12px;
     margin: 0.75em 0;
   }
@@ -101,7 +101,7 @@ $addon-padding: 20px;
   }
 
   .heading {
-    color: $primary-font-color;
+    color: $header-copy-font-color;
     font-size: 14px;
     line-height: 1.2;
     font-weight: medium;
@@ -112,18 +112,20 @@ $addon-padding: 20px;
     a:focus,
     a:hover,
     a:active {
-      color: $primary-font-color;
-      text-decoration: none;
+      color: $header-copy-font-color;
+      text-decoration: underline;
     }
 
     a:focus,
     a:hover {
-      text-decoration: underline;
+      color: $link-hover-color;
     }
 
+    // This only corresponds to the link for add-ons not themes which is all a link.
     span {
       color: $secondary-font-color;
-      font-size: 14px;
+      display: block;
+      font-size: 10px;
       font-weight: normal;
 
       a:link,
@@ -132,19 +134,12 @@ $addon-padding: 20px;
       a:hover,
       a:active {
         color: $secondary-font-color;
-        text-decoration: none;
       }
 
       a:focus,
       a:hover {
-        text-decoration: underline;
+        color: $link-hover-color;
       }
-    }
-  }
-
-  @include respond-to('large') {
-    .heading {
-      font-size: 18px;
     }
   }
 

--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -4,10 +4,10 @@ $page-background: #fbfbfb;
 $primary-font-color: #000;
 $secondary-font-color: #6a6a6a;
 
-$header-copy-font-color: #444444;
+$header-copy-font-color: #444;
 $header-border-color: #b1b1b1;
 
-$link-hover-color: #0996F8;
+$link-hover-color: #0996f8;
 
 $breakpoints: (
   small: '(max-width: 719px)',

--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -4,8 +4,10 @@ $page-background: #fbfbfb;
 $primary-font-color: #000;
 $secondary-font-color: #6a6a6a;
 
-$header-copy-font-color: #414141;
+$header-copy-font-color: #444444;
 $header-border-color: #b1b1b1;
+
+$link-hover-color: #0996F8;
 
 $breakpoints: (
   small: '(max-width: 719px)',


### PR DESCRIPTION
<img width="702" alt="screenshot 2016-08-13 23 06 06" src="https://cloud.githubusercontent.com/assets/211578/17647125/9dc3acd0-61aa-11e6-907d-176aa70e8277.png">
> Full view

<img width="691" alt="screenshot 2016-08-13 23 06 15" src="https://cloud.githubusercontent.com/assets/211578/17647128/b652b354-61aa-11e6-8bb2-f257438a1536.png">
> Hover over link

<img width="696" alt="screenshot 2016-08-13 22 56 44" src="https://cloud.githubusercontent.com/assets/211578/17647109/e81cc538-61a9-11e6-91db-0fbee86a4835.png">
> Hover over link

Fixes #899.

This depends on the changes in https://github.com/mozilla/addons-server/pull/3270.