### PR TITLE
fix: add locale URL exception (fix #1867)

### DIFF
--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -25,9 +25,34 @@ module.exports = {
   },
   enableTrailingSlashesMiddleware: true,
   fxaConfig: 'amo',
+
+  // This needs to be kept in sync with addons-server's SUPPORTED_NONLOCALES
+  // settings value: https://github.com/mozilla/addons-server/blob/master/src/olympia/lib/settings_base.py#L274
+  // These are URLs that are ignored by our prefix middleware that will add
+  // a locale (e.g. `en-US`) to any URL that doesn't have a valid locale.
+  // These are all URLs that should not get a locale prepended to the URL,
+  // because they are locale-independant, like `/firefox/downloads/`.
+  validLocaleUrlExceptions: [
+    'contribute.json',
+    'google1f3e37b7351799a5.html',
+    'robots.txt',
+    'services',
+    'downloads',
+    // This isn't in addons-server, but instead will cause a redirect to another
+    // host.
+    'blocklist',
+    'static',
+    'user-media',
+    '__version__',
+  ],
+
   // This needs to be kept in sync with addons-server's SUPPORTED_NONAPPS
   // settings value: https://github.com/mozilla/addons-server/blob/master/src/olympia/lib/settings_base.py#L262
-  validUrlExceptions: [
+  // These are URLs that are ignored by our prefix middleware that will add
+  // a clientApp (e.g. `android`) to any URL that doesn't have a valid
+  // clientApp. These are all URLs that don't require a clientApp in them
+  // because they are app-independant, like `/en-US/developers/`.
+  validClientAppUrlExceptions: [
     'about',
     'admin',
     'apps',

--- a/config/default.js
+++ b/config/default.js
@@ -86,6 +86,8 @@ module.exports = {
     'trackingId',
     'trackingSendInitPageView',
     'validClientApplications',
+    'validLocaleUrlExceptions',
+    'validClientAppUrlExceptions',
   ],
 
   // Content Security Policy.
@@ -216,7 +218,8 @@ module.exports = {
     'firefox',
   ],
 
-  validUrlExceptions: [],
+  validLocaleUrlExceptions: [],
+  validClientAppUrlExceptions: [],
 
   // The default app used in the URL.
   defaultClientApp: 'firefox',

--- a/src/core/middleware.js
+++ b/src/core/middleware.js
@@ -3,7 +3,8 @@ import config from 'config';
 import {
   getClientApp,
   isValidClientApp,
-  isValidUrlException,
+  isValidLocaleUrlException,
+  isValidClientAppUrlException,
 } from 'core/utils';
 import { getLanguage, isValidLang } from 'core/i18n/utils';
 import log from 'core/logger';
@@ -21,16 +22,34 @@ export function prefixMiddleWare(req, res, next, { _config = config } = {}) {
   // Get language from URL or fall-back to detecting it from accept-language header.
   const acceptLanguage = req.headers['accept-language'];
   const { lang, isLangFromHeader } = getLanguage({ lang: langFromURL, acceptLanguage });
+  // Get the application from the UA if one wasn't specified in the URL (or
+  // if it turns out to be invalid).
+  const application = getClientApp(req.headers['user-agent']);
 
   const hasValidLang = isValidLang(langFromURL);
+  const hasValidLocaleException = isValidLocaleUrlException(appFromURL, { _config });
   const hasValidClientApp = isValidClientApp(appFromURL, { _config });
-  let hasValidUrlException = isValidUrlException(appFromURL, { _config });
+  let hasValidClientAppUrlException = isValidClientAppUrlException(
+    appFromURL, { _config });
 
-  let prependedLang = false;
+  let isApplicationFromHeader = false;
+  let prependedOrMovedApplication = false;
 
-  if (
+  if (hasValidLocaleException) {
+    log.info(dedent`Second part of URL is a locale exception (${URLParts[1]});
+      make sure the clientApp is valid`);
+
+    // Normally we look for a clientApp in the second part of a URL, but URLs
+    // that match a locale exception don't have a locale so we look for the
+    // clientApp in the first part of the URL.
+    if (!isValidClientApp(langFromURL, { _config })) {
+      URLParts[0] = application;
+      isApplicationFromHeader = true;
+      prependedOrMovedApplication = true;
+    }
+  } else if (
     (hasValidLang && langFromURL !== lang) || hasValidClientApp ||
-    hasValidUrlException
+    hasValidClientAppUrlException
   ) {
     // Replace the first part of the URL if:
     // * It's valid and we've mapped it e.g: pt -> pt-PT.
@@ -38,25 +57,30 @@ export function prefixMiddleWare(req, res, next, { _config = config } = {}) {
     //   e.g. /bogus/firefox/.
     log.info(`Replacing lang in URL ${URLParts[0]} -> ${lang}`);
     URLParts[0] = lang;
+  } else if (isValidLocaleUrlException(URLParts[0], { _config })) {
+    log.info(`Prepending clientApp to URL: ${application}`);
+    URLParts.splice(0, 0, application);
+    isApplicationFromHeader = true;
+    prependedOrMovedApplication = true;
   } else if (!hasValidLang) {
     // If lang wasn't valid or was missing prepend one.
     log.info(`Prepending lang to URL: ${lang}`);
     URLParts.splice(0, 0, lang);
-    prependedLang = true;
     // If we've prepended the lang to the URL we need to re-check our
     // URL exception and make sure it's valid.
-    hasValidUrlException = isValidUrlException(URLParts[1], { _config });
+    hasValidClientAppUrlException = isValidClientAppUrlException(
+      URLParts[1], { _config });
   }
 
-  let isApplicationFromHeader = false;
-
-  if (!hasValidClientApp && prependedLang &&
-      isValidClientApp(URLParts[1], { _config })) {
+  if (!hasValidClientApp && isValidClientApp(URLParts[1], { _config })) {
     // We skip prepending an app if we'd previously prepended a lang and the
     // 2nd part of the URL is now a valid app.
     log.info('Application in URL is valid following prepending a lang.');
-  } else if (hasValidUrlException) {
-    if (hasValidLang) {
+  } else if (prependedOrMovedApplication) {
+    log.info(
+      'URL is valid because we added/changed the first part to a clientApp.');
+  } else if (hasValidLocaleException || hasValidClientAppUrlException) {
+    if (hasValidLang || hasValidLocaleException) {
       log.info('Exception in URL found; we fallback to addons-server.');
 
       res.status(404).end(dedent`This page does not exist in addons-frontend.
@@ -68,7 +92,6 @@ export function prefixMiddleWare(req, res, next, { _config = config } = {}) {
     log.info('Exception in URL found; prepending lang to URL.');
   } else if (!hasValidClientApp) {
     // If the app supplied is not valid we need to prepend one.
-    const application = getClientApp(req.headers['user-agent']);
     log.info(`Prepending application to URL: ${application}`);
     URLParts.splice(1, 0, application);
     isApplicationFromHeader = true;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -216,8 +216,12 @@ export function getErrorComponent(status) {
   }
 }
 
-export function isValidUrlException(value, { _config = config } = {}) {
-  return _config.get('validUrlExceptions').includes(value);
+export function isValidLocaleUrlException(value, { _config = config } = {}) {
+  return _config.get('validLocaleUrlExceptions').includes(value);
+}
+
+export function isValidClientAppUrlException(value, { _config = config } = {}) {
+  return _config.get('validClientAppUrlExceptions').includes(value);
 }
 
 /*


### PR DESCRIPTION
fix #1867
fix #1991

Sorry, more `middleware.js` URL handling. This patch allows root URLs like `/downloads/*` or `/contribute.json` to be served properly without infinite redirects.