### PR TITLE
Prompt the user to refresh the page if their session expires

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -174,3 +174,6 @@ export const GLOBAL_EVENT_STATUS_MAP = {
 // The events here are set directly on mozAddonManager
 // they will be fired by addons and themes.
 export const GLOBAL_EVENTS = Object.keys(GLOBAL_EVENT_STATUS_MAP);
+
+// API error codes.
+export const API_ERROR_SIGNATURE_EXPIRED = 'ERROR_SIGNATURE_EXPIRED';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -179,4 +179,6 @@ export const GLOBAL_EVENTS = Object.keys(GLOBAL_EVENT_STATUS_MAP);
 export const ERROR_UNKNOWN = 'ERROR_UNKNOWN';
 // API error codes. These values match the error codes defined here:
 // http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#unauthorized-and-permission-denied
+export const API_ERROR_DECODING_SIGNATURE = 'ERROR_DECODING_SIGNATURE';
+export const API_ERROR_INVALID_HEADER = 'ERROR_INVALID_HEADER';
 export const API_ERROR_SIGNATURE_EXPIRED = 'ERROR_SIGNATURE_EXPIRED';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -175,5 +175,8 @@ export const GLOBAL_EVENT_STATUS_MAP = {
 // they will be fired by addons and themes.
 export const GLOBAL_EVENTS = Object.keys(GLOBAL_EVENT_STATUS_MAP);
 
-// API error codes.
+// Generic error codes.
+export const ERROR_UNKNOWN = 'ERROR_UNKNOWN';
+// API error codes. These values match the error codes defined here:
+// http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#unauthorized-and-permission-denied
 export const API_ERROR_SIGNATURE_EXPIRED = 'ERROR_SIGNATURE_EXPIRED';

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -11,6 +11,8 @@ $sub-text-color: #6a6a6a;
 $form-border-color: $primary-font-color;
 $error-text-color: $text-color-message;
 $error-background-color: #f03e3e;
+$error-button-background-color: $error-text-color;
+$error-button-text-color: $error-background-color;
 
 $button-background-color: #0095dd;
 

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -4,8 +4,7 @@ import { connect } from 'react-redux';
 
 import { clearError, setError } from 'core/actions/errors';
 import log from 'core/logger';
-
-import 'core/css/ErrorHandler.scss';
+import ErrorList from 'ui/components/ErrorList';
 
 function generateHandlerId({ name = '' } = {}) {
   return `${name}-${Math.random().toString(36).substr(2, 9)}`;
@@ -35,23 +34,7 @@ export class ErrorHandler {
   }
 
   renderError() {
-    return (
-      <ul className="ErrorHandler-list">
-        {this.capturedError.messages.map(
-          (msg) => {
-            let msgString = msg;
-            if (typeof msgString === 'object') {
-              // This is an unlikely scenario where an API response
-              // contains nested objects within objects. If this
-              // happens in real life let's make it prettier.
-              // Until then, let's just prevent a stack trace.
-              msgString = JSON.stringify(msg);
-            }
-            return <li className="ErrorHandler-list-item">{msgString}</li>;
-          }
-        )}
-      </ul>
-    );
+    return <ErrorList errors={[this.capturedError]} />;
   }
 
   handle(error) {

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -34,7 +34,10 @@ export class ErrorHandler {
   }
 
   renderError() {
-    return <ErrorList errors={[this.capturedError]} />;
+    const { messages, needsPageRefresh } = this.capturedError;
+    return (
+      <ErrorList messages={messages} needsPageRefresh={needsPageRefresh} />
+    );
   }
 
   handle(error) {

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -34,10 +34,8 @@ export class ErrorHandler {
   }
 
   renderError() {
-    const { messages, needsPageRefresh } = this.capturedError;
-    return (
-      <ErrorList messages={messages} needsPageRefresh={needsPageRefresh} />
-    );
+    const { code, messages } = this.capturedError;
+    return <ErrorList messages={messages} code={code} />;
   }
 
   handle(error) {

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -11,7 +11,7 @@ import log from 'core/logger';
  * http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#responses
  */
 function getMessagesFromError(error) {
-  let data = {
+  let errorData = {
     code: ERROR_UNKNOWN,
     messages: [],
   };
@@ -21,7 +21,7 @@ function getMessagesFromError(error) {
     Object.keys(error.response.data).forEach((key) => {
       const val = error.response.data[key];
       if (key === 'code') {
-        data = { ...data, code: val };
+        errorData = { ...errorData, code: val };
         return;
       }
       if (Array.isArray(val)) {
@@ -31,25 +31,25 @@ function getMessagesFromError(error) {
         val.forEach((msg) => {
           if (key === 'non_field_errors') {
             // Add a generic error not related to a specific field.
-            data.messages.push(msg);
+            errorData.messages.push(msg);
           } else {
             // Add field specific error message.
             // The field is not localized but we need to show it as a hint.
-            data.messages.push(`${key}: ${msg}`);
+            errorData.messages.push(`${key}: ${msg}`);
           }
         });
       } else {
         // This is most likely not a form field error so just show the message.
-        data.messages.push(val);
+        errorData.messages.push(val);
       }
     });
   }
 
-  if (!data.messages.length) {
+  if (!errorData.messages.length) {
     log.warn('Error object did not contain any messages', error);
   }
 
-  return data;
+  return errorData;
 }
 
 export const initialState = {};

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -13,8 +13,8 @@ import { gettext } from 'core/utils';
  */
 function getMessagesFromError(error) {
   let data = {
+    errorCode: undefined,
     messages: [gettext('An unexpected error occurred')],
-    needsPageRefresh: false,
   };
   log.info('Extracting messages from error object:', error);
 
@@ -49,16 +49,7 @@ function getMessagesFromError(error) {
       log.warn('API error response did not contain any messages', error);
     }
 
-    if (
-      error.response.data.detail &&
-      // TODO: switch to checking for a code after
-      // https://github.com/mozilla/addons-server/issues/5122
-      error.response.data.detail === 'Signature has expired.'
-    ) {
-      // In this case, the only way to recover from the error is to
-      // refresh the page. It is impossible to fully avoid this state.
-      data = { ...data, needsPageRefresh: true };
-    }
+    data = { ...data, code: error.response.data.code };
   }
   return data;
 }
@@ -73,11 +64,11 @@ export default function errors(state = initialState, action) {
         [action.payload.id]: null,
       };
     case SET_ERROR: {
-      const { messages, needsPageRefresh } =
+      const { code, messages } =
         getMessagesFromError(action.payload.error);
       return {
         ...state,
-        [action.payload.id]: { messages, needsPageRefresh },
+        [action.payload.id]: { code, messages },
       };
     }
     default:

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -13,7 +13,7 @@ import { gettext } from 'core/utils';
  */
 function getMessagesFromError(error) {
   let data = {
-    errorCode: undefined,
+    code: undefined,
     messages: [gettext('An unexpected error occurred')],
   };
   log.info('Extracting messages from error object:', error);
@@ -23,6 +23,10 @@ function getMessagesFromError(error) {
 
     Object.keys(error.response.data).forEach((key) => {
       const val = error.response.data[key];
+      if (key === 'code') {
+        data = { ...data, code: val };
+        return;
+      }
       if (Array.isArray(val)) {
         // Most API reponse errors will consist of a key (which could be a
         // form field) and an array of localized messages.
@@ -48,8 +52,6 @@ function getMessagesFromError(error) {
     } else {
       log.warn('API error response did not contain any messages', error);
     }
-
-    data = { ...data, code: error.response.data.code };
   }
   return data;
 }

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -1,14 +1,17 @@
 import classNames from 'classnames';
 import React, { PropTypes } from 'react';
+import { compose } from 'redux';
 
+import translate from 'core/i18n/translate';
 import Button from 'ui/components/Button';
 
 import './styles.scss';
 
 
-export default class ErrorList extends React.Component {
+class ErrorList extends React.Component {
   static propTypes = {
     className: PropTypes.string,
+    i18n: PropTypes.object.isRequired,
     messages: PropTypes.array.isRequired,
     needsPageRefresh: PropTypes.boolean,
   }
@@ -18,7 +21,7 @@ export default class ErrorList extends React.Component {
   };
 
   render() {
-    const { messages, needsPageRefresh } = this.props;
+    const { i18n, messages, needsPageRefresh } = this.props;
     const items = [];
 
     messages.forEach((msg) => {
@@ -34,8 +37,9 @@ export default class ErrorList extends React.Component {
     });
 
     if (needsPageRefresh) {
-      // TODO: L10n
-      items.push(<Button>{'Reload To Continue'}</Button>);
+      items.push(
+        <Button>{i18n.gettext('Reload To Continue')}</Button>
+      );
     }
 
     return (
@@ -45,3 +49,7 @@ export default class ErrorList extends React.Component {
     );
   }
 }
+
+export default compose(
+  translate({ withRef: true }),
+)(ErrorList);

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -1,0 +1,49 @@
+import classNames from 'classnames';
+import React, { PropTypes } from 'react';
+
+import Button from 'ui/components/Button';
+
+import './styles.scss';
+
+
+export default class ErrorList extends React.Component {
+  static propTypes = {
+    errors: PropTypes.array.isRequired,
+    className: PropTypes.string,
+  }
+
+  render() {
+    const { errors } = this.props;
+    let needsPageRefresh = false;
+    const items = [];
+
+    errors.forEach((error) => {
+      error.messages.forEach((msg) => {
+        let msgString = msg;
+        if (typeof msgString === 'object') {
+          // This is an unlikely scenario where an API response
+          // contains nested objects within objects. If this
+          // happens in real life let's make it prettier.
+          // Until then, let's just prevent a stack trace.
+          msgString = JSON.stringify(msgString);
+        }
+        items.push(msgString);
+      });
+
+      if (error.needsPageRefresh) {
+        needsPageRefresh = true;
+      }
+    });
+
+    if (needsPageRefresh) {
+      // TODO: L10n
+      items.push(<Button>{'Reload To Continue'}</Button>);
+    }
+
+    return (
+      <ul className="ErrorList">
+        {items.map((item) => <li className="ErrorList-item">{item}</li>)}
+      </ul>
+    );
+  }
+}

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -1,3 +1,4 @@
+/* global window */
 import classNames from 'classnames';
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
@@ -10,6 +11,7 @@ import './styles.scss';
 
 class ErrorList extends React.Component {
   static propTypes = {
+    _window: PropTypes.object,
     className: PropTypes.string,
     i18n: PropTypes.object.isRequired,
     messages: PropTypes.array.isRequired,
@@ -17,11 +19,12 @@ class ErrorList extends React.Component {
   }
 
   static defaultProps = {
+    _window: typeof window !== 'undefined' ? window : {},
     needsPageRefresh: false,
   };
 
   render() {
-    const { i18n, messages, needsPageRefresh } = this.props;
+    const { _window, className, i18n, messages, needsPageRefresh } = this.props;
     const items = [];
 
     messages.forEach((msg) => {
@@ -38,12 +41,14 @@ class ErrorList extends React.Component {
 
     if (needsPageRefresh) {
       items.push(
-        <Button>{i18n.gettext('Reload To Continue')}</Button>
+        <Button onClick={() => _window.location.reload()}>
+          {i18n.gettext('Reload To Continue')}
+        </Button>
       );
     }
 
     return (
-      <ul className="ErrorList">
+      <ul className={classNames('ErrorList', className)}>
         {items.map((item) => <li className="ErrorList-item">{item}</li>)}
       </ul>
     );

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -46,6 +46,11 @@ class ErrorList extends React.Component {
       items.push(msgString);
     });
 
+    if (!items.length) {
+      log.debug(`No messages were passed to ErrorList, code: ${code}`);
+      items.push(i18n.gettext('An unexpected error occurred'));
+    }
+
     if (code === API_ERROR_SIGNATURE_EXPIRED) {
       items.push(
         <Button onClick={() => _window.location.reload()}>

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -28,22 +28,22 @@ class ErrorList extends React.Component {
     const { _window, code, className, i18n, messages } = this.props;
     const items = [];
 
-    messages.forEach((msg) => {
-      let msgString = msg;
-      if (typeof msgString === 'object') {
+    messages.forEach((messageItem) => {
+      let message = messageItem;
+      if (typeof message === 'object') {
         // This handles an unlikely scenario where an API error response
         // contains nested objects within objects. If this happens in real
         // life let's fix it or make the display prettier.
         // Until then, let's just prevent it from triggering an exception.
-        msgString = JSON.stringify(msgString);
+        message = JSON.stringify(message);
       }
       if (code === API_ERROR_SIGNATURE_EXPIRED) {
         // This API error describes exactly what happened but that isn't
         // very helpful for AMO users. Let's help them figure it out.
-        log.debug(`Detected ${code}, replacing API translation: ${msgString}`);
-        msgString = i18n.gettext('Your session has expired');
+        log.debug(`Detected ${code}, replacing API translation: ${message}`);
+        message = i18n.gettext('Your session has expired');
       }
-      items.push(msgString);
+      items.push(message);
     });
 
     if (!items.length) {

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
 
+import { API_ERROR_SIGNATURE_EXPIRED } from 'core/constants';
 import log from 'core/logger';
 import translate from 'core/i18n/translate';
 import Button from 'ui/components/Button';
@@ -36,7 +37,7 @@ class ErrorList extends React.Component {
         // Until then, let's just prevent it from triggering an exception.
         msgString = JSON.stringify(msgString);
       }
-      if (code === 'ERROR_SIGNATURE_EXPIRED') {
+      if (code === API_ERROR_SIGNATURE_EXPIRED) {
         // This API error describes exactly what happened but that isn't
         // very helpful for AMO users. Let's help them figure it out.
         log.debug(`Detected ${code}, replacing API translation: ${msgString}`);
@@ -45,7 +46,7 @@ class ErrorList extends React.Component {
       items.push(msgString);
     });
 
-    if (code === 'ERROR_SIGNATURE_EXPIRED') {
+    if (code === API_ERROR_SIGNATURE_EXPIRED) {
       items.push(
         <Button onClick={() => _window.location.reload()}>
           {i18n.gettext('Reload To Continue')}

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -8,31 +8,29 @@ import './styles.scss';
 
 export default class ErrorList extends React.Component {
   static propTypes = {
-    errors: PropTypes.array.isRequired,
     className: PropTypes.string,
+    messages: PropTypes.array.isRequired,
+    needsPageRefresh: PropTypes.boolean,
   }
 
+  static defaultProps = {
+    needsPageRefresh: false,
+  };
+
   render() {
-    const { errors } = this.props;
-    let needsPageRefresh = false;
+    const { messages, needsPageRefresh } = this.props;
     const items = [];
 
-    errors.forEach((error) => {
-      error.messages.forEach((msg) => {
-        let msgString = msg;
-        if (typeof msgString === 'object') {
-          // This is an unlikely scenario where an API response
-          // contains nested objects within objects. If this
-          // happens in real life let's make it prettier.
-          // Until then, let's just prevent a stack trace.
-          msgString = JSON.stringify(msgString);
-        }
-        items.push(msgString);
-      });
-
-      if (error.needsPageRefresh) {
-        needsPageRefresh = true;
+    messages.forEach((msg) => {
+      let msgString = msg;
+      if (typeof msgString === 'object') {
+        // This handles an unlikely scenario where an API error response
+        // contains nested objects within objects. If this happens in real
+        // life let's fix it or make the display prettier.
+        // Until then, let's just prevent it from triggering an exception.
+        msgString = JSON.stringify(msgString);
       }
+      items.push(msgString);
     });
 
     if (needsPageRefresh) {

--- a/src/ui/components/ErrorList/styles.scss
+++ b/src/ui/components/ErrorList/styles.scss
@@ -1,6 +1,6 @@
 @import "~core/css/inc/vars";
 
-.ErrorHandler-list {
+.ErrorList {
   text-align: center;
   border-radius: $border-radius-default;
   background-color: $error-background-color;
@@ -10,6 +10,6 @@
   margin-bottom: 10px;
 }
 
-.ErrorHandler-list-item {
+.ErrorList-item {
   list-style: none;
 }

--- a/src/ui/components/ErrorList/styles.scss
+++ b/src/ui/components/ErrorList/styles.scss
@@ -12,4 +12,16 @@
 
 .ErrorList-item {
   list-style: none;
+  margin-bottom: 8px;
+
+  .Button {
+    color: $error-button-text-color;
+    background-color: $error-button-background-color;
+    border-radius: $border-radius-s;
+    font-size: $font-size-s;
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/tests/client/core/reducers/test_errors.js
+++ b/tests/client/core/reducers/test_errors.js
@@ -1,5 +1,6 @@
 import { createApiError } from 'core/api/index';
 import { clearError, setError } from 'core/actions/errors';
+import { API_ERROR_SIGNATURE_EXPIRED } from 'core/constants';
 import errors, { initialState } from 'core/reducers/errors';
 
 export function createFakeApiError({ fieldErrors = {}, nonFieldErrors } = {}) {
@@ -138,18 +139,17 @@ describe('errors reducer', () => {
   });
 
   it('adds an error code', () => {
-    const code = 'ERROR_SIGNATURE_EXPIRED';
     const error = createApiError({
       response: { status: 401 },
       apiURL: 'https://some/api/endpoint',
       jsonResponse: {
-        code,
+        code: API_ERROR_SIGNATURE_EXPIRED,
         detail: 'Any message about an expired signature.',
       },
     });
     const action = setError({ id: 'some-id', error });
     const state = errors(undefined, action);
-    assert.equal(state[action.payload.id].code, code);
+    assert.equal(state[action.payload.id].code, API_ERROR_SIGNATURE_EXPIRED);
   });
 
   it('does not turn an error code into a message', () => {
@@ -157,7 +157,7 @@ describe('errors reducer', () => {
       response: { status: 401 },
       apiURL: 'https://some/api/endpoint',
       jsonResponse: {
-        code: 'ERROR_SIGNATURE_EXPIRED',
+        code: API_ERROR_SIGNATURE_EXPIRED,
         detail: 'Some message.',
       },
     });

--- a/tests/client/core/reducers/test_errors.js
+++ b/tests/client/core/reducers/test_errors.js
@@ -151,4 +151,18 @@ describe('errors reducer', () => {
     const state = errors(undefined, action);
     assert.equal(state[action.payload.id].code, code);
   });
+
+  it('does not turn an error code into a message', () => {
+    const error = createApiError({
+      response: { status: 401 },
+      apiURL: 'https://some/api/endpoint',
+      jsonResponse: {
+        code: 'ERROR_SIGNATURE_EXPIRED',
+        detail: 'Some message.',
+      },
+    });
+    const action = setError({ id: 'some-id', error });
+    const state = errors(undefined, action);
+    assert.deepEqual(state[action.payload.id].messages, ['Some message.']);
+  });
 });

--- a/tests/client/core/reducers/test_errors.js
+++ b/tests/client/core/reducers/test_errors.js
@@ -29,7 +29,7 @@ describe('errors reducer', () => {
     const state = errors(undefined, action);
     assert.deepEqual(state[action.payload.id], {
       messages: ['An unexpected error occurred'],
-      needsPageRefresh: false,
+      code: undefined,
     });
   });
 
@@ -43,8 +43,8 @@ describe('errors reducer', () => {
     const action = setError({ id: 'some-id', error });
     const state = errors(undefined, action);
     assert.deepEqual(state[action.payload.id], {
+      code: undefined,
       messages: [message],
-      needsPageRefresh: false,
     });
   });
 
@@ -132,20 +132,23 @@ describe('errors reducer', () => {
     const action = setError({ id: 'some-id', error: createFakeApiError() });
     const state = errors(undefined, action);
     assert.deepEqual(state[action.payload.id], {
+      code: undefined,
       messages: ['An unexpected error occurred'],
-      needsPageRefresh: false,
     });
   });
 
-  it('adds a needs-refresh flag for expired signature errors', () => {
-    const message = 'Signature has expired.';
+  it('adds an error code', () => {
+    const code = 'ERROR_SIGNATURE_EXPIRED';
     const error = createApiError({
       response: { status: 401 },
       apiURL: 'https://some/api/endpoint',
-      jsonResponse: { detail: message },
+      jsonResponse: {
+        code,
+        detail: 'Any message about an expired signature.',
+      },
     });
     const action = setError({ id: 'some-id', error });
     const state = errors(undefined, action);
-    assert.strictEqual(state[action.payload.id].needsPageRefresh, true);
+    assert.equal(state[action.payload.id].code, code);
   });
 });

--- a/tests/client/core/reducers/test_errors.js
+++ b/tests/client/core/reducers/test_errors.js
@@ -1,6 +1,6 @@
 import { createApiError } from 'core/api/index';
 import { clearError, setError } from 'core/actions/errors';
-import { API_ERROR_SIGNATURE_EXPIRED } from 'core/constants';
+import { API_ERROR_SIGNATURE_EXPIRED, ERROR_UNKNOWN } from 'core/constants';
 import errors, { initialState } from 'core/reducers/errors';
 
 export function createFakeApiError({ fieldErrors = {}, nonFieldErrors } = {}) {
@@ -24,16 +24,6 @@ describe('errors reducer', () => {
     assert.deepEqual(errors(undefined, { type: 'UNRELATED' }), initialState);
   });
 
-  it('stores a simple error', () => {
-    const error = new Error('some message');
-    const action = setError({ id: 'some-id', error });
-    const state = errors(undefined, action);
-    assert.deepEqual(state[action.payload.id], {
-      messages: ['An unexpected error occurred'],
-      code: undefined,
-    });
-  });
-
   it('handles API object responses', () => {
     const message = 'Authentication credentials were not provided.';
     const error = createApiError({
@@ -44,7 +34,7 @@ describe('errors reducer', () => {
     const action = setError({ id: 'some-id', error });
     const state = errors(undefined, action);
     assert.deepEqual(state[action.payload.id], {
-      code: undefined,
+      code: ERROR_UNKNOWN,
       messages: [message],
     });
   });
@@ -90,11 +80,13 @@ describe('errors reducer', () => {
     assert.equal(state.action2.messages[0], 'action2');
   });
 
-  it('creates a default error message', () => {
+  it('stores a generic error', () => {
     const action = setError({ id: 'action1', error: new Error('any message') });
     const state = errors(undefined, action);
-    assert.deepEqual(state[action.payload.id].messages,
-                     ['An unexpected error occurred']);
+    assert.deepEqual(state[action.payload.id], {
+      code: ERROR_UNKNOWN,
+      messages: [],
+    });
   });
 
   it('gets non_field_errors from API error response', () => {
@@ -128,13 +120,13 @@ describe('errors reducer', () => {
     assert.include(messages, 'password: sorry, it cannot be 1234');
   });
 
-  it('handles API responses without any messages', () => {
+  it('stores API responses when they do not have messages', () => {
     // This API error has no messages (hopefully this won't ever happen).
     const action = setError({ id: 'some-id', error: createFakeApiError() });
     const state = errors(undefined, action);
     assert.deepEqual(state[action.payload.id], {
-      code: undefined,
-      messages: ['An unexpected error occurred'],
+      code: ERROR_UNKNOWN,
+      messages: [],
     });
   });
 

--- a/tests/client/core/reducers/test_errors.js
+++ b/tests/client/core/reducers/test_errors.js
@@ -29,6 +29,7 @@ describe('errors reducer', () => {
     const state = errors(undefined, action);
     assert.deepEqual(state[action.payload.id], {
       messages: ['An unexpected error occurred'],
+      needsPageRefresh: false,
     });
   });
 
@@ -41,7 +42,10 @@ describe('errors reducer', () => {
     });
     const action = setError({ id: 'some-id', error });
     const state = errors(undefined, action);
-    assert.deepEqual(state[action.payload.id], { messages: [message] });
+    assert.deepEqual(state[action.payload.id], {
+      messages: [message],
+      needsPageRefresh: false,
+    });
   });
 
   it('preserves existing errors', () => {
@@ -129,6 +133,19 @@ describe('errors reducer', () => {
     const state = errors(undefined, action);
     assert.deepEqual(state[action.payload.id], {
       messages: ['An unexpected error occurred'],
+      needsPageRefresh: false,
     });
+  });
+
+  it('adds a needs-refresh flag for expired signature errors', () => {
+    const message = 'Signature has expired.';
+    const error = createApiError({
+      response: { status: 401 },
+      apiURL: 'https://some/api/endpoint',
+      jsonResponse: { detail: message },
+    });
+    const action = setError({ id: 'some-id', error });
+    const state = errors(undefined, action);
+    assert.strictEqual(state[action.payload.id].needsPageRefresh, true);
   });
 });

--- a/tests/client/core/testErrorHandler.js
+++ b/tests/client/core/testErrorHandler.js
@@ -4,12 +4,14 @@ import { findRenderedComponentWithType, renderIntoDocument }
   from 'react-addons-test-utils';
 import { createStore, combineReducers } from 'redux';
 
+import I18nProvider from 'core/i18n/Provider';
 import { createApiError } from 'core/api/index';
 import translate from 'core/i18n/translate';
 import { clearError, setError } from 'core/actions/errors';
 import { ErrorHandler, withErrorHandler, withErrorHandling }
   from 'core/errorHandler';
 import errors from 'core/reducers/errors';
+import { getFakeI18nInst } from 'tests/client/helpers';
 import { createFakeApiError } from 'tests/client/core/reducers/test_errors';
 
 class SomeComponentBase extends React.Component {
@@ -35,7 +37,9 @@ function createWrappedComponent({
   })(SomeComponent);
 
   const provider = renderIntoDocument(
-    <ComponentWithErrorHandling store={store} {...customProps} />
+    <I18nProvider i18n={getFakeI18nInst()}>
+      <ComponentWithErrorHandling store={store} {...customProps} />
+    </I18nProvider>
   );
   const component = findRenderedComponentWithType(provider, SomeComponent);
 

--- a/tests/client/core/testErrorHandler.js
+++ b/tests/client/core/testErrorHandler.js
@@ -110,7 +110,7 @@ describe('errorHandler', () => {
       const { dom } = createWrappedComponent({
         store, id, decorator: withErrorHandling,
       });
-      assert.equal(dom.querySelector('.ErrorHandler-list').textContent,
+      assert.equal(dom.querySelector('.ErrorList').textContent,
                    'An unexpected error occurred');
       // It also renders component content:
       assert.equal(dom.querySelector('.SomeComponent').textContent,
@@ -132,7 +132,7 @@ describe('errorHandler', () => {
       const { dom } = createWrappedComponent({
         store, id, decorator: withErrorHandling,
       });
-      assert.equal(dom.querySelector('.ErrorHandler-list').textContent,
+      assert.equal(dom.querySelector('.ErrorList').textContent,
                    JSON.stringify(nestedMessage));
     });
 
@@ -140,7 +140,7 @@ describe('errorHandler', () => {
       const { dom } = createWrappedComponent({
         decorator: withErrorHandling,
       });
-      assert.equal(dom.querySelector('.ErrorHandler-list'), null);
+      assert.equal(dom.querySelector('.ErrorList'), null);
       assert.equal(dom.textContent, 'Component text');
     });
 
@@ -156,7 +156,7 @@ describe('errorHandler', () => {
       const { dom } = createWrappedComponent({
         store, id, decorator: withErrorHandling,
       });
-      const items = dom.querySelectorAll('.ErrorHandler-list li');
+      const items = dom.querySelectorAll('.ErrorList-item');
       assert(items.length, 'error list was not rendered');
       assert.equal(items[0].textContent, 'first error');
       assert.equal(items[1].textContent, 'second error');
@@ -172,7 +172,7 @@ describe('errorHandler', () => {
       const { dom } = createWrappedComponent({
         store, id, decorator: withErrorHandling,
       });
-      assert.equal(dom.querySelector('.ErrorHandler-list'), null);
+      assert.equal(dom.querySelector('.ErrorList'), null);
     });
 
     it('ignores errors sent by other error handlers', () => {
@@ -184,7 +184,7 @@ describe('errorHandler', () => {
       const { dom } = createWrappedComponent({
         store, id: 'this-handler-id', decorator: withErrorHandling,
       });
-      assert.equal(dom.querySelector('.ErrorHandler-list'), null);
+      assert.equal(dom.querySelector('.ErrorList'), null);
     });
 
     it('passes through wrapped component properties without an error', () => {

--- a/tests/client/ui/components/TestErrorList.js
+++ b/tests/client/ui/components/TestErrorList.js
@@ -1,13 +1,17 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
 import { findDOMNode } from 'react-dom';
-import { findRenderedComponentWithType, renderIntoDocument }
-  from 'react-addons-test-utils';
+import { renderIntoDocument, Simulate } from 'react-addons-test-utils';
 
 import I18nProvider from 'core/i18n/Provider';
 import { getFakeI18nInst } from 'tests/client/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
-function render(props = {}) {
+function render(customProps = {}) {
+  const props = {
+    messages: [],
+    _window: { location: { reload: sinon.stub() } },
+    ...customProps,
+  };
   return findDOMNode(renderIntoDocument(
     <I18nProvider i18n={getFakeI18nInst()}>
       <ErrorList {...props} />
@@ -16,6 +20,11 @@ function render(props = {}) {
 }
 
 describe('ui/components/ErrorList', () => {
+  it('supports a custom class name', () => {
+    const root = render({ className: 'MyClass' });
+    assert.include(root.className, 'MyClass');
+  });
+
   it('renders a message', () => {
     const root = render({ messages: ['Some error'] });
     assert.equal(root.textContent, 'Some error');
@@ -38,11 +47,17 @@ describe('ui/components/ErrorList', () => {
   });
 
   it('renders a reload button', () => {
+    const _window = { location: { reload: sinon.stub() } };
     const root = render({
+      _window,
       messages: ['Some error'],
       needsPageRefresh: true,
     });
     const button = root.querySelector('.ErrorList-item .Button');
     assert.equal(button.textContent, 'Reload To Continue');
+    Simulate.click(button);
+    assert.ok(
+      _window.location.reload.called,
+      'window.location.reload() not called');
   });
 });

--- a/tests/client/ui/components/TestErrorList.js
+++ b/tests/client/ui/components/TestErrorList.js
@@ -31,6 +31,11 @@ describe('ui/components/ErrorList', () => {
     assert.equal(root.textContent, 'Some error');
   });
 
+  it('renders a generic message for errors without a message', () => {
+    const root = render({ messages: [] });
+    assert.equal(root.textContent, 'An unexpected error occurred');
+  });
+
   it('renders all messages', () => {
     const root = render({
       messages: ['One', 'Two', 'Three'],

--- a/tests/client/ui/components/TestErrorList.js
+++ b/tests/client/ui/components/TestErrorList.js
@@ -46,13 +46,18 @@ describe('ui/components/ErrorList', () => {
     assert.equal(root.textContent, JSON.stringify(objectMessage));
   });
 
-  it('renders a reload button', () => {
+  it('renders a reload button for signature expired errors', () => {
     const _window = { location: { reload: sinon.stub() } };
     const root = render({
       _window,
-      messages: ['Some error'],
-      needsPageRefresh: true,
+      code: 'ERROR_SIGNATURE_EXPIRED',
+      messages: ['Signature error'],
     });
+
+    const message = root.querySelectorAll('.ErrorList-item')[0];
+    // A better message should be displayed:
+    assert.equal(message.textContent, 'Your session has expired');
+
     const button = root.querySelector('.ErrorList-item .Button');
     assert.equal(button.textContent, 'Reload To Continue');
     Simulate.click(button);

--- a/tests/client/ui/components/TestErrorList.js
+++ b/tests/client/ui/components/TestErrorList.js
@@ -3,10 +3,16 @@ import { findDOMNode } from 'react-dom';
 import { findRenderedComponentWithType, renderIntoDocument }
   from 'react-addons-test-utils';
 
+import I18nProvider from 'core/i18n/Provider';
+import { getFakeI18nInst } from 'tests/client/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
 function render(props = {}) {
-  return findDOMNode(renderIntoDocument(<ErrorList {...props} />));
+  return findDOMNode(renderIntoDocument(
+    <I18nProvider i18n={getFakeI18nInst()}>
+      <ErrorList {...props} />
+    </I18nProvider>
+  ));
 }
 
 describe('ui/components/ErrorList', () => {

--- a/tests/client/ui/components/TestErrorList.js
+++ b/tests/client/ui/components/TestErrorList.js
@@ -1,0 +1,42 @@
+import React, { PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
+import { findRenderedComponentWithType, renderIntoDocument }
+  from 'react-addons-test-utils';
+
+import ErrorList from 'ui/components/ErrorList';
+
+function render(props = {}) {
+  return findDOMNode(renderIntoDocument(<ErrorList {...props} />));
+}
+
+describe('ui/components/ErrorList', () => {
+  it('renders a message', () => {
+    const root = render({ messages: ['Some error'] });
+    assert.equal(root.textContent, 'Some error');
+  });
+
+  it('renders all messages', () => {
+    const root = render({
+      messages: ['One', 'Two', 'Three'],
+    });
+    const items = root.querySelectorAll('.ErrorList-item');
+    assert.equal(items[0].textContent, 'One');
+    assert.equal(items[1].textContent, 'Two');
+    assert.equal(items[2].textContent, 'Three');
+  });
+
+  it('renders object messages', () => {
+    const objectMessage = { thisIsNot: 'a string' };
+    const root = render({ messages: [objectMessage] });
+    assert.equal(root.textContent, JSON.stringify(objectMessage));
+  });
+
+  it('renders a reload button', () => {
+    const root = render({
+      messages: ['Some error'],
+      needsPageRefresh: true,
+    });
+    const button = root.querySelector('.ErrorList-item .Button');
+    assert.equal(button.textContent, 'Reload To Continue');
+  });
+});

--- a/tests/client/ui/components/TestErrorList.js
+++ b/tests/client/ui/components/TestErrorList.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { renderIntoDocument, Simulate } from 'react-addons-test-utils';
 
+import { API_ERROR_SIGNATURE_EXPIRED } from 'core/constants';
 import I18nProvider from 'core/i18n/Provider';
 import { getFakeI18nInst } from 'tests/client/helpers';
 import ErrorList from 'ui/components/ErrorList';
@@ -50,7 +51,7 @@ describe('ui/components/ErrorList', () => {
     const _window = { location: { reload: sinon.stub() } };
     const root = render({
       _window,
-      code: 'ERROR_SIGNATURE_EXPIRED',
+      code: API_ERROR_SIGNATURE_EXPIRED,
       messages: ['Signature error'],
     });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2238

This is a baby step toward helping users cope with expired sessions. It's definitely not ideal but it's a quick patch that may be worth landing. 

<img width="361" alt="screenshot 2017-04-10 16 31 03" src="https://cloud.githubusercontent.com/assets/55398/24883921/b7ff3460-1e0c-11e7-85cd-dfc8a1039526.png">

Here are some things to do later:

* We can probably set a timer and anticipate when a session will expire and change the state. This is a harder patch and will be done in https://github.com/mozilla/addons-frontend/issues/2237 Even after doing that patch, it will still be possible to get a signature expired result though (because the timer won't be exact).
* ~~We can switch to detecting a code instead of the 'Signature expired' string, which is https://github.com/mozilla/addons-server/issues/5122~~
* ~~I thought it would be nice to show a better message like 'Your session has expired. You need to log in again' but this was difficult because we only have `i18n` objects inside components. Maybe I can think of a way.~~