### PR TITLE
fix: Balance icons in detail

### DIFF
--- a/src/amo/components/AddonMeta.js
+++ b/src/amo/components/AddonMeta.js
@@ -16,7 +16,7 @@ export class AddonMetaBase extends React.Component {
     const { addon, i18n } = this.props;
     const averageDailyUsers = addon.average_daily_users;
     const averageRating = addon.ratings.average;
-    const addonReviewCount = addon.ratings.count;
+    const addonRatingCount = addon.ratings.count;
 
     const userCount = i18n.sprintf(
       i18n.ngettext('%(total)s user', '%(total)s users', averageDailyUsers),
@@ -31,14 +31,13 @@ export class AddonMetaBase extends React.Component {
     } else {
       starCount = i18n.gettext('Not yet rated');
     }
-    let reviewCount;
-    if (addonReviewCount) {
-      reviewCount = i18n.sprintf(
-        i18n.ngettext('%(total)s review', '%(total)s reviews', addonReviewCount),
-        { total: i18n.formatNumber(addonReviewCount) },
+    let ratingCount;
+    if (addonRatingCount) {
+      ratingCount = i18n.sprintf(
+        i18n.ngettext(
+          '%(total)s rating', '%(total)s ratings', addonRatingCount),
+        { total: i18n.formatNumber(addonRatingCount) },
       );
-    } else {
-      reviewCount = i18n.gettext('Not yet reviewed');
     }
     return (
       <div className="AddonMeta">
@@ -52,9 +51,9 @@ export class AddonMetaBase extends React.Component {
           <p className="AddonMeta-text AddonMeta-star-count">
             {starCount}
           </p>
-          <p className="AddonMeta-text AddonMeta-review-count">
-            {reviewCount}
-          </p>
+          {ratingCount ? (<p className="AddonMeta-text AddonMeta-rating-count">
+            {ratingCount}
+          </p>) : null}
         </div>
       </div>
     );

--- a/src/amo/css/AddonMeta.scss
+++ b/src/amo/css/AddonMeta.scss
@@ -17,13 +17,13 @@
 }
 
 .AddonMeta-ratings-icon {
-  height: 50px;
+  height: 60px;
   width: 50px;
 }
 
 .AddonMeta-text {
   display: inline-block;
-  line-height: 1.4;
+  line-height: 1.1;
   margin: 0;
   text-align: center;
 }

--- a/src/ui/components/Icon/star.svg
+++ b/src/ui/components/Icon/star.svg
@@ -1,5 +1,4 @@
-
-<svg width="142px" height="136px" viewBox="107 3340 142 136" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="107 3340 142 136" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
     <desc>Created with Sketch.</desc>
     <defs></defs>

--- a/tests/client/amo/components/TestAddonMeta.js
+++ b/tests/client/amo/components/TestAddonMeta.js
@@ -65,9 +65,9 @@ describe('<AddonMeta>', () => {
         '.AddonMeta-ratings > p.AddonMeta-star-count').textContent;
     }
 
-    function getReviewCount(root) {
+    function getRatingCount(root) {
       return root.querySelector(
-        '.AddonMeta-ratings > p.AddonMeta-review-count').textContent;
+        '.AddonMeta-ratings > p.AddonMeta-rating-count').textContent;
     }
 
     it('renders the average rating', () => {
@@ -81,20 +81,20 @@ describe('<AddonMeta>', () => {
       assert.include(getRating(root), '3,5');
     });
 
-    it('renders a count of multiple reviews', () => {
+    it('renders a count of multiple ratings', () => {
       const root = renderRatings({ count: 5 });
-      assert.equal(getReviewCount(root), '5 reviews');
+      assert.equal(getRatingCount(root), '5 ratings');
     });
 
-    it('renders a count of one review', () => {
+    it('renders a count of one rating', () => {
       const root = renderRatings({ count: 1 });
-      assert.equal(getReviewCount(root), '1 review');
+      assert.equal(getRatingCount(root), '1 rating');
     });
 
     it('localizes review count', () => {
       const i18n = getFakeI18nInst({ lang: 'de' });
       const root = renderRatings({ count: 1000 }, { i18n });
-      assert.include(getReviewCount(root), '1.000');
+      assert.include(getRatingCount(root), '1.000');
     });
 
     it('renders empty ratings', () => {
@@ -104,7 +104,8 @@ describe('<AddonMeta>', () => {
 
     it('renders an empty review count', () => {
       const root = renderRatings({ count: null });
-      assert.equal(getReviewCount(root), 'Not yet reviewed');
+      assert.isNull(
+        root.querySelector('.AddonMeta-ratings > p.AddonMeta-rating-count'));
     });
   });
 });


### PR DESCRIPTION
Fix #1698.

This balances the icon size of the user icon and the star icon. The best way to keep the max amount of context seemed to be adding a line below with the number of ratings (not reviews) if available. That way the numerical rating is given context (1/5 with 1,000 reviews is different than 1/5 with 3 reviews). See the screenshots below, but I think this is the best option.

The number of reviews is displayed lower in the page, which I think is better.

### Before
<img width="363" alt="2e9f2b04-e4a4-11e6-878d-a5f85774b067" src="https://cloud.githubusercontent.com/assets/55398/22556548/2976d978-e92d-11e6-8063-c7ac23d034da.png">

### After
![screen shot 2017-02-21 at 11 53 17](https://cloud.githubusercontent.com/assets/90871/23166784/d65752a6-f839-11e6-9d97-d7efa84031e4.png)
![screen shot 2017-02-21 at 13 33 37](https://cloud.githubusercontent.com/assets/90871/23166890/5ffc92dc-f83a-11e6-870c-12a1e939a889.png)

