### PR TITLE
fix: If installing a theme from Disco Pane, the description will not be displayed in more section for that theme

### DIFF
--- a/src/core/themePreview.js
+++ b/src/core/themePreview.js
@@ -11,7 +11,7 @@ export default function themeAction(node, action, _doc = document) {
   node.dispatchEvent(event);
 }
 
-export function getThemeData({ id, name, headerURL, footerURL, textcolor, accentcolor, author }) {
+export function getThemeData({ id, name, description, headerURL, footerURL, textcolor, accentcolor, author }) {
   // This extracts the relevant theme data from the larger add-on data object.
-  return { id, name, headerURL, footerURL, textcolor, accentcolor, author };
+  return { id, name, description, headerURL, footerURL, textcolor, accentcolor, author };
 }

--- a/src/core/themePreview.js
+++ b/src/core/themePreview.js
@@ -11,7 +11,9 @@ export default function themeAction(node, action, _doc = document) {
   node.dispatchEvent(event);
 }
 
-export function getThemeData({ id, name, description, headerURL, footerURL, textcolor, accentcolor, author }) {
+export function getThemeData({
+id, name, description, headerURL, footerURL, textcolor, accentcolor, author,
+}) {
   // This extracts the relevant theme data from the larger add-on data object.
   return { id, name, description, headerURL, footerURL, textcolor, accentcolor, author };
 }

--- a/src/core/themePreview.js
+++ b/src/core/themePreview.js
@@ -12,7 +12,7 @@ export default function themeAction(node, action, _doc = document) {
 }
 
 export function getThemeData({
-id, name, description, headerURL, footerURL, textcolor, accentcolor, author,
+  id, name, description, headerURL, footerURL, textcolor, accentcolor, author,
 }) {
   // This extracts the relevant theme data from the larger add-on data object.
   return { id, name, description, headerURL, footerURL, textcolor, accentcolor, author };

--- a/tests/client/core/TestThemePreview.js
+++ b/tests/client/core/TestThemePreview.js
@@ -29,6 +29,7 @@ describe('Theme Preview Lib', () => {
     const themeData = {
       id: 50,
       name: 'my theme',
+      description: 'my theme description',
       headerURL: 'foo.com',
       footerURL: 'bar.com',
       textcolor: '#fff',


### PR DESCRIPTION
Fixes: #1572 

Added description key to themeData and modified the corresponding test