### PR TITLE
fix: Fix the header when header is verbose (fix #2547)

### DIFF
--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -30,7 +30,7 @@
 
 .Icon-fox-light {
   background: url('./fox-light.svg') center no-repeat;
-  background-size: cover;
+  background-size: contain;
 }
 
 .Icon-user {


### PR DESCRIPTION
Makes sure the fox icon doesn't get cut off.

### Screenshots
![screen shot 2017-06-13 at 13 49 51](https://user-images.githubusercontent.com/90871/27083157-7994a998-503f-11e7-85bc-e37f5e04b088.png)
![screen shot 2017-06-13 at 13 49 48](https://user-images.githubusercontent.com/90871/27083156-798eb830-503f-11e7-907e-a6629fb6e26a.png)
