### PR TITLE
Add python code linting with flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,23 @@ env:
   - TASK=lint
   - TASK=unittest GUI=1
   - TASK=servertest
-  - TASK=tox TOXENV=discopane-ui-tests GUI=1
+  - TOXENV=discopane-ui-tests GUI=1 PYTEST_ADDOPTS=--base-url=http://localhost:4000
+  - TOXENV=flake8
 cache:
   directories:
   - node_modules
 before_install:
 - npm install -g npm@3
 - npm --version
-- sudo pip install tox
-- wget "https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-linux64.tar.gz"
-- gunzip -c geckodriver-v0.10.0-linux64.tar.gz | tar xopf -
-- chmod +x geckodriver
-- sudo mv geckodriver /usr/local/bin
+- if [ $TOXENV ]; then sudo pip install tox; fi
+- if [[ $TOXENV == 'discopane-ui-tests' ]]; then wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-linux64.tar.gz; fi
+- if [[ $TOXENV == 'discopane-ui-tests' ]]; then gunzip -c geckodriver.tar.gz | tar xopf -; fi
+- if [[ $TOXENV == 'discopane-ui-tests' ]]; then chmod +x geckodriver && sudo mv geckodriver /usr/local/bin; fi
 before_script:
 - if [ $GUI ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3; fi
 script:
-- if [[ $TASK == 'tox' ]]; then docker run -d -p 4000:4000 -e NODE_APP_INSTANCE=disco -e NODE_ENV=uitests $(docker build -q .) /bin/sh -c "npm run build && npm run start" && sleep 60 && tox -- --base-url=http://localhost:4000; fi
-- if [[ $TASK != 'tox' ]]; then npm run $TASK; fi
+- if [[ $TOXENV == 'discopane-ui-tests' ]]; then docker run -d -p 4000:4000 -e NODE_APP_INSTANCE=disco -e NODE_ENV=uitests $(docker build -q .) /bin/sh -c "npm run build && npm run start" && sleep 60; fi
+- if [ $TOXENV ]; then export PYTEST_ADDOPTS=--base-url=http://localhost:4000 && tox; fi
+- if [ -z $TOXENV ]; then npm run $TASK; fi
 addons:
   firefox: latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,19 @@
 [tox]
 skipsdist = true
-envlist = discopane-ui-tests
+envlist = discopane-ui-tests, flake8
 
 [testenv:discopane-ui-tests]
-passenv = DISPLAY
+passenv = DISPLAY PYTEST_ADDOPTS
 deps =
   PyPOM==1.0
   pytest==2.9.2
   pytest-selenium==1.3.1
   selenium==3.0.0b2
 commands = py.test tests/ui/test_discopane.py {posargs}
+
+[testenv:flake8]
+deps = flake8==3.0.4
+commands = flake8 {posargs:.}
+
+[flake8]
+exclude = node_modules,.tox


### PR DESCRIPTION
Fixes #792

This adds python linting using flake8, and tweaks Travis to avoid running parts when they're not needed. This is bordering on readability issues, so it might be worth either splitting Tox tasks to CircleCI or at least calling scripts stored in the repo rather than having them in the Travis config.