### PR TITLE
Revert "Update react-redux to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "react-nested-status": "0.1.2",
     "react-onclickoutside": "5.9.0",
     "react-photoswipe": "1.2.0",
-    "react-redux": "5.0.3",
+    "react-redux": "4.4.6",
     "react-router": "2.8.1",
     "react-router-scroll": "0.4.1",
     "redux": "3.6.0",


### PR DESCRIPTION
Reverts mozilla/addons-frontend#1887

This caused a regression making buttons disabled everywhere. We should definitely look at changelogs for major version bumps in future since that indicates there might be breaking changes.

Also seems odd there's nothing testswise that caught this but that's probably due to the degree to which things get mocked.