### PR TITLE
fix: Theme pages at different sizes (fix #2570)

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -80,7 +80,13 @@
   order: 1;
 
   @include respond-to(medium) {
-    width: 90%;
+    flex-basis: 100%;
+    flex-grow: 1;
+
+    .Addon-persona & {
+      flex-basis: 75%;
+      flex-grow: 0;
+    }
   }
 }
 
@@ -107,19 +113,20 @@
 }
 
 .Addon-summary {
+  flex-basis: 100%;
+  flex-grow: 1;
   order: 2;
+
+  @include respond-to(medium) {
+    flex-grow: 0;
+    margin-bottom: 0;
+    max-width: 550px;
+  }
 }
 
 .Addon .InstallButton {
   margin-top: auto;
   order: 3;
-}
-
-.Addon-summary {
-  @include respond-to(medium) {
-    margin-bottom: 0;
-    max-width: 550px;
-  }
 }
 
 .Addon .InstallButton {
@@ -133,8 +140,6 @@
 // Details section with lots of grid stuff, on larger displays.
 @include respond-to(large) {
   .Addon-details {
-    @include margin-end(10px);
-
     display: grid;
     grid-auto-flow: column dense;
     grid-gap: 10px;


### PR DESCRIPTION
Fixes #2430 
Fixes #2570

Fix issues with Theme page details.

### Desktop
![screen shot 2017-06-14 at 16 19 30](https://user-images.githubusercontent.com/90871/27140400-502989c8-511d-11e7-834f-6e63b7a1e4b8.png)

### Mobile
![screen shot 2017-06-14 at 16 19 38](https://user-images.githubusercontent.com/90871/27140392-4aac0aa2-511d-11e7-83a2-b055d1f3be7e.png)
