### PR TITLE
Use eslint to catch import mistakes and style nits

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,12 +13,72 @@
   "parser": "babel-eslint",
   "rules": {
     "arrow-parens": ["error", "always"],
-    "import/no-unresolved": "off",
+    // This makes sure imported modules exist.
+    "import/no-unresolved": ["error"],
+    // This makes sure imported names exist.
+    "import/named": ["error"],
+    // This will catch accidental default imports when no default is defined.
+    "import/default": ["error"],
+    // This makes sure `*' imports are dereferenced to real exports.
+    "import/namespace": ["error"],
+    // This catches any export mistakes.
+    "import/export": ["error"],
+    // This catches default names that conflict with actual exported names.
+    // For example, this was probably a typo:
+    //   import foo from 'bar';
+    // that should be corrected as:
+    //   import { foo } from 'bar';
+    "import/no-named-as-default": ["error"],
+    // This catches possible typos like trying to access a real export on a
+    // default import.
+    "import/no-named-as-default-member": ["error"],
+    // This prevents exporting a mutable variable.
+    "import/no-mutable-exports": ["error"],
+    // This makes sure package.json defines dev vs. prod dependencies correctly.
+    "import/no-extraneous-dependencies": ["error", {
+      // The following are not allowed to be imported. See .eslintrc in other
+      // directories (like ./test) for where this gets overidden.
+      "devDependencies": false, "optionalDependencies": false, "peerDependencies": false
+    }],
+    // This ensures imports are at the top of the file.
+    "import/imports-first": ["error"],
+    // This catches duplicate exports.
+    "import/no-duplicates": ["error"],
+    // This ensures import statements never provide a file extension in the path.
+    "import/extensions": ["error", "never"],
+    // This ensures imports are organized by type and that groups are separated
+    // by a new line.
+    "import/order": ["error", {
+      "groups": [
+        "builtin", "external", "internal", ["parent", "sibling"], "index"
+      ],
+      "newlines-between": "always"
+    }],
+    // This ensures a new line after all import statements.
+    "import/newline-after-import": ["error"],
     "no-underscore-dangle": "off",
     "space-before-function-paren": ["error", "never"],
     "react/prefer-stateless-function": "off",
     "react/jsx-indent-props": "off",
     "react/jsx-closing-bracket-location": "off",
     "react/jsx-first-prop-new-line": "off"
+  },
+  "settings": {
+    "import/ignore": [
+      // Because of CommonJS incompatibility, we can't
+      // check for bad imports in node_modules.
+      "node_modules",
+      // Ignore non-JS imports.
+      "\\.scss$",
+      "\\.jpg$",
+      "\\.mp4$",
+      "\\.webm$"
+    ],
+    "import/resolver": {
+      "node": {
+        // This adds ./src for relative imports.
+        "moduleDirectory": ["node_modules", "src"]
+      }
+    }
   }
 }

--- a/bin/.eslintrc
+++ b/bin/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", {
+      // Allow dev-dependencies in this directory.
+      "devDependencies": true
+    }],
+  }
+}

--- a/bin/build-checks.js
+++ b/bin/build-checks.js
@@ -2,7 +2,6 @@
 /* eslint-disable global-require, no-console */
 
 const chalk = require('chalk');
-
 require('babel-register');
 const config = require('config');
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -2,7 +2,6 @@
 /* eslint-disable global-require, no-console */
 
 const chalk = require('chalk');
-
 require('babel-register');
 const config = require('config');
 

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -3,14 +3,13 @@
 /* eslint-disable strict, no-console */
 
 require('babel-register');
-
 const Express = require('express');
+const config = require('config');
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
-const webpackDevConfig = require('webpack.dev.config.babel').default;
 
-const config = require('config');
+const webpackDevConfig = require('../webpack.dev.config.babel').default;
 
 const host = config.get('webpackServerHost');
 const port = config.get('webpackServerPort');

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,18 +1,20 @@
 // Karma configuration
-/* eslint-disable max-len, no-console, strict */
+/* eslint-disable max-len, no-console, strict, import/no-extraneous-dependencies */
 'use strict';
 
 require('babel-register');
 
 const fs = require('fs');
 
+const webpack = require('webpack');
+const config = require('config');
+
+const getClientConfig = require('./src/core/utils').getClientConfig;
+const webpackConfigProd = require('./webpack.prod.config.babel').default;
+
+const clientConfig = getClientConfig(config);
 const babelrc = fs.readFileSync('./.babelrc');
 const babelQuery = JSON.parse(babelrc);
-const webpack = require('webpack');
-const webpackConfigProd = require('./webpack.prod.config.babel').default;
-const config = require('config');
-const getClientConfig = require('src/core/utils').getClientConfig;
-const clientConfig = getClientConfig(config);
 
 const coverageReporters = [{
   type: 'text-summary',

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
   "homepage": "https://github.com/mozillla/addons-frontend#readme",
   "dependencies": {
     "babel-plugin-dedent": "2.0.0",
+    "babel-polyfill": "6.13.0",
     "better-npm-run": "0.0.11",
     "bunyan": "1.8.1",
     "camelcase": "3.0.0",
@@ -156,6 +157,7 @@
     "react": "15.3.0",
     "react-addons-css-transition-group": "15.3.1",
     "react-cookie": "0.4.8",
+    "react-dom": "15.3.1",
     "react-helmet": "3.1.0",
     "react-onclickoutside": "5.3.3",
     "react-redux": "4.4.5",
@@ -165,7 +167,8 @@
     "redux-logger": "2.6.1",
     "serialize-javascript": "1.3.0",
     "url": "0.11.0",
-    "url-loader": "0.5.7"
+    "url-loader": "0.5.7",
+    "webpack-isomorphic-tools": "2.5.7"
   },
   "devDependencies": {
     "autoprefixer": "6.4.0",
@@ -178,7 +181,6 @@
     "babel-plugin-transform-class-properties": "6.11.5",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
-    "babel-polyfill": "6.13.0",
     "babel-preset-es2015": "6.13.2",
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-2": "6.13.0",
@@ -213,7 +215,6 @@
     "po2json": "0.4.2",
     "postcss-loader": "0.10.1",
     "react-addons-test-utils": "15.3.1",
-    "react-dom": "15.3.1",
     "react-hot-loader": "1.3.0",
     "react-transform-hmr": "1.0.4",
     "redux-devtools": "3.3.1",
@@ -233,7 +234,6 @@
     "webpack": "1.13.2",
     "webpack-dev-middleware": "1.6.1",
     "webpack-dev-server": "1.14.1",
-    "webpack-hot-middleware": "2.12.2",
-    "webpack-isomorphic-tools": "2.5.7"
+    "webpack-hot-middleware": "2.12.2"
   }
 }

--- a/src/amo/client.js
+++ b/src/amo/client.js
@@ -1,8 +1,9 @@
 import makeClient from 'core/client/base';
-import routes from './routes';
-import createStore from './store';
 
 // Initialize the tracking.
 import 'core/tracking';
+
+import routes from './routes';
+import createStore from './store';
 
 makeClient(routes, createStore);

--- a/src/amo/components/AddonMeta.js
+++ b/src/amo/components/AddonMeta.js
@@ -4,7 +4,7 @@ import translate from 'core/i18n/translate';
 
 import 'amo/css/AddonMeta.scss';
 
-export class AddonMeta extends React.Component {
+export class AddonMetaBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object,
   }
@@ -34,4 +34,4 @@ export class AddonMeta extends React.Component {
   }
 }
 
