### PR TITLE
Fix editing of star ratings by adding auth to API request

### DIFF
--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -88,6 +88,7 @@ export function submitReview({
 
 type GetReviewsParams = {|
   addon?: number,
+  apiState?: ApiStateType,
   filter?: string,
   page?: number,
   page_size?: number,
@@ -99,27 +100,31 @@ type GetReviewsParams = {|
 type GetReviewsApiResponse = PaginatedApiResponse<ApiReviewType>;
 
 export function getReviews(
-  { user, addon, ...params }: GetReviewsParams = {}
+  { apiState, user, addon, ...params }: GetReviewsParams = {}
 ): Promise<GetReviewsApiResponse> {
   return new Promise((resolve) => {
     if (!user && !addon) {
       throw new Error('Either user or addon must be specified');
     }
     resolve(callApi({
+      // Make an authenticated request if an API token exists.
+      auth: Boolean(apiState && apiState.token),
+      state: apiState,
       endpoint: 'reviews/review',
       params: { user, addon, ...params },
     }));
   });
 }
 
-type GetLatestReviewParams = {|
+export type GetLatestReviewParams = {|
   addon: number,
+  apiState?: ApiStateType,
   user: number,
   version: number,
 |};
 
 export function getLatestUserReview(
-  { user, addon, version }: GetLatestReviewParams = {}
+  { apiState, user, addon, version }: GetLatestReviewParams = {}
 ): Promise<null | ApiReviewType> {
   return new Promise((resolve) => {
     if (!user || !addon || !version) {
@@ -127,7 +132,7 @@ export function getLatestUserReview(
     }
     // The API will only return the latest user review for this add-on
     // and version.
-    resolve(getReviews({ user, addon, version }));
+    resolve(getReviews({ apiState, user, addon, version }));
   })
     .then((response) => {
       const reviews = response.results;

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -109,9 +109,9 @@ export function getReviews(
     resolve(callApi({
       // Make an authenticated request if an API token exists.
       auth: Boolean(apiState && apiState.token),
-      state: apiState,
       endpoint: 'reviews/review',
       params: { user, addon, ...params },
+      state: apiState,
     }));
   });
 }

--- a/src/amo/components/AddonReviewList.js
+++ b/src/amo/components/AddonReviewList.js
@@ -160,7 +160,7 @@ export function loadInitialData(
 }
 
 export function mapStateToProps(
-  state: { reviews: ReviewState }, ownProps: AddonReviewListProps,
+  state: {| reviews: ReviewState |}, ownProps: AddonReviewListProps,
 ) {
   if (!ownProps || !ownProps.params || !ownProps.params.addonSlug) {
     throw new Error('The component had a falsey params.addonSlug parameter');

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -1,5 +1,5 @@
 /* @flow */
-/* global Node */
+/* global $PropertyType, Node */
 /* eslint-disable react/sort-comp, react/no-unused-prop-types */
 import React from 'react';
 import { connect } from 'react-redux';
@@ -23,7 +23,7 @@ import log from 'core/logger';
 import DefaultRating from 'ui/components/Rating';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { UserReviewType } from 'amo/actions/reviews';
-import type { SubmitReviewParams } from 'amo/api';
+import type { GetLatestReviewParams, SubmitReviewParams } from 'amo/api';
 import type { ApiStateType } from 'core/reducers/api';
 import type { DispatchFunc } from 'core/types/redux';
 import type { AddonType, AddonVersionType } from 'core/types/addons';
@@ -32,9 +32,10 @@ import type { ReactRouterLocation } from 'core/types/router';
 import './styles.scss';
 
 type LoadSavedReviewFunc = ({|
-  userId: number,
-  addonId: number,
-  versionId: number,
+  addonId: $PropertyType<GetLatestReviewParams, 'addon'>,
+  apiState: ApiStateType,
+  userId: $PropertyType<GetLatestReviewParams, 'user'>,
+  versionId: $PropertyType<GetLatestReviewParams, 'version'>,
 |}) => Promise<any>;
 
 type SubmitReviewFunc = (SubmitReviewParams) => Promise<void>;
@@ -68,11 +69,11 @@ export class RatingManagerBase extends React.Component {
 
   constructor(props: RatingManagerProps) {
     super(props);
-    const { loadSavedReview, userId, addon, version } = props;
+    const { apiState, loadSavedReview, userId, addon, version } = props;
     this.state = { showTextEntry: false };
     if (userId) {
       log.info(`loading a saved rating (if it exists) for user ${userId}`);
-      loadSavedReview({ userId, addonId: addon.id, versionId: version.id });
+      loadSavedReview({ apiState, userId, addonId: addon.id, versionId: version.id });
     }
   }
 
@@ -231,9 +232,9 @@ export const mapDispatchToProps = (
   dispatch: DispatchFunc
 ): DispatchMappedProps => ({
 
-  loadSavedReview({ userId, addonId, versionId }) {
+  loadSavedReview({ apiState, userId, addonId, versionId }) {
     return getLatestUserReview({
-      user: userId, addon: addonId, version: versionId,
+      apiState, user: userId, addon: addonId, version: versionId,
     })
       .then((review) => {
         if (review) {

--- a/tests/client/amo/components/TestRatingManager.js
+++ b/tests/client/amo/components/TestRatingManager.js
@@ -65,12 +65,17 @@ describe('RatingManager', () => {
     };
     const loadSavedReview = sinon.spy();
 
-    render({ userId, addon, version, loadSavedReview });
+    render({
+      apiState: signedInApiState, userId, addon, version, loadSavedReview,
+    });
 
     assert.equal(loadSavedReview.called, true);
     const args = loadSavedReview.firstCall.args[0];
     assert.deepEqual(args, {
-      userId, addonId: addon.id, versionId: version.id,
+      apiState: signedInApiState,
+      userId,
+      addonId: addon.id,
+      versionId: version.id,
     });
   });
 
@@ -335,10 +340,17 @@ describe('RatingManager', () => {
         const versionId = fakeReview.version.id;
         mockApi
           .expects('getLatestUserReview')
-          .withArgs({ user: userId, addon: addonId, version: versionId })
+          .withArgs({
+            apiState: signedInApiState,
+            user: userId,
+            addon: addonId,
+            version: versionId,
+          })
           .returns(Promise.resolve(fakeReview));
 
-        return actions.loadSavedReview({ userId, addonId, versionId })
+        return actions.loadSavedReview({
+          apiState: signedInApiState, userId, addonId, versionId,
+        })
           .then(() => {
             mockApi.verify();
             assert.equal(dispatch.called, true);
@@ -350,7 +362,9 @@ describe('RatingManager', () => {
         const addonId = 8765;
         mockApi.expects('getLatestUserReview').returns(Promise.resolve(null));
 
-        return actions.loadSavedReview({ userId: 123, addonId })
+        return actions.loadSavedReview({
+          apiState: initialApiState, userId: 123, addonId,
+        })
           .then(() => {
             assert.equal(dispatch.called, false);
           });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2325

This is the quickest fix I can think of but it needs some follow-up. This works around the new logic introduced by https://github.com/mozilla/addons-server/pull/5227 which now hides empty reviews (i.e. star ratings) by default. I'd like for it not to hide star ratings by default but let's do that in future patches. For now, this passes authentication to the API for list requests which will unhide reviews created by the current user.