### PR TITLE
Add Flow types for the Intl object

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,6 +11,9 @@
 
 [libs]
 # TODO: this can go away after
+# https://github.com/facebook/flow/issues/2801
+./flow/libs/intl.js.flow
+# TODO: this can go away after
 # https://github.com/mozilla/addons-frontend/issues/2092
 ./flow/libs/dedent.js.flow
 

--- a/flow/libs/intl.js.flow
+++ b/flow/libs/intl.js.flow
@@ -1,0 +1,13 @@
+// This is only a partial definition of
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
+
+declare class Intl$NumberFormat {
+  constructor(lang: string): void;
+  format(number: Number): string;
+}
+
+declare type IntlType = {
+  NumberFormat: Class<Intl$NumberFormat>,
+}
+
+declare var Intl: typeof undefined | IntlType;

--- a/flow/libs/intl.js.flow
+++ b/flow/libs/intl.js.flow
@@ -2,7 +2,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
 
 declare class Intl$NumberFormat {
-  constructor(lang: string): void;
+  constructor(locales: string | Array<string>, options?: Object): void;
   format(number: Number): string;
 }
 
@@ -10,4 +10,6 @@ declare type IntlType = {
   NumberFormat: Class<Intl$NumberFormat>,
 }
 
+// Mark it as possibly undefined since
+// Safari and some recent versions of Firefox for Android do not implement it.
 declare var Intl: typeof undefined | IntlType;

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -244,7 +244,6 @@ export function makeI18n(i18nData: I18nConfig, lang: string, _Jed: Jed = Jed) {
   // can type-check all the components that rely on the i18n object.
   // Note: the available locales for tests are controlled in tests/setup.js
   i18n.formatNumber = (number) => {
-    // $FLOW_IGNORE
     if (typeof Intl === 'object' && Object.prototype.hasOwnProperty.call(Intl, 'NumberFormat')) {
       return new Intl.NumberFormat(lang).format(number);
     }


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla/addons-frontend/pull/2480

I think this would be useful because we won't forget to be protective about accessing the `Intl` object in the future. If you forget to check it, you get:

```
src/core/i18n/utils.js:248
248:     return new Intl.NumberFormat(lang).format(number);
                         ^^^^^^^^^^^^ property `NumberFormat`. Property cannot be accessed on possibly undefined value
248:     return new Intl.NumberFormat(lang).format(number);
                    ^^^^ undefined
```