### PR TITLE
fix: Make search result pagination match the UI mock

### DIFF
--- a/src/core/components/Paginate/Paginate.scss
+++ b/src/core/components/Paginate/Paginate.scss
@@ -12,14 +12,13 @@
 }
 
 .Paginate {
-  padding: 0 10%;
-  margin-bottom: 5%;
+  padding: 0 30px;
+  margin-bottom: 30px;
 }
 
 .Paginate .Paginate-item {
-  @include button($background: #fff, $color: #000);
+  @include button($background: $base-color, $color: $link-color);
 
-  color: $link-color;
   display: inline-block;
   font-size: $font-size-s;
   font-variant: small-caps;

--- a/src/core/components/Paginate/Paginate.scss
+++ b/src/core/components/Paginate/Paginate.scss
@@ -11,16 +11,21 @@
   justify-content: space-between;
 }
 
+.Paginate {
+  padding: 0 10%;
+  margin-bottom: 5%;
+}
+
 .Paginate .Paginate-item {
   @include button($background: #fff, $color: #000);
 
+  color: $link-color;
   display: inline-block;
   font-size: $font-size-s;
   font-variant: small-caps;
   font-weight: normal;
   line-height: 2;
-  margin: 0;
-  min-width: 40%;
+  min-width: 48%;
   text-align: center;
 }
 

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -85,7 +85,7 @@
 /* Arrows */
 $default-arrow-margin: 3px;
 @mixin arrow($margin: $default-arrow-margin) {
-  background: url('~amo/img/icons/arrow.svg') 50% 50% no-repeat;
+  background: url('~amo/img/icons/arrow-link-color.svg') 50% 50% no-repeat;
   border-radius: $border-radius-m;
   content: '';
   display: inline-block;


### PR DESCRIPTION
Fixes #2064 
Before -
<img width="363" alt="before" src="https://cloud.githubusercontent.com/assets/19590302/24358054/58bc83ea-12ef-11e7-8b51-9cf16348fd93.png">

After -
![paginate](https://cloud.githubusercontent.com/assets/19590302/24358063/5e90120a-12ef-11e7-9664-cd2c70c88c61.png)