### PR TITLE
Force all /users/ URLs to be served by addons-server

### DIFF
--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -29,7 +29,10 @@ export default (
     <IndexRoute component={Home} />
     <Route path="addon/:slug/" component={DetailPage} />
     <Route path="addon/:addonSlug/reviews/" component={AddonReviewList} />
-    {/* Hack to make the proxy serve this URL from addons-server */}
+    {/* These user routes are to make the proxy serve each URL from */}
+    {/* addons-server until we can fix the :visibleAddonType route below. */}
+    {/* https://github.com/mozilla/addons-frontend/issues/2029 */}
+    <Route path="users/edit/" component={NotFound} />
     {/* https://github.com/mozilla/addons-frontend/issues/1975 */}
     <Route path="user/:user/" component={NotFound} />
     <Route path=":visibleAddonType/categories/" component={CategoryList} />

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -32,7 +32,8 @@ export default (
     {/* These user routes are to make the proxy serve each URL from */}
     {/* addons-server until we can fix the :visibleAddonType route below. */}
     {/* https://github.com/mozilla/addons-frontend/issues/2029 */}
-    <Route path="users/edit/" component={NotFound} />
+    {/* We are mimicing these URLs: https://github.com/mozilla/addons-server/blob/master/src/olympia/users/urls.py#L20 */}
+    <Route path="users/:userAction/" component={NotFound} />
     {/* https://github.com/mozilla/addons-frontend/issues/1975 */}
     <Route path="user/:user/" component={NotFound} />
     <Route path=":visibleAddonType/categories/" component={CategoryList} />

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -66,4 +66,8 @@ describe('AMO GET Requests', () => {
   it('should respond with a 404 to user pages', () => request(app)
     .get('/en-US/firefox/user/some-user/')
     .expect(404));
+
+  it('should respond with a 404 to the user edit page', () => request(app)
+    .get('/en-US/firefox/users/edit/')
+    .expect(404));
 });

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -70,4 +70,20 @@ describe('AMO GET Requests', () => {
   it('should respond with a 404 to the user edit page', () => request(app)
     .get('/en-US/firefox/users/edit/')
     .expect(404));
+
+  it('should respond with a 404 to a specific user edit', () => request(app)
+    .get('/en-US/firefox/users/edit/1234/')
+    .expect(404));
+
+  it('should respond with a 404 to user unsubscribe actions', () => request(app)
+    .get('/en-US/firefox/users/unsubscribe/token/signature/permission/')
+    .expect(404));
+
+  it('should respond with a 404 to deleting a user photo', () => request(app)
+    .get('/en-US/firefox/users/delete_photo/1234/')
+    .expect(404));
+
+  it('should respond with a 404 to any user action', () => request(app)
+    .get('/en-US/firefox/users/login/')
+    .expect(404));
 });


### PR DESCRIPTION
Temporary workaround for https://github.com/mozilla/addons-frontend/issues/2029

The real fix will arrive in https://github.com/mozilla/addons-server/pull/4890