### PR TITLE
Fix SearchInput issues

### DIFF
--- a/src/ui/components/SearchInput/index.js
+++ b/src/ui/components/SearchInput/index.js
@@ -31,7 +31,7 @@ export default class SearchInput extends React.Component {
   onBlur = () => {
     this.setState({ focus: false });
     if (!this.value) {
-      // Animation will start if there is no value.
+      // There is no transitionstart event, but animation will start if there is no value.
       this.setState({ animating: true });
     }
   }
@@ -39,7 +39,7 @@ export default class SearchInput extends React.Component {
   onFocus = () => {
     this.setState({ focus: true });
     if (!this.value) {
-      // Animation will start if there is no value.
+      // There is no transitionstart event, but animation will start if there is no value.
       this.setState({ animating: true });
     }
   }

--- a/src/ui/components/SearchInput/index.js
+++ b/src/ui/components/SearchInput/index.js
@@ -53,9 +53,11 @@ export default class SearchInput extends React.Component {
   };
 
   setIconPosition = () => {
+    if (!this.animateLeft) {
+      this.animateLeft = this.animateIcon.getBoundingClientRect().left;
+    }
     const { left: labelLeft } = this.labelIcon.getBoundingClientRect();
-    const { left: animateLeft } = this.animateIcon.getBoundingClientRect();
-    this.animateIcon.style.transform = `translateX(${labelLeft - animateLeft}px)`;
+    this.animateIcon.style.transform = `translateX(${labelLeft - this.animateLeft}px)`;
   }
 
   get value() {

--- a/src/ui/components/SearchInput/index.js
+++ b/src/ui/components/SearchInput/index.js
@@ -77,11 +77,17 @@ export default class SearchInput extends React.Component {
         ref={(el) => { this.root = el; }}
       >
         <Icon
-          name="magnifying-glass" className="SearchInput-animation-icon"
+          name="magnifying-glass"
+          className="SearchInput-animation-icon"
           getRef={(el) => { this.animateIcon = el; }}
-          onTransitionEnd={this.onTransitionEnd} />
+          onTransitionEnd={this.onTransitionEnd}
+        />
         <label className="SearchInput-label" htmlFor={id}>
-          <Icon name="magnifying-glass" getRef={(el) => { this.labelIcon = el; }} />
+          <Icon
+            name="magnifying-glass"
+            className="SearchInput-label-icon"
+            getRef={(el) => { this.labelIcon = el; }}
+          />
           {placeholder}
         </label>
         <input

--- a/src/ui/components/SearchInput/index.js
+++ b/src/ui/components/SearchInput/index.js
@@ -16,7 +16,7 @@ export default class SearchInput extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { focus: false, value: props.defaultValue };
+    this.state = { animating: false, focus: false, value: props.defaultValue };
   }
 
   componentDidMount() {
@@ -30,27 +30,27 @@ export default class SearchInput extends React.Component {
 
   onBlur = () => {
     this.setState({ focus: false });
+    if (!this.value) {
+      // Animation will start if there is no value.
+      this.setState({ animating: true });
+    }
   }
 
   onFocus = () => {
     this.setState({ focus: true });
+    if (!this.value) {
+      // Animation will start if there is no value.
+      this.setState({ animating: true });
+    }
   }
 
   onInput = (e) => {
     this.setState({ value: e.target.value });
   }
 
-  onMouseDown = (e) => {
-    this.setState({ focus: true });
-    if (!this.input.value) {
-      e.preventDefault();
-      const setFocus = () => {
-        this.input.focus();
-        this.animateIcon.removeEventListener('transitionend', setFocus);
-      };
-      this.animateIcon.addEventListener('transitionend', setFocus);
-    }
-  }
+  onTransitionEnd = () => {
+    this.setState({ animating: false });
+  };
 
   setIconPosition = () => {
     const { left: labelLeft } = this.labelIcon.getBoundingClientRect();
@@ -64,16 +64,20 @@ export default class SearchInput extends React.Component {
 
   render() {
     const { className, name, placeholder, ...props } = this.props;
-    const { focus, value } = this.state;
+    const { animating, focus, value } = this.state;
     const id = `SearchInput-input-${name}`;
     return (
       <div
-        className={classNames(className, 'SearchInput', { 'SearchInput--text': focus || value })}
+        className={classNames(className, 'SearchInput', {
+          'SearchInput--text': focus || value,
+          'SearchInput--animating': animating,
+        })}
         ref={(el) => { this.root = el; }}
       >
         <Icon
           name="magnifying-glass" className="SearchInput-animation-icon"
-          getRef={(el) => { this.animateIcon = el; }} />
+          getRef={(el) => { this.animateIcon = el; }}
+          onTransitionEnd={this.onTransitionEnd} />
         <label className="SearchInput-label" htmlFor={id}>
           <Icon name="magnifying-glass" getRef={(el) => { this.labelIcon = el; }} />
           {placeholder}
@@ -81,7 +85,7 @@ export default class SearchInput extends React.Component {
         <input
           {...props} className="SearchInput-input" placeholder={placeholder} id={id} name={name}
           autoComplete="off" ref={(el) => { this.input = el; }} onInput={this.onInput}
-          onMouseDown={this.onMouseDown} onFocus={this.onFocus} onBlur={this.onBlur} />
+          onFocus={this.onFocus} onBlur={this.onBlur} />
       </div>
     );
   }

--- a/src/ui/components/SearchInput/style.scss
+++ b/src/ui/components/SearchInput/style.scss
@@ -79,6 +79,10 @@ $transition-duration: 250ms;
   top: 0;
   width: 100%;
 
+  .SearchInput--animating & {
+    color: transparent;
+  }
+
   &::placeholder {
     color: transparent;
   }

--- a/src/ui/components/SearchInput/style.scss
+++ b/src/ui/components/SearchInput/style.scss
@@ -20,19 +20,16 @@ $transition-duration: 250ms;
 
     vertical-align: top;
   }
+}
 
-  .SearchInput-animation-icon {
-    @include start(0);
+.SearchInput-animation-icon {
+  @include start(0);
 
-    opacity: 0;
-    position: absolute;
-    transition: opacity 1ms $transition-duration, transform $transition-duration;
-  }
+  opacity: 0;
+  position: absolute;
 }
 
 .SearchInput--text {
-  @include text-align-start();
-
   .SearchInput-label {
     color: transparent;
 
@@ -46,6 +43,15 @@ $transition-duration: 250ms;
     opacity: 1;
     // Use !important to overwrite style properties added in JS.
     transform: translateX(0) !important;
+  }
+}
+
+.SearchInput--animating {
+  .SearchInput-animation-icon {
+    transition: opacity 1ms $transition-duration, transform $transition-duration;
+  }
+
+  &.SearchInput--text .SearchInput-animation-icon {
     transition: transform $transition-duration;
   }
 }
@@ -85,9 +91,5 @@ $transition-duration: 250ms;
 
   &::placeholder {
     color: transparent;
-  }
-
-  &:focus {
-    @include text-align-start();
   }
 }

--- a/src/ui/components/SearchInput/style.scss
+++ b/src/ui/components/SearchInput/style.scss
@@ -4,7 +4,6 @@
 $input-height: 48px;
 $icon-margin-start: 24px;
 $icon-margin-end: 12px;
-$transition-duration: 250ms;
 
 .SearchInput {
   position: relative;
@@ -27,32 +26,16 @@ $transition-duration: 250ms;
 
   opacity: 0;
   position: absolute;
-}
+  transition: transform 250ms;
 
-.SearchInput--text {
-  .SearchInput-label {
-    color: transparent;
-
-    & .Icon-magnifying-glass {
-      opacity: 0;
-      transition: none;
-    }
+  .SearchInput--text &,
+  .SearchInput--animating & {
+    opacity: 1;
   }
 
-  .SearchInput-animation-icon {
-    opacity: 1;
+  .SearchInput--text & {
     // Use !important to overwrite style properties added in JS.
     transform: translateX(0) !important;
-  }
-}
-
-.SearchInput--animating {
-  .SearchInput-animation-icon {
-    transition: opacity 1ms $transition-duration, transform $transition-duration;
-  }
-
-  &.SearchInput--text .SearchInput-animation-icon {
-    transition: transform $transition-duration;
   }
 }
 
@@ -66,9 +49,15 @@ $transition-duration: 250ms;
   line-height: $input-height;
   top: 0;
 
-  & .Icon-magnifying-glass {
-    opacity: 1;
-    transition: opacity 1ms $transition-duration;
+  .SearchInput--text & {
+    color: transparent;
+  }
+}
+
+.SearchInput-label-icon {
+  .SearchInput--text &,
+  .SearchInput--animating & {
+    opacity: 0;
   }
 }
 

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -95,3 +95,17 @@ export class MockedSubComponent extends React.Component {
     return <div />;
   }
 }
+
+const formatClassList = (classList) => Array.prototype.join.call(classList, ', ');
+
+export function assertHasClass(el, className) {
+  assert.ok(
+    el.classList.contains(className),
+    `expected ${className} in ${formatClassList(el.classList)}`);
+}
+
+export function assertNotHasClass(el, className) {
+  assert.notOk(
+    el.classList.contains(className),
+    `expected ${className} to not be in in ${formatClassList(el.classList)}`);
+}

--- a/tests/client/ui/TestSearchInput.js
+++ b/tests/client/ui/TestSearchInput.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { renderIntoDocument, Simulate } from 'react-addons-test-utils';
 
+import { assertHasClass, assertNotHasClass } from 'tests/client/helpers';
 import SearchInput from 'ui/components/SearchInput';
 
 describe('<SearchInput />', () => {
@@ -25,7 +26,7 @@ describe('<SearchInput />', () => {
 
   it('starts with the --text class with a defaultValue', () => {
     const root = renderIntoDocument(<SearchInput name="foo" defaultValue="wat" />);
-    assert.ok(root.root.classList.contains('SearchInput--text'));
+    assertHasClass(root.root, 'SearchInput--text');
   });
 
   it('sets the value in state on input', () => {
@@ -37,58 +38,58 @@ describe('<SearchInput />', () => {
 
   it('sets and removes the --text class on focus and blur when empty', () => {
     const root = renderIntoDocument(<SearchInput name="foo" />);
-    assert.notOk(root.root.classList.contains('SearchInput--text'));
+    assertNotHasClass(root.root, 'SearchInput--text');
     Simulate.focus(root.input);
-    assert.ok(root.root.classList.contains('SearchInput--text'));
+    assertHasClass(root.root, 'SearchInput--text');
     Simulate.blur(root.input);
-    assert.notOk(root.root.classList.contains('SearchInput--text'));
+    assertNotHasClass(root.root, 'SearchInput--text');
   });
 
   it('keeps the --text class on blur when it has text', () => {
     const root = renderIntoDocument(<SearchInput name="foo" defaultValue="Hello" />);
-    assert.ok(root.root.classList.contains('SearchInput--text'));
+    assertHasClass(root.root, 'SearchInput--text');
     Simulate.blur(root.input);
-    assert.ok(root.root.classList.contains('SearchInput--text'));
+    assertHasClass(root.root, 'SearchInput--text');
   });
 
   it('sets the --animating class on blur without a value', () => {
     const root = renderIntoDocument(<SearchInput name="foo" />);
-    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    assertNotHasClass(root.root, 'SearchInput--animating');
     Simulate.blur(root.input);
-    assert.ok(root.root.classList.contains('SearchInput--animating'));
+    assertHasClass(root.root, 'SearchInput--animating');
   });
 
   it('does not set the --animating class on blur with a value', () => {
     const root = renderIntoDocument(<SearchInput name="foo" value="yo" />);
-    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    assertNotHasClass(root.root, 'SearchInput--animating');
     Simulate.blur(root.input);
-    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    assertNotHasClass(root.root, 'SearchInput--animating');
   });
 
   it('adds the --text and --animating classes on focus without a value', () => {
     const root = renderIntoDocument(<SearchInput name="foo" />);
-    assert.notOk(root.root.classList.contains('SearchInput--text'));
-    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    assertNotHasClass(root.root, 'SearchInput--text');
+    assertNotHasClass(root.root, 'SearchInput--animating');
     Simulate.focus(root.input);
-    assert.ok(root.root.classList.contains('SearchInput--text'));
-    assert.ok(root.root.classList.contains('SearchInput--animating'));
+    assertHasClass(root.root, 'SearchInput--text');
+    assertHasClass(root.root, 'SearchInput--animating');
   });
 
   it('only adds the --text class on focus with a value', () => {
     const root = renderIntoDocument(<SearchInput name="foo" value="hey" />);
-    assert.notOk(root.root.classList.contains('SearchInput--text'));
-    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    assertNotHasClass(root.root, 'SearchInput--text');
+    assertNotHasClass(root.root, 'SearchInput--animating');
     Simulate.focus(root.input);
-    assert.ok(root.root.classList.contains('SearchInput--text'));
-    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    assertHasClass(root.root, 'SearchInput--text');
+    assertNotHasClass(root.root, 'SearchInput--animating');
   });
 
   it('clears the --animating class on transitionend', () => {
     const root = renderIntoDocument(<SearchInput name="foo" />);
     root.setState({ animating: true });
-    assert.ok(root.root.classList.contains('SearchInput--animating'));
+    assertHasClass(root.root, 'SearchInput--animating');
     Simulate.transitionEnd(root.animateIcon);
-    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    assertNotHasClass(root.root, 'SearchInput--animating');
   });
 
   it('exposes the value of the input', () => {

--- a/tests/client/ui/TestSearchInput.js
+++ b/tests/client/ui/TestSearchInput.js
@@ -5,6 +5,14 @@ import { renderIntoDocument, Simulate } from 'react-addons-test-utils';
 import SearchInput from 'ui/components/SearchInput';
 
 describe('<SearchInput />', () => {
+  it('uses the initial value for the left offset', () => {
+    // Test elements don't actually get rendered so all of the offsets are 0.
+    const root = renderIntoDocument(<SearchInput name="foo" />);
+    root.animateLeft = 100;
+    root.setIconPosition();
+    assert.equal(root.animateIcon.style.transform, 'translateX(-100px)');
+  });
+
   it('sets the icon position on resize', () => {
     const addEventListener = sinon.stub(window, 'addEventListener');
     const removeEventListener = sinon.stub(window, 'removeEventListener');

--- a/tests/client/ui/TestSearchInput.js
+++ b/tests/client/ui/TestSearchInput.js
@@ -43,40 +43,45 @@ describe('<SearchInput />', () => {
     assert.ok(root.root.classList.contains('SearchInput--text'));
   });
 
-  it('adds the --test class on mousedown', () => {
+  it('sets the --animating class on blur without a value', () => {
     const root = renderIntoDocument(<SearchInput name="foo" />);
-    assert.notOk(root.root.classList.contains('SearchInput--text'));
-    Simulate.mouseDown(root.input);
-    assert.ok(root.root.classList.contains('SearchInput--text'));
+    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    Simulate.blur(root.input);
+    assert.ok(root.root.classList.contains('SearchInput--animating'));
   });
 
-  it('delays the input focus on mousedown without text', () => (
-    new Promise((resolve) => {
-      const root = renderIntoDocument(<SearchInput name="foo" />);
-      const event = { preventDefault: sinon.spy() };
-      sinon.spy(root.input, 'focus');
+  it('does not set the --animating class on blur with a value', () => {
+    const root = renderIntoDocument(<SearchInput name="foo" value="yo" />);
+    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    Simulate.blur(root.input);
+    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+  });
 
-      Simulate.mouseDown(root.input, event);
-      assert.ok(event.preventDefault.called);
-      assert.notOk(root.input.focus.called);
-      root.animateIcon.dispatchEvent(new TransitionEvent('transitionend'));
-      requestAnimationFrame(() => {
-        assert.ok(root.input.focus.called);
-        resolve();
-      });
-    })
-  ));
+  it('adds the --text and --animating classes on focus without a value', () => {
+    const root = renderIntoDocument(<SearchInput name="foo" />);
+    assert.notOk(root.root.classList.contains('SearchInput--text'));
+    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    Simulate.focus(root.input);
+    assert.ok(root.root.classList.contains('SearchInput--text'));
+    assert.ok(root.root.classList.contains('SearchInput--animating'));
+  });
 
-  it('does not delay the input focus on mousedown with text', () => (
-    new Promise((resolve) => {
-      const root = renderIntoDocument(<SearchInput name="foo" defaultValue="yo" />);
-      const event = { preventDefault: sinon.spy() };
+  it('only adds the --text class on focus with a value', () => {
+    const root = renderIntoDocument(<SearchInput name="foo" value="hey" />);
+    assert.notOk(root.root.classList.contains('SearchInput--text'));
+    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+    Simulate.focus(root.input);
+    assert.ok(root.root.classList.contains('SearchInput--text'));
+    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+  });
 
-      Simulate.mouseDown(root.input, event);
-      assert.notOk(event.preventDefault.called);
-      resolve();
-    })
-  ));
+  it('clears the --animating class on transitionend', () => {
+    const root = renderIntoDocument(<SearchInput name="foo" />);
+    root.setState({ animating: true });
+    assert.ok(root.root.classList.contains('SearchInput--animating'));
+    Simulate.transitionEnd(root.animateIcon);
+    assert.notOk(root.root.classList.contains('SearchInput--animating'));
+  });
 
   it('exposes the value of the input', () => {
     const root = renderIntoDocument(<SearchInput name="foo" defaultValue="yo" />);


### PR DESCRIPTION
There were two problems with `SearchInput`, when typing immediately after focus keystrokes would be dropped, and when dismissing the virtual keyboard the animation would stop working and this prevented the input from being focused again.

This patch fixes both problems. The text is now transparent until the animation ends so keystrokes are not lost (instead of cancelling the focus event and manually focusing later).

The virtual keyboard issue was due to how the icon is moved over for animating (there are two icons, one on the label and one that animates to the left-aligned position). The `resize` event fires when the keyboard opens or closes and the icon's position would be recalculated but the calculation only worked if the icon had not been positioned yet. The original location of the icon is now saved when the calculation is first done which allows the `setIconPosition` function to correctly position the icon every time it is called.

![search-keyboard-dismissal mp4](https://cloud.githubusercontent.com/assets/211578/22838717/0ca12d48-ef8c-11e6-970a-bd1f18763140.gif)

Fixes #1443 and #1749.