### PR TITLE
Install button noscript fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,6 @@
     "chalk": "1.1.3",
     "cheerio": "0.22.0",
     "concurrently": "3.1.0",
-    "csp-parse": "0.0.2",
     "css-loader": "0.26.1",
     "deepcopy": "0.6.3",
     "eslint": "3.13.1",

--- a/src/amo/noscript.css
+++ b/src/amo/noscript.css
@@ -1,0 +1,6 @@
+.InstallButton .InstallButton-button {
+  display: inline-block !important;
+}
+.InstallButton .InstallButton-switch {
+  display: none !important;
+}

--- a/src/amo/noscript.css
+++ b/src/amo/noscript.css
@@ -1,6 +1,8 @@
+/* !important is needed to show the button, make sure switch is hidden */
 .InstallButton .InstallButton-button {
   display: inline-block !important;
 }
+
 .InstallButton .InstallButton-switch {
   display: none !important;
 }

--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -14,6 +14,7 @@ export default class ServerHtml extends Component {
     htmlDir: PropTypes.string,
     htmlLang: PropTypes.string,
     includeSri: PropTypes.bool.isRequired,
+    noScriptStyles: PropTypes.string,
     sriData: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     trackingEnabled: PropTypes.bool,
@@ -75,7 +76,7 @@ export default class ServerHtml extends Component {
   }
 
   render() {
-    const { component, htmlLang, htmlDir, store } = this.props;
+    const { component, htmlLang, htmlDir, noScriptStyles, store } = this.props;
     // This must happen before Helmet.rewind() see
     // https://github.com/nfl/react-helmet#server-usage for more info.
     const content = component ? ReactDOM.renderToString(component) : '';
@@ -90,6 +91,9 @@ export default class ServerHtml extends Component {
           {head.title.toComponent()}
           {head.meta.toComponent()}
           {this.getStyle()}
+          {noScriptStyles
+            ? <noscript><style dangerouslySetInnerHTML={{ __html: noScriptStyles }} /></noscript>
+            : null}
         </head>
         <body>
           <div id="react-view" dangerouslySetInnerHTML={{ __html: content }} />

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 /* global navigator, window */
 import React, { PropTypes } from 'react';
-import { camelizeKeys } from 'humps';
+import { camelizeKeys as camelCaseKeys } from 'humps';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-connect';
 import config from 'config';
@@ -118,7 +118,7 @@ export class DiscoPaneBase extends React.Component {
           </div>
         </header>
         {results.map((item) => (
-          <AddonComponent addon={item} {...camelizeKeys(item)} key={item.guid} />
+          <AddonComponent addon={item} {...camelCaseKeys(item)} key={item.guid} />
         ))}
         <div className="amo-link">
           <a href="https://addons.mozilla.org/" target="_blank"

--- a/src/disco/noscript.css
+++ b/src/disco/noscript.css
@@ -1,0 +1,6 @@
+.InstallButton .InstallButton-button {
+  display: inline-block !important;
+}
+.InstallButton .InstallButton-switch {
+  display: none !important;
+}

--- a/src/disco/noscript.css
+++ b/src/disco/noscript.css
@@ -1,6 +1,8 @@
+/* !important is needed to show the button, make sure switch is hidden */
 .InstallButton .InstallButton-button {
   display: inline-block !important;
 }
+
 .InstallButton .InstallButton-switch {
   display: none !important;
 }

--- a/tests/client/core/containers/TestServerHtml.js
+++ b/tests/client/core/containers/TestServerHtml.js
@@ -152,4 +152,21 @@ describe('<ServerHtml />', () => {
       render({ sriData: {} });
     }, Error, /SRI Data is missing/);
   });
+
+  it('does not render empty noscript styles', () => {
+    const html = findRenderedDOMComponentWithTag(render(), 'html');
+    const noScript = html.querySelector('noscript');
+    assert.notOk(noScript);
+  });
+
+  it('renders noscript styles when provided', () => {
+    const noScriptStyles = '.MyComponent { display: none; }';
+    const html = findRenderedDOMComponentWithTag(render({ noScriptStyles }), 'html');
+    const noScript = html.querySelector('noscript');
+    assert.ok(noScript);
+    assert.equal(noScript.children.length, 1);
+    const style = noScript.children[0];
+    assert.equal(style.tagName, 'STYLE');
+    assert.equal(style.textContent, noScriptStyles);
+  });
 });

--- a/tests/server/admin/TestViews.js
+++ b/tests/server/admin/TestViews.js
@@ -1,11 +1,9 @@
-/* eslint-disable no-loop-func */
 import { assert } from 'chai';
-import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
 
