### PR TITLE
fix: Long author names float images to right

### DIFF
--- a/src/core/css/SearchResult.scss
+++ b/src/core/css/SearchResult.scss
@@ -24,6 +24,7 @@
 
 .SearchResult-main {
   flex-grow: 1;
+  max-width: 100%;
 }
 
 .SearchResult-heading {
@@ -58,7 +59,9 @@
 }
 
 .SearchResult-author {
+  display: block;
   margin-right: 0.5em;
+  word-wrap: break-word;
 }
 
 .SearchResult-info {


### PR DESCRIPTION
Fixes #1546.

Closes #1699.