### PR TITLE
Handle cancelled install

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -32,6 +32,7 @@ export const REDUX_CONNECT_LOAD_FAIL = '@redux-conn/LOAD_FAIL';
 
 // Add-on error states.
 export const DOWNLOAD_FAILED = 'DOWNLOAD_FAILED';
+export const INSTALL_CANCELLED = 'INSTALL_CANCELLED';
 export const INSTALL_FAILED = 'INSTALL_FAILED';
 
 // Unrecoverable errors.
@@ -139,17 +140,6 @@ export const DOWNLOAD_PROGRESS = 'DOWNLOAD_PROGRESS';
 export const INSTALL_COMPLETE = 'INSTALL_COMPLETE';
 export const UNINSTALL_COMPLETE = 'UNINSTALL_COMPLETE';
 export const INSTALL_ERROR = 'INSTALL_ERROR';
-
-export const acceptedInstallTypes = [
-  INSTALL_STATE,
-  START_DOWNLOAD,
-  DOWNLOAD_PROGRESS,
-  INSTALL_COMPLETE,
-  UNINSTALL_COMPLETE,
-  INSTALL_ERROR,
-  THEME_PREVIEW,
-  THEME_RESET_PREVIEW,
-];
 
 // Tracking categories.
 export const INSTALL_CATEGORY = 'AMO Addon / Theme Installs';

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -20,6 +20,7 @@ import {
   FATAL_UNINSTALL_ERROR,
   INSTALL_CATEGORY,
   INSTALL_ERROR,
+  INSTALL_CANCELLED,
   INSTALL_FAILED,
   INSTALL_STATE,
   SET_ENABLE_NOT_AVAILABLE,
@@ -70,6 +71,11 @@ export function makeProgressHandler(dispatch, guid) {
       dispatch({
         type: INSTALL_ERROR,
         payload: { guid, error: DOWNLOAD_FAILED },
+      });
+    } else if (event.type === 'onInstallCancelled') {
+      dispatch({
+        type: INSTALL_CANCELLED,
+        payload: { guid },
       });
     } else if (event.type === 'onInstallFailed') {
       dispatch({

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -62,11 +62,20 @@ export function makeProgressHandler(dispatch, guid) {
     if (addonInstall.state === 'STATE_DOWNLOADING') {
       const downloadProgress = parseInt(
         (100 * addonInstall.progress) / addonInstall.maxProgress, 10);
-      dispatch({ type: DOWNLOAD_PROGRESS, payload: { guid, downloadProgress } });
+      dispatch({
+        type: DOWNLOAD_PROGRESS,
+        payload: { guid, downloadProgress },
+      });
     } else if (event.type === 'onDownloadFailed') {
-      dispatch({ type: INSTALL_ERROR, payload: { guid, error: DOWNLOAD_FAILED } });
+      dispatch({
+        type: INSTALL_ERROR,
+        payload: { guid, error: DOWNLOAD_FAILED },
+      });
     } else if (event.type === 'onInstallFailed') {
-      dispatch({ type: INSTALL_ERROR, payload: { guid, error: INSTALL_FAILED } });
+      dispatch({
+        type: INSTALL_ERROR,
+        payload: { guid, error: INSTALL_FAILED },
+      });
     }
   };
 }
@@ -102,7 +111,8 @@ export function mapStateToProps(state, ownProps) {
         _log.info(`Theme ${guid} could not be found`);
       }
       if (theme && theme.status === ENABLED) {
-        _log.info(`Theme ${guid} is already enabled! Previewing is not necessary.`);
+        _log.info(
+          `Theme ${guid} is already enabled! Previewing is not necessary.`);
       }
     },
   };
@@ -121,9 +131,12 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
       return { WrappedComponent };
     }
 
