### PR TITLE
Add overlay and card overlay components

### DIFF
--- a/src/ui/components/Overlay/Overlay.scss
+++ b/src/ui/components/Overlay/Overlay.scss
@@ -21,3 +21,15 @@
   width: 100%;
   z-index: 1000;
 }
+
+.Overlay-contents {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 50%;
+  transform: translate(0, -50%);
+  width: 100%;
+  z-index: 1001;
+}

--- a/src/ui/components/Overlay/Overlay.scss
+++ b/src/ui/components/Overlay/Overlay.scss
@@ -1,0 +1,23 @@
+@import "~core/css/inc/vars";
+
+.Overlay {
+  display: none;
+}
+
+.Overlay--visible {
+  display: block;
+}
+
+.Overlay-background {
+  background: transparentize($link-color, 0.1);
+  // This only works in WebKit right now, but it will look nice.
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1178765
+  // http://caniuse.com/#feat=css-backdrop-filter
+  backdrop-filter: blur(2px);
+  height: 100%;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+}

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -1,0 +1,51 @@
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+
+import './Overlay.scss';
+
+
+export default class Overlay extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    visibleOnLoad: PropTypes.bool.isRequired,
+  }
+
+  static defaultProps = {
+    visibleOnLoad: false,
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = { visible: props.visibleOnLoad };
+  }
+
+  hide() {
+    this.setState({ visible: false });
+  }
+
+  show() {
+    this.setState({ visible: true });
+  }
+
+  toggle() {
+    this.setState({ visible: !this.state.visible });
+  }
+
+  render() {
+    const { children, className } = this.props;
+
+    return (
+      <div className={classNames('Overlay', className, {
+        'Overlay--visible': this.state.visible,
+      })} ref={(ref) => { this.overlayContainer = ref; }}>
+        <div className="Overlay-background"
+          ref={(ref) => { this.overlayBackground = ref; }} />
+        <div className="Overlay-contents"
+          ref={(ref) => { this.overlayContents = ref; }}>
+          {children}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/ui/components/OverlayCard/OverlayCard.scss
+++ b/src/ui/components/OverlayCard/OverlayCard.scss
@@ -1,0 +1,11 @@
+@import "~core/css/inc/vars";
+
+.OverlayCard {
+  margin: 0 $padding-page;
+  width: 100%;
+
+  .Card-contents {
+    max-height: 75vh;
+    overflow: scroll;
+  }
+}

--- a/src/ui/components/OverlayCard/index.js
+++ b/src/ui/components/OverlayCard/index.js
@@ -1,0 +1,48 @@
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+
+import Card from 'ui/components/Card';
+import Overlay from 'ui/components/Overlay';
+
+import './OverlayCard.scss';
+
+
+export default class OverlayCard extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    header: PropTypes.node,
+    footer: PropTypes.node,
+    visibleOnLoad: PropTypes.bool.isRequired,
+  }
+
+  static defaultProps = {
+    visibleOnLoad: false,
+  }
+
+  hide() {
+    this.overlay.hide();
+  }
+
+  show() {
+    this.overlay.show();
+  }
+
+  toggle() {
+    this.overlay.toggle();
+  }
+
+  render() {
+    const { children, className, header, footer, visibleOnLoad } = this.props;
+
+    return (
+      <Overlay visibleOnLoad={visibleOnLoad}
+        ref={(ref) => { this.overlay = ref; }}>
+        <Card className={classNames('OverlayCard', className)} header={header}
+          footer={footer} ref={(ref) => { this.overlayCard = ref; }}>
+          {children}
+        </Card>
+      </Overlay>
+    );
+  }
+}

