### PR TITLE
Fix unintentional hovering causing theme previews

### DIFF
--- a/src/core/components/HoverIntent/index.js
+++ b/src/core/components/HoverIntent/index.js
@@ -78,11 +78,16 @@ export default class HoverIntent extends React.Component {
 
   render() {
     const child = React.Children.only(this.props.children);
+    const propOverrides = ['onMouseOver', 'onMouseOut', 'onMouseMove'];
 
-    return React.cloneElement(child, {
-      onMouseOver: this.onMouseOver,
-      onMouseOut: this.onMouseOut,
-      onMouseMove: this.onMouseMove,
+    const newProps = {};
+    propOverrides.forEach((propName) => {
+      if (child.props[propName]) {
+        throw new Error(`Cannot provide the prop [${propName}] on HoverIntent child`);
+      }
+      newProps[propName] = this[propName];
     });
+
+    return React.cloneElement(child, newProps);
   }
 }

--- a/src/core/components/HoverIntent/index.js
+++ b/src/core/components/HoverIntent/index.js
@@ -1,0 +1,76 @@
+import React, { PropTypes } from 'react';
+
+export default class HoverIntent extends React.Component {
+  static propTypes = {
+    sensitivity: PropTypes.number,
+    interval: PropTypes.number,
+    onHoverIntent: PropTypes.func.isRequired,
+    onHoverIntentEnd: PropTypes.func.isRequired,
+    children: PropTypes.element.isRequired,
+  }
+
+  static defaultProps = {
+    sensitivity: 5,
+    interval: 100,
+  }
+
+  componentWillUnmount() {
+    this.isHoverIntended = false;
+    this.clearHoverIntentDetection();
+  }
+
+  onMouseOver = (e) => {
+    e.persist();
+    const currentTarget = e.currentTarget;
+
+    const sq = (x) => x * x;
+    const distanceSq = (p1, p2) => sq(p1.x - p2.x) + sq(p1.y - p2.y);
+
+    const sensitivitySq = sq(this.props.sensitivity);
+
+    const initialPosition = { x: e.clientX, y: e.clientY };
+    let previousPosition = initialPosition;
+    this.currentMousePosition = initialPosition;
+
+    this.interval = setInterval(() => {
+      const currentPosition = this.currentMousePosition;
+      if (distanceSq(initialPosition, currentPosition) > sensitivitySq &&
+        distanceSq(previousPosition, currentPosition) < sensitivitySq) {
+        this.clearHoverIntentDetection();
+        this.isHoverIntended = true;
+
+        // construct a fake event cloned from e, but with e's initial currentTarget
+        // (currentTarget will change as the event bubbles up the DOM.)
+        this.props.onHoverIntent(Object.assign({}, e, { currentTarget }));
+      }
+
+      previousPosition = currentPosition;
+    }, this.props.interval);
+  }
+
+  onMouseOut = (e) => {
+    this.clearHoverIntentDetection();
+    if (this.isHoverIntended) {
+      this.isHoverIntended = false;
+      this.props.onHoverIntentEnd(e);
+    }
+  }
+
+  onMouseMove = (e) => {
+    this.currentMousePosition = { x: e.clientX, y: e.clientY };
+  }
+
+  clearHoverIntentDetection() {
+    clearInterval(this.interval);
+  }
+
+  render() {
+    const child = React.Children.only(this.props.children);
+
+    return React.cloneElement(child, {
+      onMouseOver: this.onMouseOver,
+      onMouseOut: this.onMouseOut,
+      onMouseMove: this.onMouseMove,
+    });
+  }
+}

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -48,6 +48,7 @@ export class AddonBase extends React.Component {
     setCurrentStatus: PropTypes.func.isRequired,
     status: PropTypes.oneOf(validInstallStates).isRequired,
     type: PropTypes.oneOf(validAddonTypes).isRequired,
+    hoverIntentInterval: PropTypes.number,
     _tracking: PropTypes.object,
   }
 
@@ -55,7 +56,12 @@ export class AddonBase extends React.Component {
     // Defaults themeAction to the imported func.
     themeAction,
     needsRestart: false,
+    hoverIntentInterval: 100,
     _tracking: tracking,
+  }
+
+  componentWillUnmount() {
+    this.clearHoverIntentDetection();
   }
 
   getError() {
@@ -91,8 +97,9 @@ export class AddonBase extends React.Component {
                  onBlur={this.resetPreviewTheme}
                  onClick={this.installTheme}
                  onFocus={this.previewTheme}
+                 onMouseMove={this.trackMouseMovement}
                  onMouseOut={this.resetPreviewTheme}
-                 onMouseOver={this.previewTheme}>
+                 onMouseOver={this.maybePreviewTheme}>
         <img src={previewURL}
           alt={sprintf(i18n.gettext('Hover to preview or click to install %(name)s'), { name })}
         /></a>);
@@ -165,11 +172,59 @@ export class AddonBase extends React.Component {
     }
   }
 
+  clearHoverIntentDetection() {
+    clearInterval(this.hoverIntentInterval);
+  }
+
+  trackMouseMovement = (e) => {
+    this.currentMousePosition = { x: e.clientX, y: e.clientY };
+  }
+
+  whenHoverIntended = (e, callback) => {
+    const sq = (x) => x * x;
+    const distanceSq = (p1, p2) => sq(p1.x - p2.x) + sq(p1.y - p2.y);
+
+    // The mouse must move 5 pixels after mouseover to preview. This prevents taking
+    // action in cases where the user only moused over the element because they switched
+    // tabs, closed a video, etc.
+    const entryThresholdDistanceSq = sq(5);
+
+    // The mouse must move less than 10 pixels in a 100ms interval in order to be
+    // considered hovering. Otherwise, it's likely that they're just mousing through
+    // the element.
+    const movementThresholdDistanceSq = sq(10);
+
+    const initialPosition = { x: e.clientX, y: e.clientY };
+    let previousPosition = initialPosition;
+    this.currentMousePosition = initialPosition;
+
+    this.hoverIntentInterval = setInterval(() => {
+      const currentPosition = this.currentMousePosition;
+      if (distanceSq(initialPosition, currentPosition) > entryThresholdDistanceSq &&
+        distanceSq(previousPosition, currentPosition) < movementThresholdDistanceSq) {
+        this.clearHoverIntentDetection();
+        callback();
+      }
+
+      previousPosition = currentPosition;
+    }, this.props.hoverIntentInterval);
+  }
+
+  maybePreviewTheme = (e) => {
+    const target = e.currentTarget;
+
+    this.whenHoverIntended(e, () => {
+      this.props.previewTheme(target);
+    });
+  }
+
   previewTheme = (e) => {
     this.props.previewTheme(e.currentTarget);
   }
 
   resetPreviewTheme = (e) => {
+    this.clearHoverIntentDetection();
+
     this.props.resetPreviewTheme(e.currentTarget);
   }
 

--- a/tests/client/core/components/TestHoverIntent.js
+++ b/tests/client/core/components/TestHoverIntent.js
@@ -6,7 +6,6 @@ import {
 } from 'react-addons-test-utils';
 import {
   findDOMNode,
-  unmountComponentAtNode,
 } from 'react-dom';
 
 import HoverIntent from 'core/components/HoverIntent';
@@ -28,8 +27,10 @@ describe('<HoverIntent />', () => {
   let hoverIntent;
   let innerElement;
   let props;
+  let clock;
 
   beforeEach(() => {
+    clock = sinon.useFakeTimers();
     props = {
       onHoverIntent: sinon.spy(),
       onHoverIntentEnd: sinon.spy(),
@@ -40,91 +41,75 @@ describe('<HoverIntent />', () => {
   });
 
   afterEach(() => {
-    unmountComponentAtNode(innerElement);
+    clock.restore();
   });
 
-  it('runs onHoverIntent if mouse slows/stops on inner element', (done) => {
+  it('runs onHoverIntent if mouse slows/stops on inner element', () => {
     Simulate.mouseOver(innerElement, { clientX: 1, clientY: 2 });
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
-    }, 75);
+    clock.tick(75);
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
-    }, 125);
+    clock.tick(50);
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
 
-    setTimeout(() => {
-      Simulate.mouseOut(innerElement);
+    clock.tick(50);
+    Simulate.mouseOut(innerElement);
 
-      const { onHoverIntent, onHoverIntentEnd } = props;
-      assert.ok(onHoverIntent.calledOnce);
-      assert.ok(onHoverIntentEnd.calledOnce);
-      done();
-    }, 175);
+    const { onHoverIntent, onHoverIntentEnd } = props;
+    assert.ok(onHoverIntent.calledOnce);
+    assert.ok(onHoverIntentEnd.calledOnce);
   });
 
-  it("does not run onHoverIntent if mouse doesn't slow on inner element", (done) => {
+  it("does not run onHoverIntent if mouse doesn't slow on inner element", () => {
     Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 5, clientY: 5 });
-    }, 75);
+    clock.tick(75);
+    Simulate.mouseMove(innerElement, { clientX: 5, clientY: 5 });
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 10 });
-    }, 125);
+    clock.tick(50);
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 10 });
 
