### PR TITLE
Fix unintentional hovering causing theme previews

### DIFF
--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -48,6 +48,9 @@ export class AddonBase extends React.Component {
     setCurrentStatus: PropTypes.func.isRequired,
     status: PropTypes.oneOf(validInstallStates).isRequired,
     type: PropTypes.oneOf(validAddonTypes).isRequired,
+    previewEntryThreshold: PropTypes.number,
+    previewMovementThreshold: PropTypes.number,
+    hoverIntentIntervalMillis: PropTypes.number,
     _tracking: PropTypes.object,
   }
 
@@ -55,6 +58,7 @@ export class AddonBase extends React.Component {
     // Defaults themeAction to the imported func.
     themeAction,
     needsRestart: false,
+    hoverIntentInterval: 100,
     _tracking: tracking,
   }
 
@@ -91,8 +95,9 @@ export class AddonBase extends React.Component {
                  onBlur={this.resetPreviewTheme}
                  onClick={this.installTheme}
                  onFocus={this.previewTheme}
+                 onMouseMove={this.trackMouseMovement}
                  onMouseOut={this.resetPreviewTheme}
-                 onMouseOver={this.previewTheme}>
+                 onMouseOver={this.maybePreviewTheme}>
         <img src={previewURL}
           alt={sprintf(i18n.gettext('Hover to preview or click to install %(name)s'), { name })}
         /></a>);
@@ -165,12 +170,68 @@ export class AddonBase extends React.Component {
     }
   }
 
+  clearHoverIntentDetection() {
+    clearInterval(this.hoverIntentInterval);
+  }
+
+  trackMouseMovement = (e) => {
+    this.currentMousePosition = { x: e.clientX, y: e.clientY };
+  }
+
+  whenHoverIntended = (e, callback) => {
+    const sq = x => x * x;
+    const distanceSq = (p1, p2) => sq(p1.x - p2.x) + sq(p1.y - p2.y);
+
+    // The mouse must move 5 pixels after mouseover to preview. This prevents taking
+    // action in cases where the user only moused over the element because they switched
+    // tabs, closed a video, etc.
+    const entryThresholdDistanceSq = sq(5);
+
+    // The mouse must move less than 10 pixels in a 100ms interval in order to be
+    // considered hovering. Otherwise, it's likely that they're just mousing through
+    // the element.
+    const movementThresholdDistanceSq = sq(10);
+
+    let initialPosition = { x: e.clientX, y: e.clientY };
+    let previousPosition = initialPosition;
+    this.currentMousePosition = initialPosition;
+
+    if (this.hoverIntentInterval) {
+      this.clearHoverIntentDetection();
+    }
+
+    this.hoverIntentInterval = setInterval(() => {
+      let currentPosition = this.currentMousePosition
+      if (distanceSq(initialPosition, currentPosition) > entryThresholdDistanceSq &&
+        distanceSq(previousPosition, currentPosition) < movementThresholdDistanceSq) {
+        this.clearHoverIntentDetection();
+        callback();
+      }
+
+      previousPosition = currentPosition;
+    }, this.props.hoverIntentInterval);
+  }
+
+  maybePreviewTheme = (e) => {
+    const target = e.currentTarget;
+
+    this.whenHoverIntended(e, () => {
+      this.props.previewTheme(target);
+    });
+  }
+
   previewTheme = (e) => {
     this.props.previewTheme(e.currentTarget);
   }
 
   resetPreviewTheme = (e) => {
+    this.clearHoverIntentDetection();
+
     this.props.resetPreviewTheme(e.currentTarget);
+  }
+
+  componentWillUnmount() {
+    this.clearHoverIntentDetection();
   }
 
   render() {

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -287,16 +287,69 @@ describe('<Addon />', () => {
     let resetPreviewTheme;
 
     beforeEach(() => {
+      let hoverIntentInterval = 10;
       previewTheme = sinon.spy();
       resetPreviewTheme = sinon.spy();
-      const data = { ...result, type: ADDON_TYPE_THEME, previewTheme, resetPreviewTheme };
+      const data = {
+        ...result,
+        type: ADDON_TYPE_THEME,
+        previewTheme,
+        resetPreviewTheme,
+        hoverIntentInterval
+      };
       root = renderAddon({ addon: data, ...data });
       themeImage = findDOMNode(root).querySelector('.theme-image');
     });
 
-    it('runs theme preview onMouseOver on theme image', () => {
-      Simulate.mouseOver(themeImage);
-      assert.ok(previewTheme.calledWith(themeImage));
+    it('runs theme preview if mouse slows/stops on theme image', (done) => {
+      Simulate.mouseOver(themeImage, { clientX: 0, clientY: 0 });
+
+      setTimeout(() => {
+        Simulate.mouseMove(themeImage, { clientX: 10, clientY: 0 });
+      }, 10);
+
+      setTimeout(() => {
+        Simulate.mouseMove(themeImage, { clientX: 10, clientY: 1 });
+      }, 20);
+
+      setTimeout(() => {
+        assert.ok(previewTheme.calledWith(themeImage));
+        done();
+      }, 30);
+    });
+
+    it("does not run theme preview if mouse doesn't slow on theme image", (done) => {
+      Simulate.mouseOver(themeImage, { clientX: 0, clientY: 0 });
+
+      setTimeout(() => {
+        Simulate.mouseMove(themeImage, { clientX: 15, clientY: 15 });
+      }, 10);
+
+      setTimeout(() => {
+        Simulate.mouseMove(themeImage, { clientX: 30, clientY: 30 });
+      }, 20);
+
+      setTimeout(() => {
+        assert.isNotOk(previewTheme.calledWith(themeImage));
+        done();
+      }, 30);
+    });
+
+    it("does not run theme preview if mouse doesn't move enough on theme image", (done) => {
+      Simulate.mouseOver(themeImage, { clientX: 0, clientY: 0 });
+
+      setTimeout(() => {
+        Simulate.mouseMove(themeImage, { clientX: 1, clientY: 0 });
+      }, 10);
+
+      setTimeout(() => {
+        Simulate.mouseMove(themeImage, { clientX: 1, clientY: 1 });
+      }, 20);
+
+      setTimeout(() => {
+        assert.isNotOk(previewTheme.calledWith(themeImage));
+        done();
+      }, 30);
     });
 
     it('resets theme preview onMouseOut on theme image', () => {


### PR DESCRIPTION
Closes #1634 
Closes #1561 

This fixes the first bug by requiring that the mouse has slowed below some threshold (10 pixels in 100 ms) before previewing the theme. It assumes that anything faster than that is just the user trying to mouse through the element, not them trying to hover over it.

It _should_ fix the second bug by requiring that the mouse moves past some threshold (5 pixels) before previewing the theme. When we get a mouseover event simply because a video closes (and the mouse is sitting on top of the theme image), the user hasn't moved their mouse yet. Once they move their mouse, they'll likely be moving it faster than the first threshold, and so they won't accidentally see the theme preview.

I was a _little_ shaky on the tests. They reliably pass for me, but I could see them potentially being flaky. Guidance / alternate solutions are very welcome!