-import { checkSRI } from '../helpers';
+import { checkSRI, parseCSP } from '../helpers';
 
 describe('Search App GET requests', () => {
   let app;
@@ -23,11 +21,11 @@ describe('Search App GET requests', () => {
     .get('/search')
     .expect(200)
     .then((res) => {
-      const policy = new Policy(res.header['content-security-policy']);
-      assert.notInclude(policy.get('script-src'), "'self'");
-      assert.include(policy.get('script-src'), 'https://addons-admin.cdn.mozilla.net');
-      assert.notInclude(policy.get('connect-src'), "'self'");
-      assert.include(policy.get('connect-src'), 'https://addons.mozilla.org');
+      const policy = parseCSP(res.header['content-security-policy']);
+      assert.notInclude(policy.scriptSrc, "'self'");
+      assert.include(policy.scriptSrc, 'https://addons-admin.cdn.mozilla.net');
+      assert.notInclude(policy.connectSrc, "'self'");
+      assert.include(policy.connectSrc, 'https://addons.mozilla.org');
     }));
 
   it('should be using SRI for script and style in /search', () => request(app)

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -31,7 +31,7 @@ describe('AMO GET Requests', () => {
       assert.include(policy.connectSrc, 'https://addons.mozilla.org');
       assert.equal(policy.styleSrc.length, 2);
       assert.include(policy.styleSrc, cdnHost);
-      assert.include(policy.styleSrc, "'sha256-8VVSrUT/1AZpxCZNGwNROSnacmbseuppeBCace7a/Wc='");
+      assert.include(policy.styleSrc, "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='");
     }));
 
   it('should be using SRI for script and style on the amo app homepage', () => request(app)

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -1,11 +1,9 @@
-/* eslint-disable no-loop-func */
 import { assert } from 'chai';
-import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
 
-import { checkSRI } from '../helpers';
+import { checkSRI, parseCSP } from '../helpers';
 
 const defaultURL = '/en-US/firefox/';
 
@@ -25,11 +23,15 @@ describe('AMO GET Requests', () => {
     .get(defaultURL)
     .expect(200)
     .then((res) => {
-      const policy = new Policy(res.header['content-security-policy']);
-      assert.notInclude(policy.get('script-src'), "'self'");
-      assert.include(policy.get('script-src'), 'https://addons-amo.cdn.mozilla.net');
-      assert.notInclude(policy.get('connect-src'), "'self'");
-      assert.include(policy.get('connect-src'), 'https://addons.mozilla.org');
+      const cdnHost = 'https://addons-amo.cdn.mozilla.net';
+      const policy = parseCSP(res.header['content-security-policy']);
+      assert.notInclude(policy.scriptSrc, "'self'");
+      assert.include(policy.scriptSrc, cdnHost);
+      assert.notInclude(policy.connectSrc, "'self'");
+      assert.include(policy.connectSrc, 'https://addons.mozilla.org');
+      assert.equal(policy.styleSrc.length, 2);
+      assert.include(policy.styleSrc, cdnHost);
+      assert.include(policy.styleSrc, "'sha256-8VVSrUT/1AZpxCZNGwNROSnacmbseuppeBCace7a/Wc='");
     }));
 
   it('should be using SRI for script and style on the amo app homepage', () => request(app)

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -31,7 +31,7 @@ describe('Discovery Pane GET requests', () => {
       assert.include(policy.connectSrc, 'https://addons.mozilla.org');
       assert.equal(policy.styleSrc.length, 2);
       assert.include(policy.styleSrc, cdnHost);
-      assert.include(policy.styleSrc, "'sha256-8VVSrUT/1AZpxCZNGwNROSnacmbseuppeBCace7a/Wc='");
+      assert.include(policy.styleSrc, "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='");
     }));
 
   it('should be using SRI for script and style', () => request(app)

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -1,11 +1,9 @@
-/* eslint-disable no-loop-func */
 import { assert } from 'chai';
-import Policy from 'csp-parse';
 import request from 'supertest-as-promised';
 
 import { runServer } from 'core/server/base';
 
-import { checkSRI } from '../helpers';
+import { checkSRI, parseCSP } from '../helpers';
 
 const defaultURL = '/en-US/firefox/discovery/pane/48.0/Darwin/normal';
 
@@ -25,11 +23,15 @@ describe('Discovery Pane GET requests', () => {
     .get(defaultURL)
     .expect(200)
     .then((res) => {
-      const policy = new Policy(res.header['content-security-policy']);
-      assert.notInclude(policy.get('script-src'), "'self'");
-      assert.include(policy.get('script-src'), 'https://addons-discovery.cdn.mozilla.net');
-      assert.notInclude(policy.get('connect-src'), "'self'");
-      assert.include(policy.get('connect-src'), 'https://addons.mozilla.org');
+      const cdnHost = 'https://addons-discovery.cdn.mozilla.net';
+      const policy = parseCSP(res.header['content-security-policy']);
+      assert.notInclude(policy.scriptSrc, "'self'");
+      assert.include(policy.scriptSrc, cdnHost);
+      assert.notInclude(policy.connectSrc, "'self'");
+      assert.include(policy.connectSrc, 'https://addons.mozilla.org');
+      assert.equal(policy.styleSrc.length, 2);
+      assert.include(policy.styleSrc, cdnHost);
+      assert.include(policy.styleSrc, "'sha256-8VVSrUT/1AZpxCZNGwNROSnacmbseuppeBCace7a/Wc='");
     }));
 
   it('should be using SRI for script and style', () => request(app)

--- a/tests/server/helpers.js
+++ b/tests/server/helpers.js
@@ -1,5 +1,6 @@
 import cheerio from 'cheerio';
 import { assert } from 'chai';
+import { camelizeKeys } from 'humps';
 
 export function checkSRI(res) {
   const $ = cheerio.load(res.text);
@@ -23,4 +24,15 @@ export function checkSRI(res) {
     assert.equal($elem.attr('crossorigin'),
       'anonymous', 'script should have crossorigin attr');
   });
+}
+
+export function parseCSP(rawCsp) {
+  return camelizeKeys(
+    rawCsp
+      .split(';')
+      .map((part) => part.trim().split(' '))
+      .reduce((parts, [partName, ...partValues]) => ({
+        ...parts,
+        [partName]: partValues,
+      }), {}));
 }

--- a/tests/server/helpers.js
+++ b/tests/server/helpers.js
@@ -1,6 +1,6 @@
 import cheerio from 'cheerio';
 import { assert } from 'chai';
-import { camelizeKeys } from 'humps';
+import { camelizeKeys as camelCaseKeys } from 'humps';
 
 export function checkSRI(res) {
   const $ = cheerio.load(res.text);
@@ -27,7 +27,7 @@ export function checkSRI(res) {
 }
 
 export function parseCSP(rawCsp) {
-  return camelizeKeys(
+  return camelCaseKeys(
     rawCsp
       .split(';')
       .map((part) => part.trim().split(' '))

--- a/tests/server/test_helpers.js
+++ b/tests/server/test_helpers.js
@@ -1,0 +1,23 @@
+import { assert } from 'chai';
+import { oneLine } from 'common-tags';
+
+import { parseCSP } from './helpers';
+
+describe('server test helpers', () => {
+  describe('parseCSP', () => {
+    it('parses the CSP header into an object', () => {
+      const headerContent = oneLine`default-src 'none'; base-uri 'self'; child-src 'none';
+        connect-src 'self' https://addons-dev-cdn.allizom.org 127.0.0.1:3001; form-action 'none';
+        frame-src 'none'; img-src 'self' 127.0.0.1:3001; media-src
+        https://addons-discovery.cdn.mozilla.net; object-src 'none'; script-src 'self'
+        https://addons-dev-cdn.allizom.org 127.0.0.1:3001; style-src 'self' blob:
+        'sha256-8VVSrUT/1AZpxCZNGwNROSnacmbseuppeBCace7a/Wc='; report-uri /__cspreport__`;
+      const policy = parseCSP(headerContent);
+      assert.deepEqual(policy.imgSrc, ["'self'", '127.0.0.1:3001']);
+      assert.deepEqual(
+        policy.styleSrc,
+        ["'self'", 'blob:', "'sha256-8VVSrUT/1AZpxCZNGwNROSnacmbseuppeBCace7a/Wc='"]);
+      assert.deepEqual(policy.reportUri, ['/__cspreport__']);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,10 +1608,6 @@ crypto-browserify@3.3.0:
     ripemd160 "0.2.0"
     sha.js "2.2.6"
 
-csp-parse@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/csp-parse/-/csp-parse-0.0.2.tgz#51b365b2dda5111a508ac1d4afd1f4541c1a0ccc"
-
 css-color-names@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.3.tgz#de0cef16f4d8aa8222a320d5b6d7e9bbada7b9f6"


### PR DESCRIPTION
This will read a `noscript.css` file from the app's root and include that in `<noscript><style>{contents}</style></noscript>` if it exists. It also sets the CSP header so that this will work in production.

I have some updates to make this work with webpack as well but I'm running into some problems with webpack-isomorphic-tools so just putting this up for now to look at.

Fixes #1604.