### PR TITLE
Prefix url

### DIFF
--- a/src/amo/components/AddonMoreInfo.js
+++ b/src/amo/components/AddonMoreInfo.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { compose } from 'redux';
 
+import Link from 'amo/components/Link';
 import translate from 'core/i18n/translate';
 import { trimAndAddProtocolToUrl } from 'core/utils';
 import Card from 'ui/components/Card';
@@ -82,10 +83,10 @@ export class AddonMoreInfoBase extends React.Component {
           ) : null}
           {addon.has_privacy_policy ? (
             <dd>
-              <a href={`/addon/${addon.slug}/privacy/`}
+              <Link href={`/addon/${addon.slug}/privacy/`}
                 ref={(ref) => { this.privacyPolicyLink = ref; }}>
                 {i18n.gettext('Read the privacy policy for this add-on')}
-              </a>
+              </Link>
             </dd>
           ) : null}
         </dl>

--- a/src/amo/components/Link.js
+++ b/src/amo/components/Link.js
@@ -19,11 +19,16 @@ export class LinkBase extends React.Component {
   }
 
   render() {
-    const { base, children, href, to } = this.props;
+    const { base, children, href, to, ...customProps } = this.props;
 
-    if (typeof href === 'string' && href.startsWith('/')) {
-      let linkHref = path.join(base, href);
-      return <Link {...this.props} href={linkHref}>{children}</Link>;
+    if (typeof href === 'string' && typeof to !== 'undefined') {
+      throw new Error(
+        'Cannot use "href" prop and "to" prop in the same Link component');
+    }
+
+    if (typeof href === 'string') {
+      const linkHref = href.startsWith('/') ? path.join(base, href) : href;
+      return <a {...customProps} href={linkHref}>{children}</a>;
     }
 
     let linkTo = to;
@@ -37,7 +42,7 @@ export class LinkBase extends React.Component {
       };
     }
 
-    return <Link {...this.props} to={linkTo}>{children}</Link>;
+    return <Link {...customProps} to={linkTo}>{children}</Link>;
   }
 }
 

--- a/src/amo/components/Link.js
+++ b/src/amo/components/Link.js
@@ -10,6 +10,7 @@ export class LinkBase extends React.Component {
   static propTypes = {
     base: PropTypes.string,
     children: PropTypes.node,
+    href: PropTypes.string,
     to: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   }
 
@@ -18,7 +19,12 @@ export class LinkBase extends React.Component {
   }
 
   render() {
-    const { base, children, to } = this.props;
+    const { base, children, href, to } = this.props;
+
+    if (typeof href === 'string' && href.startsWith('/')) {
+      let linkHref = path.join(base, href);
+      return <Link {...this.props} href={linkHref}>{children}</Link>;
+    }
 
     let linkTo = to;
     if (typeof to === 'string' && to.startsWith('/')) {

--- a/tests/client/amo/components/TestAddonMoreInfo.js
+++ b/tests/client/amo/components/TestAddonMoreInfo.js
@@ -108,7 +108,7 @@ describe('<AddonMoreInfo />', () => {
       'Read the privacy policy for this add-on');
     // TODO: Change this to an internal `<Link>` tag and use `assert.equal`
     // once https://github.com/mozilla/addons-frontend/issues/1828 is fixed.
-    assert.include(root.privacyPolicyLink.href,
+    assert.include(root.privacyPolicyLink.props.href,
       '/addon/chill-out/privacy/');
   });
 });

--- a/tests/client/amo/components/TestLink.js
+++ b/tests/client/amo/components/TestLink.js
@@ -3,6 +3,7 @@ import {
   findRenderedComponentWithType,
   renderIntoDocument,
 } from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
 import { Link } from 'react-router';
 
 import { LinkBase, mapStateToProps } from 'amo/components/Link';
@@ -12,8 +13,7 @@ describe('<Link />', () => {
   const defaultState = { api: { clientApp: 'android', lang: 'fr' } };
 
   function render(props) {
-    return renderIntoDocument(
-      <LinkBase {...props}>Hi</LinkBase>);
+    return renderIntoDocument(<LinkBase {...props} />);
   }
 
   it('uses clientApp and lang from API state', () => {
@@ -91,22 +91,54 @@ describe('<Link />', () => {
     );
   });
 
-  it('passes other `href` types through to link', () => {
+  it('renders children when `to` is used', () => {
+    const root = render({ base: '/foo/', children: 'hello', to: '/test' });
+
+    assert.equal(findDOMNode(root).textContent, 'hello');
+  });
+
+  it('does add base prop to Link component', () => {
+    const root = render({ base: '/foo/', children: 'bonjour', to: '/test' });
+
+    assert.equal(findRenderedComponentWithType(root, Link).props.base, null);
+  });
+
+  it('ignores `href` if not a string type', () => {
     const root = render({ base: null, href: null });
 
-    assert.equal(findRenderedComponentWithType(root, Link).props.href, null);
+    // If no href attribute is supplied the component will render a Link
+    // component instead of an <a> tag.
+    assert.ok(findRenderedComponentWithType(root, Link));
   });
 
-  it('passes `href` without leading slash without base', () => {
+  it('does not prepend base to `href` with no leading slash', () => {
     const root = render({ base: '/base/', href: 'test' });
 
-    assert.equal(findRenderedComponentWithType(root, Link).props.href, 'test');
+    assert.notInclude(findDOMNode(root, 'a').href, '/base/');
+    assert.include(findDOMNode(root, 'a').href, 'test');
   });
 
-  it('normalizes the href path with a string', () => {
+  it('normalizes the `href` path with a string', () => {
     const root = render({ base: '/foo/', href: '/test' });
 
-    assert.equal(
-      findRenderedComponentWithType(root, Link).props.href, '/foo/test');
+    assert.include(findDOMNode(root, 'a').href, '/foo/test');
+  });
+
+  it('renders children when `href` is used', () => {
+    const root = render({ base: '/foo/', children: 'bonjour', href: '/test' });
+
+    assert.equal(findDOMNode(root).textContent, 'bonjour');
+  });
+
+  it('does not add base prop to <a> tag', () => {
+    const root = render({ base: '/foo/', children: 'bonjour', href: '/test' });
+
+    assert.equal(findDOMNode(root).attributes.getNamedItem('base'), null);
+  });
+
+  it('throws an error if both `href` and `to` are supplied', () => {
+    assert.throws(() => {
+      render({ href: '/test', to: '/test' });
+    }, 'Cannot use "href" prop and "to" prop in the same Link component');
   });
 });

--- a/tests/client/amo/components/TestLink.js
+++ b/tests/client/amo/components/TestLink.js
@@ -90,4 +90,23 @@ describe('<Link />', () => {
       { pathname: 'test' }
     );
   });
+
+  it('passes other `href` types through to link', () => {
+    const root = render({ base: null, href: null });
+
+    assert.equal(findRenderedComponentWithType(root, Link).props.href, null);
+  });
+
+  it('passes `href` without leading slash without base', () => {
+    const root = render({ base: '/base/', href: 'test' });
+
+    assert.equal(findRenderedComponentWithType(root, Link).props.href, 'test');
+  });
+
+  it('normalizes the href path with a string', () => {
+    const root = render({ base: '/foo/', href: '/test' });
+
+    assert.equal(
+      findRenderedComponentWithType(root, Link).props.href, '/foo/test');
+  });
 });


### PR DESCRIPTION
Fixes #2419.

Simple fix to add clientApp and locales to `<Link href="/foo">` urls.