### PR TITLE
Send dimensions with initial page view

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -26,6 +26,7 @@ module.exports = {
     'rtlLangs',
     'trackingEnabled',
     'trackingId',
+    'trackingSendInitPageView',
     'useUiTour',
   ],
 
@@ -51,6 +52,9 @@ module.exports = {
   },
   trackingEnabled: true,
   trackingId: 'UA-36116321-7',
+  // We override the initial page view call in order to
+  // add custom dimension data.
+  trackingSendInitPageView: false,
 
   enablePostCssLoader: false,
 

--- a/config/default.js
+++ b/config/default.js
@@ -79,6 +79,7 @@ module.exports = {
     'rtlLangs',
     'trackingEnabled',
     'trackingId',
+    'trackingSendInitPageView',
   ],
 
   // Content Security Policy.
@@ -151,6 +152,8 @@ module.exports = {
   // and enabled on a per-app basis.
   trackingEnabled: false,
   trackingId: null,
+  // send a page view on initialization.
+  trackingSendInitPageView: true,
 
   enablePostCssLoader: true,
 

--- a/src/core/tracking.js
+++ b/src/core/tracking.js
@@ -1,6 +1,5 @@
 /* global window */
 /* eslint-disable no-underscore-dangle */
-
 import config from 'config';
 
 import { convertBoolean } from 'core/utils';
@@ -13,7 +12,7 @@ import {
 
 export class Tracking {
 
-  constructor({ trackingId, trackingEnabled, _log = log } = {}) {
+  constructor({ trackingId, trackingEnabled, trackingSendInitPageView, _log = log } = {}) {
     if (typeof window === 'undefined') {
       /* istanbul ignore next */
       return;
@@ -22,13 +21,16 @@ export class Tracking {
     this.id = trackingId;
     this.enabled = trackingEnabled && trackingId;
     this.logPrefix = `[GA: ${this.enabled ? 'ON' : 'OFF'}]`;
+    this.sendInitPageView = trackingSendInitPageView;
 
     if (this.enabled) {
       /* eslint-disable */
       // Snippet from Google UA docs: http://bit.ly/1O6Dsdh
       window.ga = window.ga || function() {(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       ga('create', trackingId, 'auto');
-      ga('send', 'pageview');
+      if (this.sendInitPageView) {
+        ga('send', 'pageview');
+      }
       /* eslint-enable */
     }
 
@@ -86,6 +88,11 @@ export class Tracking {
     this._ga('set', 'page', page);
     this.log('setPage', page);
   }
+
+  pageView(data = {}) {
+    this._ga('send', 'pageview', data);
+    this.log('pageView', JSON.stringify(data));
+  }
 }
 
 export function getAction(type) {
@@ -98,4 +105,5 @@ export function getAction(type) {
 export default new Tracking({
   trackingEnabled: convertBoolean(config.get('trackingEnabled')),
   trackingId: config.get('trackingId'),
+  trackingSendInitPageView: config.get('trackingSendInitPageView'),
 });

--- a/src/disco/client.js
+++ b/src/disco/client.js
@@ -1,9 +1,21 @@
-import makeClient from 'core/client/base';
+import config from 'config';
 
-// Initialize the tracking.
-import 'core/tracking';
+import makeClient from 'core/client/base';
+// Init tracking.
+import tracking from 'core/tracking';
+import getInstallData from 'disco/tracking';
 
 import routes from './routes';
 import createStore from './store';
+
+// Having disabled the initial page view beacon in config
+// we send our own with custom dimension data.
+if (config.get('trackingSendInitPageView') === false) {
+  const installData = getInstallData();
+  tracking.pageView({
+    dimension1: installData.hasExtensions,
+    dimension2: installData.hasThemes,
+  });
+}
 
 makeClient(routes, createStore);

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -94,7 +94,6 @@ export class AddonBase extends React.Component {
     return JSON.stringify(getThemeData(this.props));
   }
 
-
   getError() {
     const { error, i18n, status } = this.props;
     return status === ERROR ? (<div className="notification error" key="error-overlay">

--- a/src/disco/constants.js
+++ b/src/disco/constants.js
@@ -37,3 +37,15 @@ export const CLOSE_INFO = 'CLOSE_INFO';
 // Error used to know that the setEnable method on addon is
 // not available.
 export const SET_ENABLE_NOT_AVAILABLE = 'SET_ENABLE_NOT_AVAILABLE';
+
+// Keys for extensions and theme data in the discovery pane JSON blob.
+export const DISCO_DATA_THEME = 'theme';
+export const DISCO_DATA_EXTENSION = 'extension';
+export const DISCO_DATA_UNKNOWN = 'unknown';
+// Built-in extensions and themes to ignore.
+export const DISCO_DATA_GUID_IGNORE_LIST = [
+  '{972ce4c6-7e08-4474-a285-3208198ce6fd}', // Default theme.
+  'e10srollout@mozilla.org', // e10s
+  'firefox@getpocket.com', // Pocket
+  'loop@mozilla.org', // Firefox Hello
+];

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-/* global navigator */
+/* global navigator, window */
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';

--- a/src/disco/tracking.js
+++ b/src/disco/tracking.js
@@ -1,0 +1,54 @@
+/* global window */
+
+import log from 'core/logger';
+import {
+  DISCO_DATA_EXTENSION,
+  DISCO_DATA_GUID_IGNORE_LIST,
+  DISCO_DATA_THEME,
+  DISCO_DATA_UNKNOWN,
+} from 'disco/constants';
+
+
+export default function getInstallData({ _window = window } = {}) {
+  const count = {
+    themes: 0,
+    extensions: 0,
+  };
+  let jsonData = null;
+  if (_window && _window.location && _window.location.hash) {
+    try {
+      const hash = _window.decodeURIComponent(_window.location.hash).replace(/^#/, '');
+      jsonData = JSON.parse(hash);
+    } catch (e) {
+      log.error(e);
+    }
+  }
+
+  if (!jsonData) {
+    return {
+      hasThemes: DISCO_DATA_UNKNOWN,
+      hasExtensions: DISCO_DATA_UNKNOWN,
+    };
+  }
+
+  Object.keys(jsonData).forEach((key) => {
+    if (DISCO_DATA_GUID_IGNORE_LIST.includes(key)) {
+      return;
+    }
+    const item = jsonData[key];
+    if (!item.type) {
+      return;
+    }
+    if (item.type === DISCO_DATA_THEME) {
+      count.themes += 1;
+    }
+    if (item.type === DISCO_DATA_EXTENSION) {
+      count.extensions += 1;
+    }
+  });
+
+  return {
+    hasExtensions: count.extensions > 0,
+    hasThemes: count.themes > 0,
+  };
+}

--- a/tests/client/core/test_tracking.js
+++ b/tests/client/core/test_tracking.js
@@ -40,13 +40,37 @@ describe('Tracking', () => {
     assert.ok(tracking._log.info.secondCall.calledWith(sinon.match(/OFF/), 'Missing tracking id'));
   });
 
+  it('should send initial page view when enabled', () => {
+    tracking = new Tracking({
+      trackingId: 'whatever',
+      trackingEnabled: true,
+      trackingSendInitPageView: true,
+      _log: {
+        info: sinon.stub(),
+      },
+    });
+    assert.ok(window.ga.calledWith('send', 'pageview'));
+  });
+
+  it('should not send initial page view when disabled', () => {
+    tracking = new Tracking({
+      trackingId: 'whatever',
+      trackingEnabled: true,
+      trackingSendInitPageView: false,
+      _log: {
+        info: sinon.stub(),
+      },
+    });
+    assert.notOk(window.ga.calledWith('send', 'pageview'));
+  });
+
   it('should throw if page not set', () => {
     assert.throws(() => {
       tracking.setPage();
     }, Error, /page is required/);
   });
 
-  it('should call ga', () => {
+  it('should call ga with setPage', () => {
     tracking.setPage('whatever');
     assert.ok(window.ga.called);
   });
@@ -65,12 +89,21 @@ describe('Tracking', () => {
     }, Error, /action is required/);
   });
 
-  it('should call _ga', () => {
+  it('should call _ga with sendEvent', () => {
     tracking.sendEvent({
       category: 'whatever',
       action: 'some-action',
     });
     assert.ok(window.ga.called);
+  });
+
+  it('should call _ga when pageView is called', () => {
+    const data = {
+      dimension1: 'whatever',
+      dimension2: 'whatever2',
+    };
+    tracking.pageView(data);
+    assert.ok(window.ga.calledWith('send', 'pageview', data));
   });
 });
 

--- a/tests/client/disco/test_tracking.js
+++ b/tests/client/disco/test_tracking.js
@@ -1,0 +1,80 @@
+/* global window */
+
+import getInstallData from 'disco/tracking';
+import { DISCO_DATA_UNKNOWN } from 'disco/constants';
+
+
+describe('disco pane install tracking data', () => {
+  function getFakeWindow(hash) {
+    return {
+      decodeURIComponent: window.decodeURIComponent,
+      location: {
+        hash: `#${encodeURIComponent(hash)}`,
+      },
+    };
+  }
+
+  it('detects user has themes', () => {
+    const _window = getFakeWindow('{"blah": {"type": "theme"}}');
+    const result = getInstallData({ _window });
+    assert.deepEqual(getInstallData({ _window }), {
+      hasExtensions: false,
+      hasThemes: true,
+    }, sinon.format(result));
+  });
+
+  it('detects user has extensions', () => {
+    const _window = getFakeWindow('{"blah": {"type": "extension"}}');
+    const result = getInstallData({ _window });
+    assert.deepEqual(getInstallData({ _window }), {
+      hasExtensions: true,
+      hasThemes: false,
+    }, sinon.format(result));
+  });
+
+  it('ignores the default theme', () => {
+    const _window = getFakeWindow('{"{972ce4c6-7e08-4474-a285-3208198ce6fd}": {"type": "theme"}}');
+    const result = getInstallData({ _window });
+    assert.deepEqual(result, {
+      hasExtensions: false,
+      hasThemes: false,
+    }, sinon.format(result));
+  });
+
+  it('ignores built in extensions', () => {
+    const _window = getFakeWindow('{"firefox@getpocket.com": {"type": "extension"}}');
+    const result = getInstallData({ _window });
+    assert.deepEqual(result, {
+      hasExtensions: false,
+      hasThemes: false,
+    }, sinon.format(result));
+  });
+
+  it('ignores data with no type', () => {
+    const _window = getFakeWindow('{"foo": {}}');
+    const result = getInstallData({ _window });
+    assert.deepEqual(result, {
+      hasExtensions: false,
+      hasThemes: false,
+    }, sinon.format(result));
+  });
+
+  it('falls back to "unknown" when data is not present', () => {
+    const _window = getFakeWindow('');
+    const result = getInstallData({ _window });
+    assert.deepEqual(result, {
+      hasExtensions: DISCO_DATA_UNKNOWN,
+      hasThemes: DISCO_DATA_UNKNOWN,
+    }, sinon.format(result));
+  });
+
+  it('falls back to "unknown" when JSON cannot be parsed', () => {
+    const _window = getFakeWindow('{{"what"}');
+    const result = getInstallData({ _window });
+    assert.deepEqual(result, {
+      hasExtensions: DISCO_DATA_UNKNOWN,
+      hasThemes: DISCO_DATA_UNKNOWN,
+    }, sinon.format(result));
+  });
+});
+


### PR DESCRIPTION
Fixes #963 

Will send dimensions for `has-extensions`/`has-themes` with `true`, `false` or `'unknown'` if it can't be determined.