### PR TITLE
Add search sort

### DIFF
--- a/src/amo/components/SearchPage.js
+++ b/src/amo/components/SearchPage.js
@@ -3,6 +3,7 @@ import React, { PropTypes } from 'react';
 import Link from 'amo/components/Link';
 import Paginate from 'core/components/Paginate';
 import SearchResults from 'amo/components/SearchResults';
+import SearchSort from 'amo/components/SearchSort';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 
 import SearchResult from './SearchResult';
@@ -29,6 +30,7 @@ export default class SearchPage extends React.Component {
     ResultComponent: SearchResult,
     filters: {},
     pathname: '/search/',
+    results: [],
   }
 
   render() {
@@ -42,12 +44,16 @@ export default class SearchPage extends React.Component {
       <Paginate LinkComponent={LinkComponent} count={count} currentPage={page}
         pathname={pathname} queryParams={queryParams} showPages={0} />
     ) : [];
+    const searchSort = hasSearchParams && results.length ? (
+      <SearchSort filters={filters} pathname={pathname} />
+    ) : null;
 
     return (
       <div className="SearchPage">
+        {searchSort}
         <SearchResults ResultComponent={ResultComponent} count={count}
           hasSearchParams={hasSearchParams} loading={loading} results={results}
-          filters={filters} />
+          filters={filters} pathname={pathname} />
         {paginator}
       </div>
     );

--- a/src/amo/components/SearchSort/SearchSort.scss
+++ b/src/amo/components/SearchSort/SearchSort.scss
@@ -1,0 +1,82 @@
+@import '~core/css/inc/mixins';
+@import '~core/css/inc/vars';
+
+@mixin arrow-link-right-aligned() {
+  background-image: url('~amo/img/icons/arrow-link-color.svg');
+  margin-right: 0;
+  position: absolute;
+  right: 8px;
+  top: 14px;
+}
+
+.SearchSort {
+  background: $base-color;
+  border-radius: $border-radius-default;
+  border: 0;
+  margin: 0 ($padding-page * 2) $padding-page;
+  overflow: hidden;
+}
+
+.SearchSort-toggle {
+  @include button($background: $base-color, $color: $link-color);
+
+  // We do this so the button doesn't have weird edges on hover when the
+  // sort options are expanded.
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  box-sizing: border-box;
+  display: block;
+  font-size: $font-size-s;
+  font-variant: small-caps;
+  font-weight: normal;
+  line-height: 2;
+  margin: 0;
+  min-width: 40%;
+  position: relative;
+  text-align: center;
+
+  &::before {
+    background: url('~amo/img/icons/sort.svg') 50% 50% no-repeat;
+    background-size: cover;
+    content: '';
+    display: inline-block;
+    height: 16px;
+    left: -8px;
+    position: relative;
+    top: 4px;
+    width: 16px;
+  }
+
+  &::after {
+    @include arrow-down();
+    @include arrow-link-right-aligned();
+
+    .SearchSort--visible & {
+      @include arrow-up();
+      @include arrow-link-right-aligned();
+    }
+  }
+
+  &:focus {
+    background: transparentize($link-color, 0.8);
+    box-shadow: none;
+  }
+}
+
+.SearchSort-list {
+  display: none;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+  flex-flow: row;
+  flex-wrap: wrap;
+
+  .SearchSort--visible & {
+    display: flex;
+  }
+}
+
+.SearchSort-list-item {
+  display: flex;
+  width: 50%;
+}

--- a/src/amo/components/SearchSort/SearchSortLink.js
+++ b/src/amo/components/SearchSort/SearchSortLink.js
@@ -1,0 +1,36 @@
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+
+import { makeQueryString } from 'core/api';
+import { convertFiltersToQueryParams } from 'core/searchUtils';
+import Link from 'amo/components/Link';
+
+import './SearchSortLink.scss';
+
+
+export function queryString(filters) {
+  return makeQueryString(convertFiltersToQueryParams(filters));
+}
+
+export default class SearchSortLink extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    currentSort: PropTypes.string.isRequired,
+    filters: PropTypes.object.isRequired,
+    pathname: PropTypes.string.isRequired,
+    sort: PropTypes.string.isRequired,
+  }
+
+  render() {
+    const { children, currentSort, filters, pathname, sort } = this.props;
+    const sortURL = `/${pathname}/${queryString({ ...filters, sort })}`;
+
+    return (
+      <Link to={sortURL} className={classNames('SearchSortLink', {
+        'SearchSortLink--active': currentSort === sort,
+      })}>
+        {children}
+      </Link>
+    );
+  }
+}

