### PR TITLE
chore: Add eslint rule for Promises (fix #2065)

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^6.10.3",
     "fetch-mock": "^5.10.0",
     "file-loader": "^0.11.1",

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -1,9 +1,18 @@
 {
+  "extends": [
+    "plugin:promise/recommended",
+  ],
+  "plugins": [
+    "promise",
+  ],
   "rules": {
     "import/no-extraneous-dependencies": ["error", {
       // Allow dev-dependencies in this directory.
       "devDependencies": true
     }],
+    "promise/always-return": "off",
+    "promise/avoid-new": "off",
+    "promise/no-nesting": "off",
   },
   "settings": {
     "import/resolver": {


### PR DESCRIPTION
I spent a few hours doing mindless tile replacement so I felt like doing mindless code linting cleanup too. 😉 

Adds returns to all Promises and ensures all test code that
uses a Promise returns it so all code is executed.

This is a lot of noise but and makes for slightly more verbose
tests with "needless" `return true;` statements, but it will
prevent us from writing unexecuted test code in the future. 👍🏻

-----

This ends up making the code a fair bit more verbose but I think it's worth it. I know it looks like a lot of noise here but it keeps us writing smarter Promises.