### PR TITLE
Translate accept props

### DIFF
--- a/src/core/i18n/translate.js
+++ b/src/core/i18n/translate.js
@@ -34,7 +34,7 @@ export default function translate(options = {}) {
           extraProps.ref = (ref) => { this.wrappedInstance = ref; };
         }
 
-        return <WrappedComponent {...this.props} {...extraProps} />;
+        return <WrappedComponent {...extraProps} {...this.props} />;
       }
     }
 

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -18,7 +18,6 @@ import { getFakeI18nInst } from 'tests/client/helpers';
 function render({ addon = fakeAddon, ...customProps } = {}) {
   const i18n = getFakeI18nInst();
   const props = {
-    i18n,
     addon,
     // Configure AddonDetail with a non-redux depdendent OverallRating.
     OverallRating: OverallRatingWithI18n,

--- a/tests/client/amo/components/TestAddonReview.js
+++ b/tests/client/amo/components/TestAddonReview.js
@@ -13,7 +13,6 @@ import {
   mapStateToProps, AddonReviewBase,
   loadAddonReview as defaultAddonReviewLoader,
 } from 'amo/components/AddonReview';
-import I18nProvider from 'core/i18n/Provider';
 import { fakeAddon, signedInApiState } from 'tests/client/amo/helpers';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
@@ -32,9 +31,7 @@ function render({ ...customProps } = {}) {
   };
   const AddonReview = translate({ withRef: true })(AddonReviewBase);
   const root = findRenderedComponentWithType(renderIntoDocument(
-    <I18nProvider i18n={props.i18n}>
-      <AddonReview {...props} />
-    </I18nProvider>
+    <AddonReview {...props} />
   ), AddonReview);
 
   return root.getWrappedInstance();

--- a/tests/client/amo/components/TestLanguagePicker.js
+++ b/tests/client/amo/components/TestLanguagePicker.js
@@ -6,15 +6,12 @@ import {
 
 import LanguagePicker from 'amo/components/LanguagePicker';
 import { getFakeI18nInst } from 'tests/client/helpers';
-import I18nProvider from 'core/i18n/Provider';
 
 
 describe('LanguagePicker', () => {
   function renderLanguagePicker({ ...props }) {
     return findRenderedComponentWithType(renderIntoDocument(
-      <I18nProvider i18n={getFakeI18nInst()}>
-        <LanguagePicker {...props} />
-      </I18nProvider>
+      <LanguagePicker i18n={getFakeI18nInst()} {...props} />
     ), LanguagePicker).getWrappedInstance();
   }
 

--- a/tests/client/amo/components/TestMastHead.js
+++ b/tests/client/amo/components/TestMastHead.js
@@ -6,7 +6,6 @@ import {
 
 import { MastHeadBase } from 'amo/components/MastHead';
 import { getFakeI18nInst } from 'tests/client/helpers';
-import I18nProvider from 'core/i18n/Provider';
 import translate from 'core/i18n/translate';
 
 
@@ -21,9 +20,7 @@ describe('MastHead', () => {
     const MyMastHead = translate({ withRef: true })(MastHeadBase);
 
     return findRenderedComponentWithType(renderIntoDocument(
-      <I18nProvider i18n={getFakeI18nInst()}>
-        <MyMastHead {...props} />
-      </I18nProvider>
+      <MyMastHead i18n={getFakeI18nInst()} {...props} />
     ), MyMastHead).getWrappedInstance();
   }
 

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -11,7 +11,6 @@ import {
   mapDispatchToProps, mapStateToProps, OverallRatingBase,
 } from 'amo/components/OverallRating';
 import { SET_REVIEW } from 'amo/constants';
-import I18nProvider from 'core/i18n/Provider';
 import {
   createRatingResponse, fakeAddon, signedInApiState,
 } from 'tests/client/amo/helpers';
@@ -31,9 +30,7 @@ function render({ ...customProps } = {}) {
     ...customProps,
   };
   const root = findRenderedComponentWithType(renderIntoDocument(
-    <I18nProvider i18n={props.i18n}>
-      <OverallRatingBase {...props} />
-    </I18nProvider>
+    <OverallRatingBase {...props} />
   ), OverallRatingBase);
 
   return findDOMNode(root);

--- a/tests/client/amo/components/TestSearchResult.js
+++ b/tests/client/amo/components/TestSearchResult.js
@@ -5,7 +5,6 @@ import {
   renderIntoDocument,
 } from 'react-addons-test-utils';
 
-import I18nProvider from 'core/i18n/Provider';
 import SearchResult from 'amo/components/SearchResult';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
@@ -13,9 +12,7 @@ import { getFakeI18nInst } from 'tests/client/helpers';
 describe('<SearchResult />', () => {
   function renderResult(result) {
     return findRenderedComponentWithType(renderIntoDocument(
-      <I18nProvider i18n={getFakeI18nInst()}>
-        <SearchResult result={result} lang="en-US" />
-      </I18nProvider>
+      <SearchResult i18n={getFakeI18nInst()} result={result} lang="en-US" />
     ), SearchResult).getWrappedInstance();
   }
 

--- a/tests/client/core/components/TestPaginate.js
+++ b/tests/client/core/components/TestPaginate.js
@@ -8,7 +8,6 @@ import {
 } from 'react-addons-test-utils';
 import { Route, Router, createMemoryHistory } from 'react-router';
 
-import I18nProvider from 'core/i18n/Provider';
 import Paginate from 'core/components/Paginate';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
@@ -17,9 +16,9 @@ describe('<Paginate />', () => {
   describe('methods', () => {
     function renderPaginate({ count = 20, currentPage = 1, pathname, ...extra }) {
       return findRenderedComponentWithType(renderIntoDocument(
-        <I18nProvider i18n={getFakeI18nInst()}>
-          <Paginate count={count} currentPage={currentPage} pathname={pathname} {...extra} />
-        </I18nProvider>
+        <Paginate
+          i18n={getFakeI18nInst()} count={count} currentPage={currentPage} pathname={pathname}
+          {...extra} />
       ), Paginate).getWrappedInstance();
     }
 

--- a/tests/client/core/components/TestSearchResults.js
+++ b/tests/client/core/components/TestSearchResults.js
@@ -5,7 +5,6 @@ import {
   isDOMComponent,
 } from 'react-addons-test-utils';
 
-import I18nProvider from 'core/i18n/Provider';
 import SearchResults from 'core/components/Search/SearchResults';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
@@ -13,9 +12,7 @@ import { getFakeI18nInst } from 'tests/client/helpers';
 describe('<SearchResults />', () => {
   function renderResults(props) {
     return findRenderedComponentWithType(render(
-      <I18nProvider i18n={getFakeI18nInst()}>
-        <SearchResults {...props} />
-      </I18nProvider>
+      <SearchResults i18n={getFakeI18nInst()} {...props} />
     ), SearchResults).getWrappedInstance();
   }
 

--- a/tests/client/core/i18n/TestI18nProvider.js
+++ b/tests/client/core/i18n/TestI18nProvider.js
@@ -1,69 +1,34 @@
-/* eslint-disable react/no-multi-comp */
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 import {
   renderIntoDocument,
-  findRenderedComponentWithType,
 } from 'react-addons-test-utils';
 
 import I18nProvider from 'core/i18n/Provider';
-import translate from 'core/i18n/translate';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
 
-class OuterComponent extends Component {
-  static propTypes = {
-    children: PropTypes.element.isRequired,
-  }
-  render() {
-    const { children } = this.props;
-    return <div>{children}</div>;
-  }
-}
-
-class InnerComponent extends Component {
-  static propTypes = {
-    i18n: PropTypes.object.isRequired,
-  }
-  render() {
-    const { i18n } = this.props;
-    return <div>{i18n.gettext('hai')}</div>;
-  }
-}
-
-
 describe('I18nProvider', () => {
-  let i18nInst;
-  let MyComponent;
-
-  function render(props) {
-    const defaultProps = {
-      i18n: getFakeI18nInst(),
-      MyComponent: translate()(InnerComponent),
-      ...props,
+  class MyComponent extends React.Component {
+    static contextTypes = {
+      i18n: PropTypes.object.isRequired,
     };
 
-    MyComponent = defaultProps.MyComponent;
-    i18nInst = defaultProps.i18n;
+    render() {
+      return <p>{this.context.i18n.gettext('Howdy')}</p>;
+    }
+  }
 
+  function render({ i18n }) {
     return renderIntoDocument(
-      <I18nProvider i18n={defaultProps.i18n}>
-        <OuterComponent>
-          <MyComponent />
-        </OuterComponent>
+      <I18nProvider i18n={i18n}>
+        <MyComponent />
       </I18nProvider>
     );
   }
 
-  it('should call i18n.gettext in the component view', () => {
-    render();
-    assert.ok(i18nInst.gettext.called);
-  });
-
-  it('should see an exception calling getWrappedInstance without withRef', () => {
-    const root = render();
-    const wrappedComponent = findRenderedComponentWithType(root, MyComponent);
-    assert.throws(() => {
-      wrappedComponent.getWrappedInstance();
-    }, Error, 'To access the wrapped instance');
+  it('sets the i18n as context', () => {
+    const i18n = getFakeI18nInst();
+    render({ i18n });
+    assert.ok(i18n.gettext.calledWith('Howdy'));
   });
 });

--- a/tests/client/core/i18n/test_translate.js
+++ b/tests/client/core/i18n/test_translate.js
@@ -1,0 +1,78 @@
+/* eslint-disable react/no-multi-comp */
+import React, { PropTypes } from 'react';
+import {
+  renderIntoDocument,
+  findRenderedComponentWithType,
+} from 'react-addons-test-utils';
+
+import I18nProvider from 'core/i18n/Provider';
+import translate from 'core/i18n/translate';
+import { getFakeI18nInst } from 'tests/client/helpers';
+
+
+class OuterComponent extends React.Component {
+  static propTypes = {
+    children: PropTypes.element.isRequired,
+  }
+  render() {
+    const { children } = this.props;
+    return <div>{children}</div>;
+  }
+}
+
+class InnerComponent extends React.Component {
+  static propTypes = {
+    i18n: PropTypes.object.isRequired,
+  }
+  render() {
+    const { i18n } = this.props;
+    return <div>{i18n.gettext('hai')}</div>;
+  }
+}
+
+describe('translate()', () => {
+  function render({
+    Component = translate()(InnerComponent),
+    i18n = getFakeI18nInst(),
+    componentProps = {},
+  } = {}) {
+    return renderIntoDocument(
+      <I18nProvider i18n={i18n}>
+        <OuterComponent>
+          <Component {...componentProps} />
+        </OuterComponent>
+      </I18nProvider>
+    );
+  }
+
+  it('pulls i18n from context', () => {
+    const i18n = getFakeI18nInst();
+    render({ i18n });
+    assert.ok(i18n.gettext.called);
+  });
+
+  it('overrides the i18n from props', () => {
+    const contextI18n = getFakeI18nInst();
+    const propsI18n = getFakeI18nInst();
+    render({ i18n: contextI18n, componentProps: { i18n: propsI18n } });
+    assert.notOk(contextI18n.gettext.called);
+    assert.ok(propsI18n.gettext.called);
+  });
+
+  it('throws an exception calling getWrappedInstance without withRef', () => {
+    const Component = translate()(InnerComponent);
+    const root = render({ Component });
+    const wrappedComponent = findRenderedComponentWithType(root, Component);
+    assert.throws(() => {
+      wrappedComponent.getWrappedInstance();
+    }, Error, 'To access the wrapped instance');
+  });
+
+  it('returns the wrapped instance when using withRef', () => {
+    const Component = translate({ withRef: true })(InnerComponent);
+    const root = render({ Component });
+    const wrappedComponent = findRenderedComponentWithType(root, Component);
+    const component = wrappedComponent.getWrappedInstance();
+    assert.instanceOf(component, InnerComponent);
+  });
+});

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -7,7 +7,6 @@ import {
 import { findDOMNode } from 'react-dom';
 import config from 'config';
 
-import I18nProvider from 'core/i18n/Provider';
 import translate from 'core/i18n/translate';
 import {
   AddonBase,
@@ -59,9 +58,7 @@ function renderAddon({ setCurrentStatus = sinon.stub(), ...props }) {
   const MyAddon = translate({ withRef: true })(AddonBase);
 
   return findRenderedComponentWithType(renderIntoDocument(
-    <I18nProvider i18n={getFakeI18nInst()}>
-      <MyAddon {...props} setCurrentStatus={setCurrentStatus} />
-    </I18nProvider>
+    <MyAddon i18n={getFakeI18nInst()} {...props} setCurrentStatus={setCurrentStatus} />
   ), MyAddon).getWrappedInstance();
 }
 

--- a/tests/client/disco/components/TestInfoDialog.js
+++ b/tests/client/disco/components/TestInfoDialog.js
@@ -4,7 +4,6 @@ import React from 'react';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 import ReactDOM, { findDOMNode } from 'react-dom';
 
-import I18nProvider from 'core/i18n/Provider';
 import InfoDialog from 'disco/components/InfoDialog';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
@@ -17,6 +16,7 @@ function getInfoDialog(props = {}) {
     addonName: 'A Test Add-on',
     imageURL: 'https://addons-dev-cdn.allizom.org/whatever',
     closeAction,
+    i18n: getFakeI18nInst(),
     ...props,
   };
   return <InfoDialog {...renderProps} />;
@@ -24,10 +24,7 @@ function getInfoDialog(props = {}) {
 
 describe('<InfoDialog />', () => {
   function renderInfoDialog(props = {}) {
-    return renderIntoDocument(
-      <I18nProvider i18n={getFakeI18nInst()}>
-        {getInfoDialog(props)}
-      </I18nProvider>);
+    return renderIntoDocument(getInfoDialog(props));
   }
 
   it('Should render a dialog with aria role', () => {
@@ -87,12 +84,10 @@ describe('Clicking outside <InfoDialog />', () => {
     class FakeContainer extends React.Component {
       render() {
         return (
-          <I18nProvider i18n={getFakeI18nInst()}>
-            <div>
-              {getInfoDialog()}
-              <button id="outside-component" onClick={(e) => e.stopPropagation()} />
-            </div>
-          </I18nProvider>
+          <div>
+            {getInfoDialog()}
+            <button id="outside-component" onClick={(e) => e.stopPropagation()} />
+          </div>
         );
       }
     }

--- a/tests/client/disco/containers/TestApp.js
+++ b/tests/client/disco/containers/TestApp.js
@@ -5,7 +5,6 @@ import {
   renderIntoDocument,
 } from 'react-addons-test-utils';
 
-import I18nProvider from 'core/i18n/Provider';
 import App from 'disco/containers/App';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
@@ -18,11 +17,10 @@ describe('App', () => {
       }
     }
     const root = findRenderedComponentWithType(renderIntoDocument(
-      <I18nProvider i18n={getFakeI18nInst()}>
-        <App>
-          <MyComponent />
-        </App>
-      </I18nProvider>), App).getWrappedInstance();
+      <App i18n={getFakeI18nInst()}>
+        <MyComponent />
+      </App>
+    ), App).getWrappedInstance();
 
     const rootNode = findDOMNode(root);
     assert.equal(rootNode.tagName.toLowerCase(), 'div');

--- a/tests/client/disco/containers/TestDiscoPane.js
+++ b/tests/client/disco/containers/TestDiscoPane.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
-import { Provider } from 'react-redux';
 
 import { loadEntities } from 'core/actions';
-import I18nProvider from 'core/i18n/Provider';
 import {
   EXTENSION_TYPE,
   INSTALL_STATE,
@@ -36,12 +34,9 @@ describe('AddonPage', () => {
 
     // We need the providers for i18n and since InstallButton will pull data from the store.
     return findDOMNode(renderIntoDocument(
-      <I18nProvider i18n={i18n}>
-        <Provider store={store} key="provider">
-          <DiscoPaneBase results={results} i18n={i18n}
-            {...props} AddonComponent={MockedSubComponent} />
-        </Provider>
-      </I18nProvider>
+      <DiscoPaneBase
+        store={store} i18n={i18n} results={results} {...props}
+        AddonComponent={MockedSubComponent} />
     ));
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,7 +244,7 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-autoprefixer@^6.0.0, autoprefixer@^6.3.1, autoprefixer@6.5.0:
+autoprefixer@^6.0.0, autoprefixer@^6.3.1:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.5.0.tgz#910de0aa0f22af4c7d50367cbc9d4d412945162f"
   dependencies:
@@ -253,6 +253,17 @@ autoprefixer@^6.0.0, autoprefixer@^6.3.1, autoprefixer@6.5.0:
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^5.2.2"
+    postcss-value-parser "^3.2.3"
+
+autoprefixer@6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.5.1.tgz#ae759a5221e709f3da17c2d656230e67c43cbb75"
+  dependencies:
+    browserslist "~1.4.0"
+    caniuse-db "^1.0.30000554"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.4"
     postcss-value-parser "^3.2.3"
 
 aws-sign2@~0.6.0:
@@ -476,12 +487,13 @@ babel-plugin-dedent@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dedent/-/babel-plugin-dedent-2.0.0.tgz#327acf69b6b47a964cefcca8e703650df61322dd"
 
-babel-plugin-istanbul@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.1.tgz#c384916f081ceaeb9d4b44b6a7db84e07ad67418"
+babel-plugin-istanbul@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz#266b304b9109607d60748474394676982f660df4"
   dependencies:
     find-up "^1.1.2"
-    istanbul-lib-instrument "^1.1.1"
+    istanbul-lib-instrument "^1.1.4"
+    object-assign "^4.1.0"
     test-exclude "^2.1.1"
 
 babel-plugin-react-transform@2.0.2:
@@ -1108,11 +1120,11 @@ bundle-loader@0.5.4:
   dependencies:
     loader-utils "0.2.x"
 
-bunyan@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.1.tgz#68c6a4a502d5620bc9f72d6736810c1b1898097f"
+bunyan@1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.2.tgz#edcc94d47f921bc1b4030c832da21a3857aaf2a9"
   optionalDependencies:
-    dtrace-provider "~0.6"
+    dtrace-provider "~0.7"
     moment "^2.10.6"
     mv "~2"
     safe-json-stringify "~1"
@@ -1165,6 +1177,10 @@ camelize@1.0.0:
 caniuse-db@^1.0.30000187, caniuse-db@^1.0.30000539, caniuse-db@^1.0.30000540:
   version "1.0.30000553"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000553.tgz#e7e908f43b788e6ac78fc161fedc4626d6a39f24"
+
+caniuse-db@^1.0.30000554:
+  version "1.0.30000563"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000563.tgz#6958d81bc45e93310453dd70778e8169b7b55256"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -1513,6 +1529,10 @@ content-security-policy-builder@1.0.0:
   dependencies:
     dashify "^0.2.0"
 
+content-type-parser@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
+
 content-type@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
@@ -1556,6 +1576,18 @@ cosmiconfig@^2.0.0:
     graceful-fs "^4.1.2"
     js-yaml "^3.4.3"
     minimist "^1.2.0"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    require-from-string "^1.1.0"
+
+cosmiconfig@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.1.0.tgz#26e384a2055ea4e087050e5e08d53eb4eac8f86e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.1.0"
     os-homedir "^1.0.1"
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
@@ -1932,11 +1964,11 @@ dotenv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-2.0.0.tgz#bd759c357aaa70365e01c96b7b0bec08a6e0d949"
 
-dtrace-provider@~0.6:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.6.0.tgz#0b078d5517937d873101452d9146737557b75e51"
+dtrace-provider@~0.7:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.7.0.tgz#9ac6d3eb78ffbe90385063e6d14dfe7bc377005d"
   dependencies:
-    nan "^2.0.8"
+    nan "^2.3.3"
 
 duplexer@~0.1.1:
   version "0.1.1"
@@ -2143,9 +2175,9 @@ eslint-module-utils@^1.0.0:
     debug "2.2.0"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.0.0.tgz#5ccd46210162bc1a0d76221eb7518476d04fb089"
+eslint-plugin-import@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.0.1.tgz#dcfe96357d476b3f822570d42c29bec66f5d9c5c"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
@@ -2173,9 +2205,9 @@ eslint-plugin-react@6.3.0:
     doctrine "^1.2.2"
     jsx-ast-utils "^1.3.1"
 
-eslint@3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.7.1.tgz#7faa84599e0fea422f04bc32db49054051a3f11a"
+eslint@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.8.1.tgz#7d02db44cd5aaf4fa7aa489e1f083baa454342ba"
   dependencies:
     chalk "^1.1.3"
     concat-stream "^1.4.6"
@@ -2199,7 +2231,7 @@ eslint@3.7.1:
     lodash "^4.0.0"
     mkdirp "^0.5.0"
     natural-compare "^1.4.0"
-    optionator "^0.8.1"
+    optionator "^0.8.2"
     path-is-inside "^1.0.1"
     pluralize "^1.2.1"
     progress "^1.1.8"
@@ -2909,6 +2941,12 @@ html-comment-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
+html-encoding-sniffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
+  dependencies:
+    whatwg-encoding "^1.0.1"
+
 html-entities@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
@@ -2999,7 +3037,7 @@ ienoopen@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ienoopen/-/ienoopen-1.0.0.tgz#346a428f474aac8f50cf3784ea2d0f16f62bda6b"
 
-ignore@^3.1.3, ignore@^3.1.5:
+ignore@^3.1.5, ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
 
@@ -3286,9 +3324,9 @@ istanbul-lib-coverage@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.0.tgz#c3f9b6d226da12424064cce87fce0fb57fdfa7a2"
 
-istanbul-lib-instrument@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.3.tgz#66d5353d1f592b9e34d1cf9acda9c3f1ab509696"
+istanbul-lib-instrument@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.4.tgz#95be56e5c321456ffdfddc925ad4dcfc28edab9c"
   dependencies:
     babel-generator "^6.11.3"
     babel-template "^6.9.0"
@@ -3349,17 +3387,19 @@ jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
-jsdom@9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.5.0.tgz#cb7194c2a2a07c92af905f7822e45694196e27a0"
+jsdom@9.8.0:
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.8.0.tgz#8766594cf994549d8a809cf6dca0246aceef9305"
   dependencies:
     abab "^1.0.0"
     acorn "^2.4.0"
     acorn-globals "^1.0.4"
     array-equal "^1.0.0"
+    content-type-parser "^1.0.1"
     cssom ">= 0.3.0 < 0.4.0"
     cssstyle ">= 0.2.36 < 0.3.0"
     escodegen "^1.6.1"
+    html-encoding-sniffer "^1.0.1"
     iconv-lite "^0.4.13"
     nwmatcher ">= 1.3.7 < 2.0.0"
     parse5 "^1.5.1"
@@ -3368,6 +3408,7 @@ jsdom@9.5.0:
     symbol-tree ">= 3.1.0 < 4.0.0"
     tough-cookie "^2.3.1"
     webidl-conversions "^3.0.1"
+    whatwg-encoding "^1.0.1"
     whatwg-url "^3.0.0"
     xml-name-validator ">= 2.0.1 < 3.0.0"
 
@@ -3599,7 +3640,7 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.3, loader-utils@^0.2.5, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5, loader-utils@0.2.x:
+loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.3, loader-utils@^0.2.5, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5, loader-utils@0.2.x:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.16.tgz#f08632066ed8282835dff88dfb52704765adee6d"
   dependencies:
@@ -3958,9 +3999,9 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, "mkdirp@>=0.5 0", mkdirp@~0.5.0, mkdirp@~0.5.1, mk
   dependencies:
     minimist "0.0.8"
 
-mocha@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.1.1.tgz#5baa4aeefde7db4ad9248ef147ef4398b0593c80"
+mocha@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.1.2.tgz#51f93b432bf7e1b175ffc22883ccd0be32dba6b5"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"
@@ -4007,7 +4048,7 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.0.8, nan@^2.3.0, nan@^2.3.2:
+nan@^2.3.0, nan@^2.3.2, nan@^2.3.3:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
 
@@ -4275,7 +4316,7 @@ optimist@^0.6.1, optimist@~0.6.0, optimist@~0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -4464,9 +4505,9 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
-po2json@0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/po2json/-/po2json-0.4.4.tgz#5640f2a3e3e499ca50b5905cb1b30825b28aafca"
+po2json@0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/po2json/-/po2json-0.4.5.tgz#47bb2952da32d58a1be2f256a598eebc0b745118"
   dependencies:
     gettext-parser "1.1.0"
     nomnom "1.8.1"
@@ -4539,12 +4580,37 @@ postcss-less@^0.14.0:
   dependencies:
     postcss "^5.0.21"
 
-postcss-loader@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-0.13.0.tgz#72fdaf0d29444df77d3751ce4e69dc40bc99ed85"
+postcss-load-config@^1.0.0-rc:
+  version "1.0.0-rc"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-1.0.0-rc.tgz#8aed0d0fb94afe2c1ab0ba2ca69da3af5079e2cc"
   dependencies:
-    loader-utils "^0.2.15"
-    postcss "^5.2.0"
+    cosmiconfig "^2.1.0"
+    object-assign "^4.1.0"
+    postcss-load-options "^1.0.2"
+    postcss-load-plugins "^2.0.0-rc"
+
+postcss-load-options@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-load-options/-/postcss-load-options-1.0.2.tgz#b99eb5759a588f4b2dd8b6471c6985f72060e7b0"
+  dependencies:
+    cosmiconfig "^2.1.0"
+    object-assign "^4.1.0"
+
+postcss-load-plugins@^2.0.0-rc:
+  version "2.0.0-rc"
+  resolved "https://registry.yarnpkg.com/postcss-load-plugins/-/postcss-load-plugins-2.0.0-rc.tgz#21242fb78de4d3d8eac9d1fef3863b8b794aa522"
+  dependencies:
+    cosmiconfig "^2.1.0"
+    object-assign "^4.1.0"
+
+postcss-loader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-1.0.0.tgz#e3b65d0c8596c1658f79d7db2d291310748d5d2a"
+  dependencies:
+    loader-utils "^0.2.16"
+    object-assign "^4.1.0"
+    postcss "^5.2.4"
+    postcss-load-config "^1.0.0-rc"
 
 postcss-media-query-parser@^0.2.0:
   version "0.2.1"
@@ -4731,7 +4797,7 @@ postcss-zindex@^2.0.1:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
-postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.0, postcss@^5.2.2, postcss@^5.2.4:
+postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.2, postcss@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.4.tgz#8eb4bee3e5c4e091585b116df32d8db24a535f21"
   dependencies:
@@ -4892,9 +4958,9 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-dom@15.3.1:
-  version "15.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.1.tgz#6d42cd2b64c8c5e0b693f3ffaec301e6e627e24e"
+react-dom@15.3.2:
+  version "15.3.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
 
 react-helmet@3.1.0:
   version "3.1.0"
@@ -4962,9 +5028,9 @@ react-transform-hmr@1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@15.3.1:
-  version "15.3.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.3.1.tgz#f78501ed8c2ec6e6e31c3223652e97f1369d2bd6"
+react@15.3.2:
+  version "15.3.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
   dependencies:
     fbjs "^0.8.4"
     loose-envify "^1.1.0"
@@ -5743,9 +5809,9 @@ stylelint-config-standard@13.0.2:
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-13.0.2.tgz#721e090c53b6e59f70f63d6a9fce026c9120671e"
 
-stylelint@7.4.2:
-  version "7.4.2"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.4.2.tgz#b4ea1d71b2950d9a0b408877594f7d1ecb2b992e"
+stylelint@7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-7.5.0.tgz#fe19a22e793c419d4fc31d58f3948d599fdb81fb"
   dependencies:
     autoprefixer "^6.0.0"
     balanced-match "^0.4.0"
@@ -5758,7 +5824,7 @@ stylelint@7.4.2:
     globby "^6.0.0"
     globjoin "^0.1.4"
     html-tags "^1.1.1"
-    ignore "^3.1.3"
+    ignore "^3.2.0"
     known-css-properties "^0.0.5"
     lodash "^4.0.0"
     log-symbols "^1.0.2"
@@ -5778,15 +5844,15 @@ stylelint@7.4.2:
     string-width "^2.0.0"
     style-search "^0.1.0"
     stylehacks "^2.3.0"
-    sugarss "^0.1.2"
+    sugarss "^0.2.0"
     svg-tags "^1.0.0"
     table "^3.7.8"
 
-sugarss@^0.1.2:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-0.1.6.tgz#fe3ac0e1e07282aef1de84a80b72386ff4e7ea37"
+sugarss@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-0.2.0.tgz#ac34237563327c6ff897b64742bf6aec190ad39e"
   dependencies:
-    postcss "^5.2.0"
+    postcss "^5.2.4"
 
 superagent@^1.7.2:
   version "1.8.4"
@@ -6318,6 +6384,12 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
+
+whatwg-encoding@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz#3c6c451a198ee7aec55b1ec61d0920c67801a5f4"
+  dependencies:
+    iconv-lite "0.4.13"
 
 whatwg-fetch@^0.9.0:
   version "0.9.0"


### PR DESCRIPTION
This updates `translate()` to accept `i18n` from props which removes the need for setting up an `I18nProvider` component in many cases. I refactored the tests for `I18nProvider` since I think they were mostly testing `translate()` and moved those tests into their own file.

It also removes the `I18nProvider` and `Provider` wrappers from tests that did not need it.