### PR TITLE
Use native install notifications when permissionPromptsEnabled is true

### DIFF
--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -12,12 +12,20 @@ import { addQueryParams } from 'core/utils';
 const testHasWindow = () => typeof window !== 'undefined';
 
 export function hasAddonManager({ hasWindow = testHasWindow, navigator } = {}) {
-  // Returns undefined if it cannot be determined if mozAddonManager is supperted (likely server
+  // Returns undefined if it cannot be determined if mozAddonManager is supported (likely server
   // rendering with no window). Otherwise returns true/false based on mozAddonManager in navigator.
   if (!navigator && !hasWindow()) {
     return undefined;
   }
   return 'mozAddonManager' in (navigator || window.navigator);
+}
+
+export function hasPermissionPromptsEnabled({ navigator } = {}) {
+  if (module.exports.hasAddonManager({ navigator })) {
+    const _navigator = navigator || window.navigator;
+    return _navigator.mozAddonManager.permissionPromptsEnabled;
+  }
+  return undefined;
 }
 
 export function getAddon(guid, { _mozAddonManager = window.navigator.mozAddonManager } = {}) {

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -150,7 +150,9 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
         const { guid, iconUrl, name } = ownProps;
         return _addonManager.enable(guid)
           .then(() => {
-            _showInfo({ name, iconUrl });
+            if (!_addonManager.hasPermissionPromptsEnabled()) {
+              _showInfo({ name, iconUrl });
+            }
           })
           .catch((err) => {
             if (err && err.message === SET_ENABLE_NOT_AVAILABLE) {
@@ -175,7 +177,9 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
               category: INSTALL_CATEGORY,
               label: name,
             });
-            showInfo({ name, iconUrl });
+            if (!_addonManager.hasPermissionPromptsEnabled()) {
+              showInfo({ name, iconUrl });
+            }
           })
           .catch((err) => {
             log.error(err);

--- a/tests/client/core/TestAddonManager.js
+++ b/tests/client/core/TestAddonManager.js
@@ -50,6 +50,40 @@ describe('addonManager', () => {
     });
   });
 
+  describe('hasPermissionPromptsEnabled', () => {
+    it('is undefined if mozAddonManager is not available', () => {
+      assert.equal(addonManager.hasPermissionPromptsEnabled(), undefined);
+    });
+
+    it('is undefined if permissionPromptsEnabled is undefined', () => {
+      assert.equal(addonManager.hasPermissionPromptsEnabled({
+        navigator: {
+          mozAddonManager: {},
+        },
+      }), undefined);
+    });
+
+    it('is false if hasPermissionPromptsEnabled is false', () => {
+      assert.equal(addonManager.hasPermissionPromptsEnabled({
+        navigator: {
+          mozAddonManager: {
+            permissionPromptsEnabled: false,
+          },
+        },
+      }), false);
+    });
+
+    it('is true if hasPermissionPromptsEnabled is true', () => {
+      assert.equal(addonManager.hasPermissionPromptsEnabled({
+        navigator: {
+          mozAddonManager: {
+            permissionPromptsEnabled: true,
+          },
+        },
+      }), true);
+    });
+  });
+
   describe('getAddon()', () => {
     it('should call mozAddonManager.getAddonByID() with id', () => {
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -55,13 +55,15 @@ const enabledExtension = Promise.resolve({
   type: ADDON_TYPE_EXTENSION,
 });
 
-export function getFakeAddonManagerWrapper({ getAddon = enabledExtension } = {}) {
+export function getFakeAddonManagerWrapper({
+  getAddon = enabledExtension, permissionPromptsEnabled = true } = {}) {
   return {
     addChangeListeners: sinon.stub(),
     enable: sinon.stub().returns(Promise.resolve()),
     getAddon: sinon.stub().returns(getAddon),
     install: sinon.stub().returns(Promise.resolve()),
     uninstall: sinon.stub().returns(Promise.resolve()),
+    hasPermissionPromptsEnabled: sinon.stub().returns(permissionPromptsEnabled),
   };
 }
 


### PR DESCRIPTION
Fixes #1679 

Conditionally dispatch the install notification based on detecting `extensions.webextPermissionPrompts`. 

With `extensions.webextPermissionPrompts` set to false:

![fullscreen_06_02_2017__18_16](https://cloud.githubusercontent.com/assets/1514/22660165/6ae6767a-ec98-11e6-872c-9d22585a270c.png)

With `extensions.webextPermissionPrompts` set to true:

![fullscreen_06_02_2017__18_15](https://cloud.githubusercontent.com/assets/1514/22660126/4c745df6-ec98-11e6-8cbe-992e64ff5972.png)
