### PR TITLE
Add more info to addon details page (fix #1294)

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
     "concurrently": "3.1.0",
     "csp-parse": "0.0.2",
     "css-loader": "0.25.0",
+    "deepcopy": "0.6.3",
     "eslint": "3.10.2",
     "eslint-config-airbnb": "13.0.0",
     "eslint-plugin-import": "2.2.0",

--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -2,6 +2,7 @@
 import React, { PropTypes } from 'react';
 
 import AddonMeta from 'amo/components/AddonMeta';
+import AddonMoreInfo from 'amo/components/AddonMoreInfo';
 import InstallButton from 'core/components/InstallButton';
 import DefaultOverallRating from 'amo/components/OverallRating';
 import ScreenShots from 'amo/components/ScreenShots';
@@ -29,9 +30,9 @@ export const allowedDescriptionTags = [
 
 class AddonDetail extends React.Component {
   static propTypes = {
-    i18n: PropTypes.object.isRequired,
-    addon: PropTypes.object.isRequired,
     OverallRating: PropTypes.element,
+    addon: PropTypes.object.isRequired,
+    i18n: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
@@ -39,7 +40,7 @@ class AddonDetail extends React.Component {
   }
 
   render() {
-    const { i18n, addon, OverallRating } = this.props;
+    const { OverallRating, addon, i18n } = this.props;
 
     const authorList = addon.authors.map(
       (author) => `<a href="${author.url}">${author.name}</a>`);
@@ -53,7 +54,8 @@ class AddonDetail extends React.Component {
         endSpan: '</span>',
       });
 
-    const iconUrl = isAllowedOrigin(addon.icon_url) ? addon.icon_url : fallbackIcon;
+    const iconUrl = isAllowedOrigin(addon.icon_url) ? addon.icon_url :
+      fallbackIcon;
 
     return (
       <div className="AddonDetail">
@@ -71,7 +73,9 @@ class AddonDetail extends React.Component {
         </header>
 
         <section className="addon-metadata">
-          <h2 className="visually-hidden">{i18n.gettext('Extension Metadata')}</h2>
+          <h2 className="visually-hidden">
+            {i18n.gettext('Extension Metadata')}
+          </h2>
           <AddonMeta />
         </section>
 
@@ -101,6 +105,8 @@ class AddonDetail extends React.Component {
             version={addon.current_version}
           />
         </section>
+
+        <AddonMoreInfo addon={addon} />
       </div>
     );
   }

--- a/src/amo/components/AddonMoreInfo.js
+++ b/src/amo/components/AddonMoreInfo.js
@@ -1,0 +1,72 @@
+import React, { PropTypes } from 'react';
+import { compose } from 'redux';
+
+import Link from 'amo/components/Link';
+import translate from 'core/i18n/translate';
+
+import './AddonMoreInfo.scss';
+
+
+export class AddonMoreInfoBase extends React.Component {
+  static propTypes = {
+    addon: PropTypes.object.isRequired,
+    i18n: PropTypes.object.isRequired,
+  }
+
+  render() {
+    const { addon, i18n } = this.props;
+
+    // TODO: Use the addonType for the privacy text, so it reads
+    // "for this extension", "for this theme", etc.
+    return (
+      <section className="AddonMoreInfo">
+        <h2 className="AddonMoreInfo-header">
+          {i18n.gettext('More information')}
+        </h2>
+
+        <dl className="AddonMoreInfo-contents">
+          {addon.homepage ? <dt>{i18n.gettext('Website')}</dt> : null}
+          {addon.homepage ? (
+            <dd>
+              <a href={addon.homepage}
+                ref={(ref) => { this.homepageLink = ref; }}>{addon.homepage}</a>
+            </dd>
+          ) : null}
+          <dt>{i18n.gettext('Version')}</dt>
+          <dd ref={(ref) => { this.version = ref; }}>
+            {addon.current_version.version}
+          </dd>
+          <dt>{i18n.gettext('Last updated')}</dt>
+          <dd>{addon.last_updated}</dd>
+          {addon.current_version.license ? (
+            <dt ref={(ref) => { this.licenseHeader = ref; }}>
+              {i18n.gettext('License')}
+            </dt>
+          ) : null}
+          {addon.current_version.license ? (
+            <dd>
+              <a href={addon.current_version.license.url}
+                ref={(ref) => { this.licenseLink = ref; }}>
+                {addon.current_version.license.name}</a>
+            </dd>
+          ) : null}
+          {addon.has_privacy_policy ? (
+            <dt>{i18n.gettext('Privacy Policy')}</dt>
+          ) : null}
+          {addon.has_privacy_policy ? (
+            <dd>
+              <Link to={`/addons/addon/${addon.slug}/privacy-policy/`}
+                ref={(ref) => { this.privacyPolicyLink = ref; }}>
+                {i18n.gettext('Read the privacy policy for this add-on')}
+              </Link>
+            </dd>
+          ) : null}
+        </dl>
+      </section>
+    );
+  }
+}
+
+export default compose(
+  translate({ withRef: true }),
+)(AddonMoreInfoBase);

--- a/src/amo/components/AddonMoreInfo.scss
+++ b/src/amo/components/AddonMoreInfo.scss
@@ -1,0 +1,38 @@
+@import "~core/css/inc/mixins";
+@import "~core/css/inc/vars";
+
+.AddonMoreInfo-header {
+  @include addonSection();
+
+  border-top-left-radius: $border-radius-default;
+  border-top-right-radius: $border-radius-default;
+  font-size: $font-size-default;
+  margin-bottom: 1px;
+  text-align: center;
+}
+
+.AddonMoreInfo-contents {
+  @include addonSection();
+
+  border-bottom-left-radius: $border-radius-default;
+  border-bottom-right-radius: $border-radius-default;
+  font-size: $font-size-s;
+
+  dt {
+    font-weight: bold;
+    line-height: 1.2;
+    margin: 0;
+    padding: 0;
+  }
+
+  dd {
+    line-height: 1.2;
+    margin: 0 0 3px;
+    padding: 0;
+
+    a:link {
+      font-size: $font-size-s;
+      font-weight: 400;
+    }
+  }
+}

--- a/src/amo/containers/DetailPage.js
+++ b/src/amo/containers/DetailPage.js
@@ -7,6 +7,7 @@ import AddonDetail from 'amo/components/AddonDetail';
 import translate from 'core/i18n/translate';
 import { loadAddonIfNeeded } from 'core/utils';
 
+
 export class DetailPageBase extends React.Component {
   render() {
     return (

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -241,3 +241,10 @@ $color: $text-color-message) {
     margin-left: $val;
   }
 }
+
+@mixin addonSection() {
+  background: $base-color;
+  margin: 0 10px;
+  padding: 10px;
+  overflow: hidden;
+}

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -1,14 +1,15 @@
-
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import {
   findRenderedComponentWithType,
   renderIntoDocument,
 } from 'react-addons-test-utils';
+import { Provider } from 'react-redux';
 
 import AddonDetail, { allowedDescriptionTags }
   from 'amo/components/AddonDetail';
 import { OverallRatingWithI18n } from 'amo/components/OverallRating';
+import createStore from 'amo/store';
 import I18nProvider from 'core/i18n/Provider';
 import InstallButton from 'core/components/InstallButton';
 import { fakeAddon } from 'tests/client/amo/helpers';
@@ -17,6 +18,7 @@ import { getFakeI18nInst } from 'tests/client/helpers';
 
 function render({ addon = fakeAddon, ...customProps } = {}) {
   const i18n = getFakeI18nInst();
+  const initialState = { api: { clientApp: 'android', lang: 'pt' } };
   const props = {
     addon,
     // Configure AddonDetail with a non-redux depdendent OverallRating.
@@ -25,9 +27,11 @@ function render({ addon = fakeAddon, ...customProps } = {}) {
   };
 
   return findRenderedComponentWithType(renderIntoDocument(
-    <I18nProvider i18n={i18n}>
-      <AddonDetail {...props} />
-    </I18nProvider>
+    <Provider store={createStore(initialState)}>
+      <I18nProvider i18n={i18n}>
+        <AddonDetail {...props} />
+      </I18nProvider>
+    </Provider>
   ), AddonDetail);
 }
 
@@ -226,5 +230,11 @@ describe('AddonDetail', () => {
     });
     const src = rootNode.querySelector('.icon img').getAttribute('src');
     assert.include(src, 'image/png');
+  });
+
+  it('renders an AddonMoreInfo component when there is an add-on', () => {
+    const rootNode = renderAsDOMNode();
+
+    assert.ok(rootNode.querySelector('.AddonMoreInfo-contents'));
   });
 });

--- a/tests/client/amo/components/TestAddonMoreInfo.js
+++ b/tests/client/amo/components/TestAddonMoreInfo.js
@@ -1,0 +1,76 @@
+import deepcopy from 'deepcopy';
+import React from 'react';
+import {
+  findRenderedComponentWithType,
+  renderIntoDocument,
+} from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+import { Provider } from 'react-redux';
+
+import createStore from 'amo/store';
+import { AddonMoreInfoBase } from 'amo/components/AddonMoreInfo';
+import { fakeAddon } from 'tests/client/amo/helpers';
+import { getFakeI18nInst } from 'tests/client/helpers';
+
+
+describe('<AddonMoreInfo />', () => {
+  const initialState = { api: { clientApp: 'android', lang: 'pt' } };
+
+  function render(props) {
+    return findRenderedComponentWithType(renderIntoDocument(
+      <Provider store={createStore(initialState)}>
+        <AddonMoreInfoBase i18n={getFakeI18nInst()} addon={fakeAddon}
+          {...props} />
+      </Provider>
+    ), AddonMoreInfoBase);
+  }
+
+  it('does not render a homepage if none exists', () => {
+    const partialAddon = deepcopy(fakeAddon);
+    delete partialAddon.homepage;
+    const root = render({ addon: partialAddon });
+
+    assert.equal(root.homepageLink, undefined);
+  });
+
+  it('renders the homepage of an add-on', () => {
+    const root = render();
+
+    assert.equal(root.homepageLink.textContent, 'http://hamsterdance.com/');
+    assert.equal(root.homepageLink.tagName, 'A');
+    assert.equal(root.homepageLink.href, 'http://hamsterdance.com/');
+  });
+
+  it('renders the version number of an add-on', () => {
+    const root = render();
+
+    assert.equal(root.version.textContent, '2.0.0');
+    assert.equal(root.version.tagName, 'DD');
+  });
+
+  it('renders the license and link', () => {
+    const root = render();
+
+    assert.equal(root.licenseHeader.textContent, 'License');
+    assert.equal(root.licenseLink.textContent, 'tofulicense');
+    assert.equal(root.licenseLink.tagName, 'A');
+    assert.equal(root.licenseLink.href, 'http://license.com/');
+  });
+
+  it('does not render a privacy policy if none exists', () => {
+    const partialAddon = deepcopy(fakeAddon);
+    partialAddon.has_privacy_policy = false;
+    const root = render({ addon: partialAddon });
+
+    assert.equal(root.privacyPolicyLink, undefined);
+  });
+
+  it('renders the privacy policy and link', () => {
+    const root = render();
+
+    assert.equal(findDOMNode(root.privacyPolicyLink).textContent,
+      'Read the privacy policy for this add-on');
+    assert.equal(root.privacyPolicyLink.props.to,
+      '/addons/addon/chill-out/privacy-policy/');
+  });
+});

--- a/tests/client/amo/helpers.js
+++ b/tests/client/amo/helpers.js
@@ -6,9 +6,15 @@ export const fakeAddon = {
     name: 'Krupa',
     url: 'http://olympia.dev/en-US/firefox/user/krupa/',
   }],
-  current_version: { id: 123, version: '2.0.0' },
+  current_version: {
+    id: 123,
+    license: { name: 'tofulicense', url: 'http://license.com/' },
+    version: '2.0.0',
+  },
   summary: 'This is a summary of the chill out add-on',
   description: 'This is a longer description of the chill out add-on',
+  has_privacy_policy: true,
+  homepage: 'http://hamsterdance.com/',
 };
 
 export const fakeReview = {


### PR DESCRIPTION
So! I've fixed this up and sent it as a separate PR. Supersedes #1354.

Adds "More information" to addon detail pages. (Same as before.)

### Before
<img width="324" alt="screenshot 2016-11-08 14 13 38" src="https://cloud.githubusercontent.com/assets/90871/20102310/9416c9ae-a5bd-11e6-8449-3d57ffede7b2.png">

### After
<img width="324" alt="screenshot 2016-11-08 14 25 34" src="https://cloud.githubusercontent.com/assets/90871/20102795/4d688112-a5bf-11e6-8453-ee07207fd378.png">