### PR TITLE
fix: Add protocol to homepage URLs (fix #1647)

### DIFF
--- a/src/amo/components/AddonMoreInfo.js
+++ b/src/amo/components/AddonMoreInfo.js
@@ -17,14 +17,21 @@ export class AddonMoreInfoBase extends React.Component {
   render() {
     const { addon, i18n } = this.props;
 
+    let homepage = addon.homepage ? addon.homepage.trim() : null;
+    if (homepage && !homepage.match(/^https?:\/\//)) {
+      homepage = `http://${homepage}`;
+    }
+
     return (
       <Card className="AddonMoreInfo" header={i18n.gettext('More information')}>
         <dl className="AddonMoreInfo-contents">
           {addon.homepage ? <dt>{i18n.gettext('Website')}</dt> : null}
-          {addon.homepage ? (
+          {homepage ? (
             <dd>
-              <a href={addon.homepage}
-                ref={(ref) => { this.homepageLink = ref; }}>{addon.homepage}</a>
+              <a href={homepage}
+                ref={(ref) => { this.homepageLink = ref; }}>
+                {homepage.replace(/^https?:\/\//, '')}
+              </a>
             </dd>
           ) : null}
           <dt>{i18n.gettext('Version')}</dt>

--- a/tests/client/amo/components/TestAddonMoreInfo.js
+++ b/tests/client/amo/components/TestAddonMoreInfo.js
@@ -36,9 +36,34 @@ describe('<AddonMoreInfo />', () => {
   it('renders the homepage of an add-on', () => {
     const root = render();
 
-    assert.equal(root.homepageLink.textContent, 'http://hamsterdance.com/');
+    assert.equal(root.homepageLink.textContent, 'hamsterdance.com/');
     assert.equal(root.homepageLink.tagName, 'A');
     assert.equal(root.homepageLink.href, 'http://hamsterdance.com/');
+  });
+
+  it('adds a protocol to a homepage URL if missing', () => {
+    const root = render({ addon: { ...fakeAddon, homepage: 'test.com' } });
+
+    assert.equal(root.homepageLink.textContent, 'test.com');
+    assert.equal(root.homepageLink.tagName, 'A');
+    assert.equal(root.homepageLink.href, 'http://test.com/');
+  });
+
+  it('trims leading whitespace on a URL', () => {
+    const root = render({ addon: { ...fakeAddon, homepage: ' test.com ' } });
+
+    assert.equal(root.homepageLink.textContent, 'test.com');
+    assert.equal(root.homepageLink.tagName, 'A');
+    assert.equal(root.homepageLink.href, 'http://test.com/');
+  });
+
+  it('works with HTTPS URLs', () => {
+    const root = render(
+      { addon: { ...fakeAddon, homepage: 'https://test.com' } });
+
+    assert.equal(root.homepageLink.textContent, 'test.com');
+    assert.equal(root.homepageLink.tagName, 'A');
+    assert.equal(root.homepageLink.href, 'https://test.com/');
   });
 
   it('renders the version number of an add-on', () => {


### PR DESCRIPTION
Adds `http://` to homepage URLs that are missing it; will fix https://addons-dev.allizom.org/en-US/firefox/addon/awesome-screenshot-plus-/

Also omits the `http://` in the actual text of the URL in the page, which looks nicer.

I guess this means `gopher://` and `ftp://` homepages won't work. 😉

Seriously though it means a protocol other than HTTP(S) won't work, but I figure that's fine.