### PR TITLE
Updating an old review should create a new review against the current add-on version

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -99,9 +99,7 @@ class AddonDetail extends React.Component {
         <section className="overall-rating">
           <h2>{i18n.gettext('Rate your experience')}</h2>
           <OverallRating
-            addonName={addon.name}
-            addonId={addon.id}
-            addonSlug={addon.slug}
+            addon={addon}
             version={addon.current_version}
           />
         </section>

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -51,10 +51,18 @@ export class OverallRatingBase extends React.Component {
       userId,
     };
 
-    if (userReview && userReview.versionId === params.versionId) {
-      log.info(
-        `Updating reviewId ${userReview.id} for versionId ${params.versionId}`);
-      params.reviewId = userReview.id;
+    if (userReview) {
+      log.info(`Editing reviewId ${userReview.id}`);
+      if (userReview.versionId === params.versionId) {
+        log.info(
+          `Updating reviewId ${userReview.id} for versionId ${params.versionId}`);
+        params.reviewId = userReview.id;
+      } else {
+        // Since we have a version mismatch, submit the review against the
+        // current most version, similar to how new reviews are created.
+        params.versionId = this.props.addon.current_version.id;
+        log.info(`Submitting a new review for versionId ${params.versionId}`);
+      }
     } else {
       log.info(`Submitting a new review for versionId ${params.versionId}`);
     }

--- a/src/amo/components/OverallRating.js
+++ b/src/amo/components/OverallRating.js
@@ -14,9 +14,7 @@ import 'amo/css/OverallRating.scss';
 
 export class OverallRatingBase extends React.Component {
   static propTypes = {
-    addonName: PropTypes.string.isRequired,
-    addonSlug: PropTypes.string.isRequired,
-    addonId: PropTypes.number.isRequired,
+    addon: PropTypes.object.isRequired,
     apiState: PropTypes.object,
     i18n: PropTypes.object.isRequired,
     loadSavedReview: PropTypes.func.isRequired,
@@ -29,11 +27,11 @@ export class OverallRatingBase extends React.Component {
 
   constructor(props) {
     super(props);
-    const { loadSavedReview, userId, addonId } = props;
+    const { loadSavedReview, userId, addon } = props;
     this.ratingButtons = {};
     if (userId) {
       log.info(`loading a saved rating (if it exists) for user ${userId}`);
-      loadSavedReview({ userId, addonId });
+      loadSavedReview({ userId, addonId: addon.id });
     }
   }
 
@@ -46,8 +44,8 @@ export class OverallRatingBase extends React.Component {
     const params = {
       rating: parseInt(button.value, 10),
       apiState: this.props.apiState,
-      addonId: this.props.addonId,
-      addonSlug: this.props.addonSlug,
+      addonId: this.props.addon.id,
+      addonSlug: this.props.addon.slug,
       router: this.props.router,
       versionId: version.id,
       userId,
@@ -80,10 +78,10 @@ export class OverallRatingBase extends React.Component {
   }
 
   render() {
-    const { i18n, addonName } = this.props;
+    const { i18n, addon } = this.props;
     const prompt = i18n.sprintf(
       i18n.gettext('How are you enjoying your experience with %(addonName)s?'),
-      { addonName });
+      { addonName: addon.name });
 
     // TODO: Disable rating ability when not logged in
     // (when props.userId is empty)
@@ -112,12 +110,12 @@ export const mapStateToProps = (state, ownProps) => {
   let userReview;
 
   // Look for the latest saved review by this user for this add-on.
-  if (userId && state.reviews) {
+  if (userId && state.reviews && ownProps.addon) {
     log.info(dedent`Checking state for review by user ${userId},
-      addonId ${ownProps.addonId}, versionId ${ownProps.version.id}`);
+      addonId ${ownProps.addon.id}, versionId ${ownProps.version.id}`);
 
     const allUserReviews = state.reviews[userId] || {};
-    const addonReviews = allUserReviews[ownProps.addonId] || {};
+    const addonReviews = allUserReviews[ownProps.addon.id] || {};
     const latestId = Object.keys(addonReviews).find(
       (reviewId) => addonReviews[reviewId].isLatest);
 

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -119,9 +119,7 @@ describe('AddonDetail', () => {
   it('configures the overall ratings section', () => {
     const root = findRenderedComponentWithType(render(),
                                                OverallRatingWithI18n);
-    assert.equal(root.props.addonName, fakeAddon.name);
-    assert.equal(root.props.addonId, fakeAddon.id);
-    assert.equal(root.props.addonSlug, fakeAddon.slug);
+    assert.deepEqual(root.props.addon, fakeAddon);
   });
 
   it('renders a summary', () => {

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -20,9 +20,7 @@ import { getFakeI18nInst, userAuthToken } from 'tests/client/helpers';
 
 function render({ ...customProps } = {}) {
   const props = {
-    addonName: fakeAddon.name,
-    addonSlug: fakeAddon.slug,
-    addonId: fakeAddon.id,
+    addon: fakeAddon,
     apiState: signedInApiState,
     version: fakeAddon.current_version,
     i18n: getFakeI18nInst(),
@@ -48,24 +46,24 @@ describe('OverallRating', () => {
   }
 
   it('prompts you to rate the add-on by name', () => {
-    const root = render({ addonName: 'Some Add-on' });
+    const root = render({ addon: { ...fakeAddon, name: 'Some Add-on' } });
     assert.include(root.ratingLegend.textContent, 'Some Add-on');
   });
 
   it('loads saved ratings on construction', () => {
     const userId = 12889;
-    const addonId = 3344;
+    const addon = { ...fakeAddon, id: 3344 };
     const version = {
       ...fakeAddon.current_version,
       id: 9966,
     };
     const loadSavedReview = sinon.spy();
 
-    render({ userId, addonId, version, loadSavedReview });
+    render({ userId, addon, version, loadSavedReview });
 
     assert.equal(loadSavedReview.called, true);
     const args = loadSavedReview.firstCall.args[0];
-    assert.deepEqual(args, { userId, addonId });
+    assert.deepEqual(args, { userId, addonId: addon.id });
   });
 
   it('does not load saved ratings when userId is empty', () => {
@@ -83,7 +81,7 @@ describe('OverallRating', () => {
       submitReview,
       apiState: { ...signedInApiState, token: 'new-token' },
       version: { id: 321 },
-      addonId: 12345,
+      addon: { ...fakeAddon, id: 12345, slug: 'some-slug' },
       userId: 92345,
       router,
     });
@@ -94,7 +92,7 @@ describe('OverallRating', () => {
     assert.equal(call.versionId, 321);
     assert.equal(call.apiState.token, 'new-token');
     assert.equal(call.addonId, 12345);
-    assert.equal(call.addonSlug, 'chill-out');
+    assert.equal(call.addonSlug, 'some-slug');
     assert.equal(call.userId, 92345);
     assert.equal(call.router, router);
     assert.strictEqual(call.reviewId, undefined);
@@ -106,7 +104,6 @@ describe('OverallRating', () => {
       submitReview,
       apiState: { ...signedInApiState, token: 'new-token' },
       version: { id: fakeReview.version.id },
-      addonId: 12345,
       userId: 92345,
       userReview: setReview(fakeReview).data,
     });
@@ -137,7 +134,7 @@ describe('OverallRating', () => {
       submitReview,
       apiState: { ...signedInApiState, token: 'new-token' },
       version: { id: oldVersionId },
-      addonId: newReview.addon.id,
+      addon: { ...fakeAddon, id: newReview.addon.id },
       userId: 92345,
       userReview: setReview(newReview).data,
     });
@@ -316,7 +313,7 @@ describe('OverallRating', () => {
     function getMappedProps({
       state = store.getState(),
       componentProps = {
-        addonId: fakeAddon.id,
+        addon: fakeAddon,
         version: fakeAddon.current_version,
       },
     } = {}) {

--- a/tests/client/amo/components/TestOverallRating.js
+++ b/tests/client/amo/components/TestOverallRating.js
@@ -129,14 +129,15 @@ describe('OverallRating', () => {
         id: 2,
       },
     };
+    const addon = { ...fakeAddon, id: newReview.addon.id };
 
     const root = render({
-      submitReview,
       apiState: { ...signedInApiState, token: 'new-token' },
       version: { id: oldVersionId },
-      addon: { ...fakeAddon, id: newReview.addon.id },
       userId: 92345,
       userReview: setReview(newReview).data,
+      submitReview,
+      addon,
     });
     selectRating(root, newReview.rating);
     assert.ok(submitReview.called);
@@ -145,7 +146,7 @@ describe('OverallRating', () => {
     // newly created against the current version.
     const call = submitReview.firstCall.args[0];
     assert.equal(call.reviewId, undefined);
-    assert.equal(call.versionId, oldVersionId);
+    assert.equal(call.versionId, addon.current_version.id);
     assert.equal(call.rating, newReview.rating);
     assert.equal(call.addonId, newReview.addon.id);
   });


### PR DESCRIPTION
This is pretty edge-casey since we don't currently have a way to view history add-on versions but I think it's the right thing to do. It should future proof the site for when we do show multiple versions (or is that YAGNI? Sigh).

Fixes https://github.com/mozilla/addons-frontend/issues/1390