### PR TITLE
Don't show "no results" in between searches

### DIFF
--- a/src/amo/components/SearchResults.js
+++ b/src/amo/components/SearchResults.js
@@ -31,25 +31,25 @@ class SearchResults extends React.Component {
 
     let messageText;
 
-    if (hasSearchParams && loading) {
+    if (loading) {
       messageText = i18n.gettext('Searching...');
-    } else if (!loading && count === 0) {
+    } else if (count === 0 && hasSearchParams) {
       if (query) {
         messageText = i18n.sprintf(
           i18n.gettext('No results were found for "%(query)s".'), { query });
-      } else if (hasSearchParams) {
+      } else {
         // TODO: Add the extension type, if available, so it says
         // "no extensions" found that match your search or something.
         messageText = i18n.gettext('No results were found.');
-      } else {
-        messageText = i18n.gettext(
-          'Please enter a search term to search Mozilla Add-ons.');
       }
+    } else if (!hasSearchParams) {
+      messageText = i18n.gettext(
+        'Please enter a search term to search Mozilla Add-ons.');
     }
 
     return (
       <div ref={(ref) => { this.container = ref; }} className="SearchResults">
-        <AddonsCard addons={results}>
+        <AddonsCard addons={hasSearchParams ? results : null}>
           {messageText ? (
             <p ref={(ref) => { this.message = ref; }}
               className="SearchResults-message">

--- a/src/core/actions/search.js
+++ b/src/core/actions/search.js
@@ -5,10 +5,10 @@ import {
 } from 'core/constants';
 
 
-export function searchStart({ page, filters }) {
+export function searchStart({ filters, page, results }) {
   return {
     type: SEARCH_STARTED,
-    payload: { page, filters },
+    payload: { filters, page, results },
   };
 }
 

--- a/src/core/reducers/search.js
+++ b/src/core/reducers/search.js
@@ -16,21 +16,19 @@ export default function search(state = initialState, action) {
   const { payload } = action;
   switch (action.type) {
     case SEARCH_STARTED:
-      return { ...state, ...payload, count: 0, loading: true, results: [] };
+      return { ...state, ...payload, loading: true };
     case SEARCH_LOADED:
       return {
         ...state,
         count: payload.result.count,
         loading: false,
         filters: payload.filters,
-        results: payload.result.results.map((slug) => payload.entities.addons[slug]),
+        results: payload.result.results.map((slug) => (
+          payload.entities.addons[slug]
+        )),
       };
     case SEARCH_FAILED:
-      return {
-        ...initialState,
-        page: payload.page,
-        filters: payload.filters,
-      };
+      return { ...initialState, filters: payload.filters, page: payload.page };
     default:
       return state;
   }

--- a/tests/client/amo/components/TestSearchResults.js
+++ b/tests/client/amo/components/TestSearchResults.js
@@ -5,6 +5,7 @@ import {
 } from 'react-addons-test-utils';
 
 import SearchResults from 'amo/components/SearchResults';
+import { fakeAddon } from 'tests/client/amo/helpers';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
 
@@ -18,6 +19,16 @@ describe('<SearchResults />', () => {
   it('renders empty search results container', () => {
     const root = renderResults();
     assert.include(root.message.textContent, 'enter a search term');
+  });
+
+  it('renders no results if hasSearchParams is false', () => {
+    const root = renderResults({
+      hasSearchParams: false,
+      loading: false,
+      results: [fakeAddon],
+    });
+    assert.include(root.message.textContent, 'enter a search term');
+    assert.notInclude(root.container.textContent, fakeAddon.name);
   });
 
   it('renders no results when searched but nothing is found', () => {

--- a/tests/client/amo/containers/TestCategoryPage.js
+++ b/tests/client/amo/containers/TestCategoryPage.js
@@ -25,7 +25,7 @@ describe('CategoryPage.mapStateToProps()', () => {
 
   it('passes the search state if the filters and state matches', () => {
     const store = createStore();
-    store.dispatch(searchStart({ filters }));
+    store.dispatch(searchStart({ filters, results: [] }));
     const props = mapStateToProps(store.getState(), ownProps);
 
     assert.deepEqual(props, {

--- a/tests/client/amo/containers/TestSearch.js
+++ b/tests/client/amo/containers/TestSearch.js
@@ -15,6 +15,7 @@ describe('Search.mapStateToProps()', () => {
       cd: { slug: 'cd', name: 'cd-block' },
     },
     search: {
+      count: 5,
       filters: { query: 'ad-block' },
       hasSearchParams: true,
       loading: false,
@@ -23,13 +24,22 @@ describe('Search.mapStateToProps()', () => {
   };
 
   it('passes the search state if the URL and state query matches', () => {
-    const props = mapStateToProps(state, { location: { query: { q: 'ad-block' } } });
+    const props = mapStateToProps(
+      state,
+      { location: { query: { q: 'ad-block' } } }
+    );
     assert.deepEqual(props, state.search);
   });
 
-  it('does not pass search state if the URL and state query do not match', () => {
-    const props = mapStateToProps(state, { location: { query: { q: 'more-ads' } } });
-    assert.deepEqual(props, { hasSearchParams: true });
+  it('passes search state even if the URL and state query do not match', () => {
+    const props = mapStateToProps(
+      state,
+      { location: { query: { q: 'more-ads' } } }
+    );
+    assert.deepEqual(
+      props,
+      { ...state.search, filters: { query: 'more-ads' } }
+    );
   });
 });
 

--- a/tests/client/core/actions/test_search.js
+++ b/tests/client/core/actions/test_search.js
@@ -1,14 +1,16 @@
 import * as actions from 'core/actions/search';
 
 describe('SEARCH_STARTED', () => {
-  const action = actions.searchStart({ filters: { query: 'foo' }, page: 5 });
+  const action = actions.searchStart(
+    { filters: { query: 'foo' }, page: 5, results: [] });
 
   it('sets the type', () => {
     assert.equal(action.type, 'SEARCH_STARTED');
   });
 
-  it('sets the query', () => {
-    assert.deepEqual(action.payload, { filters: { query: 'foo' }, page: 5 });
+  it('sets the query and existing results', () => {
+    assert.deepEqual(action.payload,
+      { filters: { query: 'foo' }, page: 5, results: [] });
   });
 });
 

--- a/tests/client/core/reducers/test_search.js
+++ b/tests/client/core/reducers/test_search.js
@@ -27,7 +27,7 @@ describe('search reducer', () => {
         { type: 'SEARCH_STARTED', payload: { filters: { query: 'foo' } } });
       assert.deepEqual(state.filters, { query: 'foo' });
       assert.strictEqual(state.loading, true);
-      assert.deepEqual(state.results, []);
+      assert.deepEqual(state.results, [{ slug: 'bar' }]);
     });
   });
 

--- a/tests/client/core/test_searchUtils.js
+++ b/tests/client/core/test_searchUtils.js
@@ -17,7 +17,7 @@ describe('searchUtils mapStateToProps()', () => {
     // clientApp is always supplied and it's not enough to search on, so we
     // don't allow searches on it.
     const props = mapStateToProps(state, { location: { query: { } } });
-    assert.deepEqual(props, { hasSearchParams: false });
+    assert.deepEqual(props, { filters: {}, hasSearchParams: false });
   });
 });
 


### PR DESCRIPTION
Fixes #1485.

This fixes some of the wonky search result text we had in the past. It also preserves the search results on screen during the `SEARCH_STARTED` action so they stay until new results are loaded, which is less jarring.

Obvious the "searching..." text isn't great, we might UX on that in the future, but already this is better.

![dec-19-2016 11-12-44](https://cloud.githubusercontent.com/assets/90871/21310887/5169f402-c5dc-11e6-97e3-614f982cb499.gif)
