### PR TITLE
Stop using .development() on server (fix #1235)

### DIFF
--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -230,7 +230,8 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
 
 export function runServer({ listen = true, app = appName } = {}) {
   if (!app) {
-    log.fatal(`Please specify a valid appName from ${config.get('validAppNames')}`);
+    log.fatal(
+      `Please specify a valid appName from ${config.get('validAppNames')}`);
     process.exit(1);
   }
 
@@ -238,7 +239,7 @@ export function runServer({ listen = true, app = appName } = {}) {
   const host = config.get('serverHost');
 
   const isoMorphicServer = new WebpackIsomorphicTools(WebpackIsomorphicToolsConfig);
-  return isoMorphicServer.development(isDevelopment)
+  return isoMorphicServer
     .server(config.get('basePath'))
     .then(() => {
       global.webpackIsomorphicTools = isoMorphicServer;


### PR DESCRIPTION
This was bugging me so I stopped it.

Apparently this didn't do anything anymore, which does make me ask: what were we relying on it to do and will it break anything in development?

But everything seems fine so I submit this for review.