### PR TITLE
Disable CSP for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,31 +130,12 @@ to learn more about how configuration is applied.
 
 When developing locally with a webpack server, the randomly generated asset
 URL will fail our Content Security Policy (CSP) and clutter your console
-with errors. You can turn off all CSP errors by adding this to any of your
-local config files, such as `local-development-amo.js`:
+with errors. You can turn off all CSP errors by settings CSP to `false`
+in any local config file, such as `local-development-amo.js`. Example:
 
 ````javascript
-const allCspHosts = ['*', 'data:'];
-
 module.exports = {
-  CSP: {
-    directives: {
-      defaultSrc: allCspHosts,
-      baseUri: allCspHosts,
-      childSrc: allCspHosts,
-      connectSrc: allCspHosts,
-      formAction: allCspHosts,
-      frameSrc: allCspHosts,
-      imgSrc: allCspHosts,
-      mediaSrc: allCspHosts,
-      objectSrc: allCspHosts,
-      scriptSrc: allCspHosts.concat(["'unsafe-inline'", "'unsafe-eval'"]),
-      styleSrc: allCspHosts.concat(["'unsafe-inline'"]),
-      reportUri: '/__cspreport__',
-    },
-    reportOnly: true,
-  },
-  // Other configuration...
+  CSP: false,
 };
 ````
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,38 @@ Consult the
 [config file loading order docs](https://github.com/lorenwest/node-config/wiki/Configuration-Files#file-load-order)
 to learn more about how configuration is applied.
 
+#### Disabling CSP for local development
+
+When developing locally with a webpack server, the randomly generated asset
+URL will fail our Content Security Policy (CSP) and clutter your console
+with errors. You can turn off all CSP errors by adding this to any of your
+local config files, such as `local-development-amo.js`:
+
+````javascript
+const allCspHosts = ['*', 'data:'];
+
+module.exports = {
+  CSP: {
+    directives: {
+      defaultSrc: allCspHosts,
+      baseUri: allCspHosts,
+      childSrc: allCspHosts,
+      connectSrc: allCspHosts,
+      formAction: allCspHosts,
+      frameSrc: allCspHosts,
+      imgSrc: allCspHosts,
+      mediaSrc: allCspHosts,
+      objectSrc: allCspHosts,
+      scriptSrc: allCspHosts.concat(["'unsafe-inline'", "'unsafe-eval'"]),
+      styleSrc: allCspHosts.concat(["'unsafe-inline'"]),
+      reportUri: '/__cspreport__',
+    },
+    reportOnly: true,
+  },
+  // Other configuration...
+};
+````
+
 ### Building and running services
 
 The following are scripts that are used in deployment - you generally won't

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -99,14 +99,18 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
   // CSP configuration.
   const csp = config.get('CSP');
   const noScriptStyles = getNoScriptStyles({ appName: appInstanceName });
-  if (noScriptStyles) {
-    const hash = crypto.createHash('sha256').update(noScriptStyles).digest('base64');
-    const cspValue = `'sha256-${hash}'`;
-    if (!csp.directives.styleSrc.includes(cspValue)) {
-      csp.directives.styleSrc.push(cspValue);
+  if (csp) {
+    if (noScriptStyles) {
+      const hash = crypto.createHash('sha256').update(noScriptStyles).digest('base64');
+      const cspValue = `'sha256-${hash}'`;
+      if (!csp.directives.styleSrc.includes(cspValue)) {
+        csp.directives.styleSrc.push(cspValue);
+      }
     }
+    app.use(helmet.contentSecurityPolicy(csp));
+  } else {
+    log.warn('CSP has been disabled from the config');
   }
-  app.use(helmet.contentSecurityPolicy(csp));
 
   if (config.get('enableNodeStatics')) {
     app.use(Express.static(path.join(config.get('basePath'), 'dist')));


### PR DESCRIPTION
We used to have support for `CSP: false`. We should probably just bring that back but until then, this seems worth documenting.