### PR TITLE
Show a 500 page for asyncConnect loaders that throw

### DIFF
--- a/src/admin/containers/AddonPage/index.js
+++ b/src/admin/containers/AddonPage/index.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-connect';
 
-import { gettext as _, loadAddonIfNeeded } from 'core/utils';
+import { gettext as _, loadAddonIfNeeded, safePromise } from 'core/utils';
 import NotFound from 'core/components/ErrorPage/NotFound';
 import JsonData from 'admin/components/JsonData';
 
@@ -132,7 +132,7 @@ function mapStateToProps(state, ownProps) {
 const CurrentAddonPage = asyncConnect([{
   key: 'AddonPage',
   deferred: true,
-  promise: loadAddonIfNeeded,
+  promise: safePromise(loadAddonIfNeeded),
 }])(connect(mapStateToProps)(AddonPage));
 
 export default CurrentAddonPage;

--- a/src/admin/containers/AddonPage/index.js
+++ b/src/admin/containers/AddonPage/index.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { asyncConnect } from 'redux-connect';
+import { compose } from 'redux';
 
-import { gettext as _, loadAddonIfNeeded, safePromise } from 'core/utils';
+import { gettext as _, loadAddonIfNeeded, safeAsyncConnect } from 'core/utils';
 import NotFound from 'core/components/ErrorPage/NotFound';
 import JsonData from 'admin/components/JsonData';
 
@@ -129,10 +129,10 @@ function mapStateToProps(state, ownProps) {
   };
 }
 
-const CurrentAddonPage = asyncConnect([{
-  key: 'AddonPage',
-  deferred: true,
-  promise: safePromise(loadAddonIfNeeded),
-}])(connect(mapStateToProps)(AddonPage));
-
-export default CurrentAddonPage;
+export default compose(
+  safeAsyncConnect([{
+    key: 'AddonPage',
+    promise: loadAddonIfNeeded,
+  }]),
+  connect(mapStateToProps),
+)(AddonPage);

--- a/src/admin/containers/SearchPage.js
+++ b/src/admin/containers/SearchPage.js
@@ -1,16 +1,12 @@
 import { connect } from 'react-redux';
-import { asyncConnect } from 'redux-connect';
 import { compose } from 'redux';
 
 import AdminSearchPage from 'admin/components/SearchPage';
 import { loadSearchResultsIfNeeded, mapStateToProps } from 'core/searchUtils';
-import { safePromise } from 'core/utils';
+import { safeAsyncConnect } from 'core/utils';
 
 
 export default compose(
-  asyncConnect([{
-    deferred: true,
-    promise: safePromise(loadSearchResultsIfNeeded),
-  }]),
+  safeAsyncConnect([{ promise: loadSearchResultsIfNeeded }]),
   connect(mapStateToProps)
 )(AdminSearchPage);

--- a/src/admin/containers/SearchPage.js
+++ b/src/admin/containers/SearchPage.js
@@ -4,12 +4,13 @@ import { compose } from 'redux';
 
 import AdminSearchPage from 'admin/components/SearchPage';
 import { loadSearchResultsIfNeeded, mapStateToProps } from 'core/searchUtils';
+import { safePromise } from 'core/utils';
 
 
 export default compose(
   asyncConnect([{
     deferred: true,
-    promise: loadSearchResultsIfNeeded,
+    promise: safePromise(loadSearchResultsIfNeeded),
   }]),
   connect(mapStateToProps)
 )(AdminSearchPage);

--- a/src/admin/containers/UserPage/index.js
+++ b/src/admin/containers/UserPage/index.js
@@ -1,10 +1,10 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { asyncConnect } from 'redux-connect';
+import { compose } from 'redux';
 
 import { loadEntities, setCurrentUser } from 'core/actions';
 import { fetchProfile } from 'core/api';
-import { safePromise } from 'core/utils';
+import { safeAsyncConnect } from 'core/utils';
 
 import './styles.scss';
 
@@ -49,8 +49,10 @@ export function loadProfileIfNeeded({ store: { getState, dispatch } }) {
   return Promise.resolve();
 }
 
