### PR TITLE
fix: yarn test no longer runs lint test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test-coverage": "bin/config-check.js && jest --coverage --watch",
     "test-coverage-once": "bin/config-check.js && jest --coverage",
     "test-once": "bin/config-check.js && jest",
+    "test-once-with-lint": "bin/config-check.js && jest && npm run eslint && npm run stylelint",
     "version-check": "node bin/version-check.js",
     "webpack-dev-server": "npm run build-locales && better-npm-run webpack-dev-server"
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "test": "bin/config-check.js && jest --watch",
     "test-coverage": "bin/config-check.js && jest --coverage --watch",
     "test-coverage-once": "bin/config-check.js && jest --coverage",
-    "test-once": "bin/config-check.js && jest",
-    "test-once-with-lint": "bin/config-check.js && jest && npm run eslint && npm run stylelint",
+    "test-once": "bin/config-check.js && jest && npm run lint",
     "version-check": "node bin/version-check.js",
     "webpack-dev-server": "npm run build-locales && better-npm-run webpack-dev-server"
   },


### PR DESCRIPTION
Fixes: #2489 

Modified `test-once` to include lint tests