### PR TITLE
Downgrade karma-webpack from 2.0.0 to 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,7 +234,7 @@
     "karma-mocha-reporter": "2.2.0",
     "karma-sinon": "1.0.5",
     "karma-sourcemap-loader": "0.3.7",
-    "karma-webpack": "2.0.0",
+    "karma-webpack": "1.8.1",
     "mocha": "3.2.0",
     "node-sass": "4.2.0",
     "po2json": "0.4.5",


### PR DESCRIPTION
I was a little surprised the tests passed but didn't see and upgrade docs so figured they just rewrote a bunch and decided on a major bump.

This entirely broke the unit tests even though they kept passing 😠

Backing out the change, not sure if it's meant for webpack 2. We can deal with it later.