### PR TITLE
Stop defaulting to Sentry prod for client side errors

### DIFF
--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -101,4 +101,7 @@ module.exports = {
 
   trackingEnabled: true,
   trackingId: 'UA-36116321-7',
+
+  // https://sentry.prod.mozaws.net/operations/addons-frontend-amo-prod/
+  publicSentryDsn: 'https://dbce4e759d8b4dc6a1731d3301fdaab7@sentry.prod.mozaws.net/183',
 };

--- a/config/default.js
+++ b/config/default.js
@@ -236,6 +236,5 @@ module.exports = {
   allowErrorSimulation: false,
 
   sentryDsn: process.env.SENTRY_DSN || null,
-  // https://sentry.prod.mozaws.net/operations/addons-frontend-amo-prod/
-  publicSentryDsn: 'https://dbce4e759d8b4dc6a1731d3301fdaab7@sentry.prod.mozaws.net/183',
+  publicSentryDsn: null,
 };


### PR DESCRIPTION
This will fix https://github.com/mozilla/addons-frontend/issues/2106 and probably other things in the future that we'll forget about.