### PR TITLE
Revert "chore(package): update webpack-dev-middleware to version 1.8.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "supertest-as-promised": "4.0.0",
     "svg-url-loader": "1.1.0",
     "webpack": "1.13.2",
-    "webpack-dev-middleware": "1.8.2",
+    "webpack-dev-middleware": "1.6.1",
     "webpack-dev-server": "1.16.1",
     "webpack-hot-middleware": "2.12.2"
   }


### PR DESCRIPTION
This reverts commit fefb2495cfe041bfd784204fc1a501955bdbfd70.

Hey @kumar303, looks like it did indeed still break things, so reverting this.

Sorry about that, I've made a note to not merge dev server stuff without testing.