### PR TITLE
Do not use the cache for tox installs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
   zope.component==4.3.0
   zope.event==4.2.0
   zope.interface==4.3.0
-install_command = pip install --no-deps {opts} {packages}
+install_command = pip install --no-cache-dir --no-deps {opts} {packages}
 commands = pytest tests/ui/test_discopane.py {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
This is an attempt to fix an error we were seeing in circle-ci which was blocking automatic deployment to dev. I was able to reproduce the error locally but only once. As you can see from the following traceback, it may have been related to the pip cache. It looks like maybe an older cached version of appdirs caused some confusion somehow.

````
indigo:addons-frontend kumar$ tox -e discopane-ui-tests -- --base-url=http://localhost:3000
discopane-ui-tests create: /Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests
discopane-ui-tests installdeps: appdirs==1.4.2, packaging==16.8, PyPOM==1.1.1, py==1.4.32, pyparsing==2.1.10, pytest==3.0.6, pytest_base_url==1.3.0, pytest_html==1.14.1, pytest-metadata==1.2.0, pytest-selenium==1.9.0, pytest_variables==1.4, requests==2.13.0, selenium==3.0.2, six==1.10.0, zope.component==4.3.0, zope.event==4.2.0, zope.interface==4.3.0
ERROR: invocation failed (exit code 2), logfile: /Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/log/discopane-ui-tests-1.log
ERROR: actionid: discopane-ui-tests
msg: getenv
cmdargs: ['/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/bin/pip', 'install', '--no-deps', 'appdirs==1.4.2', 'packaging==16.8', 'PyPOM==1.1.1', 'py==1.4.32', 'pyparsing==2.1.10', 'pytest==3.0.6', 'pytest_base_url==1.3.0', 'pytest_html==1.14.1', 'pytest-metadata==1.2.0', 'pytest-selenium==1.9.0', 'pytest_variables==1.4', 'requests==2.13.0', 'selenium==3.0.2', 'six==1.10.0', 'zope.component==4.3.0', 'zope.event==4.2.0', 'zope.interface==4.3.0']
env: {'GOPATH': '/Users/kumar/golang', 'NVM_CD_FLAGS': '', 'TERM_PROGRAM_VERSION': '3.0.14', 'TMPDIR': '/var/folders/8g/npvxp6j96sn_07b1f6b3h0qm0000gn/T/', 'LOGNAME': 'kumar', 'NVM_NODEJS_ORG_MIRROR': 'https://nodejs.org/dist', 'NVM_DIR': '/Users/kumar/.nvm', 'HOME': '/Users/kumar', 'PATH': '/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/bin:/Users/kumar/.nvm/versions/node/v6.9.4/bin:/Users/kumar/.nvm/versions/node/v6.9.4/bin:/Users/kumar/src/android-sdk-macosx/tools:/Users/kumar/src/android-sdk-macosx/platform-tools:./node_modules/.bin:/Users/kumar/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/share/python:/Users/kumar/dev/toolbox:/Users/kumar/src/geckodriver-bin:/Users/kumar/golang/bin', 'NVM_IOJS_ORG_MIRROR': 'https://iojs.org/dist', 'TERM_PROGRAM': 'iTerm.app', 'LANG': 'en_US.UTF-8', '__CF_USER_TEXT_ENCODING': '0x1F5:0x0:0x0', 'TERM': 'xterm-256color', 'SHELL': '/bin/bash', 'COLORFGBG': '11;15', 'SHLVL': '1', 'SECURITYSESSIONID': '186a7', 'XPC_FLAGS': '0x0', 'HISTSIZE': '50000', 'NVM_BIN': '/Users/kumar/.nvm/versions/node/v6.9.4/bin', 'ITERM_SESSION_ID': 'w0t0p1:93B11BE1-9F11-48B7-B30C-B2DFCE57C518', 'PYTHONHASHSEED': '974049221', 'EDITOR': 'vim', 'MANPATH': '/Users/kumar/.nvm/versions/node/v6.9.4/share/man:/usr/local/share/man:/usr/share/man:/Library/Developer/CommandLineTools/usr/share/man', 'TERM_SESSION_ID': 'w0t0p1:93B11BE1-9F11-48B7-B30C-B2DFCE57C518', 'SSH_AUTH_SOCK': '/private/tmp/com.apple.launchd.pLp5WNhpkN/Listeners', 'XPC_SERVICE_NAME': '0', 'VIRTUAL_ENV': '/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests', 'Apple_PubSub_Socket_Render': '/private/tmp/com.apple.launchd.0U8d1pgXbA/Render', 'ITERM_PROFILE': 'Default', '_': '/usr/local/bin/tox', 'OLDPWD': '/Users/kumar', 'HISTCONTROL': 'erasedups', 'PWD': '/Users/kumar/dev/addons-frontend', 'OLYMPIA_SITE_URL': 'http://olympia.dev', 'USER': 'kumar'}

Collecting appdirs==1.4.2
  Using cached appdirs-1.4.2-py2.py3-none-any.whl
Requirement already satisfied: packaging==16.8 in ./.tox/discopane-ui-tests/lib/python2.7/site-packages
Collecting PyPOM==1.1.1
  Downloading PyPOM-1.1.1-py2.py3-none-any.whl
Collecting py==1.4.32
  Using cached py-1.4.32-py2.py3-none-any.whl
Collecting pyparsing==2.1.10
  Using cached pyparsing-2.1.10-py2.py3-none-any.whl
Collecting pytest==3.0.6
  Downloading pytest-3.0.6-py2.py3-none-any.whl (172kB)
Collecting pytest_base_url==1.3.0
  Using cached pytest_base_url-1.3.0-py2.py3-none-any.whl
Collecting pytest_html==1.14.1
  Downloading pytest_html-1.14.1-py2.py3-none-any.whl
Collecting pytest-metadata==1.2.0
  Using cached pytest_metadata-1.2.0-py2.py3-none-any.whl
Collecting pytest-selenium==1.9.0
  Downloading pytest_selenium-1.9.0-py2.py3-none-any.whl
Collecting pytest_variables==1.4
  Using cached pytest_variables-1.4-py2-none-any.whl
Collecting requests==2.13.0
  Using cached requests-2.13.0-py2.py3-none-any.whl
Collecting selenium==3.0.2
  Downloading selenium-3.0.2-py2.py3-none-any.whl (915kB)
Requirement already satisfied: six==1.10.0 in ./.tox/discopane-ui-tests/lib/python2.7/site-packages
Collecting zope.component==4.3.0
  Downloading zope.component-4.3.0.tar.gz (85kB)
Collecting zope.event==4.2.0
  Downloading zope.event-4.2.0-py2-none-any.whl
Collecting zope.interface==4.3.0
  Downloading zope.interface-4.3.0-cp27-cp27m-macosx_10_9_x86_64.whl (133kB)
Building wheels for collected packages: zope.component
  Running setup.py bdist_wheel for zope.component: started
  Running setup.py bdist_wheel for zope.component: finished with status 'done'
  Stored in directory: /Users/kumar/Library/Caches/pip/wheels/05/9e/85/645f4e7dff4031a97bd56c59b627688976b0afe32e2a54ece1
Successfully built zope.component
Installing collected packages: appdirs, PyPOM, py, pyparsing, pytest, pytest-base-url, pytest-html, pytest-metadata, pytest-selenium, pytest-variables, requests, selenium, zope.component, zope.event, zope.interface
  Found existing installation: appdirs 1.4.3
    Uninstalling appdirs-1.4.3:
      Successfully uninstalled appdirs-1.4.3
  Rolling back uninstall of appdirs
Exception:
Traceback (most recent call last):
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pip/commands/install.py", line 342, in run
    prefix=options.prefix_path,
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pip/req/req_set.py", line 784, in install
    **kwargs
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pip/req/req_install.py", line 851, in install
    self.move_wheel_files(self.source_dir, root=root, prefix=prefix)
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pip/req/req_install.py", line 1064, in move_wheel_files
    isolated=self.isolated,
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pip/wheel.py", line 247, in move_wheel_files
    prefix=prefix,
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pip/locations.py", line 140, in distutils_scheme
    d = Distribution(dist_args)
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/setuptools/dist.py", line 320, in __init__
    _Distribution.__init__(self, attrs)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 287, in __init__
    self.finalize_options()
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/setuptools/dist.py", line 386, in finalize_options
    ep.require(installer=self.fetch_build_egg)
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2324, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 862, in resolve
    new_requirements = dist.requires(req.extras)[::-1]
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2568, in requires
    dm = self._dep_map
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2815, in _dep_map
    self.__dep_map = self._compute_dependencies()
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2824, in _compute_dependencies
    for req in self._parsed_pkg_info.get_all('Requires-Dist') or []:
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2806, in _parsed_pkg_info
    metadata = self.get_metadata(self.PKG_INFO)
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1468, in get_metadata
    value = self._get(self._fn(self.egg_info, name))
  File "/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1577, in _get
    with open(path, 'rb') as stream:
IOError: [Errno 2] No such file or directory: '/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/lib/python2.7/site-packages/appdirs-1.4.3.dist-info/METADATA'

ERROR: could not install deps [appdirs==1.4.2, packaging==16.8, PyPOM==1.1.1, py==1.4.32, pyparsing==2.1.10, pytest==3.0.6, pytest_base_url==1.3.0, pytest_html==1.14.1, pytest-metadata==1.2.0, pytest-selenium==1.9.0, pytest_variables==1.4, requests==2.13.0, selenium==3.0.2, six==1.10.0, zope.component==4.3.0, zope.event==4.2.0, zope.interface==4.3.0]; v = InvocationError('/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/bin/pip install --no-deps appdirs==1.4.2 packaging==16.8 PyPOM==1.1.1 py==1.4.32 pyparsing==2.1.10 pytest==3.0.6 pytest_base_url==1.3.0 pytest_html==1.14.1 pytest-metadata==1.2.0 pytest-selenium==1.9.0 pytest_variables==1.4 requests==2.13.0 selenium==3.0.2 six==1.10.0 zope.component==4.3.0 zope.event==4.2.0 zope.interface==4.3.0 (see /Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/log/discopane-ui-tests-1.log)', 2)
_____________________________________________________________ summary ______________________________________________________________
ERROR:   discopane-ui-tests: could not install deps [appdirs==1.4.2, packaging==16.8, PyPOM==1.1.1, py==1.4.32, pyparsing==2.1.10, pytest==3.0.6, pytest_base_url==1.3.0, pytest_html==1.14.1, pytest-metadata==1.2.0, pytest-selenium==1.9.0, pytest_variables==1.4, requests==2.13.0, selenium==3.0.2, six==1.10.0, zope.component==4.3.0, zope.event==4.2.0, zope.interface==4.3.0]; v = InvocationError('/Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/bin/pip install --no-deps appdirs==1.4.2 packaging==16.8 PyPOM==1.1.1 py==1.4.32 pyparsing==2.1.10 pytest==3.0.6 pytest_base_url==1.3.0 pytest_html==1.14.1 pytest-metadata==1.2.0 pytest-selenium==1.9.0 pytest_variables==1.4 requests==2.13.0 selenium==3.0.2 six==1.10.0 zope.component==4.3.0 zope.event==4.2.0 zope.interface==4.3.0 (see /Users/kumar/dev/addons-frontend/.tox/discopane-ui-tests/log/discopane-ui-tests-1.log)', 2)
```` 