### PR TITLE
Force a 404 on user pages

### DIFF
--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -29,7 +29,8 @@ export default (
     <IndexRoute component={Home} />
     <Route path="addon/:slug/" component={DetailPage} />
     <Route path="addon/:addonSlug/reviews/" component={AddonReviewList} />
-    {/* FIXME: tempoary hack to make the proxy serve from addons-server */}
+    {/* Hack to make the proxy serve this URL from addons-server */}
+    {/* https://github.com/mozilla/addons-frontend/issues/1975 */}
     <Route path="user/:user/" component={NotFound} />
     <Route path=":visibleAddonType/categories/" component={CategoryList} />
     <Route path=":visibleAddonType/featured/" component={FeaturedAddons} />

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -29,6 +29,8 @@ export default (
     <IndexRoute component={Home} />
     <Route path="addon/:slug/" component={DetailPage} />
     <Route path="addon/:addonSlug/reviews/" component={AddonReviewList} />
+    {/* FIXME: tempoary hack to make the proxy serve from addons-server */}
+    <Route path="user/:user/" component={NotFound} />
     <Route path=":visibleAddonType/categories/" component={CategoryList} />
     <Route path=":visibleAddonType/featured/" component={FeaturedAddons} />
     <Route path=":visibleAddonType/:slug/" component={CategoryPage} />

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -62,4 +62,8 @@ describe('AMO GET Requests', () => {
       assert.equal(res.header.location,
         '/en-US/firefox/search/');
     }));
+
+  it('should respond with a 404 to user pages', () => request(app)
+    .get('/en-US/firefox/user/some-user/')
+    .expect(404));
 });


### PR DESCRIPTION
Kinda sorta addresses https://github.com/mozilla/addons-frontend/issues/1975

Dumbest fix ever? I couldn't fully test this locally but doing `curl -I http://localhost:3000/en-US/firefox/user/eXXile/` gave me a 500 before and a 404 after. I think our local proxy script is a little different which is maybe why I couldn't fully reproduce it when clicking on a user link from the details page.