### PR TITLE
Strip indent from extract and gettext

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "autoprefixer": "6.7.5",
     "babel-core": "6.23.1",
     "babel-eslint": "7.1.0",
-    "babel-gettext-extractor": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#ecd85dea4553247a3cb579da817df29f381df5b9",
+    "babel-gettext-extractor": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#d3f882f6b47f1d391c43b227b731dd22c62f23b2",
     "babel-loader": "6.3.2",
     "babel-plugin-istanbul": "4.0.0",
     "babel-plugin-react-transform": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "autoprefixer": "6.7.5",
     "babel-core": "6.23.1",
     "babel-eslint": "7.1.0",
-    "babel-gettext-extractor": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#d3f882f6b47f1d391c43b227b731dd22c62f23b2",
+    "babel-gettext-extractor": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6",
     "babel-loader": "6.3.2",
     "babel-plugin-istanbul": "4.0.0",
     "babel-plugin-react-transform": "2.0.2",

--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-danger */
-import { oneLine } from 'common-tags';
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -51,14 +50,14 @@ export class AddonCompatibilityErrorBase extends React.Component {
     }
 
     if (reason === INCOMPATIBLE_NOT_FIREFOX) {
-      message = i18n.sprintf(i18n.gettext(oneLine`You need to
+      message = i18n.sprintf(i18n.gettext(`You need to
         <a href="%(downloadUrl)s">download Firefox</a> to install this add-on.`
       ), { downloadUrl });
     } else if (reason === INCOMPATIBLE_FIREFOX_FOR_IOS) {
       message = i18n.gettext(
         'Firefox for iOS does not currently support add-ons.');
     } else if (reason === INCOMPATIBLE_UNDER_MIN_VERSION) {
-      message = i18n.sprintf(i18n.gettext(oneLine`This add-on requires a
+      message = i18n.sprintf(i18n.gettext(`This add-on requires a
         <a href="%(downloadUrl)s">newer version of Firefox</a> (at least
         version %(minVersion)s). You are using Firefox %(yourVersion)s.`
       ), {
@@ -72,7 +71,7 @@ export class AddonCompatibilityErrorBase extends React.Component {
       log.warn(
         'Unknown reason code supplied to AddonCompatibilityError', reason);
 
-      message = i18n.sprintf(i18n.gettext(oneLine`Your browser does not
+      message = i18n.sprintf(i18n.gettext(`Your browser does not
         support add-ons. You can <a href="%(downloadUrl)s">download Firefox</a>
         to install this add-on.`
       ), { downloadUrl });

--- a/src/amo/components/ErrorPage/NotAuthorized/index.js
+++ b/src/amo/components/ErrorPage/NotAuthorized/index.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { oneLine } from 'common-tags';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 
@@ -19,7 +18,7 @@ export class NotAuthorizedBase extends React.Component {
   render() {
     const { i18n } = this.props;
 
-    const fileAnIssueText = i18n.sprintf(i18n.gettext(oneLine`
+    const fileAnIssueText = i18n.sprintf(i18n.gettext(`
       If you are signed in and think this message is an error, please
       <a href="%(url)s">file an issue</a>. Tell us where you came from
       and what you were trying to access, and we'll fix the issue.`),
@@ -33,7 +32,7 @@ export class NotAuthorizedBase extends React.Component {
         <Card className="ErrorPage NotAuthorized"
           header={i18n.gettext('Not Authorized')}>
           <p>
-            {i18n.gettext(oneLine`
+            {i18n.gettext(`
               Sorry, but you aren't authorized to access this page. If you
               aren't signed in, try signing in using the link at the top
               of the page.`)}

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { oneLine } from 'common-tags';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 
@@ -19,7 +18,7 @@ export class NotFoundBase extends React.Component {
   render() {
     const { i18n } = this.props;
 
-    const fileAnIssueText = i18n.sprintf(i18n.gettext(oneLine`
+    const fileAnIssueText = i18n.sprintf(i18n.gettext(`
       If you followed a link from somewhere, please
       <a href="%(url)s">file an issue</a>. Tell us where you came from and
       what you were looking for, and we'll do our best to fix it.`),
@@ -32,7 +31,7 @@ export class NotFoundBase extends React.Component {
         <Card className="ErrorPage NotFound"
           header={i18n.gettext('Page not found')}>
           <p>
-            {i18n.gettext(oneLine`
+            {i18n.gettext(`
               Sorry, but we can't find anything at the address you entered.
               If you followed a link to an add-on, it's possible that add-on
               has been removed by its author.`)}

--- a/src/amo/components/ErrorPage/ServerError/index.js
+++ b/src/amo/components/ErrorPage/ServerError/index.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { oneLine } from 'common-tags';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 
@@ -19,7 +18,7 @@ export class ServerErrorBase extends React.Component {
   render() {
     const { i18n } = this.props;
 
-    const fileAnIssueText = i18n.gettext(oneLine`
+    const fileAnIssueText = i18n.gettext(`
       If you have additional information that would help us you can
       <a href="https://github.com/mozilla/addons-frontend/issues/new/">file an
       issue</a>. Tell us what steps you took that lead to the error and we'll
@@ -31,7 +30,7 @@ export class ServerErrorBase extends React.Component {
         <Card className="ErrorPage ServerError"
           header={i18n.gettext('Server Error')}>
           <p>
-            {i18n.gettext(oneLine`
+            {i18n.gettext(`
               Sorry, but there was an error with our server and we couldn't
               complete your request. We have logged this error and will
               investigate it.`)}

--- a/src/amo/containers/Home.js
+++ b/src/amo/containers/Home.js
@@ -36,7 +36,7 @@ export class HomePageBase extends React.Component {
       <div className="HomePage">
         <div className="HomePage-welcome">
           <p className="HomePage-welcome-text">
-            {i18n.gettext(dedent`Extensions are special features you can add to Firefox.
+            {i18n.gettext(`Extensions are special features you can add to Firefox.
             Themes let you change your browser's appearance.`)}
           </p>
           <div className="HomePage-welcome-links">

--- a/src/core/components/ErrorPage/GenericError/index.js
+++ b/src/core/components/ErrorPage/GenericError/index.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { oneLine } from 'common-tags';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 
@@ -25,7 +24,7 @@ export class GenericErrorBase extends React.Component {
           <h1>{i18n.gettext('Server Error')}</h1>
 
           <p>
-            {i18n.gettext(oneLine`
+            {i18n.gettext(`
               Sorry, but there was an error and we couldn't complete your
               request. We have logged this error and will investigate it.`)}
           </p>

--- a/src/core/components/ErrorPage/NotFound/index.js
+++ b/src/core/components/ErrorPage/NotFound/index.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { oneLine } from 'common-tags';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 
@@ -24,7 +23,7 @@ export class NotFoundBase extends React.Component {
         <div className="ErrorPage NotFound">
           <h1>{i18n.gettext('Page not found')}</h1>
           <p>
-            {i18n.gettext(oneLine`
+            {i18n.gettext(`
               Sorry, but we can't find anything at the URL you entered.`)}
           </p>
 

--- a/src/core/components/ErrorPage/NotFound/index.js
+++ b/src/core/components/ErrorPage/NotFound/index.js
@@ -23,8 +23,7 @@ export class NotFoundBase extends React.Component {
         <div className="ErrorPage NotFound">
           <h1>{i18n.gettext('Page not found')}</h1>
           <p>
-            {i18n.gettext(`
-              Sorry, but we can't find anything at the URL you entered.`)}
+            {i18n.gettext("Sorry, but we can't find anything at the URL you entered.")}
           </p>
 
           <p>

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -181,6 +181,17 @@ export function makeMomentLocale(locale) {
   return locale.replace('_', '-').toLowerCase();
 }
 
+// TODO Have this replacement made available for import from babel-gettext-extractor.
+// this will ensure that the function used is in-sync for both extraction
+// and retrieval of translations.
+// Functionality based on oneLine form declandewet/common-tags https://goo.gl/4PzaJI
+function oneLineTranslationString(str) {
+  if (str && str.replace && str.trim) {
+    return str.replace(/(?:\n(?:\s*))+/g, ' ').trim();
+  }
+  return str;
+}
+
 // Create an i18n object with a translated moment object available we can
 // use for translated dates across the app.
 export function makeI18n(i18nData, lang, _Jed = Jed) {
@@ -195,6 +206,14 @@ export function makeI18n(i18nData, lang, _Jed = Jed) {
     i18n.options._momentDefineLocale();
     moment.locale(makeMomentLocale(i18n.lang));
   }
+
+  // Wrap the core Jed functionality so that we can always strip leading whitespace
+  // from translation keys to match the same process used in extraction.
+  i18n._dcnpgettext = i18n.dcnpgettext;
+  i18n.dcnpgettext = function dcnpgettext(domain, context, singularKey, pluralKey, val) {
+    return i18n._dcnpgettext(domain, context, oneLineTranslationString(singularKey),
+                             oneLineTranslationString(pluralKey), val);
+  };
 
   // We add a translated "moment" property to our `i18n` object
   // to make translated date/time/etc. easy.

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -181,10 +181,9 @@ export function makeMomentLocale(locale) {
   return locale.replace('_', '-').toLowerCase();
 }
 
-// TODO Have this replacement made available for import from babel-gettext-extractor.
-// this will ensure that the function used is in-sync for both extraction
-// and retrieval of translations.
 // Functionality based on oneLine form declandewet/common-tags https://goo.gl/4PzaJI
+// If this function is altered muffinresearch/babel-gettext-extractor also needs
+// to be updated.
 function oneLineTranslationString(str) {
   if (str && str.replace && str.trim) {
     return str.replace(/(?:\n(?:\s*))+/g, ' ').trim();

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -182,13 +182,13 @@ export function makeMomentLocale(locale) {
 }
 
 // Functionality based on oneLine form declandewet/common-tags https://goo.gl/4PzaJI
-// If this function is altered muffinresearch/babel-gettext-extractor also needs
-// to be updated.
-function oneLineTranslationString(str) {
-  if (str && str.replace && str.trim) {
-    return str.replace(/(?:\n(?:\s*))+/g, ' ').trim();
+// If this function is changed https://github.com/muffinresearch/babel-gettext-extractor/
+// also needs to be updated.
+function oneLineTranslationString(translationKey) {
+  if (translationKey && translationKey.replace && translationKey.trim) {
+    return translationKey.replace(/(?:\n(?:\s*))+/g, ' ').trim();
   }
-  return str;
+  return translationKey;
 }
 
 // Create an i18n object with a translated moment object available we can

--- a/tests/client/helpers.js
+++ b/tests/client/helpers.js
@@ -1,12 +1,11 @@
 import base64url from 'base64url';
 import config from 'config';
-import { sprintf } from 'jed';
+import Jed from 'jed';
 import React from 'react';
 import { createRenderer } from 'react-addons-test-utils';
 import UAParser from 'ua-parser-js';
 
 import { ADDON_TYPE_EXTENSION } from 'core/constants';
-import { ngettext } from 'core/utils';
 import { makeI18n } from 'core/i18n/utils';
 
 /*
@@ -72,23 +71,24 @@ export function unexpectedSuccess() {
   return assert.fail(null, null, 'Unexpected success');
 }
 
-class FakeJed {
-  gettext = sinon.spy((str) => str)
-  dgettext = sinon.stub()
-  ngettext = sinon.spy(ngettext)
-  dngettext = sinon.stub()
-  pgettext = sinon.stub()
-  dpgettext = sinon.stub()
-  npgettext = sinon.stub()
-  dnpgettext = sinon.stub()
-  sprintf = sinon.spy(sprintf)
+export function JedSpy(data = {}) {
+  const _Jed = new Jed(data);
+  _Jed.gettext = sinon.spy(_Jed.gettext);
+  _Jed.dgettext = sinon.spy(_Jed.gettext);
+  _Jed.ngettext = sinon.spy(_Jed.ngettext);
+  _Jed.dngettext = sinon.spy(_Jed.dngettext);
+  _Jed.dpgettext = sinon.spy(_Jed.dpgettext);
+  _Jed.npgettext = sinon.spy(_Jed.npgettext);
+  _Jed.dnpgettext = sinon.spy(_Jed.dnpgettext);
+  _Jed.sprintf = sinon.spy(_Jed.sprintf);
+  return _Jed;
 }
 
 /*
  * Creates a stand-in for a jed instance,
  */
 export function getFakeI18nInst({ lang = config.get('defaultLang') } = {}) {
-  return makeI18n({}, lang, FakeJed);
+  return makeI18n({}, lang, JedSpy);
 }
 
 export class MockedSubComponent extends React.Component {

--- a/webpack.l10n.config.babel.js
+++ b/webpack.l10n.config.babel.js
@@ -57,6 +57,7 @@ const babelL10nPlugins = [
     },
     fileName: `locale/templates/LC_MESSAGES/${appName}.pot`,
     baseDirectory: process.cwd(),
+    stripTemplateLiteralIndent: true,
   }],
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -273,7 +273,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@6.23.1, babel-core@^6.23.0:
+babel-core@6.23.1, babel-core@^6.0.0, babel-core@^6.23.0:
   version "6.23.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.23.1.tgz#c143cb621bb2f621710c220c5d579d15b8a442df"
   dependencies:
@@ -319,11 +319,11 @@ babel-generator@^6.18.0, babel-generator@^6.23.0:
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"babel-gettext-extractor@git+https://github.com/muffinresearch/babel-gettext-extractor.git#ecd85dea4553247a3cb579da817df29f381df5b9":
+"babel-gettext-extractor@git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6":
   version "1.0.2"
-  resolved "git+https://github.com/muffinresearch/babel-gettext-extractor.git#ecd85dea4553247a3cb579da817df29f381df5b9"
+  resolved "git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6"
   dependencies:
-    babel-runtime "^5.0.0"
+    babel-core "^6.0.0"
     gettext-parser "^1.1.2"
 
 babel-helper-bindify-decorators@^6.22.0:
@@ -891,12 +891,6 @@ babel-register@6.23.0, babel-register@^6.23.0:
     lodash "^4.2.0"
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
-
-babel-runtime@^5.0.0:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
-  dependencies:
-    core-js "^1.0.0"
 
 babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.6.1, babel-runtime@^6.9.1:
   version "6.23.0"


### PR DESCRIPTION
Fixes #2059

I've now updated the fork of babel-gettext-extractor [1] after a bit of a clean-up and overhaul adding more tests and fixing up the lint.

This branch updates to the rev of that lib with the new features this now supports removing leading indents from extracted values. 

This patch also wraps our Jed instance functions to support stripping the same indent from keys because otherwise the lookups would fail. This means from now on any multiline translations should use untagged template literals and not use dedent or oneLine. 

I'll also add a commit to this to update the docs so it's clear and we should also look to add a eslint rule to check for tagged template literals as args to any Jed gettext methods.

Lastly to ensure tests see the actual Jed output this changes the FakeJed to be a spy wrapped real Jed. Otherwise several tests look at translation strings broke due to leading whitespace in the text.

[1]  https://github.com/muffinresearch/babel-gettext-extractor/commits/master

## Note

After landing we'll need to extract and merge both amo and the disco pane so that the new strings currently missing can be translated.