### PR TITLE
chore: Move to propTypes package

### DIFF
--- a/docs/adding-a-page.md
+++ b/docs/adding-a-page.md
@@ -110,7 +110,8 @@ react-redux's `connect()` to set the props for us as if it were pulling the data
 
 ```jsx
 // src/search/containers/UserPage/index.js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
@@ -250,7 +251,8 @@ use [redux-connect](https://github.com/makeomatic/redux-connect)'s `asyncConnect
 
 ```jsx
 // src/search/containers/AddonPage/index.js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { asyncConnect } from 'redux-connect';

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -110,7 +110,9 @@ Here's an example of a basic component setup for translation:
 
 
 ```javascript
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
+
 import translate from 'core/i18n/translate';
 
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "mozilla-version-comparator": "1.0.2",
     "normalize.css": "7.0.0",
     "normalizr": "3.2.2",
+    "prop-types": "15.5.10",
     "raven": "1.2.1",
     "raven-js": "3.14.2",
     "react": "15.5.4",

--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 

--- a/src/amo/components/AddonDetail.js
+++ b/src/amo/components/AddonDetail.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 

--- a/src/amo/components/AddonMeta.js
+++ b/src/amo/components/AddonMeta.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';

--- a/src/amo/components/AddonMoreInfo.js
+++ b/src/amo/components/AddonMoreInfo.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import Link from 'amo/components/Link';

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import SearchResult from 'amo/components/SearchResult';
 import CardList from 'ui/components/CardList';

--- a/src/amo/components/Categories.js
+++ b/src/amo/components/Categories.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 

--- a/src/amo/components/ErrorPage/NotAuthorized/index.js
+++ b/src/amo/components/ErrorPage/NotAuthorized/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 

--- a/src/amo/components/ErrorPage/ServerError/index.js
+++ b/src/amo/components/ErrorPage/ServerError/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 

--- a/src/amo/components/FeaturedAddons/index.js
+++ b/src/amo/components/FeaturedAddons/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 

--- a/src/amo/components/Footer.js
+++ b/src/amo/components/Footer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';

--- a/src/amo/components/LandingPage.js
+++ b/src/amo/components/LandingPage.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 

--- a/src/amo/components/LanguagePicker.js
+++ b/src/amo/components/LanguagePicker.js
@@ -1,5 +1,6 @@
 /* global window */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 

--- a/src/amo/components/Link.js
+++ b/src/amo/components/Link.js
@@ -1,6 +1,7 @@
 import path from 'path';
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';

--- a/src/amo/components/MastHead.js
+++ b/src/amo/components/MastHead.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import Link from 'amo/components/Link';

--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -1,7 +1,8 @@
 /* global document, requestAnimationFrame, window
  * eslint-disable jsx-a11y/href-no-hash */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { PhotoSwipeGallery } from 'react-photoswipe';
 import 'react-photoswipe/lib/photoswipe.css';
 

--- a/src/amo/components/SearchForm.js
+++ b/src/amo/components/SearchForm.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 

--- a/src/amo/components/SearchPage.js
+++ b/src/amo/components/SearchPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Link from 'amo/components/Link';
 import Paginate from 'core/components/Paginate';

--- a/src/amo/components/SearchResult.js
+++ b/src/amo/components/SearchResult.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import fallbackIcon from 'amo/img/icons/default-64.png';

--- a/src/amo/components/SearchResults.js
+++ b/src/amo/components/SearchResults.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import AddonsCard from 'amo/components/AddonsCard';

--- a/src/amo/components/SearchSort/SearchSortLink.js
+++ b/src/amo/components/SearchSort/SearchSortLink.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import { makeQueryString } from 'core/api';
 import { convertFiltersToQueryParams } from 'core/searchUtils';

--- a/src/amo/components/SearchSort/index.js
+++ b/src/amo/components/SearchSort/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import SearchSortLink from 'amo/components/SearchSort/SearchSortLink';

--- a/src/amo/components/SuggestedPages/index.js
+++ b/src/amo/components/SuggestedPages/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import Link from 'amo/components/Link';

--- a/src/amo/containers/Home.js
+++ b/src/amo/containers/Home.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import Link from 'amo/components/Link';

--- a/src/core/components/ErrorPage/GenericError/index.js
+++ b/src/core/components/ErrorPage/GenericError/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 

--- a/src/core/components/ErrorPage/NotFound/index.js
+++ b/src/core/components/ErrorPage/NotFound/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 

--- a/src/core/components/ErrorPage/index.js
+++ b/src/core/components/ErrorPage/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 

