### PR TITLE
Refresh add-on after posting a review to update review count

### DIFF
--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -45,10 +45,10 @@ export class AddonReviewBase extends React.Component {
   }
 
   onSubmit = (event, { overlayCard = this.overlayCard } = {}) => {
+    const { reviewBody, reviewTitle } = this.state;
     event.preventDefault();
     event.stopPropagation();
 
-    const { reviewBody, reviewTitle } = this.state;
     const addonSlug = this.props.review.addonSlug;
     const apiState = this.props.apiState;
 

--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -4,6 +4,7 @@ import { compose } from 'redux';
 
 import { submitReview } from 'amo/api';
 import { setReview } from 'amo/actions/reviews';
+import { refreshAddon } from 'core/utils';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import OverlayCard from 'ui/components/OverlayCard';
@@ -16,8 +17,9 @@ export class AddonReviewBase extends React.Component {
     apiState: PropTypes.object,
     errorHandler: PropTypes.object.isRequired,
     i18n: PropTypes.object.isRequired,
+    refreshAddon: PropTypes.func.isRequired,
     review: PropTypes.object.isRequired,
-    updateReviewText: PropTypes.func,
+    updateReviewText: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -43,23 +45,27 @@ export class AddonReviewBase extends React.Component {
   }
 
   onSubmit = (event, { overlayCard = this.overlayCard } = {}) => {
-    const { reviewBody, reviewTitle } = this.state;
     event.preventDefault();
     event.stopPropagation();
+
+    const { reviewBody, reviewTitle } = this.state;
+    const addonSlug = this.props.review.addonSlug;
+    const apiState = this.props.apiState;
+
     const params = {
+      addonSlug,
+      apiState,
       body: reviewBody,
       title: reviewTitle,
-      addonSlug: this.props.review.addonSlug,
       errorHandler: this.props.errorHandler,
       reviewId: this.props.review.id,
-      apiState: this.props.apiState,
     };
     // TODO: render a progress indicator in the UI.
     // https://github.com/mozilla/addons-frontend/issues/1156
     return this.props.updateReviewText(params)
-      .then(() => {
-        overlayCard.hide();
-      });
+      // This will update the review count on the add-on detail page.
+      .then(() => this.props.refreshAddon({ addonSlug, apiState }))
+      .then(() => { overlayCard.hide(); });
   }
 
   onTitleInput = (event) => {
@@ -137,6 +143,9 @@ export const mapStateToProps = (state) => ({
 });
 
 export const mapDispatchToProps = (dispatch) => ({
+  refreshAddon({ addonSlug, apiState }) {
+    return refreshAddon({ addonSlug, apiState, dispatch });
+  },
   updateReviewText(...params) {
     return submitReview(...params)
       .then((review) => dispatch(setReview(review)));

--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -63,9 +63,9 @@ export class AddonReviewBase extends React.Component {
     // TODO: render a progress indicator in the UI.
     // https://github.com/mozilla/addons-frontend/issues/1156
     return this.props.updateReviewText(params)
+      .then(() => overlayCard.hide())
       // This will update the review count on the add-on detail page.
-      .then(() => this.props.refreshAddon({ addonSlug, apiState }))
-      .then(() => { overlayCard.hide(); });
+      .then(() => this.props.refreshAddon({ addonSlug, apiState }));
   }
 
   onTitleInput = (event) => {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -88,6 +88,11 @@ export function findAddon(state, slug) {
   return state.addons[slug];
 }
 
+export function refreshAddon({ addonSlug, apiState, dispatch } = {}) {
+  return fetchAddon({ slug: addonSlug, api: apiState })
+    .then(({ entities }) => dispatch(loadEntities(entities)));
+}
+
 // asyncConnect() helper for loading an add-on by slug.
 //
 // This accepts component properties and returns a promise
@@ -95,17 +100,19 @@ export function findAddon(state, slug) {
 // If the add-on has already been fetched, the add-on value is returned.
 //
 export function loadAddonIfNeeded(
-  { store: { dispatch, getState }, params: { slug } }
+  { store: { dispatch, getState }, params: { slug } },
+  { _refreshAddon = refreshAddon } = {},
 ) {
   const state = getState();
   const addon = findAddon(state, slug);
   if (addon) {
-    log.info(`Found addon ${addon.id} in state`);
+    log.info(`Found add-on ${slug}, ${addon.id} in state`);
     return addon;
   }
-  log.info(`Fetching addon ${slug} from API`);
-  return fetchAddon({ slug, api: state.api })
-    .then(({ entities }) => dispatch(loadEntities(entities)));
+  log.info(`Add-on ${slug} not found in state; fetching from API`);
+  // This loads the add-on into state. The return value is not always
+  // used; check each caller.
+  return _refreshAddon({ addonSlug: slug, apiState: state.api, dispatch });
 }
 
 // asyncConnect() helper for loading categories for browsing and displaying

--- a/tests/client/amo/components/TestAddonReview.js
+++ b/tests/client/amo/components/TestAddonReview.js
@@ -28,9 +28,9 @@ function render({ ...customProps } = {}) {
     }),
     i18n: getFakeI18nInst(),
     apiState: signedInApiState,
-    refreshAddon: () => {},
+    refreshAddon: () => Promise.resolve(),
     review: defaultReview,
-    updateReviewText: () => {},
+    updateReviewText: () => Promise.resolve(),
     ...customProps,
   };
   const AddonReview = translate({ withRef: true })(AddonReviewBase);

--- a/tests/client/core/test_utils.js
+++ b/tests/client/core/test_utils.js
@@ -13,14 +13,16 @@ import {
   findAddon,
   getClientApp,
   getClientConfig,
-  ngettext,
   isAllowedOrigin,
   isValidClientApp,
   loadAddonIfNeeded,
   loadCategoriesIfNeeded,
+  ngettext,
   nl2br,
+  refreshAddon,
   visibleAddonType,
 } from 'core/utils';
+import { fakeAddon, signedInApiState } from 'tests/client/amo/helpers';
 import { unexpectedSuccess } from 'tests/client/helpers';
 
 
@@ -249,8 +251,49 @@ describe('findAddon', () => {
   });
 });
 
+describe('refreshAddon', () => {
+  const addonSlug = fakeAddon.slug;
+  const apiState = signedInApiState;
+  let dispatch;
+  let mockApi;
+
+  beforeEach(() => {
+    dispatch = sinon.spy();
+    mockApi = sinon.mock(api);
+  });
+
+  it('fetches and dispatches an add-on', () => {
+    const entities = { [addonSlug]: fakeAddon };
+    mockApi
+      .expects('fetchAddon')
+      .once()
+      .withArgs({ slug: addonSlug, api: apiState })
+      .returns(Promise.resolve({ entities }));
+
+    return refreshAddon({ addonSlug, apiState, dispatch })
+      .then(() => {
+        assert.ok(dispatch.called);
+        assert.deepEqual(dispatch.firstCall.args[0],
+                         actions.loadEntities(entities));
+        mockApi.verify();
+      });
+  });
+
+  it('handles 404s when loading the add-on', () => {
+    mockApi
+      .expects('fetchAddon')
+      .once()
+      .withArgs({ slug: addonSlug, api: signedInApiState })
+      .returns(Promise.reject(new Error('Error accessing API')));
+    return refreshAddon({ addonSlug, apiState, dispatch })
+      .then(unexpectedSuccess,
+        () => {
+          assert.equal(dispatch.called, false);
+        });
+  });
+});
+
 describe('loadAddonIfNeeded', () => {
-  const apiState = { token: 'my.jwt.token' };
   const loadedSlug = 'my-addon';
   let loadedAddon;
   let dispatch;
@@ -267,7 +310,7 @@ describe('loadAddonIfNeeded', () => {
           addons: {
             [loadedSlug]: loadedAddon,
           },
-          api: apiState,
+          api: signedInApiState,
         }),
         dispatch,
       },
@@ -281,49 +324,20 @@ describe('loadAddonIfNeeded', () => {
 
   it('loads the add-on if it is not loaded', () => {
     const slug = 'other-addon';
-    const props = makeProps(slug, apiState);
-    const addon = sinon.stub();
-    const entities = { [slug]: addon };
-    const mockApi = sinon.mock(api);
-    mockApi
-      .expects('fetchAddon')
+    const props = makeProps(slug);
+    const mockAddonRefresher = sinon.mock()
       .once()
-      .withArgs({ slug, api: apiState })
-      .returns(Promise.resolve({ entities }));
-    const action = sinon.stub();
-    const mockActions = sinon.mock(actions);
-    mockActions
-      .expects('loadEntities')
-      .once()
-      .withArgs(entities)
-      .returns(action);
-    return loadAddonIfNeeded(props).then(() => {
-      assert(dispatch.calledWith(action), 'dispatch not called');
-      mockApi.verify();
-      mockActions.verify();
-    });
-  });
+      .withArgs({
+        addonSlug: slug,
+        apiState: signedInApiState,
+        dispatch,
+      })
+      .returns(Promise.resolve());
 
-  it('handles 404s when loading the add-on', () => {
-    const slug = 'other-addon';
-    const props = makeProps(slug, apiState);
-    const mockApi = sinon.mock(api);
-    mockApi
-      .expects('fetchAddon')
-      .once()
-      .withArgs({ slug, api: apiState })
-      .returns(Promise.reject(new Error('Error accessing API')));
-    const mockActions = sinon.mock(actions);
-    mockActions
-      .expects('loadEntities')
-      .never();
-    return loadAddonIfNeeded(props)
-      .then(unexpectedSuccess,
-        () => {
-          assert(!dispatch.called, 'dispatch called');
-          mockApi.verify();
-          mockActions.verify();
-        });
+    return loadAddonIfNeeded(props, { _refreshAddon: mockAddonRefresher })
+      .then(() => {
+        mockAddonRefresher.verify();
+      });
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1738

After reading the bug, here's what you need to know about the patch:
* The behavior where the review is missing from the list seemed to be solved by https://github.com/mozilla/addons-frontend/pull/1706 (I could reproduce it before but not after). This patch did not need to address that.
* The review count was not getting updated on the add-on detail page after submitting a new review. This patch addresses that.