### PR TITLE
Make a star look selected during keybaord navigation

### DIFF
--- a/src/amo/css/OverallRating.scss
+++ b/src/amo/css/OverallRating.scss
@@ -19,7 +19,9 @@ $star-size: 46px;
 // only the first three stars appear selected.
 
 // First, make all stars appear selected when you hover over the group.
-.OverallRating-star-group:hover .OverallRating-choice {
+.OverallRating-star-group:hover .OverallRating-choice,
+// For keyboard navigation, make the focused star appear selected.
+.OverallRating-choice:focus {
   background-image: url('../img/ratings/big-star-selected.svg');
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1360

Using the keyboard to navigate and submit a rating was working for me so this fix just adds some styling:

<img width="385" alt="screenshot 2016-11-10 11 54 38" src="https://cloud.githubusercontent.com/assets/55398/20188156/0221a20e-a73d-11e6-8ab9-4b09728412e6.png">
