### PR TITLE
Remove noop ngettext usage from amo

### DIFF
--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -17,7 +17,6 @@ import { withInstallHelpers } from 'core/installAddon';
 import {
   isAllowedOrigin,
   getClientCompatibility as _getClientCompatibility,
-  ngettext,
   nl2br,
   sanitizeHTML,
 } from 'core/utils';
@@ -128,7 +127,7 @@ export class AddonDetailBase extends React.Component {
     if (addon.ratings.count) {
       const count = addon.ratings.count;
       const linkText = i18n.sprintf(
-        ngettext('Read %(count)s review', 'Read all %(count)s reviews', count),
+        i18n.ngettext('Read %(count)s review', 'Read all %(count)s reviews', count),
         { count: i18n.formatNumber(count) },
       );
 


### PR DESCRIPTION
Fixes #2378 

Before: 
<img width="480" alt="modules_pour_firefox" src="https://cloud.githubusercontent.com/assets/1514/26009670/c2b251c8-3741-11e7-9d06-9a155ef6d931.png">

After:
<img width="477" alt="modules_pour_firefox" src="https://cloud.githubusercontent.com/assets/1514/26009619/874bd848-3741-11e7-9e9c-9127b35bf517.png">
