### PR TITLE
fix: Use convertFiltersToQueryParams on LandingPage

### DIFF
--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -3,6 +3,7 @@ import React, { PropTypes } from 'react';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
+import { convertFiltersToQueryParams } from 'core/searchUtils';
 
 import './LandingAddonsCard.scss';
 
@@ -18,8 +19,12 @@ export default class LandingAddonsCard extends React.Component {
 
   render() {
     const { addons, className, footerLink, footerText, header } = this.props;
+    const linkSearchURL = {
+      ...footerLink,
+      query: convertFiltersToQueryParams(footerLink.query),
+    };
     const footer = (
-      <Link className="LandingAddonsCard-more-link" to={footerLink}>
+      <Link className="LandingAddonsCard-more-link" to={linkSearchURL}>
         {footerText}
       </Link>
     );

--- a/src/amo/components/LandingPage.js
+++ b/src/amo/components/LandingPage.js
@@ -28,7 +28,10 @@ export class LandingPageBase extends React.Component {
         featuredHeader: i18n.gettext('Featured extensions'),
         // TODO: Add this search/route, see:
         // https://github.com/mozilla/addons-frontend/issues/1535
-        featuredFooterLink: '#/extensions/featured',
+        featuredFooterLink: {
+          pathname: '#/extensions/featured',
+          query: { addonType: 'theme' },
+        },
         featuredFooterText: i18n.gettext('More featured extensions'),
         popularHeader: i18n.gettext('Most popular extensions'),
         popularFooterLink: {
@@ -47,7 +50,10 @@ export class LandingPageBase extends React.Component {
         featuredHeader: i18n.gettext('Featured themes'),
         // TODO: Add this search/route, see:
         // https://github.com/mozilla/addons-frontend/issues/1535
-        featuredFooterLink: '#/themes/featured',
+        featuredFooterLink: {
+          pathname: '#/themes/featured',
+          query: { addonType: 'theme' },
+        },
         featuredFooterText: i18n.gettext('More featured themes'),
         popularHeader: i18n.gettext('Most popular themes'),
         popularFooterLink: {


### PR DESCRIPTION
fix #1542.

I should have been using `convertFilterstoQueryParams` here and wasn't, so the extension type wasn't being passed to search.