### PR TITLE
Fix flow defs for Intl

### DIFF
--- a/flow/libs/intl.js.flow
+++ b/flow/libs/intl.js.flow
@@ -1,15 +1,17 @@
-// This is only a partial definition of
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
+// This is only a partial definition of Intl (https://mzl.la/1dsIHLk MDN)
 
 declare class Intl$NumberFormat {
   constructor(locales: string | Array<string>, options?: Object): void;
-  format(number: Number): string;
+  format(number: number): string;
 }
 
 declare type IntlType = {
   NumberFormat: Class<Intl$NumberFormat>,
 }
 
-// Mark it as possibly undefined since
-// Safari and some recent versions of Firefox for Android do not implement it.
-declare var Intl: typeof undefined | IntlType;
+
+// Intl can be undefined since Safari and some recent versions of Firefox 
+// for Android do not implement it.
+// The expected declaration here is `declare var Intl: void | IntlType;`
+// but that breaks, see https://github.com/facebook/flow/issues/4077
+declare var Intl: IntlType;

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -236,8 +236,7 @@ type I18nConfig = {|
 |};
 
 type makeI18nOptions = {|
-  // FIXME this should be tied back to the Intl type.
-  _Intl?: any,
+  _Intl?: typeof Intl,
 |};
 
 


### PR DESCRIPTION
Fixes #2500

After using the flow env to try things out with a reduced test case this seems to work. It appears that you can't use `|` for global definitions or at least removing that makes it work.

See: http://bit.ly/2rI8UbW for the try flow env to see the reduced test case. (Works better in Chrome sadly)