### PR TITLE
Match switch uninstalled background to mocks

### DIFF
--- a/src/ui/components/Switch/Switch.scss
+++ b/src/ui/components/Switch/Switch.scss
@@ -18,9 +18,9 @@ $switchStrokeWidth: 1px;
 $switchHandleActivePosition: round(($size * $switchToBackgroundRatio) - ($size + ($switchHandleGap * 2 + $switchStrokeWidth)));
 
 $switchBackgroundOn: #57bd35;
-$switchBackgroundOff: #919191;
+$switchBackgroundOff: #b1b1b1;
 
-$uninstallStripeColor1: #b1b1b1;
+$uninstallStripeColor1: $switchBackgroundOff;
 $uninstallStripeColor2: #d4d4d4;
 
 $installStripeColor1: #00a920;
@@ -60,7 +60,7 @@ $installStripeColor2: #00c42e;
   }
 
   input + label {
-    background: #919191;
+    background: $switchBackgroundOff;
     border-radius: $size;
     border: $switchStrokeWidth solid $switchStrokeOff;
     cursor: pointer;


### PR DESCRIPTION
The switch uninstalled colour was a bit darker than the mocks. I've lightened it up a bit.

<img width="300" alt="screen shot 2017-01-06 at 1 00 34 pm" src="https://cloud.githubusercontent.com/assets/211578/21729570/350eead6-d411-11e6-8e1e-e77e29954602.png"><img width="300" alt="screen shot 2017-01-06 at 1 03 19 pm" src="https://cloud.githubusercontent.com/assets/211578/21729571/350f9c7e-d411-11e6-905b-b4a31c038081.png">

<img width="672" alt="screen shot 2017-01-06 at 1 06 28 pm" src="https://cloud.githubusercontent.com/assets/211578/21729572/350fe2ec-d411-11e6-95ac-33a7711fef40.png"><img width="674" alt="screen shot 2017-01-06 at 1 05 56 pm" src="https://cloud.githubusercontent.com/assets/211578/21729573/35114dee-d411-11e6-96e5-5c2362be9a14.png">
