### PR TITLE
Truncate and style description (fix #1296)

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -12,6 +12,8 @@ import fallbackIcon from 'amo/img/icons/default-64.png';
 import { withInstallHelpers } from 'core/installAddon';
 import { isAllowedOrigin, nl2br, sanitizeHTML } from 'core/utils';
 import translate from 'core/i18n/translate';
+import ShowMoreCard from 'ui/components/ShowMoreCard';
+
 
 export const allowedDescriptionTags = [
   'a',
@@ -63,6 +65,7 @@ export class AddonDetailBase extends React.Component {
     const iconUrl = isAllowedOrigin(addon.icon_url) ? addon.icon_url :
       fallbackIcon;
 
+    // eslint-disable react/no-danger
     return (
       <div className="AddonDetail">
         <header>
@@ -73,9 +76,8 @@ export class AddonDetailBase extends React.Component {
             <h1 dangerouslySetInnerHTML={sanitizeHTML(title, ['a', 'span'])} />
             <InstallButton {...this.props} />
           </div>
-          <div className="description">
-            <p dangerouslySetInnerHTML={sanitizeHTML(addon.summary)} />
-          </div>
+          <p className="AddonDetail-summary"
+            dangerouslySetInnerHTML={sanitizeHTML(addon.summary)} />
         </header>
 
         <section className="addon-metadata">
@@ -94,13 +96,15 @@ export class AddonDetailBase extends React.Component {
 
         <hr />
 
-        <section className="about">
-          <h2>{i18n.gettext('About this extension')}</h2>
-          <div dangerouslySetInnerHTML={sanitizeHTML(nl2br(addon.description),
-                                                     allowedDescriptionTags)} />
-        </section>
-
-        <hr />
+        <ShowMoreCard header={i18n.sprintf(
+          i18n.gettext('About this %(addonType)s'), { addonType: addon.type }
+        )} className="AddonDescription">
+          <div className="AddonDescription-contents"
+            ref={(ref) => { this.addonDescription = ref; }}
+            dangerouslySetInnerHTML={
+              sanitizeHTML(nl2br(addon.description), allowedDescriptionTags)
+            } />
+        </ShowMoreCard>
 
         <section className="overall-rating">
           <h2>{i18n.gettext('Rate your experience')}</h2>
@@ -113,6 +117,7 @@ export class AddonDetailBase extends React.Component {
         <AddonMoreInfo addon={addon} />
       </div>
     );
+    // eslint-enable react/no-danger
   }
 }
 

--- a/src/amo/css/AddonDetail.scss
+++ b/src/amo/css/AddonDetail.scss
@@ -12,9 +12,9 @@
 
   .icon,
   .title,
-  .description,
   .screenshots,
   .about,
+  .AddonDetail-summary,
   .overall-rating {
     overflow: hidden;
     padding: 20px;
@@ -56,13 +56,9 @@
   .switch {
     float: right;
   }
+}
 
-  .description {
-    background: darken($masthead-color, 5.5%);
-    font-size: 18px;
-
-    p:first-child {
-      margin-top: 0;
-    }
-  }
+.AddonDetail-summary {
+  margin-bottom: 0;
+  margin-top: 0;
 }

--- a/src/ui/components/ShowMoreCard/ShowMoreCard.scss
+++ b/src/ui/components/ShowMoreCard/ShowMoreCard.scss
@@ -1,0 +1,38 @@
+@import "~core/css/inc/vars";
+
+.ShowMoreCard {
+  margin: 0 $padding-page;
+}
+
+.ShowMoreCard-contents {
+  &::after {
+    background: linear-gradient(transparent 10px, $base-color);
+    content: '';
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
+  max-height: 150px;
+  position: relative;
+  overflow: hidden;
+
+  .ShowMoreCard--expanded & {
+    &::after {
+      display: none;
+    }
+
+    max-height: none;
+  }
+}
+
+.ShowMoreCard-revealMoreLink {
+  display: block;
+  text-align: center;
+
+  .ShowMoreCard--expanded & {
+    display: none;
+  }
+}

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -1,0 +1,66 @@
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import { compose } from 'redux';
+
+import translate from 'core/i18n/translate';
+import Card from 'ui/components/Card';
+
+import './ShowMoreCard.scss';
+
+
+export class ShowMoreCardBase extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    header: PropTypes.node,
+    footer: PropTypes.node,
+    i18n: PropTypes.object.isRequired,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = { expanded: false };
+  }
+
+  componentDidMount() {
+    this.expandIfDescriptionIsShortEnough();
+  }
+
+  expandIfDescriptionIsShortEnough = () => {
+    // If the add-on description is short enough it doesn't need a "show more"
+    // link, we'll expand the description by default.
+    if (ReactDOM.findDOMNode(this.contents).clientHeight < 100) {
+      this.setState({ expanded: true });
+    }
+  }
+
+  expandText = (event) => {
+    event.preventDefault();
+    this.setState({ expanded: true });
+  }
+
+  render() {
+    const { children, className, header, footer, i18n } = this.props;
+    const { expanded } = this.state;
+
+    return (
+      <Card className={classNames('ShowMoreCard', className, {
+        'ShowMoreCard--expanded': expanded,
+      })} header={header} footer={footer}>
+        <div className="ShowMoreCard-contents"
+          ref={(ref) => { this.contents = ref; }}>
+          {children}
+        </div>
+        <a className="ShowMoreCard-revealMoreLink" href="#show-more"
+          onClick={this.expandText}>
+          {i18n.gettext('Show more info…')}
+        </a>
+      </Card>
+    );
+  }
+}
+
+export default compose(
+  translate({ withRef: true }),
+)(ShowMoreCardBase);

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -127,37 +127,10 @@ describe('AddonDetail', () => {
     assert.equal(root.props.slug, fakeAddon.slug);
   });
 
-  it('configures the overall ratings section', () => {
-    const root = findRenderedComponentWithType(render(),
-                                               OverallRatingWithI18n);
-    assert.deepEqual(root.props.addon, fakeAddon);
-  });
-
-  it('renders a summary', () => {
+  it('sets the type in the header', () => {
     const rootNode = renderAsDOMNode();
-    assert.include(rootNode.querySelector('div.description').textContent,
-                   fakeAddon.summary);
-  });
-
-  it('sanitizes a summary', () => {
-    const scriptHTML = '<script>alert(document.cookie);</script>';
-    const rootNode = renderAsDOMNode({
-      addon: {
-        ...fakeAddon,
-        summary: scriptHTML,
-      },
-    });
-    // Make sure an actual script tag was not created.
-    assert.equal(rootNode.querySelector('div.description script'), null);
-    // Make sure the script HTML has been escaped and removed.
-    assert.notInclude(rootNode.querySelector('div.description').textContent,
-                      scriptHTML);
-  });
-
-  it('renders a description', () => {
-    const rootNode = renderAsDOMNode();
-    assert.include(rootNode.querySelector('section.about').textContent,
-                   fakeAddon.description);
+    assert.include(rootNode.querySelector('.AddonDescription h2').textContent,
+                   'About this extension');
   });
 
   it('sanitizes bad description HTML', () => {
@@ -169,10 +142,10 @@ describe('AddonDetail', () => {
       },
     });
     // Make sure an actual script tag was not created.
-    assert.equal(rootNode.querySelector('section.about script'), null);
+    assert.equal(rootNode.querySelector('.AddonDescription script'), null);
     // Make sure the script HTML has been escaped and removed.
-    assert.notInclude(rootNode.querySelector('section.about').textContent,
-                      scriptHTML);
+    assert.notInclude(
+      rootNode.querySelector('.AddonDescription').textContent, scriptHTML);
   });
 
   it('converts new lines in the description to breaks', () => {
@@ -182,7 +155,7 @@ describe('AddonDetail', () => {
         description: '\n\n\n',
       },
     });
-    assert.equal(rootNode.querySelectorAll('section.about br').length, 3);
+    assert.lengthOf(rootNode.querySelectorAll('.AddonDescription br'), 3);
   });
 
   it('preserves certain HTML tags in the description', () => {
@@ -194,14 +167,13 @@ describe('AddonDetail', () => {
     for (const tag of allowedTags) {
       description = `${description} <${tag}>placeholder</${tag}>`;
     }
-    const rootNode = renderAsDOMNode({
-      addon: { ...fakeAddon, description },
-    });
+    const rootNode = renderAsDOMNode({ addon: { ...fakeAddon, description } });
     // eslint-disable-next-line no-restricted-syntax
     for (const tagToCheck of allowedTags) {
-      assert.equal(
-        rootNode.querySelectorAll(`section.about ${tagToCheck}`).length, 1,
-        `${tagToCheck} tag was not whitelisted`);
+      assert.lengthOf(
+        rootNode.querySelectorAll(`.AddonDescription-contents ${tagToCheck}`),
+        1, `${tagToCheck} tag was not whitelisted`
+      );
     }
   });
 
@@ -213,9 +185,23 @@ describe('AddonDetail', () => {
           '<a href="javascript:alert(document.cookie)" onclick="sneaky()">placeholder</a>',
       },
     });
-    const anchor = rootNode.querySelector('section.about a');
+    const anchor = rootNode.querySelector('.AddonDescription a');
     assert.equal(anchor.attributes.onclick, null);
     assert.equal(anchor.attributes.href, null);
+  });
+
+  it('configures the overall ratings section', () => {
+    const root = findRenderedComponentWithType(render(),
+                                               OverallRatingWithI18n);
+    assert.deepEqual(root.props.addon, fakeAddon);
+  });
+
+  it('renders a summary', () => {
+    const rootNode = renderAsDOMNode();
+    assert.include(
+      rootNode.querySelector('.AddonDetail-summary').textContent,
+      fakeAddon.summary
+    );
   });
 
   it('renders an amo CDN icon image', () => {

--- a/tests/client/amo/helpers.js
+++ b/tests/client/amo/helpers.js
@@ -16,6 +16,7 @@ export const fakeAddon = {
   description: 'This is a longer description of the chill out add-on',
   has_privacy_policy: true,
   homepage: 'http://hamsterdance.com/',
+  type: 'extension',
 };
 
 export const fakeReview = {

--- a/tests/client/ui/components/TestShowMoreCard.js
+++ b/tests/client/ui/components/TestShowMoreCard.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
+
+import { ShowMoreCardBase } from 'ui/components/ShowMoreCard';
+import { getFakeI18nInst } from 'tests/client/helpers';
+
+
+function render(props) {
+  return renderIntoDocument(
+    <ShowMoreCardBase i18n={getFakeI18nInst()} {...props} />
+  );
+}
+
+describe('<ShowMoreCard />', () => {
+  it('reveals more text when clicking "show more" link', () => {
+    const root = render({ children: 'Hello I am description' });
+    const rootNode = findDOMNode(root);
+
+    // We have to manually set the expanded flag to false because we
+    // don't have a clientHeight in the tests.
+    root.setState({ expanded: false });
+    assert.notInclude(rootNode.className, '.ShowMoreCard--expanded');
+    assert.strictEqual(root.state.expanded, false);
+
+    Simulate.click(rootNode.querySelector('.ShowMoreCard-revealMoreLink'));
+
+    assert.include(rootNode.className, 'ShowMoreCard--expanded');
+    assert.strictEqual(root.state.expanded, true);
+  });
+
+  it('renders className', () => {
+    const root = render({
+      children: <p>Hi</p>,
+      className: 'test',
+    });
+    const rootNode = findDOMNode(root);
+    assert.include(rootNode.className, 'test');
+  });
+
+  it('renders header and footer', () => {
+    const root = render({ header: 'What is up', footer: 'I am down' });
+    const rootNode = findDOMNode(root);
+    assert.equal(rootNode.querySelector('h2').textContent, 'What is up');
+    assert.equal(
+      rootNode.querySelector('.Card-footer').textContent, 'I am down');
+  });
+
+  it('renders children', () => {
+    const root = render({ children: 'Hello I am description' });
+    const rootNode = findDOMNode(root);
+    assert.include(rootNode.textContent, 'Hello I am description');
+  });
+});


### PR DESCRIPTION
Screenshot:
![ezgif com-383fe5fed6](https://cloud.githubusercontent.com/assets/90871/20819410/0702be48-b82c-11e6-8920-d37c434fe466.gif)

-----

This moves some things from the `AddonDetail` component into an `AddonDescription` component (which is nice for smaller components used to build bigger ones) so it looks like more than it actually is as I moved the tests about too.

It also shows the description in the new style and deals with truncation using size rather than text content (anything too tall is rendered with a "show more" link that just sets a new class). Stuff that is short enough just shows with no truncation.