### PR TITLE
Ensure installURL is set before calling withInstallHelpers 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_install:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-linux64.tar.gz; fi
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then gunzip -c geckodriver.tar.gz | tar xopf -; fi
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then chmod +x geckodriver && sudo mv geckodriver /usr/local/bin; fi
+install:
+- npm install
 before_script:
 - if [ $GUI ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3; fi
 script:

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "bunyan": "1.8.5",
     "camelcase": "4.0.0",
     "classnames": "2.2.5",
+    "common-tags": "^1.4.0",
     "config": "1.24.0",
     "dompurify": "0.8.4",
     "express": "4.14.0",

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -1,5 +1,6 @@
 /* global CustomEvent, document, window */
 import { connect } from 'react-redux';
+import { oneLine } from 'common-tags';
 import config from 'config';
 
 import log from 'core/logger';
@@ -11,6 +12,7 @@ import {
   DOWNLOAD_PROGRESS,
   ENABLED,
   ERROR,
+  EXTENSION_TYPE,
   FATAL_ERROR,
   FATAL_INSTALL_ERROR,
   FATAL_UNINSTALL_ERROR,
@@ -54,6 +56,11 @@ export function makeMapDispatchToProps({ src }) {
   ) {
     if (config.get('server')) {
       return {};
+    }
+
+    if (ownProps.type === EXTENSION_TYPE && ownProps.installURL === undefined) {
+      throw new Error(oneLine`installURL is required, ensure component props are set before
+        withInstallHelpers is called`);
     }
 
     // Set the default here otherwise server code will blow up.

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -244,6 +244,6 @@ export function mapStateToProps(state, ownProps, { _tracking = tracking } = {}) 
 
 export default compose(
   translate({ withRef: true }),
-  withInstallHelpers({ src: 'discovery-promo' }),
   connect(mapStateToProps, undefined, undefined, { withRef: true }),
+  withInstallHelpers({ src: 'discovery-promo' }),
 )(AddonBase);

--- a/tests/client/core/TestInstallAddon.js
+++ b/tests/client/core/TestInstallAddon.js
@@ -548,5 +548,17 @@ describe('withInstallHelpers inner functions', () => {
       assert(configStub.calledOnce);
       assert(configStub.calledWith('server'));
     });
+
+    it('requires an installURL for extensions', () => {
+      assert.throws(() => {
+        makeMapDispatchToProps({})(sinon.spy(), { type: EXTENSION_TYPE });
+      }, /installURL is required/);
+      assert.doesNotThrow(() => {
+        makeMapDispatchToProps({})(sinon.spy(), { type: EXTENSION_TYPE, installURL: 'foo.com' });
+      });
+      assert.doesNotThrow(() => {
+        makeMapDispatchToProps({})(sinon.spy(), { type: THEME_TYPE });
+      });
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,6 +1504,12 @@ commander@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.6.0.tgz#9df7e52fb2a0cb0fb89058ee80c3104225f37e1d"
 
+common-tags:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"


### PR DESCRIPTION
The props weren't getting set for the updated `withInstallHelpers` HOC so it was failing on install. I made it throw now if it is misconfigured.

Just had to reorder the `compose()` in `Addon` to fix this.

This also tells Travis to use `npm install` instead of `yarn` to install things since their update seems to have broken the build? Maybe we need to update some config but I'm not sure what.

Fixes mozilla/addons-server#4035.

Moved from https://github.com/mozilla/addons-frontend/pull/1400 since when Travis runs yarn it seems to break that PR for good.