### PR TITLE
Localise user count in search results

### DIFF
--- a/src/amo/components/AddonMeta.js
+++ b/src/amo/components/AddonMeta.js
@@ -17,7 +17,7 @@ export class AddonMetaBase extends React.Component {
 
     const userCount = i18n.sprintf(
       i18n.ngettext('%(total)s user', '%(total)s users', averageDailyUsers),
-      { total: averageDailyUsers.toLocaleString(i18n.lang) },
+      { total: i18n.formatNumber(averageDailyUsers) },
     );
     return (
       <div className="AddonMeta">

--- a/src/amo/components/AddonMeta.js
+++ b/src/amo/components/AddonMeta.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';
@@ -11,15 +10,14 @@ export class AddonMetaBase extends React.Component {
   static propTypes = {
     averageDailyUsers: PropTypes.number.isRequired,
     i18n: PropTypes.object.isRequired,
-    lang: PropTypes.string.isRequired,
   }
 
   render() {
-    const { lang, averageDailyUsers, i18n } = this.props;
+    const { averageDailyUsers, i18n } = this.props;
 
     const userCount = i18n.sprintf(
       i18n.ngettext('%(total)s user', '%(total)s users', averageDailyUsers),
-      { total: averageDailyUsers.toLocaleString(lang) },
+      { total: averageDailyUsers.toLocaleString(i18n.lang) },
     );
     return (
       <div className="AddonMeta">
@@ -33,9 +31,6 @@ export class AddonMetaBase extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => ({ lang: state.api.lang });
-
 export default compose(
-  connect(mapStateToProps),
   translate({ withRef: true }),
 )(AddonMetaBase);

--- a/src/amo/components/SearchResult.js
+++ b/src/amo/components/SearchResult.js
@@ -15,6 +15,7 @@ export class SearchResultBase extends React.Component {
 
   render() {
     const { addon, i18n } = this.props;
+    const averageDailyUsers = addon.average_daily_users;
 
     // TODO: Implement a rating component and style the stars.
     const rating = addon.ratings && addon.ratings.average ? (
@@ -40,9 +41,8 @@ export class SearchResultBase extends React.Component {
             {rating}
             <h3 className="SearchResult-author">{addon.authors[0].name}</h3>
             <h3 className="SearchResult-users">{i18n.sprintf(
-              i18n.ngettext('%(users)s user', '%(users)s users',
-                            addon.average_daily_users),
-              { users: addon.average_daily_users }
+              i18n.ngettext('%(total)s user', '%(total)s users', averageDailyUsers),
+              { total: averageDailyUsers.toLocaleString(i18n.lang) },
             )}
             </h3>
           </section>

--- a/src/amo/components/SearchResult.js
+++ b/src/amo/components/SearchResult.js
@@ -42,7 +42,7 @@ export class SearchResultBase extends React.Component {
             <h3 className="SearchResult-author">{addon.authors[0].name}</h3>
             <h3 className="SearchResult-users">{i18n.sprintf(
               i18n.ngettext('%(total)s user', '%(total)s users', averageDailyUsers),
-              { total: averageDailyUsers.toLocaleString(i18n.lang) },
+              { total: i18n.formatNumber(averageDailyUsers) },
             )}
             </h3>
           </section>

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -24,7 +24,7 @@ export default function makeClient(routes, createStore) {
   const appName = config.get('appName');
 
   function renderApp(i18nData) {
-    const i18n = makeI18n(i18nData);
+    const i18n = makeI18n(i18nData, lang);
 
     if (initialStateContainer) {
       try {

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -187,6 +187,8 @@ export function makeI18n(i18nData, lang, _Jed = Jed) {
   const i18n = new _Jed(i18nData);
   i18n.lang = lang;
 
+  i18n.formatNumber = (number) => number.toLocaleString(lang);
+
   // This adds the correct moment locale for the active locale so we can get
   // localised dates, times, etc.
   if (i18n.options && typeof i18n.options._momentDefineLocale === 'function') {

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -183,14 +183,15 @@ export function makeMomentLocale(locale) {
 
 // Create an i18n object with a translated moment object available we can
 // use for translated dates across the app.
-export function makeI18n(i18nData, _Jed = Jed) {
+export function makeI18n(i18nData, lang, _Jed = Jed) {
   const i18n = new _Jed(i18nData);
+  i18n.lang = lang;
 
   // This adds the correct moment locale for the active locale so we can get
   // localised dates, times, etc.
   if (i18n.options && typeof i18n.options._momentDefineLocale === 'function') {
     i18n.options._momentDefineLocale();
-    moment.locale(makeMomentLocale(i18n.options.locale_data.messages[''].lang));
+    moment.locale(makeMomentLocale(i18n.lang));
   }
 
   // We add a translated "moment" property to our `i18n` object

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -229,7 +229,7 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
             log.info(
               `Falling back to default lang: "${config.get('defaultLang')}".`);
           }
-          const i18n = makeI18n(i18nData);
+          const i18n = makeI18n(i18nData, lang);
 
           const InitialComponent = (
             <I18nProvider i18n={i18n}>

--- a/tests/client/amo/components/TestAddonMeta.js
+++ b/tests/client/amo/components/TestAddonMeta.js
@@ -3,16 +3,12 @@ import { renderIntoDocument } from 'react-addons-test-utils';
 import { findDOMNode } from 'react-dom';
 
 import AddonMeta from 'amo/components/AddonMeta';
-import createStore from 'amo/store';
-import { setLang } from 'core/actions';
 import { getFakeI18nInst } from 'tests/client/helpers';
 
 function render({ ...customProps } = {}) {
   const props = {
     averageDailyUsers: 5,
-    store: createStore(),
     i18n: getFakeI18nInst(),
-    lang: 'en-US',
     ...customProps,
   };
   const root = renderIntoDocument(<AddonMeta {...props} />);
@@ -36,11 +32,8 @@ describe('<AddonMeta>', () => {
     });
 
     it('localizes the user count', () => {
-      const store = createStore();
-      store.dispatch(setLang('de'));
-      const root = render({
-        store, averageDailyUsers: 1000,
-      });
+      const i18n = getFakeI18nInst({ lang: 'de' });
+      const root = render({ averageDailyUsers: 1000, i18n });
       assert.match(getUserCount(root), /^1\.000/);
     });
   });

--- a/tests/client/amo/components/TestSearchResult.js
+++ b/tests/client/amo/components/TestSearchResult.js
@@ -12,12 +12,12 @@ import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('<SearchResult />', () => {
-  function renderResult(result) {
-    const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
+  function renderResult(result, { lang = 'en-GB' } = {}) {
+    const initialState = { api: { clientApp: 'android', lang } };
 
     return findRenderedComponentWithType(renderIntoDocument(
       <Provider store={createStore(initialState)}>
-        <SearchResult i18n={getFakeI18nInst()} addon={result} />
+        <SearchResult i18n={getFakeI18nInst({ lang })} addon={result} />
       </Provider>
     ), SearchResult).getWrappedInstance();
   }
@@ -27,7 +27,7 @@ describe('<SearchResult />', () => {
       { name: 'A funky déveloper' },
       { name: 'A groovy developer' },
     ],
-    average_daily_users: 553,
+    average_daily_users: 5253,
     name: 'A search result',
     slug: 'a-search-result',
   };
@@ -53,7 +53,14 @@ describe('<SearchResult />', () => {
 
   it('renders the user count', () => {
     const users = findRenderedDOMComponentWithClass(root, 'SearchResult-users');
-    assert.equal(users.textContent, '553 users');
+    assert.equal(users.textContent, '5,253 users');
+  });
+
+  it('localises the user count', () => {
+    const localisedRoot = renderResult(result, { lang: 'fr' });
+    const users = findRenderedDOMComponentWithClass(localisedRoot, 'SearchResult-users');
+    // \xa0 is a non-breaking space.
+    assert.match(users.textContent, /5\xa0253/);
   });
 
   it('renders the user count as singular', () => {

--- a/tests/client/core/i18n/test_utils.js
+++ b/tests/client/core/i18n/test_utils.js
@@ -391,15 +391,11 @@ describe('i18n utils', () => {
   });
 
   describe('makeI18n', () => {
-    let FakeJed;
-
-    before(() => {
-      FakeJed = class {
-        constructor(i18nData) {
-          return i18nData;
-        }
-      };
-    });
+    class FakeJed {
+      constructor(i18nData) {
+        return i18nData;
+      }
+    }
 
     beforeEach(() => {
       // FIXME: Our moment is not immutable so we reset it before each test.
@@ -442,6 +438,16 @@ describe('i18n utils', () => {
 
       const i18n = utils.makeI18n(i18nData, 'en', FakeJed);
       assert.equal(i18n.moment.locale(), 'en');
+    });
+
+    it('formats a number', () => {
+      const i18n = utils.makeI18n({}, 'en', FakeJed);
+      assert.equal(i18n.formatNumber(9518231), '9,518,231');
+    });
+
+    it('localised formatting a number', () => {
+      const i18n = utils.makeI18n({}, 'de', FakeJed);
+      assert.equal(i18n.formatNumber(9518231), '9.518.231');
     });
   });
 });

--- a/tests/client/core/i18n/test_utils.js
+++ b/tests/client/core/i18n/test_utils.js
@@ -411,9 +411,14 @@ describe('i18n utils', () => {
 
     it('adds a localised moment to the i18n object', () => {
       const i18nData = {};
-      const i18n = utils.makeI18n(i18nData, FakeJed);
+      const i18n = utils.makeI18n(i18nData, 'en-US', FakeJed);
       assert.ok(i18n.moment);
       assert.typeOf(i18n.moment, 'function');
+    });
+
+    it('exposes the lang', () => {
+      const i18n = utils.makeI18n({}, 'af', FakeJed);
+      assert.equal(i18n.lang, 'af');
     });
 
     it('tries to localise moment', () => {
@@ -423,7 +428,7 @@ describe('i18n utils', () => {
           locale_data: { messages: { '': { lang: 'fr' } } },
         },
       };
-      const i18n = utils.makeI18n(i18nData, FakeJed);
+      const i18n = utils.makeI18n(i18nData, 'fr', FakeJed);
       assert.equal(i18n.moment.locale(), 'fr');
     });
 
@@ -435,7 +440,7 @@ describe('i18n utils', () => {
         },
       };
 
-      const i18n = utils.makeI18n(i18nData, FakeJed);
+      const i18n = utils.makeI18n(i18nData, 'en', FakeJed);
       assert.equal(i18n.moment.locale(), 'en');
     });
   });

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -1,11 +1,12 @@
 import base64url from 'base64url';
+import config from 'config';
 import { sprintf } from 'jed';
-import moment from 'moment';
 import React from 'react';
 import { createRenderer } from 'react-addons-test-utils';
 
 import { ADDON_TYPE_EXTENSION } from 'core/constants';
 import { ngettext } from 'core/utils';
+import { makeI18n } from 'core/i18n/utils';
 
 /*
  * Return a fake authentication token (a JWT) that can be
@@ -68,23 +69,23 @@ export function unexpectedSuccess() {
   return assert.fail(null, null, 'Unexpected success');
 }
 
+class FakeJed {
+  gettext = sinon.spy((str) => str)
+  dgettext = sinon.stub()
+  ngettext = sinon.spy(ngettext)
+  dngettext = sinon.stub()
+  pgettext = sinon.stub()
+  dpgettext = sinon.stub()
+  npgettext = sinon.stub()
+  dnpgettext = sinon.stub()
+  sprintf = sinon.spy(sprintf)
+}
+
 /*
  * Creates a stand-in for a jed instance,
  */
-export function getFakeI18nInst({ lang = 'en-US' } = {}) {
-  return {
-    gettext: sinon.spy((str) => str),
-    dgettext: sinon.stub(),
-    ngettext: sinon.spy(ngettext),
-    dngettext: sinon.stub(),
-    pgettext: sinon.stub(),
-    dpgettext: sinon.stub(),
-    npgettext: sinon.stub(),
-    dnpgettext: sinon.stub(),
-    sprintf: sinon.spy(sprintf),
-    lang,
-    moment,
-  };
+export function getFakeI18nInst({ lang = config.get('defaultLang') } = {}) {
+  return makeI18n({}, lang, FakeJed);
 }
 
 export class MockedSubComponent extends React.Component {

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -71,7 +71,7 @@ export function unexpectedSuccess() {
 /*
  * Creates a stand-in for a jed instance,
  */
-export function getFakeI18nInst() {
+export function getFakeI18nInst({ lang = 'en-US' } = {}) {
   return {
     gettext: sinon.spy((str) => str),
     dgettext: sinon.stub(),
@@ -82,6 +82,7 @@ export function getFakeI18nInst() {
     npgettext: sinon.stub(),
     dnpgettext: sinon.stub(),
     sprintf: sinon.spy(sprintf),
+    lang,
     moment,
   };
 }


### PR DESCRIPTION
I updated how the lang is acquired. Rather than using state it uses `i18n.lang` and the lang is passed to the `makeI18n()` function to be set rather than pulling it from the first message (I'm curious what that would do if the string wasn't translated or we maybe didn't have any translations for a locale).

I updated the string to match the one from `AddonMeta` since they have different names for the number so it would have caused there to be an extra translation string (I think).

Screenshots:

<details><summary>English</summary><img src="https://cloud.githubusercontent.com/assets/211578/22001524/5843545e-dc0b-11e6-843f-5b380c0a6190.png" alt="screen shot 2017-01-16 at 16 31 59" style="width: 300px; max-width:50%;">
</details>

<details><summary>French</summary>

![screen shot 2017-01-16 at 16 45 00](https://cloud.githubusercontent.com/assets/211578/22001560/a1e35870-dc0b-11e6-843f-74a08ebf6e86.png)
</details>
&nbsp;

Fixes #1608.