--- a/src/amo/components/SearchSort/SearchSortLink.scss
+++ b/src/amo/components/SearchSort/SearchSortLink.scss
@@ -1,0 +1,32 @@
+@import '~core/css/inc/mixins';
+@import '~core/css/inc/vars';
+
+.SearchSortLink {
+  @include button($background: $base-color, $color: $link-color);
+
+  border-radius: 0;
+  font-size: $font-size-default;
+  flex-grow: 1;
+  padding: 6px 0;
+  text-align: center;
+
+  &:focus {
+    background: transparentize($link-color, 0.8);
+    box-shadow: none;
+  }
+}
+
+.SearchSortLink--active,
+.SearchSortLink--active:link {
+  @include button($background: $link-color, $color: $base-color);
+
+  border-radius: 0;
+  color: $base-color;
+  font-size: $font-size-default;
+  padding: 6px 0;
+
+  &:focus {
+    background: transparentize($link-color, 0.2);
+    box-shadow: none;
+  }
+}

--- a/src/amo/components/SearchSort/index.js
+++ b/src/amo/components/SearchSort/index.js
@@ -1,0 +1,85 @@
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+import { compose } from 'redux';
+
+import SearchSortLink from 'amo/components/SearchSort/SearchSortLink';
+import translate from 'core/i18n/translate';
+
+import './SearchSort.scss';
+
+
+const DEFAULT_SORT = 'relevance';
+
+export class SearchSortBase extends React.Component {
+  static propTypes = {
+    filters: PropTypes.object.isRequired,
+    i18n: PropTypes.object.isRequired,
+    pathname: PropTypes.string.isRequired,
+  }
+
+  state = { sortVisible: false };
+
+  onClick = (event) => {
+    event.preventDefault();
+    // Blur the search sort toggle if we're closing it, but only if
+    // we've clicked on it; if the link was keyboard activated we don't want
+    // to mess with focus, see:
+    // https://github.com/mozilla/addons-frontend/pull/1544#discussion_r96052790
+    this.toggleSort({ allowBlur: true });
+  }
+
+  onKeyPress = (event) => {
+    event.preventDefault();
+    this.toggleSort();
+  }
+
+  sortOptions() {
+    const { i18n } = this.props;
+
+    return [
+      { sort: 'updated', text: i18n.gettext('Recently Updated') },
+      { sort: 'relevance', text: i18n.gettext('Relevance') },
+      { sort: 'users', text: i18n.gettext('Most Users') },
+      { sort: 'rating', text: i18n.gettext('Top Rated') },
+    ];
+  }
+
+  toggleSort({ allowBlur = false } = {}) {
+    if (allowBlur === true && this.state.sortVisible) {
+      this.searchToggle.blur();
+    }
+    this.setState({ sortVisible: !this.state.sortVisible });
+  }
+
+  render() {
+    const { filters, i18n, pathname } = this.props;
+    const { sortVisible } = this.state;
+    const currentSort = filters.sort || DEFAULT_SORT;
+
+    return (
+      <div className={classNames('SearchSort', {
+        'SearchSort--visible': sortVisible,
+      })}>
+        <a className="SearchSort-toggle" href="#SearchSortOptions"
+          onClick={this.onClick} onKeyPress={this.onKeyPress}
+          ref={(ref) => { this.searchToggle = ref; }}>
+          {i18n.gettext('Sort')}
+        </a>
+        <ul id="SearchSortOptions" className="SearchSort-list">
+          {this.sortOptions().map((option) => (
+            <li className="SearchSort-list-item">
+              <SearchSortLink currentSort={currentSort} filters={filters}
+                pathname={pathname} sort={option.sort}>
+                {option.text}
+              </SearchSortLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+}
+
+export default compose(
+  translate({ withRef: true }),
+)(SearchSortBase);

--- a/src/amo/img/icons/arrow-link-color.svg
+++ b/src/amo/img/icons/arrow-link-color.svg
@@ -1,0 +1,6 @@
+<svg width="11px" height="15px" viewBox="114 5 32 44" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 40.3 (33839) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <polygon id="Shape-Copy-26" stroke="#0568ba" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" points="117 45 117 9 142.714286 27"></polygon>
+</svg>

--- a/src/amo/img/icons/sort.svg
+++ b/src/amo/img/icons/sort.svg
@@ -1,0 +1,12 @@
+
+<svg width="62px" height="56px" viewBox="344 36 62 56" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Group-4" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(347.000000, 39.000000)" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M0,0 L55.1724138,0" id="Shape" stroke="#0675D3" stroke-width="6"></path>
+        <path d="M7.35632184,14.7126437 L47.816092,14.7126437" id="Shape" stroke="#0675D3" stroke-width="6"></path>
+        <path d="M14.7126437,29.4252874 L40.4597701,29.4252874" id="Shape" stroke="#0675D3" stroke-width="6"></path>
+        <path d="M22.0689655,44.137931 L33.1034483,44.137931" id="Shape" stroke="#0675D3" stroke-width="6"></path>
+    </g>
+</svg>

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -17,7 +17,7 @@ export const addon = new Entity('addons', {}, { idAttribute: 'slug' });
 export const category = new Entity('categories', {}, { idAttribute: 'slug' });
 export const user = new Entity('users', {}, { idAttribute: 'username' });
 
-function makeQueryString(query) {
+export function makeQueryString(query) {
   return url.format({ query });
 }
 

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -93,7 +93,14 @@ $default-arrow-margin: 3px;
   }
 }
 
-// Just an alias to make it easier to differentiate when both mixins are used
+@mixin arrow-down($margin: $default-arrow-margin) {
+  @include arrow($margin);
+
+  transform: rotate(90deg);
+}
+
+// This alias to arrow (which is the same as arrow-next) makes it easier to
+// differentiate two arrows when both arrow-next and arrow-previous are used
 // near each other.
 @mixin arrow-next($margin: $default-arrow-margin) {
   @include arrow($margin);
@@ -115,6 +122,12 @@ $default-arrow-margin: 3px;
     right: -$margin;
     transform: none;
   }
+}
+
+@mixin arrow-up($margin: $default-arrow-margin) {
+  @include arrow($margin);
+
+  transform: rotate(270deg);
 }
 
 /* Button */

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -32,8 +32,12 @@ export class ShowMoreCardBase extends React.Component {
     this.truncateToMaxHeight(ReactDOM.findDOMNode(this.contents));
   }
 
-  expandText = (event) => {
+  onClick = (event) => {
     event.preventDefault();
+    this.expandText();
+  }
+
+  expandText() {
     this.setState({ expanded: true });
   }
 
@@ -58,7 +62,7 @@ export class ShowMoreCardBase extends React.Component {
           {children}
         </div>
         <a className="ShowMoreCard-revealMoreLink" href="#show-more"
-          onClick={this.expandText} dangerouslySetInnerHTML={sanitizeHTML(
+          onClick={this.onClick} dangerouslySetInnerHTML={sanitizeHTML(
             i18n.gettext(
               // l10n: The "Expand to" text is for screenreaders so the link
               // makes sense out of context. The HTML makes it hidden from

--- a/tests/client/amo/components/TestSearchPage.js
+++ b/tests/client/amo/components/TestSearchPage.js
@@ -3,6 +3,7 @@ import React from 'react';
 import SearchPage from 'amo/components/SearchPage';
 import SearchResult from 'amo/components/SearchResult';
 import SearchResults from 'amo/components/SearchResults';
+import SearchSort from 'amo/components/SearchSort';
 import Paginate from 'core/components/Paginate';
 import { findAllByTag, findByTag, shallowRender } from 'tests/client/helpers';
 
@@ -16,30 +17,39 @@ describe('<SearchPage />', () => {
 
   beforeEach(() => {
     props = {
+      ResultComponent: SearchResult,
       count: 80,
       filters: { query: 'foo' },
       hasSearchParams: true,
       page: 3,
+      pathname: '/search/',
       handleSearch: sinon.spy(),
       loading: false,
       results: [{ name: 'Foo', slug: 'foo' }, { name: 'Bar', slug: 'bar' }],
-      ResultComponent: SearchResult,
     };
   });
 
   it('renders the results', () => {
     const root = render();
     const results = findByTag(root, SearchResults);
+    assert.strictEqual(results.props.ResultComponent, props.ResultComponent);
     assert.strictEqual(results.props.count, props.count);
     assert.strictEqual(results.props.results, props.results);
     assert.strictEqual(results.props.hasSearchParams, props.hasSearchParams);
     assert.strictEqual(results.props.filters, props.filters);
     assert.strictEqual(results.props.loading, props.loading);
-    assert.strictEqual(results.props.ResultComponent, props.ResultComponent);
+    assert.strictEqual(results.props.pathname, props.pathname);
     assert.deepEqual(
       Object.keys(results.props).sort(),
-      ['count', 'filters', 'hasSearchParams', 'loading', 'results',
-        'ResultComponent'].sort()
+      [
+        'ResultComponent',
+        'count',
+        'filters',
+        'hasSearchParams',
+        'loading',
+        'pathname',
+        'results',
+      ].sort()
     );
   });
 
@@ -56,5 +66,22 @@ describe('<SearchPage />', () => {
     const root = render({ filters: { query: null }, count: 0 });
     const paginators = findAllByTag(root, Paginate);
     assert.deepEqual(paginators, []);
+  });
+
+  it('does render a SearchSort when there are filters and results', () => {
+    const root = render();
+    const sort = findByTag(root, SearchSort);
+    assert.equal(sort.props.filters, props.filters);
+    assert.equal(sort.props.pathname, props.pathname);
+  });
+
+  it('does not render a SearchSort when there are no filters', () => {
+    const root = render({ hasSearchParams: false, results: [] });
+    assert.throws(() => findByTag(root, SearchSort), 'child is null');
+  });
+
+  it('does not render a SearchSort when there are no results', () => {
+    const root = render({ hasSearchParams: true, results: [] });
+    assert.throws(() => findByTag(root, SearchSort), 'child is null');
   });
 });

--- a/tests/client/amo/components/TestSearchResults.js
+++ b/tests/client/amo/components/TestSearchResults.js
@@ -3,16 +3,25 @@ import {
   renderIntoDocument as render,
   findRenderedComponentWithType,
 } from 'react-addons-test-utils';
+import { Provider } from 'react-redux';
 
+import createStore from 'amo/store';
 import SearchResults from 'amo/components/SearchResults';
+import I18nProvider from 'core/i18n/Provider';
 import { fakeAddon } from 'tests/client/amo/helpers';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('<SearchResults />', () => {
   function renderResults(props) {
+    const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
+
     return findRenderedComponentWithType(render(
-      <SearchResults i18n={getFakeI18nInst()} {...props} />
+      <Provider store={createStore(initialState)}>
+        <I18nProvider i18n={getFakeI18nInst()}>
+          <SearchResults {...props} />
+        </I18nProvider>
+      </Provider>
     ), SearchResults).getWrappedInstance();
   }
 

--- a/tests/client/amo/components/TestSearchSort.js
+++ b/tests/client/amo/components/TestSearchSort.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import {
+  Simulate,
+  findRenderedComponentWithType,
+  renderIntoDocument,
+} from 'react-addons-test-utils';
+import { Provider } from 'react-redux';
+
+import createStore from 'amo/store';
+import I18nProvider from 'core/i18n/Provider';
+import SearchSort from 'amo/components/SearchSort';
+import { getFakeI18nInst } from 'tests/client/helpers';
+
+
+function render(props) {
+  const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
+
+  return findRenderedComponentWithType(renderIntoDocument(
+    <Provider store={createStore(initialState)}>
+      <I18nProvider i18n={getFakeI18nInst()}>
+        <SearchSort {...props} />
+      </I18nProvider>
+    </Provider>
+  ), SearchSort).getWrappedInstance();
+}
+
+describe('<SearchSortBase />', () => {
+  it('toggles the search sort options when clicking "sort" link', () => {
+    const root = render({ filters: { query: 'test' }, pathname: '/search/' });
+    const rootNode = findDOMNode(root);
+
+    assert.notInclude(rootNode.className, 'SearchSort--visible');
+
+    Simulate.click(root.searchToggle);
+
+    assert.include(rootNode.className, 'SearchSort--visible');
+  });
+
+  it('blurs the toggle when closing the sort options with a click/tap', () => {
+    const root = render({ filters: { query: 'test' }, pathname: '/search/' });
+    const blurSpy = sinon.spy(root.searchToggle, 'blur');
+
+    // Open the sort options.
+    Simulate.click(root.searchToggle);
+    assert.ok(blurSpy.notCalled);
+
+    // Close the sort options, which should blur the toggle link.
+    Simulate.click(root.searchToggle);
+    assert.ok(blurSpy.calledOnce);
+  });
+
+  it('does not alter keyboard focus when keypress closes the sorter', () => {
+    const root = render({ filters: { query: 'test' }, pathname: '/search/' });
+    const blurSpy = sinon.spy(root.searchToggle, 'blur');
+
+    // Open the sort options.
+    Simulate.keyPress(root.searchToggle);
+
+    // Close the sort options, which should not blur the toggle link as it's
+    // done with the keyboard and not a click/tap.
+    Simulate.keyPress(root.searchToggle);
+    assert.ok(blurSpy.notCalled);
+  });
+});


### PR DESCRIPTION
Fixes #1297.

Right now we're using "relevance" from the mocks as the default but I'm not sure that's exactly what the default search from the API actually is. http://addons-server.readthedocs.io/en/latest/topics/api/addons.html#search says "sorted by weekly downloads" is the default, so perhaps we need to add a "relevance" sort option (which should be the default).

cc @diox: should I file a bug for addons-server to get "relevance" as a sort option? Or is calling the default sort "relevance" appropriate enough here?

## Screenshots:
<img width="319" alt="screenshot 2016-12-30 15 42 15" src="https://cloud.githubusercontent.com/assets/90871/21567760/92eea184-cea6-11e6-99e2-05da371c1c9e.png">
<img width="317" alt="screenshot 2016-12-30 15 42 11" src="https://cloud.githubusercontent.com/assets/90871/21567761/92efb196-cea6-11e6-819a-49df10c5d91b.png">

## Video:
![dec-30-2016 15-41-35](https://cloud.githubusercontent.com/assets/90871/21567751/7e87a006-cea6-11e6-8ea3-8a531e394a13.gif)
(Note: is keyboard accessible)