--- a/src/core/components/HoverIntent/index.js
+++ b/src/core/components/HoverIntent/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function square(x) {
   return x * x;

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -1,6 +1,7 @@
 /* global window */
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 

--- a/src/core/components/InstallSwitch/index.js
+++ b/src/core/components/InstallSwitch/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';

--- a/src/core/components/LoginPage/index.js
+++ b/src/core/components/LoginPage/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 
 import { startLoginUrl } from 'core/api';

--- a/src/core/components/NavBar/index.js
+++ b/src/core/components/NavBar/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 import 'core/components/NavBar/styles.scss';

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import PaginatorLink from 'core/components/PaginatorLink';

--- a/src/core/components/PaginatorLink/index.js
+++ b/src/core/components/PaginatorLink/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 

--- a/src/core/containers/HandleLogin/index.js
+++ b/src/core/containers/HandleLogin/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import cookie from 'react-cookie';
 import { connect } from 'react-redux';
 import { compose } from 'redux';

--- a/src/core/containers/InfoDialog/index.js
+++ b/src/core/containers/InfoDialog/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 import { connect } from 'react-redux';
 import { compose } from 'redux';

--- a/src/core/containers/LoginRequired/index.js
+++ b/src/core/containers/LoginRequired/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 

--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-danger */
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom/server';
 import serialize from 'serialize-javascript';
 import Helmet from 'react-helmet';

--- a/src/core/i18n/Provider.js
+++ b/src/core/i18n/Provider.js
@@ -1,4 +1,5 @@
-import { Children, Component, PropTypes } from 'react';
+import { Children, Component } from 'react';
+import PropTypes from 'prop-types';
 
 /*
  * This Provider expects to be passed an initialized

--- a/src/core/i18n/translate.js
+++ b/src/core/i18n/translate.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 
 function getDisplayName(component) {

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -1,5 +1,6 @@
 /* global CustomEvent, document, window */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { oneLine } from 'common-tags';

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -2,7 +2,8 @@
 
 import classNames from 'classnames';
 import { sprintf } from 'jed';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import { connect } from 'react-redux';
 import { compose } from 'redux';

--- a/src/disco/containers/App.js
+++ b/src/disco/containers/App.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'redux';

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 /* global navigator, window */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { camelizeKeys as camelCaseKeys } from 'humps';
 import { connect } from 'react-redux';
 import { compose } from 'redux';

--- a/src/ui/components/Button/index.js
+++ b/src/ui/components/Button/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Link from 'amo/components/Link';
 

--- a/src/ui/components/Card/index.js
+++ b/src/ui/components/Card/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import './Card.scss';
 

--- a/src/ui/components/CardList/index.js
+++ b/src/ui/components/CardList/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Card from 'ui/components/Card';
 

--- a/src/ui/components/ErrorList/index.js
+++ b/src/ui/components/ErrorList/index.js
@@ -1,6 +1,7 @@
 /* global window */
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import { API_ERROR_SIGNATURE_EXPIRED } from 'core/constants';

--- a/src/ui/components/Icon/index.js
+++ b/src/ui/components/Icon/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import './styles.scss';

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import './Overlay.scss';
 

--- a/src/ui/components/OverlayCard/index.js
+++ b/src/ui/components/OverlayCard/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Card from 'ui/components/Card';
 import Overlay from 'ui/components/Overlay';

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import log from 'core/logger';

--- a/src/ui/components/SearchInput/index.js
+++ b/src/ui/components/SearchInput/index.js
@@ -1,5 +1,6 @@
 /* global document, window */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Icon from 'ui/components/Icon';

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -1,7 +1,8 @@
 /* eslint-disable react/no-danger */
 
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { compose } from 'redux';
 

--- a/src/ui/components/Switch/index.js
+++ b/src/ui/components/Switch/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import './Switch.scss';

--- a/tests/client/core/containers/TestServerHtml.js
+++ b/tests/client/core/containers/TestServerHtml.js
@@ -1,5 +1,6 @@
 import Helmet from 'react-helmet';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import {
   findRenderedDOMComponentWithTag,

--- a/tests/client/core/i18n/TestI18nProvider.js
+++ b/tests/client/core/i18n/TestI18nProvider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
   renderIntoDocument,
 } from 'react-addons-test-utils';

--- a/tests/client/core/i18n/test_translate.js
+++ b/tests/client/core/i18n/test_translate.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-multi-comp */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
   renderIntoDocument,
   findRenderedComponentWithType,

--- a/tests/client/core/testErrorHandler.js
+++ b/tests/client/core/testErrorHandler.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { findRenderedComponentWithType, renderIntoDocument }
   from 'react-addons-test-utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5524,7 +5524,7 @@ promisify-node@^0.4.0:
     nodegit-promise "~4.0.0"
     object-assign "^4.0.1"
 
-prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@~15.5.7:
+prop-types@15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -5686,9 +5686,9 @@ react-dom@15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-helmet@5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.0.3.tgz#c6da63ee96e83aa7c8fe6d041f28dd288b1b006d"
+react-helmet@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.1.3.tgz#cd40626593a29eecf684b6d38d711f44c48188af"
   dependencies:
     deep-equal "^1.0.1"
     object-assign "^4.1.1"


### PR DESCRIPTION
I left out patches to the `admin` app for this because I didn't want to mess up #2373 more than needed.

This arguably closes #2475 as much as we can without moving to react-router 4.1.1.