### PR TITLE
Fix set timeout breakage

### DIFF
--- a/src/core/containers/SimulateError.js
+++ b/src/core/containers/SimulateError.js
@@ -1,9 +1,9 @@
 import log from 'core/logger';
 
 // This HOC can be connected to a route to test internal error handling.
-export default ({ _setTimeout = setTimeout } = {}) => {
+export default () => {
   log.info('Simulating an error');
-  _setTimeout(() => {
+  setTimeout(() => {
     throw new Error('This is a simulated error in the event loop');
   }, 50);
   throw new Error('This is a simulated error in Component.render()');

--- a/src/core/containers/SimulateError.js
+++ b/src/core/containers/SimulateError.js
@@ -1,9 +1,9 @@
 import log from 'core/logger';
 
 // This HOC can be connected to a route to test internal error handling.
-export default () => {
+export default ({ _setTimeout = setTimeout } = {}) => {
   log.info('Simulating an error');
-  setTimeout(() => {
+  _setTimeout(() => {
     throw new Error('This is a simulated error in the event loop');
   }, 50);
   throw new Error('This is a simulated error in Component.render()');

--- a/tests/client/core/containers/TestSimulateError.js
+++ b/tests/client/core/containers/TestSimulateError.js
@@ -4,9 +4,31 @@ import { renderIntoDocument } from 'react-addons-test-utils';
 import SimulateError from 'core/containers/SimulateError';
 
 describe('SimulateError', () => {
-  it('simulates an error', () => {
-    assert.throws(
-      () => renderIntoDocument(<SimulateError />),
-      /simulated error/);
+  let clock;
+  before(() => {
+    // This is only precautionary in case stubbing out setTimeout fails.
+    clock = sinon.useFakeTimers();
+  });
+
+  after(() => {
+    clock.restore();
+  });
+
+  function render(customProps = {}) {
+    const props = { _setTimeout: sinon.stub(), ...customProps };
+    return renderIntoDocument(<SimulateError {...props} />);
+  }
+
+  it('throws a simulated error', () => {
+    assert.throws(() => render(), /simulated error in Component.render/);
+  });
+
+  it('throws an async error', () => {
+    const fakeSetTimeout = sinon.stub();
+    assert.throws(() => render({ _setTimeout: fakeSetTimeout }));
+
+    assert.ok(fakeSetTimeout.called, 'setTimeout was not called');
+    const callback = fakeSetTimeout.firstCall.args[0];
+    assert.throws(() => callback(), /simulated error in the event loop/);
   });
 });

--- a/tests/client/core/containers/TestSimulateError.js
+++ b/tests/client/core/containers/TestSimulateError.js
@@ -5,30 +5,24 @@ import SimulateError from 'core/containers/SimulateError';
 
 describe('SimulateError', () => {
   let clock;
-  before(() => {
-    // This is only precautionary in case stubbing out setTimeout fails.
+
+  beforeEach(() => {
     clock = sinon.useFakeTimers();
   });
 
-  after(() => {
+  afterEach(() => {
     clock.restore();
   });
 
-  function render(customProps = {}) {
-    const props = { _setTimeout: sinon.stub(), ...customProps };
-    return renderIntoDocument(<SimulateError {...props} />);
-  }
-
   it('throws a simulated error', () => {
-    assert.throws(() => render(), /simulated error in Component.render/);
+    assert.throws(
+      () => renderIntoDocument(<SimulateError />),
+      /simulated error in Component.render/);
   });
 
   it('throws an async error', () => {
-    const fakeSetTimeout = sinon.stub();
-    assert.throws(() => render({ _setTimeout: fakeSetTimeout }));
-
-    assert.ok(fakeSetTimeout.called, 'setTimeout was not called');
-    const callback = fakeSetTimeout.firstCall.args[0];
-    assert.throws(() => callback(), /simulated error in the event loop/);
+    assert.throws(() => renderIntoDocument(<SimulateError />));
+    // Trigger the setTimeout() callback:
+    assert.throws(() => clock.tick(50), /simulated error in the event loop/);
   });
 });

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -65,12 +65,14 @@ describe('AMO GET Requests', () => {
     }));
 
   describe('error simulation', () => {
-    before(function() {
-      this.clock = sinon.useFakeTimers();
+    let clock;
+    before(() => {
+      // Prevent setTimeout() from really throwing an error.
+      clock = sinon.useFakeTimers();
     });
 
-    after(function() {
-      this.clock.restore();
+    after(() => {
+      clock.restore();
     });
 
     it('can simulate a thrown error', () => request(app)

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -66,6 +66,7 @@ describe('AMO GET Requests', () => {
 
   describe('error simulation', () => {
     let clock;
+
     before(() => {
       // Prevent setTimeout() from really throwing an error.
       clock = sinon.useFakeTimers();


### PR DESCRIPTION
whoops, this addresses more fallout from https://github.com/mozilla/addons-frontend/pull/1910 but because the Node shutdown sequence is a little random (or maybe mocha has a bug), the error first showed up in https://travis-ci.org/mozilla/addons-frontend/jobs/205981589