### PR TITLE
Hook up AddonReview for API error handling

### DIFF
--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -23,10 +23,6 @@ export class AddonReviewBase extends React.Component {
     updateReviewText: PropTypes.func,
   }
 
-  constructor(props) {
-    super(props);
-  }
-
   onSubmit = (event) => {
     event.preventDefault();
     const body = this.reviewTextarea.value;

--- a/src/amo/css/AddonReview.scss
+++ b/src/amo/css/AddonReview.scss
@@ -20,13 +20,6 @@
   min-height: 200px;
 }
 
-.AddonReview-error {
-  color: $error-text-color;
-  background: $error-background-color;
-  margin-bottom: 1em;
-  padding: 0.5em;
-}
-
 .AddonReview-button-row {
   margin-top: 1em;
   text-align: left;

--- a/src/core/css/ErrorHandler.scss
+++ b/src/core/css/ErrorHandler.scss
@@ -5,5 +5,6 @@
   background-color: $error-background-color;
   color: $error-text-color;
   padding: 10px;
+  margin: 0;
   margin-bottom: 10px;
 }

--- a/tests/client/amo/components/TestAddonReview.js
+++ b/tests/client/amo/components/TestAddonReview.js
@@ -22,6 +22,7 @@ const defaultReview = {
 
 function render({ ...customProps } = {}) {
   const props = {
+    errorHandler: sinon.stub(),
     i18n: getFakeI18nInst(),
     apiState: signedInApiState,
     review: defaultReview,
@@ -41,7 +42,8 @@ describe('AddonReview', () => {
   it('can update a review', () => {
     const router = { push: sinon.stub() };
     const updateReviewText = sinon.spy(() => Promise.resolve());
-    const root = render({ updateReviewText, router });
+    const errorHandler = sinon.stub();
+    const root = render({ updateReviewText, router, errorHandler });
     const event = { preventDefault: sinon.stub() };
 
     const textarea = root.reviewTextarea;
@@ -54,6 +56,7 @@ describe('AddonReview', () => {
         const params = updateReviewText.firstCall.args[0];
         assert.equal(params.body, 'some review');
         assert.equal(params.addonSlug, defaultReview.addonSlug);
+        assert.equal(params.errorHandler, errorHandler);
         assert.equal(params.reviewId, defaultReview.id);
         assert.equal(params.apiState, signedInApiState);
 
@@ -95,17 +98,6 @@ describe('AddonReview', () => {
 
     // Make sure the submit handler is hooked up.
     assert.ok(updateReviewText.called);
-  });
-
-  it('requires the review text to be non-empty', () => {
-    const root = render();
-    assert.equal(root.errorMessage, undefined);
-
-    // By default the textarea for the review is empty.
-    Simulate.submit(root.reviewForm);
-
-    assert.ok(root.errorMessage);
-    assert.equal(root.errorMessage.textContent, 'Please enter some text');
   });
 
   it('requires a review object', () => {


### PR DESCRIPTION
At first I wanted to make a global error handler (https://github.com/mozilla/addons-frontend/issues/1484) but that got hairy so I set it aside.

As a compromise, I looked through all AMO components that work with the API and added `withErrorHandling()` to make sure they display errors. I didn't look at any of the API actions that are executed via `asyncConnect` because that's not compatible with our higher order error handler component (specifically, there is no way to get the `errorHandler` property from the component props, unless I'm missing a way?). This leaves only one component: `AddonReview`. Am I forgetting anything?

Adding API error handling for it is pretty straight forward. The new behavior looks like this:

![screenshot 2016-12-19 15 07 39](https://cloud.githubusercontent.com/assets/55398/21329200/1a63257a-c5fd-11e6-9999-322acf70d29c.png)