-    if (ownProps.type === ADDON_TYPE_EXTENSION && ownProps.installURL === undefined) {
-      throw new Error(oneLine`installURL is required, ensure component props are set before
-        withInstallHelpers is called`);
+    if (
+      ownProps.type === ADDON_TYPE_EXTENSION &&
+      ownProps.installURL === undefined
+    ) {
+      throw new Error(oneLine`installURL is required, ensure component props
+        are set before withInstallHelpers is called`);
     }
 
     function showInfo({ name, iconUrl }) {
@@ -166,15 +179,19 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
         const { installURL } = ownProps;
         const guid = getGuid(ownProps);
         const payload = { guid, url: installURL };
+
         return _addonManager.getAddon(guid)
           .then((addon) => {
-            const status = addon.isActive && addon.isEnabled ? ENABLED : DISABLED;
+            const status = addon.isActive && addon.isEnabled ?
+              ENABLED : DISABLED;
+
             dispatch({
               type: INSTALL_STATE,
               payload: { ...payload, status },
             });
           }, () => {
-            log.info(`Add-on "${guid}" not found so setting status to UNINSTALLED`);
+            log.info(
+              `Add-on "${guid}" not found so setting status to UNINSTALLED`);
             dispatch({
               type: INSTALL_STATE,
               payload: { ...payload, status: UNINSTALLED },
@@ -182,7 +199,8 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
           })
           .catch((err) => {
             log.error(err);
-            // Dispatch a generic error should the success/error functions throw.
+            // Dispatch a generic error should the success/error functions
+            // throw.
             dispatch({
               type: INSTALL_STATE,
               payload: { guid, status: ERROR, error: FATAL_ERROR },
@@ -200,7 +218,8 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
           })
           .catch((err) => {
             if (err && err.message === SET_ENABLE_NOT_AVAILABLE) {
-              log.info(`addon.setEnabled not available. Unable to enable ${guid}`);
+              log.info(
+                `addon.setEnabled not available. Unable to enable ${guid}`);
             } else {
               log.error(err);
               dispatch({
@@ -214,7 +233,9 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
       install() {
         const { guid, iconUrl, installURL, name } = ownProps;
         dispatch({ type: START_DOWNLOAD, payload: { guid } });
-        return _addonManager.install(installURL, makeProgressHandler(dispatch, guid), { src })
+        return _addonManager.install(
+          installURL, makeProgressHandler(dispatch, guid), { src }
+        )
           .then(() => {
             _tracking.sendEvent({
               action: TRACKING_TYPE_EXTENSION,
@@ -235,7 +256,11 @@ export function makeMapDispatchToProps({ WrappedComponent, src }) {
       },
 
       uninstall({ guid, name, type }) {
-        dispatch({ type: INSTALL_STATE, payload: { guid, status: UNINSTALLING } });
+        dispatch({
+          type: INSTALL_STATE,
+          payload: { guid, status: UNINSTALLING },
+        });
+
         const action = getAction(type);
         return _addonManager.uninstall(guid)
           .then(() => {
@@ -289,11 +314,15 @@ export class WithInstallHelpers extends React.Component {
   }
 }
 
-export function withInstallHelpers({ _makeMapDispatchToProps = makeMapDispatchToProps, src }) {
+export function withInstallHelpers({
+  _makeMapDispatchToProps = makeMapDispatchToProps, src,
+}) {
   if (!src) {
     throw new Error('src is required for withInstallHelpers');
   }
   return (WrappedComponent) => compose(
-    connect(mapStateToProps, _makeMapDispatchToProps({ WrappedComponent, src })),
+    connect(
+      mapStateToProps, _makeMapDispatchToProps({ WrappedComponent, src })
+    ),
   )(WithInstallHelpers);
 }

--- a/src/core/reducers/installations.js
+++ b/src/core/reducers/installations.js
@@ -3,6 +3,7 @@ import {
   DOWNLOADING,
   ERROR,
   INSTALLED,
+  INSTALL_CANCELLED,
   INSTALL_COMPLETE,
   INSTALL_ERROR,
   INSTALL_STATE,
@@ -11,50 +12,88 @@ import {
   THEME_RESET_PREVIEW,
   UNINSTALLED,
   UNINSTALL_COMPLETE,
-  acceptedInstallTypes,
 } from 'core/constants';
+import log from 'core/logger';
 
+
+export function loadAddon({ guid, state }) {
+  if (state[guid]) {
+    return { ...state[guid] };
+  }
+
+  log.warn(`No add-on with guid ${guid} found.`);
+  return null;
+}
 
 export default function installations(state = {}, { type, payload }) {
-  if (!acceptedInstallTypes.includes(type)) {
-    return state;
-  }
   let addon;
-  if (state[payload.guid]) {
-    addon = { ...state[payload.guid] };
-  }
 
-  if (type === INSTALL_STATE) {
-    addon = {
-      guid: payload.guid,
-      url: payload.url,
-      error: payload.error,
-      downloadProgress: 0,
-      status: payload.status,
-      needsRestart: payload.needsRestart || false,
-    };
-  } else if (type === START_DOWNLOAD) {
-    addon.status = DOWNLOADING;
-  } else if (type === DOWNLOAD_PROGRESS) {
-    addon.downloadProgress = payload.downloadProgress;
-  } else if (type === INSTALL_COMPLETE) {
-    addon.status = INSTALLED;
-  } else if (type === UNINSTALL_COMPLETE) {
-    addon.status = UNINSTALLED;
-  /* istanbul ignore else */
-  } else if (type === INSTALL_ERROR) {
-    addon.downloadProgress = 0;
-    addon.status = ERROR;
-    addon.error = payload.error;
-  } else if (type === THEME_PREVIEW) {
-    addon.isPreviewingTheme = true;
-    addon.themePreviewNode = payload.themePreviewNode;
-  } else if (type === THEME_RESET_PREVIEW) {
-    addon.isPreviewingTheme = false;
-  }
+  switch (type) {
+    case INSTALL_STATE:
+      addon = {
+        guid: payload.guid,
+        url: payload.url,
+        error: payload.error,
+        downloadProgress: 0,
+        status: payload.status,
+        needsRestart: payload.needsRestart || false,
+      };
 
-  return {
-    ...state,
-    [payload.guid]: addon,
-  };
+      return { ...state, [payload.guid]: addon };
+    case START_DOWNLOAD:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.status = DOWNLOADING;
+
+      return { ...state, [payload.guid]: addon };
+    case DOWNLOAD_PROGRESS:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.downloadProgress = payload.downloadProgress;
+
+      return { ...state, [payload.guid]: addon };
+    case INSTALL_COMPLETE:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.status = INSTALLED;
+
+      return { ...state, [payload.guid]: addon };
+    case UNINSTALL_COMPLETE:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.status = UNINSTALLED;
+
+      return { ...state, [payload.guid]: addon };
+    case INSTALL_CANCELLED:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.downloadProgress = 0;
+      addon.status = UNINSTALLED;
+
+      return { ...state, [payload.guid]: addon };
+    /* istanbul ignore case */
+    case INSTALL_ERROR:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.downloadProgress = 0;
+      addon.status = ERROR;
+      addon.error = payload.error;
+
+      return { ...state, [payload.guid]: addon };
+    case THEME_PREVIEW:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.isPreviewingTheme = true;
+      addon.themePreviewNode = payload.themePreviewNode;
+
+      return { ...state, [payload.guid]: addon };
+    case THEME_RESET_PREVIEW:
+      addon = loadAddon({ guid: payload.guid, state });
+
+      addon.isPreviewingTheme = false;
+
+      return { ...state, [payload.guid]: addon };
+    default:
+      return state;
+  }
 }

--- a/tests/client/core/TestInstallAddon.js
+++ b/tests/client/core/TestInstallAddon.js
@@ -16,6 +16,7 @@ import {
   FATAL_INSTALL_ERROR,
   FATAL_UNINSTALL_ERROR,
   INSTALL_CATEGORY,
+  INSTALL_CANCELLED,
   INSTALL_FAILED,
   INSTALL_STATE,
   INSTALLED,
@@ -278,15 +279,26 @@ describe('withInstallHelpers inner functions', () => {
       }));
     });
 
+    it('resets status to uninstalled on onInstallCancelled', () => {
+      const dispatch = sinon.spy();
+      const guid = '{my-addon}';
+      const handler = makeProgressHandler(dispatch, guid);
+      handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallCancelled' });
+      assert.deepEqual(dispatch.firstCall.args[0], {
+        type: INSTALL_CANCELLED,
+        payload: { guid },
+      });
+    });
+
     it('sets status to error on onInstallFailed', () => {
       const dispatch = sinon.spy();
       const guid = '{my-addon}';
       const handler = makeProgressHandler(dispatch, guid);
       handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallFailed' });
-      assert(dispatch.calledWith({
+      assert.deepEqual(dispatch.firstCall.args[0], {
         type: 'INSTALL_ERROR',
         payload: { guid, error: INSTALL_FAILED },
-      }));
+      });
     });
 
     it('does nothing on unknown events', () => {

--- a/tests/client/core/reducers/test_installations.js
+++ b/tests/client/core/reducers/test_installations.js
@@ -4,6 +4,7 @@ import {
   DOWNLOAD_PROGRESS,
   ENABLED,
   ERROR,
+  INSTALL_CANCELLED,
   INSTALL_COMPLETE,
   INSTALL_ERROR,
   INSTALL_STATE,
@@ -16,7 +17,7 @@ import {
   UNINSTALLED,
   UNINSTALLING,
 } from 'core/constants';
-import installations from 'core/reducers/installations';
+import installations, { loadAddon } from 'core/reducers/installations';
 
 describe('installations reducer', () => {
   it('is an empty object by default', () => {
@@ -216,6 +217,25 @@ describe('installations reducer', () => {
       });
   });
 
+  it('updates the status on INSTALL_CANCELLED', () => {
+    const state = {
+      'my-addon@me.com': {
+        guid: 'my-addon@me.com',
+        url: 'https://cdn.amo/download/my-addon.xpi',
+        downloadProgress: 100,
+        status: DOWNLOAD_PROGRESS,
+      },
+    };
+    const installationsState = installations(state, {
+      type: INSTALL_CANCELLED,
+      payload: { guid: 'my-addon@me.com' },
+    });
+    const addon = installationsState['my-addon@me.com'];
+
+    assert.equal(addon.downloadProgress, 0);
+    assert.equal(addon.status, UNINSTALLED);
+  });
+
   it('updates the status on UNINSTALL_COMPLETE', () => {
     const state = {
       'my-addon@me.com': {
@@ -316,5 +336,12 @@ describe('installations reducer', () => {
           isPreviewingTheme: false,
         },
       });
+  });
+});
+
+describe('installations loadAddon', () => {
+  it('returns null when no add-on found', () => {
+    const addon = loadAddon({ guid: '302', state: {} });
+    assert.equal(addon, null);
   });
 });


### PR DESCRIPTION
Fixes #1435.

Allows an installation to be cancelled after the switch is toggled on. Resets the switch to uninstalled.

Screenshot:

![apr-25-2017 18-45-30](https://cloud.githubusercontent.com/assets/90871/25401424/76a3ae82-29ed-11e7-8dd2-8cf96b60391c.gif)
