### PR TITLE
Bail test runs on test syntax error

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,7 @@
 // Karma configuration
-/* eslint-disable max-len, no-console */
+/* eslint-disable max-len, no-console, strict */
+'use strict';
+
 require('babel-register');
 
 const fs = require('fs');
@@ -28,6 +30,30 @@ const newWebpackConfig = Object.assign({}, webpackConfigProd, {
     new webpack.NormalModuleReplacementPlugin(/core\/logger$/, 'core/client/logger.js'),
     // Use the browser's window for window.
     new webpack.NormalModuleReplacementPlugin(/core\/window/, 'core/browserWindow.js'),
+    // Plugin to show any webpack warnings and prevent tests from running
+    // Based on: https://gist.github.com/Stuk/6b574049435df532e905
+    function WebpackWarningPlugin() {
+      this.plugin('done', (_stats) => {
+        const stats = _stats;
+        let flagError;
+
+        if (stats.compilation.warnings.length) {
+          // Log each of the warnings
+          stats.compilation.warnings.forEach((_warning) => {
+            const warning = _warning.message || _warning || '';
+            if (warning.indexOf('SyntaxError') > -1) {
+              console.log(warning);
+              flagError = true;
+            }
+          });
+
+          // Bail if syntax errors were encountered.
+          if (flagError) {
+            throw new Error('Syntax error encountered, bailing');
+          }
+        }
+      });
+    },
   ],
   devtool: 'inline-source-map',
   module: {


### PR DESCRIPTION
Fixes #903 

This addition will halt the tests and shows a nice message pointing to the error.

<img  alt="image showing syntax error message" src="https://cloud.githubusercontent.com/assets/1514/17661357/8a55ba12-62d6-11e6-8785-9306a1d96d1c.png">
