### PR TITLE
Fix rating error style and fix 'No reviews yet' style

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -114,9 +114,10 @@ export class AddonDetailBase extends React.Component {
     );
   }
 
-  readReviewsFooter() {
-    const { addon, i18n } = this.props;
+  renderRatingsCard() {
+    const { addon, i18n, RatingManager } = this.props;
     let content;
+    let footerPropName;
 
     if (addon.ratings.count) {
       const count = addon.ratings.count;
@@ -125,6 +126,7 @@ export class AddonDetailBase extends React.Component {
         { count: i18n.formatNumber(count) },
       );
 
+      footerPropName = 'footerLink';
       content = (
         <Link className="AddonDetail-all-reviews-link"
           to={`/addon/${addon.slug}/reviews/`}>
@@ -132,14 +134,29 @@ export class AddonDetailBase extends React.Component {
         </Link>
       );
     } else {
+      footerPropName = 'footerText';
       content = i18n.gettext('No reviews yet');
     }
 
-    return <div className="AddonDetail-read-reviews-footer">{content}</div>;
+    const props = {
+      [footerPropName]: (
+        <div className="AddonDetail-read-reviews-footer">{content}</div>),
+    };
+    return (
+      <Card
+        header={i18n.gettext('Rate your experience')}
+        className="AddonDetail-overall-rating"
+        {...props}>
+        <RatingManager
+          addon={addon}
+          version={addon.current_version}
+        />
+      </Card>
+    );
   }
 
   render() {
-    const { RatingManager, addon, i18n } = this.props;
+    const { addon, i18n } = this.props;
 
     const authorList = addon.authors.map(
       (author) => `<a href="${author.url}">${author.name}</a>`);
@@ -192,15 +209,7 @@ export class AddonDetailBase extends React.Component {
             } />
         </ShowMoreCard>
 
-        <Card
-          header={i18n.gettext('Rate your experience')}
-          footer={this.readReviewsFooter()}
-          className="AddonDetail-overall-rating">
-          <RatingManager
-            addon={addon}
-            version={addon.current_version}
-          />
-        </Card>
+        {this.renderRatingsCard()}
 
         <AddonMoreInfo addon={addon} />
       </div>

--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -115,7 +115,7 @@ export class AddonDetailBase extends React.Component {
   }
 
   renderRatingsCard() {
-    const { addon, i18n, RatingManager } = this.props;
+    const { RatingManager, addon, i18n } = this.props;
     let content;
     let footerPropName;
 

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -20,11 +20,11 @@ export default class LandingAddonsCard extends React.Component {
       ...footerLink,
       query: convertFiltersToQueryParams(footerLink.query),
     };
-    const footer = <Link to={linkSearchURL}>{footerText}</Link>;
+    const footerLinkHtml = <Link to={linkSearchURL}>{footerText}</Link>;
 
     return (
       <AddonsCard className={classNames('LandingAddonsCard', className)}
-        addons={addons} footer={footer} header={header} />
+        addons={addons} footerLink={footerLinkHtml} header={header} />
     );
   }
 }

--- a/src/core/css/ErrorHandler.scss
+++ b/src/core/css/ErrorHandler.scss
@@ -2,6 +2,7 @@
 
 .ErrorHandler-list {
   text-align: center;
+  border-radius: $border-radius-default;
   background-color: $error-background-color;
   color: $error-text-color;
   padding: 10px;

--- a/src/core/css/ErrorHandler.scss
+++ b/src/core/css/ErrorHandler.scss
@@ -8,8 +8,8 @@
   padding: 10px;
   margin: 0;
   margin-bottom: 10px;
+}
 
-  > li {
-    list-style: none;
-  }
+.ErrorHandler-list-item {
+  list-style: none;
 }

--- a/src/core/css/ErrorHandler.scss
+++ b/src/core/css/ErrorHandler.scss
@@ -7,4 +7,8 @@
   padding: 10px;
   margin: 0;
   margin-bottom: 10px;
+
+  > li {
+    list-style: none;
+  }
 }

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -37,7 +37,9 @@ export class ErrorHandler {
   renderError() {
     return (
       <ul className="ErrorHandler-list">
-        {this.capturedError.messages.map((msg) => <li>{msg}</li>)}
+        {this.capturedError.messages.map(
+          (msg) => <li className="ErrorHandler-list-item">{msg}</li>
+        )}
       </ul>
     );
   }

--- a/src/ui/components/Card/Card.scss
+++ b/src/ui/components/Card/Card.scss
@@ -29,24 +29,32 @@
   font-size: $font-size-s;
 }
 
-.Card-footer {
+$footer-padding: 10px;
+
+.Card-footer-link,
+.Card-footer-text {
   @include addonSection();
 
   border-bottom-left-radius: $border-radius-default;
   border-bottom-right-radius: $border-radius-default;
   margin-top: 1px;
+  padding: 0;
   text-align: center;
   font-variant: all-small-caps;
-  padding: 10px;
 
   a,
   a:active,
   a:hover,
   a:link,
   a:visited {
+    padding: $footer-padding;
     color: $link-color;
     display: block;
     font-weight: normal;
     text-decoration: none;
   }
+}
+
+.Card-footer-text {
+  padding: $footer-padding;
 }

--- a/src/ui/components/Card/Card.scss
+++ b/src/ui/components/Card/Card.scss
@@ -35,7 +35,6 @@
   border-bottom-left-radius: $border-radius-default;
   border-bottom-right-radius: $border-radius-default;
   margin-top: 1px;
-  padding: 0;
   text-align: center;
   font-variant: all-small-caps;
   padding: 10px;

--- a/src/ui/components/Card/Card.scss
+++ b/src/ui/components/Card/Card.scss
@@ -37,6 +37,8 @@
   margin-top: 1px;
   padding: 0;
   text-align: center;
+  font-variant: all-small-caps;
+  padding: 10px;
 
   a,
   a:active,
@@ -45,9 +47,7 @@
   a:visited {
     color: $link-color;
     display: block;
-    font-variant: all-small-caps;
     font-weight: normal;
-    padding: 10px;
     text-decoration: none;
   }
 }

--- a/src/ui/components/Card/index.js
+++ b/src/ui/components/Card/index.js
@@ -8,12 +8,26 @@ export default class Card extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    footer: PropTypes.node,
+    footerLink: PropTypes.node,
+    footerText: PropTypes.node,
     header: PropTypes.node,
   }
 
   render() {
-    const { children, className, footer, header } = this.props;
+    const { children, className, footerText, footerLink, header } = this.props;
+
+    let footer;
+    let footerClass;
+    if (footerText && footerLink) {
+      throw new Error(
+        'You cannot specify footerLink and footerText at the same time');
+    } else if (footerText) {
+      footer = footerText;
+      footerClass = 'Card-footer-text';
+    } else if (footerLink) {
+      footer = footerLink;
+      footerClass = 'Card-footer-link';
+    }
 
     return (
       <section className={classNames('Card', className, {
@@ -34,7 +48,7 @@ export default class Card extends React.Component {
         ) : null}
 
         {footer ? (
-          <footer className="Card-footer" ref={(ref) => { this.footer = ref; }}>
+          <footer className={footerClass} ref={(ref) => { this.footer = ref; }}>
             {footer}
           </footer>
         ) : null}

--- a/src/ui/components/OverlayCard/index.js
+++ b/src/ui/components/OverlayCard/index.js
@@ -12,7 +12,8 @@ export default class OverlayCard extends React.Component {
     children: PropTypes.node,
     className: PropTypes.string,
     header: PropTypes.node,
-    footer: PropTypes.node,
+    footerLink: PropTypes.node,
+    footerText: PropTypes.node,
     visibleOnLoad: PropTypes.bool.isRequired,
   }
 
@@ -33,13 +34,19 @@ export default class OverlayCard extends React.Component {
   }
 
   render() {
-    const { children, className, header, footer, visibleOnLoad } = this.props;
+    const {
+      children, className, header, footerLink, footerText, visibleOnLoad,
+    } = this.props;
 
     return (
       <Overlay visibleOnLoad={visibleOnLoad}
         ref={(ref) => { this.overlay = ref; }}>
-        <Card className={classNames('OverlayCard', className)} header={header}
-          footer={footer} ref={(ref) => { this.overlayCard = ref; }}>
+        <Card
+          className={classNames('OverlayCard', className)}
+          header={header}
+          footerLink={footerLink}
+          footerText={footerText}
+          ref={(ref) => { this.overlayCard = ref; }}>
           {children}
         </Card>
       </Overlay>

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -67,7 +67,7 @@ export class ShowMoreCardBase extends React.Component {
     return (
       <Card className={classNames('ShowMoreCard', className, {
         'ShowMoreCard--expanded': expanded,
-      })} header={header} footer={expanded ? null : readMoreLink}>
+      })} header={header} footerLink={expanded ? null : readMoreLink}>
         <div className="ShowMoreCard-contents"
           ref={(ref) => { this.contents = ref; }}>
           {children}

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -357,6 +357,8 @@ describe('AddonDetail', () => {
       const footer =
         root.querySelector('.AddonDetail-read-reviews-footer');
       assert.equal(footer.textContent, 'No reviews yet');
+      assert.equal(root.querySelector('footer').className,
+                   'Card-footer-text');
     });
 
     it('prompts you to read one review', () => {
@@ -366,6 +368,8 @@ describe('AddonDetail', () => {
       const footer =
         root.querySelector('.AddonDetail-read-reviews-footer');
       assert.equal(footer.textContent, 'Read 1 review');
+      assert.equal(root.querySelector('footer').className,
+                   'Card-footer-link');
     });
 
     it('prompts you to read many reviews', () => {

--- a/tests/client/ui/components/TestCard.js
+++ b/tests/client/ui/components/TestCard.js
@@ -28,10 +28,25 @@ describe('<Card />', () => {
     assert.include(root.cardContainer.className, 'Card--no-header');
   });
 
-  it('shows footer if supplied', () => {
-    const root = render({ footer: 'foo' });
+  it('shows footer text if supplied', () => {
+    const root = render({ footerText: 'foo' });
     assert(root.footer);
     assert.equal(root.footer.textContent, 'foo');
+    assert.equal(root.footer.className, 'Card-footer-text');
+  });
+
+  it('shows a footer link if supplied', () => {
+    const root = render({ footerLink: <a href="#">Some link</a> });
+    assert(root.footer);
+    assert.equal(root.footer.textContent, 'Some link');
+    assert.equal(root.footer.className, 'Card-footer-link');
+  });
+
+  it('throws an error if you mix footer content', () => {
+    assert.throws(() => render({
+      footerLink: <a href="#">Some link</a>,
+      footerText: 'something else',
+    }), /cannot specify footerLink and footerText/);
   });
 
   it('hides footer if none supplied', () => {

--- a/tests/client/ui/components/TestCard.js
+++ b/tests/client/ui/components/TestCard.js
@@ -36,7 +36,7 @@ describe('<Card />', () => {
   });
 
   it('shows a footer link if supplied', () => {
-    const root = render({ footerLink: <a href="#">Some link</a> });
+    const root = render({ footerLink: <a href="/some-link">Some link</a> });
     assert(root.footer);
     assert.equal(root.footer.textContent, 'Some link');
     assert.equal(root.footer.className, 'Card-footer-link');
@@ -44,7 +44,7 @@ describe('<Card />', () => {
 
   it('throws an error if you mix footer content', () => {
     assert.throws(() => render({
-      footerLink: <a href="#">Some link</a>,
+      footerLink: <a href="/some-link">Some link</a>,
       footerText: 'something else',
     }), /cannot specify footerLink and footerText/);
   });

--- a/tests/client/ui/components/TestOverlayCard.js
+++ b/tests/client/ui/components/TestOverlayCard.js
@@ -23,12 +23,20 @@ describe('<OverlayCard />', () => {
       rootNode.querySelector('.Card-header').textContent, 'header');
   });
 
-  it('passes the footer', () => {
-    const root = render({ footer: 'footer' });
+  it('passes a footer link', () => {
+    const root = render({ footerLink: <a href="/somewhere">link</a> });
     const rootNode = findDOMNode(root);
 
     assert.include(
-      rootNode.querySelector('.Card-footer').textContent, 'footer');
+      rootNode.querySelector('.Card-footer-link').textContent, 'link');
+  });
+
+  it('passes footer text', () => {
+    const root = render({ footerText: 'footer text' });
+    const rootNode = findDOMNode(root);
+
+    assert.include(
+      rootNode.querySelector('.Card-footer-text').textContent, 'footer text');
   });
 
   it('passes children', () => {

--- a/tests/client/ui/components/TestShowMoreCard.js
+++ b/tests/client/ui/components/TestShowMoreCard.js
@@ -22,14 +22,15 @@ describe('<ShowMoreCard />', () => {
     root.setState({ expanded: false });
     assert.notInclude(rootNode.className, '.ShowMoreCard--expanded');
     assert.strictEqual(root.state.expanded, false);
-    assert.equal(rootNode.querySelector('.Card-footer').textContent, 'Expand to Read more');
+    assert.equal(rootNode.querySelector('.Card-footer-link').textContent,
+                 'Expand to Read more');
 
-    Simulate.click(rootNode.querySelector('.Card-footer a'));
+    Simulate.click(rootNode.querySelector('.Card-footer-link a'));
 
     assert.include(rootNode.className, 'ShowMoreCard--expanded');
     assert.strictEqual(root.state.expanded, true);
 
-    assert.equal(rootNode.querySelector('.Card-footer'), null);
+    assert.equal(rootNode.querySelector('.Card-footer-link'), null);
   });
 
   it('is expanded by default', () => {


### PR DESCRIPTION
* Fixes https://github.com/mozilla/addons-frontend/issues/1771
  * The rating error no longer has a white dot
* Fixes https://github.com/mozilla/addons-frontend/issues/1782
  * The 'No reviews yet' text is now styled more consistently. We don't technically have a mock of this.
* The error style is more consistent with the palette now

<img width="306" alt="screenshot 2017-02-13 18 04 47" src="https://cloud.githubusercontent.com/assets/55398/22909041/5e6110b6-f217-11e6-9d22-e3256f13d73b.png">
