### PR TITLE
Simplify version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "jed": "1.1.1",
     "jsdom": "9.8.3",
     "mozilla-tabzilla": "0.5.1",
-    "mozilla-version-comparator": "1.0.2",
     "normalize.css": "5.0.0",
     "normalizr": "2.2.1",
     "piping": "0.3.2",

--- a/src/disco/containers/App.js
+++ b/src/disco/containers/App.js
@@ -3,7 +3,6 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import classNames from 'classnames';
-import mozVersionCompare from 'mozilla-version-comparator';
 
 import 'disco/css/App.scss';
 import translate from 'core/i18n/translate';
@@ -19,13 +18,7 @@ export class AppBase extends React.Component {
   render() {
     const { browserVersion, children, i18n } = this.props;
     const classes = classNames('disco-pane', {
-      /*
-       * mozVersionCompare(v1, v2) returns:
-       * 0 if the two versions are considered equal.
-       * -1 if v1 is less than v2
-       * 1 if v1 is greater than v2
-       */
-      'padding-compensation': mozVersionCompare(browserVersion || '', '50') === -1,
+      'padding-compensation': parseInt(browserVersion, 10) < 50,
     });
 
     return (

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -41,16 +41,16 @@ img {
   .disco-pane {
     padding-top: 50px;
   }
+}
 
-  // Special class to apply compensation
-  // for the padding applied by xul in FF < 50.
-  .padding-compensation {
-    padding-right: 68px; // 48px + 20px;
+// Special class to apply compensation
+// for the padding applied by xul in FF < 50.
+.padding-compensation {
+  padding-right: 68px; // 48px + 20px;
 
-    [dir=rtl] & {
-      padding-right: 0;
-      padding-left: 68px;
-    }
+  [dir=rtl] & {
+    padding-right: 0;
+    padding-left: 68px;
   }
 }
 

--- a/tests/client/disco/containers/TestApp.js
+++ b/tests/client/disco/containers/TestApp.js
@@ -40,14 +40,14 @@ describe('App', () => {
     assert.include(rootNode.className, 'padding-compensation');
   });
 
-  it('renders padding compensation class for a bogus value', () => {
+  it('does not render padding compensation class for a bogus value', () => {
     const rootNode = renderApp({ browserVersion: 'whatever' });
-    assert.include(rootNode.className, 'padding-compensation');
+    assert.notInclude(rootNode.className, 'padding-compensation');
   });
 
-  it('renders padding compensation class for a undefined value', () => {
+  it('does not render padding compensation class for a undefined value', () => {
     const rootNode = renderApp({ browserVersion: undefined });
-    assert.include(rootNode.className, 'padding-compensation');
+    assert.notInclude(rootNode.className, 'padding-compensation');
   });
 
   it('does not render padding compensation class for FF == 50', () => {


### PR DESCRIPTION
Relates to #639 and is a follow-up to #1308 

@mstriemer Thanks for the suggestions. 

This branch contains the switch to `parseInt` and I've pulled the padding out of the media query. The padding won't affect FF Android since mozAddonManager only works on ff Android from 51 onwards anyway (and we're not linking to it for android yet in any case).