### PR TITLE
[WIP] Store translations in redux, support lang updates without reload

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -46,7 +46,7 @@ poFiles.forEach((pofile) => {
   // Add the moment locale JS into our locale file, if one is available and
   // we're building for AMO (which is the only app that uses moment right
   // now).
-  if (appName === 'amo') {
+  if (false && appName === 'amo') {
     var defineLocale = null;
     try {
       const momentLocale = locale.replace('_', '-').toLowerCase();

--- a/src/amo/components/LanguagePicker.js
+++ b/src/amo/components/LanguagePicker.js
@@ -1,8 +1,10 @@
 /* global window */
+import config from 'config';
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
+import { setLang } from 'core/actions';
 import languages from 'core/languages';
 import translate from 'core/i18n/translate';
 import { addQueryParams } from 'core/utils';
@@ -20,8 +22,7 @@ export class LanguagePickerBase extends React.Component {
   static propTypes = {
     currentLocale: PropTypes.string.isRequired,
     i18n: PropTypes.object.isRequired,
-    location: PropTypes.object.isRequired,
-    _window: PropTypes.object,
+    dispatch: PropTypes.func.isRequired,
   }
 
   onChange = (event) => {
@@ -30,13 +31,15 @@ export class LanguagePickerBase extends React.Component {
   }
 
   changeLanguage(newLocale) {
-    const { currentLocale, location, _window } = this.props;
+    const { currentLocale } = this.props;
 
     if (currentLocale !== newLocale) {
-      const newURL = changeLocaleURL({ currentLocale, location, newLocale });
-      // We change location because a locale change requires a full page
-      // reload to get the new translations, etc.
-      (_window || window).location = newURL;
+      const appName = config.get('appName');
+      // eslint-disable-next-line max-len, global-require, import/no-dynamic-require
+      require(`bundle?name=[name]-i18n-[folder]!../../locale/${newLocale}/${appName}.js`)((i18nData) => {
+        this.props.dispatch(setLang(newLocale));
+        this.props.dispatch({ type: 'SET_I18N', payload: i18nData });
+      });
     }
   }
 

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -8,6 +8,7 @@ import api from 'core/reducers/api';
 import auth from 'core/reducers/authentication';
 import categories from 'core/reducers/categories';
 import errors from 'core/reducers/errors';
+import i18n from 'core/reducers/i18n';
 import infoDialog from 'core/reducers/infoDialog';
 import installations from 'core/reducers/installations';
 import search from 'core/reducers/search';
@@ -22,6 +23,7 @@ export default function createStore(initialState = {}) {
       auth,
       categories,
       errors,
+      i18n,
       infoDialog,
       installations,
       landing,

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -1,7 +1,6 @@
 /* global document */
 
 import 'babel-polyfill';
-import config from 'config';
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
@@ -9,8 +8,6 @@ import { applyRouterMiddleware, Router, browserHistory } from 'react-router';
 import { ReduxAsyncConnect } from 'redux-connect';
 import useScroll from 'react-router-scroll/lib/useScroll';
 
-import { langToLocale, makeI18n, sanitizeLanguage } from 'core/i18n/utils';
-import I18nProvider from 'core/i18n/Provider';
 import log from 'core/logger';
 
 
@@ -18,59 +15,34 @@ export default function makeClient(routes, createStore) {
   const initialStateContainer = document.getElementById('redux-store-state');
   let initialState;
 
-  const html = document.querySelector('html');
-  const lang = sanitizeLanguage(html.getAttribute('lang'));
-  const locale = langToLocale(lang);
-  const appName = config.get('appName');
-
-  function renderApp(i18nData) {
-    const i18n = makeI18n(i18nData, lang);
-
-    if (initialStateContainer) {
-      try {
-        initialState = JSON.parse(initialStateContainer.textContent);
-      } catch (error) {
-        log.error('Could not load initial redux data');
-      }
+  if (initialStateContainer) {
+    try {
+      initialState = JSON.parse(initialStateContainer.textContent);
+    } catch (error) {
+      log.error('Could not load initial redux data');
     }
-    const store = createStore(initialState);
-
-    // wrapper to make redux-connect applyRouterMiddleware compatible see
-    // https://github.com/taion/react-router-scroll/issues/3
-    const useReduxAsyncConnect = () => ({
-      renderRouterContext: (child, props) => (
-        <ReduxAsyncConnect {...props}>{child}</ReduxAsyncConnect>
-      ),
-    });
-
-    const middleware = applyRouterMiddleware(
-      useScroll(),
-      useReduxAsyncConnect(),
-    );
-
-    render(
-      <I18nProvider i18n={i18n}>
-        <Provider store={store} key="provider">
-          <Router render={middleware} history={browserHistory}>
-            {routes}
-          </Router>
-        </Provider>
-      </I18nProvider>,
-      document.getElementById('react-view')
-    );
   }
+  const store = createStore(initialState);
 
+  // wrapper to make redux-connect applyRouterMiddleware compatible see
+  // https://github.com/taion/react-router-scroll/issues/3
+  const useReduxAsyncConnect = () => ({
+    renderRouterContext: (child, props) => (
+      <ReduxAsyncConnect {...props}>{child}</ReduxAsyncConnect>
+    ),
+  });
 
-  try {
-    if (locale !== langToLocale(config.get('defaultLang'))) {
-      // eslint-disable-next-line max-len, global-require, import/no-dynamic-require
-      require(`bundle?name=[name]-i18n-[folder]!../../locale/${locale}/${appName}.js`)(renderApp);
-    } else {
-      renderApp({});
-    }
-  } catch (e) {
-    log.info(dedent`Locale not found or required for locale: "${locale}".
-      Falling back to default lang: "${config.get('defaultLang')}"`);
-    renderApp({});
-  }
+  const middleware = applyRouterMiddleware(
+    useScroll(),
+    useReduxAsyncConnect(),
+  );
+
+  render(
+    <Provider store={store} key="provider">
+      <Router render={middleware} history={browserHistory}>
+        {routes}
+      </Router>
+    </Provider>,
+    document.getElementById('react-view')
+  );
 }

--- a/src/core/i18n/Provider.js
+++ b/src/core/i18n/Provider.js
@@ -1,27 +1,25 @@
 import { Children, Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import { makeI18n } from 'core/i18n/utils';
 
 /*
- * This Provider expects to be passed an initialized
- * Jed i18n object,
+ * This Provider expects to be passed the current lang.
  */
 
-export default class I18nProvider extends Component {
+class I18nProvider extends Component {
   static propTypes = {
-    i18n: PropTypes.object.isRequired,
     children: PropTypes.element.isRequired,
+    i18n: PropTypes.object.isRequired,
   }
 
   static childContextTypes = {
     i18n: PropTypes.object.isRequired,
   }
 
-  constructor(props, context) {
-    super(props, context);
-    this.i18n = props.i18n;
-  }
-
   getChildContext() {
-    return { i18n: this.i18n };
+    return { i18n: this.props.i18n };
   }
 
   render() {
@@ -29,3 +27,13 @@ export default class I18nProvider extends Component {
     return Children.only(children);
   }
 }
+
+function mapStateToProps({ api, i18n }) {
+  return {
+    i18n: makeI18n(i18n, api.lang),
+  };
+}
+
+export default compose(
+  connect(mapStateToProps),
+)(I18nProvider);

--- a/src/core/i18n/translate.js
+++ b/src/core/i18n/translate.js
@@ -1,4 +1,7 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+import { makeI18n } from 'core/i18n/utils';
 
 
 function getDisplayName(component) {
@@ -10,14 +13,6 @@ export default function translate(options = {}) {
 
   return function Wrapper(WrappedComponent) {
     class Translate extends Component {
-      constructor(props, context) {
-        super(props, context);
-        this.i18n = context.i18n;
-        this.state = {
-          i18nLoadedAt: null,
-        };
-      }
-
       getWrappedInstance() {
         if (!withRef) {
           throw new Error(dedent`To access the wrapped instance, you need to specify
@@ -49,6 +44,12 @@ export default function translate(options = {}) {
 
     Translate.displayName = `Translate[${getDisplayName(WrappedComponent)}]`;
 
-    return Translate;
+    function mapStateToProps({ api, i18n }) {
+      return {
+        i18n: makeI18n(i18n, api.lang),
+      };
+    }
+
+    return connect(mapStateToProps)(Translate);
   };
 }

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -184,6 +184,7 @@ export function makeMomentLocale(locale) {
 // Create an i18n object with a translated moment object available we can
 // use for translated dates across the app.
 export function makeI18n(i18nData, lang, _Jed = Jed) {
+  console.log(`creating i18n instance for ${lang}`);
   const i18n = new _Jed(i18nData);
   i18n.lang = lang;
 
@@ -191,10 +192,10 @@ export function makeI18n(i18nData, lang, _Jed = Jed) {
 
   // This adds the correct moment locale for the active locale so we can get
   // localised dates, times, etc.
-  if (i18n.options && typeof i18n.options._momentDefineLocale === 'function') {
-    i18n.options._momentDefineLocale();
-    moment.locale(makeMomentLocale(i18n.lang));
-  }
+  // if (i18n.options && typeof i18n.options._momentDefineLocale === 'function') {
+  //   i18n.options._momentDefineLocale();
+  //   moment.locale(makeMomentLocale(i18n.lang));
+  // }
 
   // We add a translated "moment" property to our `i18n` object
   // to make translated date/time/etc. easy.

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -184,7 +184,6 @@ export function makeMomentLocale(locale) {
 // Create an i18n object with a translated moment object available we can
 // use for translated dates across the app.
 export function makeI18n(i18nData, lang, _Jed = Jed) {
-  console.log(`creating i18n instance for ${lang}`);
   const i18n = new _Jed(i18nData);
   i18n.lang = lang;
 

--- a/src/core/reducers/i18n.js
+++ b/src/core/reducers/i18n.js
@@ -1,0 +1,6 @@
+export default function i18n(state = {}, action) {
+  if (action.type === 'SET_I18N') {
+    return action.payload;
+  }
+  return state;
+}

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -28,9 +28,7 @@ import {
   getDirection,
   isValidLang,
   langToLocale,
-  makeI18n,
 } from 'core/i18n/utils';
-import I18nProvider from 'core/i18n/Provider';
 
 import WebpackIsomorphicToolsConfig from './webpack-isomorphic-tools-config';
 
@@ -233,14 +231,13 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
             log.info(
               `Falling back to default lang: "${config.get('defaultLang')}".`);
           }
-          const i18n = makeI18n(i18nData, lang);
+
+          store.dispatch({ type: 'SET_I18N', payload: i18nData });
 
           const InitialComponent = (
-            <I18nProvider i18n={i18n}>
-              <Provider store={store} key="provider">
-                <ReduxAsyncConnect {...renderProps} />
-              </Provider>
-            </I18nProvider>
+            <Provider store={store} key="provider">
+              <ReduxAsyncConnect {...renderProps} />
+            </Provider>
           );
 
           const asyncConnectLoadState = store.getState().reduxAsyncConnect.loadState || {};

--- a/tests/client/amo/components/TestSearchResult.js
+++ b/tests/client/amo/components/TestSearchResult.js
@@ -31,7 +31,11 @@ describe('<SearchResult />', () => {
     name: 'A search result',
     slug: 'a-search-result',
   };
-  const root = renderResult(result);
+  let root;
+
+  beforeEach(() => {
+    root = renderResult(result);
+  });
 
   it('renders the heading', () => {
     const heading = findRenderedDOMComponentWithClass(


### PR DESCRIPTION
This adds support for updating the language without reloading the entire page. Formatting the numbers works but moment support was removed (should be easy to add back in with `serialize` but I just wanted this to work).

TODO:

- [ ] Update the URL when language changes.
- [ ] Support moment.
- [ ] Make the tests pass.
- [ ] Shave a few yaks.

The `I18nProvider` is no longer needed as the `translate()` HOC will create the i18n instance for components to use (this may use more memory but that's what has to happen I think).

The change is essentially to put the translations into redux instead of passing the i18n instance in with the translations included and have `translate()` pull the translations and create the `i18n` instance. The loading of strings on the client side has moved from `client/base.js` to `LanguagePicker` (I don't know how this will perform in production mode but I think hypothetically it should work).

<img src="https://cloud.githubusercontent.com/assets/211578/22124461/8c57dcdc-de55-11e6-8c2e-3d5f6ee0bc8f.gif" alt="translations-without-reload mov" style="max-width:100%;" width="350">

I'm just putting this here so the code is sitting around somewhere, I'm not sure how much work it will take to make it mergeable.