### PR TITLE
fix: Use Firefox categories for Android themes (fix #2170)

### DIFF
--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -1,6 +1,7 @@
 import config from 'config';
 
 import {
+  ADDON_TYPE_THEME,
   CATEGORIES_GET,
   CATEGORIES_LOAD,
   CATEGORIES_FAILED,
@@ -50,6 +51,16 @@ export default function categories(state = initialState, action) {
             ), {});
         });
       });
+
+      // Android doesn't have any theme categories but because all lightweight
+      // themes (personas) are installable on Firefox Desktop and Android
+      // we share categories and themes across clientApps.
+      // See: https://github.com/mozilla/addons-frontend/issues/2170
+      //
+      // This can be removed once
+      // https://github.com/mozilla/addons-server/issues/4766 is fixed.
+      categoryList.android[ADDON_TYPE_THEME] = categoryList
+        .firefox[ADDON_TYPE_THEME];
 
       return {
         ...state,

--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -1,3 +1,4 @@
+import { oneLine } from 'common-tags';
 import config from 'config';
 
 import {
@@ -6,6 +7,7 @@ import {
   CATEGORIES_LOAD,
   CATEGORIES_FAILED,
 } from 'core/constants';
+import log from 'core/logger';
 
 
 export function emptyCategoryList() {
@@ -21,53 +23,58 @@ const initialState = {
 
 export default function categories(state = initialState, action) {
   const { payload } = action;
-  let categoryList;
 
   switch (action.type) {
     case CATEGORIES_GET:
       return { ...state, ...payload, loading: true };
     case CATEGORIES_LOAD:
-      categoryList = emptyCategoryList();
-      payload.result.forEach((result) => {
-        // If the API returns data for an application we don't support,
-        // we'll ignore it for now.
-        if (!categoryList[result.application]) {
-          return;
-        }
+      {
+        const categoryList = emptyCategoryList();
+        payload.result.forEach((result) => {
+          // If the API returns data for an application we don't support,
+          // we'll ignore it for now.
+          if (!categoryList[result.application]) {
+            log.warn(oneLine`Category data for unknown application
+              "${result.application}" received from API.`);
+            return;
+          }
 
-        if (!categoryList[result.application][result.type]) {
-          categoryList[result.application][result.type] = [];
-        }
+          if (!categoryList[result.application][result.type]) {
+            categoryList[result.application][result.type] = [];
+          }
 
-        categoryList[result.application][result.type].push(result);
-      });
-
-      Object.keys(categoryList).forEach((appName) => {
-        Object.keys(categoryList[appName]).forEach((addonType) => {
-          categoryList[appName][addonType] = categoryList[appName][addonType]
-            .sort((a, b) => a.name >= b.name)
-            .reduce((object, value) => (
-              { ...object, [value.slug]: value }
-            ), {});
+          categoryList[result.application][result.type].push(result);
         });
-      });
 
-      // Android doesn't have any theme categories but because all lightweight
-      // themes (personas) are installable on Firefox Desktop and Android
-      // we share categories and themes across clientApps.
-      // See: https://github.com/mozilla/addons-frontend/issues/2170
-      //
-      // This can be removed once
-      // https://github.com/mozilla/addons-server/issues/4766 is fixed.
-      categoryList.android[ADDON_TYPE_THEME] = categoryList
-        .firefox[ADDON_TYPE_THEME];
+        Object.keys(categoryList).forEach((appName) => {
+          Object.keys(categoryList[appName]).forEach((addonType) => {
+            categoryList[appName][addonType] = categoryList[appName][addonType]
+              .sort((a, b) => a.name >= b.name)
+              .reduce((object, value) => (
+                { ...object, [value.slug]: value }
+              ), {});
+          });
+        });
 
-      return {
-        ...state,
-        ...payload,
-        loading: false,
-        categories: categoryList,
-      };
+        // Android doesn't have any theme categories but because all lightweight
+        // themes (personas) are installable on Firefox Desktop and Android
+        // we share categories and themes across clientApps.
+        // See: https://github.com/mozilla/addons-frontend/issues/2170
+        //
+        // TODO: Remove this code once
+        // https://github.com/mozilla/addons-server/issues/4766 is fixed.
+        log.info(oneLine`Replacing Android persona data with Firefox data until
+          https://github.com/mozilla/addons-server/issues/4766 is fixed.`);
+        categoryList.android[ADDON_TYPE_THEME] = categoryList
+          .firefox[ADDON_TYPE_THEME];
+
+        return {
+          ...state,
+          ...payload,
+          loading: false,
+          categories: categoryList,
+        };
+      }
     case CATEGORIES_FAILED:
       return { ...initialState, ...payload, error: true };
     default:

--- a/tests/client/core/reducers/test_categories.js
+++ b/tests/client/core/reducers/test_categories.js
@@ -103,7 +103,27 @@ describe('categories reducer', () => {
     });
 
     it('sets the categories', () => {
-      // Notice all Firefox theme cateories are also set as Android theme
+      const themes = {
+        anime: {
+          application: 'firefox',
+          name: 'Anime',
+          slug: 'anime',
+          type: ADDON_TYPE_THEME,
+        },
+        naturé: {
+          application: 'firefox',
+          name: 'Naturé',
+          slug: 'naturé',
+          type: ADDON_TYPE_THEME,
+        },
+        painting: {
+          application: 'firefox',
+          name: 'Painting',
+          slug: 'painting',
+          type: ADDON_TYPE_THEME,
+        },
+      };
+      // Notice all Firefox theme categories are also set as Android theme
       // categories and no Android categories are returned. This reflects the
       // current state of AMO.
       // See: https://github.com/mozilla/addons-frontend/issues/2170
@@ -126,26 +146,7 @@ describe('categories reducer', () => {
               type: ADDON_TYPE_EXTENSION,
             },
           },
-          [ADDON_TYPE_THEME]: {
-            anime: {
-              application: 'firefox',
-              name: 'Anime',
-              slug: 'anime',
-              type: ADDON_TYPE_THEME,
-            },
-            naturé: {
-              application: 'firefox',
-              name: 'Naturé',
-              slug: 'naturé',
-              type: ADDON_TYPE_THEME,
-            },
-            painting: {
-              application: 'firefox',
-              name: 'Painting',
-              slug: 'painting',
-              type: ADDON_TYPE_THEME,
-            },
-          },
+          [ADDON_TYPE_THEME]: themes,
         },
         android: {
           [ADDON_TYPE_EXTENSION]: {
@@ -168,26 +169,7 @@ describe('categories reducer', () => {
               type: ADDON_TYPE_EXTENSION,
             },
           },
-          [ADDON_TYPE_THEME]: {
-            anime: {
-              application: 'firefox',
-              name: 'Anime',
-              slug: 'anime',
-              type: ADDON_TYPE_THEME,
-            },
-            naturé: {
-              application: 'firefox',
-              name: 'Naturé',
-              slug: 'naturé',
-              type: ADDON_TYPE_THEME,
-            },
-            painting: {
-              application: 'firefox',
-              name: 'Painting',
-              slug: 'painting',
-              type: ADDON_TYPE_THEME,
-            },
-          },
+          [ADDON_TYPE_THEME]: themes,
         },
       });
     });

--- a/tests/client/core/reducers/test_categories.js
+++ b/tests/client/core/reducers/test_categories.js
@@ -45,28 +45,28 @@ describe('categories reducer', () => {
           application: 'android',
           name: 'Alerts & Update',
           slug: 'alert-update',
-          type: 'extension',
+          type: ADDON_TYPE_EXTENSION,
         },
         {
           application: 'android',
           name: 'Games',
           slug: 'Games',
-          type: 'extension',
+          type: ADDON_TYPE_EXTENSION,
         },
         {
           application: 'android',
           name: 'Blogging',
           slug: 'blogging',
-          type: 'extension',
+          type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          application: 'firefox',
           name: 'Naturé',
           slug: 'naturé',
           type: ADDON_TYPE_THEME,
         },
         {
-          application: 'android',
+          application: 'firefox',
           name: 'Painting',
           slug: 'painting',
           type: ADDON_TYPE_THEME,
@@ -81,19 +81,19 @@ describe('categories reducer', () => {
           application: 'firefox',
           name: 'Alerts & Update',
           slug: 'alert-update',
-          type: 'extension',
+          type: ADDON_TYPE_EXTENSION,
         },
         {
           application: 'firefox',
           name: 'Security',
           slug: 'security',
-          type: 'extension',
+          type: ADDON_TYPE_EXTENSION,
         },
         {
           application: 'netscape',
           name: 'I should not appear',
           slug: 'i-should-not-appear',
-          type: 'extension',
+          type: ADDON_TYPE_EXTENSION,
         },
       ];
       state = categories(initialState, {
@@ -103,6 +103,13 @@ describe('categories reducer', () => {
     });
 
     it('sets the categories', () => {
+      // Notice all Firefox theme cateories are also set as Android theme
+      // categories and no Android categories are returned. This reflects the
+      // current state of AMO.
+      // See: https://github.com/mozilla/addons-frontend/issues/2170
+      //
+      // This can be changed once
+      // https://github.com/mozilla/addons-server/issues/4766 is fixed.
       assert.deepEqual(state.categories, {
         firefox: {
           [ADDON_TYPE_EXTENSION]: {
@@ -110,13 +117,13 @@ describe('categories reducer', () => {
               application: 'firefox',
               name: 'Alerts & Update',
               slug: 'alert-update',
-              type: 'extension',
+              type: ADDON_TYPE_EXTENSION,
             },
             security: {
               application: 'firefox',
               name: 'Security',
               slug: 'security',
-              type: 'extension',
+              type: ADDON_TYPE_EXTENSION,
             },
           },
           [ADDON_TYPE_THEME]: {
@@ -124,6 +131,18 @@ describe('categories reducer', () => {
               application: 'firefox',
               name: 'Anime',
               slug: 'anime',
+              type: ADDON_TYPE_THEME,
+            },
+            naturé: {
+              application: 'firefox',
+              name: 'Naturé',
+              slug: 'naturé',
+              type: ADDON_TYPE_THEME,
+            },
+            painting: {
+              application: 'firefox',
+              name: 'Painting',
+              slug: 'painting',
               type: ADDON_TYPE_THEME,
             },
           },
@@ -134,30 +153,36 @@ describe('categories reducer', () => {
               application: 'android',
               name: 'Alerts & Update',
               slug: 'alert-update',
-              type: 'extension',
+              type: ADDON_TYPE_EXTENSION,
             },
             blogging: {
               application: 'android',
               name: 'Blogging',
               slug: 'blogging',
-              type: 'extension',
+              type: ADDON_TYPE_EXTENSION,
             },
             Games: {
               application: 'android',
               name: 'Games',
               slug: 'Games',
-              type: 'extension',
+              type: ADDON_TYPE_EXTENSION,
             },
           },
           [ADDON_TYPE_THEME]: {
+            anime: {
+              application: 'firefox',
+              name: 'Anime',
+              slug: 'anime',
+              type: ADDON_TYPE_THEME,
+            },
             naturé: {
-              application: 'android',
+              application: 'firefox',
               name: 'Naturé',
               slug: 'naturé',
               type: ADDON_TYPE_THEME,
             },
             painting: {
-              application: 'android',
+              application: 'firefox',
               name: 'Painting',
               slug: 'painting',
               type: ADDON_TYPE_THEME,


### PR DESCRIPTION
fix #2170

Similar to the solution used for searching Android Themes, except we patch the data in the reducer/state instead of the API call because the category list API just returns all categories for all clientApps.

### Before
![mar-25-2017 23-05-52](https://cloud.githubusercontent.com/assets/90871/24326840/c841b050-11af-11e7-91ea-cf078b515161.gif)

### After
![mar-25-2017 23-05-00](https://cloud.githubusercontent.com/assets/90871/24326841/cb84e160-11af-11e7-9a3c-5adc32f9cd71.gif)