-export default asyncConnect([{
-  key: 'UserPage',
-  deferred: true,
-  promise: safePromise(loadProfileIfNeeded),
-}])(connect(mapStateToProps)(UserPageBase));
+export default compose(
+  safeAsyncConnect([{
+    key: 'UserPage',
+    promise: loadProfileIfNeeded,
+  }]),
+  connect(mapStateToProps),
+)(UserPageBase);

--- a/src/admin/containers/UserPage/index.js
+++ b/src/admin/containers/UserPage/index.js
@@ -4,6 +4,7 @@ import { asyncConnect } from 'redux-connect';
 
 import { loadEntities, setCurrentUser } from 'core/actions';
 import { fetchProfile } from 'core/api';
+import { safePromise } from 'core/utils';
 
 import './styles.scss';
 
@@ -51,5 +52,5 @@ export function loadProfileIfNeeded({ store: { getState, dispatch } }) {
 export default asyncConnect([{
   key: 'UserPage',
   deferred: true,
-  promise: loadProfileIfNeeded,
+  promise: safePromise(loadProfileIfNeeded),
 }])(connect(mapStateToProps)(UserPageBase));

--- a/src/amo/components/AddonReviewList.js
+++ b/src/amo/components/AddonReviewList.js
@@ -1,13 +1,12 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { asyncConnect } from 'redux-connect';
 
 import Rating from 'ui/components/Rating';
 import { setAddonReviews } from 'amo/actions/reviews';
 import { getReviews } from 'amo/api';
 import translate from 'core/i18n/translate';
-import { findAddon, loadAddonIfNeeded, safePromise } from 'core/utils';
+import { findAddon, loadAddonIfNeeded, safeAsyncConnect } from 'core/utils';
 import Link from 'amo/components/Link';
 import CardList from 'ui/components/CardList';
 
@@ -117,10 +116,7 @@ export function mapStateToProps(state, ownProps) {
 }
 
 export default compose(
-  asyncConnect([{
-    deferred: true,
-    promise: safePromise(loadInitialData),
-  }]),
+  safeAsyncConnect([{ promise: loadInitialData }]),
   connect(mapStateToProps),
   translate({ withRef: true }),
 )(AddonReviewListBase);

--- a/src/amo/components/AddonReviewList.js
+++ b/src/amo/components/AddonReviewList.js
@@ -7,7 +7,7 @@ import Rating from 'ui/components/Rating';
 import { setAddonReviews } from 'amo/actions/reviews';
 import { getReviews } from 'amo/api';
 import translate from 'core/i18n/translate';
-import { findAddon, loadAddonIfNeeded } from 'core/utils';
+import { findAddon, loadAddonIfNeeded, safePromise } from 'core/utils';
 import Link from 'amo/components/Link';
 import CardList from 'ui/components/CardList';
 
@@ -119,7 +119,7 @@ export function mapStateToProps(state, ownProps) {
 export default compose(
   asyncConnect([{
     deferred: true,
-    promise: loadInitialData,
+    promise: safePromise(loadInitialData),
   }]),
   connect(mapStateToProps),
   translate({ withRef: true }),

--- a/src/amo/components/FeaturedAddons/index.js
+++ b/src/amo/components/FeaturedAddons/index.js
@@ -1,13 +1,12 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { asyncConnect } from 'redux-connect';
 import { compose } from 'redux';
 
 import SearchResults from 'amo/components/SearchResults';
 import { loadFeaturedAddons } from 'amo/utils';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import translate from 'core/i18n/translate';
-import { safePromise } from 'core/utils';
+import { safeAsyncConnect } from 'core/utils';
 
 import './FeaturedAddons.scss';
 
@@ -62,9 +61,7 @@ export function mapStateToProps(state) {
 }
 
 export default compose(
-  asyncConnect([
-    { deferred: true, promise: safePromise(loadFeaturedAddons) },
-  ]),
+  safeAsyncConnect([{ promise: loadFeaturedAddons }]),
   connect(mapStateToProps),
   translate(),
 )(FeaturedAddonsBase);

--- a/src/amo/components/FeaturedAddons/index.js
+++ b/src/amo/components/FeaturedAddons/index.js
@@ -7,6 +7,7 @@ import SearchResults from 'amo/components/SearchResults';
 import { loadFeaturedAddons } from 'amo/utils';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import translate from 'core/i18n/translate';
+import { safePromise } from 'core/utils';
 
 import './FeaturedAddons.scss';
 
@@ -62,7 +63,7 @@ export function mapStateToProps(state) {
 
 export default compose(
   asyncConnect([
-    { deferred: true, promise: loadFeaturedAddons },
+    { deferred: true, promise: safePromise(loadFeaturedAddons) },
   ]),
   connect(mapStateToProps),
   translate(),

--- a/src/amo/components/LandingPage.js
+++ b/src/amo/components/LandingPage.js
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
-import { asyncConnect } from 'redux-connect';
 import { connect } from 'react-redux';
 
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
@@ -17,7 +16,7 @@ import { AddonTypeNotFound } from 'core/errors';
 import log from 'core/logger';
 import {
   apiAddonType as getApiAddonType,
-  safePromise,
+  safeAsyncConnect,
   visibleAddonType as getVisibleAddonType,
 } from 'core/utils';
 import translate from 'core/i18n/translate';
@@ -139,9 +138,7 @@ export function mapStateToProps(state) {
 }
 
 export default compose(
-  asyncConnect([
-    { deferred: true, promise: safePromise(loadLandingAddons) },
-  ]),
+  safeAsyncConnect([{ promise: loadLandingAddons }]),
   connect(mapStateToProps),
   translate({ withRef: true }),
 )(LandingPageBase);

--- a/src/amo/components/LandingPage.js
+++ b/src/amo/components/LandingPage.js
@@ -17,6 +17,7 @@ import { AddonTypeNotFound } from 'core/errors';
 import log from 'core/logger';
 import {
   apiAddonType as getApiAddonType,
+  safePromise,
   visibleAddonType as getVisibleAddonType,
 } from 'core/utils';
 import translate from 'core/i18n/translate';
@@ -139,7 +140,7 @@ export function mapStateToProps(state) {
 
 export default compose(
   asyncConnect([
-    { deferred: true, promise: loadLandingAddons },
+    { deferred: true, promise: safePromise(loadLandingAddons) },
   ]),
   connect(mapStateToProps),
   translate({ withRef: true }),

--- a/src/amo/containers/CategoryList.js
+++ b/src/amo/containers/CategoryList.js
@@ -3,7 +3,7 @@ import { asyncConnect } from 'redux-connect';
 import { connect } from 'react-redux';
 
 import Categories from 'amo/components/Categories';
-import { loadCategoriesIfNeeded, apiAddonType } from 'core/utils';
+import { loadCategoriesIfNeeded, apiAddonType, safePromise } from 'core/utils';
 
 
 export function mapStateToProps(state, ownProps) {
@@ -24,7 +24,7 @@ export default compose(
   asyncConnect([{
     deferred: true,
     key: 'CategoriesPage',
-    promise: loadCategoriesIfNeeded,
+    promise: safePromise(loadCategoriesIfNeeded),
   }]),
   connect(mapStateToProps),
 )(Categories);

--- a/src/amo/containers/CategoryList.js
+++ b/src/amo/containers/CategoryList.js
@@ -1,9 +1,10 @@
 import { compose } from 'redux';
-import { asyncConnect } from 'redux-connect';
 import { connect } from 'react-redux';
 
 import Categories from 'amo/components/Categories';
-import { loadCategoriesIfNeeded, apiAddonType, safePromise } from 'core/utils';
+import {
+  loadCategoriesIfNeeded, apiAddonType, safeAsyncConnect,
+} from 'core/utils';
 
 
 export function mapStateToProps(state, ownProps) {
@@ -21,10 +22,9 @@ export function mapStateToProps(state, ownProps) {
 }
 
 export default compose(
-  asyncConnect([{
-    deferred: true,
+  safeAsyncConnect([{
     key: 'CategoriesPage',
-    promise: safePromise(loadCategoriesIfNeeded),
+    promise: loadCategoriesIfNeeded,
   }]),
   connect(mapStateToProps),
 )(Categories);

--- a/src/amo/containers/CategoryPage.js
+++ b/src/amo/containers/CategoryPage.js
@@ -6,7 +6,7 @@ import { compose } from 'redux';
 
 import SearchPage from 'amo/components/SearchPage';
 import { loadByCategoryIfNeeded, parsePage } from 'core/searchUtils';
-import { apiAddonType } from 'core/utils';
+import { apiAddonType, safePromise } from 'core/utils';
 
 
 export function CategoryPageBase(props) {
@@ -42,7 +42,7 @@ export function mapStateToProps(state, ownProps) {
 export default compose(
   asyncConnect([{
     deferred: true,
-    promise: loadByCategoryIfNeeded,
+    promise: safePromise(loadByCategoryIfNeeded),
   }]),
   connect(mapStateToProps),
 )(CategoryPageBase);

--- a/src/amo/containers/CategoryPage.js
+++ b/src/amo/containers/CategoryPage.js
@@ -1,12 +1,11 @@
 import deepEqual from 'deep-eql';
 import React from 'react';
 import { connect } from 'react-redux';
-import { asyncConnect } from 'redux-connect';
 import { compose } from 'redux';
 
 import SearchPage from 'amo/components/SearchPage';
 import { loadByCategoryIfNeeded, parsePage } from 'core/searchUtils';
-import { apiAddonType, safePromise } from 'core/utils';
+import { apiAddonType, safeAsyncConnect } from 'core/utils';
 
 
 export function CategoryPageBase(props) {
@@ -40,9 +39,6 @@ export function mapStateToProps(state, ownProps) {
 }
 
 export default compose(
-  asyncConnect([{
-    deferred: true,
-    promise: safePromise(loadByCategoryIfNeeded),
-  }]),
+  safeAsyncConnect([{ promise: loadByCategoryIfNeeded }]),
   connect(mapStateToProps),
 )(CategoryPageBase);

--- a/src/amo/containers/DetailPage.js
+++ b/src/amo/containers/DetailPage.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import AddonDetail from 'amo/components/AddonDetail';
 import { UNKNOWN } from 'core/constants';
-import { loadAddonIfNeeded } from 'core/utils';
+import { loadAddonIfNeeded, safePromise } from 'core/utils';
 
 
 export class DetailPageBase extends React.Component {
@@ -33,7 +33,7 @@ export default compose(
   asyncConnect([{
     key: 'DetailPage',
     deferred: true,
-    promise: loadAddonIfNeeded,
+    promise: safePromise(loadAddonIfNeeded),
   }]),
   connect(mapStateToProps),
 )(DetailPageBase);

--- a/src/amo/containers/DetailPage.js
+++ b/src/amo/containers/DetailPage.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { compose } from 'redux';
-import { asyncConnect } from 'redux-connect';
 import { connect } from 'react-redux';
 
 import AddonDetail from 'amo/components/AddonDetail';
 import { UNKNOWN } from 'core/constants';
-import { loadAddonIfNeeded, safePromise } from 'core/utils';
+import { loadAddonIfNeeded, safeAsyncConnect } from 'core/utils';
 
 
 export class DetailPageBase extends React.Component {
@@ -30,10 +29,9 @@ export function mapStateToProps(state, ownProps) {
 }
 
 export default compose(
-  asyncConnect([{
+  safeAsyncConnect([{
     key: 'DetailPage',
-    deferred: true,
-    promise: safePromise(loadAddonIfNeeded),
+    promise: loadAddonIfNeeded,
   }]),
   connect(mapStateToProps),
 )(DetailPageBase);

--- a/src/amo/containers/SearchPage.js
+++ b/src/amo/containers/SearchPage.js
@@ -1,16 +1,12 @@
 import { connect } from 'react-redux';
-import { asyncConnect } from 'redux-connect';
 import { compose } from 'redux';
 
 import SearchPage from 'amo/components/SearchPage';
 import { loadSearchResultsIfNeeded, mapStateToProps } from 'core/searchUtils';
-import { safePromise } from 'core/utils';
+import { safeAsyncConnect } from 'core/utils';
 
 
 export default compose(
-  asyncConnect([{
-    deferred: true,
-    promise: safePromise(loadSearchResultsIfNeeded),
-  }]),
+  safeAsyncConnect([{ promise: loadSearchResultsIfNeeded }]),
   connect(mapStateToProps),
 )(SearchPage);

--- a/src/amo/containers/SearchPage.js
+++ b/src/amo/containers/SearchPage.js
@@ -4,12 +4,13 @@ import { compose } from 'redux';
 
 import SearchPage from 'amo/components/SearchPage';
 import { loadSearchResultsIfNeeded, mapStateToProps } from 'core/searchUtils';
+import { safePromise } from 'core/utils';
 
 
 export default compose(
   asyncConnect([{
     deferred: true,
-    promise: loadSearchResultsIfNeeded,
+    promise: safePromise(loadSearchResultsIfNeeded),
   }]),
   connect(mapStateToProps),
 )(SearchPage);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -202,6 +202,26 @@ export function isValidUrlException(value, { _config = config } = {}) {
   return _config.get('validUrlExceptions').includes(value);
 }
 
+/*
+ * Make sure a callback returns a rejected promise instead of throwing an error.
+ *
+ * This is for use with asyncConnect() so that the promise callback never
+ * throws an error (which will get lost).
+ *
+ * If the callback throws an error, a rejected promise will be returned
+ * instead. If the callback runs without an error, its return value is not
+ * altered. In other words, it may or may not return a promise because
+ * asyncConnect supports either case.
+ *
+ * You would use it like this:
+ *
+ * export default compose(
+ *   asyncConnect([{
+ *     deferred: true,
+ *     promise: safePromise(loadSomeData),
+ *   }])
+ * )(YourComponentBase)
+ */
 export const safePromise = (promiseOrNot) => (...args) => {
   try {
     return promiseOrNot(...args);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -204,6 +204,21 @@ export function isValidUrlException(value, { _config = config } = {}) {
 }
 
 /*
+ * Make sure a callback returns a rejected promise instead of throwing an error.
+ *
+ * If the callback throws an error, a rejected promise will be returned
+ * instead. If the callback runs without an error, its return value is not
+ * altered. In other words, it may or may not return a promise and that's ok.
+ */
+export const safePromise = (callback) => (...args) => {
+  try {
+    return callback(...args);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+/*
  * A wrapper around asyncConnect to make it safer to use.
  *
  * You don't need to specify deferred: true because it will be set
@@ -231,18 +246,3 @@ export function safeAsyncConnect(
   });
   return asyncConnect(safeConfigs);
 }
-
-/*
- * Make sure a callback returns a rejected promise instead of throwing an error.
- *
- * If the callback throws an error, a rejected promise will be returned
- * instead. If the callback runs without an error, its return value is not
- * altered. In other words, it may or may not return a promise and that's ok.
- */
-export const safePromise = (callback) => (...args) => {
-  try {
-    return callback(...args);
-  } catch (error) {
-    return Promise.reject(error);
-  }
-};

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -201,3 +201,11 @@ export function getErrorComponent(status) {
 export function isValidUrlException(value, { _config = config } = {}) {
   return _config.get('validUrlExceptions').includes(value);
 }
+
+export const safePromise = (promiseOrNot) => (...args) => {
+  try {
+    return promiseOrNot(...args);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -3,7 +3,7 @@
 import React, { PropTypes } from 'react';
 import { camelizeKeys as camelCaseKeys } from 'humps';
 import { connect } from 'react-redux';
-import { asyncConnect } from 'redux-connect';
+import { compose } from 'redux';
 import config from 'config';
 
 import { loadEntities } from 'core/actions';
@@ -12,7 +12,7 @@ import tracking from 'core/tracking';
 import { INSTALL_STATE } from 'core/constants';
 import InfoDialog from 'core/containers/InfoDialog';
 import { addChangeListeners } from 'core/addonManager';
-import { safePromise } from 'core/utils';
+import { safeAsyncConnect } from 'core/utils';
 import {
   NAVIGATION_CATEGORY,
   VIDEO_CATEGORY,
@@ -167,7 +167,11 @@ export function mapDispatchToProps(dispatch, { _config = config } = {}) {
   };
 }
 
-export default asyncConnect([{
-  key: 'DiscoPane',
-  promise: safePromise(loadDataIfNeeded),
-}])(connect(mapStateToProps, mapDispatchToProps)(translate()(DiscoPaneBase)));
+export default compose(
+  safeAsyncConnect([{
+    key: 'DiscoPane',
+    promise: loadDataIfNeeded,
+  }]),
+  connect(mapStateToProps, mapDispatchToProps),
+  translate(),
+)(DiscoPaneBase);

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -12,6 +12,7 @@ import tracking from 'core/tracking';
 import { INSTALL_STATE } from 'core/constants';
 import InfoDialog from 'core/containers/InfoDialog';
 import { addChangeListeners } from 'core/addonManager';
+import { safePromise } from 'core/utils';
 import {
   NAVIGATION_CATEGORY,
   VIDEO_CATEGORY,
@@ -168,5 +169,5 @@ export function mapDispatchToProps(dispatch, { _config = config } = {}) {
 
 export default asyncConnect([{
   key: 'DiscoPane',
-  promise: loadDataIfNeeded,
+  promise: safePromise(loadDataIfNeeded),
 }])(connect(mapStateToProps, mapDispatchToProps)(translate()(DiscoPaneBase)));

--- a/tests/client/core/test_utils.js
+++ b/tests/client/core/test_utils.js
@@ -633,12 +633,12 @@ describe('safePromise', () => {
   });
 
   it('catches errors and returns them as rejected promises', () => {
-    const msg = 'well, that was unfortunate';
+    const message = 'well, that was unfortunate';
     const asPromised = safePromise(() => {
-      throw new Error(msg);
+      throw new Error(message);
     });
     return asPromised().then(unexpectedSuccess, (error) => {
-      assert.equal(error.message, msg);
+      assert.equal(error.message, message);
     });
   });
 });

--- a/tests/client/core/test_utils.js
+++ b/tests/client/core/test_utils.js
@@ -555,8 +555,8 @@ describe('safeAsyncConnect', () => {
 
     assert.ok(asyncConnect.called, 'asyncConnect() was not called');
 
-    const config = asyncConnect.firstCall.args[0][0];
-    return config.promise().then(unexpectedSuccess, (error) => {
+    const aConfig = asyncConnect.firstCall.args[0][0];
+    return aConfig.promise().then(unexpectedSuccess, (error) => {
       assert.equal(error.message, 'error in callback');
     });
   });
@@ -580,8 +580,8 @@ describe('safeAsyncConnect', () => {
 
     assert.ok(asyncConnect.called, 'asyncConnect() was not called');
 
-    const config = asyncConnect.firstCall.args[0][0];
-    assert.strictEqual(config.deferred, true);
+    const aConfig = asyncConnect.firstCall.args[0][0];
+    assert.strictEqual(aConfig.deferred, true);
   });
 
   it('passes through other params', () => {
@@ -597,8 +597,8 @@ describe('safeAsyncConnect', () => {
 
     assert.ok(asyncConnect.called, 'asyncConnect() was not called');
 
-    const config = asyncConnect.firstCall.args[0][0];
-    assert.equal(config.key, 'SomeKey');
+    const aConfig = asyncConnect.firstCall.args[0][0];
+    assert.equal(aConfig.key, 'SomeKey');
   });
 
   it('passes through all configs', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/1880

This makes sure that any `promise` callback passed to `asyncConnect` never throws an error. As for the bug in question, the request will now render a 500 page. This fix should also prevent any other page from circumventing our 500 handler in the same way.