### PR TITLE
Move NavBar to admin app (fix #999)

### DIFF
--- a/src/admin/components/NavBar/index.js
+++ b/src/admin/components/NavBar/index.js
@@ -5,13 +5,13 @@ import {
   NavBarLink,
 } from 'core/components/NavBar';
 
-const SearchNavBar = () => (
+const AdminNavBar = () => (
   <NavBar>
     <NavBarLink to="/search">Search</NavBarLink>
   </NavBar>
 );
-SearchNavBar.propTypes = {
+AdminNavBar.propTypes = {
   logout: PropTypes.func.isRequired,
 };
 
-export default SearchNavBar;
+export default AdminNavBar;

--- a/src/admin/containers/App.js
+++ b/src/admin/containers/App.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import Helmet from 'react-helmet';
 
 import { gettext as _ } from 'core/utils';
-import NavBar from 'search/components/NavBar';
+import NavBar from 'admin/components/NavBar';
 
 import 'admin/css/App.scss';
 

--- a/tests/client/admin/components/TestNavBar.js
+++ b/tests/client/admin/components/TestNavBar.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { NavBar, NavBarLink } from 'core/components/NavBar';
-import SearchNavBar from 'search/components/NavBar';
+import AdminNavBar from 'admin/components/NavBar';
 import { shallowRender } from 'tests/client/helpers';
 
-describe('<SearchNavBar />', () => {
+describe('<AdminNavBar />', () => {
   it('renders a link to Search', () => {
-    const root = shallowRender(<SearchNavBar />);
+    const root = shallowRender(<AdminNavBar />);
     assert.equal(root.type, NavBar);
     const link = root.props.children;
     assert.equal(link.type, NavBarLink);


### PR DESCRIPTION
Not sure if I didn't catch this in #967 or if it crept in via another later PR. Either way, now everything admin is in the admin app/folders :)