### PR TITLE
Freeze all tox deps for no suprise upgrades

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,21 @@ envlist = discopane-ui-tests, flake8
 [testenv:discopane-ui-tests]
 passenv = DISPLAY PYTEST_ADDOPTS
 deps =
+  appdirs==1.4.1
+  packaging==16.8
   PyPOM==1.0
+  py==1.4.32
+  pyparsing==2.1.10
   pytest==2.9.2
+  pytest_base_url==1.2.0
+  pytest_html==1.13.0
   pytest-selenium==1.3.1
+  pytest_variables==1.4
+  requests==2.13.0
   selenium==3.0.0b2
+  six==1.10.0
+  wheel==0.29.0
+install_command = pip install --no-deps {opts} {packages}
 commands = py.test tests/ui/test_discopane.py {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
This downgrades some sub-deps and freezes all deps to work around https://github.com/mozilla/addons-frontend/issues/1927