### PR TITLE
Fix scrolling when Android keyboard is open

### DIFF
--- a/src/amo/css/AddonReview.scss
+++ b/src/amo/css/AddonReview.scss
@@ -3,7 +3,6 @@
 .AddonReview .Card-contents {
   padding-left: 0;
   padding-right: 0;
-  overflow: hidden;
 }
 
 .AddonReview-form-input {

--- a/src/ui/components/OverlayCard/OverlayCard.scss
+++ b/src/ui/components/OverlayCard/OverlayCard.scss
@@ -7,6 +7,6 @@
 
   .Card-contents {
     max-height: 75vh;
-    overflow: scroll;
+    overflow: auto;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1773

Does what it says on the tin! The scrollbars are only added when needed.