### PR TITLE
Add "More information" to Details page (fix #1294)

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -4,6 +4,7 @@ import React, { PropTypes } from 'react';
 import AddonMeta from 'amo/components/AddonMeta';
 import InstallButton from 'core/components/InstallButton';
 import DefaultOverallRating from 'amo/components/OverallRating';
+import MoreInfo from 'amo/components/MoreInfo';
 import ScreenShots from 'amo/components/ScreenShots';
 import translate from 'core/i18n/translate';
 import { isAllowedOrigin, nl2br, sanitizeHTML } from 'core/utils';
@@ -29,9 +30,10 @@ export const allowedDescriptionTags = [
 
 class AddonDetail extends React.Component {
   static propTypes = {
-    i18n: PropTypes.object.isRequired,
-    addon: PropTypes.object.isRequired,
     OverallRating: PropTypes.element,
+    addon: PropTypes.object.isRequired,
+    i18n: PropTypes.object.isRequired,
+    versionDetails: PropTypes.object,
   }
 
   static defaultProps = {
@@ -39,7 +41,7 @@ class AddonDetail extends React.Component {
   }
 
   render() {
-    const { i18n, addon, OverallRating } = this.props;
+    const { OverallRating, addon, i18n, versionDetails } = this.props;
 
     const authorList = addon.authors.map(
       (author) => `<a href="${author.url}">${author.name}</a>`);
@@ -101,6 +103,8 @@ class AddonDetail extends React.Component {
             version={addon.current_version}
           />
         </section>
+
+        <MoreInfo addon={addon} versionDetails={versionDetails} />
       </div>
     );
   }

--- a/src/amo/components/MoreInfo.js
+++ b/src/amo/components/MoreInfo.js
@@ -1,0 +1,80 @@
+import React, { PropTypes } from 'react';
+import { compose } from 'redux';
+
+import Link from 'amo/components/Link';
+import translate from 'core/i18n/translate';
+
+import './MoreInfo.scss';
+
+
+export class MoreInfoBase extends React.Component {
+  static propTypes = {
+    addon: PropTypes.object.isRequired,
+    i18n: PropTypes.object.isRequired,
+    versionDetails: PropTypes.object,
+  }
+
+  render() {
+    const { addon, i18n, versionDetails } = this.props;
+    const license = versionDetails ? versionDetails.license : null;
+
+    if (versionDetails && versionDetails.loading) {
+      return (
+        <section className="MoreInfo">
+          <h2 className="MoreInfo-header">{i18n.gettext('More information')}</h2>
+          <div className="MoreInfo-contents">Loading...</div>
+        </section>
+      );
+    }
+
+    // TODO: Use the addonType for the privacy text, so it reads
+    // "for this extension", "for this theme", etc.
+    return (
+      <section className="MoreInfo">
+        <h2 className="MoreInfo-header">{i18n.gettext('More information')}</h2>
+
+        <dl className="MoreInfo-contents">
+          {addon.homepage ? <dt>{i18n.gettext('Website')}</dt> : null}
+          {addon.homepage ? (
+            <dd>
+              <a href={addon.homepage}
+                ref={(ref) => { this.homepageLink = ref; }}>{addon.homepage}</a>
+            </dd>
+          ) : null}
+          <dt>{i18n.gettext('Version')}</dt>
+          <dd>{addon.current_version.version}</dd>
+          <dt>{i18n.gettext('Last updated')}</dt>
+          <dd>{addon.last_updated}</dd>
+          {license ? (
+            <dt ref={(ref) => { this.licenseHeader = ref; }}>
+              {i18n.gettext('License')}
+            </dt>
+          ) : null}
+          {license ? (
+            <dd>
+              <a href={license.url}
+                ref={(ref) => { this.licenseLink = ref; }}>{license.name}</a>
+            </dd>
+          ) : null}
+          {addon.has_privacy_policy ?
+            <dt>{i18n.gettext('Privacy Policy')}</dt> : null}
+          {addon.has_privacy_policy ?
+            (
+              <dd>
+                <Link to={`/addons/addon/${addon.slug}/privacy-policy/`}
+                  ref={(ref) => { this.privacyPolicyLink = ref; }}>
+                  {i18n.gettext('Read the privacy policy for this add-on')}
+                </Link>
+              </dd>
+            ) : null
+          }
+          {versionDetails && versionDetails.error ? 'VersionLoad failed' : null}
+        </dl>
+      </section>
+    );
+  }
+}
+
+export default compose(
+  translate({ withRef: true }),
+)(MoreInfoBase);

--- a/src/amo/components/MoreInfo.scss
+++ b/src/amo/components/MoreInfo.scss
@@ -1,0 +1,38 @@
+@import "~core/css/inc/mixins";
+@import "~core/css/inc/vars";
+
+.MoreInfo-header {
+  @include addonSection();
+
+  border-top-left-radius: $border-radius-default;
+  border-top-right-radius: $border-radius-default;
+  font-size: $font-size-default;
+  margin-bottom: 1px;
+  text-align: center;
+}
+
+.MoreInfo-contents {
+  @include addonSection();
+
+  border-bottom-left-radius: $border-radius-default;
+  border-bottom-right-radius: $border-radius-default;
+  font-size: $font-size-s;
+
+  dt {
+    font-weight: bold;
+    line-height: 1.2;
+    margin: 0;
+    padding: 0;
+  }
+
+  dd {
+    line-height: 1.2;
+    margin: 0 0 3px;
+    padding: 0;
+
+    a:link {
+      font-size: $font-size-s;
+      font-weight: 400;
+    }
+  }
+}

--- a/src/amo/containers/CategoryPage.js
+++ b/src/amo/containers/CategoryPage.js
@@ -1,0 +1,22 @@
+import { connect } from 'react-redux';
+import { asyncConnect } from 'redux-connect';
+import { compose } from 'redux';
+
+import SearchPage from 'amo/components/SearchPage';
+import { loadSearchResultsIfNeeded, mapStateToProps } from 'core/searchUtils';
+import { loadCategoriesIfNeeded } from 'core/utils';
+
+
+export default compose(
+  asyncConnect([
+    {
+      deferred: true,
+      promise: loadSearchResultsIfNeeded,
+    },
+    {
+      deferred: true,
+      promise: loadCategoriesIfNeeded,
+    },
+  ]),
+  connect(mapStateToProps)
+)(SearchPage);

--- a/src/amo/containers/DetailPage.js
+++ b/src/amo/containers/DetailPage.js
@@ -5,7 +5,8 @@ import { connect } from 'react-redux';
 
 import AddonDetail from 'amo/components/AddonDetail';
 import translate from 'core/i18n/translate';
-import { loadAddonIfNeeded } from 'core/utils';
+import { loadAddonAndVersionDetail } from 'core/utils';
+
 
 export class DetailPageBase extends React.Component {
   render() {
@@ -19,9 +20,12 @@ export class DetailPageBase extends React.Component {
 
 function mapStateToProps(state, ownProps) {
   const { slug } = ownProps.params;
+  const addon = state.addons[slug];
   return {
-    addon: state.addons[slug],
+    addon,
     slug,
+    versionDetails: addon && state.version[addon.current_version.id] ?
+      state.version[addon.current_version.id] : state.version,
   };
 }
 
@@ -29,7 +33,7 @@ export default compose(
   asyncConnect([{
     key: 'DetailPage',
     deferred: true,
-    promise: loadAddonIfNeeded,
+    promise: loadAddonAndVersionDetail,
   }]),
   connect(mapStateToProps),
   translate({ withRef: true }),

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -8,11 +8,20 @@ import auth from 'core/reducers/authentication';
 import categories from 'core/reducers/categories';
 import reviews from 'amo/reducers/reviews';
 import search from 'core/reducers/search';
+import version from 'core/reducers/version';
+
 
 export default function createStore(initialState = {}) {
   return _createStore(
     combineReducers({
-      addons, api, auth, categories, search, reviews, reduxAsyncConnect,
+      addons,
+      api,
+      auth,
+      categories,
+      reduxAsyncConnect,
+      reviews,
+      search,
+      version,
     }),
     initialState,
     middleware(),

--- a/src/core/actions/version.js
+++ b/src/core/actions/version.js
@@ -1,0 +1,29 @@
+import {
+  VERSION_GET,
+  VERSION_LOADED,
+  VERSION_FAILED,
+} from 'core/constants';
+
+
+export function versionGet({ slug, versionID }) {
+  return {
+    type: VERSION_GET,
+    payload: { slug, versionID },
+  };
+}
+
+export function versionLoad({ entities }) {
+  return {
+    type: VERSION_LOADED,
+    payload: {
+      result: entities ? entities.versions : null,
+    },
+  };
+}
+
+export function versionFail({ slug, versionID }) {
+  return {
+    type: VERSION_FAILED,
+    payload: { slug, versionID },
+  };
+}

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -14,6 +14,7 @@ const API_BASE = `${config.get('apiHost')}${config.get('apiPath')}`;
 export const addon = new Schema('addons', { idAttribute: 'slug' });
 export const category = new Schema('categories', { idAttribute: 'slug' });
 export const user = new Schema('users', { idAttribute: 'username' });
+export const version = new Schema('versions', { idAttribute: 'id' });
 
 function makeQueryString(query) {
   return url.format({ query });
@@ -81,6 +82,15 @@ export function fetchAddon({ api, slug }) {
   return callApi({
     endpoint: `addons/addon/${slug}`,
     schema: addon,
+    auth: true,
+    state: api,
+  });
+}
+
+export function versionDetail({ api, slug, versionID }) {
+  return callApi({
+    endpoint: `addons/addon/${slug}/versions/${versionID}`,
+    schema: version,
     auth: true,
     state: api,
   });

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -56,6 +56,9 @@ export const SET_CLIENT_APP = 'SET_CLIENT_APP';
 export const SET_CURRENT_USER = 'SET_CURRENT_USER';
 export const SET_JWT = 'SET_JWT';
 export const SET_LANG = 'SET_LANG';
+export const VERSION_GET = 'VERSION_GET';
+export const VERSION_LOADED = 'VERSION_LOADED';
+export const VERSION_FAILED = 'VERSION_FAILED';
 
 // InfoDialog action types.
 export const CLOSE_INFO = 'CLOSE_INFO';

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -241,3 +241,10 @@ $color: $text-color-message) {
     margin-left: $val;
   }
 }
+
+@mixin addonSection() {
+  background: #fff;
+  margin: 0 10px;
+  padding: 10px;
+  overflow: hidden;
+}

--- a/src/core/reducers/version.js
+++ b/src/core/reducers/version.js
@@ -1,0 +1,26 @@
+import {
+  VERSION_GET,
+  VERSION_LOADED,
+  VERSION_FAILED,
+} from 'core/constants';
+
+const initialState = {
+  loading: false,
+};
+
+export default function version(state = initialState, action) {
+  const { payload } = action;
+  switch (action.type) {
+    case VERSION_GET:
+      return { ...state, ...payload, loading: true };
+    case VERSION_LOADED:
+      return { ...state, ...payload.result, loading: false };
+    case VERSION_FAILED:
+      return {
+        ...initialState,
+        error: true,
+      };
+    default:
+      return state;
+  }
+}

--- a/tests/client/amo/components/TestMoreInfo.js
+++ b/tests/client/amo/components/TestMoreInfo.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  findRenderedComponentWithType,
+  renderIntoDocument,
+} from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+import { Provider } from 'react-redux';
+
+import createStore from 'amo/store';
+import { MoreInfoBase } from 'amo/components/MoreInfo';
+import { getFakeI18nInst } from 'tests/client/helpers';
+
+
+describe('<MoreInfo />', () => {
+  const initialState = { api: { clientApp: 'android', lang: 'pt' } };
+  const addon = {
+    current_version: { id: 20 },
+    homepage: 'http://hamsterdance.com/',
+    has_privacy_policy: true,
+    slug: 'my-addon',
+  };
+
+  function render(props) {
+    return findRenderedComponentWithType(renderIntoDocument(
+      <Provider store={createStore(initialState)}>
+        <MoreInfoBase i18n={getFakeI18nInst()} addon={addon} {...props} />
+      </Provider>
+    ), MoreInfoBase);
+  }
+
+  it('renders loading when loading more info', () => {
+    const rootNode = findDOMNode(render({ versionDetails: { loading: true } }));
+
+    assert.equal(rootNode.querySelector('.MoreInfo-contents').textContent,
+      'Loading...');
+  });
+
+  it('does not render a homepage if none exists', () => {
+    const root = render({ addon: {
+      current_version: { id: 20, version: '1.0' },
+    } });
+
+    assert.equal(root.homepageLink, undefined);
+  });
+
+  it('renders the homepage of an add-on', () => {
+    const root = render();
+
+    assert.equal(root.homepageLink.textContent, 'http://hamsterdance.com/');
+    assert.equal(root.homepageLink.tagName, 'A');
+    assert.equal(root.homepageLink.href, 'http://hamsterdance.com/');
+  });
+
+  it('renders the license and link', () => {
+    const root = render({ versionDetails: {
+      license: { name: 'tofulicense', url: 'http://license.com/' },
+    } });
+
+    assert.equal(root.licenseHeader.textContent, 'License');
+    assert.equal(root.licenseLink.textContent, 'tofulicense');
+    assert.equal(root.licenseLink.tagName, 'A');
+    assert.equal(root.licenseLink.href, 'http://license.com/');
+  });
+
+  it('does not render a privacy policy if none exists', () => {
+    const root = render({ addon: {
+      current_version: { id: 20, version: '1.0' },
+      has_privacy_policy: false,
+    } });
+
+    assert.equal(root.privacyPolicyLink, undefined);
+  });
+
+  it('renders the privacy policy and link', () => {
+    const root = render();
+
+    assert.equal(findDOMNode(root.privacyPolicyLink).textContent,
+      'Read the privacy policy for this add-on');
+    assert.equal(root.privacyPolicyLink.props.to,
+      '/addons/addon/my-addon/privacy-policy/');
+  });
+});

--- a/tests/client/amo/test_store.js
+++ b/tests/client/amo/test_store.js
@@ -5,8 +5,10 @@ describe('amo createStore', () => {
     const store = createStore();
     assert.deepEqual(
       Object.keys(store.getState()).sort(),
-      ['addons', 'api', 'auth', 'categories', 'reduxAsyncConnect', 'reviews',
-       'search']
+      [
+        'addons', 'api', 'auth', 'categories', 'reduxAsyncConnect', 'reviews',
+        'search', 'version',
+      ]
     );
   });
 

--- a/tests/client/core/actions/test_version.js
+++ b/tests/client/core/actions/test_version.js
@@ -1,0 +1,43 @@
+import {
+  VERSION_GET,
+  VERSION_LOADED,
+  VERSION_FAILED,
+} from 'core/constants';
+import * as actions from 'core/actions/version';
+
+describe(VERSION_GET, () => {
+  const action = actions.versionGet({ slug: 'foo', versionID: 20 });
+
+  it('sets the type', () => {
+    assert.equal(action.type, VERSION_GET);
+  });
+
+  it('sets the query', () => {
+    assert.deepEqual(action.payload, { slug: 'foo', versionID: 20 });
+  });
+});
+
+describe(VERSION_LOADED, () => {
+  const entities = { versions: 'foo' };
+  const action = actions.versionLoad({ entities });
+
+  it('sets the type', () => {
+    assert.equal(action.type, VERSION_LOADED);
+  });
+
+  it('sets the payload', () => {
+    assert.deepEqual(action.payload, { result: 'foo' });
+  });
+});
+
+describe(VERSION_FAILED, () => {
+  const action = actions.versionFail({ slug: 'foo', versionID: 20 });
+
+  it('sets the type', () => {
+    assert.equal(action.type, VERSION_FAILED);
+  });
+
+  // it('sets the payload', () => {
+  //   assert.deepEqual(action.payload, { loading: false });
+  // });
+});

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -192,6 +192,53 @@ describe('api', () => {
     });
   });
 
+  describe('versionDetail api', () => {
+    function mockResponse() {
+      return Promise.resolve({
+        ok: true,
+        json() {
+          return Promise.resolve({
+            id: 20,
+            license: { url: 'http://foo.com/license.html' },
+          });
+        },
+      });
+    }
+
+    it('sets the lang query and id/slug params', () => {
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/addon/my-addon/versions/3/?lang=fr`)
+        .once()
+        .returns(mockResponse());
+      return api.versionDetail({
+        api: { lang: 'fr' },
+        slug: 'my-addon',
+        versionID: 3,
+      })
+        .then(() => mockWindow.verify());
+    });
+
+    it('normalizes the response', () => {
+      mockWindow.expects('fetch').once().returns(mockResponse());
+      return api.versionDetail({
+        api: { lang: 'en-US' }, slug: 'my-addon', versionID: 20,
+      })
+        .then((response) => {
+          assert.deepEqual(response, {
+            entities: {
+              versions: {
+                20: {
+                  id: 20,
+                  license: { url: 'http://foo.com/license.html' },
+                },
+              },
+            },
+            result: 20,
+          });
+        });
+    });
+  });
+
   describe('add-on api', () => {
     function mockResponse() {
       return Promise.resolve({

--- a/tests/client/core/reducers/test_version.js
+++ b/tests/client/core/reducers/test_version.js
@@ -1,0 +1,55 @@
+import {
+  VERSION_GET,
+  VERSION_LOADED,
+  VERSION_FAILED,
+} from 'core/constants';
+import version from 'core/reducers/version';
+
+
+describe('version reducer', () => {
+  it('defaults to not loading', () => {
+    const { loading } = version(undefined, { type: 'unrelated' });
+    assert.strictEqual(loading, false);
+  });
+
+  describe(VERSION_GET, () => {
+    it('sets loading', () => {
+      const state = version(
+        { loading: false, slug: 'my-addon' },
+        { type: VERSION_GET, payload: { slug: 'your-addon' } });
+
+      assert.equal(state.slug, 'your-addon');
+      assert.strictEqual(state.loading, true);
+    });
+  });
+
+  describe(VERSION_LOADED, () => {
+    it('sets the payload and loading', () => {
+      const state = version(
+        { loading: true },
+        { type: VERSION_LOADED,
+          payload: {
+            result: {
+              42626: { license: { url: 'foo.com' } },
+            },
+          },
+        },
+      );
+
+      assert.equal(state[42626].license.url, 'foo.com');
+      assert.strictEqual(state.loading, false);
+    });
+  });
+
+  describe(VERSION_FAILED, () => {
+    it('sets the error and loading', () => {
+      const state = version(
+        { loading: true },
+        { type: VERSION_FAILED },
+      );
+
+      assert.strictEqual(state.loading, false);
+      assert.strictEqual(state.error, true);
+    });
+  });
+});


### PR DESCRIPTION
Adds "More information" to addon detail pages.

### Before
<img width="324" alt="screenshot 2016-11-08 14 13 38" src="https://cloud.githubusercontent.com/assets/90871/20102310/9416c9ae-a5bd-11e6-8449-3d57ffede7b2.png">

### After
<img width="324" alt="screenshot 2016-11-08 14 25 34" src="https://cloud.githubusercontent.com/assets/90871/20102795/4d688112-a5bf-11e6-8453-ee07207fd378.png">

