### PR TITLE
fix: Encode query params (fix #1680)

### DIFF
--- a/src/amo/components/SearchForm.js
+++ b/src/amo/components/SearchForm.js
@@ -25,9 +25,10 @@ export class SearchFormBase extends React.Component {
 
   goToSearch(query) {
     const { api, pathname } = this.props;
-    const encodedQuery = query ? encodeURIComponent(query) : '';
-    this.context.router.push(
-      `/${api.lang}/${api.clientApp}${pathname}?q=${encodedQuery}`);
+    this.context.router.push({
+      pathname: `/${api.lang}/${api.clientApp}${pathname}`,
+      query: { q: query },
+    });
   }
 
   handleSearch = (e) => {

--- a/src/amo/components/SearchForm.js
+++ b/src/amo/components/SearchForm.js
@@ -25,8 +25,9 @@ export class SearchFormBase extends React.Component {
 
   goToSearch(query) {
     const { api, pathname } = this.props;
+    const encodedQuery = query ? encodeURIComponent(query) : '';
     this.context.router.push(
-      `/${api.lang}/${api.clientApp}${pathname}?q=${query}`);
+      `/${api.lang}/${api.clientApp}${pathname}?q=${encodedQuery}`);
   }
 
   handleSearch = (e) => {

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -56,7 +56,7 @@ export function mapStateToProps(state, ownProps) {
   // to be able to search on only clientApp this would need changing or
   // would need to be overridden.
   const hasSearchParams = Object.values(location.query).some((param) => (
-    typeof param !== 'undefined' && param.length
+    param && param.length
   ));
 
   return { ...state.search, filters, hasSearchParams };

--- a/tests/client/amo/components/TestSearchForm.js
+++ b/tests/client/amo/components/TestSearchForm.js
@@ -12,8 +12,8 @@ import { getFakeI18nInst } from 'tests/client/helpers';
 
 
 describe('<SearchForm />', () => {
-  const pathname = '/somewhere';
-  let api = { clientApp: 'firefox', lang: 'de' };
+  const pathname = '/search/';
+  const api = { clientApp: 'firefox', lang: 'de' };
   let loadAddon;
   let router;
   let root;
@@ -41,7 +41,6 @@ describe('<SearchForm />', () => {
   beforeEach(() => {
     router = { push: sinon.spy() };
     loadAddon = sinon.stub();
-    api = sinon.stub();
     root = renderIntoDocument(<SearchFormWrapper />).root;
     form = root.form;
     input = root.searchQuery.input;
@@ -60,7 +59,7 @@ describe('<SearchForm />', () => {
     assert.equal(input.value, 'foo');
   });
 
-  it('does changes the URL on submit', () => {
+  it('changes the URL on submit', () => {
     assert(!router.push.called);
     input.value = 'adblock';
     Simulate.submit(form);
@@ -87,6 +86,13 @@ describe('<SearchForm />', () => {
     input.value = 'adblock';
     Simulate.click(root.submitButton);
     assert(router.push.called);
+  });
+
+  it('encodes the value of the search text', () => {
+    assert(!router.push.called);
+    input.value = '& 26 %';
+    Simulate.click(root.submitButton);
+    assert(router.push.calledWith('/de/firefox/search/?q=%26%2026%20%25'));
   });
 });
 

--- a/tests/client/amo/components/TestSearchForm.js
+++ b/tests/client/amo/components/TestSearchForm.js
@@ -92,7 +92,10 @@ describe('<SearchForm />', () => {
     assert(!router.push.called);
     input.value = '& 26 %';
     Simulate.click(root.submitButton);
-    assert(router.push.calledWith('/de/firefox/search/?q=%26%2026%20%25'));
+    assert(router.push.calledWith({
+      pathname: '/de/firefox/search/',
+      query: { q: '& 26 %' },
+    }));
   });
 });
 

--- a/tests/client/amo/containers/TestSearch.js
+++ b/tests/client/amo/containers/TestSearch.js
@@ -23,6 +23,22 @@ describe('Search.mapStateToProps()', () => {
     },
   };
 
+  it('does not have search params with undefined query params', () => {
+    const props = mapStateToProps(
+      state,
+      { location: { query: { q: undefined } } }
+    );
+    assert.isFalse(props.hasSearchParams);
+  });
+
+  it('should handle queries that need encoding', () => {
+    const props = mapStateToProps(
+      state,
+      { location: { query: { q: '&' } } }
+    );
+    assert.isTrue(props.hasSearchParams);
+  });
+
   it('passes the search state if the URL and state query matches', () => {
     const props = mapStateToProps(
       state,


### PR DESCRIPTION
Fix #1680.

Can't believe we weren't doing this!

### Before
<img width="549" alt="screenshot 2017-02-16 19 53 45" src="https://cloud.githubusercontent.com/assets/90871/23038353/a6412f08-f481-11e6-9da3-8bc0c6674236.png">
<img width="852" alt="screenshot 2017-02-16 19 53 35" src="https://cloud.githubusercontent.com/assets/90871/23038354/a6418e8a-f481-11e6-9b5a-7801ae4ec0c5.png">

### After
![screen shot 2017-02-16 at 19 51 57](https://cloud.githubusercontent.com/assets/90871/23038326/8ae003b0-f481-11e6-8e96-129ab5e78119.png)