-    setTimeout(() => {
-      Simulate.mouseOut(innerElement);
+    clock.tick(50);
+    Simulate.mouseOut(innerElement);
 
-      const { onHoverIntent, onHoverIntentEnd } = props;
-      assert.isNotOk(onHoverIntent.calledOnce);
-      assert.isNotOk(onHoverIntentEnd.calledOnce);
-      done();
-    }, 175);
+    const { onHoverIntent, onHoverIntentEnd } = props;
+    assert.isNotOk(onHoverIntent.calledOnce);
+    assert.isNotOk(onHoverIntentEnd.calledOnce);
   });
 
-  it("does not run onHoverIntent if mouse doesn't move enough on inner element", (done) => {
+  it("does not run onHoverIntent if mouse doesn't move enough on inner element", () => {
     Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 1, clientY: 0 });
-    }, 75);
+    clock.tick(75);
+    Simulate.mouseMove(innerElement, { clientX: 1, clientY: 0 });
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 1, clientY: 1 });
-    }, 125);
+    clock.tick(50);
+    Simulate.mouseMove(innerElement, { clientX: 1, clientY: 1 });
 
-    setTimeout(() => {
-      Simulate.mouseOut(innerElement);
+    clock.tick(50);
+    Simulate.mouseOut(innerElement);
 
-      const { onHoverIntent, onHoverIntentEnd } = props;
-      assert.isNotOk(onHoverIntent.calledOnce);
-      assert.isNotOk(onHoverIntentEnd.calledOnce);
-      done();
-    }, 175);
+    const { onHoverIntent, onHoverIntentEnd } = props;
+    assert.isNotOk(onHoverIntent.calledOnce);
+    assert.isNotOk(onHoverIntentEnd.calledOnce);
   });
 
