### PR TITLE
fix: Button text-shadow and hover in SearchSort

### DIFF
--- a/src/amo/components/SearchSort/SearchSort.scss
+++ b/src/amo/components/SearchSort/SearchSort.scss
@@ -1,5 +1,6 @@
 @import '~core/css/inc/mixins';
 @import '~core/css/inc/vars';
+@import '~ui/css/vars';
 
 .SearchSort {
   background: $base-color;
@@ -10,7 +11,12 @@
 }
 
 .SearchSort-toggle {
-  @include button($background: $base-color, $color: $link-color);
+  @include button(
+    $background: $light-base-color,
+    $background-active: $light-active-color,
+    $background-hover: $light-hover-color,
+    $color: $link-color
+  );
 
   // We do this so the button doesn't have weird edges on hover when the
   // sort options are expanded.
@@ -26,6 +32,7 @@
   min-width: 40%;
   position: relative;
   text-align: center;
+  text-shadow: none;
 
   &::before {
     background: url('~amo/img/icons/sort.svg') 50% 50% no-repeat;

--- a/src/amo/components/SearchSort/SearchSortLink.scss
+++ b/src/amo/components/SearchSort/SearchSortLink.scss
@@ -1,14 +1,21 @@
 @import '~core/css/inc/mixins';
 @import '~core/css/inc/vars';
+@import '~ui/css/vars';
 
 .SearchSortLink {
-  @include button($background: $base-color, $color: $link-color);
+  @include button(
+    $background: $light-base-color,
+    $background-active: $light-active-color,
+    $background-hover: $light-hover-color,
+    $color: $link-color
+  );
 
   border-radius: 0;
   font-size: $font-size-default;
   flex-grow: 1;
   padding: 6px 0;
   text-align: center;
+  text-shadow: none;
 
   &:focus {
     background: transparentize($link-color, 0.8);

--- a/src/core/components/Paginate/Paginate.scss
+++ b/src/core/components/Paginate/Paginate.scss
@@ -1,4 +1,5 @@
 @import '~core/css/inc/mixins';
+@import '~ui/css/vars';
 
 .Paginate-page-number {
   font-weight: bold;
@@ -17,7 +18,12 @@
 }
 
 .Paginate .Paginate-item {
-  @include button($background: $base-color, $color: $link-color);
+  @include button(
+    $background: $light-base-color,
+    $background-active: $light-active-color,
+    $background-hover: $light-hover-color,
+    $color: $link-color
+  );
 
   display: inline-block;
   font-size: $font-size-s;
@@ -26,6 +32,7 @@
   line-height: 2;
   min-width: 48%;
   text-align: center;
+  text-shadow: none;
 }
 
 .Paginate-previous {


### PR DESCRIPTION
Closes #2436.

Fixes the search sort to not have a text-shadow after a button refresh.

In the future (as I redo the search page for desktop) the search sort could do with a general CSS cleanup but this fixes the issue for now.

### Before
![2017-06-07_1510](https://user-images.githubusercontent.com/15685960/26877706-783b26ea-4b93-11e7-83c0-ebccd5608271.png)

### After
<img width="982" alt="screenshot 2017-06-07 17 23 31" src="https://user-images.githubusercontent.com/90871/26889418-0b4bb000-4ba6-11e7-99d8-b84a6594d3b8.png">
