### PR TITLE
Better admin search results

### DIFF
--- a/src/search/components/SearchResult/index.js
+++ b/src/search/components/SearchResult/index.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import { sprintf } from 'jed';
@@ -18,6 +19,20 @@ function fileCountText(version) {
   return sprintf(ngettext('%(count)s file', '%(count)s files', count), { count });
 }
 
+const ResultLink = ({ children, end, middle, start, ...props }) =>
+  <a
+    className={classNames('SearchResult-link', 'button', {
+      'button-end': end,
+      'button-middle': middle,
+      'button-start': start,
+    })} rel="noopener noreferrer" target="_blank" {...props} >{children}</a>;
+ResultLink.propTypes = {
+  children: PropTypes.node.isRequired,
+  end: PropTypes.bool,
+  middle: PropTypes.bool,
+  start: PropTypes.bool,
+};
+
 export default class SearchResult extends React.Component {
   static propTypes = {
     result: PropTypes.object.isRequired,
@@ -26,16 +41,35 @@ export default class SearchResult extends React.Component {
   render() {
     const { result } = this.props;
     return (
-      <Link to={`/search/addons/${result.slug}`} className="search-result" ref="container">
-        <div className="search-result--name" ref="name">
-          {result.name}
+      <li className="SearchResult" ref="container">
+        <div>
+          <img
+            className="SearchResult-icon"
+            src={result.icon_url}
+            height="64"
+            width="64"
+            alt="Icon"
+          />
         </div>
-        <span className="search-result--info" ref="type">{result.type}</span>
-        <span className="search-result--info" ref="status">{result.status}</span>
-        <span className="search-result--info" ref="fileCount">
-          {fileCountText(result.current_version)}
-        </span>
-      </Link>
+        <div className="SearchResult-main">
+          <h2 className="SearchResult-heading">
+            <Link to={`/search/addons/${result.slug}`} className="SearchResult-name" ref="name">
+              {result.name}
+            </Link>
+          </h2>
+          <div className="SearchResult-info" ref="guid">{result.guid}</div>
+          <span className="SearchResult-info" ref="type">{result.type}</span>
+          <span className="SearchResult-info" ref="status">{result.status}</span>
+          <span className="SearchResult-info" ref="fileCount">
+            {fileCountText(result.current_version)}
+          </span>
+        </div>
+        <div className="SearchResult-actions">
+          <ResultLink href={result.url} start>Listing</ResultLink>
+          <ResultLink href={result.edit_url} middle>Edit</ResultLink>
+          <ResultLink href={result.review_url} end>Editors</ResultLink>
+        </div>
+      </li>
     );
   }
 }

--- a/src/search/components/SearchResult/index.js
+++ b/src/search/components/SearchResult/index.js
@@ -41,7 +41,7 @@ export default class SearchResult extends React.Component {
   render() {
     const { result } = this.props;
     return (
-      <li className="SearchResult" ref="container">
+      <li className="SearchResult">
         <div>
           <img className="SearchResult-icon" src={result.icon_url} alt="Icon" />
         </div>

--- a/src/search/components/SearchResult/index.js
+++ b/src/search/components/SearchResult/index.js
@@ -43,24 +43,25 @@ export default class SearchResult extends React.Component {
     return (
       <li className="SearchResult" ref="container">
         <div>
-          <img
-            className="SearchResult-icon"
-            src={result.icon_url}
-            height="64"
-            width="64"
-            alt="Icon"
-          />
+          <img className="SearchResult-icon" src={result.icon_url} alt="Icon" />
         </div>
         <div className="SearchResult-main">
           <h2 className="SearchResult-heading">
-            <Link to={`/search/addons/${result.slug}`} className="SearchResult-name" ref="name">
+            <Link to={`/search/addons/${result.slug}`} className="SearchResult-name"
+                  ref={(el) => { this.name = el; }}>
               {result.name}
             </Link>
           </h2>
-          <div className="SearchResult-info" ref="guid">{result.guid}</div>
-          <span className="SearchResult-info" ref="type">{result.type}</span>
-          <span className="SearchResult-info" ref="status">{result.status}</span>
-          <span className="SearchResult-info" ref="fileCount">
+          <div className="SearchResult-info" ref={(el) => { this.guid = el; }}>
+            {result.guid}
+          </div>
+          <span className="SearchResult-info" ref={(el) => { this.type = el; }}>
+            {result.type}
+          </span>
+          <span className="SearchResult-info" ref={(el) => { this.status = el; }}>
+            {result.status}
+          </span>
+          <span className="SearchResult-info" ref={(el) => { this.fileCount = el; }}>
             {fileCountText(result.current_version)}
           </span>
         </div>

--- a/src/search/components/SearchResult/style.scss
+++ b/src/search/components/SearchResult/style.scss
@@ -1,6 +1,5 @@
 .SearchResult {
-  border-color: #cfcfcf;
-  border-style: solid;
+  border: solid #cfcfcf;
   border-width: 1px 1px 0;
   color: #333;
   display: flex;

--- a/src/search/components/SearchResult/style.scss
+++ b/src/search/components/SearchResult/style.scss
@@ -1,22 +1,59 @@
-.search-result {
-  border-bottom: 1px solid #cfcfcf;
+.SearchResult {
+  border-color: #cfcfcf;
+  border-style: solid;
+  border-width: 1px 1px 0 1px;
   color: #333;
-  display: block;
+  display: flex;
   margin: 0;
-  padding: 1em 0;
+  padding: 1em;
+  text-decoration: none;
+  width: 100%;
+
+  &:last-of-type {
+    border-bottom-width: 1px;
+  }
+
+  &:hover {
+    background-color: #efefef;
+  }
+}
+
+.SearchResult-main {
+  flex-grow: 1;
+  margin: 0 1em;
+}
+
+.SearchResult-heading {
+  font-size: 1.25em;
+  margin: 0 0 0.1em;
+}
+
+.SearchResult-name {
+  color: #333;
+  margin-bottom: 0.25em;
   text-decoration: none;
 
-  &:hover .search-result--name {
+  &:hover {
     text-decoration: underline;
   }
 }
 
-.search-result--name {
-  font-size: 1.25em;
-  margin-bottom: 0.25em;
-}
-
-.search-result--info {
+.SearchResult-info {
   font-size: 0.8em;
   margin-right: 1em;
+}
+
+.SearchResult-link.button {
+  font-size: 0.75em;
+}
+
+.SearchResult-actions {
+  align-items: center;
+  display: flex;
+}
+
+.SearchResult-icon {
+  display: block;
+  height: 64px;
+  width: 64px;
 }

--- a/src/search/components/SearchResult/style.scss
+++ b/src/search/components/SearchResult/style.scss
@@ -1,7 +1,7 @@
 .SearchResult {
   border-color: #cfcfcf;
   border-style: solid;
-  border-width: 1px 1px 0 1px;
+  border-width: 1px 1px 0;
   color: #333;
   display: flex;
   margin: 0;

--- a/src/search/components/SearchResults.js
+++ b/src/search/components/SearchResults.js
@@ -31,8 +31,8 @@ export default class SearchResults extends React.Component {
       messageText = sprintf(
         _('Your search for "%(query)s" returned %(count)s results.'), { query, count });
       searchResults = (
-        <ul ref="results" className="search-results">
-          {results.map((result) => <li key={result.slug}><SearchResult result={result} /></li>)}
+        <ul ref="results" className="SearchResults-list">
+          {results.map((result) => <SearchResult result={result} key={result.slug} />)}
         </ul>
       );
     } else if (query && loading) {
@@ -46,7 +46,7 @@ export default class SearchResults extends React.Component {
     const message = messageText ? <p ref="message">{messageText}</p> : null;
 
     return (
-      <div ref="container" className="search-page">
+      <div ref="container" className="SearchResults">
         {message}
         {searchResults}
       </div>

--- a/src/search/css/SearchResults.scss
+++ b/src/search/css/SearchResults.scss
@@ -1,14 +1,9 @@
-.serach-page {
+.SearchResults {
   margin-top: 1em 0 0;
 }
 
-.search-results {
+.SearchResults-list {
   list-style-type: none;
   margin: 0;
   padding: 0;
-
-  li {
-    margin: 0;
-    padding: 0;
-  }
 }

--- a/src/search/css/lib/buttons.scss
+++ b/src/search/css/lib/buttons.scss
@@ -40,6 +40,11 @@ button.button {
   }
 }
 
+.button.button-start {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
 .button.button-middle {
   border-radius: 0;
 }

--- a/tests/client/search/components/TestSearchResult.js
+++ b/tests/client/search/components/TestSearchResult.js
@@ -16,28 +16,28 @@ describe('<SearchResult />', () => {
   const root = renderIntoDocument(<SearchResult result={result} />);
 
   it('renders the name', () => {
-    assert.equal(root.refs.name.props.children, 'A search result');
+    assert.equal(root.name.props.children, 'A search result');
   });
 
   it('renders the type', () => {
-    assert.equal(root.refs.type.textContent, 'Extension');
+    assert.equal(root.type.textContent, 'Extension');
   });
 
   it('renders the status', () => {
-    assert.equal(root.refs.status.textContent, 'Fully Reviewed');
+    assert.equal(root.status.textContent, 'Fully Reviewed');
   });
 
   it('renders the number of files', () => {
-    assert.equal(root.refs.fileCount.textContent, '2 files');
+    assert.equal(root.fileCount.textContent, '2 files');
   });
 
   it('links to the detail page', () => {
-    assert.equal(root.refs.name.props.to, '/search/addons/a-search-result');
+    assert.equal(root.name.props.to, '/search/addons/a-search-result');
   });
 
   it('renders the number of files singularly', () => {
     const thisResult = { ...result, current_version: { files: [{}] } };
     const thisRoot = renderIntoDocument(<SearchResult result={thisResult} />);
-    assert.equal(thisRoot.refs.fileCount.textContent, '1 file');
+    assert.equal(thisRoot.fileCount.textContent, '1 file');
   });
 });

--- a/tests/client/search/components/TestSearchResult.js
+++ b/tests/client/search/components/TestSearchResult.js
@@ -16,7 +16,7 @@ describe('<SearchResult />', () => {
   const root = renderIntoDocument(<SearchResult result={result} />);
 
   it('renders the name', () => {
-    assert.equal(root.refs.name.textContent, 'A search result');
+    assert.equal(root.refs.name.props.children, 'A search result');
   });
 
   it('renders the type', () => {
@@ -32,7 +32,7 @@ describe('<SearchResult />', () => {
   });
 
   it('links to the detail page', () => {
-    assert.equal(root.refs.container.props.to, '/search/addons/a-search-result');
+    assert.equal(root.refs.name.props.to, '/search/addons/a-search-result');
   });
 
   it('renders the number of files singularly', () => {


### PR DESCRIPTION
![search-results-improved mov](https://cloud.githubusercontent.com/assets/211578/17988061/56a2ee18-6ae9-11e6-988f-0a405e9b731e.gif)

This adds the guid and links to the listing, edit and editors to the search results.

The fake data I have locally is missing theme icons and the links don't work but I checked the data on dev and it should be fine with real data.

Fixes #978.