### PR TITLE
fix: Hide search sort in categories (fix #1626)

### DIFF
--- a/src/amo/components/SearchPage.js
+++ b/src/amo/components/SearchPage.js
@@ -11,6 +11,7 @@ export default class SearchPage extends React.Component {
   static propTypes = {
     LinkComponent: PropTypes.node.isRequired,
     count: PropTypes.number,
+    enableSearchSort: PropTypes.bool,
     filters: PropTypes.object,
     hasSearchParams: PropTypes.bool.isRequired,
     loading: PropTypes.bool.isRequired,
@@ -23,6 +24,7 @@ export default class SearchPage extends React.Component {
   static defaultProps = {
     LinkComponent: Link,
     count: 0,
+    enableSearchSort: true,
     filters: {},
     pathname: '/search/',
     results: [],
@@ -30,8 +32,8 @@ export default class SearchPage extends React.Component {
 
   render() {
     const {
-      LinkComponent, count, filters, hasSearchParams, loading, page, pathname,
-      results,
+      LinkComponent, count, enableSearchSort, filters, hasSearchParams,
+      loading, page, pathname, results,
     } = this.props;
     const queryParams = this.props.queryParams ||
       convertFiltersToQueryParams(filters);
@@ -39,7 +41,7 @@ export default class SearchPage extends React.Component {
       <Paginate LinkComponent={LinkComponent} count={count} currentPage={page}
         pathname={pathname} queryParams={queryParams} />
     ) : [];
-    const searchSort = hasSearchParams && results.length ? (
+    const searchSort = enableSearchSort && hasSearchParams && results.length ? (
       <SearchSort filters={filters} pathname={pathname} />
     ) : null;
 

--- a/src/amo/containers/CategoryPage.js
+++ b/src/amo/containers/CategoryPage.js
@@ -1,4 +1,5 @@
 import deepEqual from 'deep-eql';
+import React from 'react';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-connect';
 import { compose } from 'redux';
@@ -7,6 +8,10 @@ import SearchPage from 'amo/components/SearchPage';
 import { loadByCategoryIfNeeded, parsePage } from 'core/searchUtils';
 import { apiAddonType } from 'core/utils';
 
+
+export function CategoryPageBase(props) {
+  return <SearchPage enableSearchSort={false} {...props} />;
+}
 
 export function mapStateToProps(state, ownProps) {
   const filters = {
@@ -40,4 +45,4 @@ export default compose(
     promise: loadByCategoryIfNeeded,
   }]),
   connect(mapStateToProps),
-)(SearchPage);
+)(CategoryPageBase);

--- a/tests/client/amo/components/TestSearchPage.js
+++ b/tests/client/amo/components/TestSearchPage.js
@@ -80,4 +80,12 @@ describe('<SearchPage />', () => {
     const root = render({ hasSearchParams: true, results: [] });
     assert.throws(() => findByTag(root, SearchSort), 'child is null');
   });
+
+  it('does not render SearchSort when enableSearchSort is false', () => {
+    const root = render({
+      enableSearchSort: false,
+      hasSearchParams: true,
+    });
+    assert.throws(() => findByTag(root, SearchSort), 'child is null');
+  });
 });

--- a/tests/client/amo/containers/TestCategoryPage.js
+++ b/tests/client/amo/containers/TestCategoryPage.js
@@ -1,8 +1,22 @@
-import { mapStateToProps } from 'amo/containers/CategoryPage';
+import React from 'react';
+
+import { CategoryPageBase, mapStateToProps } from 'amo/containers/CategoryPage';
 import createStore from 'amo/store';
 import { searchStart } from 'core/actions/search';
 import { ADDON_TYPE_THEME } from 'core/constants';
+import { shallowRender } from 'tests/client/helpers';
 
+
+describe('CategoryPage.mapStateToProps()', () => {
+  function render(props = {}) {
+    return shallowRender(<CategoryPageBase {...props} />);
+  }
+
+  it('sets enableSearchSort to `false`', () => {
+    const root = render();
+    assert.equal(root.props.enableSearchSort, false);
+  });
+});
 
 describe('CategoryPage.mapStateToProps()', () => {
   let filters;


### PR DESCRIPTION
Removes the search sort from categories as it isn't needed there and was buggy.

-----

### Before
![sortmobile](https://cloud.githubusercontent.com/assets/1583842/22699144/4c314968-ed5f-11e6-9b99-564e06851c09.gif)

### After
<img width="554" alt="screenshot 2017-02-15 18 19 29" src="https://cloud.githubusercontent.com/assets/90871/22990810/3bb72518-f3b2-11e6-9a5f-0be0261ed580.png">
