### PR TITLE
fix: Long author names cause horizontal scrolling

### DIFF
--- a/src/amo/css/AddonDetail.scss
+++ b/src/amo/css/AddonDetail.scss
@@ -21,6 +21,7 @@ $page-margin: 20px 10px;
 .AddonDetail-author {
   display: block;
   opacity: 0.75;
+  word-wrap: break-word;
 
   a,
   a:link {


### PR DESCRIPTION
Fixes #1607 
Before - (contains a horizontal scroll bar at the bottom)
![before](https://cloud.githubusercontent.com/assets/19590302/22927404/0ae5170a-f2d7-11e6-8438-815238dfe719.png)
After - (no horizontal scroll bar at the bottom)
![after](https://cloud.githubusercontent.com/assets/19590302/22927427/3035faf6-f2d7-11e6-9909-1bd69cdff992.png)