### PR TITLE
fix: Too much space between header and category buttons 

### DIFF
--- a/src/amo/css/Home.scss
+++ b/src/amo/css/Home.scss
@@ -28,6 +28,8 @@
 
 .HomePage-subheading {
   text-align: center;
+  margin-top: 18px;
+  margin-bottom: -10px;
 }
 
 .HomePage-category-list {


### PR DESCRIPTION
Fixes #1741 
Before - 
![before](https://cloud.githubusercontent.com/assets/19590302/22951452/2fe0bbc4-f32f-11e6-924e-3676717a88a6.png)

After - 
![after](https://cloud.githubusercontent.com/assets/19590302/22951354/edc52a36-f32e-11e6-980c-4d34852fc730.png)
