### PR TITLE
fix: Remove all comments from production build (fix #2113)

### DIFF
--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -103,9 +103,10 @@ const settings = {
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.UglifyJsPlugin({
+      comments: false,
       compress: {
-        warnings: false,
         drop_console: true,
+        warnings: false,
       },
     }),
     new WebpackIsomorphicToolsPlugin(webpackIsomorphicToolsConfig),


### PR DESCRIPTION
This saves about 6kB which is pretty tiny, but it might save more in the future and is worth doing. It's an easy optimisation so why not?