### PR TITLE
Fix hover on ratings

### DIFF
--- a/src/amo/css/OverallRating.scss
+++ b/src/amo/css/OverallRating.scss
@@ -2,6 +2,7 @@
 .OverallRating-choices {
   display: flex;
   justify-content: center;
+  margin: 15px 0;
 }
 
 $star-size: 46px;
@@ -10,7 +11,6 @@ $star-size: 46px;
   background: url('../img/ratings/big-star.svg') center/$star-size no-repeat;
   cursor: pointer;
   height: $star-size + 10px;
-  padding-top: 80px;
   width: $star-size + 10px;
 }
 


### PR DESCRIPTION
Fixes #1399 by removing the padding and replacing with a margin to retain the whitepace now makes the height of the span the same as the buttons.