### PR TITLE
Proxy server for AMO development

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ To see this report while running tests locally, type:
 
 A proxy server is provided for running the AMO app with the API on the same host as the frontend.
 This provides a setup that is closer to production than running the frontend on its own. The
-default configuration for this is to use a local addons-server for the API. This comes
-pre-configured to use a local addons-server which can be setup according to the
+default configuration for this is to use a local addons-server for the API which can be setup
+according to the
 [addons-server docs](https://addons-server.readthedocs.io/en/latest/topics/install/index.html).
 Docker is the preferred method of running addons-server.
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Generic scripts that don't need env vars. Use these for development:
 | Script                  | Description                                           |
 |-------------------------|-------------------------------------------------------|
 | npm run dev:admin       |  Starts the dev server (admin app)                    |
-| npm run dev:amo         |  Starts the dev server (amo)                          |
-| npm run dev:amo:proxy   |  Starts the dev server with proxy (amo)               |
+| npm run dev:amo         |  Starts the dev server and proxy (amo)                |
+| npm run dev:amo:no-proxy|  Starts the dev server without proxy (amo)            |
 | npm run dev:disco       |  Starts the dev server (discovery pane)               |
 | npm run eslint          |  Lints the JS                                         |
 | npm run stylelint       |  Lints the SCSS                                       |
@@ -95,17 +95,19 @@ To see this report while running tests locally, type:
 
     open ./coverage/index.html
 
-### Running development AMO similar to production
+### Running AMO for local development
 
 A proxy server is provided for running the AMO app with the API on the same host as the frontend.
-This provides a setup that is closer to production than running the frontend on its own. The only
-supported method of doing this is to also be running an instance of addons-server at
-http://olympia.dev (this is its default configuration in development mode). You can find
-instructions on settings up addons-server in the
+This provides a setup that is closer to production than running the frontend on its own. The
+default configuration for this is to use a local addons-server for the API. This comes
+pre-configured to use a local addons-server which can be setup according to the
 [addons-server docs](https://addons-server.readthedocs.io/en/latest/topics/install/index.html).
 Docker is the preferred method of running addons-server.
 
-To run the development server with the proxy use `npm run dev:amo:proxy`.
+This should work without any issues with a local addons-server and can also be configured to use
+`https://addons-dev.allizom.org` as the API but the addons-server views will not all work as
+expected. If you would like to use `https://addons-dev.allizom.org` for the API you should use the
+`npm run dev:amo:no-proxy` command to start the server without the proxy.j
 
 ### Configuring for local development
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Generic scripts that don't need env vars. Use these for development:
 |-------------------------|-------------------------------------------------------|
 | npm run dev:admin       |  Starts the dev server (admin app)                    |
 | npm run dev:amo         |  Starts the dev server (amo)                          |
+| npm run dev:amo:proxy   |  Starts the dev server with proxy (amo)               |
 | npm run dev:disco       |  Starts the dev server (discovery pane)               |
 | npm run eslint          |  Lints the JS                                         |
 | npm run stylelint       |  Lints the SCSS                                       |
@@ -93,6 +94,18 @@ The continuous integration process will give you a link to view the report.
 To see this report while running tests locally, type:
 
     open ./coverage/index.html
+
+### Running development AMO similar to production
+
+A proxy server is provided for running the AMO app with the API on the same host as the frontend.
+This provides a setup that is closer to production than running the frontend on its own. The only
+supported method of doing this is to also be running an instance of addons-server at
+http://olympia.dev (this is its default configuration in development mode). You can find
+instructions on settings up addons-server in the
+[addons-server docs](https://addons-server.readthedocs.io/en/latest/topics/install/index.html).
+Docker is the preferred method of running addons-server.
+
+To run the development server with the proxy use `npm run dev:amo:proxy`.
 
 ### Configuring for local development
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,12 @@ according to the
 [addons-server docs](https://addons-server.readthedocs.io/en/latest/topics/install/index.html).
 Docker is the preferred method of running addons-server.
 
-This should work without any issues with a local addons-server and can also be configured to use
-`https://addons-dev.allizom.org` as the API but the addons-server views will not all work as
-expected. If you would like to use `https://addons-dev.allizom.org` for the API you should use the
+Authentication will work when initiated from addons-frontend and will persist to addons-server but
+it will not work when logging in from an addons-server page. See
+[mozilla/addons-server#4684](https://github.com/mozilla/addons-server/issues/4684) for more
+information on fixing this.
+
+If you would like to use `https://addons-dev.allizom.org` for the API you should use the
 `npm run dev:amo:no-proxy` command with an `API_HOST` to start the server without the proxy. For
 example: `API_HOST=https://addons-dev.allizom.org npm run dev:amo:no-proxy`.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Docker is the preferred method of running addons-server.
 This should work without any issues with a local addons-server and can also be configured to use
 `https://addons-dev.allizom.org` as the API but the addons-server views will not all work as
 expected. If you would like to use `https://addons-dev.allizom.org` for the API you should use the
-`npm run dev:amo:no-proxy` command to start the server without the proxy.j
+`npm run dev:amo:no-proxy` command with an `API_HOST` to start the server without the proxy. For
+example: `API_HOST=https://addons-dev.allizom.org npm run dev:amo:no-proxy`.
 
 ### Configuring for local development
 

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -1,7 +1,6 @@
 require('babel-register');
 
 const http = require('http');
-const url = require('url');
 
 const bunyan = require('bunyan');
 const config = require('config');
@@ -51,12 +50,10 @@ function getHost(req) {
 
 const server = http.createServer((req, res) => {
   const host = getHost(req);
-  const hostUrl = url.parse(host);
   return proxy.web(req, res, {
     target: host,
     changeOrigin: true,
     autoRewrite: true,
-    hostRewrite: hostUrl.host,
     protocolRewrite: 'http',
     cookieDomainRewrite: '',
   });

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -42,7 +42,7 @@ function unsecureCookie(req, res, proxyRes) {
 }
 
 function getHost(req) {
-  const useDesktop = cookie.parse(req.headers.cookie).mamo === 'off';
+  const useDesktop = req.headers.cookie && cookie.parse(req.headers.cookie).mamo === 'off';
   if (useDesktop || req.url.startsWith('/api/')) {
     return apiHost;
   }

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -5,6 +5,7 @@ const url = require('url');
 
 const bunyan = require('bunyan');
 const config = require('config');
+const cookie = require('cookie');
 const httpProxy = require('http-proxy');
 
 const log = bunyan.createLogger({
@@ -41,7 +42,8 @@ function unsecureCookie(req, res, proxyRes) {
 }
 
 function getHost(req) {
-  if (!req.headers['user-agent'].includes('Android') || req.url.startsWith('/api/')) {
+  const useDesktop = cookie.parse(req.headers.cookie).mamo === 'off';
+  if (useDesktop || req.url.startsWith('/api/')) {
     return apiHost;
   }
   return frontendHost;

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -1,0 +1,45 @@
+require('babel-register');
+
+const http = require('http');
+
+const bunyan = require('bunyan');
+const config = require('config');
+const httpProxy = require('http-proxy');
+
+const log = bunyan.createLogger({
+  name: 'proxy',
+  app: config.get('appName'),
+  serializers: bunyan.stdSerializers,
+});
+
+const proxy = httpProxy.createProxyServer();
+const apiHost = config.get('proxyApiHost', null) || config.get('apiHost');
+const frontendHost = `http://${config.get('serverHost')}:${config.get('serverPort')}`;
+
+log.info(`apiHost: ${apiHost}`);
+log.info(`frontendHost: ${frontendHost}`);
+
+function getHost(req) {
+  if (!req.headers['user-agent'].includes('Android') || req.url.startsWith('/api/')) {
+    return apiHost;
+  }
+  return frontendHost;
+}
+
+const server = http.createServer((req, res) => (
+  proxy.web(req, res, { target: getHost(req), changeOrigin: true, autoRewrite: true })
+));
+
+proxy.on('proxyRes', (proxyRes, req) => {
+  log.info(`${proxyRes.statusCode} ~> ${getHost(req)}${req.url}`);
+});
+
+proxy.on('error', (error, req, res) => {
+  log.error(`ERR ~> ${getHost(req)}${req.url} ${error}`);
+  res.writeHead(500, { 'Content-type': 'text/plain' });
+  res.end('Proxy error');
+});
+
+const port = parseInt(config.get('proxyPort', '3333'), 10);
+log.info(`🚦 Proxy running at http://localhost:${port}`);
+server.listen(port);

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,5 +1,7 @@
 {
   "apiHost": "API_HOST",
+  "proxyApiHost": "PROXY_API_HOST",
+  "proxyPort": "PROXY_PORT",
   "serverHost": "SERVER_HOST",
   "serverPort": "SERVER_PORT",
   "staticHost": "STATIC_HOST",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,6 +1,7 @@
 {
   "apiHost": "API_HOST",
   "proxyApiHost": "PROXY_API_HOST",
+  "proxyEnabled": "PROXY_ENABLED",
   "proxyPort": "PROXY_PORT",
   "serverHost": "SERVER_HOST",
   "serverPort": "SERVER_PORT",

--- a/config/default.js
+++ b/config/default.js
@@ -170,4 +170,6 @@ module.exports = {
   defaultClientApp: 'firefox',
 
   fxaConfig: null,
+
+  proxyEnabled: false,
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -1,3 +1,7 @@
 module.exports = {
+  apiHost: 'http://localhost:3000',
+  proxyApiHost: 'http://olympia.dev',
+  proxyPort: 3000,
+  proxyEnabled: true,
   fxaConfig: 'local',
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "dev:amo:no-proxy": {
       "command": "better-npm-run start-dev",
       "env": {
-        "NODE_APP_INSTANCE": "amo"
+        "NODE_APP_INSTANCE": "amo",
+        "PROXY_ENABLED": "false"
       }
     },
     "dev:disco": {
@@ -75,12 +76,9 @@
     "start-dev-proxy": {
       "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | bunyan' 'npm run proxy | bunyan'",
       "env": {
-        "API_HOST": "http://localhost:3000",
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",
         "NODE_PATH": "./:./src",
-        "PROXY_API_HOST": "http://olympia.dev",
-        "PROXY_PORT": "3000",
         "SERVER_PORT": "3333"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "clean": "rimraf './dist/*!(.gitkeep)' './webpack-assets.json'",
     "dev:admin": "better-npm-run dev:admin",
     "dev:amo": "better-npm-run dev:amo",
+    "dev:amo:proxy": "better-npm-run dev:amo:proxy",
     "dev:disco": "better-npm-run dev:disco",
     "eslint": "eslint .",
     "stylelint": "stylelint --syntax scss **/*.scss",
     "lint": "npm run eslint && npm run stylelint",
+    "proxy": "NODE_PATH='./:./src' node bin/proxy.js",
     "servertest": "bin/config-check.js && ADDONS_FRONTEND_BUILD_ALL=1 npm run build && better-npm-run servertest && better-npm-run servertest:amo && better-npm-run servertest:disco && better-npm-run servertest:admin",
     "start": "npm run version-check && NODE_PATH='./:./src' node bin/server.js",
     "test": "bin/config-check.js && better-npm-run test",
@@ -43,6 +45,12 @@
         "NODE_APP_INSTANCE": "amo"
       }
     },
+    "dev:amo:proxy": {
+      "command": "better-npm-run start-dev-proxy",
+      "env": {
+        "NODE_APP_INSTANCE": "amo"
+      }
+    },
     "dev:disco": {
       "command": "better-npm-run start-dev",
       "env": {
@@ -62,6 +70,18 @@
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",
         "NODE_PATH": "./:./src"
+      }
+    },
+    "start-dev-proxy": {
+      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | bunyan' 'npm run proxy | bunyan'",
+      "env": {
+        "API_HOST": "http://localhost:3000",
+        "ENABLE_PIPING": "true",
+        "NODE_ENV": "development",
+        "NODE_PATH": "./:./src",
+        "PROXY_API_HOST": "http://olympia.dev",
+        "PROXY_PORT": "3000",
+        "SERVER_PORT": "3333"
       }
     },
     "servertest": {
@@ -225,6 +245,7 @@
     "fetch-mock": "5.9.3",
     "file-loader": "0.10.0",
     "glob": "7.1.1",
+    "http-proxy": "1.16.2",
     "json-loader": "0.5.4",
     "karma": "1.4.1",
     "karma-chai": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "chalk": "1.1.3",
     "cheerio": "0.22.0",
     "concurrently": "3.3.0",
+    "cookie": "0.3.1",
     "css-loader": "0.26.1",
     "deepcopy": "0.6.3",
     "eslint": "3.14.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       }
     },
     "start-dev-proxy": {
-      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | bunyan' 'npm run proxy | bunyan'",
+      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | bunyan' 'node bin/proxy.js | bunyan'",
       "env": {
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf './dist/*!(.gitkeep)' './webpack-assets.json'",
     "dev:admin": "better-npm-run dev:admin",
     "dev:amo": "better-npm-run dev:amo",
-    "dev:amo:proxy": "better-npm-run dev:amo:proxy",
+    "dev:amo:no-proxy": "better-npm-run dev:amo:no-proxy",
     "dev:disco": "better-npm-run dev:disco",
     "eslint": "eslint .",
     "stylelint": "stylelint --syntax scss **/*.scss",
@@ -40,13 +40,13 @@
       }
     },
     "dev:amo": {
-      "command": "better-npm-run start-dev",
+      "command": "better-npm-run start-dev-proxy",
       "env": {
         "NODE_APP_INSTANCE": "amo"
       }
     },
-    "dev:amo:proxy": {
-      "command": "better-npm-run start-dev-proxy",
+    "dev:amo:no-proxy": {
+      "command": "better-npm-run start-dev",
       "env": {
         "NODE_APP_INSTANCE": "amo"
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "eslint": "eslint .",
     "stylelint": "stylelint --syntax scss **/*.scss",
     "lint": "npm run eslint && npm run stylelint",
-    "proxy": "NODE_PATH='./:./src' node bin/proxy.js",
     "servertest": "bin/config-check.js && ADDONS_FRONTEND_BUILD_ALL=1 npm run build && better-npm-run servertest && better-npm-run servertest:amo && better-npm-run servertest:disco && better-npm-run servertest:admin",
     "start": "npm run version-check && NODE_PATH='./:./src' node bin/server.js",
     "test": "bin/config-check.js && better-npm-run test",

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -26,7 +26,7 @@ export default (
     <Route path=":visibleAddonType/categories/" component={CategoryList} />
     <Route path=":visibleAddonType/featured/" component={FeaturedAddons} />
     <Route path=":visibleAddonType/:slug/" component={CategoryPage} />
-    <Route path="fxa-authenticate" component={HandleLogin} />
+    <Route path="/api/v3/accounts/authenticate/" component={HandleLogin} />
     <Route path="search/" component={SearchPage} />
     <Route path="401/"
       component={config.get('isDevelopment') ? NotAuthorized : NotFound} />

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -317,12 +317,22 @@ export function runServer({
             if (err) {
               return reject(err);
             }
-            log.info(oneLine`🔥  Addons-frontend server is running [ENV:${env}]
-              [APP:${app}] [isDevelopment:${isDevelopment}
-              [isDeployed:${isDeployed}] [apiHost:${config.get('apiHost')}]
-              [apiPath:${config.get('apiPath')}]`);
-            log.info(
-              `👁  Open your browser at http://${host}:${port} to view it.`);
+            const proxyPort = config.has('proxyPort') ? config.get('proxyPort') : undefined;
+            // Not using oneLine here since it seems to change '  ' to ' '.
+            log.info([
+              `🔥  Addons-frontend server is running [ENV:${env}] [APP:${app}]`,
+              `[isDevelopment:${isDevelopment}] [isDeployed:${isDeployed}]`,
+              `[apiHost:${config.get('apiHost')}] [apiPath:${config.get('apiPath')}]`,
+            ].join(' '));
+            if (proxyPort) {
+              log.info(
+                `🚦  Proxy detected, frontend running at http://${host}:${port}.`);
+              log.info(
+                `👁  Open your browser at http://localhost:${proxyPort} to view it.`);
+            } else {
+              log.info(
+                `👁  Open your browser at http://${host}:${port} to view it.`);
+            }
             return resolve(server);
           });
         } else {

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -317,14 +317,15 @@ export function runServer({
             if (err) {
               return reject(err);
             }
-            const proxyPort = config.has('proxyPort') ? config.get('proxyPort') : undefined;
+            const proxyEnabled = convertBoolean(config.get('proxyEnabled'));
             // Not using oneLine here since it seems to change '  ' to ' '.
             log.info([
               `🔥  Addons-frontend server is running [ENV:${env}] [APP:${app}]`,
               `[isDevelopment:${isDevelopment}] [isDeployed:${isDeployed}]`,
               `[apiHost:${config.get('apiHost')}] [apiPath:${config.get('apiPath')}]`,
             ].join(' '));
-            if (proxyPort) {
+            if (proxyEnabled) {
+              const proxyPort = config.get('proxyPort');
               log.info(
                 `🚦  Proxy detected, frontend running at http://${host}:${port}.`);
               log.info(


### PR DESCRIPTION
Start the proxy server with `npm run dev:amo`. You need to be running an API server at `http://olympia.dev`. Access the site as usual at http://localhost:3000.

Fixes #1716.

Depends on https://github.com/mozilla/addons-server/pull/4681.