### PR TITLE
Create responsive detail page

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -121,7 +121,7 @@ export class AddonBase extends React.Component {
     }
     return (
       <div className="Addon-icon">
-        <img alt="" src={iconUrl} />
+        <img className="Addon-icon-image" alt="" src={iconUrl} />
       </div>
     );
   }
@@ -200,53 +200,64 @@ export class AddonBase extends React.Component {
     // eslint-disable react/no-danger
     return (
       <div className="Addon">
-        <header className="Addon-header">
-          {this.headerImage({ compatible })}
-          <div className="Addon-title">
-            <h1
-              dangerouslySetInnerHTML={sanitizeHTML(title, ['a', 'span'])}
-              className="Addon-title-heading" />
-          </div>
-          <p className="Addon-summary"
-            dangerouslySetInnerHTML={summarySanitized} />
-        </header>
+        <Card className="" photonStyle>
+          <header className="Addon-header">
+            <section className="Addon-title-section">
+              <h1
+                className="Addon-title"
+                dangerouslySetInnerHTML={sanitizeHTML(title, ['a', 'span'])}
+              />
 
-        <section className="Addon-metadata">
-          <h2 className="visually-hidden">
-            {i18n.gettext('Extension Metadata')}
-          </h2>
-          <AddonMeta addon={addon} />
-          <InstallButton
-            {...this.props}
-            className="Button--action Button--small"
-            disabled={!compatible}
-            ref={(ref) => { this.installButton = ref; }}
-            status={installStatus}
-          />
+              <p className="Addon-summary"
+                dangerouslySetInnerHTML={summarySanitized} />
+
+              <InstallButton
+                {...this.props}
+                className="Button--action Button--small"
+                disabled={!compatible}
+                ref={(ref) => { this.installButton = ref; }}
+                status={installStatus}
+              />
+            </section>
+
+            <section className="Addon-metadata">
+              {this.headerImage({ compatible })}
+
+              <h2 className="visually-hidden">
+                {i18n.gettext('Extension Metadata')}
+              </h2>
+              <AddonMeta addon={addon} />
+            </section>
+          </header>
+
           {!compatible ? (
             <AddonCompatibilityError maxVersion={maxVersion}
               minVersion={minVersion} reason={reason} />
           ) : null}
-        </section>
+        </Card>
 
-        {addon.previews.length > 0
-          ? (
-            <Card className="Addon-screenshots">
+        <div className="Addon-details">
+          {addon.previews.length > 0 ? (
+            <Card
+              className="Addon-screenshots"
+              header={i18n.gettext('Screenshots')}
+            >
               <ScreenShots previews={addon.previews} />
             </Card>
           ) : null}
 
-        <ShowMoreCard header={i18n.sprintf(
-          i18n.gettext('About this %(addonType)s'), { addonType: addon.type }
-        )} className="AddonDescription">
-          <div className="AddonDescription-contents"
-            ref={(ref) => { this.addonDescription = ref; }}
-            dangerouslySetInnerHTML={descriptionSanitized} />
-        </ShowMoreCard>
+          <ShowMoreCard header={i18n.sprintf(
+            i18n.gettext('About this %(addonType)s'), { addonType: addon.type }
+          )} className="AddonDescription">
+            <div className="AddonDescription-contents"
+              ref={(ref) => { this.addonDescription = ref; }}
+              dangerouslySetInnerHTML={descriptionSanitized} />
+          </ShowMoreCard>
 
-        {this.renderRatingsCard()}
+          {this.renderRatingsCard()}
 
-        <AddonMoreInfo addon={addon} />
+          <AddonMoreInfo addon={addon} />
+        </div>
       </div>
     );
     // eslint-enable react/no-danger

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -1,95 +1,127 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
 @import "~ui/css/vars";
-@import "~ui/components/Icon/vars";
 
-$page-margin: 20px 10px;
+.Addon {
+  padding: 20px 10px;
+}
 
-// Put the margin on the immediate children so that the header can be full width and blue.
-.Addon > * {
-  margin: $page-margin;
+.Addon-header {
+  display: flex;
+  flex-flow: column;
+  justify-content: space-between;
+}
+
+.Addon-icon-image {
+  height: 48px;
+  width: 48px;
+
+  @include respond-to(medium) {
+    height: 64px;
+    width: 64px;
+  }
+}
+
+.Addon-title-section {
+  display: flex;
+  flex: auto;
+  flex-flow: row wrap;
+  order: 2;
+
+  .InstallButton {
+    @include margin-start(auto);
+  }
 }
 
 .Addon-title {
-  margin-top: 10px;
-}
-
-.Addon-title-heading {
+  color: $black;
   font-size: $font-size-l;
-  margin-bottom: 10px;
+  margin: 10px 0;
+  width: 100%;
   word-wrap: break-word;
+
+  @include respond-to(medium) {
+    font-size: $font-size-xl;
+  }
 }
 
 .Addon-author {
   display: block;
-  opacity: 0.75;
   word-wrap: break-word;
 
+  &,
   a,
   a:link {
-    color: $header-font-color;
-    font-size: $font-size-l;
+    color: $black;
+    font-size: $font-size-m;
+    font-weight: normal;
     text-decoration: none;
+
+    @include respond-to(medium) {
+      font-size: $font-size-l;
+    }
   }
 }
 
 .Addon-summary {
-  margin-bottom: 0;
-  margin-top: 0;
-
-  a,
-  a:link {
-    color: $header-font-color;
-  }
-}
-
-.Addon-header {
-  background: $header-base-color;
-  color: $header-font-color;
-  margin: 0;
-  padding: $page-margin;
-
-  h1 {
-    margin-top: 0;
-    color: $header-font-color;
+  @include respond-to(medium) {
+    margin-bottom: 0;
+    max-width: 550px;
   }
 }
 
 .Addon-metadata {
-  align-items: center;
-  background-color: $header-search-color;
-  color: $white;
   display: flex;
-  flex-flow: row wrap;
+  flex-direction: row;
   justify-content: space-between;
-  margin: 0;
-  padding: 10px;
+  order: 1;
+}
 
-  .AddonCompatibilityError {
-    margin-top: 10px;
-    width: 100%;
+.Addon .AddonMeta {
+  text-align: right;
+}
+
+.Addon .InstallButton {
+  @include respond-to(medium) {
+    @include margin-start(auto);
+
+    align-self: flex-end;
   }
 }
 
-.Addon-theme-header-label {
-  $label-margin: 12px;
+// Details section with lots of flexbox stuff, on all but mobile displays.
+@include respond-to(medium) {
+  .Addon-details {
+    @include margin-end(10px);
 
-  @include start($label-margin);
+    display: grid;
+    grid-auto-flow: column dense;
+    grid-gap: 10px;
+    grid-template-columns: 35% 65%;
 
-  bottom: $label-margin;
-  position: absolute;
-}
+    .AddonDescription {
+      grid-column: 2;
+      grid-row: 1 / 5;
+    }
+  }
 
-.Addon-theme-header {
-  line-height: 0;
-  position: relative;
-}
+  .Addon-screenshots {
+    grid-column: 1 / 2;
+  }
 
-.Addon-theme-header-image {
-  border-radius: 12px;
-  object-fit: cover;
-  object-position: top right;
-  height: 100px;
-  display: block;
-  width: 100%;
+  .Addon-overall-rating {
+    grid-column: 1 / 2;
+  }
+
+  .AddonMoreInfo {
+    grid-column: 1 / 2;
+  }
+
+  // We hide this "Read reviews" link on larger displays as we actually show
+  // the first page of reviews on the page.
+  // TODO: Enable this once we load reviews on the addon page.
+  // See: https://github.com/mozilla/addons-frontend/issues/2552
+  // .Addon-overall-rating .Card-footer-link {
+  //   display: none;
+  // }
 }

--- a/src/amo/components/AddonMeta.js
+++ b/src/amo/components/AddonMeta.js
@@ -41,9 +41,9 @@ export class AddonMetaBase extends React.Component {
         <div className="AddonMeta-item AddonMeta-users">
           <h3 className="visually-hidden">{i18n.gettext('Used by')}</h3>
           <p className="AddonMeta-text">{userCount}</p>
-          <Rating className="AddonMeta-Rating" rating={averageRating} readOnly
-            styleName="small-monochrome" />
           <p className="AddonMeta-text AddonMeta-review-count">{reviewCount}</p>
+          <Rating className="AddonMeta-Rating" rating={averageRating} readOnly
+            styleName="small" />
         </div>
       </div>
     );

--- a/src/amo/components/AddonMoreInfo.scss
+++ b/src/amo/components/AddonMoreInfo.scss
@@ -19,16 +19,13 @@
 
     a:link {
       font-size: $font-size-s;
-      font-weight: 400;
+      font-weight: bold;
     }
   }
 }
 
 .AddonMoreInfo-contents-links-list {
+  list-style: none;
   margin: 0;
-  padding: 0 0 0 10px;
-
-  [dir=rtl] & {
-    padding: 0 10px 0 0;
-  }
+  padding: 0;
 }

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -2,10 +2,11 @@
 @import "~core/css/inc/lib";
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
+@import "~ui/css/vars";
 
 html,
 body {
-  background: $masthead-color;
+  background: $footer-base-color;
   height: 100%;
 }
 
@@ -38,7 +39,7 @@ body {
 }
 
 .App-content {
-  background: $accent-color;
+  background: $background-grey;
   flex-grow: 1;
   padding: 0 0 $padding-page;
 }

--- a/src/amo/components/SearchForm.scss
+++ b/src/amo/components/SearchForm.scss
@@ -10,6 +10,6 @@
 .SearchInput-input,
 .SearchForm-form {
   color: $base-color;
-  font-size: $font-size-m;
+  font-size: $font-size-search;
   white-space: nowrap;
 }

--- a/src/amo/css/AddonMeta.scss
+++ b/src/amo/css/AddonMeta.scss
@@ -1,3 +1,7 @@
+@import '~core/css/inc/mixins';
+@import '~amo/css/inc/vars';
+@import '~ui/css/vars';
+
 .AddonMeta {
   display: flex;
 }
@@ -9,13 +13,18 @@
 
 .AddonMeta-text {
   display: inline-block;
-  line-height: 1.1;
+  font-size: $font-size-s;
+  font-weight: bold;
   margin: 0;
   padding: 0;
+
+  @include respond-to(medium) {
+    margin-bottom: 4px;
+  }
 }
 
 .AddonMeta-Rating {
   justify-content: flex-start;
-  margin: 2px 0 2px -2.5px;
+  margin: 0;
   padding: 0;
 }

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -328,6 +328,16 @@ $default-arrow-margin: 3px;
   }
 }
 
+@mixin padding-start($val) {
+  [dir=ltr] & {
+    padding-left: $val;
+  }
+
+  [dir=rtl] & {
+    padding-right: $val;
+  }
+}
+
 @mixin padding-end($val) {
   [dir=ltr] & {
     padding-right: $val;
@@ -340,6 +350,6 @@ $default-arrow-margin: 3px;
 
 @mixin addonSection() {
   background: $base-color;
-  padding: 10px;
+  padding: 10px 20px;
   overflow: hidden;
 }

--- a/src/ui/components/Card/Card.scss
+++ b/src/ui/components/Card/Card.scss
@@ -8,7 +8,7 @@
   border-top-right-radius: $border-radius-default;
   font-size: $font-size-default;
   margin-bottom: 1px;
-  text-align: center;
+  text-align: left;
 }
 
 .Card-contents {
@@ -24,6 +24,10 @@
   .Card--no-footer & {
     border-bottom-left-radius: $border-radius-default;
     border-bottom-right-radius: $border-radius-default;
+  }
+
+  .Card--photon & {
+    padding: 20px 15px;
   }
 
   font-size: $font-size-s;

--- a/src/ui/components/Card/index.js
+++ b/src/ui/components/Card/index.js
@@ -12,10 +12,26 @@ export default class Card extends React.Component {
     footerLink: PropTypes.node,
     footerText: PropTypes.node,
     header: PropTypes.node,
+    photonStyle: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    // Photon is the name of the new Firefox design language. This flag
+    // modifies the card style to left-align the header, add padding, and tweak
+    // the styles to be in line with the new photon mocks while we migrate
+    // the rest of the site over.
+    photonStyle: false,
   }
 
   render() {
-    const { children, className, footerText, footerLink, header } = this.props;
+    const {
+      children,
+      className,
+      footerText,
+      footerLink,
+      header,
+      photonStyle,
+    } = this.props;
 
     let footer;
     let footerClass;
@@ -32,6 +48,7 @@ export default class Card extends React.Component {
 
     return (
       <section className={classNames('Card', className, {
+        'Card--photon': photonStyle,
         'Card--no-header': !header,
         'Card--no-footer': !footer,
       })} ref={(ref) => { this.cardContainer = ref; }}>

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -40,4 +40,14 @@ $background-gray: $background-grey;
 
 $type-black: $black;
 
-$header-accent-color: #0d96ff;
+$link-color: #0d96ff;
+
+$header-accent-color: $link-color;
+
+// Fonts
+$font-size-s: 12px;
+$font-size-search: 14px;
+$font-size-m: 18px;
+$font-size-l: 24px;
+$font-size-xl: 36px;
+$font-size-xxl: 42px;

--- a/tests/unit/ui/components/TestCard.js
+++ b/tests/unit/ui/components/TestCard.js
@@ -17,6 +17,16 @@ describe('<Card />', () => {
     expect(root.cardContainer.className).toContain('TofuSection');
   });
 
+  it('does not use photon class by default', () => {
+    const root = render({ children: 'hello' });
+    expect(root.cardContainer.className).not.toContain('Card--photon');
+  });
+
+  it('uses photon class if marked', () => {
+    const root = render({ children: 'hello', photonStyle: true });
+    expect(root.cardContainer.className).toContain('Card--photon');
+  });
+
   it('shows header if supplied', () => {
     const root = render({ header: 'foo' });
     expect(root.header).toBeTruthy();
@@ -24,7 +34,7 @@ describe('<Card />', () => {
 
   it('hides header if none supplied', () => {
     const root = render({ children: 'hello' });
-    expect(!root.header).toBeTruthy();
+    expect(root.header).toBeFalsy();
     expect(root.cardContainer.className).toContain('Card--no-header');
   });
 
@@ -51,7 +61,7 @@ describe('<Card />', () => {
 
   it('hides footer if none supplied', () => {
     const root = render({ children: 'hello' });
-    expect(!root.footer).toBeTruthy();
+    expect(root.footer).toBeFalsy();
     expect(root.cardContainer.className).toContain('Card--no-footer');
   });
 
@@ -63,6 +73,6 @@ describe('<Card />', () => {
 
   it('omits the content div with no children', () => {
     const root = render();
-    expect(!root.contents).toBeTruthy();
+    expect(root.contents).toBeFalsy();
   });
 });

--- a/webpack-common.js
+++ b/webpack-common.js
@@ -144,7 +144,10 @@ export function getPlugins({ excludeOtherAppLocales = true } = {}) {
         options: {
           context: path.resolve(__dirname),
           postcss: [
-            autoprefixer({ browsers: ['last 2 versions'] }),
+            autoprefixer({
+              browsers: ['last 2 versions'],
+              grid: false,
+            }),
           ],
         },
       })


### PR DESCRIPTION
This is the first crack at a responsive detail page for extension. Fixes #2430.

Note that I reversed the screenshots and info from the mocks because of #2550. I'd argue this closes #2550 if there aren't any complains from UX.

### Desktop
![screen shot 2017-06-10 at 22 02 40](https://user-images.githubusercontent.com/90871/27006353-e1a329be-4e29-11e7-9a8b-888117496a9a.png)
-----
![jun-10-2017 21-46-28](https://user-images.githubusercontent.com/90871/27006354-e65a1918-4e29-11e7-97e0-9d919a520677.gif)

### Mobile
![screen shot 2017-06-10 at 22 02 34](https://user-images.githubusercontent.com/90871/27006361-084c01c6-4e2a-11e7-9c01-5a2fd6bc6280.png)
