### PR TITLE
fix: Correct search sort icons in RTL (fix #1918)

### DIFF
--- a/src/amo/components/SearchSort/SearchSort.scss
+++ b/src/amo/components/SearchSort/SearchSort.scss
@@ -1,14 +1,6 @@
 @import '~core/css/inc/mixins';
 @import '~core/css/inc/vars';
 
-@mixin arrow-link-right-aligned() {
-  background-image: url('~amo/img/icons/arrow-link-color.svg');
-  margin-right: 0;
-  position: absolute;
-  right: 8px;
-  top: 14px;
-}
-
 .SearchSort {
   background: $base-color;
   border-radius: $border-radius-default;
@@ -45,6 +37,11 @@
     position: relative;
     top: 4px;
     width: 16px;
+
+    [dir=rtl] & {
+      left: auto;
+      right: -8px;
+    }
   }
 
   &::after {

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -97,6 +97,10 @@ $default-arrow-margin: 3px;
   @include arrow($margin);
 
   transform: rotate(90deg);
+
+  [dir=rtl] & {
+    transform: rotate(270deg);
+  }
 }
 
 // This alias to arrow (which is the same as arrow-next) makes it easier to
@@ -128,6 +132,23 @@ $default-arrow-margin: 3px;
   @include arrow($margin);
 
   transform: rotate(270deg);
+
+  [dir=rtl] & {
+    transform: rotate(90deg);
+  }
+}
+
+@mixin arrow-link-right-aligned() {
+  background-image: url('~amo/img/icons/arrow-link-color.svg');
+  margin-right: 0;
+  position: absolute;
+  right: 8px;
+  top: 14px;
+
+  [dir=rtl] & {
+    left: 8px;
+    right: auto;
+  }
 }
 
 /* Button */


### PR DESCRIPTION
Fixes #1918 

### Postfix screenshots:

![screen shot 2017-02-27 at 22 40 42](https://cloud.githubusercontent.com/assets/90871/23383534/cd818e26-fd3e-11e6-8712-01496c169301.png)
![screen shot 2017-02-27 at 22 40 39](https://cloud.githubusercontent.com/assets/90871/23383533/cd7c099c-fd3e-11e6-9f92-6d0ad07f3c02.png)
