### PR TITLE
fix: Don't spread theme_data description

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -260,16 +260,23 @@ export class AddonBase extends React.Component {
             </Card>
           ) : null}
 
-          <ShowMoreCard header={i18n.sprintf(
-            i18n.gettext('About this %(addonType)s'), { addonType: addon.type }
-          )} className="AddonDescription">
-            <div className="AddonDescription-contents"
-              ref={(ref) => { this.addonDescription = ref; }}
-              dangerouslySetInnerHTML={
-                sanitizeHTML(nl2br(description), allowedDescriptionTags)
-              }
-            />
-          </ShowMoreCard>
+          {description && description.length ? (
+            <ShowMoreCard
+              header={i18n.sprintf(
+                i18n.gettext('About this %(addonType)s'),
+                { addonType: addon.type }
+              )}
+              className="AddonDescription"
+            >
+              <div
+                className="AddonDescription-contents"
+                ref={(ref) => { this.addonDescription = ref; }}
+                dangerouslySetInnerHTML={
+                  sanitizeHTML(nl2br(description), allowedDescriptionTags)
+                }
+              />
+            </ShowMoreCard>
+          ) : null}
 
           {this.renderRatingsCard()}
 

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -30,6 +30,14 @@ export default function addon(state = initialState, action) {
         newState[key] = {
           ...thisAddon,
           ...thisAddon.theme_data,
+          // TODO: Remove this when
+          // https://github.com/mozilla/addons-frontend/issues/1416 is fixed.
+          // theme_data will contain `description: 'None'` when the description
+          // is actually `null` and we don't want to set that on the addon
+          // itself so we reset it in case it's been overwritten.
+          //
+          // See also https://github.com/mozilla/addons-server/issues/5650.
+          description: thisAddon.description,
           guid: getGuid(thisAddon),
           type: ADDON_TYPE_THEME,
         };

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -208,6 +208,18 @@ describe('Addon', () => {
     expect(rootNode.querySelector('.AddonDescription-contents').textContent).toEqual(addon.summary);
   });
 
+  it('hides the description if description and summary are null', () => {
+    const addon = { ...fakeAddon, description: null, summary: null };
+    const rootNode = renderAsDOMNode({ addon });
+    expect(rootNode.querySelector('.AddonDescription')).toEqual(null);
+  });
+
+  it('hides the description if description and summary are blank', () => {
+    const addon = { ...fakeAddon, description: '', summary: '' };
+    const rootNode = renderAsDOMNode({ addon });
+    expect(rootNode.querySelector('.AddonDescription')).toEqual(null);
+  });
+
   it('converts new lines in the description to breaks', () => {
     const rootNode = renderAsDOMNode({
       addon: {

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -1,85 +1,108 @@
-import addons from 'core/reducers/addons';
+import { loadEntities } from 'core/actions';
 import { ADDON_TYPE_THEME } from 'core/constants';
+import addons, { denormalizeAddon } from 'core/reducers/addons';
+import { createFetchAddonResult } from 'tests/unit/helpers';
+import { fakeAddon } from 'tests/unit/amo/helpers';
+
 
 describe('addon reducer', () => {
-  let originalState;
+  let addonsState;
 
   beforeEach(() => {
-    originalState = { foo: { slug: 'foo' }, bar: { slug: 'bar' } };
+    const anotherFakeAddon = { ...fakeAddon, slug: 'testing123', id: 64 };
+
+    addonsState = addons({},
+      loadEntities(createFetchAddonResult(fakeAddon).entities));
+    addonsState = addons(addonsState,
+      loadEntities(createFetchAddonResult(anotherFakeAddon).entities));
   });
 
   it('returns the old state', () => {
-    expect(originalState).toBe(addons(originalState, { type: 'BLAH' }));
+    expect(addonsState)
+      .toEqual(addons(addonsState, { type: 'UNRELATED_ACTION' }));
   });
 
   it('stores addons from entities', () => {
-    const state = addons(originalState, {
-      payload: {
-        entities: {
-          addons: {
-            baz: { slug: 'baz' },
-          },
-        },
-      },
+    const anotherFakeAddon = { ...fakeAddon, slug: 'testing1234', id: 6401 };
+
+    const newAddonsState = addons(addonsState,
+      loadEntities(createFetchAddonResult(anotherFakeAddon).entities));
+    expect(newAddonsState).toEqual({
+      ...addonsState,
+      [anotherFakeAddon.slug]: denormalizeAddon(anotherFakeAddon),
     });
-    expect(state).toEqual({ foo: { slug: 'foo' }, bar: { slug: 'bar' }, baz: { slug: 'baz' } });
   });
 
   it('pulls down the install URL from the file', () => {
-    const fileOne = { url: 'https://a.m.o/download.xpi' };
-    const fileTwo = { file: 'data' };
     const addon = {
+      ...fakeAddon,
       slug: 'installable',
       current_version: {
-        files: [fileOne, fileTwo],
+        ...fakeAddon.current_version,
+        files: [{ url: 'https://a.m.o/download.xpi' }, { file: 'data' }],
       },
     };
+
     expect(
-      addons(undefined, { payload: { entities: { addons: { installable: addon } } } })
+      addons(undefined, loadEntities(createFetchAddonResult(addon).entities))
     ).toEqual({
-      installable: {
+      installable: denormalizeAddon({
         ...addon,
         installURL: 'https://a.m.o/download.xpi',
-      },
+      }),
     });
   });
 
   it('sets the icon_url as iconUrl', () => {
     const addon = {
+      ...fakeAddon,
       slug: 'installable',
       icon_url: 'http://foo.com/img.png',
     };
+
     expect(
-      addons(undefined, { payload: { entities: { addons: { installable: addon } } } })
+      addons(undefined, loadEntities(createFetchAddonResult(addon).entities))
     ).toEqual({
       installable: {
         ...addon,
-        iconUrl: 'http://foo.com/img.png',
+        iconUrl: addon.icon_url,
       },
     });
   });
 
   it('flattens theme data', () => {
-    const type = ADDON_TYPE_THEME;
-    const state = addons(originalState, {
-      payload: {
-        entities: {
-          addons: {
-            baz: { slug: 'baz', id: 42, theme_data: { theme_thing: 'some-data' }, type },
-          },
-        },
-      },
+    const theme = {
+      ...fakeAddon,
+      slug: 'baz',
+      id: 42,
+      theme_data: { theme_thing: 'some-data' },
+      type: ADDON_TYPE_THEME,
+    };
+    const state = addons(
+      {}, loadEntities(createFetchAddonResult(theme).entities));
+
+    expect(state).toMatchObject({
+      baz: { theme_thing: 'some-data' },
     });
-    expect(state).toEqual({
-      foo: { slug: 'foo' },
-      bar: { slug: 'bar' },
-      baz: {
-        id: 42,
-        slug: 'baz',
-        theme_thing: 'some-data',
-        guid: '42@personas.mozilla.org',
-        type: ADDON_TYPE_THEME,
-      },
+  });
+
+  it('does not use description from theme_data', () => {
+    // See: https://github.com/mozilla/addons-frontend/issues/2569
+    // Can be removed when
+    // https://github.com/mozilla/addons-frontend/issues/1416 is fixed.
+    const theme = {
+      ...fakeAddon,
+      description: null,
+      slug: 'baz',
+      id: 42,
+      theme_data: { theme_thing: 'some-data', description: 'None' },
+      type: ADDON_TYPE_THEME,
+    };
+    const state = addons(
+      {}, loadEntities(createFetchAddonResult(theme).entities));
+
+    expect(state).toMatchObject({
+      baz: { description: null },
     });
   });
 });


### PR DESCRIPTION
Hide the "About this extension" when description and summary are blank.

Fixes #2233.
Fixes #2569.

### Desktop
<img width="1194" alt="screenshot 2017-06-15 01 20 19" src="https://user-images.githubusercontent.com/90871/27160120-b42d6aa6-5169-11e7-837a-3b385cf12670.png">

### Mobile
![screen shot 2017-06-15 at 01 20 35](https://user-images.githubusercontent.com/90871/27160117-a7f59574-5169-11e7-9346-739914e22c0c.png)