-  it('clears the hover intent interval when component unmounts', (done) => {
+  it('clears the hover intent interval when component unmounts', () => {
     Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
     hoverIntent.componentWillUnmount();
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
-    }, 75);
+    clock.tick(75);
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
 
-    setTimeout(() => {
-      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
-    }, 125);
+    clock.tick(50);
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
 
-    setTimeout(() => {
-      Simulate.mouseOut(innerElement);
+    clock.tick(50);
+    Simulate.mouseOut(innerElement);
 
-      const { onHoverIntent, onHoverIntentEnd } = props;
-      assert.isNotOk(onHoverIntent.calledOnce);
-      assert.isNotOk(onHoverIntentEnd.calledOnce);
-      done();
-    }, 175);
+    const { onHoverIntent, onHoverIntentEnd } = props;
+    assert.isNotOk(onHoverIntent.calledOnce);
+    assert.isNotOk(onHoverIntentEnd.calledOnce);
   });
 });

--- a/tests/client/core/components/TestHoverIntent.js
+++ b/tests/client/core/components/TestHoverIntent.js
@@ -45,71 +45,114 @@ describe('<HoverIntent />', () => {
   });
 
   it('runs onHoverIntent if mouse slows/stops on inner element', () => {
-    Simulate.mouseOver(innerElement, { clientX: 1, clientY: 2 });
-
-    clock.tick(75);
-    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
-
-    clock.tick(50);
-    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
-
-    clock.tick(50);
-    Simulate.mouseOut(innerElement);
-
     const { onHoverIntent, onHoverIntentEnd } = props;
+
+    Simulate.mouseOver(innerElement, { clientX: 1, clientY: 2 });
+    clock.tick(75);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
+    clock.tick(50);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
+    clock.tick(50);
     assert.ok(onHoverIntent.calledOnce);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseOut(innerElement);
     assert.ok(onHoverIntentEnd.calledOnce);
   });
 
   it("does not run onHoverIntent if mouse doesn't slow on inner element", () => {
-    Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
-
-    clock.tick(75);
-    Simulate.mouseMove(innerElement, { clientX: 5, clientY: 5 });
-
-    clock.tick(50);
-    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 10 });
-
-    clock.tick(50);
-    Simulate.mouseOut(innerElement);
-
     const { onHoverIntent, onHoverIntentEnd } = props;
