### PR TITLE
Allow font-src in CSP rules for AMO prod

### DIFF
--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -13,6 +13,7 @@ module.exports = {
         "'self'",
         amoProdCDN,
         'https://www.google-analytics.com/analytics.js',
+        'data:',
       ],
       styleSrc: [amoProdCDN],
       imgSrc: [

--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -1,6 +1,6 @@
 import { amoProdCDN } from './lib/shared';
 
-const staticHost = 'https://addons-amo.cdn.mozilla.net';
+const staticHost = 'https://addons.cdn.mozilla.net';
 
 module.exports = {
   staticHost,

--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -7,6 +7,7 @@ module.exports = {
 
   CSP: {
     directives: {
+      fontSrc: [staticHost],
       formAction: [
         "'self'",
       ],

--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -1,7 +1,9 @@
 import { amoProdCDN } from './lib/shared';
 
+const staticHost = 'https://addons-amo.cdn.mozilla.net';
+
 module.exports = {
-  staticHost: amoProdCDN,
+  staticHost,
 
   CSP: {
     directives: {
@@ -10,16 +12,15 @@ module.exports = {
       ],
       // Script is limited to the amo specific CDN.
       scriptSrc: [
-        "'self'",
-        amoProdCDN,
+        staticHost,
         'https://www.google-analytics.com/analytics.js',
-        'data:',
       ],
-      styleSrc: [amoProdCDN],
+      styleSrc: [staticHost],
       imgSrc: [
         "'self'",
         'data:',
         amoProdCDN,
+        staticHost,
         'https://www.google-analytics.com',
       ],
     },

--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -1,9 +1,7 @@
 import { amoProdCDN } from './lib/shared';
 
-const staticHost = 'https://addons.cdn.mozilla.net';
-
 module.exports = {
-  staticHost,
+  staticHost: amoProdCDN,
 
   CSP: {
     directives: {
@@ -12,15 +10,15 @@ module.exports = {
       ],
       // Script is limited to the amo specific CDN.
       scriptSrc: [
-        staticHost,
+        "'self'",
+        amoProdCDN,
         'https://www.google-analytics.com/analytics.js',
       ],
-      styleSrc: [staticHost],
+      styleSrc: [amoProdCDN],
       imgSrc: [
         "'self'",
         'data:',
         amoProdCDN,
-        staticHost,
         'https://www.google-analytics.com',
       ],
     },


### PR DESCRIPTION
In [testing prod](https://mana.mozilla.org/wiki/display/SVCOPS/AMO+Dev+Resources#AMODevResources-Testingaddons-frontendAMOinProd) I see the following CSP errors (screenshots). This adjusts the config to fix them.
<img width="1165" alt="screenshot 2017-03-08 12 26 25" src="https://cloud.githubusercontent.com/assets/55398/23717697/7eaf72fa-03fa-11e7-8002-c09cccf6e663.png">
