### PR TITLE
docs: Restore `test-ci` to README (see #2474)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Here are some commands you can run:
 | yarn test-coverage        | Run all tests and generate code coverage report (Enters [jest][] in `--watch` mode) |
 | yarn test-coverage-once   | Run all tests, generate code coverage report, then exit |
 | yarn test-once            | Run all tests with [jest][], then exit |
+| yarn test-ci              | Run all continuous integration checks. This is only meant to run on TravisCI. |
 
 ### Running tests
 


### PR DESCRIPTION
Restores the CI script info in the README.