### PR TITLE
Break long words in add-on review listing

### DIFF
--- a/src/amo/css/AddonReviewList.scss
+++ b/src/amo/css/AddonReviewList.scss
@@ -40,6 +40,8 @@
 }
 
 .AddonReviewList-li {
+  word-break: break-all;
+
   > h3 {
     padding: 0;
     margin: 0;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1770

<img width="309" alt="screenshot 2017-02-10 17 02 47" src="https://cloud.githubusercontent.com/assets/55398/22847909/f388c242-efb5-11e6-8bc4-031bc25808eb.png">
