### PR TITLE
Upgrade react to 15.3.2 to fix unmet dep warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "normalize.css": "5.0.0",
     "normalizr": "2.2.1",
     "piping": "0.3.2",
-    "react": "15.3.1",
+    "react": "15.3.2",
     "react-addons-css-transition-group": "15.3.2",
     "react-cookie": "0.4.8",
     "react-dom": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "react": "15.3.2",
     "react-addons-css-transition-group": "15.3.2",
     "react-cookie": "0.4.8",
-    "react-dom": "15.3.1",
+    "react-dom": "15.3.2",
     "react-helmet": "3.1.0",
     "react-onclickoutside": "5.7.1",
     "react-redux": "4.4.5",


### PR DESCRIPTION
Other deps are complaining about unmet peer dependencies so this is a manual upgrade to `react@15.3.2`, I'm not sure why we didn't get a greenkeeper PR for this one.