### PR TITLE
feat: Add trailing slashes to URLs (fix #843)

### DIFF
--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -2,7 +2,6 @@ const amoCDN = 'https://addons.cdn.mozilla.net';
 const staticHost = 'https://addons-amo.cdn.mozilla.net';
 
 module.exports = {
-  fxaConfig: 'amo',
   CSP: {
     directives: {
       formAction: [
@@ -23,6 +22,8 @@ module.exports = {
       ],
     },
   },
+  enableTrailingSlashesMiddleware: true,
+  fxaConfig: 'amo',
   // This needs to be kept in sync with addons-server's SUPPORTED_NONAPPS
   // settings value: https://github.com/mozilla/addons-server/blob/master/src/olympia/lib/settings_base.py#L262
   validUrlExceptions: [

--- a/config/default.js
+++ b/config/default.js
@@ -147,6 +147,7 @@ module.exports = {
   po2jsonFuzzyOutput: false,
 
   enablePrefixMiddleware: true,
+  enableTrailingSlashesMiddleware: false,
 
   localeDir: path.resolve(path.join(__dirname, '../locale')),
 

--- a/src/core/middleware.js
+++ b/src/core/middleware.js
@@ -102,3 +102,15 @@ export function prefixMiddleWare(req, res, next, { _config = config } = {}) {
 
   return next();
 }
+
+export function trailingSlashesMiddleware(req, res, next) {
+  const URLParts = req.originalUrl.split('?');
+
+  // If the URL doesn't end with a trailing slash, we'll add one.
+  if (URLParts[0].substr(-1) !== '/') {
+    URLParts[0] = `${URLParts[0]}/`;
+    return res.redirect(301, URLParts.join('?'));
+  }
+
+  return next();
+}

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -19,7 +19,7 @@ import WebpackIsomorphicTools from 'webpack-isomorphic-tools';
 
 import { createApiError } from 'core/api';
 import ServerHtml from 'core/containers/ServerHtml';
-import { prefixMiddleWare } from 'core/middleware';
+import { prefixMiddleWare, trailingSlashesMiddleware } from 'core/middleware';
 import { convertBoolean } from 'core/utils';
 import { setClientApp, setLang, setJwt } from 'core/actions';
 import log from 'core/logger';
@@ -181,6 +181,11 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
   // Handle application and lang redirections.
   if (config.get('enablePrefixMiddleware')) {
     app.use(prefixMiddleWare);
+  }
+
+  // Add trailing slashes to URLs
+  if (config.get('enableTrailingSlashesMiddleware')) {
+    app.use(trailingSlashesMiddleware);
   }
 
   app.use((req, res) => {

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -48,4 +48,18 @@ describe('AMO GET Requests', () => {
       assert.equal(res.header.location,
         '/en-US/firefox/');
     }));
+
+  it('should NOT redirect a URL without a trailing slash if exception exists',
+  () => request(app)
+    .get('/en-US/about')
+    .expect(404)
+    );
+
+  it('should redirect a URL without a trailing slash', () => request(app)
+    .get('/en-US/firefox/search')
+    .expect(301)
+    .then((res) => {
+      assert.equal(res.header.location,
+        '/en-US/firefox/search/');
+    }));
 });


### PR DESCRIPTION
This adds a config option to enable a middleware that adds trailing
slashes to all URLs that don't have one. It's only enabled on AMO
for now as Disco Pane definitely have URLs that are declared without
trailing slash and this does the dumbest thing possible which is
redirect all requests.