### PR TITLE
Don't bail if watch arg is supplied

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -51,8 +51,8 @@ const newWebpackConfig = Object.assign({}, webpackConfigProd, {
             }
           });
 
-          // Bail if syntax errors were encountered.
-          if (flagError) {
+          // Bail if syntax errors were encountered and we're not watching.
+          if (flagError && process.argv.indexOf('--watch') === -1) {
             throw new Error('Syntax error encountered, bailing');
           }
         }
@@ -150,7 +150,6 @@ module.exports = function karmaConf(conf) {
       'karma-sourcemap-loader',
       'karma-webpack',
     ],
-    autoWatch: true,
     browsers: ['Firefox'],
     singleRun: false,
     concurrency: Infinity,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,22 +39,32 @@ const newWebpackConfig = Object.assign({}, webpackConfigProd, {
     function WebpackWarningPlugin() {
       this.plugin('done', (_stats) => {
         const stats = _stats;
-        let flagError;
+        let flagException = false;
 
-        if (stats.compilation.warnings.length) {
-          // Log each of the warnings
-          stats.compilation.warnings.forEach((_warning) => {
-            const warning = _warning.message || _warning || '';
-            if (warning.indexOf('SyntaxError') > -1) {
-              console.log(warning);
-              flagError = true;
-            }
-          });
+        const loggedExceptions = [
+          'SyntaxError',
+        ];
 
-          // Bail if syntax errors were encountered and we're not watching.
-          if (flagError && process.argv.indexOf('--watch') === -1) {
-            throw new Error('Syntax error encountered, bailing');
+        function strContainsException(str) {
+          return loggedExceptions.some((substring) => str.includes(substring));
+        }
+
+        ['errors', 'warnings'].forEach((key) => {
+          const loggedStack = stats.compilation[key];
+          if (loggedStack && loggedStack.length) {
+            stats.compilation[key].forEach((item) => {
+              const message = item.message || '';
+              if (strContainsException(message)) {
+                console.log(message);
+                flagException = true;
+              }
+            });
           }
+        });
+
+        // Bail if syntax errors were encountered and we're not watching.
+        if (flagException && process.argv.indexOf('--watch') === -1) {
+          throw new Error('Error encountered, bailing');
         }
       });
     },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
       }
     },
     "unittest:dev": {
-      "command": "karma start",
+      "command": "karma start --watch",
       "env": {
         "NODE_PATH": "./:./src",
         "NODE_ENV": "test"


### PR DESCRIPTION
Fixes #1103 

@kumar303 Give this a spin it - should not bail when running with `npm run unittest:dev` when there's an syntax error.

Note: if the syntax error is in a test file then the syntax error info will be above the rest of the test output. If it's a src file it will not run the tests. Coverage is the useful guide in the first case.