### PR TITLE
Switch to node:6-slim and perform build optimization. fixes #1120

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM node:4.6
+FROM node:6-slim
 
 # Install node_modules into a different directory to avoid npm/npm#9863.
 RUN mkdir -p /srv/node
 ADD package.json /srv/node/
 WORKDIR /srv/node
-RUN npm install -g npm@3
-RUN npm install
+
+RUN buildDeps=' \
+    git \
+    ' && \
+    # install deps
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends $buildDeps && \
+	npm install -g npm@3 && \
+	npm install && npm cache clean && \
+    # cleanup
+    # apt-get purge -y $buildDeps && \
+    rm -rf /var/lib/apt/lists/*
 
 ADD . /srv/code/
 WORKDIR /srv/code


### PR DESCRIPTION
Switching to the -slim image reduces the image size by 500MB, currently it is 1.3GB.

r?