### PR TITLE
Handle displaying 401 errors and other non-form-validation API responses

### DIFF
--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -38,7 +38,17 @@ export class ErrorHandler {
     return (
       <ul className="ErrorHandler-list">
         {this.capturedError.messages.map(
-          (msg) => <li className="ErrorHandler-list-item">{msg}</li>
+          (msg) => {
+            let msgString = msg;
+            if (typeof msgString === 'object') {
+              // This is an unlikely scenario where an API response
+              // contains nested objects within objects. If this
+              // happens in real life let's make it prettier.
+              // Until then, let's just prevent a stack trace.
+              msgString = JSON.stringify(msg);
+            }
+            return <li className="ErrorHandler-list-item">{msgString}</li>;
+          }
         )}
       </ul>
     );

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -17,15 +17,19 @@ function getMessagesFromError(error) {
 
     Object.keys(error.response.data).forEach((key) => {
       const val = error.response.data[key];
-      val.forEach((msg) => {
-        if (key === 'non_field_errors') {
-          // Add generic messages for the API response.
-          apiMessages.push(msg);
-        } else {
-          // Add field specific error messages.
-          apiMessages.push(`${key}: ${msg}`);
-        }
-      });
+      if (Array.isArray(val)) {
+        val.forEach((msg) => {
+          if (key === 'non_field_errors') {
+            // Add generic messages for the API response.
+            apiMessages.push(msg);
+          } else {
+            // Add field specific error messages.
+            apiMessages.push(`${key}: ${msg}`);
+          }
+        });
+      } else {
+        apiMessages.push(val);
+      }
     });
 
     if (apiMessages.length) {

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -7,6 +7,9 @@ import { gettext } from 'core/utils';
  *
  * If the error has an API response then messages will be extracted
  * from it. Otherwise, an array containing a generic error message is returned.
+ *
+ * Read more about API responses here:
+ * http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#responses
  */
 function getMessagesFromError(error) {
   let messages = [gettext('An unexpected error occurred')];
@@ -18,16 +21,21 @@ function getMessagesFromError(error) {
     Object.keys(error.response.data).forEach((key) => {
       const val = error.response.data[key];
       if (Array.isArray(val)) {
+        // Most API reponse errors will consist of a key (which could be a
+        // form field) and an array of localized messages.
+        // More info: http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#bad-requests
         val.forEach((msg) => {
           if (key === 'non_field_errors') {
-            // Add generic messages for the API response.
+            // Add a generic error not related to a specific field.
             apiMessages.push(msg);
           } else {
-            // Add field specific error messages.
+            // Add field specific error message.
+            // The field is not localized but we need to show it as a hint.
             apiMessages.push(`${key}: ${msg}`);
           }
         });
       } else {
+        // This is most likely not a form field error so just show the message.
         apiMessages.push(val);
       }
     });

--- a/tests/client/core/reducers/test_errors.js
+++ b/tests/client/core/reducers/test_errors.js
@@ -32,6 +32,18 @@ describe('errors reducer', () => {
     });
   });
 
+  it('handles API object responses', () => {
+    const message = 'Authentication credentials were not provided.';
+    const error = createApiError({
+      response: { status: 401 },
+      apiURL: 'https://some/api/endpoint',
+      jsonResponse: { detail: message },
+    });
+    const action = setError({ id: 'some-id', error });
+    const state = errors(undefined, action);
+    assert.deepEqual(state[action.payload.id], { messages: [message] });
+  });
+
   it('preserves existing errors', () => {
     const action1 = setError({
       id: 'action1', error: createFakeApiError({ nonFieldErrors: ['action1'] }),

--- a/tests/client/core/testErrorHandler.js
+++ b/tests/client/core/testErrorHandler.js
@@ -4,6 +4,7 @@ import { findRenderedComponentWithType, renderIntoDocument }
   from 'react-addons-test-utils';
 import { createStore, combineReducers } from 'redux';
 
+import { createApiError } from 'core/api/index';
 import translate from 'core/i18n/translate';
 import { clearError, setError } from 'core/actions/errors';
 import { ErrorHandler, withErrorHandler, withErrorHandling }
@@ -114,6 +115,25 @@ describe('errorHandler', () => {
       // It also renders component content:
       assert.equal(dom.querySelector('.SomeComponent').textContent,
                    'Component text');
+    });
+
+    it('renders a nested API response object', () => {
+      const id = 'some-handler-id';
+
+      const nestedMessage = { nested: { message: 'end' } };
+      const store = createErrorStore();
+      const error = createApiError({
+        response: { status: 401 },
+        apiURL: 'https://some/api/endpoint',
+        jsonResponse: { message: nestedMessage },
+      });
+      store.dispatch(setError({ id, error }));
+
+      const { dom } = createWrappedComponent({
+        store, id, decorator: withErrorHandling,
+      });
+      assert.equal(dom.querySelector('.ErrorHandler-list').textContent,
+                   JSON.stringify(nestedMessage));
     });
 
     it('renders component content when there is no error', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1527

These are unlikely but possible:

<img width="361" alt="screenshot 2017-02-14 16 28 27" src="https://cloud.githubusercontent.com/assets/55398/22953353/6b66ef0a-f2d6-11e6-9124-d9170c9299bd.png">