-export default translate({ withRef: true })(AddonMeta);
+export default translate({ withRef: true })(AddonMetaBase);

--- a/src/amo/components/LikeButton.js
+++ b/src/amo/components/LikeButton.js
@@ -4,7 +4,7 @@ import translate from 'core/i18n/translate';
 
 import 'amo/css/LikeButton.scss';
 
-export class LikeButton extends React.Component {
+export class LikeButtonBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object,
   }
@@ -21,4 +21,4 @@ export class LikeButton extends React.Component {
   }
 }
 
-export default translate({ withRef: true })(LikeButton);
+export default translate({ withRef: true })(LikeButtonBase);

--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -5,7 +5,7 @@ import translate from 'core/i18n/translate';
 import 'amo/css/ScreenShots.scss';
 
 
-export class ScreenShots extends React.Component {
+export class ScreenShotsBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object,
   }
@@ -36,4 +36,4 @@ export class ScreenShots extends React.Component {
   }
 }
 
-export default translate({ withRef: true })(ScreenShots);
+export default translate({ withRef: true })(ScreenShotsBase);

--- a/src/amo/components/SearchBox.js
+++ b/src/amo/components/SearchBox.js
@@ -5,7 +5,7 @@ import translate from 'core/i18n/translate';
 import 'amo/css/SearchBox.scss';
 
 
-export class SearchBox extends React.Component {
+export class SearchBoxBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object,
   }
@@ -22,4 +22,4 @@ export class SearchBox extends React.Component {
   }
 }
 
-export default translate({ withRef: true })(SearchBox);
+export default translate({ withRef: true })(SearchBoxBase);

--- a/src/amo/containers/App.js
+++ b/src/amo/containers/App.js
@@ -6,7 +6,7 @@ import 'amo/css/App.scss';
 import translate from 'core/i18n/translate';
 
 
-export class App extends React.Component {
+export class AppBase extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     i18n: PropTypes.object.isRequired,
@@ -25,4 +25,4 @@ export class App extends React.Component {
   }
 }
 
-export default translate({ withRef: true })(App);
+export default translate({ withRef: true })(AppBase);

--- a/src/amo/containers/DetailPage.js
+++ b/src/amo/containers/DetailPage.js
@@ -7,7 +7,7 @@ import AddonDetail from 'amo/components/AddonDetail';
 import translate from 'core/i18n/translate';
 import { loadAddonIfNeeded } from 'core/utils';
 
-export class DetailPage extends React.Component {
+export class DetailPageBase extends React.Component {
   static propTypes = {
     addon: PropTypes.object,
   }
@@ -36,4 +36,4 @@ export default compose(
   }]),
   connect(mapStateToProps),
   translate({ withRef: true }),
-)(DetailPage);
+)(DetailPageBase);

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -1,7 +1,7 @@
 import { createStore as _createStore, combineReducers } from 'redux';
 import { reducer as reduxAsyncConnect } from 'redux-async-connect';
-import { middleware } from 'core/store';
 
+import { middleware } from 'core/store';
 import addons from 'core/reducers/addons';
 import api from 'core/reducers/api';
 

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -1,9 +1,8 @@
-import { Schema, arrayOf, normalize } from 'normalizr';
 import url from 'url';
 
-import config from 'config';
-
 import 'isomorphic-fetch';
+import { Schema, arrayOf, normalize } from 'normalizr';
+import config from 'config';
 
 const API_BASE = `${config.get('apiHost')}${config.get('apiPath')}`;
 

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -1,15 +1,14 @@
 import 'babel-polyfill';
-import React from 'react';
-
 import config from 'config';
+import Jed from 'jed';
+import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
 import { ReduxAsyncConnect } from 'redux-async-connect';
+
 import { langToLocale, sanitizeLanguage } from 'core/i18n/utils';
 import I18nProvider from 'core/i18n/Provider';
-import Jed from 'jed';
-
 import log from 'core/logger';
 
 

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
-import translate from 'core/i18n/translate';
 