--- a/tests/client/ui/components/TestOverlay.js
+++ b/tests/client/ui/components/TestOverlay.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
+
+import Overlay from 'ui/components/Overlay';
+
+
+describe('<Overlay />', () => {
+  function render(props = {}) {
+    return renderIntoDocument(<Overlay {...props} />);
+  }
+
+  it('renders an Overlay', () => {
+    const root = render();
+    assert(root.overlayContainer);
+    assert(root.overlayBackground);
+    assert.equal(root.overlayContainer.tagName, 'DIV');
+    assert.include(root.overlayContainer.className, 'Overlay');
+  });
+
+  it('renders extra className if provided', () => {
+    const root = render({ className: 'I-am-so-over-it' });
+    assert.include(root.overlayContainer.className, 'Overlay');
+    assert.include(root.overlayContainer.className, 'I-am-so-over-it');
+  });
+
+  it('renders children', () => {
+    const root = render({ children: 'hello' });
+    assert(root.overlayContents);
+    assert.include(root.overlayContents.textContent, 'hello');
+  });
+
+  it('is hidden by default', () => {
+    const root = render();
+    assert.notInclude(root.overlayContainer.className, 'Overlay--visible');
+  });
+
+  it('is visible when the `visibleOnLoad` prop is passed', () => {
+    const root = render({ visibleOnLoad: true });
+    assert.include(root.overlayContainer.className, 'Overlay--visible');
+  });
+
+  it('is shown and hidden when `hide()` and `show()` are called', () => {
+    const root = render();
+
+    root.show();
+    assert.include(root.overlayContainer.className, 'Overlay--visible');
+
+    root.hide();
+    assert.notInclude(root.overlayContainer.className, 'Overlay--visible');
+  });
+
+  it('is toggled', () => {
+    const root = render();
+
+    root.toggle();
+    assert.include(root.overlayContainer.className, 'Overlay--visible');
+
+    root.toggle();
+    assert.notInclude(root.overlayContainer.className, 'Overlay--visible');
+  });
+});

--- a/tests/client/ui/components/TestOverlayCard.js
+++ b/tests/client/ui/components/TestOverlayCard.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
+
+import OverlayCard from 'ui/components/OverlayCard';
+
+
+describe('<OverlayCard />', () => {
+  function render(props = {}) {
+    return renderIntoDocument(<OverlayCard {...props} />);
+  }
+
+  it('renders an OverlayCard', () => {
+    const root = render();
+    assert(root.overlayCard);
+  });
+
+  it('passes the header', () => {
+    const root = render({ header: 'header' });
+    const rootNode = findDOMNode(root);
+
+    assert.include(
+      rootNode.querySelector('.Card-header').textContent, 'header');
+  });
+
+  it('passes the footer', () => {
+    const root = render({ footer: 'footer' });
+    const rootNode = findDOMNode(root);
+
+    assert.include(
+      rootNode.querySelector('.Card-footer').textContent, 'footer');
+  });
+
+  it('passes children', () => {
+    const root = render({ children: <div className="kids">hi</div> });
+    const rootNode = findDOMNode(root);
+
+    assert.include(
+      rootNode.querySelector('.kids').textContent, 'hi');
+  });
+
+  it('is hidden by default', () => {
+    const root = render();
+    assert.notInclude(
+      root.overlay.overlayContainer.className, 'Overlay--visible');
+  });
+
+  it('is visible when the `visibleOnLoad` prop is passed', () => {
+    const root = render({ visibleOnLoad: true });
+    assert.include(root.overlay.overlayContainer.className, 'Overlay--visible');
+  });
+
+  it('is shown and hidden when `hide()` and `show()` are called', () => {
+    const root = render();
+
+    root.show();
+    assert.include(root.overlay.overlayContainer.className, 'Overlay--visible');
+
+    root.hide();
+    assert.notInclude(
+      root.overlay.overlayContainer.className, 'Overlay--visible');
+  });
+
+  it('is toggled', () => {
+    const root = render();
+
+    root.toggle();
+    assert.include(root.overlay.overlayContainer.className, 'Overlay--visible');
+
+    root.toggle();
+    assert.notInclude(
+      root.overlay.overlayContainer.className, 'Overlay--visible');
+  });
+});


### PR DESCRIPTION
Adds a very generic overlay and more useful `OverlayCard` for the restyle of the reviews (and probably other things too, this seemed a useful thing to make generic).

The component automatically stretches to fill the screen and has a max height of 75% of the viewport.

Fixes #1553.

### Screenshot

<img width="338" alt="screenshot 2017-01-01 16 50 37" src="https://cloud.githubusercontent.com/assets/90871/21582111/28f508c4-d043-11e6-8c6c-8b852c3f4985.png">
