### PR TITLE
Hack around bug in PhotoSwipe

### DIFF
--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -18,7 +18,9 @@ const PHOTO_SWIPE_OPTIONS = {
   counterEl: true,
   arrowEl: true,
   preloaderEl: true,
-  getThumbBoundsFn: function getThumbBoundsFn(index) {
+  // Overload getThumbsBoundsFn as workaround to
+  // https://github.com/minhtranite/react-photoswipe/issues/23
+  getThumbBoundsFn: /* istanbul ignore next */ function getThumbBoundsFn(index) {
     const thumbnail = document.querySelectorAll('.pswp-thumbnails')[index];
     if (thumbnail && thumbnail.getElementsByTagName) {
       const img = thumbnail.getElementsByTagName('img')[0];

--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -18,6 +18,16 @@ const PHOTO_SWIPE_OPTIONS = {
   counterEl: true,
   arrowEl: true,
   preloaderEl: true,
+  getThumbBoundsFn: function getThumbBoundsFn(index) {
+    const thumbnail = document.querySelectorAll('.pswp-thumbnails')[index];
+    if (thumbnail && thumbnail.getElementsByTagName) {
+      const img = thumbnail.getElementsByTagName('img')[0];
+      const pageYScroll = window.pageYOffset || document.documentElement.scrollTop;
+      const rect = img.getBoundingClientRect();
+      return { x: rect.left, y: rect.top + pageYScroll, w: rect.width };
+    }
+    return false;
+  },
 };
 
 const formatPreviews = (previews) => (


### PR DESCRIPTION
Fixes #1712 

Original function is here: https://github.com/minhtranite/react-photoswipe/blob/05602e52755cc69d1f530a64a65cc5b6b0b225b9/src/PhotoSwipeGallery.js#L36

This is a bit of a hack but it overloads the function used to get thumbnails so that the second time photoswipe is loaded it continues to work.

This will need coverage (or skips to coverage) but if you have a moment it would be spin this up in review and check it solves the problem.