### PR TITLE
Allow scrolling when previewing theme

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -47,10 +47,19 @@ export class AddonDetailBase extends React.Component {
     OverallRating: DefaultOverallRating,
   }
 
+  constructor(props) {
+    super(props);
+    this.state = { mounted: false };
+  }
+
+  componentDidMount() {
+    // Disabling react/no-did-mount-set-state because it is to prevent additional renders, but
+    // that's exactly what we want in this case (use background-image with JS).
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({ mounted: true });
+  }
+
   onTouchStart = (event) => {
-    // We preventDefault so that the image long-press menu doesn't appear.
-    // This unfortunately prevents scrolling :(
-    event.preventDefault();
     this.props.previewTheme(event.currentTarget);
   }
 
@@ -61,11 +70,22 @@ export class AddonDetailBase extends React.Component {
   headerImage() {
     const { addon, getBrowserThemeData, i18n } = this.props;
     const { previewURL, type } = addon;
+    const { mounted } = this.state;
     const iconUrl = isAllowedOrigin(addon.icon_url) ? addon.icon_url :
       fallbackIcon;
 
     if (type === THEME_TYPE) {
       const label = i18n.gettext('Press to preview');
+      const imageClassName = 'AddonDetail-theme-header-image';
+      let headerImage;
+
+      if (mounted) {
+        const style = { backgroundImage: `url(${previewURL})` };
+        headerImage = <div style={style} className={imageClassName} />;
+      } else {
+        headerImage = <img alt={label} className={imageClassName} src={previewURL} />;
+      }
+
       return (
         <div
           className="AddonDetail-theme-header"
@@ -73,15 +93,13 @@ export class AddonDetailBase extends React.Component {
           data-browsertheme={getBrowserThemeData()}
           onTouchStart={this.onTouchStart}
           onTouchEnd={this.onTouchEnd}
+          ref={(el) => { this.wrapper = el; }}
         >
           <label className="AddonDetail-theme-header-label" htmlFor="AddonDetail-theme-header">
             <Icon name="eye" className="AddonDetail-theme-preview-icon" />
             {label}
           </label>
-          <img
-            alt={label}
-            className="AddonDetail-theme-header-image"
-            src={previewURL} />
+          {headerImage}
         </div>
       );
     }

--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -54,7 +54,9 @@ export class AddonDetailBase extends React.Component {
 
   componentDidMount() {
     // Disabling react/no-did-mount-set-state because it is to prevent additional renders, but
-    // that's exactly what we want in this case (use background-image with JS).
+    // that's exactly what we want in this case. We want to render an img tag on the server since
+    // we can't use inline styles there, but use an inline background-image in JS to prevent the
+    // context menu you get from long pressing on an image.
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ mounted: true });
   }

--- a/src/amo/css/AddonDetail.scss
+++ b/src/amo/css/AddonDetail.scss
@@ -56,11 +56,20 @@ $theme-header-horizontal-padding: 10px;
 }
 
 .AddonDetail-theme-header-image {
+  background-position: top right;
+  background-clip: content-box;
+  background-repeat: no-repeat;
+  background-size: cover;
   border-radius: 12px;
   height: 100px;
   object-fit: cover;
   object-position: top right;
+  user-select: none;
   width: 100%;
+
+  [dir=rtl] & {
+    background-position: top left;
+  }
 }
 
 .AddonDetail-theme-header-label {
@@ -77,6 +86,7 @@ $theme-header-horizontal-padding: 10px;
   padding: $label-margin;
   position: absolute;
   text-transform: uppercase;
+  user-select: none;
 }
 
 .AddonDetail-theme-preview-icon {

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -240,7 +240,7 @@ describe('AddonDetail', () => {
     const rootNode = findDOMNode(root);
     root.setState({ mounted: false });
 
-    let image = rootNode.querySelector('.AddonDetail-theme-header-image');
+    const image = rootNode.querySelector('.AddonDetail-theme-header-image');
     assert.equal(image.tagName, 'IMG');
     assert.ok(image.classList.contains('AddonDetail-theme-header-image'));
     assert.equal(image.src, 'https://amo/preview.png');
@@ -256,7 +256,6 @@ describe('AddonDetail', () => {
       },
       getBrowserThemeData: () => '{}',
     });
-    const rootNode = findDOMNode(root);
     root.setState({ mounted: false });
 
     root.componentDidMount();

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -245,11 +245,23 @@ describe('AddonDetail', () => {
     assert.ok(image.classList.contains('AddonDetail-theme-header-image'));
     assert.equal(image.src, 'https://amo/preview.png');
     assert.equal(image.alt, 'Press to preview');
+  });
+
+  it('sets mounted in the state in componentDidMount', () => {
+    const root = render({
+      addon: {
+        ...fakeAddon,
+        type: THEME_TYPE,
+        previewURL: 'https://amo/preview.png',
+      },
+      getBrowserThemeData: () => '{}',
+    });
+    const rootNode = findDOMNode(root);
+    root.setState({ mounted: false });
 
     root.componentDidMount();
 
-    image = rootNode.querySelector('.AddonDetail-theme-header-image');
-    assert.equal(image.style.backgroundImage, 'url("https://amo/preview.png")');
+    assert.equal(root.state.mounted, true);
   });
 
   it('renders a theme preview as a background image when mounted', () => {


### PR DESCRIPTION
This fixes the not being able to scroll while previewing a theme bug by replacing the `<img>` with a `<div>` that has a background image once the component mounts. This is done to avoid the CSP errors that we'd get for rendering on the server with inline styles.

> [div version?](https://cloud.githubusercontent.com/assets/211578/21670248/7beff1c8-d2d8-11e6-85e6-bc527e1abc97.png)
> [img version?](https://cloud.githubusercontent.com/assets/211578/21670249/7c11d0f4-d2d8-11e6-8889-0fc127c4cff0.png)
> Screenshots of the two versions, I forget which is which but they look the same


![theme-preview-with-scrolling mp4](https://cloud.githubusercontent.com/assets/211578/21670426/a15b3e3a-d2d9-11e6-926e-549a5a2f83a9.gif)

Fixes #1445.