-    assert.isNotOk(onHoverIntent.calledOnce);
-    assert.isNotOk(onHoverIntentEnd.calledOnce);
+
+    Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
+    clock.tick(75);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseMove(innerElement, { clientX: 5, clientY: 5 });
+    clock.tick(50);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseMove(innerElement, { clientX: 10, clientY: 10 });
+    clock.tick(50);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseOut(innerElement);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
   });
 
   it("does not run onHoverIntent if mouse doesn't move enough on inner element", () => {
-    Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
-
-    clock.tick(75);
-    Simulate.mouseMove(innerElement, { clientX: 1, clientY: 0 });
-
-    clock.tick(50);
-    Simulate.mouseMove(innerElement, { clientX: 1, clientY: 1 });
-
-    clock.tick(50);
-    Simulate.mouseOut(innerElement);
-
     const { onHoverIntent, onHoverIntentEnd } = props;
-    assert.isNotOk(onHoverIntent.calledOnce);
-    assert.isNotOk(onHoverIntentEnd.calledOnce);
+
+    Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
+    clock.tick(75);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseMove(innerElement, { clientX: 1, clientY: 0 });
+    clock.tick(50);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseMove(innerElement, { clientX: 1, clientY: 1 });
+    clock.tick(50);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
+    Simulate.mouseOut(innerElement);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
   });
 
   it('clears the hover intent interval when component unmounts', () => {
+    const { onHoverIntent, onHoverIntentEnd } = props;
+
     Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
+    clock.tick(75);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
     hoverIntent.componentWillUnmount();
 
-    clock.tick(75);
     Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
-
     clock.tick(50);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+
     Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
-
     clock.tick(50);
-    Simulate.mouseOut(innerElement);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
 
-    const { onHoverIntent, onHoverIntentEnd } = props;
-    assert.isNotOk(onHoverIntent.calledOnce);
-    assert.isNotOk(onHoverIntentEnd.calledOnce);
+    Simulate.mouseOut(innerElement);
+    assert.isNotOk(onHoverIntent.called);
+    assert.isNotOk(onHoverIntentEnd.called);
+  });
+
+  it('throws if child provides onMouse events', () => {
+    assert.throws(() => renderIntoDocument(
+      <HoverIntent {...props} sensitivity={5} interval={10}>
+        <span onMouseOver={() => {}}>Test</span>
+      </HoverIntent>
+    ), /onMouseOver/);
+
+    assert.throws(() => renderIntoDocument(
+      <HoverIntent {...props} sensitivity={5} interval={10}>
+        <span onMouseOut={() => {}}>Test</span>
+      </HoverIntent>
+    ), /onMouseOut/);
+
+    assert.throws(() => renderIntoDocument(
+      <HoverIntent {...props} sensitivity={5} interval={10}>
+        <span onMouseMove={() => {}}>Test</span>
+      </HoverIntent>
+    ), /onMouseMove/);
   });
 });

