### PR TITLE
Make perPage default for pagination match the API

### DIFF
--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -29,7 +29,7 @@ export class PaginateBase extends React.Component {
 
   static defaultProps = {
     LinkComponent: Link,
-    perPage: 20,
+    perPage: 25, // The default number of results per page returned by the API.
     showPages: 0,
   }
 


### PR DESCRIPTION
Fixes #1946

This is a quick fix for #1946, the reason for the empty pages was we were assuming pages of 20 when the API by default returns 25.

The best way to fix this properly would be to have the API expose the perPage value in the results. That way the pagination would dynamically react to the API response and it would prevent needing to match a request page size with the pagination output configuration.

~I'll file an issue for that separately.~ See https://github.com/mozilla/addons-server/issues/4837 for an API issue to update the response to include the number of results per page in the response.