### PR TITLE
Make log out work on mobile pages

### DIFF
--- a/src/admin/containers/App.js
+++ b/src/admin/containers/App.js
@@ -4,8 +4,8 @@ import cookie from 'react-cookie';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 
+import { logOutUser } from 'core/actions';
 import { gettext as _ } from 'core/utils';
-import { LOG_OUT_USER } from 'core/constants';
 import NavBar from 'admin/components/NavBar';
 
 import 'admin/css/App.scss';
@@ -39,8 +39,8 @@ export const mapStateToProps = (state) => ({
 
 export const mapDispatchToProps = {
   handleLogOut: () => {
-    cookie.remove(config.get('cookieName'));
-    return { type: LOG_OUT_USER };
+    cookie.remove(config.get('cookieName'), { path: '/' });
+    return logOutUser();
   },
 };
 

--- a/src/amo/components/MastHead.js
+++ b/src/amo/components/MastHead.js
@@ -12,7 +12,7 @@ import './MastHead.scss';
 export class MastHeadBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object.isRequired,
-    isHomePage: PropTypes.bool,
+    isHomePage: PropTypes.bool.isRequired,
     location: PropTypes.object.isRequired,
     SearchFormComponent: PropTypes.node.isRequired,
     query: PropTypes.string,

--- a/src/amo/components/MastHead.js
+++ b/src/amo/components/MastHead.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 
 import Link from 'amo/components/Link';
 import SearchForm from 'amo/components/SearchForm';
+import AuthenticateButton from 'core/components/AuthenticateButton';
 import translate from 'core/i18n/translate';
 
 import 'mozilla-tabzilla/css/_tabzilla.scss';
@@ -10,9 +11,9 @@ import './MastHead.scss';
 
 export class MastHeadBase extends React.Component {
   static propTypes = {
-    children: PropTypes.node,
-    isHomePage: PropTypes.bool.isRequired,
     i18n: PropTypes.object.isRequired,
+    isHomePage: PropTypes.bool,
+    location: PropTypes.object.isRequired,
     SearchFormComponent: PropTypes.node.isRequired,
     query: PropTypes.string,
   }
@@ -23,9 +24,7 @@ export class MastHeadBase extends React.Component {
   }
 
   render() {
-    const {
-      SearchFormComponent, children, i18n, isHomePage, query,
-    } = this.props;
+    const { SearchFormComponent, i18n, isHomePage, location, query } = this.props;
     const headerLink = (
       <Link className="MastHead-title" to="/">
         {i18n.gettext('Firefox Add-ons')}
@@ -34,10 +33,12 @@ export class MastHeadBase extends React.Component {
 
     return (
       <div className="MastHead">
-        <div id="tabzilla">
-          <a href="https://www.mozilla.org">Mozilla</a>
+        <div className="MastHead-top-row">
+          <div id="tabzilla">
+            <a href="https://www.mozilla.org">Mozilla</a>
+          </div>
+          <AuthenticateButton className="MastHead-auth-button" size="small" location={location} />
         </div>
-        {children}
         <header className="MastHead-header">
           {isHomePage
             ? <h1 className="MastHead-title-wrapper">{headerLink}</h1>

--- a/src/amo/components/MastHead.scss
+++ b/src/amo/components/MastHead.scss
@@ -60,6 +60,7 @@
 
   .Icon {
     @include margin-end(0.5em);
+
     vertical-align: top;
   }
 }

--- a/src/amo/components/MastHead.scss
+++ b/src/amo/components/MastHead.scss
@@ -1,15 +1,5 @@
 @import "~amo/css/inc/vars";
 
-#tabzilla {
-  left: 14px;
-  position: absolute;
-
-  [dir=rtl] & {
-    left: auto;
-    right: 14px;
-  }
-}
-
 .MastHead {
   background: $masthead-color;
   min-height: 100px;
@@ -52,38 +42,22 @@
   }
 }
 
-.AccountButton.button {
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 7px;
-  color: $header-font-color;
-  font-size: 12px;
-  padding: 8px;
-  position: absolute;
-  right: 15px;
-  top: 15px;
+.MastHead-top-row {
+  display: flex;
+  margin: 0 15px;
+  justify-content: space-between;
+}
 
-  [dir=rtl] & {
-    left: 15px;
-    right: auto;
+.MastHead-auth-button {
+  background: $masthead-light-color;
+  color: $header-font-color;
+  margin-top: 15px;
+
+  &:hover {
+    background: lighten($masthead-light-color, 10%);
   }
 
-  span {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-
-    &::before {
-      background: url('../img/icons/login-person.svg') no-repeat 0 0;
-      content: '';
-      display: inline-block;
-      height: 16px;
-      margin-right: 5px;
-      position: relative;
-      width: 13px;
-
-      [dir=rtl] & {
-        margin: 0 0 0 5px;
-      }
-    }
+  .Icon {
+    vertical-align: top;
   }
 }

--- a/src/amo/components/MastHead.scss
+++ b/src/amo/components/MastHead.scss
@@ -1,3 +1,4 @@
+@import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
 
 .MastHead {
@@ -7,7 +8,7 @@
 }
 
 .MastHead-header {
-  padding: 80px 0 30px;
+  padding: 30px 0;
   text-align: center;
 
   h1 {
@@ -48,16 +49,17 @@
   justify-content: space-between;
 }
 
-.MastHead-auth-button {
-  background: $masthead-light-color;
-  color: $header-font-color;
+.Button.MastHead-auth-button {
+  color: $masthead-color;
   margin-top: 15px;
 
+  &,
   &:hover {
-    background: lighten($masthead-light-color, 10%);
+    background: #fff;
   }
 
   .Icon {
+    @include margin-end(0.5em);
     vertical-align: top;
   }
 }

--- a/src/amo/containers/App.js
+++ b/src/amo/containers/App.js
@@ -1,14 +1,15 @@
 /* global navigator, window */
 import config from 'config';
 import React, { PropTypes } from 'react';
-import Helmet from 'react-helmet';
 import cookie from 'react-cookie';
+import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import 'core/fonts/fira.scss';
 import 'amo/css/App.scss';
 import SearchForm from 'amo/components/SearchForm';
+import { logOutUser } from 'core/actions';
 import { addChangeListeners } from 'core/addonManager';
 import { INSTALL_STATE } from 'core/constants';
 import InfoDialog from 'core/containers/InfoDialog';
@@ -29,6 +30,7 @@ export class AppBase extends React.Component {
     clientApp: PropTypes.string.isRequired,
     handleGlobalEvent: PropTypes.func.isRequired,
     handleLogIn: PropTypes.func.isRequired,
+    handleLogOut: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
     isAuthenticated: PropTypes.bool,
     lang: PropTypes.string.isRequired,
@@ -59,10 +61,10 @@ export class AppBase extends React.Component {
   }
 
   accountButton() {
-    const { handleLogIn, i18n, isAuthenticated, location } = this.props;
+    const { handleLogIn, handleLogOut, i18n, isAuthenticated, location } = this.props;
     return (
       <button className="button AccountButton"
-              onClick={() => handleLogIn(location)}
+              onClick={() => (isAuthenticated ? handleLogOut() : handleLogIn(location))}
               ref={(ref) => { this.logInButton = ref; }}>
         <span>{ isAuthenticated ? i18n.gettext('Log out') : i18n.gettext('Log in/Sign up') }</span>
       </button>
@@ -116,6 +118,10 @@ export function mapDispatchToProps(dispatch) {
   return {
     handleGlobalEvent(payload) {
       dispatch({ type: INSTALL_STATE, payload });
+    },
+    handleLogOut() {
+      cookie.remove(config.get('cookieName'), { path: '/' });
+      dispatch(logOutUser());
     },
   };
 }

--- a/src/amo/img/icons/login-person.svg
+++ b/src/amo/img/icons/login-person.svg
@@ -1,9 +1,0 @@
-<svg width="13px" height="16px" viewBox="24 24 39 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 40 (33762) - http://www.bohemiancoding.com/sketch -->
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Group-31" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(24.000000, 24.000000)">
-        <path d="M24,30.4 L14.4,30.4 C6.4472,30.4 0,36.8472 0,44.8 L0,44.8 C0,44.8 7.2,48 19.2,48 C31.2,48 38.4,44.8 38.4,44.8 L38.4,44.8 C38.4,36.8472 31.9528,30.4 24,30.4 L24,30.4 Z" id="Shape" fill="#FFFFFF"></path>
-        <path d="M8,11.2 C8,5.0144 13.0144,0 19.2,0 C25.3856,0 30.4,5.0144 30.4,11.2 C30.4,17.3856 25.3856,24 19.2,24 C13.0144,24 8,17.3856 8,11.2 L8,11.2 Z" id="Shape" fill="#FFFFFF"></path>
-    </g>
-</svg>

--- a/src/core/actions/index.js
+++ b/src/core/actions/index.js
@@ -1,4 +1,5 @@
 import {
+  LOG_OUT_USER,
   SET_JWT,
   SET_CLIENT_APP,
   SET_LANG,
@@ -11,6 +12,10 @@ export function setJWT(token) {
     type: SET_JWT,
     payload: { token },
   };
+}
+
+export function logOutUser() {
+  return { type: LOG_OUT_USER };
 }
 
 export function setClientApp(clientApp) {

--- a/src/core/actions/index.js
+++ b/src/core/actions/index.js
@@ -7,7 +7,7 @@ import {
   SET_CURRENT_USER,
 } from 'core/constants';
 
-export function setJWT(token) {
+export function setJwt(token) {
   return {
     type: SET_JWT,
     payload: { token },

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -36,7 +36,8 @@ export class AuthenticateButtonBase extends React.Component {
     const text = isAuthenticated ? i18n.gettext('Log out') : i18n.gettext('Log in/Sign up');
     return (
       <Button onClick={this.onClick} {...otherProps}>
-        <Icon name="user" />
+        {/* TODO: Allow the caller to decide on the icon or move the content to children. */}
+        <Icon name="user-dark" />
         {text}
       </Button>
     );

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -1,0 +1,64 @@
+/* global window */
+import config from 'config';
+import React, { PropTypes } from 'react';
+import cookie from 'react-cookie';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import { logOutUser } from 'core/actions';
+import { startLoginUrl } from 'core/api';
+import translate from 'core/i18n/translate';
+import Button from 'ui/components/Button';
+import Icon from 'ui/components/Icon';
+
+
+export class AuthenticateButtonBase extends React.Component {
+  static propTypes = {
+    className: PropTypes.string,
+    handleLogIn: PropTypes.func.isRequired,
+    handleLogOut: PropTypes.func.isRequired,
+    i18n: PropTypes.object.isRequired,
+    isAuthenticated: PropTypes.bool.isRequired,
+    location: PropTypes.object.isRequired,
+  }
+
+  onClick = () => {
+    const { handleLogIn, handleLogOut, isAuthenticated, location } = this.props;
+    if (isAuthenticated) {
+      handleLogOut();
+    } else {
+      handleLogIn(location);
+    }
+  }
+
+  render() {
+    const { i18n, isAuthenticated, ...otherProps } = this.props;
+    const text = isAuthenticated ? i18n.gettext('Log out') : i18n.gettext('Log in/Sign up');
+    return (
+      <Button onClick={this.onClick} {...otherProps}>
+        <Icon name="user" />
+        {text}
+      </Button>
+    );
+  }
+}
+
+export const mapStateToProps = (state) => ({
+  isAuthenticated: !!state.auth.token,
+  handleLogIn(location, { _window = window } = {}) {
+    // eslint-disable-next-line no-param-reassign
+    _window.location = startLoginUrl({ location });
+  },
+});
+
+export const mapDispatchToProps = (dispatch) => ({
+  handleLogOut() {
+    cookie.remove(config.get('cookieName'), { path: '/' });
+    dispatch(logOutUser());
+  },
+});
+
+export default compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  translate(),
+)(AuthenticateButtonBase);

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -45,7 +45,7 @@ export class AuthenticateButtonBase extends React.Component {
 }
 
 export const mapStateToProps = (state) => ({
-  isAuthenticated: !!state.auth.token,
+  isAuthenticated: !!state.api.token,
   handleLogIn(location, { _window = window } = {}) {
     // eslint-disable-next-line no-param-reassign
     _window.location = startLoginUrl({ location });

--- a/src/core/containers/HandleLogin/index.js
+++ b/src/core/containers/HandleLogin/index.js
@@ -5,7 +5,7 @@ import { compose } from 'redux';
 import config from 'config';
 import { withRouter } from 'react-router';
 
-import { setJWT } from 'core/actions';
+import { setJwt } from 'core/actions';
 import { login } from 'core/api';
 import LoginPage from 'core/components/LoginPage';
 import log from 'core/logger';
@@ -57,7 +57,7 @@ function createLoadData(dispatch) {
     if (code && state) {
       return login({ api, code, state })
         .then(({ token }) => {
-          dispatch(setJWT(token));
+          dispatch(setJwt(token));
           cookie.save(config.get('cookieName'), token, {
             path: '/',
             secure: config.get('cookieSecure'),

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -133,6 +133,8 @@ $default-arrow-margin: 3px;
 /* Button */
 @mixin button($background: $button-background-color,
 $color: $text-color-message) {
+  @include font-regular();
+
   background: $background;
   border-radius: $border-radius-default;
   border: 0;

--- a/src/core/reducers/api.js
+++ b/src/core/reducers/api.js
@@ -1,4 +1,5 @@
 import {
+  LOG_OUT_USER,
   SET_JWT,
   SET_LANG,
   SET_CLIENT_APP,
@@ -12,6 +13,13 @@ export default function api(state = {}, action) {
       return { ...state, lang: action.payload.lang };
     case SET_CLIENT_APP:
       return { ...state, clientApp: action.payload.clientApp };
+    case LOG_OUT_USER:
+      // Create a lexical scope for the const.
+      {
+        const newState = { ...state };
+        delete newState.token;
+        return newState;
+      }
     default:
       return state;
   }

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -22,7 +22,7 @@ import {
 } from 'core/resourceErrors/reduxConnectErrors';
 import { prefixMiddleWare } from 'core/middleware';
 import { convertBoolean } from 'core/utils';
-import { setClientApp, setLang, setJWT } from 'core/actions';
+import { setClientApp, setLang, setJwt } from 'core/actions';
 import log from 'core/logger';
 import {
   getDirection,
@@ -172,7 +172,7 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
       const store = createStore();
       const token = cookie.load(config.get('cookieName'));
       if (token) {
-        store.dispatch(setJWT(token));
+        store.dispatch(setJwt(token));
       }
       // Get SRI for deployed services only.
       const sriData = (isDeployed) ? JSON.parse(

--- a/src/ui/components/Button/Button.scss
+++ b/src/ui/components/Button/Button.scss
@@ -5,7 +5,7 @@
   @include button();
 
   &.Button--small {
-    border-radius: 3px;
+    border-radius: $border-radius-s;
     font-size: 13px;
   }
 }

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -8,18 +8,22 @@
 }
 
 .Icon-magnifying-glass {
-  background: url('~amo/img/icons/magnifying-glass.svg') 0 50% no-repeat;
+  background: url('~amo/img/icons/magnifying-glass.svg') center no-repeat;
   background-size: cover;
 }
 
 .Icon-eye {
-  background: url('./eye.svg') 0 50% no-repeat;
+  background: url('./eye.svg') center no-repeat;
   background-size: cover;
   width: 23px;
 }
 
 .Icon-user {
-  background: url('./user.svg') 0 50% no-repeat;
+  background: url('./user.svg') center no-repeat;
   background-size: contain;
-  width: 23px;
+}
+
+.Icon-user-dark {
+  background: url('./user-dark.svg') center no-repeat;
+  background-size: contain;
 }

--- a/src/ui/components/Icon/user-dark.svg
+++ b/src/ui/components/Icon/user-dark.svg
@@ -1,0 +1,10 @@
+
+<svg width="83px" height="102px" viewBox="55 -3 83 102" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+  <desc>Created with Sketch.</desc>
+  <defs></defs>
+  <g id="Group-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(58.000000, 0.000000)">
+    <path d="M48,60.8 L28.8,60.8 C12.8944,60.8 0,73.6944 0,89.6 L0,89.6 C0,89.6 14.4,96 38.4,96 C62.4,96 76.8,89.6 76.8,89.6 L76.8,89.6 C76.8,73.6944 63.9056,60.8 48,60.8 L48,60.8 Z" id="Shape" stroke="#343a40" stroke-width="6"></path>
+    <path d="M16,22.4 C16,10.0288 26.0288,0 38.4,0 C50.7712,0 60.8,10.0288 60.8,22.4 C60.8,34.7712 50.7712,48 38.4,48 C26.0288,48 16,34.7712 16,22.4 L16,22.4 Z" id="Shape" stroke="#343a40" stroke-width="6"></path>
+  </g>
+</svg>

--- a/tests/client/amo/components/TestMastHead.js
+++ b/tests/client/amo/components/TestMastHead.js
@@ -10,6 +10,7 @@ import createStore from 'amo/store';
 import { MastHeadBase } from 'amo/components/MastHead';
 import { getFakeI18nInst } from 'tests/client/helpers';
 import translate from 'core/i18n/translate';
+import I18nProvider from 'core/i18n/Provider';
 
 
 class FakeChild extends React.Component {
@@ -25,7 +26,9 @@ describe('MastHead', () => {
 
     return findRenderedComponentWithType(renderIntoDocument(
       <Provider store={createStore(initialState)}>
-        <MyMastHead i18n={getFakeI18nInst()} {...props} />
+        <I18nProvider i18n={getFakeI18nInst()}>
+          <MyMastHead {...props} />
+        </I18nProvider>
       </Provider>
     ), MyMastHead).getWrappedInstance();
   }

--- a/tests/client/amo/components/TestRatingManager.js
+++ b/tests/client/amo/components/TestRatingManager.js
@@ -5,7 +5,7 @@ import {
 } from 'react-addons-test-utils';
 
 import translate from 'core/i18n/translate';
-import { setJWT } from 'core/actions';
+import { setJwt } from 'core/actions';
 import * as amoApi from 'amo/api';
 import createStore from 'amo/store';
 import { setReview } from 'amo/actions/reviews';
@@ -261,7 +261,7 @@ describe('RatingManager', () => {
     }
 
     function signIn({ userId = 98765 } = {}) {
-      store.dispatch(setJWT(userAuthToken({
+      store.dispatch(setJwt(userAuthToken({
         user_id: userId,
       })));
     }

--- a/tests/client/amo/containers/TestApp.js
+++ b/tests/client/amo/containers/TestApp.js
@@ -16,7 +16,7 @@ import {
   setupMapStateToProps,
 } from 'amo/containers/App';
 import createStore from 'amo/store';
-import { setJWT } from 'core/actions';
+import { setJwt } from 'core/actions';
 import * as api from 'core/api';
 import { INSTALL_STATE } from 'core/constants';
 import { getFakeI18nInst, userAuthToken } from 'tests/client/helpers';
@@ -113,7 +113,7 @@ describe('App', () => {
     sinon.stub(cookie, 'remove');
     sinon.stub(config, 'get').withArgs('cookieName').returns('authcookie');
     const store = createStore();
-    store.dispatch(setJWT(userAuthToken({ user_id: 99 })));
+    store.dispatch(setJwt(userAuthToken({ user_id: 99 })));
     const { handleLogOut } = mapDispatchToProps(store.dispatch);
     assert.ok(store.getState().api.token);
     handleLogOut();

--- a/tests/client/core/actions/test_index.js
+++ b/tests/client/core/actions/test_index.js
@@ -1,9 +1,9 @@
 import * as actions from 'core/actions';
 
-describe('core actions setJWT', () => {
+describe('core actions setJwt', () => {
   it('creates a SET_JWT action', () => {
     assert.deepEqual(
-      actions.setJWT('my.amo.token'),
+      actions.setJwt('my.amo.token'),
       { type: 'SET_JWT', payload: { token: 'my.amo.token' } });
   });
 });

--- a/tests/client/core/components/TestAuthenticateButton.js
+++ b/tests/client/core/components/TestAuthenticateButton.js
@@ -1,0 +1,69 @@
+import config from 'config';
+import React from 'react';
+import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
+import cookie from 'react-cookie';
+import { findDOMNode } from 'react-dom';
+
+import createStore from 'amo/store';
+import { setJwt } from 'core/actions';
+import * as api from 'core/api';
+import {
+  AuthenticateButtonBase,
+  mapDispatchToProps,
+  mapStateToProps,
+} from 'core/components/AuthenticateButton';
+import { getFakeI18nInst, userAuthToken } from 'tests/client/helpers';
+
+describe('<AuthenticateButton />', () => {
+  function render(props) {
+    return findDOMNode(
+        renderIntoDocument(<AuthenticateButtonBase i18n={getFakeI18nInst()} {...props} />));
+  }
+
+  it('passes along a className', () => {
+    const root = render({ className: 'MyComponent-auth-button' });
+    assert.ok(root.classList.contains('MyComponent-auth-button'));
+  });
+
+  it('shows a log in button when unauthenticated', () => {
+    const handleLogIn = sinon.spy();
+    const location = sinon.stub();
+    const root = render({ isAuthenticated: false, handleLogIn, location });
+    assert.equal(root.textContent, 'Log in/Sign up');
+    Simulate.click(root);
+    assert.ok(handleLogIn.calledWith(location));
+  });
+
+  it('shows a log out button when authenticated', () => {
+    const handleLogOut = sinon.spy();
+    const root = render({ handleLogOut, isAuthenticated: true });
+    assert.equal(root.textContent, 'Log out');
+    Simulate.click(root);
+    assert.ok(handleLogOut.called);
+  });
+
+  it('updates the location on handleLogIn', () => {
+    const _window = { location: '/foo' };
+    const location = { pathname: '/bar', query: { q: 'wat' } };
+    const startLoginUrlStub = sinon.stub(api, 'startLoginUrl').returns('https://a.m.org/login');
+    const { handleLogIn } = mapStateToProps({
+      auth: {},
+      api: { lang: 'en-GB' },
+    });
+    handleLogIn(location, { _window });
+    assert.equal(_window.location, 'https://a.m.org/login');
+    assert.ok(startLoginUrlStub.calledWith({ location }));
+  });
+
+  it('clears the cookie and JWT on handleLogOut', () => {
+    sinon.stub(cookie, 'remove');
+    sinon.stub(config, 'get').withArgs('cookieName').returns('authcookie');
+    const store = createStore();
+    store.dispatch(setJwt(userAuthToken({ user_id: 99 })));
+    const { handleLogOut } = mapDispatchToProps(store.dispatch);
+    assert.ok(store.getState().api.token);
+    handleLogOut();
+    assert.notOk(store.getState().api.token);
+    assert.ok(cookie.remove.calledWith('authcookie', { path: '/' }));
+  });
+});

--- a/tests/client/core/components/TestAuthenticateButton.js
+++ b/tests/client/core/components/TestAuthenticateButton.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 import cookie from 'react-cookie';
 import { findDOMNode } from 'react-dom';
+import { combineReducers, createStore as _createStore } from 'redux';
 
-import createStore from 'amo/store';
 import { setJwt } from 'core/actions';
 import * as api from 'core/api';
 import {
@@ -12,7 +12,12 @@ import {
   mapDispatchToProps,
   mapStateToProps,
 } from 'core/components/AuthenticateButton';
+import apiReducer from 'core/reducers/api';
 import { getFakeI18nInst, userAuthToken } from 'tests/client/helpers';
+
+function createStore() {
+  return _createStore(combineReducers({ api: apiReducer }));
+}
 
 describe('<AuthenticateButton />', () => {
   function render(props) {
@@ -65,5 +70,12 @@ describe('<AuthenticateButton />', () => {
     handleLogOut();
     assert.notOk(store.getState().api.token);
     assert.ok(cookie.remove.calledWith('authcookie', { path: '/' }));
+  });
+
+  it('pulls isAuthenticated from state', () => {
+    const store = createStore(combineReducers({ api }));
+    assert.equal(mapStateToProps(store.getState()).isAuthenticated, false);
+    store.dispatch(setJwt(userAuthToken({ user_id: 123 })));
+    assert.equal(mapStateToProps(store.getState()).isAuthenticated, true);
   });
 });

--- a/tests/client/core/reducers/test_api.js
+++ b/tests/client/core/reducers/test_api.js
@@ -13,6 +13,13 @@ describe('api reducer', () => {
       { type: 'SET_JWT', payload: { token } }), { foo: 'bar', token });
   });
 
+  it('clears the JWT on log out', () => {
+    assert.deepEqual(
+      api({ lang: 'fr', clientApp: 'firefox', token: 'secret' },
+          actions.logOutUser()),
+      { lang: 'fr', clientApp: 'firefox' });
+  });
+
   it('stores the lang', () => {
     const lang = 'de';
     assert.deepEqual(api({ bar: 'baz' },


### PR DESCRIPTION
Logs you out in the same way as it does on the admin. We have an extra cookie that we'll need to clear on addons-server. I'll submit a follow up patch for that later, tracked in #1557 and an addons-server issue near you.

This also clears the JWT from the `api` reducer on log out. That was definitely a bug.

Maybe we should get rid of the authentication reducer. I filed #1644 for that, I think it was intended to store info about the user but that can go in a "user" reducer and shouldn't store the JWT.

I also renamed `setJWT` to `setJwt` since it was bothering me, in a separate commit.

[demo gif (7.5MB)](https://cloud.githubusercontent.com/assets/211578/22137092/91609c20-de9e-11e6-915b-d0f78fec2f03.gif)

Fixes #1632.