### PR TITLE
Log out from server

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -184,3 +184,13 @@ export function categories({ api }) {
     state: api,
   });
 }
+
+export function logOutFromServer({ api }) {
+  return callApi({
+    auth: true,
+    credentials: true,
+    endpoint: 'accounts/session',
+    method: 'delete',
+    state: api,
+  });
+}

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -1,7 +1,5 @@
 /* global window */
-import config from 'config';
 import React, { PropTypes } from 'react';
-import cookie from 'react-cookie';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
@@ -56,16 +54,8 @@ export const mapStateToProps = (state) => ({
 
 export const mapDispatchToProps = (dispatch) => ({
   handleLogOut({ api }) {
-    const { location } = window;
-    if (config.get('apiHost') === `${location.protocol}//${location.host}`) {
-      // Deployed config, server manages cookie.
-      return logOutFromServer({ api })
-        .then(() => dispatch(logOutUser()));
-    }
-    // Local development, we manage our own cookie.
-    cookie.remove(config.get('cookieName'), { path: '/' });
-    dispatch(logOutUser());
-    return Promise.resolve();
+    return logOutFromServer({ api })
+      .then(() => dispatch(logOutUser()));
   },
 });
 

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import { logOutUser } from 'core/actions';
-import { startLoginUrl } from 'core/api';
+import { logOutFromServer, startLoginUrl } from 'core/api';
 import translate from 'core/i18n/translate';
 import Button from 'ui/components/Button';
 import Icon from 'ui/components/Icon';
@@ -14,6 +14,7 @@ import Icon from 'ui/components/Icon';
 
 export class AuthenticateButtonBase extends React.Component {
   static propTypes = {
+    api: PropTypes.object.isRequired,
     className: PropTypes.string,
     handleLogIn: PropTypes.func.isRequired,
     handleLogOut: PropTypes.func.isRequired,
@@ -23,9 +24,9 @@ export class AuthenticateButtonBase extends React.Component {
   }
 
   onClick = () => {
-    const { handleLogIn, handleLogOut, isAuthenticated, location } = this.props;
+    const { api, handleLogIn, handleLogOut, isAuthenticated, location } = this.props;
     if (isAuthenticated) {
-      handleLogOut();
+      handleLogOut({ api });
     } else {
       handleLogIn(location);
     }
@@ -45,6 +46,7 @@ export class AuthenticateButtonBase extends React.Component {
 }
 
 export const mapStateToProps = (state) => ({
+  api: state.api,
   isAuthenticated: !!state.api.token,
   handleLogIn(location, { _window = window } = {}) {
     // eslint-disable-next-line no-param-reassign
@@ -53,9 +55,17 @@ export const mapStateToProps = (state) => ({
 });
 
 export const mapDispatchToProps = (dispatch) => ({
-  handleLogOut() {
+  handleLogOut({ api }) {
+    const { location } = window;
+    if (config.get('apiHost') === `${location.protocol}//${location.host}`) {
+      // Deployed config, server manages cookie.
+      return logOutFromServer({ api })
+        .then(() => dispatch(logOutUser()));
+    }
+    // Local development, we manage our own cookie.
     cookie.remove(config.get('cookieName'), { path: '/' });
     dispatch(logOutUser());
+    return Promise.resolve();
   },
 });
 

--- a/tests/client/amo/helpers.js
+++ b/tests/client/amo/helpers.js
@@ -1,3 +1,5 @@
+import { signedInApiState as coreSignedInApiState } from '../helpers';
+
 export const fakeAddon = {
   id: 1234,
   guid: '1234@my-addons.firefox',
@@ -50,8 +52,7 @@ export const fakeReview = {
 /*
  * Redux store state for when a user has signed in.
  */
-export const signedInApiState = {
-  lang: 'en-US',
+export const signedInApiState = Object.freeze({
+  ...coreSignedInApiState,
   clientApp: 'firefox',
-  token: 'secret-token',
-};
+});

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -4,7 +4,7 @@ import config from 'config';
 import * as api from 'core/api';
 import { ADDON_TYPE_THEME } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
-import { unexpectedSuccess } from 'tests/client/helpers';
+import { signedInApiState, unexpectedSuccess } from 'tests/client/helpers';
 
 
 export function generateHeaders(
@@ -474,13 +474,13 @@ describe('api', () => {
       mockWindow.expects('fetch')
         .withArgs(`${apiHost}/api/v3/accounts/session/?lang=en-US`, {
           credentials: 'include',
-          headers: { authorization: 'Bearer my-token' },
+          headers: { authorization: 'Bearer secret-token' },
           method: 'DELETE',
         })
         .once()
         .returns(mockResponse);
       return api.logOutFromServer({
-        api: { lang: 'en-US', token: 'my-token' },
+        api: signedInApiState,
       });
     });
   });

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -479,9 +479,8 @@ describe('api', () => {
         })
         .once()
         .returns(mockResponse);
-      return api.logOutFromServer({
-        api: signedInApiState,
-      });
+      return api.logOutFromServer({ api: signedInApiState })
+        .then(() => mockWindow.verify());
     });
   });
 });

--- a/tests/client/core/api/test_api.js
+++ b/tests/client/core/api/test_api.js
@@ -467,4 +467,21 @@ describe('api', () => {
         .then(() => mockWindow.verify());
     });
   });
+
+  describe('logOutFromServer', () => {
+    it('makes a delete request to the session endpoint', () => {
+      const mockResponse = createApiResponse({ jsonData: { ok: true } });
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/accounts/session/?lang=en-US`, {
+          credentials: 'include',
+          headers: { authorization: 'Bearer my-token' },
+          method: 'DELETE',
+        })
+        .once()
+        .returns(mockResponse);
+      return api.logOutFromServer({
+        api: { lang: 'en-US', token: 'my-token' },
+      });
+    });
+  });
 });

--- a/tests/client/core/components/TestAuthenticateButton.js
+++ b/tests/client/core/components/TestAuthenticateButton.js
@@ -1,7 +1,6 @@
 import config from 'config';
 import React from 'react';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
-import cookie from 'react-cookie';
 import { findDOMNode } from 'react-dom';
 import { combineReducers, createStore as _createStore } from 'redux';
 
@@ -60,20 +59,7 @@ describe('<AuthenticateButton />', () => {
     assert.ok(startLoginUrlStub.calledWith({ location }));
   });
 
-  it('clears the cookie and JWT in handleLogOut when not on the API host', () => {
-    sinon.stub(cookie, 'remove');
-    const _config = { cookieName: 'authcookie', apiHost: 'http://someotherhost' };
-    sinon.stub(config, 'get', (key) => _config[key]);
-    const store = createStore();
-    store.dispatch(setJwt(userAuthToken({ user_id: 99 })));
-    const { handleLogOut } = mapDispatchToProps(store.dispatch);
-    assert.ok(store.getState().api.token);
-    handleLogOut({ api: {} });
-    assert.notOk(store.getState().api.token);
-    assert.ok(cookie.remove.calledWith('authcookie', { path: '/' }));
-  });
-
-  it('asks the server to clear the cookie and JWT in handleLogOut when on the API host', () => {
+  it('gets the server to clear the cookie and JWT in handleLogOut', () => {
     sinon.stub(api, 'logOutFromServer').returns(Promise.resolve());
     const _config = { cookieName: 'authcookie', apiHost: 'http://localhost:9876' };
     sinon.stub(config, 'get', (key) => _config[key]);

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -109,3 +109,8 @@ export function assertNotHasClass(el, className) {
     el.classList.contains(className),
     `expected ${className} to not be in in ${formatClassList(el.classList)}`);
 }
+
+export const signedInApiState = Object.freeze({
+  lang: 'en-US',
+  token: 'secret-token',
+});


### PR DESCRIPTION
Logging in and out now works across both addons-server and addons-frontend. The local development setup is unchanged, based on whether the app is running on the same domain as the API.

![login-logout-same-domain mov](https://cloud.githubusercontent.com/assets/211578/22613721/5378bad4-ea40-11e6-9363-b7df84c3f399.gif)

Fixes #1557.