### PR TITLE
Link fallback for installation without mozAddonManager

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -40,15 +40,10 @@ export class AddonDetailBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     previewTheme: PropTypes.func.isRequired,
     resetPreviewTheme: PropTypes.func.isRequired,
-    setCurrentStatus: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
     OverallRating: DefaultOverallRating,
-  }
-
-  componentDidMount() {
-    this.props.setCurrentStatus();
   }
 
   onTouchStart = (event) => {

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -9,16 +9,23 @@ import {
 import { addQueryParams } from 'core/utils';
 
 
+export function hasAddonManager({ navigator } = {}) {
+  return typeof window !== 'undefined' && 'mozAddonManager' in (navigator || window.navigator);
+}
+
 export function getAddon(guid, { _mozAddonManager = window.navigator.mozAddonManager } = {}) {
-  // Resolves a promise with the addon on success.
-  return _mozAddonManager.getAddonByID(guid)
-    .then((addon) => {
-      if (!addon) {
-        throw new Error('Addon not found');
-      }
-      log.info('Add-on found', addon);
-      return addon;
-    });
+  if (_mozAddonManager || module.exports.hasAddonManager()) {
+    // Resolves a promise with the addon on success.
+    return _mozAddonManager.getAddonByID(guid)
+      .then((addon) => {
+        if (!addon) {
+          throw new Error('Addon not found');
+        }
+        log.info('Add-on found', addon);
+        return addon;
+      });
+  }
+  return Promise.reject(new Error('Cannot check add-on status'));
 }
 
 export function install(

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -1,126 +1,42 @@
 import React, { PropTypes } from 'react';
+import { compose } from 'redux';
 
+import InstallSwitch from 'core/components/InstallSwitch';
+import { THEME_TYPE } from 'core/constants';
 import translate from 'core/i18n/translate';
-import {
-  DOWNLOADING,
-  DISABLED,
-  ENABLED,
-  ENABLING,
-  INSTALLING,
-  INSTALLED,
-  THEME_TYPE,
-  UNINSTALLED,
-  UNINSTALLING,
-  UNKNOWN,
-  validAddonTypes,
-  validInstallStates as validStates,
-} from 'core/constants';
 import { getThemeData } from 'core/themePreview';
-import Switch from 'ui/components/Switch';
+import Button from 'ui/components/Button';
 
 export class InstallButtonBase extends React.Component {
   static propTypes = {
-    downloadProgress: PropTypes.number,
-    enable: PropTypes.func,
-    guid: PropTypes.string.isRequired,
-    handleChange: PropTypes.func,
+    addon: PropTypes.object.isRequired,
+    hasAddonManager: PropTypes.bool.isRequired,
     i18n: PropTypes.object.isRequired,
-    install: PropTypes.func.isRequired,
     installTheme: PropTypes.func.isRequired,
-    installURL: PropTypes.string,
-    name: PropTypes.string.isRequired,
-    slug: PropTypes.string.isRequired,
-    status: PropTypes.oneOf(validStates),
-    type: PropTypes.oneOf(validAddonTypes),
-    uninstall: PropTypes.func.isRequired,
+    status: PropTypes.string.isRequired,
   }
 
-  static defaultProps = {
-    status: UNKNOWN,
-    downloadProgress: 0,
-  }
-
-  getLabel() {
-    const { i18n, name, status } = this.props;
-    let label;
-    switch (status) {
-      case DOWNLOADING:
-        label = i18n.gettext('Downloading %(name)s.');
-        break;
-      case INSTALLING:
-        label = i18n.gettext('Installing %(name)s.');
-        break;
-      case ENABLED:
-      case INSTALLED:
-        label = i18n.gettext('%(name)s is installed and enabled. Click to uninstall.');
-        break;
-      case DISABLED:
-        label = i18n.gettext('%(name)s is disabled. Click to enable.');
-        break;
-      case UNINSTALLING:
-        label = i18n.gettext('Uninstalling %(name)s.');
-        break;
-      case UNINSTALLED:
-        label = i18n.gettext('%(name)s is uninstalled. Click to install.');
-        break;
-      default:
-        label = i18n.gettext('Install state for %(name)s is unknown.');
-        break;
-    }
-    return i18n.sprintf(label, { name });
-  }
-
-  getDownloadProgress() {
-    const { downloadProgress, status } = this.props;
-    if (status === DOWNLOADING) {
-      return downloadProgress;
-    } else if ([INSTALLING, ENABLING].includes(status)) {
-      return Infinity;
-    } else if (status === UNINSTALLING) {
-      return -Infinity;
-    }
-    return undefined;
-  }
-
-  handleClick = (e) => {
-    e.preventDefault();
-    const {
-      guid, enable, install, installURL, name, status, installTheme, type, uninstall,
-    } = this.props;
-    if (type === THEME_TYPE && [UNINSTALLED, DISABLED].includes(status)) {
-      installTheme(this.themeData, guid, name);
-    } else if (status === UNINSTALLED) {
-      install();
-    } else if (status === DISABLED) {
-      enable();
-    } else if ([INSTALLED, ENABLED].includes(status)) {
-      uninstall({ guid, installURL, name, type });
-    }
+  installTheme = (event) => {
+    event.preventDefault();
+    const { addon, status, installTheme } = this.props;
+    installTheme(event.currentTarget, { ...addon, status });
   }
 
   render() {
-    const browsertheme = JSON.stringify(getThemeData(this.props));
-    const { handleChange, slug, status } = this.props;
-
-    if (!validStates.includes(status)) {
-      throw new Error(`Invalid add-on status ${status}`);
+    const { addon, hasAddonManager, i18n } = this.props;
+    if (hasAddonManager) {
+      return <InstallSwitch {...this.props} />;
+    } else if (addon.type === THEME_TYPE) {
+      return (
+        <Button data-browsertheme={JSON.stringify(getThemeData(addon))} onClick={this.installTheme}>
+          {i18n.gettext('Install Theme')}
+        </Button>
+      );
     }
-
-    const isChecked = [INSTALLED, INSTALLING, ENABLING, ENABLED].includes(status);
-    const isDisabled = status === UNKNOWN;
-    const isSuccess = [ENABLED, INSTALLED].includes(status);
-
-    return (
-      <div data-browsertheme={browsertheme} ref={(el) => { this.themeData = el; }}>
-        <Switch
-          checked={isChecked} disabled={isDisabled} progress={this.getDownloadProgress()}
-          name={slug} success={isSuccess} label={this.getLabel()}
-          onChange={handleChange} onClick={this.handleClick}
-          ref={(el) => { this.switchEl = el; }}
-        />
-      </div>
-    );
+    return <Button href={addon.installURL}>{i18n.gettext('Add to Firefox')}</Button>;
   }
 }
 
-export default translate()(InstallButtonBase);
+export default compose(
+  translate(),
+)(InstallButtonBase);

--- a/src/core/components/InstallSwitch/index.js
+++ b/src/core/components/InstallSwitch/index.js
@@ -1,0 +1,127 @@
+import React, { PropTypes } from 'react';
+
+import translate from 'core/i18n/translate';
+import {
+  DOWNLOADING,
+  DISABLED,
+  ENABLED,
+  ENABLING,
+  INSTALLING,
+  INSTALLED,
+  THEME_TYPE,
+  UNINSTALLED,
+  UNINSTALLING,
+  UNKNOWN,
+  validAddonTypes,
+  validInstallStates as validStates,
+} from 'core/constants';
+import { getThemeData } from 'core/themePreview';
+import Switch from 'ui/components/Switch';
+
+export class InstallSwitchBase extends React.Component {
+  static propTypes = {
+    addon: PropTypes.object.isRequired,
+    downloadProgress: PropTypes.number,
+    enable: PropTypes.func,
+    guid: PropTypes.string.isRequired,
+    handleChange: PropTypes.func,
+    i18n: PropTypes.object.isRequired,
+    install: PropTypes.func.isRequired,
+    installTheme: PropTypes.func.isRequired,
+    installURL: PropTypes.string,
+    name: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
+    status: PropTypes.oneOf(validStates),
+    type: PropTypes.oneOf(validAddonTypes),
+    uninstall: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    status: UNKNOWN,
+    downloadProgress: 0,
+  }
+
+  getLabel() {
+    const { i18n, name, status } = this.props;
+    let label;
+    switch (status) {
+      case DOWNLOADING:
+        label = i18n.gettext('Downloading %(name)s.');
+        break;
+      case INSTALLING:
+        label = i18n.gettext('Installing %(name)s.');
+        break;
+      case ENABLED:
+      case INSTALLED:
+        label = i18n.gettext('%(name)s is installed and enabled. Click to uninstall.');
+        break;
+      case DISABLED:
+        label = i18n.gettext('%(name)s is disabled. Click to enable.');
+        break;
+      case UNINSTALLING:
+        label = i18n.gettext('Uninstalling %(name)s.');
+        break;
+      case UNINSTALLED:
+        label = i18n.gettext('%(name)s is uninstalled. Click to install.');
+        break;
+      default:
+        label = i18n.gettext('Install state for %(name)s is unknown.');
+        break;
+    }
+    return i18n.sprintf(label, { name });
+  }
+
+  getDownloadProgress() {
+    const { downloadProgress, status } = this.props;
+    if (status === DOWNLOADING) {
+      return downloadProgress;
+    } else if ([INSTALLING, ENABLING].includes(status)) {
+      return Infinity;
+    } else if (status === UNINSTALLING) {
+      return -Infinity;
+    }
+    return undefined;
+  }
+
+  handleClick = (e) => {
+    e.preventDefault();
+    const {
+      addon, guid, enable, install, installURL, name, status, installTheme, type, uninstall,
+    } = this.props;
+    if (type === THEME_TYPE && [UNINSTALLED, DISABLED].includes(status)) {
+      installTheme(this.themeData, { ...addon, status });
+    } else if (status === UNINSTALLED) {
+      install();
+    } else if (status === DISABLED) {
+      enable();
+    } else if ([INSTALLED, ENABLED].includes(status)) {
+      uninstall({ guid, installURL, name, type });
+    }
+  }
+
+  render() {
+    const browsertheme = JSON.stringify(getThemeData(this.props));
+    const { handleChange, slug, status } = this.props;
+
+    if (!validStates.includes(status)) {
+      throw new Error(`Invalid add-on status ${status}`);
+    }
+
+    const isChecked = [INSTALLED, INSTALLING, ENABLING, ENABLED].includes(status);
+    const isDisabled = status === UNKNOWN;
+    const isSuccess = [ENABLED, INSTALLED].includes(status);
+
+    return (
+      <div data-browsertheme={browsertheme} ref={(el) => { this.themeData = el; }}>
+        <Switch
+          checked={isChecked} disabled={isDisabled} progress={this.getDownloadProgress()}
+          name={slug} success={isSuccess} label={this.getLabel()}
+          onChange={handleChange} onClick={this.handleClick}
+          ref={(el) => { this.switchEl = el; }}
+        />
+      </div>
+    );
+  }
+}
+
+export default translate()(InstallSwitchBase);

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -1,4 +1,6 @@
 /* global CustomEvent, document, window */
+import React, { PropTypes } from 'react';
+import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { oneLine } from 'common-tags';
 import config from 'config';

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -119,7 +119,9 @@ export class DiscoPaneBase extends React.Component {
             </div>
           </div>
         </header>
-        {results.map((item) => <AddonComponent {...camelCaseProps(item)} key={item.guid} />)}
+        {results.map((item) => (
+          <AddonComponent addon={item} {...camelCaseProps(item)} key={item.guid} />
+        ))}
         <div className="amo-link">
           <a href="https://addons.mozilla.org/" target="_blank"
             rel="noopener noreferrer" onClick={this.showMoreAddons}>

--- a/src/ui/components/Button/Button.scss
+++ b/src/ui/components/Button/Button.scss
@@ -1,0 +1,5 @@
+@import '~core/css/inc/mixins';
+.Button,
+.Button:link {
+  @include button();
+}

--- a/src/ui/components/Button/Button.scss
+++ b/src/ui/components/Button/Button.scss
@@ -1,4 +1,5 @@
 @import '~core/css/inc/mixins';
+
 .Button,
 .Button:link {
   @include button();

--- a/src/ui/components/Button/index.js
+++ b/src/ui/components/Button/index.js
@@ -1,0 +1,26 @@
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+
+import './Button.scss';
+
+export default class Button extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    href: PropTypes.string,
+  }
+
+  render() {
+    const { children, className, href, ...rest } = this.props;
+    const props = {
+      className: classNames('Button', className),
+      ...rest,
+    };
+
+    if (href) {
+      return <Link {...props} href={href}>{children}</Link>;
+    }
+    return <button {...props}>{children}</button>;
+  }
+}

--- a/src/ui/components/Switch/Switch.scss
+++ b/src/ui/components/Switch/Switch.scss
@@ -52,6 +52,7 @@ $installStripeColor2: #00c42e;
 }
 
 .Switch {
+  display: inline-block;
   position: relative;
 
   input:focus + label {

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -54,12 +54,6 @@ describe('AddonDetail', () => {
                    'Chill Out');
   });
 
-  it('gets the add-on status on componentDidMount()', () => {
-    const setCurrentStatus = sinon.spy();
-    renderAsDOMNode({ setCurrentStatus });
-    assert.ok(setCurrentStatus.called);
-  });
-
   it('renders a single author', () => {
     const authorUrl = 'http://olympia.dev/en-US/firefox/user/krupa/';
     const rootNode = renderAsDOMNode({

--- a/tests/client/core/TestAddonManager.js
+++ b/tests/client/core/TestAddonManager.js
@@ -36,6 +36,16 @@ describe('addonManager', () => {
     };
   });
 
+  describe('hasAddonManager', () => {
+    it('is true if mozAddonManager is in navigator', () => {
+      assert.ok(addonManager.hasAddonManager({ navigator: { mozAddonManager: {} } }));
+    });
+
+    it('is false if mozAddonManager is not in navigator', () => {
+      assert.notOk(addonManager.hasAddonManager());
+    });
+  });
+
   describe('getAddon()', () => {
     it('should call mozAddonManager.getAddonByID() with id', () => {
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
@@ -50,6 +60,12 @@ describe('addonManager', () => {
       return addonManager.getAddon('test-id', { _mozAddonManager: fakeMozAddonManager })
         .then(unexpectedSuccess,
           (err) => assert.equal(err.message, 'Addon not found'));
+    });
+
+    it('rejects if thre is no addon manager', () => {
+      sinon.stub(addonManager, 'hasAddonManager').returns(false);
+      return addonManager.getAddon('foo')
+        .then(unexpectedSuccess, (err) => assert.equal(err.message, 'Cannot check add-on status'));
     });
   });
 

--- a/tests/client/core/TestInstallAddon.js
+++ b/tests/client/core/TestInstallAddon.js
@@ -1,5 +1,8 @@
 import config from 'config';
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
 
+import createStore from 'amo/store';
 import {
   CLOSE_INFO,
   DISABLED,
@@ -27,7 +30,7 @@ import {
   UNINSTALLING,
 } from 'core/constants';
 import {
-  getFakeAddonManagerWrapper, getFakeI18nInst,
+  getFakeAddonManagerWrapper, getFakeI18nInst, shallowRender,
 } from 'tests/client/helpers';
 import * as installAddon from 'core/installAddon';
 import * as themePreview from 'core/themePreview';
@@ -44,6 +47,14 @@ describe('withInstallHelpers', () => {
     const WrappedComponent = sinon.stub();
     withInstallHelpers({ src: 'Howdy', _makeMapDispatchToProps })(WrappedComponent);
     assert.ok(_makeMapDispatchToProps.calledWith({ WrappedComponent, src: 'Howdy' }));
+  });
+
+  it('wraps the component in WithInstallHelpers', () => {
+    const _makeMapDispatchToProps = sinon.spy();
+    const Component = withInstallHelpers({ src: 'Howdy', _makeMapDispatchToProps })(() => {});
+    const store = createStore();
+    const root = shallowRender(<Component store={store} />);
+    assert.equal(root.type, WithInstallHelpers);
   });
 
   it('throws without a src', () => {

--- a/tests/client/core/components/TestInstallButton.js
+++ b/tests/client/core/components/TestInstallButton.js
@@ -2,194 +2,61 @@ import React from 'react';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 
-import {
-  InstallButtonBase,
-} from 'core/components/InstallButton';
-import {
-  DISABLED,
-  DISABLING,
-  DOWNLOADING,
-  ENABLED,
-  ENABLING,
-  INSTALLED,
-  INSTALLING,
-  THEME_TYPE,
-  UNINSTALLED,
-  UNINSTALLING,
-  UNKNOWN,
-} from 'core/constants';
+import { InstallButtonBase } from 'core/components/InstallButton';
+import InstallSwitch from 'core/components/InstallSwitch';
+import { EXTENSION_TYPE, THEME_TYPE, UNKNOWN } from 'core/constants';
 import * as themePreview from 'core/themePreview';
-import { getFakeI18nInst } from 'tests/client/helpers';
-
+import { getFakeI18nInst, shallowRender } from 'tests/client/helpers';
+import Button from 'ui/components/Button';
 
 describe('<InstallButton />', () => {
-  function renderButton(props = {}) {
-    const renderProps = {
-      dispatch: sinon.spy(),
-      enable: sinon.spy(),
-      install: sinon.spy(),
-      installTheme: sinon.spy(),
-      uninstall: sinon.spy(),
-      i18n: getFakeI18nInst(),
-      slug: 'foo',
-      name: 'test-addon',
-      ...props,
-    };
-
-    return renderIntoDocument(
-      <InstallButtonBase {...renderProps} />);
-  }
-
-  it('should be disabled if isDisabled status is UNKNOWN', () => {
-    const button = renderButton({ status: UNKNOWN });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.disabled, true);
-  });
-
-  it('should reflect DISABLED status', () => {
-    const button = renderButton({ status: DISABLED });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.disabled, false);
-    assert.include(switchEl.props.label, 'test-addon is disabled');
-    assert.include(switchEl.props.label, 'Click to enable');
-  });
-
-  it('should reflect UNINSTALLED status', () => {
-    const button = renderButton({ status: UNINSTALLED });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.disabled, false);
-    assert.include(switchEl.props.label, 'test-addon is uninstalled');
-    assert.include(switchEl.props.label, 'Click to install');
-  });
-
-  it('should reflect INSTALLED status', () => {
-    const button = renderButton({ status: INSTALLED });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.checked, true);
-    assert.equal(switchEl.props.success, true);
-  });
-
-  it('should reflect ENABLED status', () => {
-    const button = renderButton({ status: ENABLED });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.checked, true);
-    assert.include(switchEl.props.label, 'test-addon is installed and enabled');
-    assert.include(switchEl.props.label, 'Click to uninstall');
-    assert.equal(switchEl.props.success, true);
-  });
-
-  it('should reflect download downloadProgress', () => {
-    const button = renderButton({ status: DOWNLOADING, downloadProgress: 50 });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.progress, 50);
-    assert.include(switchEl.props.label, 'Downloading test-addon');
-  });
-
-  it('should reflect installation', () => {
-    const button = renderButton({ status: INSTALLING });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.checked, true);
-    assert.include(switchEl.props.label, 'Installing test-addon');
-  });
-
-  it('should reflect ENABLING status', () => {
-    const button = renderButton({ status: ENABLING });
-    const switchEl = button.switchEl;
-    assert.equal(switchEl.props.checked, true);
-  });
-
-  it('should reflect uninstallation', () => {
-    const button = renderButton({ status: UNINSTALLING });
-    const switchEl = button.switchEl;
-    assert.include(switchEl.props.label, 'Uninstalling test-addon');
-  });
-
-  it('should not call anything on click when neither installed or uninstalled', () => {
-    const install = sinon.stub();
-    const uninstall = sinon.stub();
-    const button = renderButton({ status: DOWNLOADING, install, uninstall });
-    const root = findDOMNode(button);
-    Simulate.click(root);
-    assert.ok(!install.called);
-    assert.ok(!uninstall.called);
-  });
-
-  it('should associate the label and input with id and for attributes', () => {
-    const button = renderButton({ status: UNINSTALLED, slug: 'foo' });
-    const root = findDOMNode(button);
-    assert.equal(root.querySelector('input').getAttribute('id'),
-                'install-button-foo', 'id is set');
-    assert.equal(root.querySelector('label').getAttribute('for'),
-                'install-button-foo', 'for attribute matches id');
-  });
-
-  it('should throw on bogus status', () => {
-    assert.throws(() => {
-      renderButton({ status: 'BOGUS' });
-    }, Error, 'Invalid add-on status');
-  });
-
-  it('should not throw for ENABLING', () => {
-    renderButton({ status: ENABLING });
-  });
-
-  it('should not throw for DISABLING', () => {
-    renderButton({ status: DISABLING });
-  });
-
-  it('should call installTheme function on click when uninstalled theme', () => {
-    const installTheme = sinon.spy();
-    const browsertheme = { theme: 'data' };
-    sinon.stub(themePreview, 'getThemeData').returns(browsertheme);
-    const guid = 'test-guid';
-    const name = 'hai';
-    const button = renderButton({
-      installTheme,
-      type: THEME_TYPE,
-      guid,
-      name,
-      status: UNINSTALLED,
+  it('renders InstallSwitch when mozAddonManager is available', () => {
+    const i18n = getFakeI18nInst();
+    const root = shallowRender(<InstallButtonBase foo="foo" hasAddonManager i18n={i18n} />);
+    assert.equal(root.type, InstallSwitch);
+    assert.deepEqual(root.props, {
+      foo: 'foo',
+      hasAddonManager: true,
+      i18n,
     });
-    const root = findDOMNode(button.switchEl);
-    Simulate.click(root);
-    assert.ok(installTheme.calledOnce, installTheme.callCount);
-    const themeDataEl = installTheme.args[0][0];
-    assert.equal(themeDataEl.getAttribute('data-browsertheme'), JSON.stringify(browsertheme));
   });
 
-  it('should call install function on click when uninstalled', () => {
-    const guid = '@foo';
-    const name = 'hai';
-    const install = sinon.spy();
+  it('renders a theme button when mozAddonManager is not available', () => {
     const i18n = getFakeI18nInst();
-    const installURL = 'https://my.url/download';
-    const button = renderButton({ guid, i18n, install, installURL, name, status: UNINSTALLED });
-    const root = findDOMNode(button.switchEl);
-    Simulate.click(root);
-    assert(install.calledWith());
+    const addon = { type: THEME_TYPE, id: 'foo@personas.mozilla.org' };
+    const root = shallowRender(
+      <InstallButtonBase
+        addon={addon} foo="foo" hasAddonManager={false} i18n={i18n} />);
+    assert.equal(root.type, Button);
+    assert.equal(root.props.children, 'Install Theme');
+    assert.equal(root.props['data-browsertheme'], JSON.stringify(themePreview.getThemeData(addon)));
   });
 
-  it('should call enable function on click when uninstalled', () => {
-    const guid = '@foo';
-    const name = 'hai';
-    const enable = sinon.spy();
+
+  it('calls installTheme when clicked', () => {
+    const installTheme = sinon.spy();
     const i18n = getFakeI18nInst();
-    const installURL = 'https://my.url/download';
-    const button = renderButton({ guid, i18n, enable, installURL, name, status: DISABLED });
-    const root = findDOMNode(button.switchEl);
-    Simulate.click(root);
-    assert(enable.calledWith());
+    const addon = { type: THEME_TYPE, id: 'foo@personas.mozilla.org' };
+    const root = findDOMNode(renderIntoDocument(
+      <InstallButtonBase
+        addon={addon} foo="foo" hasAddonManager={false} i18n={i18n}
+        status={UNKNOWN} installTheme={installTheme} />));
+    const preventDefault = sinon.spy();
+    Simulate.click(root, { preventDefault });
+    assert.ok(preventDefault.called);
+    assert.ok(installTheme.called);
+    assert.ok(installTheme.calledWith(root, { ...addon, status: UNKNOWN }));
   });
 
-  it('should call uninstall function on click when installed', () => {
-    const guid = '@foo';
-    const installURL = 'https://my.url/download';
-    const name = 'hai';
-    const type = 'whatevs';
-    const uninstall = sinon.spy();
-    const button = renderButton({ guid, installURL, name, status: INSTALLED, type, uninstall });
-    const root = findDOMNode(button.switchEl);
-    Simulate.click(root);
-    assert(uninstall.calledWith({ guid, installURL, name, type }));
+  it('renders an add-on button when mozAddonManager is not available', () => {
+    const i18n = getFakeI18nInst();
+    const addon = { type: EXTENSION_TYPE, installURL: 'https://addons.mozilla.org/download' };
+    const root = shallowRender(
+      <InstallButtonBase addon={addon} foo="foo" hasAddonManager={false} i18n={i18n} />);
+    assert.equal(root.type, Button);
+    assert.deepEqual(root.props, {
+      children: 'Add to Firefox',
+      href: 'https://addons.mozilla.org/download',
+    });
   });
 });

--- a/tests/client/core/components/TestInstallSwitch.js
+++ b/tests/client/core/components/TestInstallSwitch.js
@@ -1,0 +1,195 @@
+import React from 'react';
+import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+
+import {
+  InstallSwitchBase,
+} from 'core/components/InstallSwitch';
+import {
+  DISABLED,
+  DISABLING,
+  DOWNLOADING,
+  ENABLED,
+  ENABLING,
+  INSTALLED,
+  INSTALLING,
+  THEME_TYPE,
+  UNINSTALLED,
+  UNINSTALLING,
+  UNKNOWN,
+} from 'core/constants';
+import * as themePreview from 'core/themePreview';
+import { getFakeI18nInst } from 'tests/client/helpers';
+
+
+describe('<InstallSwitch />', () => {
+  function renderButton(props = {}) {
+    const renderProps = {
+      dispatch: sinon.spy(),
+      enable: sinon.spy(),
+      install: sinon.spy(),
+      installTheme: sinon.spy(),
+      uninstall: sinon.spy(),
+      i18n: getFakeI18nInst(),
+      slug: 'foo',
+      name: 'test-addon',
+      ...props,
+    };
+
+    return renderIntoDocument(
+      <InstallSwitchBase {...renderProps} />);
+  }
+
+  it('should be disabled if isDisabled status is UNKNOWN', () => {
+    const button = renderButton({ status: UNKNOWN });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.disabled, true);
+  });
+
+  it('should reflect DISABLED status', () => {
+    const button = renderButton({ status: DISABLED });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.disabled, false);
+    assert.include(switchEl.props.label, 'test-addon is disabled');
+    assert.include(switchEl.props.label, 'Click to enable');
+  });
+
+  it('should reflect UNINSTALLED status', () => {
+    const button = renderButton({ status: UNINSTALLED });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.disabled, false);
+    assert.include(switchEl.props.label, 'test-addon is uninstalled');
+    assert.include(switchEl.props.label, 'Click to install');
+  });
+
+  it('should reflect INSTALLED status', () => {
+    const button = renderButton({ status: INSTALLED });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.checked, true);
+    assert.equal(switchEl.props.success, true);
+  });
+
+  it('should reflect ENABLED status', () => {
+    const button = renderButton({ status: ENABLED });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.checked, true);
+    assert.include(switchEl.props.label, 'test-addon is installed and enabled');
+    assert.include(switchEl.props.label, 'Click to uninstall');
+    assert.equal(switchEl.props.success, true);
+  });
+
+  it('should reflect download downloadProgress', () => {
+    const button = renderButton({ status: DOWNLOADING, downloadProgress: 50 });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.progress, 50);
+    assert.include(switchEl.props.label, 'Downloading test-addon');
+  });
+
+  it('should reflect installation', () => {
+    const button = renderButton({ status: INSTALLING });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.checked, true);
+    assert.include(switchEl.props.label, 'Installing test-addon');
+  });
+
+  it('should reflect ENABLING status', () => {
+    const button = renderButton({ status: ENABLING });
+    const switchEl = button.switchEl;
+    assert.equal(switchEl.props.checked, true);
+  });
+
+  it('should reflect uninstallation', () => {
+    const button = renderButton({ status: UNINSTALLING });
+    const switchEl = button.switchEl;
+    assert.include(switchEl.props.label, 'Uninstalling test-addon');
+  });
+
+  it('should not call anything on click when neither installed or uninstalled', () => {
+    const install = sinon.stub();
+    const uninstall = sinon.stub();
+    const button = renderButton({ status: DOWNLOADING, install, uninstall });
+    const root = findDOMNode(button);
+    Simulate.click(root);
+    assert.ok(!install.called);
+    assert.ok(!uninstall.called);
+  });
+
+  it('should associate the label and input with id and for attributes', () => {
+    const button = renderButton({ status: UNINSTALLED, slug: 'foo' });
+    const root = findDOMNode(button);
+    assert.equal(root.querySelector('input').getAttribute('id'),
+                'install-button-foo', 'id is set');
+    assert.equal(root.querySelector('label').getAttribute('for'),
+                'install-button-foo', 'for attribute matches id');
+  });
+
+  it('should throw on bogus status', () => {
+    assert.throws(() => {
+      renderButton({ status: 'BOGUS' });
+    }, Error, 'Invalid add-on status');
+  });
+
+  it('should not throw for ENABLING', () => {
+    renderButton({ status: ENABLING });
+  });
+
+  it('should not throw for DISABLING', () => {
+    renderButton({ status: DISABLING });
+  });
+
+  it('should call installTheme function on click when uninstalled theme', () => {
+    const installTheme = sinon.spy();
+    const browsertheme = { theme: 'data' };
+    sinon.stub(themePreview, 'getThemeData').returns(browsertheme);
+    const guid = 'test-guid';
+    const name = 'hai';
+    const button = renderButton({
+      installTheme,
+      type: THEME_TYPE,
+      guid,
+      name,
+      status: UNINSTALLED,
+    });
+    const root = findDOMNode(button.switchEl);
+    Simulate.click(root);
+    assert.ok(installTheme.calledOnce, installTheme.callCount);
+    const themeDataEl = installTheme.args[0][0];
+    assert.equal(themeDataEl.getAttribute('data-browsertheme'), JSON.stringify(browsertheme));
+  });
+
+  it('should call install function on click when uninstalled', () => {
+    const guid = '@foo';
+    const name = 'hai';
+    const install = sinon.spy();
+    const i18n = getFakeI18nInst();
+    const installURL = 'https://my.url/download';
+    const button = renderButton({ guid, i18n, install, installURL, name, status: UNINSTALLED });
+    const root = findDOMNode(button.switchEl);
+    Simulate.click(root);
+    assert(install.calledWith());
+  });
+
+  it('should call enable function on click when uninstalled', () => {
+    const guid = '@foo';
+    const name = 'hai';
+    const enable = sinon.spy();
+    const i18n = getFakeI18nInst();
+    const installURL = 'https://my.url/download';
+    const button = renderButton({ guid, i18n, enable, installURL, name, status: DISABLED });
+    const root = findDOMNode(button.switchEl);
+    Simulate.click(root);
+    assert(enable.calledWith());
+  });
+
+  it('should call uninstall function on click when installed', () => {
+    const guid = '@foo';
+    const installURL = 'https://my.url/download';
+    const name = 'hai';
+    const type = 'whatevs';
+    const uninstall = sinon.spy();
+    const button = renderButton({ guid, installURL, name, status: INSTALLED, type, uninstall });
+    const root = findDOMNode(button.switchEl);
+    Simulate.click(root);
+    assert(uninstall.calledWith({ guid, installURL, name, type }));
+  });
+});

--- a/tests/client/ui/components/TestButton.js
+++ b/tests/client/ui/components/TestButton.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+import { shallowRender } from 'tests/client/helpers';
+import Button from 'ui/components/Button';
+
+describe('<Button />', () => {
+  it('renders a button', () => {
+    const onClick = sinon.spy();
+    const button = shallowRender(<Button className="Foo" onClick={onClick}>My button!</Button>);
+    assert.equal(button.type, 'button');
+    assert.equal(button.props.className, 'Button Foo');
+    assert.strictEqual(button.props.onClick, onClick);
+    assert.equal(button.props.children, 'My button!');
+  });
+
+  it('renders a link with an href', () => {
+    const href = 'https://addons.mozilla.org';
+    const button = shallowRender(<Button className="Bar" href={href}>Link text!</Button>);
+    assert.equal(button.type, Link);
+    assert.equal(button.props.className, 'Button Bar');
+    assert.strictEqual(button.props.href, href);
+    assert.equal(button.props.children, 'Link text!');
+  });
+});


### PR DESCRIPTION
Buttons on http://localhost:3000 and switches on https://discovery.addons.mozilla.org.

![install-addon-fallback mov](https://cloud.githubusercontent.com/assets/211578/20637311/b15e79fa-b349-11e6-8e4a-4f485758488d.gif)
![install-addon-one-click mov](https://cloud.githubusercontent.com/assets/211578/20637313/b16b86f4-b349-11e6-8d84-8b197215e333.gif)
![install-theme-fallback mov](https://cloud.githubusercontent.com/assets/211578/20637314/b16bff58-b349-11e6-9f9a-6e671da8ac9d.gif)
![install-theme-one-click mov](https://cloud.githubusercontent.com/assets/211578/20637312/b165649a-b349-11e6-88db-cf602c1b498f.gif)

TODO: Make sure we aren't calling `setCurrentStatus()` anywhere it won't work, or make it a no-op if we don't have `mozAddonManager`. That's probably nicer.

Fixes #946.