### PR TITLE
Screenshot viewer on add-on detail

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -68,6 +68,9 @@ const newWebpackConfig = Object.assign({}, webpackConfigProd, {
         loader: 'babel',
         query: babelQuery,
       }, {
+        test: /\.css$/,
+        loader: 'style!css?importLoaders=2!postcss?outputStyle=expanded',
+      }, {
         test: /\.scss$/,
         loader: 'style!css?importLoaders=2!postcss!sass?outputStyle=expanded',
       }, {
@@ -79,6 +82,9 @@ const newWebpackConfig = Object.assign({}, webpackConfigProd, {
       }, {
         test: /\.png$/,
         loader: 'url?limit=10000&mimetype=image/png',
+      }, {
+        test: /\.gif/,
+        loader: 'url?limit=10000&mimetype=image/gif',
       }, {
         test: /\.webm$/,
         loader: 'url?limit=10000&mimetype=video/webm',

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "react-dom": "15.4.1",
     "react-helmet": "3.2.3",
     "react-onclickoutside": "5.7.1",
+    "react-photoswipe": "^1.2.0",
     "react-redux": "5.0.1",
     "react-router": "2.8.1",
     "react-router-scroll": "0.4.1",

--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -127,14 +127,9 @@ export class AddonDetailBase extends React.Component {
           <AddonMeta />
         </section>
 
-        <hr />
-
         <section className="screenshots">
-          <h2>{i18n.gettext('Screenshots')}</h2>
-          <ScreenShots />
+          <ScreenShots previews={addon.previews} />
         </section>
-
-        <hr />
 
         <ShowMoreCard header={i18n.sprintf(
           i18n.gettext('About this %(addonType)s'), { addonType: addon.type }

--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -9,6 +9,30 @@ import 'amo/css/ScreenShots.scss';
 
 const HEIGHT = 200;
 const WIDTH = 320;
+const PHOTO_SWIPE_OPTIONS = {
+  closeEl: true,
+  captionEl: true,
+  fullscreenEl: false,
+  zoomEl: false,
+  shareEl: false,
+  counterEl: true,
+  arrowEl: true,
+  preloaderEl: true,
+};
+
+const formatPreviews = (previews) => (
+  previews.map((preview) => ({
+    src: preview.image_url,
+    thumbnail_src: preview.thumbnail_url,
+    h: HEIGHT,
+    w: WIDTH,
+    title: preview.caption,
+  }))
+);
+
+export const thumbnailContent = (item) => (
+  <img src={item.src} className="ScreenShots-image" height={HEIGHT} width={WIDTH} alt="" />
+);
 
 export default class ScreenShots extends React.Component {
   static propTypes = {
@@ -23,35 +47,14 @@ export default class ScreenShots extends React.Component {
     list.scrollLeft += offset - list.getBoundingClientRect().x;
   }
 
-  thumbnailContent = (item) => (
-    <img src={item.src} className="ScreenShots-image" height={HEIGHT} width={WIDTH} alt="" />
-  )
-
   render() {
     const { previews } = this.props;
-    const items = previews.map((preview) => ({
-      src: preview.image_url,
-      thumbnail_src: preview.thumbnail_url,
-      h: HEIGHT,
-      w: WIDTH,
-      title: preview.caption,
-    }));
-    const photoSwipeOptions = {
-      closeEl: true,
-      captionEl: true,
-      fullscreenEl: false,
-      zoomEl: false,
-      shareEl: false,
-      counterEl: true,
-      arrowEl: true,
-      preloaderEl: true,
-    };
     return (
       <div className="ScreenShots">
         <div className="ScreenShots-viewport" ref={(el) => { this.viewport = el; }}>
           <PhotoSwipeGallery
-            className="ScreenShots-list" close={this.onClose} items={items}
-            options={photoSwipeOptions} thumbnailContent={this.thumbnailContent} />
+            className="ScreenShots-list" close={this.onClose} items={formatPreviews(previews)}
+            options={PHOTO_SWIPE_OPTIONS} thumbnailContent={thumbnailContent} />
         </div>
       </div>
     );

--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -1,41 +1,59 @@
-/* eslint-disable jsx-a11y/href-no-hash */
+/* global document, requestAnimationFrame, window
+ * eslint-disable jsx-a11y/href-no-hash */
 
 import React, { PropTypes } from 'react';
-
-import translate from 'core/i18n/translate';
+import { PhotoSwipeGallery } from 'react-photoswipe';
+import 'react-photoswipe/lib/photoswipe.css';
 
 import 'amo/css/ScreenShots.scss';
 
+const HEIGHT = 200;
+const WIDTH = 320;
 
-export class ScreenShotsBase extends React.Component {
+export default class ScreenShots extends React.Component {
   static propTypes = {
-    i18n: PropTypes.object.isRequired,
+    previews: PropTypes.array.isRequired,
   }
 
-  render() {
-    const { i18n } = this.props;
-    const totalImages = 5;
+  onClose = (photoswipe) => {
+    const index = photoswipe.getCurrentIndex();
+    const list = this.viewport.querySelector('.pswp-thumbnails');
+    const currentItem = list.children[index];
+    const offset = currentItem.getBoundingClientRect().x;
+    list.scrollLeft += offset - list.getBoundingClientRect().x;
+  }
 
-    // This is just a placeholder.
+  thumbnailContent = (item) => (
+    <img src={item.src} className="ScreenShots-image" height={HEIGHT} width={WIDTH} alt="" />
+  )
+
+  render() {
+    const { previews } = this.props;
+    const items = previews.map((preview) => ({
+      src: preview.image_url,
+      thumbnail_src: preview.thumbnail_url,
+      h: HEIGHT,
+      w: WIDTH,
+      title: preview.caption,
+    }));
+    const photoSwipeOptions = {
+      closeEl: true,
+      captionEl: true,
+      fullscreenEl: false,
+      zoomEl: false,
+      shareEl: false,
+      counterEl: true,
+      arrowEl: true,
+      preloaderEl: true,
+    };
     return (
       <div className="ScreenShots">
-        <img alt="" />
-        <ol>
-          {[...Array(totalImages)].map((x, i) =>
-            (<li>
-              <a href="#" className={i + 1 === 2 ? 'active' : null}>
-                <span className="visually-hidden">
-                  {i18n.sprintf(i18n.gettext(
-                    'screenshot %(imageNumber)s of %(totalImages)s'
-                  ), { imageNumber: i + 1, totalImages })}
-                </span>
-              </a>
-            </li>)
-          )}
-        </ol>
+        <div className="ScreenShots-viewport" ref={(el) => { this.viewport = el; }}>
+          <PhotoSwipeGallery
+            className="ScreenShots-list" close={this.onClose} items={items}
+            options={photoSwipeOptions} thumbnailContent={this.thumbnailContent} />
+        </div>
       </div>
     );
   }
 }
-
-export default translate({ withRef: true })(ScreenShotsBase);

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,41 +1,45 @@
-.ScreenShots {
-  ol {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    list-style-type: none;
-    padding: 0;
-    width: 100%;
+@import "~core/css/inc/mixins";
+@import "~core/css/inc/vars";
+
+$screenshot-height: 200px;
+$screenshot-width: 320px;
+
+.ScreenShots .pswp-thumbnails {
+  line-height: 0;
+}
+
+.ScreenShots-viewport {
+  height: $screenshot-height;
+}
+
+.ScreenShots-list .pswp-thumbnails {
+  display: flex;
+  height: $screenshot-height;
+  list-style-type: none;
+  margin: 0;
+  overflow-x: scroll;
+  padding: 0;
+  width: auto;
+}
+
+.ScreenShots-list .pswp-thumbnail {
+  display: inline-block;
+  margin: 0 10px;
+
+  &:first-of-type {
+    @include margin-start(0);
   }
+}
 
-  li {
-    display: inline-block;
-  }
+.ScreenShots-image {
+  cursor: pointer;
+  display: inline-block;
+  height: $screenshot-height;
+  width: $screenshot-width;
+}
 
-  li a {
-    display: inline-block;
-    padding: 5px;
-
-    &::before {
-      background: #000;
-      border-radius: 50%;
-      content: '';
-      display: block;
-      flex-direction: row;
-      height: 12px;
-      width: 12px;
-    }
-
-    &.active::before {
-      border: 3px solid #000;
-      background: #fff;
-    }
-  }
-
-  img {
-    width: 100%;
-    padding-bottom: 75%;
-    display: block;
-    background: #eee;
-  }
+// Don't stretch the images.
+.ScreenShots-image,
+.pswp__img {
+  object-fit: contain;
 }

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -232,6 +232,16 @@ $color: $text-color-message) {
   }
 }
 
+@mixin margin-start($val) {
+  [dir=ltr] & {
+    margin-left: $val;
+  }
+
+  [dir=rtl] & {
+    margin-right: $val;
+  }
+}
+
 @mixin margin-end($val) {
   [dir=ltr] & {
     margin-right: $val;

--- a/src/core/server/webpack-isomorphic-tools-config.js
+++ b/src/core/server/webpack-isomorphic-tools-config.js
@@ -26,7 +26,7 @@ export default {
       parser: WebpackIsomorphicToolsPlugin.url_loader_parser,
     },
     style_modules: {
-      extensions: ['scss'],
+      extensions: ['css', 'scss'],
       filter: (module, regex, options, log) => {
         if (options.development) {
           // in development mode there's webpack "style-loader",

--- a/tests/client/amo/components/TestScreenShots.js
+++ b/tests/client/amo/components/TestScreenShots.js
@@ -2,11 +2,10 @@ import React from 'react';
 import { renderIntoDocument } from 'react-addons-test-utils';
 import { PhotoSwipeGallery } from 'react-photoswipe';
 
-import ScreenShots from 'amo/components/ScreenShots';
+import ScreenShots, { thumbnailContent } from 'amo/components/ScreenShots';
 import { shallowRender } from 'tests/client/helpers';
 
 describe('<ScreenShots />', () => {
-  const onePxImg = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
   const previews = [
     {
       caption: 'A screenshot',
@@ -41,12 +40,12 @@ describe('<ScreenShots />', () => {
     const gallery = root.props.children.props.children;
     assert.equal(gallery.type, PhotoSwipeGallery);
     assert.deepEqual(gallery.props.items, items);
+    assert.deepEqual(gallery.props.thumbnailContent, thumbnailContent);
   });
 
-  it('sets renders thumbnails', () => {
-    const root = renderIntoDocument(<ScreenShots previews={[]} />);
+  it('renders custom thumbnail', () => {
     const item = { src: 'https://foo.com/img.png' };
-    const thumbnail = root.thumbnailContent(item);
+    const thumbnail = thumbnailContent(item);
     assert.equal(thumbnail.type, 'img');
     assert.equal(thumbnail.props.src, 'https://foo.com/img.png');
     assert.equal(thumbnail.props.height, '200');
@@ -55,7 +54,8 @@ describe('<ScreenShots />', () => {
   });
 
   it('scrolls to the active item on close', () => {
-    const newPreviews = previews.map((preview) => ({ ...preview, image_url: onePxImg }));
+    const onePixelImage = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
+    const newPreviews = previews.map((preview) => ({ ...preview, image_url: onePixelImage }));
     const root = renderIntoDocument(<ScreenShots previews={newPreviews} />);
     const item = { getBoundingClientRect: () => ({ x: 500 }) };
     const list = {

--- a/tests/client/amo/components/TestScreenShots.js
+++ b/tests/client/amo/components/TestScreenShots.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
+import { PhotoSwipeGallery } from 'react-photoswipe';
+
+import ScreenShots from 'amo/components/ScreenShots';
+import { shallowRender } from 'tests/client/helpers';
+
+describe('<ScreenShots />', () => {
+  const onePxImg = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
+  const previews = [
+    {
+      caption: 'A screenshot',
+      image_url: 'http://img.com/one',
+      thumbnail_url: 'http://img.com/1',
+    },
+    {
+      caption: 'Another screenshot',
+      image_url: 'http://img.com/two',
+      thumbnail_url: 'http://img.com/2',
+    },
+  ];
+
+  it('renders the previews', () => {
+    const items = [
+      {
+        title: 'A screenshot',
+        src: 'http://img.com/one',
+        thumbnail_src: 'http://img.com/1',
+        h: 200,
+        w: 320,
+      },
+      {
+        title: 'Another screenshot',
+        src: 'http://img.com/two',
+        thumbnail_src: 'http://img.com/2',
+        h: 200,
+        w: 320,
+      },
+    ];
+    const root = shallowRender(<ScreenShots previews={previews} />);
+    const gallery = root.props.children.props.children;
+    assert.equal(gallery.type, PhotoSwipeGallery);
+    assert.deepEqual(gallery.props.items, items);
+  });
+
+  it('sets renders thumbnails', () => {
+    const root = renderIntoDocument(<ScreenShots previews={[]} />);
+    const item = { src: 'https://foo.com/img.png' };
+    const thumbnail = root.thumbnailContent(item);
+    assert.equal(thumbnail.type, 'img');
+    assert.equal(thumbnail.props.src, 'https://foo.com/img.png');
+    assert.equal(thumbnail.props.height, '200');
+    assert.equal(thumbnail.props.width, '320');
+    assert.equal(thumbnail.props.alt, '');
+  });
+
+  it('scrolls to the active item on close', () => {
+    const newPreviews = previews.map((preview) => ({ ...preview, image_url: onePxImg }));
+    const root = renderIntoDocument(<ScreenShots previews={newPreviews} />);
+    const item = { getBoundingClientRect: () => ({ x: 500 }) };
+    const list = {
+      children: [null, item],
+      getBoundingClientRect: () => ({ x: 55 }),
+      scrollLeft: 0,
+    };
+    sinon.stub(root.viewport, 'querySelector').returns(list);
+    const photoswipe = { getCurrentIndex: () => 1 };
+    root.onClose(photoswipe);
+    // 0 += 500 - 55
+    assert.equal(list.scrollLeft, 445);
+  });
+});

--- a/tests/client/amo/helpers.js
+++ b/tests/client/amo/helpers.js
@@ -12,6 +12,7 @@ export const fakeAddon = {
     license: { name: 'tofulicense', url: 'http://license.com/' },
     version: '2.0.0',
   },
+  previews: [],
   summary: 'This is a summary of the chill out add-on',
   description: 'This is a longer description of the chill out add-on',
   has_privacy_policy: true,

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -71,6 +71,9 @@ export default Object.assign({}, webpackConfig, {
         loader: 'babel',
         query: BABEL_QUERY,
       }, {
+        test: /\.css$/,
+        loader: 'style!css?importLoaders=2!postcss?outputStyle=expanded',
+      }, {
         test: /\.scss$/,
         loader: 'style!css?importLoaders=2!postcss!sass?outputStyle=expanded',
       }, {
@@ -82,6 +85,9 @@ export default Object.assign({}, webpackConfig, {
       }, {
         test: /\.png$/,
         loader: 'url?limit=10000&mimetype=image/png',
+      }, {
+        test: /\.gif/,
+        loader: 'url?limit=10000&mimetype=image/gif',
       }, {
         test: /\.webm$/,
         loader: 'url?limit=10000&mimetype=video/webm',

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -42,6 +42,9 @@ const settings = {
         exclude: /node_modules/,
         loader: 'babel',
       }, {
+        test: /\.css$/,
+        loader: ExtractTextPlugin.extract('style', 'css?importLoaders=2&sourceMap!postcss?outputStyle=expanded&sourceMap=true&sourceMapContents=true'),
+      }, {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract('style', 'css?importLoaders=2&sourceMap!postcss!sass?outputStyle=expanded&sourceMap=true&sourceMapContents=true'),
       }, {
@@ -53,6 +56,9 @@ const settings = {
       }, {
         test: /\.png$/,
         loader: 'url?limit=10000&mimetype=image/png',
+      }, {
+        test: /\.gif/,
+        loader: 'url?limit=10000&mimetype=image/gif',
       }, {
         test: /\.webm$/,
         loader: 'url?limit=10000&mimetype=video/webm',
@@ -110,8 +116,9 @@ const settings = {
     },
     root: [
       path.resolve(__dirname),
+      path.resolve('./src'),
     ],
-    modulesDirectories: ['node_modules', 'src'],
+    modulesDirectories: ['node_modules'],
     extensions: ['', '.js', '.jsx'],
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,7 +1337,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@2.2.5:
+classnames@2.2.5, classnames@^2.2.3:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -4509,6 +4509,10 @@ pbkdf2-compat@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288"
 
+photoswipe@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/photoswipe/-/photoswipe-4.1.1.tgz#41b756a2387e220c286598945503014bf622bba9"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -5056,6 +5060,14 @@ react-onclickoutside@5.7.1:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-5.7.1.tgz#30c2c124a6423ba4b321f3f5ce06e2a61f27257b"
   dependencies:
     object-assign "^4.0.1"
+
+react-photoswipe@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-photoswipe/-/react-photoswipe-1.2.0.tgz#e296e1150ed153bb2ddbc7222165291c13fe4e8c"
+  dependencies:
+    classnames "^2.2.3"
+    lodash.pick "^4.2.1"
+    photoswipe "^4.1.0"
 
 react-proxy@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Going to look through this diff one more time later tonight but wanted to get the PR up.

![screenshots-portrait mov](https://cloud.githubusercontent.com/assets/211578/21334278/b0670a0a-c61b-11e6-861d-b83b6a611f7f.gif)

![screenshots-landscape mov](https://cloud.githubusercontent.com/assets/211578/21334305/e8d79d64-c61b-11e6-9586-d429e487af5a.gif)


Fixes #936.