### PR TITLE
First pass at styled search result (fix #1117)

### DIFF
--- a/src/amo/components/SearchResult.js
+++ b/src/amo/components/SearchResult.js
@@ -1,34 +1,39 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 
+import translate from 'core/i18n/translate';
+
 import 'core/css/SearchResult.scss';
 
-export default class SearchResult extends React.Component {
+class SearchResult extends React.Component {
   static propTypes = {
+    i18n: PropTypes.object.isRequired,
     lang: PropTypes.string.isRequired,
     result: PropTypes.object.isRequired,
   }
 
   render() {
-    const { lang, result } = this.props;
+    const { i18n, lang, result } = this.props;
     return (
       <li className="SearchResult">
         <Link to={`/${lang}/firefox/addon/${result.slug}/`}
               className="SearchResult-link"
               ref={(el) => { this.name = el; }}>
-          <div>
-            <img className="SearchResult-icon" src={result.icon_url}
-                 alt="Icon" />
-          </div>
           <section className="SearchResult-main">
-            <h2 className="SearchResult-heading">
-              <span className="SearchResult-name">
-                {result.name}
-              </span>
-            </h2>
+            <img className="SearchResult-icon" src={result.icon_url} alt="" />
+            <h2 className="SearchResult-heading">{result.name}</h2>
+            <h3 className="SearchResult-author">{result.authors[0].name}</h3>
+            <h3 className="SearchResult-users">{i18n.sprintf(
+              i18n.ngettext('%(users)s user', '%(users)s users',
+                            result.average_daily_users),
+              { users: result.average_daily_users }
+            )}
+            </h3>
           </section>
         </Link>
       </li>
     );
   }
 }
+
+export default translate({ withRef: true })(SearchResult);

--- a/src/core/components/Search/SearchResults.js
+++ b/src/core/components/Search/SearchResults.js
@@ -1,16 +1,17 @@
+import classNames from 'classnames';
 import React, { PropTypes } from 'react';
-import { sprintf } from 'jed';
 
-import { gettext as _ } from 'core/utils';
+import translate from 'core/i18n/translate';
 
 import 'core/css/SearchResults.scss';
 
 import SearchResult from './SearchResult';
 
 
-export default class SearchResults extends React.Component {
+class SearchResults extends React.Component {
   static propTypes = {
     count: PropTypes.number,
+    i18n: PropTypes.object.isRequired,
     lang: PropTypes.string.isRequired,
     loading: PropTypes.bool,
     query: PropTypes.string,
@@ -26,7 +27,7 @@ export default class SearchResults extends React.Component {
   }
 
   render() {
-    const { count, lang, loading, query, ResultComponent,
+    const { ResultComponent, count, i18n, lang, loading, query,
             results } = this.props;
 
     let searchResults;
@@ -35,8 +36,14 @@ export default class SearchResults extends React.Component {
 
     if (query && count > 0) {
       hideMessageText = true;
-      messageText = sprintf(
-        _('Your search for "%(query)s" returned %(count)s results.'), { query, count });
+      messageText = i18n.sprintf(
+        i18n.ngettext(
+          'Your search for "%(query)s" returned %(count)s result.',
+          'Your search for "%(query)s" returned %(count)s results.',
+          count,
+        ),
+        { query, count }
+      );
       searchResults = (
         <ul className="SearchResults-list"
             ref={(ref) => { this.results = ref; }}>
@@ -46,16 +53,19 @@ export default class SearchResults extends React.Component {
         </ul>
       );
     } else if (query && loading) {
-      messageText = _('Searching...');
+      messageText = i18n.gettext('Searching...');
     } else if (query && results.length === 0) {
-      messageText = sprintf(_('No results were found for "%(query)s".'), { query });
+      messageText = i18n.sprintf(
+        i18n.gettext('No results were found for "%(query)s".'), { query });
     } else if (query !== null) {
-      messageText = _('Please supply a valid search');
+      messageText = i18n.gettext('Please supply a valid search');
     }
 
     const message = messageText ?
-      <p className={hideMessageText ? 'visually-hidden' : ''}
-         ref={(ref) => { this.message = ref; }}>{messageText}</p> : null;
+      <p ref={(ref) => { this.message = ref; }} className={classNames({
+        'visually-hidden': hideMessageText,
+        'SearchReuslts-message': !hideMessageText,
+      })}>{messageText}</p> : null;
 
     return (
       <div ref={(ref) => { this.container = ref; }} className="SearchResults">
@@ -65,3 +75,5 @@ export default class SearchResults extends React.Component {
     );
   }
 }
+
+export default translate({ withRef: true })(SearchResults);

--- a/src/core/css/SearchResult.scss
+++ b/src/core/css/SearchResult.scss
@@ -1,18 +1,27 @@
-.SearchResult {
-  border: solid #cfcfcf;
-  border-width: 1px 1px 0;
+@import "~core/css/inc/vars";
 
-  &:last-of-type {
-    border-bottom-width: 1px;
+$border-radius: 9px;
+$secondary-color: #6a6a6a;
+
+.SearchResult {
+  background: $background-accent-color;
+  border-bottom: 6px solid #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+
+  &:first-of-type {
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
   }
 
-  &:hover {
-    background-color: #efefef;
+  &:last-of-type {
+    border-bottom: 0;
+    border-bottom-left-radius: $border-radius;
+    border-bottom-right-radius: $border-radius;
   }
 }
 
 .SearchResult-link {
-  color: #333;
+  color: $text-color-default;
   display: flex;
   margin: 0;
   padding: 1em;
@@ -22,22 +31,33 @@
 
 .SearchResult-main {
   flex-grow: 1;
-  margin: 0 1em;
 }
 
 .SearchResult-heading {
-  font-size: 1.25em;
+  color: $primary-font-color;
+  font-size: $font-size-m;
+  font-weight: normal;
   margin: 0 0 0.1em;
-}
-
-.SearchResult-name {
-  color: #333;
-  margin-bottom: 0.25em;
+  padding: 0;
   text-decoration: none;
 
   &:hover {
     text-decoration: underline;
   }
+}
+
+.SearchResult-author,
+.SearchResult-users {
+  color: $secondary-color;
+  display: inline-block;
+  font-size: $font-size-default;
+  font-weight: normal;
+  margin: 0;
+  padding: 0;
+}
+
+.SearchResult-author {
+  margin-right: 0.5em;
 }
 
 .SearchResult-info {
@@ -55,7 +75,8 @@
 }
 
 .SearchResult-icon {
-  display: block;
-  height: 64px;
-  width: 64px;
+  display: inline-block;
+  float: right;
+  height: 38px;
+  width: 38px;
 }

--- a/src/core/css/SearchResults.scss
+++ b/src/core/css/SearchResults.scss
@@ -1,9 +1,25 @@
-.SearchResults {
-  margin-top: 1em 0 0;
-}
+@import "~core/css/inc/vars";
 
 .SearchResults-list {
+  background: $background-accent-color;
+  border-bottom: 6px solid #fff;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
   list-style-type: none;
-  margin: 0;
+  margin: 1em 0 0;
   padding: 0;
+}
+
+.SearchResults-type-header {
+  color: #000;
+  font-size: $font-size-default;
+  text-align: center;
+}
+
+.SearchResults-message {
+  background: $background-accent-color;
+  font-size: $font-size-m;
+  margin: 0;
+  padding: 1em;
+  text-align: center;
 }

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -15,6 +15,8 @@ $button-background-color: #0095dd;
 $button-background-disabled-color: #8a9ba8;
 $button-background-hover-color: #08c;
 
+$background-accent-color: #f5f5f5;
+
 $warning: #d63920;
 
 $focus-outline-color: #0096dc;

--- a/tests/client/amo/components/TestSearchResult.js
+++ b/tests/client/amo/components/TestSearchResult.js
@@ -1,22 +1,63 @@
 import React from 'react';
 import {
+  findRenderedComponentWithType,
   findRenderedDOMComponentWithClass,
   renderIntoDocument,
 } from 'react-addons-test-utils';
 
+import I18nProvider from 'core/i18n/Provider';
 import SearchResult from 'amo/components/SearchResult';
+import { getFakeI18nInst } from 'tests/client/helpers';
+
 
 describe('<SearchResult />', () => {
+  function renderResult(result) {
+    return findRenderedComponentWithType(renderIntoDocument(
+      <I18nProvider i18n={getFakeI18nInst()}>
+        <SearchResult result={result} lang="en-US" />
+      </I18nProvider>
+    ), SearchResult).getWrappedInstance();
+  }
+
   const result = {
+    authors: [
+      { name: 'A funky déveloper' },
+      { name: 'A groovy developer' },
+    ],
+    average_daily_users: 553,
     name: 'A search result',
     slug: 'a-search-result',
   };
-  const root = renderIntoDocument(
-    <SearchResult result={result} lang="en-US" />);
+  const root = renderResult(result);
 
-  it('renders the name', () => {
-    const name = findRenderedDOMComponentWithClass(root, 'SearchResult-name');
-    assert.equal(name.textContent, 'A search result');
+  it('renders the heading', () => {
+    const heading = findRenderedDOMComponentWithClass(
+      root, 'SearchResult-heading');
+    assert.equal(heading.textContent, 'A search result');
+  });
+
+  it('renders the author', () => {
+    const node = findRenderedDOMComponentWithClass(root,
+                                                   'SearchResult-author');
+    assert.ok(node);
+  });
+
+  it("renders only the first author's name when there are multiple", () => {
+    const authors = findRenderedDOMComponentWithClass(root,
+                                                      'SearchResult-author');
+    assert.equal(authors.textContent, 'A funky déveloper');
+  });
+
+  it('renders the user count', () => {
+    const users = findRenderedDOMComponentWithClass(root, 'SearchResult-users');
+    assert.equal(users.textContent, '553 users');
+  });
+
+  it('renders the user count as singular', () => {
+    const renderedResult = renderResult({ ...result, average_daily_users: 1 });
+    const users = findRenderedDOMComponentWithClass(renderedResult,
+                                                    'SearchResult-users');
+    assert.equal(users.textContent, '1 user');
   });
 
   it('links to the detail page', () => {

--- a/tests/client/core/components/TestSearchResults.js
+++ b/tests/client/core/components/TestSearchResults.js
@@ -1,12 +1,22 @@
 import React from 'react';
-import { renderIntoDocument as render, isDOMComponent } from 'react-addons-test-utils';
+import {
+  renderIntoDocument as render,
+  findRenderedComponentWithType,
+  isDOMComponent,
+} from 'react-addons-test-utils';
 
+import I18nProvider from 'core/i18n/Provider';
 import SearchResults from 'core/components/Search/SearchResults';
+import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('<SearchResults />', () => {
   function renderResults(props) {
-    return render(<SearchResults {...props} />);
+    return findRenderedComponentWithType(render(
+      <I18nProvider i18n={getFakeI18nInst()}>
+        <SearchResults {...props} />
+      </I18nProvider>
+    ), SearchResults).getWrappedInstance();
   }
 
   it('renders empty search results container', () => {
@@ -18,16 +28,17 @@ describe('<SearchResults />', () => {
 
   it('renders error when query is an empty string', () => {
     const root = renderResults({ query: '' });
-    const searchResultsMsg = root.message;
-    assert.include(searchResultsMsg.firstChild.nodeValue, 'supply a valid search');
+    const searchResultsMessage = root.message;
+    assert.include(searchResultsMessage.firstChild.nodeValue,
+                   'supply a valid search');
   });
 
   it('renders error when no results and valid query', () => {
     const root = renderResults({ query: 'test' });
-    const searchResultsMsg = root.message;
+    const searchResultsMessage = root.message;
     // Using textContent here since we want to see the text inside the p.
     // Since it has dynamic content is wrapped in a span implicitly.
-    assert.include(searchResultsMsg.textContent, 'No results were found');
+    assert.include(searchResultsMessage.textContent, 'No results were found');
   });
 
   it('renders a loading message when loading', () => {
@@ -35,8 +46,8 @@ describe('<SearchResults />', () => {
       query: 'test',
       loading: true,
     });
-    const searchResultsMsg = root.message;
-    assert.equal(searchResultsMsg.textContent, 'Searching...');
+    const searchResultsMessage = root.message;
+    assert.equal(searchResultsMessage.textContent, 'Searching...');
   });
 
   it('renders search results when supplied', () => {
@@ -48,11 +59,25 @@ describe('<SearchResults />', () => {
         { name: 'result 2', slug: '2' },
       ],
     });
-    const searchResultsMsg = root.message;
-    assert.include(searchResultsMsg.textContent, 'Your search for "test" returned 5 results');
+    const searchResultsMessage = root.message;
+    assert.include(searchResultsMessage.textContent,
+                   'Your search for "test" returned 5 results');
 
     const searchResultsList = root.results;
     assert.include(searchResultsList.textContent, 'result 1');
     assert.include(searchResultsList.textContent, 'result 2');
+  });
+
+  it('renders search results in the singular', () => {
+    const root = renderResults({
+      count: 1,
+      query: 'test',
+      results: [
+        { name: 'result 1', slug: '1' },
+      ],
+    });
+    const searchResultsMessage = root.message;
+    assert.include(searchResultsMessage.textContent,
+                   'Your search for "test" returned 1 result');
   });
 });

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { createRenderer } from 'react-addons-test-utils';
 
 import { EXTENSION_TYPE } from 'core/constants';
+import { ngettext } from 'core/utils';
 
 export function shallowRender(stuff) {
   const renderer = createRenderer();
@@ -43,7 +44,7 @@ export function getFakeI18nInst() {
   return {
     gettext: sinon.spy((str) => str),
     dgettext: sinon.stub(),
-    ngettext: sinon.stub(),
+    ngettext: sinon.spy(ngettext),
     dngettext: sinon.stub(),
     pgettext: sinon.stub(),
     dpgettext: sinon.stub(),


### PR DESCRIPTION
This styles the search result, but further work will be needed for the extension/theme separation in the mocks. Will file issues for that.

### Screenshots
<img width="346" alt="screenshot 2016-09-28 17 13 00" src="https://cloud.githubusercontent.com/assets/90871/18922279/daea0aa0-859f-11e6-972a-e879ac37389e.png">
<img width="361" alt="screenshot 2016-09-28 17 12 52" src="https://cloud.githubusercontent.com/assets/90871/18922278/dae5ebf0-859f-11e6-8eef-f0df179fa51d.png">
