### PR TITLE
Show install switch by default

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -2,5 +2,6 @@
   "apiHost": "API_HOST",
   "serverHost": "SERVER_HOST",
   "serverPort": "SERVER_PORT",
+  "staticHost": "STATIC_HOST",
   "trackingEnabled": "TRACKING_ENABLED"
 }

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -10,7 +10,10 @@ import { addQueryParams } from 'core/utils';
 
 
 export function hasAddonManager({ navigator } = {}) {
-  return typeof window !== 'undefined' && 'mozAddonManager' in (navigator || window.navigator);
+  if (!navigator && typeof window === 'undefined') {
+    return undefined;
+  }
+  return 'mozAddonManager' in (navigator || window.navigator);
 }
 
 export function getAddon(guid, { _mozAddonManager = window.navigator.mozAddonManager } = {}) {

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -9,8 +9,10 @@ import {
 import { addQueryParams } from 'core/utils';
 
 
-export function hasAddonManager({ navigator } = {}) {
-  if (!navigator && typeof window === 'undefined') {
+const testHasWindow = () => typeof window !== 'undefined';
+
+export function hasAddonManager({ hasWindow = testHasWindow, navigator } = {}) {
+  if (!navigator && !hasWindow()) {
     return undefined;
   }
   return 'mozAddonManager' in (navigator || window.navigator);

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -12,6 +12,8 @@ import { addQueryParams } from 'core/utils';
 const testHasWindow = () => typeof window !== 'undefined';
 
 export function hasAddonManager({ hasWindow = testHasWindow, navigator } = {}) {
+  // Returns undefined if it cannot be determined if mozAddonManager is supperted (likely server
+  // rendering with no window). Otherwise returns true/false based on mozAddonManager in navigator.
   if (!navigator && !hasWindow()) {
     return undefined;
   }

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -52,6 +52,7 @@ export class InstallButtonBase extends React.Component {
     return (
       <div className={classNames('InstallButton', className, {
         'InstallButton--use-button': useButton,
+        'InstallButton--use-switch': !useButton,
       })}>
         <InstallSwitch {...this.props} className="InstallButton-switch" />
         {button}

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
 
@@ -7,12 +8,17 @@ import translate from 'core/i18n/translate';
 import { getThemeData } from 'core/themePreview';
 import Button from 'ui/components/Button';
 
+import './styles.scss';
+
+
 export class InstallButtonBase extends React.Component {
   static propTypes = {
     addon: PropTypes.object.isRequired,
-    hasAddonManager: PropTypes.bool.isRequired,
+    className: PropTypes.string,
+    hasAddonManager: PropTypes.bool,
     i18n: PropTypes.object.isRequired,
     installTheme: PropTypes.func.isRequired,
+    size: PropTypes.string,
     status: PropTypes.string.isRequired,
   }
 
@@ -23,17 +29,34 @@ export class InstallButtonBase extends React.Component {
   }
 
   render() {
-    const { addon, hasAddonManager, i18n } = this.props;
-    if (hasAddonManager) {
-      return <InstallSwitch {...this.props} />;
-    } else if (addon.type === THEME_TYPE) {
-      return (
-        <Button data-browsertheme={JSON.stringify(getThemeData(addon))} onClick={this.installTheme}>
+    const { addon, className, hasAddonManager, i18n, size } = this.props;
+    const useButton = hasAddonManager !== undefined && !hasAddonManager;
+    let button;
+    if (addon.type === THEME_TYPE) {
+      button = (
+        <Button
+          data-browsertheme={JSON.stringify(getThemeData(addon))}
+          onClick={this.installTheme}
+          size={size}
+          className="InstallButton-button">
           {i18n.gettext('Install Theme')}
         </Button>
       );
+    } else {
+      button = (
+        <Button href={addon.installURL} size={size} className="InstallButton-button">
+          {i18n.gettext('Add to Firefox')}
+        </Button>
+      );
     }
-    return <Button href={addon.installURL}>{i18n.gettext('Add to Firefox')}</Button>;
+    return (
+      <div className={classNames('InstallButton', className, {
+        'InstallButton--use-button': useButton,
+      })}>
+        <InstallSwitch {...this.props} className="InstallButton-switch" />
+        {button}
+      </div>
+    );
   }
 }
 

--- a/src/core/components/InstallButton/styles.scss
+++ b/src/core/components/InstallButton/styles.scss
@@ -1,15 +1,16 @@
 .InstallButton {
   .InstallButton-button {
-    display: none;
     white-space: nowrap;
   }
 
   &.InstallButton--use-button {
-    .InstallButton-button {
-      display: inline-block;
-    }
-
     .InstallButton-switch {
+      display: none;
+    }
+  }
+
+  &.InstallButton--use-button {
+    .InstallButton-button {
       display: none;
     }
   }

--- a/src/core/components/InstallButton/styles.scss
+++ b/src/core/components/InstallButton/styles.scss
@@ -9,7 +9,7 @@
     }
   }
 
-  &.InstallButton--use-button {
+  &.InstallButton--use-switch {
     .InstallButton-button {
       display: none;
     }

--- a/src/core/components/InstallButton/styles.scss
+++ b/src/core/components/InstallButton/styles.scss
@@ -1,0 +1,16 @@
+.InstallButton {
+  .InstallButton-button {
+    display: none;
+    white-space: nowrap;
+  }
+
+  &.InstallButton--use-button {
+    .InstallButton-button {
+      display: inline-block;
+    }
+
+    .InstallButton-switch {
+      display: none;
+    }
+  }
+}

--- a/src/core/components/InstallSwitch/index.js
+++ b/src/core/components/InstallSwitch/index.js
@@ -101,7 +101,7 @@ export class InstallSwitchBase extends React.Component {
 
   render() {
     const browsertheme = JSON.stringify(getThemeData(this.props));
-    const { handleChange, slug, status, ...props } = this.props;
+    const { handleChange, slug, status, ...otherProps } = this.props;
 
     if (!validStates.includes(status)) {
       throw new Error(`Invalid add-on status ${status}`);
@@ -114,7 +114,7 @@ export class InstallSwitchBase extends React.Component {
     return (
       <div data-browsertheme={browsertheme} ref={(el) => { this.themeData = el; }}>
         <Switch
-          {...props}
+          {...otherProps}
           checked={isChecked} disabled={isDisabled} progress={this.getDownloadProgress()}
           name={slug} success={isSuccess} label={this.getLabel()}
           onChange={handleChange} onClick={this.handleClick}

--- a/src/core/components/InstallSwitch/index.js
+++ b/src/core/components/InstallSwitch/index.js
@@ -114,11 +114,11 @@ export class InstallSwitchBase extends React.Component {
     return (
       <div data-browsertheme={browsertheme} ref={(el) => { this.themeData = el; }}>
         <Switch
+          {...props}
           checked={isChecked} disabled={isDisabled} progress={this.getDownloadProgress()}
           name={slug} success={isSuccess} label={this.getLabel()}
           onChange={handleChange} onClick={this.handleClick}
           ref={(el) => { this.switchEl = el; }}
-          {...props}
         />
       </div>
     );

--- a/src/core/components/InstallSwitch/index.js
+++ b/src/core/components/InstallSwitch/index.js
@@ -101,7 +101,7 @@ export class InstallSwitchBase extends React.Component {
 
   render() {
     const browsertheme = JSON.stringify(getThemeData(this.props));
-    const { handleChange, slug, status } = this.props;
+    const { handleChange, slug, status, ...props } = this.props;
 
     if (!validStates.includes(status)) {
       throw new Error(`Invalid add-on status ${status}`);
@@ -118,6 +118,7 @@ export class InstallSwitchBase extends React.Component {
           name={slug} success={isSuccess} label={this.getLabel()}
           onChange={handleChange} onClick={this.handleClick}
           ref={(el) => { this.switchEl = el; }}
+          {...props}
         />
       </div>
     );

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -206,9 +206,7 @@ export class AddonBase extends React.Component {
               dangerouslySetInnerHTML={sanitizeHTML(heading, ['a', 'span'])} />
             {this.getDescription()}
           </div>
-          <div className="install-button">
-            <InstallButton {...this.props} />
-          </div>
+          <InstallButton className="Addon-install-button" size="small" {...this.props} />
         </div>
       </div>
     );

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -53,7 +53,7 @@ $addon-padding: 20px;
     }
   }
 
-  .install-button {
+  .Addon-install-button {
     margin: 0 20px 0 30px;
 
     [dir=rtl] & {
@@ -61,7 +61,7 @@ $addon-padding: 20px;
     }
   }
 
-  &:not(.theme) .install-button {
+  &:not(.theme) .Addon-install-button {
     align-self: stretch;
     border-top: 1px solid rgba(0, 0, 0, 0.1);
     margin: 0 0 15px;
@@ -77,7 +77,7 @@ $addon-padding: 20px;
   }
 
   @include respond-to('large') {
-    &:not(.theme) .install-button {
+    &:not(.theme) .Addon-install-button {
       align-self: center;
       border: 0;
       margin: 0 20px 0 30px;

--- a/src/ui/components/Button/Button.scss
+++ b/src/ui/components/Button/Button.scss
@@ -3,4 +3,9 @@
 .Button,
 .Button:link {
   @include button();
+
+  &.Button--small {
+    border-radius: 3px;
+    font-size: 13px;
+  }
 }

--- a/src/ui/components/Button/index.js
+++ b/src/ui/components/Button/index.js
@@ -9,12 +9,19 @@ export default class Button extends React.Component {
     children: PropTypes.node,
     className: PropTypes.string,
     href: PropTypes.string,
+    size: PropTypes.string.isRequired,
   }
 
+  static defaultProps = {
+    size: 'normal',
+  };
+
   render() {
-    const { children, className, href, ...rest } = this.props;
+    const { children, className, href, size, ...rest } = this.props;
     const props = {
-      className: classNames('Button', className),
+      className: classNames('Button', className, {
+        'Button--small': size === 'small',
+      }),
       ...rest,
     };
 

--- a/tests/client/core/TestAddonManager.js
+++ b/tests/client/core/TestAddonManager.js
@@ -44,6 +44,10 @@ describe('addonManager', () => {
     it('is false if mozAddonManager is not in navigator', () => {
       assert.notOk(addonManager.hasAddonManager());
     });
+
+    it('is undefined if there is no window', () => {
+      assert.equal(addonManager.hasAddonManager({ hasWindow: () => false }), undefined);
+    });
   });
 
   describe('getAddon()', () => {

--- a/tests/client/core/components/TestInstallButton.js
+++ b/tests/client/core/components/TestInstallButton.js
@@ -12,9 +12,16 @@ import Button from 'ui/components/Button';
 describe('<InstallButton />', () => {
   it('renders InstallSwitch when mozAddonManager is available', () => {
     const i18n = getFakeI18nInst();
-    const root = shallowRender(<InstallButtonBase foo="foo" hasAddonManager i18n={i18n} />);
-    assert.equal(root.type, InstallSwitch);
-    assert.deepEqual(root.props, {
+    const addon = { type: THEME_TYPE, id: 'foo@personas.mozilla.org' };
+    const root = shallowRender(
+      <InstallButtonBase foo="foo" addon={addon} hasAddonManager i18n={i18n} />);
+    assert.equal(root.type, 'div');
+    assert.equal(root.props.className, 'InstallButton InstallButton--use-switch');
+    const switchComponent = root.props.children[0];
+    assert.equal(switchComponent.type, InstallSwitch);
+    assert.deepEqual(switchComponent.props, {
+      addon,
+      className: 'InstallButton-switch',
       foo: 'foo',
       hasAddonManager: true,
       i18n,
@@ -27,9 +34,14 @@ describe('<InstallButton />', () => {
     const root = shallowRender(
       <InstallButtonBase
         addon={addon} foo="foo" hasAddonManager={false} i18n={i18n} />);
-    assert.equal(root.type, Button);
-    assert.equal(root.props.children, 'Install Theme');
-    assert.equal(root.props['data-browsertheme'], JSON.stringify(themePreview.getThemeData(addon)));
+    assert.equal(root.type, 'div');
+    assert.equal(root.props.className, 'InstallButton InstallButton--use-button');
+    const buttonComponent = root.props.children[1];
+    assert.equal(buttonComponent.type, Button);
+    assert.equal(buttonComponent.props.children, 'Install Theme');
+    assert.equal(
+        buttonComponent.props['data-browsertheme'],
+        JSON.stringify(themePreview.getThemeData(addon)));
   });
 
 
@@ -42,10 +54,11 @@ describe('<InstallButton />', () => {
         addon={addon} foo="foo" hasAddonManager={false} i18n={i18n}
         status={UNKNOWN} installTheme={installTheme} />));
     const preventDefault = sinon.spy();
-    Simulate.click(root, { preventDefault });
+    const buttonComponent = root.querySelector('.InstallButton-button');
+    Simulate.click(buttonComponent, { preventDefault });
     assert.ok(preventDefault.called);
     assert.ok(installTheme.called);
-    assert.ok(installTheme.calledWith(root, { ...addon, status: UNKNOWN }));
+    assert.ok(installTheme.calledWith(buttonComponent, { ...addon, status: UNKNOWN }));
   });
 
   it('renders an add-on button when mozAddonManager is not available', () => {
@@ -53,10 +66,15 @@ describe('<InstallButton />', () => {
     const addon = { type: EXTENSION_TYPE, installURL: 'https://addons.mozilla.org/download' };
     const root = shallowRender(
       <InstallButtonBase addon={addon} foo="foo" hasAddonManager={false} i18n={i18n} />);
-    assert.equal(root.type, Button);
-    assert.deepEqual(root.props, {
+    assert.equal(root.type, 'div');
+    assert.equal(root.props.className, 'InstallButton InstallButton--use-button');
+    const buttonComponent = root.props.children[1];
+    assert.equal(buttonComponent.type, Button);
+    assert.deepEqual(buttonComponent.props, {
       children: 'Add to Firefox',
+      className: 'InstallButton-button',
       href: 'https://addons.mozilla.org/download',
+      size: 'normal',
     });
   });
 });

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -48,15 +48,9 @@ function renderAddon({ setCurrentStatus = sinon.stub(), ...props }) {
 
 describe('<Addon />', () => {
   describe('<Addon type="extension"/>', () => {
-    let root;
-
-    beforeEach(() => {
-      root = renderAddon(result);
-    });
-
     it('renders a default error overlay with no close link', () => {
       const data = { ...result, status: ERROR, setCurrentStatus: sinon.stub() };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const error = findDOMNode(root).querySelector('.notification.error');
       assert.equal(
         error.querySelector('p').textContent,
@@ -72,7 +66,7 @@ describe('<Addon />', () => {
         setCurrentStatus: sinon.stub(),
         error: FATAL_ERROR,
       };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const error = findDOMNode(root).querySelector('.notification.error');
       assert.equal(
         error.querySelector('p').textContent,
@@ -88,7 +82,7 @@ describe('<Addon />', () => {
         setCurrentStatus: sinon.stub(),
         error: FATAL_INSTALL_ERROR,
       };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const error = findDOMNode(root).querySelector('.notification.error');
       assert.equal(
         error.querySelector('p').textContent,
@@ -104,7 +98,7 @@ describe('<Addon />', () => {
         setCurrentStatus: sinon.stub(),
         error: FATAL_UNINSTALL_ERROR,
       };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const error = findDOMNode(root).querySelector('.notification.error');
       assert.equal(
         error.querySelector('p').textContent,
@@ -117,7 +111,7 @@ describe('<Addon />', () => {
       const data = {
         ...result, status: ERROR, error: INSTALL_FAILED, setCurrentStatus: sinon.stub(),
       };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const error = findDOMNode(root).querySelector('.notification.error');
       assert.equal(
         error.querySelector('p').textContent,
@@ -131,7 +125,7 @@ describe('<Addon />', () => {
       const data = {
         ...result, status: ERROR, error: DOWNLOAD_FAILED, setCurrentStatus: sinon.stub(),
       };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const error = findDOMNode(root).querySelector('.notification.error');
       assert.equal(
         error.querySelector('p').textContent,
@@ -142,12 +136,13 @@ describe('<Addon />', () => {
     });
 
     it('does not normally render an error', () => {
+      const root = renderAddon({ addon: result, ...result });
       assert.notOk(findDOMNode(root).querySelector('.notification.error'));
     });
 
     it('renders a default restart notification', () => {
       const data = { ...result, needsRestart: true };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const restart = findDOMNode(root).querySelector('.notification.restart');
       assert.equal(
         restart.querySelector('p').textContent,
@@ -157,7 +152,7 @@ describe('<Addon />', () => {
 
     it('renders a uninstallation restart notification', () => {
       const data = { ...result, needsRestart: true, status: UNINSTALLING };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const restart = findDOMNode(root).querySelector('.notification.restart');
       assert.equal(
         restart.querySelector('p').textContent,
@@ -166,68 +161,78 @@ describe('<Addon />', () => {
     });
 
     it('does not normally render a restart notification', () => {
+      const root = renderAddon({ addon: result, ...result });
       assert.notOk(findDOMNode(root).querySelector('.notification.restart'));
     });
 
     it('renders the heading', () => {
+      const root = renderAddon({ addon: result, ...result });
       assert.include(root.heading.textContent, 'test-heading');
     });
 
     it('renders the editorial description', () => {
+      const root = renderAddon({ addon: result, ...result });
       assert.equal(root.editorialDescription.textContent, 'test-editorial-description');
     });
 
     it('purifies the heading', () => {
-      root = renderAddon({
+      const data = {
         ...result,
         heading: '<script>alert("hi")</script><em>Hey!</em> <i>This is <span>an add-on</span></i>',
-      });
+      };
+      const root = renderAddon({ addon: data, ...data });
       assert.include(root.heading.innerHTML, 'Hey! This is <span>an add-on</span>');
     });
 
     it('purifies the heading with a link and adds link attrs', () => {
-      root = renderAddon({
+      const data = {
         ...result,
         heading: 'This is <span>an <a href="https://addons.mozilla.org">add-on</a>/span>',
-      });
+      };
+      const root = renderAddon({ addon: data, ...data });
       const link = root.heading.querySelector('a');
       assert.equal(link.getAttribute('rel'), 'noopener noreferrer');
       assert.equal(link.getAttribute('target'), '_blank');
     });
 
     it('purifies the heading with a bad link', () => {
-      root = renderAddon({
+      const data = {
         ...result,
         heading: 'This is <span>an <a href="javascript:alert(1)">add-on</a>/span>',
-      });
+      };
+      const root = renderAddon({ addon: data, ...data });
       const link = root.heading.querySelector('a');
       assert.equal(link.getAttribute('href'), null);
     });
 
     it('purifies the editorial description', () => {
-      root = renderAddon({
+      const data = {
         ...result,
         description: '<script>foo</script><blockquote>This is an add-on!</blockquote> ' +
                      '<i>Reviewed by <cite>a person</cite></i>',
-      });
+      };
+      const root = renderAddon({ addon: data, ...data });
       assert.equal(
         root.editorialDescription.innerHTML,
         '<blockquote>This is an add-on!</blockquote> Reviewed by <cite>a person</cite>');
     });
 
     it('does render a logo for an extension', () => {
+      const root = renderAddon({ addon: result, ...result });
       assert.ok(findDOMNode(root).querySelector('.logo'));
     });
 
     it("doesn't render a theme image for an extension", () => {
+      const root = renderAddon({ addon: result, ...result });
       assert.equal(findDOMNode(root).querySelector('.theme-image'), null);
     });
 
     it('throws on invalid add-on type', () => {
+      const root = renderAddon({ addon: result, ...result });
       assert.include(root.heading.textContent, 'test-heading');
       const data = { ...result, type: 'Whatever' };
       assert.throws(() => {
-        renderAddon(data);
+        renderAddon({ addon: data, ...data });
       }, Error, 'Invalid addon type');
     });
 
@@ -242,7 +247,7 @@ describe('<Addon />', () => {
         heading: 'This is <span>an <a href="https://addons.mozilla.org">add-on</a>/span>',
         type: EXTENSION_TYPE,
       };
-      root = renderAddon(data);
+      const root = renderAddon({ addon: data, ...data });
       const heading = findDOMNode(root).querySelector('.heading');
       // We click the heading providing the link nodeName to emulate
       // bubbling.
@@ -261,7 +266,7 @@ describe('<Addon />', () => {
 
     beforeEach(() => {
       const data = { ...result, type: THEME_TYPE };
-      root = renderAddon(data);
+      root = renderAddon({ addon: data, ...data });
     });
 
     it('does render the theme image for a theme', () => {
@@ -284,7 +289,7 @@ describe('<Addon />', () => {
       previewTheme = sinon.spy();
       resetPreviewTheme = sinon.spy();
       const data = { ...result, type: THEME_TYPE, previewTheme, resetPreviewTheme };
-      root = renderAddon(data);
+      root = renderAddon({ addon: data, ...data });
       themeImage = findDOMNode(root).querySelector('.theme-image');
     });
 


### PR DESCRIPTION
This makes the install buttons default to the switch when rendering on the server then flips to the blue button if `mozAddonManager` isn't supported once the page loads.

No support for `<noscript>` yet (I have it working in dev but need to get around CSP still for production).

![disco-mozaddonmanager mov](https://cloud.githubusercontent.com/assets/211578/21774115/0613094a-d657-11e6-850c-b3d166c6b572.gif)
> With `mozAddonManager`

![disco-no-mozaddonmanager mov](https://cloud.githubusercontent.com/assets/211578/21774114/0612458c-d657-11e6-8f39-b96b6929aaf1.gif)
> No `mozAddonManager`

Fixes #1568.