### PR TITLE
Add Link component for auto-URL-prefixes (fix #1136)

### DIFF
--- a/src/amo/components/Footer.js
+++ b/src/amo/components/Footer.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
-import { Link } from 'react-router';
 import { compose } from 'redux';
 
 import LanguagePicker from 'amo/components/LanguagePicker';
+import Link from 'amo/components/Link';
 import translate from 'core/i18n/translate';
 
 import './Footer.scss';
@@ -11,25 +11,22 @@ import './Footer.scss';
 export class FooterBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object.isRequired,
-    lang: PropTypes.string.isRequired,
   }
 
   render() {
-    const { i18n, lang } = this.props;
+    const { i18n } = this.props;
 
     return (
       <footer className="Footer">
-        <LanguagePicker lang={lang}
-          ref={(ref) => { this.languagePicker = ref; }} />
+        <LanguagePicker ref={(ref) => { this.languagePicker = ref; }} />
         <ul className="Footer-links">
           <li>
-            <Link to={`/${lang}/firefox/privacy`}
-              className="Footer-link">
+            <Link to={'/privacy/'} className="Footer-link">
               {i18n.gettext('Privacy policy')}
             </Link>
           </li>
           <li>
-            <Link to={`/${lang}/firefox/legal`} className="Footer-link">
+            <Link to={'/legal/'} className="Footer-link">
               {i18n.gettext('Legal notices')}
             </Link>
           </li>

--- a/src/amo/components/Link.js
+++ b/src/amo/components/Link.js
@@ -1,0 +1,46 @@
+import path from 'path';
+
+import React, { PropTypes } from 'react';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { Link } from 'react-router';
+
+
+export class LinkBase extends React.Component {
+  static propTypes = {
+    base: PropTypes.string,
+    children: PropTypes.node,
+    to: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  }
+
+  static defaultProps = {
+    base: '',
+  }
+
+  render() {
+    const { base, children, to } = this.props;
+
+    let linkTo = to;
+    if (typeof to === 'string' && to.startsWith('/')) {
+      linkTo = path.join(base, to);
+    } else if (to && to.pathname) {
+      linkTo = {
+        ...to,
+        pathname: to.pathname.startsWith('/') ?
+          path.join(base, to.pathname) : to.pathname,
+      };
+    }
+
+    return <Link {...this.props} to={linkTo}>{children}</Link>;
+  }
+}
+
+export function mapStateToProps(state) {
+  return {
+    base: `/${state.api.lang}/${state.api.clientApp}`,
+  };
+}
+
+export default compose(
+  connect(mapStateToProps),
+)(LinkBase);

--- a/src/amo/components/MastHead.js
+++ b/src/amo/components/MastHead.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 
+import Link from 'amo/components/Link';
 import SearchForm from 'amo/components/SearchForm';
 import translate from 'core/i18n/translate';
 
@@ -12,7 +13,6 @@ export class MastHeadBase extends React.Component {
     children: PropTypes.node,
     i18n: PropTypes.object.isRequired,
     isHomePage: PropTypes.bool,
-    lang: PropTypes.string.isRequired,
     SearchFormComponent: PropTypes.node.isRequired,
     query: PropTypes.string,
   }
@@ -23,10 +23,10 @@ export class MastHeadBase extends React.Component {
   }
 
   render() {
-    const { SearchFormComponent, children, i18n, isHomePage, lang,
-            query } = this.props;
+    const {
+      SearchFormComponent, children, i18n, isHomePage, query,
+    } = this.props;
     const headerTitle = i18n.gettext('Firefox Add-ons');
-    const pathname = `/${lang}/firefox/search/`;
 
     return (
       <div className="MastHead">
@@ -36,14 +36,16 @@ export class MastHeadBase extends React.Component {
         {children}
         <header className="MastHead-header">
           {isHomePage
-            ? <h1 ref={(ref) => { this.title = ref; }} className="MastHead-title MastHead-homepage">
+            ? <h1 ref={(ref) => { this.title = ref; }}
+                className="MastHead-title MastHead-homepage">
               {headerTitle}
             </h1>
-            : <a ref={(ref) => { this.title = ref; }} href="/" className="MastHead-title">
+            : <Link ref={(ref) => { this.title = ref; }} to="/"
+                className="MastHead-title">
               {headerTitle}
-            </a>}
+            </Link>}
         </header>
-        <SearchFormComponent pathname={pathname} query={query} />
+        <SearchFormComponent pathname="/search/" query={query} />
       </div>
     );
   }

--- a/src/amo/components/SearchForm.js
+++ b/src/amo/components/SearchForm.js
@@ -11,6 +11,7 @@ import './SearchForm.scss';
 
 export class SearchFormBase extends React.Component {
   static propTypes = {
+    api: PropTypes.object.isRequired,
     pathname: PropTypes.string.isRequired,
     query: PropTypes.string.isRequired,
   }
@@ -19,8 +20,9 @@ export class SearchFormBase extends React.Component {
   }
 
   goToSearch(query) {
-    const { pathname } = this.props;
-    this.context.router.push(`${pathname}?q=${query}`);
+    const { api, pathname } = this.props;
+    this.context.router.push(
+      `/${api.lang}/${api.clientApp}${pathname}?q=${query}`);
   }
 
   handleSearch = (e) => {
@@ -29,10 +31,11 @@ export class SearchFormBase extends React.Component {
   }
 
   render() {
-    const { pathname, query } = this.props;
+    const { api, pathname, query } = this.props;
     return (
-      <form method="GET" action={pathname} onSubmit={this.handleSearch}
-            className="SearchForm-form" ref={(ref) => { this.form = ref; }}>
+      <form method="GET" action={`/${api.lang}/${api.clientApp}${pathname}`}
+        onSubmit={this.handleSearch} className="SearchForm-form"
+        ref={(ref) => { this.form = ref; }}>
         <label className="visually-hidden" htmlFor="q">{_('Search')}</label>
         <input ref={(ref) => { this.searchQuery = ref; }} type="search" name="q"
                placeholder={_('Search extensions and themes')}

--- a/src/amo/components/SearchPage.js
+++ b/src/amo/components/SearchPage.js
@@ -1,15 +1,17 @@
 import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
 
+import Link from 'amo/components/Link';
 import Paginate from 'core/components/Paginate';
 import SearchResults from 'core/components/Search/SearchResults';
 
 import SearchResult from './SearchResult';
 
 
-export default class SearchPage extends React.Component {
+export class SearchPageBase extends React.Component {
   static propTypes = {
     count: PropTypes.number,
-    lang: PropTypes.string.isRequired,
     loading: PropTypes.bool.isRequired,
     page: PropTypes.number,
     results: PropTypes.array,
@@ -17,17 +19,25 @@ export default class SearchPage extends React.Component {
   }
 
   render() {
-    const { count, lang, loading, page, query, results } = this.props;
-    const pathname = `/${lang}/firefox/search/`;
+    const { count, loading, page, query, results } = this.props;
     const paginator = query && count > 0 ?
-      <Paginate count={count} pathname={pathname} query={{ q: query }}
-        currentPage={page} showPages={0} /> : [];
+      <Paginate LinkComponent={Link} count={count} currentPage={page}
+        pathname="/search/" query={{ q: query }} showPages={0} /> : [];
+
     return (
       <div className="search-page">
         <SearchResults results={results} query={query} loading={loading}
-          count={count} ResultComponent={SearchResult} lang={lang} />
+          count={count} ResultComponent={SearchResult} />
         {paginator}
       </div>
     );
   }
 }
+
+export function mapStateToProps(state) {
+  return { clientApp: state.api.clientApp, lang: state.api.lang };
+}
+
+export default compose(
+  connect(mapStateToProps),
+)(SearchPageBase);

--- a/src/amo/components/SearchResult.js
+++ b/src/amo/components/SearchResult.js
@@ -1,19 +1,20 @@
 import React, { PropTypes } from 'react';
-import { Link } from 'react-router';
+import { compose } from 'redux';
 
+import Link from 'amo/components/Link';
 import translate from 'core/i18n/translate';
 
 import 'core/css/SearchResult.scss';
 
-class SearchResult extends React.Component {
+
+export class SearchResultBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object.isRequired,
-    lang: PropTypes.string.isRequired,
     result: PropTypes.object.isRequired,
   }
 
   render() {
-    const { i18n, lang, result } = this.props;
+    const { i18n, result } = this.props;
 
     // TODO: Implement a rating component and style the stars.
     const rating = result.ratings && result.ratings.average ? (
@@ -30,7 +31,7 @@ class SearchResult extends React.Component {
     );
     return (
       <li className="SearchResult">
-        <Link to={`/${lang}/firefox/addon/${result.slug}/`}
+        <Link to={`/addon/${result.slug}/`}
               className="SearchResult-link"
               ref={(el) => { this.name = el; }}>
           <section className="SearchResult-main">
@@ -51,4 +52,6 @@ class SearchResult extends React.Component {
   }
 }
 
-export default translate({ withRef: true })(SearchResult);
+export default compose(
+  translate({ withRef: true }),
+)(SearchResultBase);

--- a/src/amo/containers/App.js
+++ b/src/amo/containers/App.js
@@ -22,7 +22,6 @@ export class AppBase extends React.Component {
     handleLogIn: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
     isAuthenticated: PropTypes.bool,
-    lang: PropTypes.string.isRequired,
     location: PropTypes.object.isRequired,
   }
 
@@ -44,32 +43,25 @@ export class AppBase extends React.Component {
 
   render() {
     const {
-      FooterComponent,
-      MastHeadComponent,
-      children,
-      i18n,
-      lang,
-      location,
+      FooterComponent, MastHeadComponent, children, i18n, location,
     } = this.props;
     const query = location.query ? location.query.q : null;
     return (
       <div className="amo">
         <Helmet defaultTitle={i18n.gettext('Add-ons for Firefox')} />
-        <MastHeadComponent SearchFormComponent={SearchForm} lang={lang}
-                           query={query}>
+        <MastHeadComponent SearchFormComponent={SearchForm} query={query}>
           {this.accountButton()}
         </MastHeadComponent>
         <div className="App-content">
           {children}
         </div>
-        <FooterComponent lang={lang} />
+        <FooterComponent />
       </div>
     );
   }
 }
 
 export const setupMapStateToProps = (_window) => (state) => ({
-  lang: state.api.lang,
   isAuthenticated: !!state.auth.token,
   handleLogIn(location) {
     // eslint-disable-next-line no-param-reassign

--- a/src/amo/containers/Home.js
+++ b/src/amo/containers/Home.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
-import { Link } from 'react-router';
 
+import Link from 'amo/components/Link';
 import translate from 'core/i18n/translate';
 
 import 'amo/css/Home.scss';
@@ -24,7 +24,9 @@ export class HomePageBase extends React.Component {
           <li className="HomePage-be-social"><Link to="#share-stuff"><span>{i18n.gettext('Be social')}</span></Link></li>
           <li className="HomePage-share-stuff"><Link to="#share-stuff"><span>{i18n.gettext('Share stuff')}</span></Link></li>
         </ul>
-        <Link className="HomePage-extensions-link" href="#extensions">{i18n.gettext('Browse all extensions')}</Link>
+        <Link className="HomePage-extensions-link" to="#extensions">
+          {i18n.gettext('Browse all extensions')}
+        </Link>
 
         <h2 className="HomePage-subheading">{i18n.gettext('How do you want Firefox to look?')}</h2>
         <ul className="HomePage-cat-list">
@@ -35,7 +37,9 @@ export class HomePageBase extends React.Component {
           <li className="HomePage-sporty"><Link to="#sporty"><span>{i18n.gettext('Sporty')}</span></Link></li>
           <li className="HomePage-mystical"><Link to="#mystical"><span>{i18n.gettext('Mystical')}</span></Link></li>
         </ul>
-        <Link className="HomePage-themes-link" to="#themes">{i18n.gettext('Browse all themes')}</Link>
+        <Link className="HomePage-themes-link" to="#themes">
+          {i18n.gettext('Browse all themes')}
+        </Link>
       </div>
     );
   }

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -17,6 +17,7 @@ function makePageNumbers({ start, end }) {
 
 export class PaginateBase extends React.Component {
   static propTypes = {
+    LinkComponent: PropTypes.object.isRequired,
     count: PropTypes.number.isRequired,
     currentPage: PropTypes.number.isRequired,
     i18n: PropTypes.object.isRequired,
@@ -27,6 +28,7 @@ export class PaginateBase extends React.Component {
   }
 
   static defaultProps = {
+    LinkComponent: Link,
     perPage: 20,
     query: {},
     showPages: 9,
@@ -62,6 +64,7 @@ export class PaginateBase extends React.Component {
   }
 
   makeLink({ currentPage, page, pathname, query, text, className }) {
+    const { LinkComponent } = this.props;
     if (currentPage === page || page < 1 || page > this.pageCount()) {
       return (
         <span key={page}
@@ -73,10 +76,10 @@ export class PaginateBase extends React.Component {
 
     const newQuery = { ...query, page };
     return (
-      <Link to={{ pathname, query: newQuery }}
+      <LinkComponent to={{ pathname, query: newQuery }}
         className={classNames('Paginator-item', className)}>
         {text || page}
-      </Link>
+      </LinkComponent>
     );
   }
 

--- a/src/core/components/Search/SearchResult.js
+++ b/src/core/components/Search/SearchResult.js
@@ -4,15 +4,14 @@ import { Link } from 'react-router';
 
 export default class SearchResult extends React.Component {
   static propTypes = {
-    lang: PropTypes.string.isRequired,
     result: PropTypes.object.isRequired,
   }
 
   render() {
-    const { lang, result } = this.props;
+    const { result } = this.props;
     return (
       <li className="SearchResult">
-        <Link to={`/${lang}/firefox/addon/${result.slug}/`}
+        <Link to={`/addon/${result.slug}/`}
               className="SearchResult-link"
               ref={(el) => { this.name = el; }}>
           <section className="SearchResult-main">

--- a/src/core/components/Search/SearchResults.js
+++ b/src/core/components/Search/SearchResults.js
@@ -12,7 +12,6 @@ class SearchResults extends React.Component {
   static propTypes = {
     count: PropTypes.number,
     i18n: PropTypes.object.isRequired,
-    lang: PropTypes.string.isRequired,
     loading: PropTypes.bool,
     query: PropTypes.string,
     results: PropTypes.arrayOf(PropTypes.object),
@@ -27,8 +26,9 @@ class SearchResults extends React.Component {
   }
 
   render() {
-    const { ResultComponent, count, i18n, lang, loading, query,
-            results } = this.props;
+    const {
+      ResultComponent, count, i18n, loading, query, results,
+    } = this.props;
 
     let searchResults;
     let messageText;
@@ -48,7 +48,7 @@ class SearchResults extends React.Component {
         <ul className="SearchResults-list"
             ref={(ref) => { this.results = ref; }}>
           {results.map((result) => (
-            <ResultComponent result={result} key={result.slug} lang={lang} />
+            <ResultComponent result={result} key={result.slug} />
           ))}
         </ul>
       );

--- a/tests/client/amo/components/TestFooter.js
+++ b/tests/client/amo/components/TestFooter.js
@@ -3,25 +3,29 @@ import {
   renderIntoDocument,
   findRenderedComponentWithType,
 } from 'react-addons-test-utils';
+import { Provider } from 'react-redux';
 
 import Footer from 'amo/components/Footer';
+import createStore from 'amo/store';
 import { getFakeI18nInst } from 'tests/client/helpers';
 import I18nProvider from 'core/i18n/Provider';
 
 
 describe('Footer', () => {
   function renderFooter({ ...props }) {
+    const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
+
     return findRenderedComponentWithType(renderIntoDocument(
-      <I18nProvider i18n={getFakeI18nInst()}>
-        <Footer {...props} />
-      </I18nProvider>
+      <Provider store={createStore(initialState)}>
+        <I18nProvider i18n={getFakeI18nInst()}>
+          <Footer {...props} />
+        </I18nProvider>
+      </Provider>
     ), Footer).getWrappedInstance();
   }
 
   it('renders a footer', () => {
-    const root = renderFooter({
-      lang: 'en-GB',
-    });
+    const root = renderFooter();
 
     assert.equal(root.desktopLink.textContent, 'View desktop site');
     assert.equal(root.desktopLink.tagName, 'A');

--- a/tests/client/amo/components/TestLanguagePicker.js
+++ b/tests/client/amo/components/TestLanguagePicker.js
@@ -16,9 +16,7 @@ describe('LanguagePicker', () => {
   }
 
   it('renders a LanguagePicker', () => {
-    const root = renderLanguagePicker({
-      lang: 'en-GB',
-    });
+    const root = renderLanguagePicker();
 
     assert.equal(root.selector.tagName, 'SELECT');
   });

--- a/tests/client/amo/components/TestLink.js
+++ b/tests/client/amo/components/TestLink.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import {
+  findRenderedComponentWithType,
+  renderIntoDocument,
+} from 'react-addons-test-utils';
+import { Link } from 'react-router';
+
+import { LinkBase, mapStateToProps } from 'amo/components/Link';
+
+
+describe('<Link />', () => {
+  const defaultState = { api: { clientApp: 'android', lang: 'fr' } };
+
+  function render(props) {
+    return renderIntoDocument(
+      <LinkBase {...props}>Hi</LinkBase>);
+  }
+
+  it('uses clientApp and lang from API state', () => {
+    const props = mapStateToProps(defaultState);
+
+    assert(props.base, '/fr/android');
+  });
+
+  it('accepts an empty base', () => {
+    const root = render({ to: 'test' });
+
+    assert.equal(
+      findRenderedComponentWithType(root, Link).props.to, 'test');
+  });
+
+  it('allows overrides to base', () => {
+    const root = render({ base: '/en-US', to: '/categories' });
+
+    assert.equal(
+      findRenderedComponentWithType(root, Link).props.to, '/en-US/categories');
+  });
+
+  it('passes an object through as a to param', () => {
+    const root = render({ base: '/en-US', to: { pathname: '/categories' } });
+
+    assert.deepEqual(
+      findRenderedComponentWithType(root, Link).props.to,
+      { pathname: '/en-US/categories' }
+    );
+  });
+
+  it('passes other `to` types through to link', () => {
+    const root = render({ base: null, to: null });
+
+    assert.equal(findRenderedComponentWithType(root, Link).props.to, null);
+  });
+
+  it('passes `to` without leading slash without base', () => {
+    const root = render({ base: '/base/', to: 'test' });
+
+    assert.equal(findRenderedComponentWithType(root, Link).props.to, 'test');
+  });
+
+  it('passes `to.pathname` without leading slash without base', () => {
+    const root = render({ base: '/base/', to: { pathname: 'test' } });
+
+    assert.deepEqual(
+      findRenderedComponentWithType(root, Link).props.to,
+      { pathname: 'test' }
+    );
+  });
+
+  it('normalizes the path with a string', () => {
+    const root = render({ base: '/foo/', to: '/test' });
+
+    assert.equal(
+      findRenderedComponentWithType(root, Link).props.to, '/foo/test');
+  });
+
+  it('normalizes the path with an object', () => {
+    const root = render({ base: '/foo', to: { pathname: 'test' } });
+
+    assert.deepEqual(
+      findRenderedComponentWithType(root, Link).props.to,
+      { pathname: 'test' }
+    );
+  });
+
+  it('normalizes the path with an object', () => {
+    const root = render({ base: '/foo', to: { pathname: 'test' } });
+
+    assert.deepEqual(
+      findRenderedComponentWithType(root, Link).props.to,
+      { pathname: 'test' }
+    );
+  });
+});

--- a/tests/client/amo/components/TestMastHead.js
+++ b/tests/client/amo/components/TestMastHead.js
@@ -3,7 +3,10 @@ import {
   renderIntoDocument,
   findRenderedComponentWithType,
 } from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+import { Provider } from 'react-redux';
 
+import createStore from 'amo/store';
 import { MastHeadBase } from 'amo/components/MastHead';
 import { getFakeI18nInst } from 'tests/client/helpers';
 import translate from 'core/i18n/translate';
@@ -18,9 +21,12 @@ class FakeChild extends React.Component {
 describe('MastHead', () => {
   function renderMastHead({ ...props }) {
     const MyMastHead = translate({ withRef: true })(MastHeadBase);
+    const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
 
     return findRenderedComponentWithType(renderIntoDocument(
-      <MyMastHead i18n={getFakeI18nInst()} {...props} />
+      <Provider store={createStore(initialState)}>
+        <MyMastHead i18n={getFakeI18nInst()} {...props} />
+      </Provider>
     ), MyMastHead).getWrappedInstance();
   }
 
@@ -29,7 +35,6 @@ describe('MastHead', () => {
     const root = renderMastHead({
       isHomePage: true,
       children: FakeChild,
-      lang: 'en-GB',
       SearchFormComponent: FakeChild,
     });
     assert.equal(root.title.textContent, 'Firefox Add-ons');
@@ -40,10 +45,11 @@ describe('MastHead', () => {
     const root = renderMastHead({
       isHomePage: false,
       children: FakeChild,
-      lang: 'en-GB',
       SearchFormComponent: FakeChild,
     });
-    assert.equal(root.title.textContent, 'Firefox Add-ons');
-    assert.equal(root.title.tagName, 'A');
+    const titleLink = findDOMNode(root).querySelectorAll('.MastHead-title')[0];
+
+    assert.equal(titleLink.textContent, 'Firefox Add-ons');
+    assert.equal(titleLink.tagName, 'A');
   });
 });

--- a/tests/client/amo/components/TestSearchForm.js
+++ b/tests/client/amo/components/TestSearchForm.js
@@ -12,7 +12,7 @@ import {
 
 describe('<SearchForm />', () => {
   const pathname = '/somewhere';
-  let api;
+  let api = { clientApp: 'firefox', lang: 'de' };
   let loadAddon;
   let router;
   let root;
@@ -29,10 +29,10 @@ describe('<SearchForm />', () => {
     }
 
     render() {
-      return (<SearchFormBase
-        pathname={pathname} api={api} query="foo"
-        loadAddon={loadAddon} ref={(ref) => { this.root = ref; }}
-      />);
+      return (
+        <SearchFormBase pathname={pathname} api={api} query="foo"
+          loadAddon={loadAddon} ref={(ref) => { this.root = ref; }} />
+      );
     }
   }
 
@@ -76,13 +76,13 @@ describe('<SearchForm />', () => {
     assert(!router.push.called);
     input.value = 'adblock';
     Simulate.click(root.submitButton);
-    assert(router.push.calledWith('/somewhere?q=adblock'));
+    assert(router.push.called);
   });
 });
 
 describe('SearchForm mapStateToProps', () => {
   it('passes the api through', () => {
-    const api = { lang: 'de', token: 'someauthtoken' };
+    const api = { clientApp: 'firefox', lang: 'de', token: 'someauthtoken' };
     assert.deepEqual(mapStateToProps({ foo: 'bar', api }), { api });
   });
 });

--- a/tests/client/amo/components/TestSearchPage.js
+++ b/tests/client/amo/components/TestSearchPage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import SearchPage from 'amo/components/SearchPage';
+import { SearchPageBase, mapStateToProps } from 'amo/components/SearchPage';
 import SearchResult from 'amo/components/SearchResult';
 import SearchResults from 'core/components/Search/SearchResults';
 import Paginate from 'core/components/Paginate';
@@ -10,16 +10,16 @@ describe('<SearchPage />', () => {
   let props;
 
   function render(extra = {}) {
-    return shallowRender(
-      <SearchPage {...{ ...props, ...extra }} />);
+    return shallowRender(<SearchPageBase {...{ ...props, ...extra }} />);
   }
 
   beforeEach(() => {
     props = {
+      clientApp: 'firefox',
       count: 80,
+      lang: 'en-GB',
       page: 3,
       handleSearch: sinon.spy(),
-      lang: 'en-GB',
       loading: false,
       results: [{ name: 'Foo', slug: 'foo' }, { name: 'Bar', slug: 'bar' }],
       query: 'foo',
@@ -31,15 +31,14 @@ describe('<SearchPage />', () => {
     const root = render();
     const results = findByTag(root, SearchResults);
     assert.strictEqual(results.props.count, props.count);
-    assert.strictEqual(results.props.lang, props.lang);
     assert.strictEqual(results.props.results, props.results);
     assert.strictEqual(results.props.query, props.query);
     assert.strictEqual(results.props.loading, props.loading);
     assert.strictEqual(results.props.ResultComponent, props.ResultComponent);
     assert.deepEqual(
       Object.keys(results.props).sort(),
-        ['count', 'lang', 'loading', 'results', 'ResultComponent',
-         'query'].sort());
+      ['count', 'loading', 'results', 'ResultComponent', 'query'].sort()
+    );
   });
 
   it('renders a Paginate', () => {
@@ -47,13 +46,21 @@ describe('<SearchPage />', () => {
     const paginator = findByTag(root, Paginate);
     assert.equal(paginator.props.count, 80);
     assert.equal(paginator.props.currentPage, 3);
-    assert.equal(paginator.props.pathname, '/en-GB/firefox/search/');
+    assert.equal(paginator.props.pathname, '/search/');
     assert.deepEqual(paginator.props.query, { q: 'foo' });
   });
 
   it('does not render a Paginate when there is no search term', () => {
-    const root = render({ query: null, count: 0, lang: 'en-GB' });
+    const root = render({ query: null, count: 0 });
     const paginators = findAllByTag(root, Paginate);
     assert.deepEqual(paginators, []);
+  });
+
+  it('maps api state to props', () => {
+    const stateProps = mapStateToProps({
+      api: { clientApp: 'android', lang: 'de' },
+    });
+
+    assert.deepEqual(stateProps, { clientApp: 'android', lang: 'de' });
   });
 });

--- a/tests/client/amo/components/TestSearchResult.js
+++ b/tests/client/amo/components/TestSearchResult.js
@@ -4,15 +4,21 @@ import {
   findRenderedDOMComponentWithClass,
   renderIntoDocument,
 } from 'react-addons-test-utils';
+import { Provider } from 'react-redux';
 
+import createStore from 'amo/store';
 import SearchResult from 'amo/components/SearchResult';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('<SearchResult />', () => {
   function renderResult(result) {
+    const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
+
     return findRenderedComponentWithType(renderIntoDocument(
-      <SearchResult i18n={getFakeI18nInst()} result={result} lang="en-US" />
+      <Provider store={createStore(initialState)}>
+        <SearchResult i18n={getFakeI18nInst()} result={result} />
+      </Provider>
     ), SearchResult).getWrappedInstance();
   }
 
@@ -58,6 +64,6 @@ describe('<SearchResult />', () => {
   });
 
   it('links to the detail page', () => {
-    assert.equal(root.name.props.to, '/en-US/firefox/addon/a-search-result/');
+    assert.equal(root.name.props.to, '/addon/a-search-result/');
   });
 });

--- a/tests/client/amo/containers/TestHome.js
+++ b/tests/client/amo/containers/TestHome.js
@@ -1,16 +1,25 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import {
+  findRenderedComponentWithType,
   renderIntoDocument,
 } from 'react-addons-test-utils';
+import { Provider } from 'react-redux';
 
+import createStore from 'amo/store';
 import { getFakeI18nInst } from 'tests/client/helpers';
 import Home from 'amo/containers/Home';
 
 
 describe('Home', () => {
   it('renders a heading', () => {
-    const root = renderIntoDocument(<Home i18n={getFakeI18nInst()} />);
+    const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
+
+    const root = findRenderedComponentWithType(renderIntoDocument(
+      <Provider store={createStore(initialState)}>
+        <Home i18n={getFakeI18nInst()} />
+      </Provider>
+    ), Home).getWrappedInstance();
     const rootNode = findDOMNode(root);
     const content = [
       'What do you want Firefox to do?',


### PR DESCRIPTION
Finally got around to doing this as I was being driven mad by all the `lang` passing.

Moves all of our AMO links to use a local `<Link />` component that still uses `to` instead of the propsed `href` in #1136 (so it looks the same as other React links).
r?