### PR TITLE
fix: Downgrade react-redux-loading-bar (fix #2395)

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "react-onclickoutside": "5.11.1",
     "react-photoswipe": "1.2.0",
     "react-redux": "4.4.6",
-    "react-redux-loading-bar": "2.9.0",
+    "react-redux-loading-bar": "2.8.2",
     "react-router": "2.8.1",
     "react-router-scroll": "0.4.2",
     "redux": "3.6.0",


### PR DESCRIPTION
This restores the loading bar, tested locally with a prod build.