### PR TITLE
Fix css/sass build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then gunzip -c geckodriver.tar.gz | tar xopf -; fi
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then chmod +x geckodriver && sudo mv geckodriver /usr/local/bin; fi
 before_script:
-- echo "TODO: npm rebuild node-sass"
 - if [ $GUI ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3; fi
 script:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ before_install:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then gunzip -c geckodriver.tar.gz | tar xopf -; fi
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then chmod +x geckodriver && sudo mv geckodriver /usr/local/bin; fi
 before_script:
+# Make sure we have the right node-sass. See:
+# https://github.com/webpack-contrib/css-loader/issues/240#issuecomment-252661267
+- npm rebuild node-sass
 - if [ $GUI ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3; fi
 script:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then gunzip -c geckodriver.tar.gz | tar xopf -; fi
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then chmod +x geckodriver && sudo mv geckodriver /usr/local/bin; fi
 before_script:
+- echo "TODO: npm rebuild node-sass"
 - if [ $GUI ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3; fi
 script:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then


### PR DESCRIPTION
This should stop failures like this from happening: https://travis-ci.org/mozilla/addons-frontend/jobs/222881961

It appears that Travis had some cached artifacts of `node-sass` lying around and when it upgraded to a new LTS Node version, `node-sass` was left in a broken state.