### PR TITLE
Fill in empty safeAsyncConnect keys to preserve LOAD_FAIL

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -250,6 +250,14 @@ export function safeAsyncConnect(
   configs, { asyncConnect = defaultAsyncConnect } = {}
 ) {
   const safeConfigs = configs.map((conf) => {
+    if (!conf.key) {
+      // If asyncConnect does not get a key in its config, it
+      // will not dispatch LOAD_FAIL for thrown errors!
+      // Other than that, the key is used to set a magic component
+      // property (which we never rely on) so it's really not so
+      // important.
+      conf.key = '__safeAsyncConnect_key__';
+    }
     if (!conf.promise) {
       // This is the only way we use asyncConnect() for now.
       throw new Error(

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -250,13 +250,14 @@ export function safeAsyncConnect(
   configs, { asyncConnect = defaultAsyncConnect } = {}
 ) {
   const safeConfigs = configs.map((conf) => {
-    if (!conf.key) {
+    let key = conf.key;
+    if (!key) {
       // If asyncConnect does not get a key in its config, it
       // will not dispatch LOAD_FAIL for thrown errors!
       // Other than that, the key is used to set a magic component
       // property (which we never rely on) so it's really not so
       // important.
-      conf.key = '__safeAsyncConnect_key__';
+      key = '__safeAsyncConnect_key__';
     }
     if (!conf.promise) {
       // This is the only way we use asyncConnect() for now.
@@ -266,6 +267,7 @@ export function safeAsyncConnect(
     }
     return {
       ...conf,
+      key,
       deferred: true,
       promise: safePromise(conf.promise),
     };

--- a/tests/client/core/test_utils.js
+++ b/tests/client/core/test_utils.js
@@ -733,6 +733,18 @@ describe('safeAsyncConnect', () => {
     assert.equal(asyncConnect.firstCall.args[0][0].key, 'one');
     assert.equal(asyncConnect.firstCall.args[0][1].key, 'two');
   });
+
+  it('fills in an empty key to configs', () => {
+    const asyncConnect = sinon.stub();
+
+    safeAsyncConnect([{
+      promise: () => Promise.resolve(),
+    }], { asyncConnect });
+
+    assert.equal(
+      asyncConnect.firstCall.args[0][0].key,
+      '__safeAsyncConnect_key__');
+  });
 });
 
 describe('safePromise', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2211

I tried to make a smarter test for this that sets up a `safeAsyncConnect` decoration and makes sure `LOAD_FAIL` gets dispatched but I think it's too difficult because of `redux-connect`'s reliance on middleware. Oh well. I manually tested it after this patch and `LOAD_FAIL` actions are getting dispatched.