### PR TITLE
Revert "Force all /users/ URLs to be served by addons-server (#2034)"

### DIFF
--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -29,11 +29,7 @@ export default (
     <IndexRoute component={Home} />
     <Route path="addon/:slug/" component={DetailPage} />
     <Route path="addon/:addonSlug/reviews/" component={AddonReviewList} />
-    {/* These user routes are to make the proxy serve each URL from */}
-    {/* addons-server until we can fix the :visibleAddonType route below. */}
-    {/* https://github.com/mozilla/addons-frontend/issues/2029 */}
-    {/* We are mimicing these URLs: https://github.com/mozilla/addons-server/blob/master/src/olympia/users/urls.py#L20 */}
-    <Route path="users/:userAction/" component={NotFound} />
+    {/* Hack to make the proxy serve this URL from addons-server */}
     {/* https://github.com/mozilla/addons-frontend/issues/1975 */}
     <Route path="user/:user/" component={NotFound} />
     <Route path=":visibleAddonType/categories/" component={CategoryList} />

--- a/tests/server/amo/TestViews.js
+++ b/tests/server/amo/TestViews.js
@@ -66,24 +66,4 @@ describe('AMO GET Requests', () => {
   it('should respond with a 404 to user pages', () => request(app)
     .get('/en-US/firefox/user/some-user/')
     .expect(404));
-
-  it('should respond with a 404 to the user edit page', () => request(app)
-    .get('/en-US/firefox/users/edit/')
-    .expect(404));
-
-  it('should respond with a 404 to a specific user edit', () => request(app)
-    .get('/en-US/firefox/users/edit/1234/')
-    .expect(404));
-
-  it('should respond with a 404 to user unsubscribe actions', () => request(app)
-    .get('/en-US/firefox/users/unsubscribe/token/signature/permission/')
-    .expect(404));
-
-  it('should respond with a 404 to deleting a user photo', () => request(app)
-    .get('/en-US/firefox/users/delete_photo/1234/')
-    .expect(404));
-
-  it('should respond with a 404 to any user action', () => request(app)
-    .get('/en-US/firefox/users/login/')
-    .expect(404));
 });


### PR DESCRIPTION
This will make https://github.com/mozilla/addons-frontend/issues/2037 go away but only until we shadow some other URL.

This reverts commit f42934e542ae7383a8302296d85ac7255238177c because a 500 is going to be more helpful until we have implementations of these pages.