### PR TITLE
Don't reset review state when submitting a new review

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -1,6 +1,6 @@
 import { SET_ADDON_REVIEWS, SET_REVIEW } from 'amo/constants';
 
-function denormalizeReview(review) {
+export function denormalizeReview(review) {
   return {
     addonId: review.addon.id,
     addonSlug: review.addon.slug,
@@ -18,17 +18,23 @@ function denormalizeReview(review) {
   };
 }
 
+const setReviewAction = (review) => ({ type: SET_REVIEW, payload: review });
+
 export const setReview = (review, reviewOverrides = {}) => {
   if (!review) {
     throw new Error('review cannot be empty');
   }
-  return {
-    type: SET_REVIEW,
-    payload: {
-      ...denormalizeReview(review),
-      ...reviewOverrides,
-    },
-  };
+  return setReviewAction({
+    ...denormalizeReview(review),
+    ...reviewOverrides,
+  });
+};
+
+export const setDenormalizedReview = (review) => {
+  if (!review) {
+    throw new Error('review cannot be empty');
+  }
+  return setReviewAction(review);
 };
 
 export const setAddonReviews = ({ addonSlug, reviews }) => {

--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import { submitReview } from 'amo/api';
-import { setReview } from 'amo/actions/reviews';
+import { setDenormalizedReview, setReview } from 'amo/actions/reviews';
 import { refreshAddon } from 'core/utils';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -19,6 +19,7 @@ export class AddonReviewBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     refreshAddon: PropTypes.func.isRequired,
     review: PropTypes.object.isRequired,
+    setDenormalizedReview: PropTypes.func.isRequired,
     updateReviewText: PropTypes.func.isRequired,
   }
 
@@ -47,18 +48,34 @@ export class AddonReviewBase extends React.Component {
     const addonSlug = this.props.review.addonSlug;
     const apiState = this.props.apiState;
 
+    const newReviewParams = {
+      body: reviewBody,
+    };
+
+    const updatedReview = {
+      ...this.props.review,
+      ...newReviewParams,
+    };
+
     const params = {
       addonSlug,
       apiState,
-      body: reviewBody,
       errorHandler: this.props.errorHandler,
       reviewId: this.props.review.id,
+      ...newReviewParams,
     };
     // TODO: render a progress indicator in the UI.
     // https://github.com/mozilla/addons-frontend/issues/1156
+
+    // First, put the new review in state so that the
+    // component doesn't re-render with old data while
+    // our API request is in the air.
+    this.props.setDenormalizedReview(updatedReview);
+
+    // Next, update the review for real with an API call.
     return this.props.updateReviewText(params)
       .then(() => overlayCard.hide())
-      // This will update the review count on the add-on detail page.
+      // Finally, update the review count on the add-on detail page.
       .then(() => this.props.refreshAddon({ addonSlug, apiState }));
   }
 
@@ -128,6 +145,9 @@ export const mapStateToProps = (state) => ({
 export const mapDispatchToProps = (dispatch) => ({
   refreshAddon({ addonSlug, apiState }) {
     return refreshAddon({ addonSlug, apiState, dispatch });
+  },
+  setDenormalizedReview(review) {
+    dispatch(setDenormalizedReview(review));
   },
   updateReviewText(...params) {
     return submitReview(...params)

--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -67,12 +67,12 @@ export class AddonReviewBase extends React.Component {
     // TODO: render a progress indicator in the UI.
     // https://github.com/mozilla/addons-frontend/issues/1156
 
-    // First, put the new review in state so that the
+    // First, dispatch the new review to state so that the
     // component doesn't re-render with old data while
-    // our API request is in the air.
+    // the API request is in progress.
     this.props.setDenormalizedReview(updatedReview);
 
-    // Next, update the review for real with an API call.
+    // Next, update the review with an actual API request.
     return this.props.updateReviewText(params)
       .then(() => overlayCard.hide())
       // Finally, update the review count on the add-on detail page.

--- a/tests/client/amo/actions/testReviews.js
+++ b/tests/client/amo/actions/testReviews.js
@@ -1,10 +1,45 @@
-import { setReview, setAddonReviews } from 'amo/actions/reviews';
+import {
+  denormalizeReview,
+  setDenormalizedReview,
+  setReview,
+  setAddonReviews,
+} from 'amo/actions/reviews';
+import { SET_REVIEW } from 'amo/constants';
 import { fakeAddon, fakeReview } from 'tests/client/amo/helpers';
 
+// See reducer tests for more coverage of review actions.
 describe('amo.actions.reviews', () => {
   describe('setReview', () => {
     it('requires a truthy review', () => {
       assert.throws(() => setReview(), /review cannot be empty/);
+    });
+
+    it('denormalizes a review', () => {
+      const action = setReview(fakeReview);
+      assert.deepEqual(action.payload,
+                       denormalizeReview(fakeReview));
+    });
+
+    it('sets an action type', () => {
+      const action = setReview(fakeReview);
+      assert.equal(action.type, SET_REVIEW);
+    });
+  });
+
+  describe('setDenormalizedReview', () => {
+    it('requires a truthy review', () => {
+      assert.throws(() => setDenormalizedReview(), /review cannot be empty/);
+    });
+
+    it('creates an action with the exact review object', () => {
+      const review = denormalizeReview(fakeReview);
+      const action = setDenormalizedReview(review);
+      assert.deepEqual(action.payload, review);
+    });
+
+    it('sets an action type', () => {
+      const action = setDenormalizedReview(denormalizeReview(fakeReview));
+      assert.equal(action.type, SET_REVIEW);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1779

Here's an explanation of what was happening:
* Let's say a user creates a rating and a written review
* The user returns to edit the written review
* When the user presses 'submit' on their text change, the component patches the API with the new review object and waits
* Meanwhile, the error handler resets itself since a new API request has been initiated. This triggers a re-render of the AddonReview component
* The AddonReview component renders using the old review object from state and sets the form text to the old text. To the user, it looks like pressing the submit button just erased what they had written.
* The API response finally completes and puts the new review object in state. By the time the overlay for the form has already closed.

The solution to this problem (in this patch) is to optimistically dispatch the new review object before the API request has completed. When the API responds, the resulting object will also be dispatched to state.