### PR TITLE
Reverts the change that allowed local production configs

### DIFF
--- a/bin/config-check.js
+++ b/bin/config-check.js
@@ -20,8 +20,9 @@ if (!fs.statSync(configDir).isDirectory()) {
 }
 
 const disallowedFiles = fs.readdirSync(configDir)
-  // Disallow any local configs that could possibly pollute the tests.
-  .filter((name) => name === 'local.js' || name.startsWith('local-test'))
+  // Disallow any local configs except for development configs.
+  .filter((name) =>
+    name.startsWith('local') && !name.startsWith('local-development'))
   .map((name) => path.join(configDir, name).replace(process.cwd(), '.'));
 
 if (disallowedFiles.length) {


### PR DESCRIPTION
We still have tests that rely on the production config so local files will pollute those tests.