### PR TITLE
fix: Don't play the disco pane video in tests (fix #765)

### DIFF
--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -59,14 +59,12 @@ export class DiscoPaneBase extends React.Component {
   }
 
   showVideo = (e) => {
-    const { _tracking, _video } = this.props;
-    if (_video) {
-      this.video = _video;
-    }
+    const { _tracking } = this.props;
+    const _video = this.props._video || this.video;
 
     e.preventDefault();
     this.setState({ showVideo: true });
-    this.video.play();
+    _video.play();
     _tracking.sendEvent({
       action: 'play',
       category: VIDEO_CATEGORY,
@@ -74,14 +72,12 @@ export class DiscoPaneBase extends React.Component {
   }
 
   closeVideo = (e) => {
-    const { _tracking, _video } = this.props;
-    if (_video) {
-      this.video = _video;
-    }
+    const { _tracking } = this.props;
+    const _video = this.props._video || this.video;
 
     e.preventDefault();
     this.setState({ showVideo: false });
-    this.video.pause();
+    _video.pause();
     _tracking.sendEvent({
       action: 'close',
       category: VIDEO_CATEGORY,

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -34,8 +34,6 @@ export class DiscoPaneBase extends React.Component {
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     _addChangeListeners: PropTypes.func,
     _tracking: PropTypes.object,
-    // We allow the video to be overloaded for testing, see:
-    // https://github.com/mozilla/addons-frontend/issues/765
     _video: PropTypes.object,
   }
 

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -34,6 +34,9 @@ export class DiscoPaneBase extends React.Component {
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     _addChangeListeners: PropTypes.func,
     _tracking: PropTypes.object,
+    // We allow the video to be overloaded for testing, see:
+    // https://github.com/mozilla/addons-frontend/issues/765
+    _video: PropTypes.object,
   }
 
   static defaultProps = {
@@ -41,6 +44,7 @@ export class DiscoPaneBase extends React.Component {
     mozAddonManager: config.get('server') ? {} : navigator.mozAddonManager,
     _addChangeListeners: addChangeListeners,
     _tracking: tracking,
+    _video: null,
   }
 
   constructor() {
@@ -55,7 +59,11 @@ export class DiscoPaneBase extends React.Component {
   }
 
   showVideo = (e) => {
-    const { _tracking } = this.props;
+    const { _tracking, _video } = this.props;
+    if (_video) {
+      this.video = _video;
+    }
+
     e.preventDefault();
     this.setState({ showVideo: true });
     this.video.play();
@@ -66,7 +74,11 @@ export class DiscoPaneBase extends React.Component {
   }
 
   closeVideo = (e) => {
-    const { _tracking } = this.props;
+    const { _tracking, _video } = this.props;
+    if (_video) {
+      this.video = _video;
+    }
+
     e.preventDefault();
     this.setState({ showVideo: false });
     this.video.pause();

--- a/tests/client/disco/containers/TestDiscoPane.js
+++ b/tests/client/disco/containers/TestDiscoPane.js
@@ -25,6 +25,14 @@ const { DiscoPaneBase } = helpers;
 
 
 describe('AddonPage', () => {
+  let fakeVideo;
+  let fakeTracking;
+
+  beforeEach(() => {
+    fakeTracking = { sendEvent: sinon.stub() };
+    fakeVideo = { play: sinon.stub(), pause: sinon.stub() };
+  });
+
   function render(props) {
     // Stub InfoDialog since it uses the store and is irrelevant.
     sinon.stub(InfoDialog, 'default', () => <p>InfoDialog</p>);
@@ -35,11 +43,17 @@ describe('AddonPage', () => {
     const results = [{ addon: 'foo', type: ADDON_TYPE_EXTENSION }];
     const i18n = getFakeI18nInst();
 
-    // We need the providers for i18n and since InstallButton will pull data from the store.
+    // We need providers because InstallButton will pull data from the store.
     return findDOMNode(renderIntoDocument(
       <DiscoPaneBase
-        store={store} i18n={i18n} results={results} {...props}
-        AddonComponent={MockedSubComponent} />
+        AddonComponent={MockedSubComponent}
+        i18n={i18n}
+        results={results}
+        store={store}
+        _tracking={fakeTracking}
+        _video={fakeVideo}
+        {...props}
+      />
     ));
   }
 
@@ -58,27 +72,23 @@ describe('AddonPage', () => {
     });
 
     it('tracks video being played', () => {
-      const fakeTracking = {
-        sendEvent: sinon.stub(),
-      };
-      const root = render({ _tracking: fakeTracking });
+      const root = render();
       Simulate.click(root.querySelector('.play-video'));
       assert.ok(fakeTracking.sendEvent.calledWith({
         category: VIDEO_CATEGORY,
         action: 'play',
       }));
+      assert.ok(fakeVideo.play.calledOnce);
     });
 
     it('tracks video being closed', () => {
-      const fakeTracking = {
-        sendEvent: sinon.stub(),
-      };
-      const root = render({ _tracking: fakeTracking });
+      const root = render();
       Simulate.click(root.querySelector('.close-video a'));
       assert.ok(fakeTracking.sendEvent.calledWith({
         category: VIDEO_CATEGORY,
         action: 'close',
       }));
+      assert.ok(fakeVideo.pause.calledOnce);
     });
   });
 
@@ -175,10 +185,7 @@ describe('AddonPage', () => {
 
   describe('See more add-ons link', () => {
     it('tracks see more addons link being clicked', () => {
-      const fakeTracking = {
-        sendEvent: sinon.stub(),
-      };
-      const root = render({ _tracking: fakeTracking });
+      const root = render();
       Simulate.click(root.querySelector('.amo-link a'));
       assert.ok(fakeTracking.sendEvent.calledWith({
         category: NAVIGATION_CATEGORY,


### PR DESCRIPTION
This fixes #765, so our tests shouldn't have memory leaks and also shouldn't spook me when I'm testing with loud volume settings late at night.