### PR TITLE
fix: Don't force two taps on mobile <button> (fix #1904)

### DIFF
--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -219,6 +219,13 @@ $default-arrow-margin: 3px;
     font-weight: 400;
   }
 
+  // This is required because a <button> element with a :hover effect
+  // that changes its appearance will transition to the hover state onClick
+  // when using a mobile browser.
+  // This is the cause of
+  // https://github.com/mozilla/addons-frontend/issues/1904
+  //
+  // For more info, see: https://css-tricks.com/annoying-mobile-double-tap-link-issue/#article-header-id-2
   @media (pointer: fine) {
     &:hover {
       background: $background-hover;

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -219,8 +219,10 @@ $default-arrow-margin: 3px;
     font-weight: 400;
   }
 
-  &:hover {
-    background: $background-hover;
+  @media (pointer: fine) {
+    &:hover {
+      background: $background-hover;
+    }
   }
 
   &:active,


### PR DESCRIPTION
Fixes #1904 by removing the hover styles on mobile browsers for buttons with a media query. Added some docs and a link to https://css-tricks.com/annoying-mobile-double-tap-link-issue/#article-header-id-2 because this one was weeeeeird.