### PR TITLE
Tweak add-on blocks

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -6,7 +6,8 @@ $addon-padding: 20px;
 .addon {
   align-items: center;
   background: #fff;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2);
+  border-radius: 3px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.4);
   display: flex;
   flex-direction: row;
   line-height: 1.5;
@@ -36,6 +37,8 @@ $addon-padding: 20px;
   }
 
   .theme-image {
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
     display: block;
     overflow: hidden;
 


### PR DESCRIPTION
Fixes #1047

Looks like this:

<img alt="discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/18475491/823c60ac-79be-11e6-801e-48dfe0cde194.png">


Increasing the shadow alpha to 0.4 (from 0.3) looks like this (click to see best quality).

<img alt="discover_add-ons" src="https://cloud.githubusercontent.com/assets/1514/18475482/74387234-79be-11e6-8d96-222f0edd455f.png">

