### PR TITLE
Blur search input on search (fix #1384)

### DIFF
--- a/src/amo/components/SearchForm.js
+++ b/src/amo/components/SearchForm.js
@@ -28,6 +28,7 @@ export class SearchFormBase extends React.Component {
 
   handleSearch = (e) => {
     e.preventDefault();
+    this.searchQuery.input.blur();
     this.goToSearch(this.searchQuery.value);
   }
 

--- a/tests/client/amo/components/TestSearchForm.js
+++ b/tests/client/amo/components/TestSearchForm.js
@@ -65,6 +65,14 @@ describe('<SearchForm />', () => {
     assert(router.push.called);
   });
 
+  it('blurs the form on submit', () => {
+    const blurSpy = sinon.stub(input, 'blur');
+    assert(!blurSpy.called);
+    input.value = 'something';
+    Simulate.submit(form);
+    assert(blurSpy.called);
+  });
+
   it('does nothing on non-Enter keydowns', () => {
     assert(!router.push.called);
     input.value = 'adblock';


### PR DESCRIPTION
Simple fix to hide virtual keyboard (I did the screenshot on the simulator because I broke my Android simulator and I'm too lazy to fix it but it should work).

Before:
![nov-24-2016 00-55-59](https://cloud.githubusercontent.com/assets/90871/20583323/d113ccba-b1e0-11e6-83a1-63764f7fb7ee.gif)

After:
![nov-24-2016 00-48-52](https://cloud.githubusercontent.com/assets/90871/20583244/6e907e62-b1e0-11e6-81dc-6fd56cf895a9.gif)