### PR TITLE
Button for trying on themes

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -10,7 +10,7 @@ import Link from 'amo/components/Link';
 import 'amo/css/AddonDetail.scss';
 import fallbackIcon from 'amo/img/icons/default-64.png';
 import InstallButton from 'core/components/InstallButton';
-import { ADDON_TYPE_THEME } from 'core/constants';
+import { ADDON_TYPE_THEME, ENABLED } from 'core/constants';
 import { withInstallHelpers } from 'core/installAddon';
 import { isAllowedOrigin, ngettext, nl2br, sanitizeHTML } from 'core/utils';
 import translate from 'core/i18n/translate';
@@ -83,7 +83,7 @@ export class AddonDetailBase extends React.Component {
           ref={(el) => { this.wrapper = el; }}
           onClick={this.onClick}
         >
-          {status !== 'ENABLED' ?
+          {status !== ENABLED ?
             <button className="Button AddonDetail-theme-header-label" htmlFor="AddonDetail-theme-header">
               <Icon name="eye" className="AddonDetail-theme-preview-icon" />
               {label}

--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -41,69 +41,53 @@ export class AddonDetailBase extends React.Component {
     addon: PropTypes.object.isRequired,
     getBrowserThemeData: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
+    isPreviewingTheme: PropTypes.bool.isRequired,
     location: PropTypes.object.isRequired,
-    previewTheme: PropTypes.func.isRequired,
-    resetPreviewTheme: PropTypes.func.isRequired,
+    resetThemePreview: PropTypes.func.isRequired,
+    themePreviewNode: PropTypes.element,
+    status: PropTypes.string.isRequired,
+    toggleThemePreview: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
     RatingManager: DefaultRatingManager,
   }
 
-  constructor(props) {
-    super(props);
-    this.state = { mounted: false };
+  componentWillUnmount() {
+    const { isPreviewingTheme, resetThemePreview, themePreviewNode } = this.props;
+    if (isPreviewingTheme && themePreviewNode) {
+      resetThemePreview(themePreviewNode);
+    }
   }
 
-  componentDidMount() {
-    // Disabling react/no-did-mount-set-state because it is to prevent additional renders, but
-    // that's exactly what we want in this case. We want to render an img tag on the server since
-    // we can't use inline styles there, but use an inline background-image in JS to prevent the
-    // context menu you get from long pressing on an image.
-    // eslint-disable-next-line react/no-did-mount-set-state
-    this.setState({ mounted: true });
-  }
-
-  onTouchStart = (event) => {
-    this.props.previewTheme(event.currentTarget);
-  }
-
-  onTouchEnd = (event) => {
-    this.props.resetPreviewTheme(event.currentTarget);
+  onClick = (event) => {
+    this.props.toggleThemePreview(event.currentTarget);
   }
 
   headerImage() {
-    const { addon, getBrowserThemeData, i18n } = this.props;
+    const { addon, getBrowserThemeData, i18n, isPreviewingTheme, status } = this.props;
     const { previewURL, type } = addon;
-    const { mounted } = this.state;
     const iconUrl = isAllowedOrigin(addon.icon_url) ? addon.icon_url :
       fallbackIcon;
 
     if (type === ADDON_TYPE_THEME) {
-      const label = i18n.gettext('Press to preview');
+      const label = isPreviewingTheme ? i18n.gettext('Cancel preview') : i18n.gettext('Tap to preview');
       const imageClassName = 'AddonDetail-theme-header-image';
-      let headerImage;
-
-      if (mounted) {
-        const style = { backgroundImage: `url(${previewURL})` };
-        headerImage = <div style={style} className={imageClassName} />;
-      } else {
-        headerImage = <img alt={label} className={imageClassName} src={previewURL} />;
-      }
+      const headerImage = <img alt={label} className={imageClassName} src={previewURL} />;
 
       return (
         <div
           className="AddonDetail-theme-header"
           id="AddonDetail-theme-header"
           data-browsertheme={getBrowserThemeData()}
-          onTouchStart={this.onTouchStart}
-          onTouchEnd={this.onTouchEnd}
           ref={(el) => { this.wrapper = el; }}
+          onClick={this.onClick}
         >
-          <label className="AddonDetail-theme-header-label" htmlFor="AddonDetail-theme-header">
-            <Icon name="eye" className="AddonDetail-theme-preview-icon" />
-            {label}
-          </label>
+          {status !== 'ENABLED' ?
+            <button className="Button AddonDetail-theme-header-label" htmlFor="AddonDetail-theme-header">
+              <Icon name="eye" className="AddonDetail-theme-preview-icon" />
+              {label}
+            </button> : null}
           {headerImage}
         </div>
       );

--- a/src/amo/css/AddonDetail.scss
+++ b/src/amo/css/AddonDetail.scss
@@ -69,21 +69,12 @@ $page-margin: 20px 10px;
 }
 
 .AddonDetail-theme-header-image {
-  background-position: top right;
-  background-clip: content-box;
-  background-repeat: no-repeat;
-  background-size: cover;
   border-radius: 12px;
-  height: 100px;
   object-fit: cover;
   object-position: top right;
-  user-select: none;
+  height: 100px;
+  display: block;
   width: 100%;
-
-  [dir=rtl] & {
-    background-position: top left;
-    object-position: top left;
-  }
 }
 
 .AddonDetail-theme-header-label {
@@ -91,7 +82,6 @@ $page-margin: 20px 10px;
 
   @include start($label-margin);
 
-  background: rgba(255, 255, 255, 0.5);
   border-radius: 8px;
   bottom: $label-margin;
   color: #fff;

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -140,6 +140,8 @@ export const acceptedInstallTypes = [
   INSTALL_COMPLETE,
   UNINSTALL_COMPLETE,
   INSTALL_ERROR,
+  THEME_PREVIEW,
+  THEME_RESET_PREVIEW,
 ];
 
 // Tracking categories.

--- a/src/core/css/SearchResult.scss
+++ b/src/core/css/SearchResult.scss
@@ -104,10 +104,6 @@
     object-fit: cover;
     object-position: top right;
     width: 100%;
-
-    [dir=rtl] & {
-      object-position: top left;
-    }
   }
 }
 

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -72,15 +72,32 @@ export function makeProgressHandler(dispatch, guid) {
 }
 
 export function mapStateToProps(state, ownProps) {
+  const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+  const addon = state.installations[guid] || {};
+
   return {
+    isPreviewingTheme: addon.isPreviewingTheme,
+    themePreviewNode: addon.isPreviewingTheme ? addon.themePreviewNode : null,
     getBrowserThemeData() {
       return JSON.stringify(getThemeData(ownProps));
     },
-    previewTheme(node, _themeAction = themeAction) {
-      _themeAction(node, THEME_PREVIEW);
-    },
-    resetPreviewTheme(node, _themeAction = themeAction) {
-      _themeAction(node, THEME_RESET_PREVIEW);
+    toggleThemePreview(node, _themeAction = themeAction, _log = log) {
+      const theme = addon && addon.guid ? addon : null;
+      if (theme && theme.status !== ENABLED) {
+        if (!theme.isPreviewingTheme) {
+          _log.info('Previewing theme');
+          this.previewTheme(node, _themeAction);
+        } else {
+          _log.info('Resetting theme preview');
+          this.resetThemePreview(node, _themeAction);
+        }
+      }
+      if (!theme) {
+        _log.info(`Theme ${guid} could not be found`);
+      }
+      if (theme && theme.status === ENABLED) {
+        _log.info(`Theme ${guid} is already enabled! Previewing is not necessary.`);
+      }
     },
   };
 }
@@ -118,6 +135,27 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
 
     return {
       WrappedComponent,
+      previewTheme(node, _themeAction = themeAction) {
+        const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+        _themeAction(node, THEME_PREVIEW);
+        dispatch({
+          type: THEME_PREVIEW,
+          payload: {
+            guid,
+            themePreviewNode: node,
+          },
+        });
+      },
+      resetThemePreview(node, _themeAction = themeAction) {
+        const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+        _themeAction(node, THEME_RESET_PREVIEW);
+        dispatch({
+          type: THEME_RESET_PREVIEW,
+          payload: {
+            guid,
+          },
+        });
+      },
       setCurrentStatus() {
         const { installURL } = ownProps;
         const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -71,8 +71,14 @@ export function makeProgressHandler(dispatch, guid) {
   };
 }
 
+export function getGuid(ownProps) {
+  // Returns guid directly on ownProps or if ownProps
+  // has an addons object return the guid from there.
+  return ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+}
+
 export function mapStateToProps(state, ownProps) {
-  const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+  const guid = getGuid(ownProps);
   const addon = state.installations[guid] || {};
 
   return {
@@ -85,10 +91,10 @@ export function mapStateToProps(state, ownProps) {
       const theme = addon && addon.guid ? addon : null;
       if (theme && theme.status !== ENABLED) {
         if (!theme.isPreviewingTheme) {
-          _log.info('Previewing theme');
+          _log.info(`Previewing theme: ${guid}`);
           this.previewTheme(node, _themeAction);
         } else {
-          _log.info('Resetting theme preview');
+          _log.info(`Resetting theme preview: ${guid}`);
           this.resetThemePreview(node, _themeAction);
         }
       }
@@ -136,7 +142,7 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
     return {
       WrappedComponent,
       previewTheme(node, _themeAction = themeAction) {
-        const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+        const guid = getGuid(ownProps);
         _themeAction(node, THEME_PREVIEW);
         dispatch({
           type: THEME_PREVIEW,
@@ -147,7 +153,7 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
         });
       },
       resetThemePreview(node, _themeAction = themeAction) {
-        const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+        const guid = getGuid(ownProps);
         _themeAction(node, THEME_RESET_PREVIEW);
         dispatch({
           type: THEME_RESET_PREVIEW,
@@ -158,7 +164,7 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
       },
       setCurrentStatus() {
         const { installURL } = ownProps;
-        const guid = ownProps.guid || (ownProps.addon && ownProps.addon.guid);
+        const guid = getGuid(ownProps);
         const payload = { guid, url: installURL };
         return _addonManager.getAddon(guid)
           .then((addon) => {

--- a/src/core/reducers/installations.js
+++ b/src/core/reducers/installations.js
@@ -7,6 +7,8 @@ import {
   INSTALL_ERROR,
   INSTALL_STATE,
   START_DOWNLOAD,
+  THEME_PREVIEW,
+  THEME_RESET_PREVIEW,
   UNINSTALLED,
   UNINSTALL_COMPLETE,
   acceptedInstallTypes,
@@ -21,6 +23,7 @@ export default function installations(state = {}, { type, payload }) {
   if (state[payload.guid]) {
     addon = { ...state[payload.guid] };
   }
+
   if (type === INSTALL_STATE) {
     addon = {
       guid: payload.guid,
@@ -43,7 +46,13 @@ export default function installations(state = {}, { type, payload }) {
     addon.downloadProgress = 0;
     addon.status = ERROR;
     addon.error = payload.error;
+  } else if (type === THEME_PREVIEW) {
+    addon.isPreviewingTheme = true;
+    addon.themePreviewNode = payload.themePreviewNode;
+  } else if (type === THEME_RESET_PREVIEW) {
+    addon.isPreviewingTheme = false;
   }
+
   return {
     ...state,
     [payload.guid]: addon,

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -45,7 +45,7 @@ export class AddonBase extends React.Component {
     previewTheme: PropTypes.func.isRequired,
     previewURL: PropTypes.string,
     name: PropTypes.string.isRequired,
-    resetPreviewTheme: PropTypes.func.isRequired,
+    resetThemePreview: PropTypes.func.isRequired,
     setCurrentStatus: PropTypes.func.isRequired,
     status: PropTypes.oneOf(validInstallStates).isRequired,
     type: PropTypes.oneOf(validAddonTypes).isRequired,
@@ -90,10 +90,10 @@ export class AddonBase extends React.Component {
       return (
         <HoverIntent
           onHoverIntent={this.previewTheme}
-          onHoverIntentEnd={this.resetPreviewTheme}>
+          onHoverIntentEnd={this.resetThemePreview}>
           <a href="#" className="theme-image"
             data-browsertheme={getBrowserThemeData()}
-            onBlur={this.resetPreviewTheme}
+            onBlur={this.resetThemePreview}
             onClick={this.installTheme}
             onFocus={this.previewTheme}>
             <img src={previewURL}
@@ -175,8 +175,8 @@ export class AddonBase extends React.Component {
     this.props.previewTheme(e.currentTarget);
   }
 
-  resetPreviewTheme = (e) => {
-    this.props.resetPreviewTheme(e.currentTarget);
+  resetThemePreview = (e) => {
+    this.props.resetThemePreview(e.currentTarget);
   }
 
   render() {

--- a/tests/client/amo/components/TestAddonDetail.js
+++ b/tests/client/amo/components/TestAddonDetail.js
@@ -267,7 +267,7 @@ describe('AddonDetail', () => {
     assert.include(src, 'image/png');
   });
 
-  it('renders a theme preview as an img before mounting', () => {
+  it('renders a theme preview as an img', () => {
     const root = render({
       addon: {
         ...fakeAddon,
@@ -277,42 +277,28 @@ describe('AddonDetail', () => {
       getBrowserThemeData: () => '{}',
     });
     const rootNode = findDOMNode(root);
-    root.setState({ mounted: false });
-
     const image = rootNode.querySelector('.AddonDetail-theme-header-image');
     assert.equal(image.tagName, 'IMG');
     assert.ok(image.classList.contains('AddonDetail-theme-header-image'));
     assert.equal(image.src, 'https://amo/preview.png');
-    assert.equal(image.alt, 'Press to preview');
+    assert.equal(image.alt, 'Tap to preview');
   });
 
-  it('sets mounted in the state in componentDidMount', () => {
+  it('unsets the theme preview on component unmount', () => {
+    const resetThemePreview = sinon.spy();
     const root = render({
       addon: {
         ...fakeAddon,
         type: ADDON_TYPE_THEME,
         previewURL: 'https://amo/preview.png',
+        isPreviewingTheme: true,
+        themePreviewNode: 'theme-preview-node',
+        resetThemePreview,
       },
       getBrowserThemeData: () => '{}',
     });
-    root.setState({ mounted: false });
-
-    root.componentDidMount();
-
-    assert.equal(root.state.mounted, true);
-  });
-
-  it('renders a theme preview as a background image when mounted', () => {
-    const rootNode = renderAsDOMNode({
-      addon: {
-        ...fakeAddon,
-        type: ADDON_TYPE_THEME,
-        previewURL: 'https://amo/preview.png',
-      },
-      getBrowserThemeData: () => '{}',
-    });
-    const image = rootNode.querySelector('.AddonDetail-theme-header-image');
-    assert.equal(image.style.backgroundImage, 'url("https://amo/preview.png")');
+    root.componentWillUnmount();
+    assert.ok(resetThemePreview.calledWith('theme-preview-node'));
   });
 
   it('sets the browsertheme data on the header', () => {
@@ -328,34 +314,19 @@ describe('AddonDetail', () => {
     assert.equal(header.dataset.browsertheme, '{"the":"themedata"}');
   });
 
-  it('previews a theme on touchstart', () => {
-    const previewTheme = sinon.spy();
+  it('toggles a theme on click', () => {
+    const toggleThemePreview = sinon.spy();
     const rootNode = renderAsDOMNode({
       addon: {
         ...fakeAddon,
         type: ADDON_TYPE_THEME,
       },
       getBrowserThemeData: () => '{}',
-      previewTheme,
+      toggleThemePreview,
     });
     const header = rootNode.querySelector('.AddonDetail-theme-header');
-    Simulate.touchStart(header);
-    assert.ok(previewTheme.calledWith(header));
-  });
-
-  it('resets a theme preview on touchend', () => {
-    const resetPreviewTheme = sinon.spy();
-    const rootNode = renderAsDOMNode({
-      addon: {
-        ...fakeAddon,
-        type: ADDON_TYPE_THEME,
-      },
-      getBrowserThemeData: () => '{}',
-      resetPreviewTheme,
-    });
-    const header = rootNode.querySelector('.AddonDetail-theme-header');
-    Simulate.touchEnd(header);
-    assert.ok(resetPreviewTheme.calledWith(header));
+    Simulate.click(header);
+    assert.ok(toggleThemePreview.calledWith(header));
   });
 
   it('renders an AddonMoreInfo component when there is an add-on', () => {

--- a/tests/client/core/TestInstallAddon.js
+++ b/tests/client/core/TestInstallAddon.js
@@ -87,8 +87,8 @@ describe('withInstallHelpers inner functions', () => {
   const WrappedComponent = sinon.stub();
   let mapDispatchToProps;
 
-  function getMapStateToProps({ _tracking } = {}) {
-    return mapStateToProps({ installations: {}, addons: {} }, {}, { _tracking });
+  function getMapStateToProps({ _tracking, installations = {}, state = {} } = {}) {
+    return mapStateToProps({ installations, addons: {} }, state, { _tracking });
   }
 
   before(() => {
@@ -625,6 +625,47 @@ describe('withInstallHelpers inner functions', () => {
         makeMapDispatchToProps({})(sinon.spy(), { type: ADDON_TYPE_THEME });
       });
     });
+
+    describe('previewTheme', () => {
+      it('calls theme action with THEME_PREVIEW', () => {
+        const dispatchSpy = sinon.spy();
+        const { previewTheme } = makeMapDispatchToProps({})(dispatchSpy, {
+          type: ADDON_TYPE_THEME,
+          guid: 'fake-guid@whatever',
+        });
+        const themeAction = sinon.spy();
+        const node = sinon.stub();
+        previewTheme(node, themeAction);
+        assert.ok(themeAction.calledWith(node, THEME_PREVIEW));
+        assert.ok(dispatchSpy.calledWith({
+          type: THEME_PREVIEW,
+          payload: {
+            guid: 'fake-guid@whatever',
+            themePreviewNode: node,
+          },
+        }));
+      });
+    });
+
+    describe('resetThemePreview', () => {
+      it('calls theme action with THEME_RESET_PREVIEW', () => {
+        const dispatchSpy = sinon.spy();
+        const { resetThemePreview } = makeMapDispatchToProps({})(dispatchSpy, {
+          type: ADDON_TYPE_THEME,
+          guid: 'fake-guid@whatever',
+        });
+        const themeAction = sinon.spy();
+        const node = sinon.stub();
+        resetThemePreview(node, themeAction);
+        assert.ok(themeAction.calledWith(node, THEME_RESET_PREVIEW));
+        assert.ok(dispatchSpy.calledWith({
+          type: THEME_RESET_PREVIEW,
+          payload: {
+            guid: 'fake-guid@whatever',
+          },
+        }));
+      });
+    });
   });
 
   describe('installTheme', () => {
@@ -691,23 +732,95 @@ describe('withInstallHelpers inner functions', () => {
     });
   });
 
-  describe('previewTheme', () => {
-    it('calls theme action with THEME_PREVIEW', () => {
-      const { previewTheme } = getMapStateToProps();
+  describe('toggleThemePreview', () => {
+    it('calls previewTheme if theme is not enabled', () => {
+      const fakeLog = {
+        info: sinon.spy(),
+      };
       const themeAction = sinon.spy();
-      const node = sinon.stub();
-      previewTheme(node, themeAction);
-      assert.ok(themeAction.calledWith(node, THEME_PREVIEW));
+      const node = 'fake-node';
+      const guid = 'foo@bar.com';
+      const props = mapStateToProps({
+        installations: {
+          [guid]: {
+            status: UNINSTALLED,
+            guid,
+          },
+        },
+      }, {
+        guid,
+      });
+      props.previewTheme = sinon.spy();
+      props.toggleThemePreview(node, themeAction, fakeLog);
+      assert.ok(props.previewTheme.calledWith(node, themeAction));
     });
-  });
 
-  describe('resetPreviewTheme', () => {
-    it('calls theme action with THEME_RESET_PREVIEW', () => {
-      const { resetPreviewTheme } = getMapStateToProps();
+    it('calls previewTheme if theme is not enabled', () => {
+      const fakeLog = {
+        info: sinon.spy(),
+      };
       const themeAction = sinon.spy();
-      const node = sinon.stub();
-      resetPreviewTheme(node, themeAction);
-      assert.ok(themeAction.calledWith(node, THEME_RESET_PREVIEW));
+      const node = 'fake-node';
+      const guid = 'foo@bar.com';
+      const props = mapStateToProps({
+        installations: {
+          [guid]: {
+            status: UNINSTALLED,
+            isPreviewingTheme: true,
+            guid,
+          },
+        },
+      }, {
+        guid,
+      });
+      props.resetThemePreview = sinon.spy();
+      props.toggleThemePreview(node, themeAction, fakeLog);
+      assert.ok(props.resetThemePreview.calledWith(node, themeAction));
+    });
+
+    it('logs if theme is not available', () => {
+      const fakeLog = {
+        info: sinon.spy(),
+      };
+      const themeAction = sinon.spy();
+      const node = 'fake-node';
+      const guid = 'foo@bar.com';
+      const props = mapStateToProps({
+        installations: {
+          [guid]: {
+            status: UNINSTALLED,
+            isPreviewingTheme: true,
+          },
+        },
+      }, {
+        guid,
+      });
+      props.resetThemePreview = sinon.spy();
+      props.toggleThemePreview(node, themeAction, fakeLog);
+      assert.ok(fakeLog.info.calledWith('Theme foo@bar.com could not be found'));
+    });
+
+    it('logs if theme is already enabled', () => {
+      const fakeLog = {
+        info: sinon.spy(),
+      };
+      const themeAction = sinon.spy();
+      const node = 'fake-node';
+      const guid = 'foo@bar.com';
+      const props = mapStateToProps({
+        installations: {
+          [guid]: {
+            status: ENABLED,
+            isPreviewingTheme: true,
+            guid,
+          },
+        },
+      }, {
+        guid,
+      });
+      props.resetThemePreview = sinon.spy();
+      props.toggleThemePreview(node, themeAction, fakeLog);
+      assert.ok(fakeLog.info.calledWith(sinon.match('Theme foo@bar.com is already enabled')));
     });
   });
 });

--- a/tests/client/core/reducers/test_installations.js
+++ b/tests/client/core/reducers/test_installations.js
@@ -10,6 +10,8 @@ import {
   INSTALLED,
   INSTALLING,
   START_DOWNLOAD,
+  THEME_PREVIEW,
+  THEME_RESET_PREVIEW,
   UNINSTALL_COMPLETE,
   UNINSTALLED,
   UNINSTALLING,
@@ -264,6 +266,54 @@ describe('installations reducer', () => {
           downloadProgress: 0,
           status: ERROR,
           error: 'an-error',
+        },
+      });
+  });
+
+  it('sets isPreviewingTheme and themePreviewNode', () => {
+    const state = {
+      'my-addon@me.com': {
+        guid: 'my-addon@me.com',
+        url: 'https://cdn.amo/download/my-addon.xpi',
+      },
+    };
+    assert.deepEqual(
+      installations(state, {
+        type: THEME_PREVIEW,
+        payload: {
+          guid: 'my-addon@me.com',
+          themePreviewNode: 'preview-theme-node',
+        },
+      }),
+      {
+        'my-addon@me.com': {
+          guid: 'my-addon@me.com',
+          url: 'https://cdn.amo/download/my-addon.xpi',
+          themePreviewNode: 'preview-theme-node',
+          isPreviewingTheme: true,
+        },
+      });
+  });
+
+  it('unsets isPreviewingTheme', () => {
+    const state = {
+      'my-addon@me.com': {
+        guid: 'my-addon@me.com',
+        url: 'https://cdn.amo/download/my-addon.xpi',
+      },
+    };
+    assert.deepEqual(
+      installations(state, {
+        type: THEME_RESET_PREVIEW,
+        payload: {
+          guid: 'my-addon@me.com',
+        },
+      }),
+      {
+        'my-addon@me.com': {
+          guid: 'my-addon@me.com',
+          url: 'https://cdn.amo/download/my-addon.xpi',
+          isPreviewingTheme: false,
         },
       });
   });

--- a/tests/client/disco/components/TestAddon.js
+++ b/tests/client/disco/components/TestAddon.js
@@ -287,16 +287,16 @@ describe('<Addon />', () => {
     let root;
     let themeImage;
     let previewTheme;
-    let resetPreviewTheme;
+    let resetThemePreview;
 
     beforeEach(() => {
       previewTheme = sinon.spy();
-      resetPreviewTheme = sinon.spy();
+      resetThemePreview = sinon.spy();
       const data = {
         ...result,
         type: ADDON_TYPE_THEME,
         previewTheme,
-        resetPreviewTheme,
+        resetThemePreview,
       };
       root = renderAddon({ addon: data, ...data });
       themeImage = findDOMNode(root).querySelector('.theme-image');
@@ -311,7 +311,7 @@ describe('<Addon />', () => {
     it('resets theme preview onHoverIntentEnd on theme image', () => {
       const hoverIntent = findRenderedComponentWithType(root, HoverIntent);
       hoverIntent.props.onHoverIntentEnd({ currentTarget: themeImage });
-      assert.ok(resetPreviewTheme.calledWith(themeImage));
+      assert.ok(resetThemePreview.calledWith(themeImage));
     });
 
     it('runs theme preview onFocus on theme image', () => {
@@ -321,7 +321,7 @@ describe('<Addon />', () => {
 
     it('resets theme preview onBlur on theme image', () => {
       Simulate.blur(themeImage);
-      assert.ok(resetPreviewTheme.calledWith(themeImage));
+      assert.ok(resetThemePreview.calledWith(themeImage));
     });
 
     it('calls installTheme on click', () => {

--- a/tests/client/init.js
+++ b/tests/client/init.js
@@ -4,6 +4,7 @@ const realSinon = sinon;
 window.sinon = realSinon.sandbox.create();
 window.sinon.createStubInstance = realSinon.createStubInstance;
 window.sinon.format = realSinon.format;
+window.sinon.assert = realSinon.assert;
 
 afterEach(() => {
   window.sinon.restore();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5576,6 +5576,12 @@ rimraf@2, rimraf@2.6.1, rimraf@^2.2.8, rimraf@^2.6.0:
   dependencies:
     glob "^7.0.5"
 
+rimraf@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
+
 rimraf@~2.4.0:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"


### PR DESCRIPTION
Fixes #1657
Fixes #1677
Fixes #1776
Fixes #1777 
Fixes #1879 

- Themes now previewed on a click. 
- Click again to turn off the theme preview. 
- Preview button goes if the theme is seen as installed + enabled
- Preview goes away when you navigate away (on component unmount)
- Previewing now dispatches in order to provide toggling based on state.

![screen shot 2017-02-27 at 20 59 18](https://cloud.githubusercontent.com/assets/1514/23379645/a3791bee-fd2f-11e6-97aa-24b1ce630ee3.png)