--- a/tests/client/core/components/TestHoverIntent.js
+++ b/tests/client/core/components/TestHoverIntent.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import {
+  findRenderedComponentWithType,
+  renderIntoDocument,
+  Simulate,
+} from 'react-addons-test-utils';
+import {
+  findDOMNode,
+  unmountComponentAtNode,
+} from 'react-dom';
+
+import HoverIntent from 'core/components/HoverIntent';
+
+function renderHoverIntent({ ...props }) {
+  const sensitivity = 5;
+  const interval = 50;
+  const hoverIntent = findRenderedComponentWithType(renderIntoDocument(
+    <HoverIntent {...props} sensitivity={sensitivity} interval={interval}>
+      <span id="text-content">Text content</span>
+    </HoverIntent>
+  ), HoverIntent);
+  const innerElement = findDOMNode(hoverIntent);
+
+  return { hoverIntent, innerElement };
+}
+
+describe('<HoverIntent />', () => {
+  let hoverIntent;
+  let innerElement;
+  let props;
+
+  beforeEach(() => {
+    props = {
+      onHoverIntent: sinon.spy(),
+      onHoverIntentEnd: sinon.spy(),
+    };
+    const rendered = renderHoverIntent(props);
+    hoverIntent = rendered.hoverIntent;
+    innerElement = rendered.innerElement;
+  });
+
+  afterEach(() => {
+    unmountComponentAtNode(innerElement);
+  });
+
+  it('runs onHoverIntent if mouse slows/stops on inner element', (done) => {
+    Simulate.mouseOver(innerElement, { clientX: 1, clientY: 2 });
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
+    }, 75);
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
+    }, 125);
+
+    setTimeout(() => {
+      Simulate.mouseOut(innerElement);
+
+      const { onHoverIntent, onHoverIntentEnd } = props;
+      assert.ok(onHoverIntent.calledOnce);
+      assert.ok(onHoverIntentEnd.calledOnce);
+      done();
+    }, 175);
+  });
+
+  it("does not run onHoverIntent if mouse doesn't slow on inner element", (done) => {
+    Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 5, clientY: 5 });
+    }, 75);
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 10 });
+    }, 125);
+
+    setTimeout(() => {
+      Simulate.mouseOut(innerElement);
+
+      const { onHoverIntent, onHoverIntentEnd } = props;
+      assert.isNotOk(onHoverIntent.calledOnce);
+      assert.isNotOk(onHoverIntentEnd.calledOnce);
+      done();
+    }, 175);
+  });
+
+  it("does not run onHoverIntent if mouse doesn't move enough on inner element", (done) => {
+    Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 1, clientY: 0 });
+    }, 75);
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 1, clientY: 1 });
+    }, 125);
+
+    setTimeout(() => {
+      Simulate.mouseOut(innerElement);
+
+      const { onHoverIntent, onHoverIntentEnd } = props;
+      assert.isNotOk(onHoverIntent.calledOnce);
+      assert.isNotOk(onHoverIntentEnd.calledOnce);
+      done();
+    }, 175);
+  });
+
+  it('clears the hover intent interval when component unmounts', (done) => {
+    Simulate.mouseOver(innerElement, { clientX: 0, clientY: 0 });
+    hoverIntent.componentWillUnmount();
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 0 });
+    }, 75);
+
+    setTimeout(() => {
+      Simulate.mouseMove(innerElement, { clientX: 10, clientY: 1 });
+    }, 125);
+
+    setTimeout(() => {
+      Simulate.mouseOut(innerElement);
+
+      const { onHoverIntent, onHoverIntentEnd } = props;
+      assert.isNotOk(onHoverIntent.calledOnce);
+      assert.isNotOk(onHoverIntentEnd.calledOnce);
+      done();
+    }, 175);
+  });
+});

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -6,7 +6,6 @@ import {
 } from 'react-addons-test-utils';
 import {
   findDOMNode,
-  unmountComponentAtNode,
 } from 'react-dom';
 
 import translate from 'core/i18n/translate';
@@ -301,10 +300,6 @@ describe('<Addon />', () => {
       };
       root = renderAddon({ addon: data, ...data });
       themeImage = findDOMNode(root).querySelector('.theme-image');
-    });
-
-    afterEach(() => {
-      unmountComponentAtNode(findDOMNode(root));
     });
 
     it('runs theme preview onHoverIntent on theme image', () => {


### PR DESCRIPTION
Closes #1634
Closes #1561

This fixes the first bug by requiring that the mouse has slowed below some threshold (10 pixels in 100 ms) before previewing the theme. It assumes that anything faster than that is just the user trying to mouse through the element, not them trying to hover over it.

It _should_ fix the second bug by requiring that the mouse moves past some threshold (5 pixels) before previewing the theme. When we get a mouseover event simply because a video closes (and the mouse is sitting on top of the theme image), the user hasn't moved their mouse yet. Once they move their mouse, they'll likely be moving it faster than the first threshold, and so they won't accidentally see the theme preview.

I was a _little_ shaky on the tests. They reliably pass for me, but I could see them potentially being flaky. Guidance / alternate solutions are very welcome!