### PR TITLE
fix: Use installStatus, not add-on status for InstallButton (fix #2545)

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -174,6 +174,7 @@ export class AddonBase extends React.Component {
       clientApp,
       getClientCompatibility,
       i18n,
+      installStatus,
       userAgentInfo,
     } = this.props;
 
@@ -219,6 +220,8 @@ export class AddonBase extends React.Component {
             {...this.props}
             className="Button--action Button--small"
             disabled={!compatible}
+            ref={(ref) => { this.installButton = ref; }}
+            status={installStatus}
           />
           {!compatible ? (
             <AddonCompatibilityError maxVersion={maxVersion}

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -322,6 +322,18 @@ describe('Addon', () => {
     expect(rootNode.querySelector('.InstallButton-switch input').disabled).toBe(true);
   });
 
+  it('passes installStatus to installButton, not add-on status', () => {
+    const root = render({ addon: fakeAddon, installStatus: UNKNOWN });
+
+    expect(root.installButton.props.status).not.toEqual(fakeAddon.status);
+    expect(root.installButton.props.status).toEqual(UNKNOWN);
+  });
+
+  it('throws when unsupported type passed to installButton', () => {
+    expect(() => { render({ installStatus: 'public' }); })
+      .toThrow('Invalid add-on status public');
+  });
+
   it('enables a theme preview for non-enabled add-ons', () => {
     const rootNode = renderAsDOMNode({
       addon: {


### PR DESCRIPTION
Fixes #2545

We were relying on weird object spread for this in the past and with the cleanup it got removed. Added a few tests so hopefully we don't get bit by this again.