### PR TITLE
Fix for top margin for search sort

### DIFF
--- a/src/amo/components/SearchSort/SearchSort.scss
+++ b/src/amo/components/SearchSort/SearchSort.scss
@@ -13,7 +13,7 @@
   background: $base-color;
   border-radius: $border-radius-default;
   border: 0;
-  margin: 0 ($padding-page * 2) $padding-page;
+  margin: ($padding-page * 2) $padding-page;
   overflow: hidden;
 }
 

--- a/src/amo/components/SearchSort/SearchSort.scss
+++ b/src/amo/components/SearchSort/SearchSort.scss
@@ -13,7 +13,7 @@
   background: $base-color;
   border-radius: $border-radius-default;
   border: 0;
-  margin: ($padding-page * 2) $padding-page;
+  margin: $padding-page ($padding-page * 2);
   overflow: hidden;
 }
 


### PR DESCRIPTION
Fixes #1663

The problem was in the first argument (the 0) in the line - https://github.com/mozilla/addons-frontend/blob/master/src/amo/components/SearchSort/SearchSort.scss#L16.