### PR TITLE
Render saved star ratings on detail page

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -1,15 +1,14 @@
 import { SET_REVIEW } from 'amo/constants';
 
-export const setReview = ({
-  id, addonId, versionId, rating, userId, isLatest,
-}) => ({
+export const setReview = (review, reviewOverrides = {}) => ({
   type: SET_REVIEW,
   data: {
-    id,
-    userId,
-    addonId,
-    versionId,
-    rating,
-    isLatest,
+    id: review.id,
+    addonId: review.addon.id,
+    rating: review.rating,
+    versionId: review.version.id,
+    isLatest: review.is_latest,
+    userId: review.user.id,
+    ...reviewOverrides,
   },
 });

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -1,6 +1,8 @@
 import { SET_REVIEW } from 'amo/constants';
 
-export const setReview = ({ id, addonId, versionId, rating, userId }) => ({
+export const setReview = ({
+  id, addonId, versionId, rating, userId, isLatest,
+}) => ({
   type: SET_REVIEW,
   data: {
     id,
@@ -8,5 +10,6 @@ export const setReview = ({ id, addonId, versionId, rating, userId }) => ({
     addonId,
     versionId,
     rating,
+    isLatest,
   },
 });

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -1,8 +1,9 @@
 import { SET_REVIEW } from 'amo/constants';
 
-export const setReview = ({ addonId, versionId, rating, userId }) => ({
+export const setReview = ({ id, addonId, versionId, rating, userId }) => ({
   type: SET_REVIEW,
   data: {
+    id,
     userId,
     addonId,
     versionId,

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -29,10 +29,15 @@ export function submitReview({
     });
 }
 
-export function getUserReviews({ userId }) {
-  // Warning: if you rely on this API as is, you'll have to implement
-  // your own paging.
-  return callApi({
-    endpoint: `accounts/account/${userId}/reviews`,
+export function getUserReviews({ userId } = {}) {
+  return new Promise((resolve) => {
+    if (!userId) {
+      throw new Error('userId cannot be falsey');
+    }
+    // Warning: if you rely on this API as is, you'll have to implement
+    // your own paging.
+    resolve(callApi({
+      endpoint: `accounts/account/${userId}/reviews`,
+    }));
   });
 }

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -1,4 +1,5 @@
 import { callApi } from 'core/api';
+import log from 'core/logger';
 
 /*
  * POST/PATCH an add-on review using the API.
@@ -33,15 +34,40 @@ export function submitReview({
     });
 }
 
-export function getUserReviews({ userId } = {}) {
+export function getUserReviews({
+  userId, addonId, onlyTheLatest = false,
+} = {}) {
   return new Promise((resolve) => {
     if (!userId) {
       throw new Error('userId cannot be falsey');
     }
-    // Warning: if you rely on this API as is, you'll have to implement
-    // your own paging.
     resolve(callApi({
       endpoint: `accounts/account/${userId}/reviews`,
     }));
-  });
+  })
+    .then((response) => {
+      // TODO: implement paging through response.next
+      if (response.next) {
+        throw new Error('paging is not yet implemented');
+      }
+      return response.results;
+    })
+    .then((reviews) => {
+      if (addonId) {
+        log.info(`Filtering user ${userId} reviews by addonId ${addonId}`);
+        return reviews.filter((review) => review.addon.id === addonId);
+      }
+      return reviews;
+    })
+    .then((reviews) => {
+      if (onlyTheLatest) {
+        log.info(`Only fetching the latest review by user ${userId}`);
+        const latest = reviews.filter((review) => review.is_latest);
+        if (latest.length === 0) {
+          return null;
+        }
+        return latest[0];
+      }
+      return reviews;
+    });
 }

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -28,3 +28,11 @@ export function submitReview({
       }));
     });
 }
+
+export function getUserReviews({ userId }) {
+  // Warning: if you rely on this API as is, you'll have to implement
+  // your own paging.
+  return callApi({
+    endpoint: `accounts/account/${userId}/reviews`,
+  });
+}

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -7,6 +7,10 @@ export function submitReview({
   rating, apiState, addonSlug, versionId, body, reviewId,
 }) {
   const data = { rating, version: versionId, body };
+  if (reviewId) {
+    // You cannot update the version of an existing review.
+    data.version = undefined;
+  }
 
   return new Promise(
     (resolve) => {

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -34,9 +34,7 @@ export function submitReview({
     });
 }
 
-export function getUserReviews({
-  userId, addonId, onlyTheLatest = false,
-} = {}) {
+export function getUserReviews({ userId, addonId } = {}) {
   return new Promise((resolve) => {
     if (!userId) {
       throw new Error('userId cannot be falsey');
@@ -58,16 +56,16 @@ export function getUserReviews({
         return reviews.filter((review) => review.addon.id === addonId);
       }
       return reviews;
-    })
+    });
+}
+
+export function getLatestUserReview(params) {
+  return getUserReviews(params)
     .then((reviews) => {
-      if (onlyTheLatest) {
-        log.info(`Only fetching the latest review by user ${userId}`);
-        const latest = reviews.filter((review) => review.is_latest);
-        if (latest.length === 0) {
-          return null;
-        }
-        return latest[0];
+      const latest = reviews.filter((review) => review.is_latest);
+      if (latest.length === 0) {
+        return null;
       }
-      return reviews;
+      return latest[0];
     });
 }

--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -148,6 +148,7 @@ export function loadAddonReview(
   })
     .then((review) => {
       dispatch(setReview({
+        id: review.id,
         addonId: review.addon.id,
         versionId: review.version.id,
         rating: review.rating,

--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -153,6 +153,7 @@ export function loadAddonReview(
         versionId: review.version.id,
         rating: review.rating,
         userId: review.user.id,
+        isLatest: review.is_latest,
       }));
 
       const reviewData = {

--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -147,15 +147,7 @@ export function loadAddonReview(
     }));
   })
     .then((review) => {
-      dispatch(setReview({
-        id: review.id,
-        addonId: review.addon.id,
-        versionId: review.version.id,
-        rating: review.rating,
-        userId: review.user.id,
-        isLatest: review.is_latest,
-      }));
-
+      dispatch(setReview(review));
       const reviewData = {
         rating: review.rating,
         addonSlug: slug,

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -158,6 +158,8 @@ export const mapDispatchToProps = (dispatch) => ({
           throw new Error(
             `Unexpectedly received more than one review for
             user ${userId}, addonId ${addonId}, versionId ${versionId}`);
+        } else {
+          log.info('No reviews found for', { addonId, versionId, userId });
         }
       });
   },

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -97,6 +97,10 @@ export const mapStateToProps = (state, componentProps = {}) => {
 };
 
 export const mapDispatchToProps = (dispatch) => ({
+
+  // TODO: create a load function that will load a user review
+  // and dispatch it if it exists.
+
   createRating({ router, addonSlug, addonId, userId, ...params }) {
     return submitReview({ addonSlug, ...params })
       .then((review) => {

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -29,6 +29,7 @@ export class OverallRatingBase extends React.Component {
   constructor(props) {
     super(props);
     const { loadSavedRating, userId, addonId, version } = props;
+    this.ratingButtons = {};
     if (userId) {
       log.info(`loading a saved rating (if it exists) for user ${userId}`);
       loadSavedRating({ userId, addonId, versionId: version.id });
@@ -54,19 +55,21 @@ export class OverallRatingBase extends React.Component {
     const { userReview } = this.props;
     return [1, 2, 3, 4, 5].map((rating) => {
       let disabled = false;
-      let cls;
+      let cls = '';
       if (userReview) {
-        // All the stars are read-only now.
         disabled = true;
+        // Render selected stars for the saved review.
         if (rating <= userReview.rating) {
           log.info(`Star ${rating} is selected`);
           cls = 'OverallRating-selected-star';
         }
       } else {
+        // Make all stars selectable.
         cls = 'OverallRating-choice';
       }
 
       return (<button
+        ref={(ref) => { this.ratingButtons[rating] = ref; }}
         value={rating} onClick={this.onClickRating}
         className={cls} id={`OverallRating-rating-${rating}`}
         disabled={disabled} />);
@@ -82,13 +85,13 @@ export class OverallRatingBase extends React.Component {
     // TODO: Disable rating ability when not logged in
     // (when props.userId is empty)
 
-    // TODO: disable rating submission if userReview is set.
-
     return (
       <div className="OverallRating">
         <form action="">
           <fieldset>
-            <legend>{prompt}</legend>
+            <legend ref={(ref) => { this.ratingLegend = ref; }}>
+              {prompt}
+            </legend>
             <div className="OverallRating-choices">
               <span className="OverallRating-star-group">
                 {this.renderRatings()}

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -55,19 +55,18 @@ export class OverallRatingBase extends React.Component {
 
   renderRatings() {
     const { userReview } = this.props;
-    return [1, 2, 3, 4, 5].map((rating) => {
-      const cls = classNames('OverallRating-choice', {
-        'OverallRating-selected-star':
-          userReview && rating <= userReview.rating,
-      });
-      return (
-        <button
-          ref={(ref) => { this.ratingButtons[rating] = ref; }}
-          value={rating} onClick={this.onClickRating}
-          className={cls} id={`OverallRating-rating-${rating}`}
-        />
-      );
-    });
+    return [1, 2, 3, 4, 5].map((rating) =>
+      <button
+        className={classNames('OverallRating-choice', {
+          'OverallRating-selected-star':
+            userReview && rating <= userReview.rating,
+        })}
+        ref={(ref) => { this.ratingButtons[rating] = ref; }}
+        value={rating}
+        onClick={this.onClickRating}
+        id={`OverallRating-rating-${rating}`}
+      />
+    );
   }
 
   render() {

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -70,10 +70,31 @@ export class OverallRatingBase extends React.Component {
   }
 }
 
-export const mapStateToProps = (state) => ({
-  apiState: state.api,
-  userId: state.auth && state.auth.userId,
-});
+export const mapStateToProps = (state, componentProps = {}) => {
+  const userId = state.auth && state.auth.userId;
+  let userReview;
+
+  // Look for an already saved review by this user for this add-on/version.
+  if (userId && state.reviews) {
+    const allUserReviews = state.reviews[userId];
+    if (allUserReviews) {
+      // TODO: adjust this when multiple reviews per version are stored
+      // in state.
+      const addonReview = allUserReviews[componentProps.addonId];
+      if (addonReview && addonReview.versionId === componentProps.version.id) {
+        // We have found an existing review by this user for this
+        // add-on and version.
+        userReview = addonReview;
+      }
+    }
+  }
+
+  return {
+    apiState: state.api,
+    userReview,
+    userId,
+  };
+};
 
 export const mapDispatchToProps = (dispatch) => ({
   createRating({ router, addonSlug, addonId, userId, ...params }) {

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -41,16 +41,26 @@ export class OverallRatingBase extends React.Component {
     event.preventDefault();
     const button = event.currentTarget;
     log.debug('Selected rating from form button:', button.value);
-    this.props.submitReview({
-      reviewId: this.props.userReview && this.props.userReview.id,
+    const { userReview, userId, version } = this.props;
+
+    const params = {
       rating: parseInt(button.value, 10),
-      versionId: this.props.version.id,
       apiState: this.props.apiState,
       addonId: this.props.addonId,
       addonSlug: this.props.addonSlug,
-      userId: this.props.userId,
       router: this.props.router,
-    });
+      versionId: version.id,
+      userId,
+    };
+
+    if (userReview && userReview.versionId === params.versionId) {
+      log.info(
+        `Updating reviewId ${userReview.id} for versionId ${params.versionId}`);
+      params.reviewId = userReview.id;
+    } else {
+      log.info(`Submitting a new review for versionId ${params.versionId}`);
+    }
+    this.props.submitReview(params);
   }
 
   renderRatings() {

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -21,7 +21,7 @@ export class OverallRatingBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     loadSavedRating: PropTypes.func.isRequired,
     router: PropTypes.object.isRequired,
-    submitRating: PropTypes.func.isRequired,
+    submitReview: PropTypes.func.isRequired,
     userId: PropTypes.number,
     userReview: PropTypes.object,
     version: PropTypes.object.isRequired,
@@ -41,7 +41,7 @@ export class OverallRatingBase extends React.Component {
     event.preventDefault();
     const button = event.currentTarget;
     log.debug('Selected rating from form button:', button.value);
-    this.props.submitRating({
+    this.props.submitReview({
       reviewId: this.props.userReview && this.props.userReview.id,
       rating: parseInt(button.value, 10),
       versionId: this.props.version.id,
@@ -139,7 +139,7 @@ export const mapDispatchToProps = (dispatch) => ({
       });
   },
 
-  submitRating({ router, addonSlug, ...params }) {
+  submitReview({ router, addonSlug, ...params }) {
     return submitReview({ addonSlug, ...params })
       .then((review) => {
         const { lang, clientApp } = params.apiState;

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -104,7 +104,7 @@ export class OverallRatingBase extends React.Component {
   }
 }
 
-export const mapStateToProps = (state, componentProps) => {
+export const mapStateToProps = (state, ownProps) => {
   const userId = state.auth && state.auth.userId;
   let userReview;
 
@@ -112,15 +112,15 @@ export const mapStateToProps = (state, componentProps) => {
   if (userId && state.reviews) {
     const allUserReviews = state.reviews[userId];
     log.info(`Checking state for review by user ${userId},
-      addonId ${componentProps.addonId},
-      versionId ${componentProps.version.id}`);
+      addonId ${ownProps.addonId},
+      versionId ${ownProps.version.id}`);
 
     if (allUserReviews) {
       // TODO: adjust this when multiple reviews per version are stored
       // in state.
       // See https://github.com/mozilla/addons-server/issues/3986
-      const addonReview = allUserReviews[componentProps.addonId];
-      if (addonReview && addonReview.versionId === componentProps.version.id) {
+      const addonReview = allUserReviews[ownProps.addonId];
+      if (addonReview && addonReview.versionId === ownProps.version.id) {
         // We have found an existing review by this user for this
         // add-on and version.
         userReview = addonReview;

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -19,7 +19,7 @@ export class OverallRatingBase extends React.Component {
     addonId: PropTypes.number.isRequired,
     apiState: PropTypes.object,
     i18n: PropTypes.object.isRequired,
-    loadSavedRating: PropTypes.func.isRequired,
+    loadSavedReview: PropTypes.func.isRequired,
     router: PropTypes.object.isRequired,
     submitReview: PropTypes.func.isRequired,
     userId: PropTypes.number,
@@ -29,11 +29,11 @@ export class OverallRatingBase extends React.Component {
 
   constructor(props) {
     super(props);
-    const { loadSavedRating, userId, addonId } = props;
+    const { loadSavedReview, userId, addonId } = props;
     this.ratingButtons = {};
     if (userId) {
       log.info(`loading a saved rating (if it exists) for user ${userId}`);
-      loadSavedRating({ userId, addonId });
+      loadSavedReview({ userId, addonId });
     }
   }
 
@@ -127,7 +127,7 @@ export const mapStateToProps = (state, ownProps) => {
 
 export const mapDispatchToProps = (dispatch) => ({
 
-  loadSavedRating({ userId, addonId }) {
+  loadSavedReview({ userId, addonId }) {
     return getLatestUserReview({ userId, addonId })
       .then((review) => {
         if (review) {

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -141,12 +141,8 @@ export const mapDispatchToProps = (dispatch) => ({
   loadSavedRating({ addonId, versionId, userId }) {
     return getUserReviews({ userId })
       .then((response) => {
-        const relevantReviews = response.results.filter((review) => {
-          if (review.addon.id === addonId && review.version.id === versionId) {
-            return review;
-          }
-          return false;
-        });
+        const relevantReviews = response.results.filter(
+          (review) => review.addon.id === addonId && review.version.id === versionId);
         if (relevantReviews.length === 1) {
           const review = relevantReviews[0];
           log.info(`Found a review for user ${userId}`, review);

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -50,8 +50,31 @@ export class OverallRatingBase extends React.Component {
     });
   }
 
+  renderRatings() {
+    const { userReview } = this.props;
+    return [1, 2, 3, 4, 5].map((rating) => {
+      let disabled = false;
+      let cls;
+      if (userReview) {
+        // All the stars are read-only now.
+        disabled = true;
+        if (rating <= userReview.rating) {
+          log.info(`Star ${rating} is selected`);
+          cls = 'OverallRating-selected-star';
+        }
+      } else {
+        cls = 'OverallRating-choice';
+      }
+
+      return (<button
+        value={rating} onClick={this.onClickRating}
+        className={cls} id={`OverallRating-rating-${rating}`}
+        disabled={disabled} />);
+    });
+  }
+
   render() {
-    const { i18n, addonName, userReview } = this.props;
+    const { i18n, addonName } = this.props;
     const prompt = i18n.sprintf(
       i18n.gettext('How are you enjoying your experience with %(addonName)s?'),
       { addonName });
@@ -68,26 +91,7 @@ export class OverallRatingBase extends React.Component {
             <legend>{prompt}</legend>
             <div className="OverallRating-choices">
               <span className="OverallRating-star-group">
-                {[1, 2, 3, 4, 5].map((rating) => {
-
-                  let disabled = false;
-                  let cls;
-                  if (userReview) {
-                    // All the stars are read-only now.
-                    disabled = true;
-                    if (rating <= userReview.rating) {
-                      log.info(`Star ${rating} is selected`);
-                      cls = 'OverallRating-selected-star';
-                    }
-                  } else {
-                    cls = 'OverallRating-choice';
-                  }
-
-                  return <button
-                    value={rating} onClick={this.onClickRating}
-                    className={cls} id={`OverallRating-rating-${rating}`}
-                    disabled={disabled} />;
-                })}
+                {this.renderRatings()}
               </span>
             </div>
           </fieldset>
@@ -116,7 +120,7 @@ export const mapStateToProps = (state, componentProps) => {
         // We have found an existing review by this user for this
         // add-on and version.
         userReview = addonReview;
-        log.info(`Re-rendering component with user review from state`,
+        log.info('Re-rendering component with user review from state',
                  userReview);
       }
     }
@@ -138,6 +142,7 @@ export const mapDispatchToProps = (dispatch) => ({
           if (review.addon.id === addonId && review.version.id === versionId) {
             return review;
           }
+          return false;
         });
         if (relevantReviews.length === 1) {
           const review = relevantReviews[0];
@@ -149,7 +154,6 @@ export const mapDispatchToProps = (dispatch) => ({
             versionId: review.version.id,
             userId,
           }));
-
         } else if (relevantReviews.length > 1) {
           throw new Error(
             `Unexpectedly received more than one review for

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -118,6 +118,7 @@ export const mapStateToProps = (state, componentProps) => {
     if (allUserReviews) {
       // TODO: adjust this when multiple reviews per version are stored
       // in state.
+      // See https://github.com/mozilla/addons-server/issues/3986
       const addonReview = allUserReviews[componentProps.addonId];
       if (addonReview && addonReview.versionId === componentProps.version.id) {
         // We have found an existing review by this user for this

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withRouter } from 'react-router';
+import classNames from 'classnames';
 
 import { setReview } from 'amo/actions/reviews';
 import { getUserReviews, submitReview } from 'amo/api';
@@ -55,17 +56,10 @@ export class OverallRatingBase extends React.Component {
   renderRatings() {
     const { userReview } = this.props;
     return [1, 2, 3, 4, 5].map((rating) => {
-      let cls = '';
-      if (userReview) {
-        // Render selected stars for the saved review.
-        if (rating <= userReview.rating) {
-          log.info(`Star ${rating} is selected`);
-          cls = 'OverallRating-selected-star';
-        }
-      } else {
-        // Make all stars selectable.
-        cls = 'OverallRating-choice';
-      }
+      const cls = classNames('OverallRating-choice', {
+        'OverallRating-selected-star':
+          userReview && rating <= userReview.rating,
+      });
       return (
         <button
           ref={(ref) => { this.ratingButtons[rating] = ref; }}

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -111,9 +111,8 @@ export const mapStateToProps = (state, ownProps) => {
   // Look for an already saved review by this user for this add-on/version.
   if (userId && state.reviews) {
     const allUserReviews = state.reviews[userId];
-    log.info(`Checking state for review by user ${userId},
-      addonId ${ownProps.addonId},
-      versionId ${ownProps.version.id}`);
+    log.info(dedent`Checking state for review by user ${userId},
+      addonId ${ownProps.addonId}, versionId ${ownProps.version.id}`);
 
     if (allUserReviews) {
       // TODO: adjust this when multiple reviews per version are stored

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router';
 import classNames from 'classnames';
 
 import { setReview } from 'amo/actions/reviews';
-import { getUserReviews, submitReview } from 'amo/api';
+import { getLatestUserReview, submitReview } from 'amo/api';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 
@@ -132,7 +132,7 @@ export const mapStateToProps = (state, ownProps) => {
 export const mapDispatchToProps = (dispatch) => ({
 
   loadSavedRating({ userId, addonId }) {
-    return getUserReviews({ userId, addonId, onlyTheLatest: true })
+    return getLatestUserReview({ userId, addonId })
       .then((review) => {
         if (review) {
           dispatch(setReview(review));

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -101,24 +101,20 @@ export const mapStateToProps = (state, ownProps) => {
   const userId = state.auth && state.auth.userId;
   let userReview;
 
-  // Look for an already saved review by this user for this add-on/version.
+  // Look for the latest saved review by this user for this add-on.
   if (userId && state.reviews) {
-    const allUserReviews = state.reviews[userId];
     log.info(dedent`Checking state for review by user ${userId},
       addonId ${ownProps.addonId}, versionId ${ownProps.version.id}`);
-    const addonReviews =
-      allUserReviews ? allUserReviews[ownProps.addonId] : null;
 
-    if (addonReviews) {
-      for (const reviewId of Object.keys(addonReviews)) {
-        const review = addonReviews[reviewId];
-        if (review.isLatest) {
-          userReview = review;
-          log.info('Found the latest review in state for this component',
-                   userReview);
-          break;
-        }
-      }
+    const allUserReviews = state.reviews[userId] || {};
+    const addonReviews = allUserReviews[ownProps.addonId] || {};
+    const latestId = Object.keys(addonReviews).find(
+      (reviewId) => addonReviews[reviewId].isLatest);
+
+    if (latestId) {
+      userReview = addonReviews[latestId];
+      log.info('Found the latest review in state for this component',
+               userReview);
     }
   }
 

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -135,14 +135,7 @@ export const mapDispatchToProps = (dispatch) => ({
     return getUserReviews({ userId, addonId, onlyTheLatest: true })
       .then((review) => {
         if (review) {
-          dispatch(setReview({
-            id: review.id,
-            addonId: review.addon.id,
-            rating: review.rating,
-            versionId: review.version.id,
-            isLatest: review.is_latest,
-            userId,
-          }));
+          dispatch(setReview(review));
         } else {
           log.info(
             `No saved review found for userId ${userId}, addonId ${addonId}`);
@@ -150,21 +143,11 @@ export const mapDispatchToProps = (dispatch) => ({
       });
   },
 
-  submitRating({ router, addonSlug, addonId, userId, ...params }) {
+  submitRating({ router, addonSlug, ...params }) {
     return submitReview({ addonSlug, ...params })
       .then((review) => {
         const { lang, clientApp } = params.apiState;
-        // TODO: when we have a user_id in the API response, we
-        // could probably use that instead.
-        // https://github.com/mozilla/addons-server/issues/3672
-        dispatch(setReview({
-          id: review.id,
-          addonId,
-          rating: review.rating,
-          versionId: review.version.id,
-          isLatest: review.is_latest,
-          userId,
-        }));
+        dispatch(setReview(review));
         router.push(
           `/${lang}/${clientApp}/addon/${addonSlug}/review/${review.id}/`);
       });

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -106,18 +106,18 @@ export const mapStateToProps = (state, ownProps) => {
     const allUserReviews = state.reviews[userId];
     log.info(dedent`Checking state for review by user ${userId},
       addonId ${ownProps.addonId}, versionId ${ownProps.version.id}`);
+    const addonReviews =
+      allUserReviews ? allUserReviews[ownProps.addonId] : null;
 
-    if (allUserReviews) {
-      // TODO: adjust this when multiple reviews per version are stored
-      // in state.
-      // See https://github.com/mozilla/addons-server/issues/3986
-      const addonReview = allUserReviews[ownProps.addonId];
-      if (addonReview && addonReview.versionId === ownProps.version.id) {
-        // We have found an existing review by this user for this
-        // add-on and version.
-        userReview = addonReview;
-        log.info('Re-rendering component with user review from state',
-                 userReview);
+    if (addonReviews) {
+      for (const reviewId of Object.keys(addonReviews)) {
+        const review = addonReviews[reviewId];
+        if (review.isLatest) {
+          userReview = review;
+          log.info('Found the latest review in state for this component',
+                   userReview);
+          break;
+        }
       }
     }
   }
@@ -140,6 +140,7 @@ export const mapDispatchToProps = (dispatch) => ({
             addonId: review.addon.id,
             rating: review.rating,
             versionId: review.version.id,
+            isLatest: review.is_latest,
             userId,
           }));
         } else {
@@ -161,6 +162,7 @@ export const mapDispatchToProps = (dispatch) => ({
           addonId,
           rating: review.rating,
           versionId: review.version.id,
+          isLatest: review.is_latest,
           userId,
         }));
         router.push(

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -149,7 +149,7 @@ export const mapDispatchToProps = (dispatch) => ({
           }));
         } else if (relevantReviews.length > 1) {
           throw new Error(
-            `Unexpectedly received more than one review for
+            dedent`Unexpectedly received more than one review for
             user ${userId}, addonId ${addonId}, versionId ${versionId}`);
         } else {
           log.info('No reviews found for', { addonId, versionId, userId });

--- a/src/amo/css/OverallRating.scss
+++ b/src/amo/css/OverallRating.scss
@@ -6,16 +6,12 @@
 
 $star-size: 46px;
 
-.OverallRating-choices button {
+.OverallRating-choice {
   background: url('../img/ratings/big-star.svg') center/$star-size no-repeat;
   cursor: pointer;
   height: $star-size + 10px;
   padding-top: 80px;
   width: $star-size + 10px;
-}
-
-.OverallRating-choices button:disabled {
-  cursor: not-allowed;
 }
 
 // The following rules make the ranges of stars appear selected when
@@ -27,7 +23,7 @@ $star-size: 46px;
 // For keyboard navigation, make the focused star appear selected.
 .OverallRating-choice:focus,
 // Stars can be selected explicitly.
-button.OverallRating-selected-star {
+.OverallRating-selected-star {
   background-image: url('../img/ratings/big-star-selected.svg');
 }
 

--- a/src/amo/css/OverallRating.scss
+++ b/src/amo/css/OverallRating.scss
@@ -6,12 +6,16 @@
 
 $star-size: 46px;
 
-.OverallRating-choice {
+.OverallRating-choices button {
   background: url('../img/ratings/big-star.svg') center/$star-size no-repeat;
   cursor: pointer;
   height: $star-size + 10px;
   padding-top: 80px;
   width: $star-size + 10px;
+}
+
+.OverallRating-choices button:disabled {
+  cursor: not-allowed;
 }
 
 // The following rules make the ranges of stars appear selected when
@@ -21,7 +25,9 @@ $star-size: 46px;
 // First, make all stars appear selected when you hover over the group.
 .OverallRating-star-group:hover .OverallRating-choice,
 // For keyboard navigation, make the focused star appear selected.
-.OverallRating-choice:focus {
+.OverallRating-choice:focus,
+// Stars can be selected explicitly.
+button.OverallRating-selected-star {
   background-image: url('../img/ratings/big-star-selected.svg');
 }
 

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -3,18 +3,23 @@ import { SET_REVIEW } from 'amo/constants';
 export const initialState = {};
 
 export default function reviews(state = initialState, { data, type }) {
+  let existingAddonReviews;
   switch (type) {
     case SET_REVIEW:
+      existingAddonReviews = state[data.userId] ? state[data.userId][data.addonId] : {};
       return {
         ...state,
-        // This is a map of reviews by user ID and addon ID.
+        // This is a map of reviews by user ID, addon ID, and review ID.
         [data.userId]: {
           ...state[data.userId],
           [data.addonId]: {
-            // TODO: expand this into a map of reviews keyed by version.
-            id: data.id,
-            rating: data.rating,
-            versionId: data.versionId,
+            ...existingAddonReviews,
+            [data.id]: {
+              id: data.id,
+              rating: data.rating,
+              versionId: data.versionId,
+              isLatest: data.isLatest,
+            },
           },
         },
       };

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -2,27 +2,41 @@ import { SET_REVIEW } from 'amo/constants';
 
 export const initialState = {};
 
+function mergeInNewReview(latestReview, oldReviews = {}) {
+  const mergedReviews = {};
+
+  Object.keys(oldReviews).forEach((id) => {
+    mergedReviews[id] = oldReviews[id];
+    if (latestReview.isLatest) {
+      // Reset the 'latest' flag for all old reviews.
+      mergedReviews[id].isLatest = false;
+    }
+  });
+
+  mergedReviews[latestReview.id] = latestReview;
+  return mergedReviews;
+}
+
 export default function reviews(state = initialState, { data, type }) {
-  let existingAddonReviews;
   switch (type) {
-    case SET_REVIEW:
-      existingAddonReviews = state[data.userId] ? state[data.userId][data.addonId] : {};
+    case SET_REVIEW: {
+      const existingReviews =
+        state[data.userId] ? state[data.userId][data.addonId] : {};
+      const latestReview = {
+        id: data.id,
+        rating: data.rating,
+        versionId: data.versionId,
+        isLatest: data.isLatest,
+      };
       return {
         ...state,
         // This is a map of reviews by user ID, addon ID, and review ID.
         [data.userId]: {
           ...state[data.userId],
-          [data.addonId]: {
-            ...existingAddonReviews,
-            [data.id]: {
-              id: data.id,
-              rating: data.rating,
-              versionId: data.versionId,
-              isLatest: data.isLatest,
-            },
-          },
+          [data.addonId]: mergeInNewReview(latestReview, existingReviews),
         },
       };
+    }
     default:
       return state;
   }

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -12,6 +12,7 @@ export default function reviews(state = initialState, { data, type }) {
           ...state[data.userId],
           [data.addonId]: {
             // TODO: expand this into a map of reviews keyed by version.
+            id: data.id,
             rating: data.rating,
             versionId: data.versionId,
           },

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -11,6 +11,7 @@ export default function reviews(state = initialState, { data, type }) {
         [data.userId]: {
           ...state[data.userId],
           [data.addonId]: {
+            // TODO: expand this into a map of reviews keyed by version.
             rating: data.rating,
             versionId: data.versionId,
           },

--- a/tests/client/amo/components/TestAddonReview.js
+++ b/tests/client/amo/components/TestAddonReview.js
@@ -178,8 +178,7 @@ describe('AddonReview', () => {
 
     it('requires URL params',
       () => loadAddonReview({ params: {} })
-        .then(() => assert(false, 'unexpected success'))
-        .catch((error) => {
+        .then(() => assert(false, 'unexpected success'), (error) => {
           assert.match(error.message, /missing URL params/);
         })
     );

--- a/tests/client/amo/components/TestAddonReview.js
+++ b/tests/client/amo/components/TestAddonReview.js
@@ -13,7 +13,7 @@ import {
   mapStateToProps, AddonReviewBase,
   loadAddonReview as defaultAddonReviewLoader,
 } from 'amo/components/AddonReview';
-import { fakeAddon, signedInApiState } from 'tests/client/amo/helpers';
+import { fakeAddon, fakeReview, signedInApiState } from 'tests/client/amo/helpers';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
 const defaultReview = {
@@ -185,39 +185,23 @@ describe('AddonReview', () => {
     );
 
     it('loads a review', () => {
-      const reviewResponse = {
-        id: 7776,
-        addon: { id: 1234 },
-        version: { id: 4321 },
-        rating: 2,
-        user: { id: 9876 },
-        is_latest: true,
-      };
-
       mockApi
         .expects('callApi')
         .withArgs({
           endpoint: `addons/addon/${fakeAddon.slug}/reviews/${defaultReview.id}`,
           method: 'GET',
         })
-        .returns(Promise.resolve(reviewResponse));
+        .returns(Promise.resolve(fakeReview));
 
       return loadAddonReview()
         .then((returnedReview) => {
           assert.equal(fakeDispatch.called, true);
           assert.deepEqual(fakeDispatch.firstCall.args[0],
-                           setReview({
-                             id: reviewResponse.id,
-                             addonId: reviewResponse.addon.id,
-                             versionId: reviewResponse.version.id,
-                             rating: reviewResponse.rating,
-                             userId: reviewResponse.user.id,
-                             isLatest: reviewResponse.is_latest,
-                           }));
+                           setReview(fakeReview));
 
           assert.equal(returnedReview.addonSlug, fakeAddon.slug);
-          assert.equal(returnedReview.rating, reviewResponse.rating);
-          assert.equal(returnedReview.id, reviewResponse.id);
+          assert.equal(returnedReview.rating, fakeReview.rating);
+          assert.equal(returnedReview.id, fakeReview.id);
 
           mockApi.verify();
         });

--- a/tests/client/amo/components/TestAddonReview.js
+++ b/tests/client/amo/components/TestAddonReview.js
@@ -206,6 +206,7 @@ describe('AddonReview', () => {
           assert.equal(fakeDispatch.called, true);
           assert.deepEqual(fakeDispatch.firstCall.args[0],
                            setReview({
+                             id: reviewResponse.id,
                              addonId: reviewResponse.addon.id,
                              versionId: reviewResponse.version.id,
                              rating: reviewResponse.rating,

--- a/tests/client/amo/components/TestAddonReview.js
+++ b/tests/client/amo/components/TestAddonReview.js
@@ -191,6 +191,7 @@ describe('AddonReview', () => {
         version: { id: 4321 },
         rating: 2,
         user: { id: 9876 },
+        is_latest: true,
       };
 
       mockApi
@@ -211,6 +212,7 @@ describe('AddonReview', () => {
                              versionId: reviewResponse.version.id,
                              rating: reviewResponse.rating,
                              userId: reviewResponse.user.id,
+                             isLatest: reviewResponse.is_latest,
                            }));
 
           assert.equal(returnedReview.addonSlug, fakeAddon.slug);

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -29,6 +29,7 @@ function render({ ...customProps } = {}) {
     i18n: getFakeI18nInst(),
     userId: 91234,
     createRating: () => {},
+    loadSavedRating: () => {},
     router: {},
     ...customProps,
   };

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -176,10 +176,11 @@ describe('OverallRating', () => {
     // Make sure only the first 3 stars are selected.
     [1, 2, 3].forEach((rating) => {
       assert.equal(root.ratingButtons[rating].className,
-                   'OverallRating-selected-star');
+                   'OverallRating-choice OverallRating-selected-star');
     });
     [4, 5].forEach((rating) => {
-      assert.equal(root.ratingButtons[rating].className, '');
+      assert.equal(root.ratingButtons[rating].className,
+                   'OverallRating-choice');
     });
   });
 

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -28,7 +28,7 @@ function render({ ...customProps } = {}) {
     i18n: getFakeI18nInst(),
     userId: 91234,
     submitReview: () => {},
-    loadSavedRating: () => {},
+    loadSavedReview: () => {},
     router: {},
     ...customProps,
   };
@@ -59,21 +59,21 @@ describe('OverallRating', () => {
       ...fakeAddon.current_version,
       id: 9966,
     };
-    const loadSavedRating = sinon.spy();
+    const loadSavedReview = sinon.spy();
 
-    render({ userId, addonId, version, loadSavedRating });
+    render({ userId, addonId, version, loadSavedReview });
 
-    assert.equal(loadSavedRating.called, true);
-    const args = loadSavedRating.firstCall.args[0];
+    assert.equal(loadSavedReview.called, true);
+    const args = loadSavedReview.firstCall.args[0];
     assert.deepEqual(args, { userId, addonId });
   });
 
   it('does not load saved ratings when userId is empty', () => {
     const userId = null;
-    const loadSavedRating = sinon.spy();
+    const loadSavedReview = sinon.spy();
 
-    render({ userId, loadSavedRating });
-    assert.equal(loadSavedRating.called, false);
+    render({ userId, loadSavedReview });
+    assert.equal(loadSavedReview.called, false);
   });
 
   it('creates a rating with add-on and version info', () => {
@@ -242,24 +242,16 @@ describe('OverallRating', () => {
       });
     });
 
-    describe('loadSavedRating', () => {
-      function loadSavedRating({
-        userId = 123,
-        addonId = fakeAddon.id,
-      } = {}) {
-        return actions.loadSavedRating({ userId, addonId });
-      }
-
+    describe('loadSavedReview', () => {
       it('finds and dispatches a review', () => {
+        const userId = fakeReview.user.id;
+        const addonId = fakeReview.addon.id;
         mockApi
           .expects('getLatestUserReview')
-          .withArgs({
-            userId: fakeReview.user.id,
-            addonId: fakeReview.addon.id,
-          })
+          .withArgs({ userId, addonId })
           .returns(Promise.resolve(fakeReview));
 
-        return loadSavedRating({ userId: fakeReview.user.id })
+        return actions.loadSavedReview({ userId, addonId })
           .then(() => {
             mockApi.verify();
             assert.equal(dispatch.called, true);
@@ -271,7 +263,7 @@ describe('OverallRating', () => {
         const addonId = 8765;
         mockApi.expects('getLatestUserReview').returns(Promise.resolve(null));
 
-        return loadSavedRating({ addonId })
+        return actions.loadSavedReview({ userId: 123, addonId })
           .then(() => {
             assert.equal(dispatch.called, false);
           });

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -53,6 +53,32 @@ describe('OverallRating', () => {
                    'Some Add-on');
   });
 
+  it('loads saved ratings on construction', () => {
+    const userId = 12889;
+    const addonId = 3344;
+    const version = {
+      ...fakeAddon.current_version,
+      id: 9966,
+    };
+    const loadSavedRating = sinon.spy();
+
+    render({ userId, addonId, version, loadSavedRating });
+
+    assert.equal(loadSavedRating.called, true);
+    const args = loadSavedRating.firstCall.args[0];
+    assert.equal(args.userId, userId);
+    assert.equal(args.addonId, addonId);
+    assert.equal(args.versionId, version.id);
+  });
+
+  it('does not load saved ratings when userId is empty', () => {
+    const userId = null;
+    const loadSavedRating = sinon.spy();
+
+    render({ userId, loadSavedRating });
+    assert.equal(loadSavedRating.called, false);
+  });
+
   it('creates a rating with add-on and version info', () => {
     const router = {};
     const createRating = sinon.stub();

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -352,6 +352,33 @@ describe('OverallRating', () => {
             assert.match(error.message, /received more than one review/);
           });
       });
+
+      it('does nothing when there are not any matching reviews', () => {
+        const addonId = 8765;
+        const response = {
+          results: [
+            // All of these have the wrong IDs:
+            { ...fakeReview, addon: { ...fakeAddon, id: 123 } },
+            { ...fakeReview, addon: { ...fakeAddon, id: 321 } },
+          ],
+        };
+        mockApi.expects('getUserReviews').returns(Promise.resolve(response));
+
+        return loadSavedRating({ addonId })
+          .then(() => {
+            assert.equal(dispatch.called, false);
+          });
+      });
+
+      it('does nothing when the API returns no reviews at all', () => {
+        const response = { results: [] };
+        mockApi.expects('getUserReviews').returns(Promise.resolve(response));
+
+        return loadSavedRating()
+          .then(() => {
+            assert.equal(dispatch.called, false);
+          });
+      });
     });
   });
 

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -332,27 +332,17 @@ describe('OverallRating', () => {
       assert.strictEqual(getMappedProps().userReview, undefined);
     });
 
-    it('sets a user review when a matching review is in state', () => {
-      const id = 888;
-      const userId = 99821;
-      const rating = 5;
+    it('sets a user review to the latest matching one in state', () => {
       const isLatest = true;
+      signIn({ userId: fakeReview.user.id });
 
-      signIn({ userId });
-
-      store.dispatch(setReview(fakeReview, {
-        id,
-        userId,
-        addonId: fakeAddon.id,
-        rating,
-        isLatest,
-      }));
+      store.dispatch(setReview(fakeReview, { isLatest }));
 
       const userReview = getMappedProps().userReview;
       assert.deepEqual(userReview, {
-        id,
+        id: fakeReview.id,
         versionId: fakeReview.version.id,
-        rating,
+        rating: fakeReview.rating,
         isLatest,
       });
     });
@@ -375,16 +365,11 @@ describe('OverallRating', () => {
     });
 
     it('ignores reviews for another add-on', () => {
-      const userId = 99821;
-      const savedRating = 5;
-
-      signIn({ userId });
+      signIn({ userId: fakeReview.user.id });
 
       store.dispatch(setReview(fakeReview, {
         isLatest: true,
-        userId,
         addonId: 554433, // this is a review for an unrelated add-on
-        rating: savedRating,
       }));
 
       assert.strictEqual(getMappedProps().userReview, undefined);

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -252,11 +252,10 @@ describe('OverallRating', () => {
 
       it('finds and dispatches a review', () => {
         mockApi
-          .expects('getUserReviews')
+          .expects('getLatestUserReview')
           .withArgs({
             userId: fakeReview.user.id,
             addonId: fakeReview.addon.id,
-            onlyTheLatest: true,
           })
           .returns(Promise.resolve(fakeReview));
 
@@ -270,7 +269,7 @@ describe('OverallRating', () => {
 
       it('does nothing when there are not any matching reviews', () => {
         const addonId = 8765;
-        mockApi.expects('getUserReviews').returns(Promise.resolve(null));
+        mockApi.expects('getLatestUserReview').returns(Promise.resolve(null));
 
         return loadSavedRating({ addonId })
           .then(() => {

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -27,7 +27,7 @@ function render({ ...customProps } = {}) {
     version: fakeAddon.current_version,
     i18n: getFakeI18nInst(),
     userId: 91234,
-    submitRating: () => {},
+    submitReview: () => {},
     loadSavedRating: () => {},
     router: {},
     ...customProps,
@@ -78,9 +78,9 @@ describe('OverallRating', () => {
 
   it('creates a rating with add-on and version info', () => {
     const router = {};
-    const submitRating = sinon.stub();
+    const submitReview = sinon.stub();
     const root = render({
-      submitRating,
+      submitReview,
       apiState: { ...signedInApiState, token: 'new-token' },
       version: { id: 321 },
       addonId: 12345,
@@ -88,9 +88,9 @@ describe('OverallRating', () => {
       router,
     });
     selectRating(root, 5);
-    assert.equal(submitRating.called, true);
+    assert.equal(submitReview.called, true);
 
-    const call = submitRating.firstCall.args[0];
+    const call = submitReview.firstCall.args[0];
     assert.equal(call.versionId, 321);
     assert.equal(call.apiState.token, 'new-token');
     assert.equal(call.addonId, 12345);
@@ -101,9 +101,9 @@ describe('OverallRating', () => {
   });
 
   it('updates a rating with the review ID', () => {
-    const submitRating = sinon.stub();
+    const submitReview = sinon.stub();
     const root = render({
-      submitRating,
+      submitReview,
       apiState: { ...signedInApiState, token: 'new-token' },
       version: { id: 321 },
       addonId: 12345,
@@ -111,50 +111,50 @@ describe('OverallRating', () => {
       userReview: fakeReview,
     });
     selectRating(root, 5);
-    assert.equal(submitRating.called, true);
+    assert.equal(submitReview.called, true);
 
-    const call = submitRating.firstCall.args[0];
+    const call = submitReview.firstCall.args[0];
     assert.equal(call.reviewId, fakeReview.id);
   });
 
   it('lets you submit a one star rating', () => {
-    const submitRating = sinon.stub();
-    const root = render({ submitRating });
+    const submitReview = sinon.stub();
+    const root = render({ submitReview });
     selectRating(root, 1);
-    assert.equal(submitRating.called, true);
-    assert.equal(submitRating.firstCall.args[0].rating, 1);
+    assert.equal(submitReview.called, true);
+    assert.equal(submitReview.firstCall.args[0].rating, 1);
   });
 
   it('lets you submit a two star rating', () => {
-    const submitRating = sinon.stub();
-    const root = render({ submitRating });
+    const submitReview = sinon.stub();
+    const root = render({ submitReview });
     selectRating(root, 2);
-    assert.equal(submitRating.called, true);
-    assert.equal(submitRating.firstCall.args[0].rating, 2);
+    assert.equal(submitReview.called, true);
+    assert.equal(submitReview.firstCall.args[0].rating, 2);
   });
 
   it('lets you submit a three star rating', () => {
-    const submitRating = sinon.stub();
-    const root = render({ submitRating });
+    const submitReview = sinon.stub();
+    const root = render({ submitReview });
     selectRating(root, 3);
-    assert.equal(submitRating.called, true);
-    assert.equal(submitRating.firstCall.args[0].rating, 3);
+    assert.equal(submitReview.called, true);
+    assert.equal(submitReview.firstCall.args[0].rating, 3);
   });
 
   it('lets you submit a four star rating', () => {
-    const submitRating = sinon.stub();
-    const root = render({ submitRating });
+    const submitReview = sinon.stub();
+    const root = render({ submitReview });
     selectRating(root, 4);
-    assert.equal(submitRating.called, true);
-    assert.equal(submitRating.firstCall.args[0].rating, 4);
+    assert.equal(submitReview.called, true);
+    assert.equal(submitReview.firstCall.args[0].rating, 4);
   });
 
   it('lets you submit a five star rating', () => {
-    const submitRating = sinon.stub();
-    const root = render({ submitRating });
+    const submitReview = sinon.stub();
+    const root = render({ submitReview });
     selectRating(root, 5);
-    assert.equal(submitRating.called, true);
-    assert.equal(submitRating.firstCall.args[0].rating, 5);
+    assert.equal(submitReview.called, true);
+    assert.equal(submitReview.firstCall.args[0].rating, 5);
   });
 
   it('renders selected stars corresponding to a saved review', () => {
@@ -209,8 +209,8 @@ describe('OverallRating', () => {
       actions = mapDispatchToProps(dispatch);
     });
 
-    describe('submitRating', () => {
-      it('posts the rating and dispatches the created rating', () => {
+    describe('submitReview', () => {
+      it('posts the reviw and dispatches the created review', () => {
         const router = { push: sinon.spy(() => {}) };
         const params = {
           rating: fakeReview.rating,
@@ -224,7 +224,7 @@ describe('OverallRating', () => {
           .withArgs(params)
           .returns(Promise.resolve({ ...fakeReview, ...params }));
 
-        return actions.submitRating({ ...params, router })
+        return actions.submitReview({ ...params, router })
           .then(() => {
             assert.equal(dispatch.called, true);
             const action = dispatch.firstCall.args[0];

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -114,6 +114,7 @@ describe('OverallRating', () => {
     assert.equal(submitReview.called, true);
 
     const call = submitReview.firstCall.args[0];
+    assert.ok(call.reviewId);
     assert.equal(call.reviewId, fakeReview.id);
   });
 

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -73,9 +73,7 @@ describe('OverallRating', () => {
 
     assert.equal(loadSavedRating.called, true);
     const args = loadSavedRating.firstCall.args[0];
-    assert.equal(args.userId, userId);
-    assert.equal(args.addonId, addonId);
-    assert.equal(args.versionId, version.id);
+    assert.deepEqual(args, { userId, addonId, versionId: version.id });
   });
 
   it('does not load saved ratings when userId is empty', () => {

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -285,11 +285,6 @@ describe('OverallRating', () => {
           rating: savedRating,
         }));
 
-        const componentProps = {
-          addonId: fakeAddon.id,
-          version: fakeAddon.current_version,
-        };
-
         assert.strictEqual(getMappedProps().userReview, undefined);
       });
 
@@ -308,11 +303,6 @@ describe('OverallRating', () => {
           },
           rating: savedRating,
         }));
-
-        const componentProps = {
-          addonId: fakeAddon.id,
-          version: fakeAddon.current_version,
-        };
 
         assert.strictEqual(getMappedProps().userReview, undefined);
       });

--- a/tests/client/amo/helpers.js
+++ b/tests/client/amo/helpers.js
@@ -16,27 +16,13 @@ export const fakeReview = {
   addon: fakeAddon,
   rating: 3,
   version: fakeAddon.current_version,
-  userId: 1234,
+  user: {
+    id: 1234,
+  },
   is_latest: false,
+  body: null,
+  title: null,
 };
-
-/*
- * Return a realistic API response to any call that creates an add-on rating.
- */
-export function createRatingResponse(customProps = {}) {
-  return {
-    id: 123,
-    user: { name: 'the_username' },
-    rating: 5,
-    version: {
-      id: 54371,
-      version: '1.0.1',
-    },
-    body: null,
-    title: null,
-    ...customProps,
-  };
-}
 
 /*
  * Redux store state for when a user has signed in.

--- a/tests/client/amo/helpers.js
+++ b/tests/client/amo/helpers.js
@@ -11,6 +11,15 @@ export const fakeAddon = {
   description: 'This is a longer description of the chill out add-on',
 };
 
+export const fakeReview = {
+  id: 8876,
+  addon: fakeAddon,
+  rating: 3,
+  version: fakeAddon.current_version,
+  userId: 1234,
+  is_latest: false,
+};
+
 /*
  * Return a realistic API response to any call that creates an add-on rating.
  */

--- a/tests/client/amo/reducers/testReviews.js
+++ b/tests/client/amo/reducers/testReviews.js
@@ -2,18 +2,11 @@ import {
   setReview as defaultReviewSetter,
 } from 'amo/actions/reviews';
 import reviews, { initialState } from 'amo/reducers/reviews';
+import { fakeReview } from 'tests/client/amo/helpers';
 
 describe('amo.reducers.reviews', () => {
   function setReview(overrides) {
-    return defaultReviewSetter({
-      id: 11422,
-      addonId: 321,
-      versionId: 54321,
-      rating: 3,
-      userId: 9123,
-      isLatest: false,
-      ...overrides,
-    });
+    return defaultReviewSetter(fakeReview, overrides);
   }
 
   it('defaults to an empty object', () => {

--- a/tests/client/amo/reducers/testReviews.js
+++ b/tests/client/amo/reducers/testReviews.js
@@ -6,10 +6,12 @@ import reviews, { initialState } from 'amo/reducers/reviews';
 describe('amo.reducers.reviews', () => {
   function setReview(overrides) {
     return defaultReviewSetter({
+      id: 11422,
       addonId: 321,
       versionId: 54321,
       rating: 3,
       userId: 9123,
+      isLatest: false,
       ...overrides,
     });
   }
@@ -24,43 +26,82 @@ describe('amo.reducers.reviews', () => {
     const addonId = 5321;
     const userId = 91234;
     const versionId = 12345;
+    const isLatest = true;
     const action = setReview({
       id,
       addonId,
       userId,
       rating: 5,
       versionId,
+      isLatest,
     });
     const state = reviews(undefined, action);
-    assert.deepEqual(state[userId][addonId],
-                     { id, rating: 5, versionId });
+    assert.deepEqual(state[userId][addonId][id],
+                     { id, rating: 5, versionId, isLatest });
   });
 
   it('preserves existing user rating data', () => {
     let state;
 
     state = reviews(state, setReview({
+      id: 1,
       userId: 1,
       addonId: 1,
       rating: 1,
     }));
 
     state = reviews(state, setReview({
+      id: 2,
       userId: 1,
       addonId: 2,
       rating: 5,
     }));
 
     state = reviews(state, setReview({
+      id: 3,
       userId: 2,
       addonId: 2,
       rating: 4,
     }));
 
-    // Make sure all reviews co-exist by user and add-on.
-    assert.equal(state[1][1].rating, 1);
-    assert.equal(state[1][2].rating, 5);
-    assert.equal(state[2][2].rating, 4);
+    // Make sure all reviews co-exist by userId, addonId, review ID.
+    assert.equal(state[1][1][1].rating, 1);
+    assert.equal(state[1][2][2].rating, 5);
+    assert.equal(state[2][2][3].rating, 4);
+  });
+
+  it('preserves existing add-on reviews', () => {
+    let state;
+    const userId = 1;
+    const addonId = 1;
+    const reviewBase = {
+      userId,
+      addonId,
+      rating: 1,
+    };
+
+    state = reviews(state, setReview({
+      ...reviewBase,
+      id: 1,
+      versionId: 1,
+    }));
+
+    state = reviews(state, setReview({
+      ...reviewBase,
+      id: 2,
+      versionId: 2,
+    }));
+
+    state = reviews(state, setReview({
+      ...reviewBase,
+      id: 3,
+      versionId: 3,
+    }));
+
+    // Make sure all reviews co-exist by userId, addonId, review ID.
+    assert.equal(state[userId][addonId][1].id, 1);
+    assert.equal(state[userId][addonId][2].id, 2);
+    assert.equal(state[userId][addonId][3].id, 3);
   });
 
   it('preserves unrelated state', () => {

--- a/tests/client/amo/reducers/testReviews.js
+++ b/tests/client/amo/reducers/testReviews.js
@@ -1,56 +1,44 @@
-import {
-  setReview as defaultReviewSetter,
-} from 'amo/actions/reviews';
+import { setReview } from 'amo/actions/reviews';
 import reviews, { initialState } from 'amo/reducers/reviews';
 import { fakeReview } from 'tests/client/amo/helpers';
 
 describe('amo.reducers.reviews', () => {
-  function setReview(overrides) {
-    return defaultReviewSetter(fakeReview, overrides);
-  }
-
   it('defaults to an empty object', () => {
     assert.deepEqual(reviews(undefined, { type: 'SOME_OTHER_ACTION' }),
                      initialState);
   });
 
-  it('adds a user reviews map', () => {
-    const id = 96644;
-    const addonId = 5321;
-    const userId = 91234;
-    const versionId = 12345;
-    const isLatest = true;
-    const action = setReview({
-      id,
-      addonId,
-      userId,
-      rating: 5,
-      versionId,
-      isLatest,
-    });
+  it('stores a user review', () => {
+    const action = setReview(fakeReview);
     const state = reviews(undefined, action);
-    assert.deepEqual(state[userId][addonId][id],
-                     { id, rating: 5, versionId, isLatest });
+    const storedReview =
+      state[fakeReview.user.id][fakeReview.addon.id][fakeReview.id];
+    assert.deepEqual(storedReview, {
+      id: fakeReview.id,
+      rating: fakeReview.rating,
+      versionId: fakeReview.version.id,
+      isLatest: fakeReview.is_latest,
+    });
   });
 
   it('preserves existing user rating data', () => {
     let state;
 
-    state = reviews(state, setReview({
+    state = reviews(state, setReview(fakeReview, {
       id: 1,
       userId: 1,
       addonId: 1,
       rating: 1,
     }));
 
-    state = reviews(state, setReview({
+    state = reviews(state, setReview(fakeReview, {
       id: 2,
       userId: 1,
       addonId: 2,
       rating: 5,
     }));
 
-    state = reviews(state, setReview({
+    state = reviews(state, setReview(fakeReview, {
       id: 3,
       userId: 2,
       addonId: 2,
@@ -65,28 +53,20 @@ describe('amo.reducers.reviews', () => {
 
   it('preserves existing add-on reviews', () => {
     let state;
-    const userId = 1;
-    const addonId = 1;
-    const reviewBase = {
-      userId,
-      addonId,
-      rating: 1,
-    };
+    const userId = fakeReview.user.id;
+    const addonId = fakeReview.addon.id;
 
-    state = reviews(state, setReview({
-      ...reviewBase,
+    state = reviews(state, setReview(fakeReview, {
       id: 1,
       versionId: 1,
     }));
 
-    state = reviews(state, setReview({
-      ...reviewBase,
+    state = reviews(state, setReview(fakeReview, {
       id: 2,
       versionId: 2,
     }));
 
-    state = reviews(state, setReview({
-      ...reviewBase,
+    state = reviews(state, setReview(fakeReview, {
       id: 3,
       versionId: 3,
     }));
@@ -99,7 +79,7 @@ describe('amo.reducers.reviews', () => {
 
   it('preserves unrelated state', () => {
     let state = { ...initialState, somethingUnrelated: 'erp' };
-    state = reviews(state, setReview());
+    state = reviews(state, setReview(fakeReview));
     assert.equal(state.somethingUnrelated, 'erp');
   });
 });

--- a/tests/client/amo/reducers/testReviews.js
+++ b/tests/client/amo/reducers/testReviews.js
@@ -82,4 +82,49 @@ describe('amo.reducers.reviews', () => {
     state = reviews(state, setReview(fakeReview));
     assert.equal(state.somethingUnrelated, 'erp');
   });
+
+  it('only allows one review to be the latest', () => {
+    const addonId = fakeReview.addon.id;
+    const userId = fakeReview.user.id;
+    let state;
+
+    state = reviews(state, setReview(fakeReview, {
+      id: 1,
+      isLatest: true,
+    }));
+
+    state = reviews(state, setReview(fakeReview, {
+      id: 2,
+      isLatest: true,
+    }));
+
+    state = reviews(state, setReview(fakeReview, {
+      id: 3,
+      isLatest: true,
+    }));
+
+    // Make sure only the newest submitted one is the latest:
+    assert.equal(state[userId][addonId][1].isLatest, false);
+    assert.equal(state[userId][addonId][2].isLatest, false);
+    assert.equal(state[userId][addonId][3].isLatest, true);
+  });
+
+  it('preserves an older latest review', () => {
+    const addonId = fakeReview.addon.id;
+    const userId = fakeReview.user.id;
+    let state;
+
+    state = reviews(state, setReview(fakeReview, {
+      id: 1,
+      isLatest: true,
+    }));
+
+    state = reviews(state, setReview(fakeReview, {
+      id: 2,
+      isLatest: false,
+    }));
+
+    assert.equal(state[userId][addonId][1].isLatest, true);
+    assert.equal(state[userId][addonId][2].isLatest, false);
+  });
 });

--- a/tests/client/amo/reducers/testReviews.js
+++ b/tests/client/amo/reducers/testReviews.js
@@ -20,10 +20,12 @@ describe('amo.reducers.reviews', () => {
   });
 
   it('adds a user reviews map', () => {
+    const id = 96644;
     const addonId = 5321;
     const userId = 91234;
     const versionId = 12345;
     const action = setReview({
+      id,
       addonId,
       userId,
       rating: 5,
@@ -31,7 +33,7 @@ describe('amo.reducers.reviews', () => {
     });
     const state = reviews(undefined, action);
     assert.deepEqual(state[userId][addonId],
-                     { rating: 5, versionId });
+                     { id, rating: 5, versionId });
   });
 
   it('preserves existing user rating data', () => {

--- a/tests/client/amo/testApi.js
+++ b/tests/client/amo/testApi.js
@@ -31,10 +31,7 @@ describe('amo.api', () => {
       };
 
       return submitReview(params)
-        .then(() => {
-          throw new Error('unexpected success');
-        })
-        .catch((error) => {
+        .then(() => assert(false, 'unexpected success'), (error) => {
           assert.match(error.message, /addonSlug is required/);
         });
     });
@@ -144,10 +141,7 @@ describe('amo.api', () => {
     it('requires a user ID', () => {
       mockApi.expects('callApi').never();
       return getUserReviews()
-        .then(() => {
-          throw new Error('unexpected success');
-        })
-        .catch((error) => {
+        .then(() => assert(false, 'unexpected success'), (error) => {
           assert.equal(error.message, 'userId cannot be falsey');
           mockApi.verify();
         });
@@ -162,10 +156,7 @@ describe('amo.api', () => {
         }));
 
       return getUserReviews({ userId: 123 })
-        .then(() => {
-          throw new Error('unexpected success');
-        })
-        .catch((error) => {
+        .then(() => assert(false, 'unexpected success'), (error) => {
           assert.match(error.message, /not yet implemented/);
         });
     });

--- a/tests/client/amo/testApi.js
+++ b/tests/client/amo/testApi.js
@@ -1,4 +1,4 @@
-import { submitReview } from 'amo/api';
+import { getUserReviews, submitReview } from 'amo/api';
 import * as api from 'core/api';
 import { signedInApiState } from 'tests/client/amo/helpers';
 
@@ -91,6 +91,37 @@ describe('amo.api', () => {
         assert.deepEqual(apiResponse, genericApiResponse);
         mockApi.verify();
       });
+    });
+  });
+
+  describe('getUserReviews', () => {
+    it('gets all user reviews', () => {
+      const userId = 8877;
+      const response = { reviews: [] };
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          endpoint: `accounts/account/${userId}/reviews`,
+        })
+        .returns(Promise.resolve(response));
+
+      return getUserReviews({ userId })
+        .then((actualResponse) => {
+          mockApi.verify();
+          assert.deepEqual(actualResponse, response);
+        });
+    });
+
+    it('requires a user ID', () => {
+      mockApi.expects('callApi').never();
+      return getUserReviews()
+        .then(() => {
+          throw new Error('unexpected success');
+        })
+        .catch((error) => {
+          assert.equal(error.message, 'userId cannot be falsey');
+          mockApi.verify();
+        });
     });
   });
 });

--- a/tests/client/amo/testApi.js
+++ b/tests/client/amo/testApi.js
@@ -92,6 +92,34 @@ describe('amo.api', () => {
         mockApi.verify();
       });
     });
+
+    it('does not patch the version for existing reviews', () => {
+      const params = {
+        ...baseParams,
+        reviewId: 987,
+        body: 'some new body',
+        versionId: 99876,
+        addonSlug: 'chill-out',
+      };
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          endpoint: `addons/addon/${params.addonSlug}/reviews/${params.reviewId}`,
+          body: {
+            // Make sure that version is not passed in.
+            ...defaultParams, body: params.body, version: undefined,
+          },
+          method: 'PATCH',
+          auth: true,
+          state: params.apiState,
+        })
+        .returns(Promise.resolve(genericApiResponse));
+
+      return submitReview(params).then(() => {
+        mockApi.verify();
+      });
+    });
   });
 
   describe('getUserReviews', () => {

--- a/tests/client/amo/testApi.js
+++ b/tests/client/amo/testApi.js
@@ -1,4 +1,4 @@
-import { getUserReviews, submitReview } from 'amo/api';
+import { getLatestUserReview, getUserReviews, submitReview } from 'amo/api';
 import * as api from 'core/api';
 import { fakeReview, signedInApiState } from 'tests/client/amo/helpers';
 
@@ -186,7 +186,9 @@ describe('amo.api', () => {
           assert.deepEqual(reviews, [fakeReview]);
         });
     });
+  });
 
+  describe('getLatestUserReview', () => {
     it('allows you to fetch only the latest review', () => {
       const latestReview = { ...fakeReview, is_latest: true };
       mockApi
@@ -198,10 +200,9 @@ describe('amo.api', () => {
           ],
         }));
 
-      return getUserReviews({
+      return getLatestUserReview({
         userId: 123,
         addonId: fakeReview.addon.id,
-        onlyTheLatest: true,
       })
         .then((review) => {
           assert.deepEqual(review, latestReview);
@@ -213,9 +214,8 @@ describe('amo.api', () => {
         .expects('callApi')
         .returns(Promise.resolve({ results: [] }));
 
-      return getUserReviews({
+      return getLatestUserReview({
         userId: 123,
-        onlyTheLatest: true,
       })
         .then((review) => {
           assert.strictEqual(review, null);


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1088

* Saved stars are rendered as "selected"
* The rating button is disabled since you can't rate an add-on twice