### PR TITLE
Hook up Sentry for error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ Example: Building and running a production instance of the admin app:
 NODE_APP_INSTANCE=admin NODE_ENV=production npm run build && npm run start
 ```
 
+## Hooking up Sentry for error reporting
+
+To hook up [Sentry](https://sentry.io/) for reporting application errors, you
+need to add some configuration.
+
+First, define this environment variable before starting the server:
+````
+SENTRY_DSN=https://<key>@sentry.io/<project>
+````
+
+Next, make sure your application config allows you to simulate errors:
+````js
+module.exports = {
+  allowErrorSimulation: true,
+};
+````
+
+This will allow you to make a request to `/simulate-error/`. You should
+see a 500 response and Sentry should have a record of the actual error.
+
 ## Overview and rationale
 
 This project will hold distinct front-ends e.g:

--- a/README.md
+++ b/README.md
@@ -178,26 +178,6 @@ Example: Building and running a production instance of the admin app:
 NODE_APP_INSTANCE=admin NODE_ENV=production npm run build && npm run start
 ```
 
-## Hooking up Sentry for error reporting
-
-To hook up [Sentry](https://sentry.io/) for reporting application errors, you
-need to add some configuration.
-
-First, define this environment variable before starting the server:
-````
-SENTRY_DSN=https://<key>@sentry.io/<project>
-````
-
-Next, make sure your application config allows you to simulate errors:
-````js
-module.exports = {
-  allowErrorSimulation: true,
-};
-````
-
-This will allow you to make a request to `/simulate-error/`. You should
-see a 500 response and Sentry should have a record of the actual error.
-
 ## Overview and rationale
 
 This project will hold distinct front-ends e.g:

--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -10,6 +10,7 @@ module.exports = {
   // Since by definition client-side code is public these config keys
   // must not contain sensitive data.
   clientConfigKeys: [
+    'allowErrorSimulation',
     'appName',
     'amoCDN',
     'apiHost',

--- a/config/default.js
+++ b/config/default.js
@@ -181,4 +181,6 @@ module.exports = {
   // to test our internal error handler.
   // allowErrorSimulation: false,
   allowErrorSimulation: false,
+
+  sentryDsn: process.env.SENTRY_DSN || null,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -63,6 +63,7 @@ module.exports = {
   // Since by definition client-side code is public these config keys
   // must not contain sensitive data.
   clientConfigKeys: [
+    'allowErrorSimulation',
     'amoCDN',
     'apiHost',
     'apiPath',
@@ -175,4 +176,9 @@ module.exports = {
   fxaConfig: null,
 
   proxyEnabled: false,
+
+  // If true, enable a route that explicitly triggers a server error
+  // to test our internal error handler.
+  // allowErrorSimulation: false,
+  allowErrorSimulation: false,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -179,7 +179,6 @@ module.exports = {
 
   // If true, enable a route that explicitly triggers a server error
   // to test our internal error handler.
-  // allowErrorSimulation: false,
   allowErrorSimulation: false,
 
   sentryDsn: process.env.SENTRY_DSN || null,

--- a/config/dev.js
+++ b/config/dev.js
@@ -30,4 +30,6 @@ module.exports = {
       ],
     },
   },
+
+  allowErrorSimulation: true,
 };

--- a/config/stage.js
+++ b/config/stage.js
@@ -28,4 +28,6 @@ module.exports = {
       ],
     },
   },
+
+  allowErrorSimulation: true,
 };

--- a/config/test.js
+++ b/config/test.js
@@ -1,4 +1,5 @@
 // Put any test configuration overrides here.
 module.exports = {
   apiHost: 'https://localhost',
+  allowErrorSimulation: true,
 };

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "normalize.css": "5.0.0",
     "normalizr": "3.2.1",
     "piping": "0.3.2",
+    "raven": "1.1.2",
     "react": "15.4.2",
     "react-addons-css-transition-group": "15.4.2",
     "react-cookie": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       "command": "mocha --compilers js:babel-register --timeout 10000 tests/server/amo",
       "env": {
         "NODE_PATH": "./:./src",
-        "NODE_ENV": "production",
+        "NODE_ENV": "test",
         "NODE_APP_INSTANCE": "amo",
         "TRACKING_ENABLED": "false"
       }

--- a/src/admin/routes.js
+++ b/src/admin/routes.js
@@ -1,6 +1,8 @@
+import config from 'config';
 import React from 'react';
 import { IndexRoute, Route } from 'react-router';
 
+import SimulateError from 'core/containers/SimulateError';
 import LoginRequired from 'core/containers/LoginRequired';
 import HandleLogin from 'core/containers/HandleLogin';
 
@@ -19,5 +21,8 @@ export default (
       <Route path="user" component={UserPage} />
     </Route>
     <Route path="fxa-authenticate" component={HandleLogin} />
+    {config.get('allowErrorSimulation') ? (
+      <Route path="simulate-error/" component={SimulateError} />
+    ) : null}
   </Route>
 );

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -2,6 +2,7 @@ import config from 'config';
 import React from 'react';
 import { IndexRoute, Route } from 'react-router';
 
+import SimulateError from 'core/containers/SimulateError';
 import HandleLogin from 'core/containers/HandleLogin';
 
 import AddonReviewList from './components/AddonReviewList';
@@ -33,6 +34,9 @@ export default (
     <Route path="404/" component={NotFound} />
     <Route path="500/"
       component={config.get('isDevelopment') ? ServerError : NotFound} />
+    {config.get('allowErrorSimulation') ? (
+      <Route path="simulate-error/" component={SimulateError} />
+    ) : null}
     <Route path=":visibleAddonType/" component={LandingPage} />
     <Route path="*" component={NotFound} />
   </Route>

--- a/src/core/containers/SimulateError.js
+++ b/src/core/containers/SimulateError.js
@@ -1,0 +1,7 @@
+import log from 'core/logger';
+
+// This HOC can be connected to a route to test internal error handling.
+export default () => {
+  log.info('Simulating an error');
+  throw new Error('This is a simulated error');
+};

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -121,7 +121,8 @@ function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
     Raven.config(sentryDsn).install();
     app.use(Raven.errorHandler());
   } else {
-    log.warn('Sentry reporting is disabled because sentryDsn was falsey');
+    log.warn(
+      'Sentry reporting is disabled; Set config.sentryDsn to enable it.');
   }
 
   app.use(logRequests);

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -7,6 +7,7 @@ import { oneLine } from 'common-tags';
 import config from 'config';
 import Express from 'express';
 import helmet from 'helmet';
+import Raven from 'raven';
 import cookie from 'react-cookie';
 import React from 'react';
 import ReactDOM from 'react-dom/server';
@@ -114,6 +115,14 @@ function logRequests(req, res, next) {
 function baseServer(routes, createStore, { appInstanceName = appName } = {}) {
   const app = new Express();
   app.disable('x-powered-by');
+
+  const sentryDsn = config.get('sentryDsn');
+  if (sentryDsn) {
+    Raven.config(sentryDsn).install();
+    app.use(Raven.errorHandler());
+  } else {
+    log.warn('Sentry reporting is disabled because sentryDsn was falsey');
+  }
 
   app.use(logRequests);
 

--- a/src/disco/routes.js
+++ b/src/disco/routes.js
@@ -4,6 +4,7 @@ import { Router, Route } from 'react-router';
 
 import GenericError from 'core/components/ErrorPage/GenericError';
 import NotFound from 'core/components/ErrorPage/NotFound';
+import SimulateError from 'core/containers/SimulateError';
 
 import App from './containers/App';
 import DiscoPane from './containers/DiscoPane';
@@ -18,6 +19,9 @@ export default (
     <Route path="/:lang/firefox/404" component={NotFound} />
     <Route path="/:lang/firefox/500"
       component={config.get('isDevelopment') ? GenericError : NotFound} />
+    {config.get('allowErrorSimulation') ? (
+      <Route path="/:lang/firefox/simulate-error/" component={SimulateError} />
+    ) : null}
     <Route path="*" component={NotFound} />
   </Router>
 );

--- a/tests/client/core/containers/TestSimulateError.js
+++ b/tests/client/core/containers/TestSimulateError.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderIntoDocument } from 'react-addons-test-utils';
+
+import SimulateError from 'core/containers/SimulateError';
+
+describe('SimulateError', () => {
+  it('simulates an error', () => {
+    assert.throws(
+      () => renderIntoDocument(<SimulateError />),
+      /simulated error/);
+  });
+});

--- a/tests/server/admin/TestViews.js
+++ b/tests/server/admin/TestViews.js
@@ -3,7 +3,7 @@ import request from 'supertest-as-promised';
 
 import { checkSRI, parseCSP, runTestServer } from '../helpers';
 
-describe('Search App GET requests', () => {
+describe('Admin views', () => {
   let app;
 
   before(() => runTestServer({ app: 'admin' })
@@ -30,4 +30,8 @@ describe('Search App GET requests', () => {
     .get('/search')
     .expect(200)
     .then((res) => checkSRI(res)));
+
+  it('can simulate a thrown error', () => request(app)
+    .get('/simulate-error/')
+    .expect(500));
 });

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -62,4 +62,8 @@ describe('AMO GET Requests', () => {
       assert.equal(res.header.location,
         '/en-US/firefox/search/');
     }));
+
+  it('can simulate a thrown error', () => request(app)
+    .get('/en-US/firefox/simulate-error/')
+    .expect(500));
 });

--- a/tests/server/disco/TestViews.js
+++ b/tests/server/disco/TestViews.js
@@ -58,4 +58,8 @@ describe('Discovery Pane GET requests', () => {
     .then((res) => {
       assert.equal(res.header['strict-transport-security'], 'max-age=31536000');
     }));
+
+  it('can simulate a thrown error', () => request(app)
+    .get('/en-US/firefox/simulate-error/')
+    .expect(500));
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1559

We'll need ops to set `SENTRY_ENV` for each server but that can come in https://github.com/mozilla/addons-frontend/issues/1886