### PR TITLE
Fix wrapping to break long strings but leave words intact

### DIFF
--- a/src/amo/css/AddonReviewList.scss
+++ b/src/amo/css/AddonReviewList.scss
@@ -40,7 +40,7 @@
 }
 
 .AddonReviewList-li {
-  word-break: break-all;
+  word-wrap: break-word;
 
   > h3 {
     padding: 0;


### PR DESCRIPTION
Fixes #2319

Before: 

![screen shot 2017-04-27 at 13 27 08](https://cloud.githubusercontent.com/assets/1514/25483403/8d59215a-2b4d-11e7-9355-f48098771d7d.png)

After:

![screen shot 2017-04-27 at 13 27 20](https://cloud.githubusercontent.com/assets/1514/25483434/b59a540e-2b4d-11e7-9d5c-a408ebd7ef79.png)