+import translate from 'core/i18n/translate';
 import {
   DOWNLOADING,
   DISABLED,
@@ -19,7 +19,7 @@ import { getThemeData } from 'disco/themePreview';
 
 import './InstallButton.scss';
 
-export class InstallButton extends React.Component {
+export class InstallButtonBase extends React.Component {
   static propTypes = {
     downloadProgress: PropTypes.number,
     enable: PropTypes.func,
@@ -122,4 +122,4 @@ export class InstallButton extends React.Component {
   }
 }
 
-export default translate()(InstallButton);
+export default translate()(InstallButtonBase);

--- a/src/core/components/NotFound.js
+++ b/src/core/components/NotFound.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { gettext as _ } from 'core/utils';
 
 export default class NotFound extends React.Component {

--- a/src/core/containers/HandleLogin/index.js
+++ b/src/core/containers/HandleLogin/index.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 import cookie from 'react-cookie';
 import { connect } from 'react-redux';
-
 import config from 'config';
+
 import { setJWT } from 'core/actions';
 import { login } from 'core/api';
 import LoginPage from 'core/components/LoginPage';

--- a/src/core/containers/LoginRequired/index.js
+++ b/src/core/containers/LoginRequired/index.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
+
 import LoginPage from 'core/components/LoginPage';
 
 export function mapStateToProps(state) {
@@ -9,7 +10,7 @@ export function mapStateToProps(state) {
 }
 
 // This class is exported for testing outside of redux.
-export class LoginRequired extends React.Component {
+export class LoginRequiredBase extends React.Component {
   static propTypes = {
     authenticated: PropTypes.bool.isRequired,
     children: PropTypes.node,
@@ -24,4 +25,4 @@ export class LoginRequired extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(LoginRequired);
+export default connect(mapStateToProps)(LoginRequiredBase);

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -1,4 +1,5 @@
 import config from 'config';
+
 import log from 'core/logger';
 
 const defaultLang = config.get('defaultLang');

--- a/src/core/middleware.js
+++ b/src/core/middleware.js
@@ -1,6 +1,7 @@
+import config from 'config';
+
 import { getClientApp, isValidClientApp } from 'core/utils';
 import { getLanguage, isValidLang } from 'core/i18n/utils';
-import config from 'config';
 import log from 'core/logger';
 
 

--- a/src/core/purify.js
+++ b/src/core/purify.js
@@ -1,4 +1,5 @@
 import createDOMPurify from 'dompurify';
+
 import universalWindow from 'core/window';
 
 const purify = createDOMPurify(universalWindow);

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -1,29 +1,28 @@
-import 'babel-polyfill';
-
 import fs from 'fs';
+import path from 'path';
+
+import 'babel-polyfill';
+import config from 'config';
 import Express from 'express';
 import helmet from 'helmet';
-import path from 'path';
+import Jed from 'jed';
 import cookie from 'react-cookie';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
-
 import { Provider } from 'react-redux';
 import { match } from 'react-router';
 import { ReduxAsyncConnect, loadOnServer } from 'redux-async-connect';
-import { prefixMiddleWare } from 'core/middleware';
-
 import WebpackIsomorphicTools from 'webpack-isomorphic-tools';
-import WebpackIsomorphicToolsConfig from 'webpack-isomorphic-tools-config';
-import ServerHtml from 'core/containers/ServerHtml';
 
-import config from 'config';
+import ServerHtml from 'core/containers/ServerHtml';
+import { prefixMiddleWare } from 'core/middleware';
 import { convertBoolean } from 'core/utils';
 import { setLang, setJWT } from 'core/actions';
 import log from 'core/logger';
 import { getDirection, isValidLang, langToLocale } from 'core/i18n/utils';
 import I18nProvider from 'core/i18n/Provider';
-import Jed from 'jed';
+
+import WebpackIsomorphicToolsConfig from './webpack-isomorphic-tools-config';
 
 
 const env = config.util.getEnv('NODE_ENV');

--- a/src/core/server/webpack-isomorphic-tools-config.js
+++ b/src/core/server/webpack-isomorphic-tools-config.js
@@ -1,8 +1,7 @@
 /* eslint-disable no-else-return */
+import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 
-const WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');
-
-module.exports = {
+export default {
   debug: false,
   assets: {
     images: {

--- a/src/core/tracking.js
+++ b/src/core/tracking.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-
 import config from 'config';
+
 import { convertBoolean } from 'core/utils';
 import log from 'core/logger';
 

--- a/src/disco/addonManager.js
+++ b/src/disco/addonManager.js
@@ -1,5 +1,4 @@
 import log from 'core/logger';
-
 import {
   globalEvents,
   globalEventStatusMap,

--- a/src/disco/client.js
+++ b/src/disco/client.js
@@ -1,8 +1,9 @@
 import makeClient from 'core/client/base';
-import routes from './routes';
-import createStore from './store';
 
 // Initialize the tracking.
 import 'core/tracking';
+
+import routes from './routes';
+import createStore from './store';
 
 makeClient(routes, createStore);

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -3,15 +3,14 @@ import { sprintf } from 'jed';
 import React, { PropTypes } from 'react';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { connect } from 'react-redux';
-import translate from 'core/i18n/translate';
-
-import { sanitizeHTML } from 'core/utils';
 import config from 'config';
+
+import translate from 'core/i18n/translate';
+import { sanitizeHTML } from 'core/utils';
 import themeAction, { getThemeData } from 'disco/themePreview';
 import tracking from 'core/tracking';
 import * as addonManager from 'disco/addonManager';
 import log from 'core/logger';
-
 import InstallButton from 'core/components/InstallButton';
 import {
   DISABLED,
@@ -46,7 +45,7 @@ import {
 
 import 'disco/css/Addon.scss';
 
-export class Addon extends React.Component {
+export class AddonBase extends React.Component {
   static propTypes = {
     accentcolor: PropTypes.string,
     description: PropTypes.string,
@@ -402,4 +401,4 @@ export function mapDispatchToProps(dispatch, { _tracking = tracking,
 
 export default translate({ withRef: true })(connect(
   mapStateToProps, mapDispatchToProps, undefined, { withRef: true }
-)(Addon));
+)(AddonBase));

--- a/src/disco/components/InfoDialog.js
+++ b/src/disco/components/InfoDialog.js
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
-import translate from 'core/i18n/translate';
 import onClickOutside from 'react-onclickoutside';
 
+import translate from 'core/i18n/translate';
 import 'disco/css/InfoDialog.scss';
 
-export class InfoDialog extends React.Component {
+export class InfoDialogBase extends React.Component {
   static propTypes = {
     addonName: PropTypes.string.isRequired,
     closeAction: PropTypes.func.isRequired,
@@ -39,4 +39,4 @@ export class InfoDialog extends React.Component {
   }
 }
 
-export default translate()(onClickOutside(InfoDialog));
+export default translate()(onClickOutside(InfoDialogBase));

--- a/src/disco/containers/App.js
+++ b/src/disco/containers/App.js
@@ -5,7 +5,7 @@ import 'disco/css/App.scss';
 import translate from 'core/i18n/translate';
 
 
-export class App extends React.Component {
+export class AppBase extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     i18n: PropTypes.object.isRequired,
@@ -27,4 +27,4 @@ export class App extends React.Component {
   }
 }
 
-export default translate({ withRef: true })(App);
+export default translate({ withRef: true })(AppBase);

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -1,32 +1,29 @@
 /* eslint-disable max-len */
-
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';
-import { camelCaseProps } from 'core/utils';
-
 import config from 'config';
-import { getDiscoveryAddons } from 'disco/api';
-import { discoResults } from 'disco/actions';
+
+import { camelCaseProps } from 'core/utils';
 import { loadEntities } from 'core/actions';
+import translate from 'core/i18n/translate';
+import tracking from 'core/tracking';
+import { INSTALL_STATE } from 'core/constants';
 import { addChangeListeners } from 'disco/addonManager';
 import {
   NAVIGATION_CATEGORY,
   VIDEO_CATEGORY,
 } from 'disco/constants';
-import { INSTALL_STATE } from 'core/constants';
-
+import { getDiscoveryAddons } from 'disco/api';
+import { discoResults } from 'disco/actions';
 import Addon from 'disco/components/Addon';
 import InfoDialog from 'disco/components/InfoDialog';
-import translate from 'core/i18n/translate';
-import tracking from 'core/tracking';
-
 import videoPoster from 'disco/img/AddOnsPoster.jpg';
 import videoMp4 from 'disco/video/AddOns.mp4';
 import videoWebm from 'disco/video/AddOns.webm';
 
 
-export class DiscoPane extends React.Component {
+export class DiscoPaneBase extends React.Component {
   static propTypes = {
     AddonComponent: PropTypes.func.isRequred,
     handleGlobalEvent: PropTypes.func.isRequired,
@@ -170,4 +167,4 @@ export function mapDispatchToProps(dispatch, { _config = config } = {}) {
 export default asyncConnect([{
   deferred: true,
   promise: loadDataIfNeeded,
-}])(connect(mapStateToProps, mapDispatchToProps)(translate()(DiscoPane)));
+}])(connect(mapStateToProps, mapDispatchToProps)(translate()(DiscoPaneBase)));

--- a/src/disco/store.js
+++ b/src/disco/store.js
@@ -1,7 +1,7 @@
 import { createStore as _createStore, combineReducers } from 'redux';
 import { reducer as reduxAsyncConnect } from 'redux-async-connect';
-import { middleware } from 'core/store';
 
+import { middleware } from 'core/store';
 import addons from 'core/reducers/addons';
 import api from 'core/reducers/api';
 import discoResults from 'disco/reducers/discoResults';

--- a/src/search/client.js
+++ b/src/search/client.js
@@ -1,4 +1,5 @@
 import makeClient from 'core/client/base';
+
 import routes from './routes';
 import createStore from './store';
 

--- a/src/search/components/SearchForm.js
+++ b/src/search/components/SearchForm.js
@@ -8,7 +8,7 @@ import { gettext as _ } from 'core/utils';
 import 'search/css/SearchForm.scss';
 import 'search/css/lib/buttons.scss';
 
-export class SearchForm extends React.Component {
+export class SearchFormBase extends React.Component {
   static propTypes = {
     api: PropTypes.object.isRequired,
     loadAddon: PropTypes.func.isRequired,
@@ -69,4 +69,4 @@ export function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchForm);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchFormBase);

--- a/src/search/components/SearchPage.js
+++ b/src/search/components/SearchPage.js
@@ -1,9 +1,10 @@
 import React, { PropTypes } from 'react';
 
 import Paginate from 'core/components/Paginate';
+import { gettext as _ } from 'core/utils';
+
 import SearchForm from './SearchForm';
 import SearchResults from './SearchResults';
-import { gettext as _ } from 'core/utils';
 
 export default class SearchPage extends React.Component {
   static propTypes = {

--- a/src/search/containers/AddonPage/index.js
+++ b/src/search/containers/AddonPage/index.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';
+
 import { gettext as _, loadAddonIfNeeded } from 'core/utils';
 import NotFound from 'core/components/NotFound';
 import JsonData from 'search/components/JsonData';

--- a/src/search/containers/CurrentSearchPage.js
+++ b/src/search/containers/CurrentSearchPage.js
@@ -1,8 +1,9 @@
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';
+
+import { search } from 'core/api';
 import SearchPage from 'search/components/SearchPage';
 import { searchStart, searchLoad, searchFail } from 'search/actions';
-import { search } from 'core/api';
 
 export function mapStateToProps(state) {
   return state.search;

--- a/src/search/containers/UserPage/index.js
+++ b/src/search/containers/UserPage/index.js
@@ -7,7 +7,7 @@ import { fetchProfile } from 'core/api';
 
 import './styles.scss';
 
-export class UserPage extends React.Component {
+export class UserPageBase extends React.Component {
   static propTypes = {
     email: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
@@ -51,4 +51,4 @@ export function loadProfileIfNeeded({ store: { getState, dispatch } }) {
 export default asyncConnect([{
   deferred: true,
   promise: loadProfileIfNeeded,
-}])(connect(mapStateToProps)(UserPage));
+}])(connect(mapStateToProps)(UserPageBase));

--- a/src/search/routes.js
+++ b/src/search/routes.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { IndexRoute, Route } from 'react-router';
 
+import LoginRequired from 'core/containers/LoginRequired';
+import HandleLogin from 'core/containers/HandleLogin';
+
 import App from './containers/App';
 import CurrentSearchPage from './containers/CurrentSearchPage';
 import AddonPage from './containers/AddonPage';
 import UserPage from './containers/UserPage';
-import LoginRequired from 'core/containers/LoginRequired';
-import HandleLogin from 'core/containers/HandleLogin';
 
 export default (
   <Route path="/" component={App}>

--- a/test-runner.js
+++ b/test-runner.js
@@ -1,5 +1,7 @@
+/* eslint-disable import/no-extraneous-dependencies */
 require('babel-polyfill');
-require('tests/client/init');
+
+require('./tests/client/init');
 
 const testsContext = require.context('./tests/client/', true, /\.js$/);
 const componentsContext = require.context(

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -4,5 +4,13 @@
       // Allow dev-dependencies in this directory.
       "devDependencies": true
     }],
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        // This adds ./src and `cwd` for relative imports.
+        "moduleDirectory": ["node_modules", "src", ""]
+      }
+    }
   }
 }

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", {
+      // Allow dev-dependencies in this directory.
+      "devDependencies": true
+    }],
+  }
+}

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -9,8 +9,7 @@ import AddonDetail, { allowedDescriptionTags }
   from 'amo/components/AddonDetail';
 import I18nProvider from 'core/i18n/Provider';
 import InstallButton from 'core/components/InstallButton';
-
-import { getFakeI18nInst } from '../../helpers';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 export const fakeAddon = {

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -10,7 +10,7 @@ import AddonDetail, { allowedDescriptionTags }
 import I18nProvider from 'core/i18n/Provider';
 import InstallButton from 'core/components/InstallButton';
 
-import { getFakeI18nInst } from 'tests/client/helpers';
+import { getFakeI18nInst } from '../../helpers';
 
 
 export const fakeAddon = {

--- a/tests/client/amo/containers/TestApp.js
+++ b/tests/client/amo/containers/TestApp.js
@@ -8,7 +8,7 @@ import {
 import App from 'amo/containers/App';
 import I18nProvider from 'core/i18n/Provider';
 
-import { getFakeI18nInst } from 'tests/client/helpers';
+import { getFakeI18nInst } from '../../helpers';
 
 
 describe('App', () => {

--- a/tests/client/amo/containers/TestApp.js
+++ b/tests/client/amo/containers/TestApp.js
@@ -7,8 +7,7 @@ import {
 
 import App from 'amo/containers/App';
 import I18nProvider from 'core/i18n/Provider';
-
-import { getFakeI18nInst } from '../../helpers';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('App', () => {

--- a/tests/client/amo/containers/TestDetail.js
+++ b/tests/client/amo/containers/TestDetail.js
@@ -9,8 +9,8 @@ import { Provider } from 'react-redux';
 import createStore from 'amo/store';
 import DetailPage from 'amo/containers/DetailPage';
 import I18nProvider from 'core/i18n/Provider';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
-import { getFakeI18nInst } from '../../helpers';
 import { fakeAddon } from '../components/TestAddonDetail';
 
 function render(

--- a/tests/client/amo/containers/TestDetail.js
+++ b/tests/client/amo/containers/TestDetail.js
@@ -7,10 +7,10 @@ import {
 import { Provider } from 'react-redux';
 
 import createStore from 'amo/store';
-import { getFakeI18nInst } from 'tests/client/helpers';
 import DetailPage from 'amo/containers/DetailPage';
 import I18nProvider from 'core/i18n/Provider';
 
+import { getFakeI18nInst } from '../../helpers';
 import { fakeAddon } from '../components/TestAddonDetail';
 
 function render(

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -1,6 +1,5 @@
 import * as api from 'core/api';
-
-import { unexpectedSuccess } from '../../helpers';
+import { unexpectedSuccess } from 'tests/client/helpers';
 
 describe('api', () => {
   let mockWindow;

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -1,5 +1,6 @@
 import * as api from 'core/api';
-import { unexpectedSuccess } from 'tests/client/helpers';
+
+import { unexpectedSuccess } from '../../helpers';
 
 describe('api', () => {
   let mockWindow;

--- a/tests/client/core/client/test_logger.js
+++ b/tests/client/core/client/test_logger.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/named
 import { bindConsoleMethod } from 'core/logger';
 
 describe('logger.bindConsoleMethod()', () => {

--- a/tests/client/core/components/TestInstallButton.js
+++ b/tests/client/core/components/TestInstallButton.js
@@ -18,8 +18,7 @@ import {
   UNINSTALLING,
   UNKNOWN,
 } from 'core/constants';
-
-import { getFakeI18nInst } from '../../helpers';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('<InstallButton />', () => {

--- a/tests/client/core/components/TestInstallButton.js
+++ b/tests/client/core/components/TestInstallButton.js
@@ -3,7 +3,7 @@ import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 
 import {
-  InstallButton,
+  InstallButtonBase,
 } from 'core/components/InstallButton';
 import {
   DISABLED,
@@ -18,7 +18,8 @@ import {
   UNINSTALLING,
   UNKNOWN,
 } from 'core/constants';
-import { getFakeI18nInst } from 'tests/client/helpers';
+
+import { getFakeI18nInst } from '../../helpers';
 
 
 describe('<InstallButton />', () => {
@@ -36,7 +37,7 @@ describe('<InstallButton />', () => {
     };
 
     return renderIntoDocument(
-      <InstallButton {...renderProps} />);
+      <InstallButtonBase {...renderProps} />);
   }
 
   it('should be disabled if isDisabled status is UNKNOWN', () => {

--- a/tests/client/core/components/TestNotFound.js
+++ b/tests/client/core/components/TestNotFound.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { renderIntoDocument } from 'react-addons-test-utils';
+
 import NotFound from 'core/components/NotFound';
 
 describe('<NotFound />', () => {

--- a/tests/client/core/components/TestPaginate.js
+++ b/tests/client/core/components/TestPaginate.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import { renderIntoDocument } from 'react-addons-test-utils';
 import { Route, Router, createMemoryHistory } from 'react-router';
+
 import Paginate from 'core/components/Paginate';
 
 describe('<Paginate />', () => {

--- a/tests/client/core/containers/TestHandleLogin.js
+++ b/tests/client/core/containers/TestHandleLogin.js
@@ -4,6 +4,7 @@ import { findDOMNode } from 'react-dom';
 import { Provider } from 'react-redux';
 import cookie from 'react-cookie';
 import { createStore } from 'redux';
+
 import HandleLogin, { mapDispatchToProps } from 'core/containers/HandleLogin';
 import * as api from 'core/api';
 

--- a/tests/client/core/containers/TestLoginRequired.js
+++ b/tests/client/core/containers/TestLoginRequired.js
@@ -3,8 +3,7 @@ import React from 'react';
 import { mapStateToProps, LoginRequiredBase }
   from 'core/containers/LoginRequired';
 import LoginPage from 'core/components/LoginPage';
-
-import { shallowRender } from '../../helpers';
+import { shallowRender } from 'tests/client/helpers';
 
 describe('<LoginRequired />', () => {
   class MyComponent extends React.Component {

--- a/tests/client/core/containers/TestLoginRequired.js
+++ b/tests/client/core/containers/TestLoginRequired.js
@@ -1,8 +1,10 @@
 import React from 'react';
 
-import { shallowRender } from 'tests/client/helpers';
-import { mapStateToProps, LoginRequired } from 'core/containers/LoginRequired';
+import { mapStateToProps, LoginRequiredBase }
+  from 'core/containers/LoginRequired';
 import LoginPage from 'core/components/LoginPage';
+
+import { shallowRender } from '../../helpers';
 
 describe('<LoginRequired />', () => {
   class MyComponent extends React.Component {
@@ -13,18 +15,18 @@ describe('<LoginRequired />', () => {
 
   it('renders <LoginPage /> when unauthenticated', () => {
     const root = shallowRender(
-      <LoginRequired authenticated={false}>
+      <LoginRequiredBase authenticated={false}>
         <MyComponent />
-      </LoginRequired>
+      </LoginRequiredBase>
     );
     assert.equal(root.type, LoginPage);
   });
 
   it('renders the children when authenticated', () => {
     const root = shallowRender(
-      <LoginRequired authenticated>
+      <LoginRequiredBase authenticated>
         <MyComponent />
-      </LoginRequired>
+      </LoginRequiredBase>
     );
     assert.equal(root.type, MyComponent);
   });

--- a/tests/client/core/containers/TestServerHtml.js
+++ b/tests/client/core/containers/TestServerHtml.js
@@ -1,7 +1,7 @@
 import Helmet from 'react-helmet';
 import React, { PropTypes } from 'react';
-
 import { findRenderedDOMComponentWithTag, renderIntoDocument } from 'react-addons-test-utils';
+
 import ServerHtml from 'core/containers/ServerHtml';
 
 describe('<ServerHtml />', () => {

--- a/tests/client/core/i18n/TestI18nProvider.js
+++ b/tests/client/core/i18n/TestI18nProvider.js
@@ -7,8 +7,7 @@ import {
 
 import I18nProvider from 'core/i18n/Provider';
 import translate from 'core/i18n/translate';
-
-import { getFakeI18nInst } from '../../helpers';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 class OuterComponent extends Component {

--- a/tests/client/core/i18n/TestI18nProvider.js
+++ b/tests/client/core/i18n/TestI18nProvider.js
@@ -1,13 +1,14 @@
 /* eslint-disable react/no-multi-comp */
 import React, { Component, PropTypes } from 'react';
-
-import I18nProvider from 'core/i18n/Provider';
-import translate from 'core/i18n/translate';
-import { getFakeI18nInst } from 'tests/client/helpers';
 import {
   renderIntoDocument,
   findRenderedComponentWithType,
 } from 'react-addons-test-utils';
+
+import I18nProvider from 'core/i18n/Provider';
+import translate from 'core/i18n/translate';
+
+import { getFakeI18nInst } from '../../helpers';
 
 
 class OuterComponent extends Component {

--- a/tests/client/core/i18n/test_utils.js
+++ b/tests/client/core/i18n/test_utils.js
@@ -1,5 +1,6 @@
-import * as utils from 'core/i18n/utils';
 import config from 'config';
+
+import * as utils from 'core/i18n/utils';
 
 const defaultLang = config.get('defaultLang');
 

--- a/tests/client/core/test_utils.js
+++ b/tests/client/core/test_utils.js
@@ -11,7 +11,7 @@ import {
   nl2br,
 } from 'core/utils';
 
-import { unexpectedSuccess } from 'tests/client/helpers';
+import { unexpectedSuccess } from '../helpers';
 
 describe('camelCaseProps', () => {
   const input = {

--- a/tests/client/core/test_utils.js
+++ b/tests/client/core/test_utils.js
@@ -10,8 +10,7 @@ import {
   loadAddonIfNeeded,
   nl2br,
 } from 'core/utils';
-
-import { unexpectedSuccess } from '../helpers';
+import { unexpectedSuccess } from 'tests/client/helpers';
 
 describe('camelCaseProps', () => {
   const input = {

--- a/tests/client/disco/TestAddonManager.js
+++ b/tests/client/disco/TestAddonManager.js
@@ -4,8 +4,7 @@ import {
   globalEventStatusMap,
   SET_ENABLE_NOT_AVAILABLE,
 } from 'disco/constants';
-
-import { unexpectedSuccess } from '../helpers';
+import { unexpectedSuccess } from 'tests/client/helpers';
 
 
 describe('addonManager', () => {

--- a/tests/client/disco/TestAddonManager.js
+++ b/tests/client/disco/TestAddonManager.js
@@ -1,10 +1,11 @@
 import * as addonManager from 'disco/addonManager';
-import { unexpectedSuccess } from 'tests/client/helpers';
 import { installEventList } from 'core/constants';
 import {
   globalEventStatusMap,
   SET_ENABLE_NOT_AVAILABLE,
 } from 'disco/constants';
+
+import { unexpectedSuccess } from '../helpers';
 
 
 describe('addonManager', () => {

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -43,8 +43,8 @@ import {
   SHOW_INFO,
   UNINSTALL_CATEGORY,
 } from 'disco/constants';
-
-import { getFakeAddonManagerWrapper, getFakeI18nInst } from '../../helpers';
+import { getFakeAddonManagerWrapper, getFakeI18nInst }
+  from 'tests/client/helpers';
 
 const result = {
   id: 'test-id',

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -6,8 +6,11 @@ import {
 } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 import config from 'config';
+
+import I18nProvider from 'core/i18n/Provider';
+import translate from 'core/i18n/translate';
 import {
-  Addon,
+  AddonBase,
   makeProgressHandler,
   mapDispatchToProps,
   mapStateToProps,
@@ -40,9 +43,8 @@ import {
   SHOW_INFO,
   UNINSTALL_CATEGORY,
 } from 'disco/constants';
-import { getFakeAddonManagerWrapper, getFakeI18nInst } from 'tests/client/helpers';
-import I18nProvider from 'core/i18n/Provider';
-import translate from 'core/i18n/translate';
+
+import { getFakeAddonManagerWrapper, getFakeI18nInst } from '../../helpers';
 
 const result = {
   id: 'test-id',
@@ -53,7 +55,7 @@ const result = {
 };
 
 function renderAddon({ setCurrentStatus = sinon.stub(), ...props }) {
-  const MyAddon = translate({ withRef: true })(Addon);
+  const MyAddon = translate({ withRef: true })(AddonBase);
 
   return findRenderedComponentWithType(renderIntoDocument(
     <I18nProvider i18n={getFakeI18nInst()}>

--- a/tests/client/disco/components/TestInfoDialog.js
+++ b/tests/client/disco/components/TestInfoDialog.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 import ReactDOM, { findDOMNode } from 'react-dom';
 
-import InfoDialog from 'disco/components/InfoDialog';
 import I18nProvider from 'core/i18n/Provider';
+import InfoDialog from 'disco/components/InfoDialog';
 
-import { getFakeI18nInst } from 'tests/client/helpers';
+import { getFakeI18nInst } from '../../helpers';
 
 
 let closeAction;

--- a/tests/client/disco/components/TestInfoDialog.js
+++ b/tests/client/disco/components/TestInfoDialog.js
@@ -4,8 +4,7 @@ import ReactDOM, { findDOMNode } from 'react-dom';
 
 import I18nProvider from 'core/i18n/Provider';
 import InfoDialog from 'disco/components/InfoDialog';
-
-import { getFakeI18nInst } from '../../helpers';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 let closeAction;

--- a/tests/client/disco/containers/TestApp.js
+++ b/tests/client/disco/containers/TestApp.js
@@ -7,8 +7,7 @@ import {
 
 import I18nProvider from 'core/i18n/Provider';
 import App from 'disco/containers/App';
-
-import { getFakeI18nInst } from '../../helpers';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('App', () => {

--- a/tests/client/disco/containers/TestApp.js
+++ b/tests/client/disco/containers/TestApp.js
@@ -5,10 +5,10 @@ import {
   renderIntoDocument,
 } from 'react-addons-test-utils';
 
-import App from 'disco/containers/App';
 import I18nProvider from 'core/i18n/Provider';
+import App from 'disco/containers/App';
 
-import { getFakeI18nInst } from 'tests/client/helpers';
+import { getFakeI18nInst } from '../../helpers';
 
 
 describe('App', () => {

--- a/tests/client/disco/containers/TestDiscoPane.js
+++ b/tests/client/disco/containers/TestDiscoPane.js
@@ -18,8 +18,7 @@ import {
   globalEvents,
 } from 'disco/constants';
 import * as helpers from 'disco/containers/DiscoPane';
-
-import { getFakeI18nInst, MockedSubComponent } from '../../helpers';
+import { getFakeI18nInst, MockedSubComponent } from 'tests/client/helpers';
 
 
 // Use DiscoPane that isn't wrapped in asyncConnect.

--- a/tests/client/disco/containers/TestDiscoPane.js
+++ b/tests/client/disco/containers/TestDiscoPane.js
@@ -2,26 +2,28 @@ import React from 'react';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 import { Provider } from 'react-redux';
-import { discoResults } from 'disco/actions';
-import * as discoApi from 'disco/api';
-import createStore from 'disco/store';
+
+import { loadEntities } from 'core/actions';
+import I18nProvider from 'core/i18n/Provider';
 import {
   EXTENSION_TYPE,
   INSTALL_STATE,
 } from 'core/constants';
+import { discoResults } from 'disco/actions';
+import * as discoApi from 'disco/api';
+import createStore from 'disco/store';
 import {
   NAVIGATION_CATEGORY,
   VIDEO_CATEGORY,
   globalEvents,
 } from 'disco/constants';
 import * as helpers from 'disco/containers/DiscoPane';
-import { getFakeI18nInst, MockedSubComponent } from 'tests/client/helpers';
-import { loadEntities } from 'core/actions';
-import I18nProvider from 'core/i18n/Provider';
+
+import { getFakeI18nInst, MockedSubComponent } from '../../helpers';
 
 
 // Use DiscoPane that isn't wrapped in asyncConnect.
-const { DiscoPane } = helpers;
+const { DiscoPaneBase } = helpers;
 
 
 describe('AddonPage', () => {
@@ -37,7 +39,7 @@ describe('AddonPage', () => {
     return findDOMNode(renderIntoDocument(
       <I18nProvider i18n={i18n}>
         <Provider store={store} key="provider">
-          <DiscoPane results={results} i18n={i18n}
+          <DiscoPaneBase results={results} i18n={i18n}
             {...props} AddonComponent={MockedSubComponent} />
         </Provider>
       </I18nProvider>

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -1,7 +1,8 @@
+import { sprintf } from 'jed';
 import React from 'react';
 import { createRenderer } from 'react-addons-test-utils';
+
 import { EXTENSION_TYPE } from 'core/constants';
-import { sprintf } from 'jed';
 
 export function shallowRender(stuff) {
   const renderer = createRenderer();

--- a/tests/client/search/components/TestJsonData.js
+++ b/tests/client/search/components/TestJsonData.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { renderIntoDocument, Simulate } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
+
 import JsonData from 'search/components/JsonData';
 
 describe('<JsonData />', () => {

--- a/tests/client/search/components/TestSearchForm.js
+++ b/tests/client/search/components/TestSearchForm.js
@@ -3,7 +3,8 @@ import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 
 import * as actions from 'core/actions';
 import * as coreApi from 'core/api';
-import { SearchForm, mapDispatchToProps, mapStateToProps } from 'search/components/SearchForm';
+import { SearchFormBase, mapDispatchToProps, mapStateToProps }
+  from 'search/components/SearchForm';
 
 const wait = (time) => new Promise((resolve) => setTimeout(resolve, time));
 
@@ -26,7 +27,10 @@ describe('<SearchForm />', () => {
     }
 
     render() {
-      return <SearchForm pathname={pathname} api={api} loadAddon={loadAddon} ref="root" />;
+      return (<SearchFormBase
+        pathname={pathname} api={api}
+        loadAddon={loadAddon} ref="root"
+      />);
     }
   }
 

--- a/tests/client/search/components/TestSearchPage.js
+++ b/tests/client/search/components/TestSearchPage.js
@@ -4,7 +4,8 @@ import SearchPage from 'search/components/SearchPage';
 import SearchResults from 'search/components/SearchResults';
 import SearchForm from 'search/components/SearchForm';
 import Paginate from 'core/components/Paginate';
-import { findAllByTag, findByTag, shallowRender } from 'tests/client/helpers';
+
+import { findAllByTag, findByTag, shallowRender } from '../../helpers';
 
 describe('<SearchPage />', () => {
   let props;

--- a/tests/client/search/components/TestSearchPage.js
+++ b/tests/client/search/components/TestSearchPage.js
@@ -4,8 +4,7 @@ import SearchPage from 'search/components/SearchPage';
 import SearchResults from 'search/components/SearchResults';
 import SearchForm from 'search/components/SearchForm';
 import Paginate from 'core/components/Paginate';
-
-import { findAllByTag, findByTag, shallowRender } from '../../helpers';
+import { findAllByTag, findByTag, shallowRender } from 'tests/client/helpers';
 
 describe('<SearchPage />', () => {
   let props;

--- a/tests/client/search/components/TestSearchResult.js
+++ b/tests/client/search/components/TestSearchResult.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { renderIntoDocument } from 'react-addons-test-utils';
+
 import SearchResult from 'search/components/SearchResult';
 
 describe('<SearchResult />', () => {

--- a/tests/client/search/containers/TestAddonPage.js
+++ b/tests/client/search/containers/TestAddonPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 import { Provider } from 'react-redux';
+
 import AddonPage from 'search/containers/AddonPage';
 import createStore from 'search/store';
 

--- a/tests/client/search/containers/TestApp.js
+++ b/tests/client/search/containers/TestApp.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import App from 'search/containers/App';
-import { shallowRender } from 'tests/client/helpers';
+
+import { shallowRender } from '../../helpers';
 
 describe('App', () => {
   it('renders its children', () => {

--- a/tests/client/search/containers/TestApp.js
+++ b/tests/client/search/containers/TestApp.js
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import App from 'search/containers/App';
-
-import { shallowRender } from '../../helpers';
+import { shallowRender } from 'tests/client/helpers';
 
 describe('App', () => {
   it('renders its children', () => {

--- a/tests/client/search/containers/TestUserPage.js
+++ b/tests/client/search/containers/TestUserPage.js
@@ -4,12 +4,13 @@ import { findDOMNode } from 'react-dom';
 
 import { loadEntities, setCurrentUser } from 'core/actions';
 import * as api from 'core/api';
-import { UserPage, mapStateToProps, loadProfileIfNeeded } from 'search/containers/UserPage';
+import { UserPageBase, mapStateToProps, loadProfileIfNeeded }
+  from 'search/containers/UserPage';
 
 describe('<UserPage />', () => {
   it('renders the username and email', () => {
     const root = findDOMNode(renderIntoDocument(
-      <UserPage email="me@example.com" username="my-username" />));
+      <UserPageBase email="me@example.com" username="my-username" />));
     assert.deepEqual(
       Array.from(root.querySelectorAll('li')).map((li) => li.textContent),
       ['username: my-username', 'email: me@example.com']);

--- a/tests/server/TestConfig.js
+++ b/tests/server/TestConfig.js
@@ -1,7 +1,8 @@
-import { getClientConfig } from 'core/utils';
 import { assert } from 'chai';
-import requireUncached from 'require-uncached';
 import config from 'config';
+import requireUncached from 'require-uncached';
+
+import { getClientConfig } from 'core/utils';
 
 const appsList = config.get('validAppNames');
 

--- a/tests/server/TestLocalesConfig.js
+++ b/tests/server/TestLocalesConfig.js
@@ -1,9 +1,11 @@
 import fs from 'fs';
-import { assert } from 'chai';
 import path from 'path';
+
+import { assert } from 'chai';
 import config from 'config';
-import { langToLocale, localeToLang } from 'core/i18n/utils';
 import glob from 'glob';
+
+import { langToLocale, localeToLang } from 'core/i18n/utils';
 
 const langs = config.get('langs');
 const basePath = config.get('basePath');

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -1,10 +1,9 @@
 /* eslint-disable no-loop-func */
-
-import request from 'supertest-as-promised';
 import { assert } from 'chai';
+import Policy from 'csp-parse';
+import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-import Policy from 'csp-parse';
 
 import { checkSRI } from '../helpers';
 

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -4,8 +4,7 @@ import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-
-import { checkSRI } from '../helpers';
+import { checkSRI } from 'tests/server/helpers';
 
 const defaultURL = '/en-US/firefox/';
 

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -4,7 +4,8 @@ import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-import { checkSRI } from 'tests/server/helpers';
+
+import { checkSRI } from '../helpers';
 
 const defaultURL = '/en-US/firefox/';
 

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -4,8 +4,7 @@ import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-
-import { checkSRI } from '../helpers';
+import { checkSRI } from 'tests/server/helpers';
 
 const defaultURL = '/en-US/firefox/discovery/pane/48.0/Darwin/normal';
 

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -1,10 +1,9 @@
 /* eslint-disable no-loop-func */
-
-import request from 'supertest-as-promised';
 import { assert } from 'chai';
+import Policy from 'csp-parse';
+import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-import Policy from 'csp-parse';
 
 import { checkSRI } from '../helpers';
 

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -4,7 +4,8 @@ import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-import { checkSRI } from 'tests/server/helpers';
+
+import { checkSRI } from '../helpers';
 
 const defaultURL = '/en-US/firefox/discovery/pane/48.0/Darwin/normal';
 

--- a/tests/server/search/TestViews.js
+++ b/tests/server/search/TestViews.js
@@ -1,10 +1,9 @@
 /* eslint-disable no-loop-func */
-
-import request from 'supertest-as-promised';
 import { assert } from 'chai';
+import Policy from 'csp-parse';
+import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-import Policy from 'csp-parse';
 
 import { checkSRI } from '../helpers';
 

--- a/tests/server/search/TestViews.js
+++ b/tests/server/search/TestViews.js
@@ -4,8 +4,7 @@ import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-
-import { checkSRI } from '../helpers';
+import { checkSRI } from 'tests/server/helpers';
 
 describe('Search App GET requests', () => {
   let app;

--- a/tests/server/search/TestViews.js
+++ b/tests/server/search/TestViews.js
@@ -4,7 +4,8 @@ import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
-import { checkSRI } from 'tests/server/helpers';
+
+import { checkSRI } from '../helpers';
 
 describe('Search App GET requests', () => {
   let app;

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -1,15 +1,17 @@
-/* eslint-disable max-len, no-console */
+/* eslint-disable max-len, no-console, import/no-extraneous-dependencies */
 
 import fs from 'fs';
 import path from 'path';
+
+import config from 'config';
 import webpack from 'webpack';
+import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 
 import { getClientConfig } from 'core/utils';
-import config from 'config';
 
 import webpackConfig from './webpack.prod.config.babel';
-import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
-import webpackIsomorphicToolsConfig from './webpack-isomorphic-tools-config';
+import webpackIsomorphicToolsConfig
+  from './src/core/server/webpack-isomorphic-tools-config';
 
 const clientConfig = getClientConfig(config);
 const localDevelopment = config.util.getEnv('NODE_ENV') === 'development';

--- a/webpack.l10n.config.babel.js
+++ b/webpack.l10n.config.babel.js
@@ -1,7 +1,8 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, import/no-extraneous-dependencies */
 import fs from 'fs';
-import config from 'config';
+
 import chalk from 'chalk';
+import config from 'config';
 
 import webpackConfig from './webpack.prod.config.babel';
 

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -1,17 +1,17 @@
-/* eslint-disable max-len */
-
-import autoprefixer from 'autoprefixer';
+/* eslint-disable max-len, import/no-extraneous-dependencies */
 import path from 'path';
 
+import autoprefixer from 'autoprefixer';
 import config from 'config';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
-import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
-import webpackIsomorphicToolsConfig from './webpack-isomorphic-tools-config';
-import webpack from 'webpack';
-
 import SriStatsPlugin from 'sri-stats-webpack-plugin';
+import webpack from 'webpack';
+import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 
 import { getClientConfig } from 'core/utils';
+
+import webpackIsomorphicToolsConfig
+  from './src/core/server/webpack-isomorphic-tools-config';
 
 const clientConfig = getClientConfig(config);
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/931

* Added checks for missing imports and bad named imports. Yay!
* Added a check to make sure we don't accidentally import a named export as a default. For example, consider this:
````javascript
import Foo from './thing';
````

If `thing.Foo` actually exists then this could have been a typo. The developer probably meant:
````javascript
import { Foo } from './thing';
````

I feel like we were abusing this to get at raw components without their redux decorators. Thus, I needed to rename all non-decorated components from `TheComponent` to `TheComponentBase`. If this makes things awkward, just let me know and we can change it back.

* Added a rule for PEP8 style import ordering (not alphabetized though)
* Added a check to make sure dev dependencies aren't used in production code. This caught some bugs!
* Relative test imports can no longer be used. Technically these work because ~~karma runs from the root~~ we set `NODE_PATH` and technically we could allow it in the linter by adding `cwd` to the import resolver. However, I think this is bad practice because it makes other imports confusing. For example, is `import config` getting the one from `node_modules` or the one at `./config` ? I don't think it's too gnarly to use relative imports in the test suite (like `../../helpers`). **UPDATE** we decided to allow relative imports in the test code.