### PR TITLE
fix: Log in button works on first click

### DIFF
--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -66,10 +66,6 @@ export class AuthenticateButtonBase extends React.Component {
     // appearance will transition to the hover state onClick when using a
     // mobile browser. This is the cause of
     // https://github.com/mozilla/addons-frontend/issues/1904
-    //
-    // We tried to use https://css-tricks.com/annoying-mobile-double-tap-link-issue/#article-header-id-2
-    // and media queries to fix this but the `href` solution worked so I'm
-    // going with this.
     return (
       <Button onClick={this.onClick} href="#" {...otherProps}>
         {noIcon ? null : <Icon name="user-dark" />}

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -60,8 +60,18 @@ export class AuthenticateButtonBase extends React.Component {
     const buttonText = isAuthenticated ?
       logOutText || i18n.gettext('Log out') :
       logInText || i18n.gettext('Log in/Sign up');
+
+    // The `href` is required because a <button> element with a :hover effect
+    // and/or focus effect (that is not part of a form) that changes its
+    // appearance will transition to the hover state onClick when using a
+    // mobile browser. This is the cause of
+    // https://github.com/mozilla/addons-frontend/issues/1904
+    //
+    // We tried to use https://css-tricks.com/annoying-mobile-double-tap-link-issue/#article-header-id-2
+    // and media queries to fix this but the `href` solution worked so I'm
+    // going with this.
     return (
-      <Button onClick={this.onClick} {...otherProps}>
+      <Button onClick={this.onClick} href="#" {...otherProps}>
         {noIcon ? null : <Icon name="user-dark" />}
         {buttonText}
       </Button>

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -219,17 +219,8 @@ $default-arrow-margin: 3px;
     font-weight: 400;
   }
 
-  // This is required because a <button> element with a :hover effect
-  // that changes its appearance will transition to the hover state onClick
-  // when using a mobile browser.
-  // This is the cause of
-  // https://github.com/mozilla/addons-frontend/issues/1904
-  //
-  // For more info, see: https://css-tricks.com/annoying-mobile-double-tap-link-issue/#article-header-id-2
-  @media (pointer: fine) {
-    &:hover {
-      background: $background-hover;
-    }
+  &:hover {
+    background: $background-hover;
   }
 
   &:active,

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -66,7 +66,7 @@ export const signedInApiState = Object.freeze({
   clientApp: 'firefox',
 });
 
-export function dispatchAnonymousActions({
+export function dispatchClientMetadata({
   store = createStore().store,
   clientApp = 'android',
   lang = 'en-US',
@@ -86,7 +86,7 @@ export function dispatchSignInActions({
   authToken = userAuthToken(),
   ...otherArgs
 } = {}) {
-  const { store } = dispatchAnonymousActions(otherArgs);
+  const { store } = dispatchClientMetadata(otherArgs);
 
   store.dispatch(setAuthToken(authToken));
 

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -66,17 +66,30 @@ export const signedInApiState = Object.freeze({
   clientApp: 'firefox',
 });
 
-export function dispatchSignInActions({
+export function dispatchAnonymousActions({
   store = createStore().store,
   clientApp = 'android',
-  authToken = userAuthToken(),
   lang = 'en-US',
   userAgent = sampleUserAgent,
 } = {}) {
-  store.dispatch(setAuthToken(authToken));
   store.dispatch(setClientApp(clientApp));
   store.dispatch(setLang(lang));
   store.dispatch(setUserAgent(userAgent));
+
+  return {
+    store,
+    state: store.getState(),
+  };
+}
+
+export function dispatchSignInActions({
+  authToken = userAuthToken(),
+  ...otherArgs
+} = {}) {
+  const { store } = dispatchAnonymousActions(otherArgs);
+
+  store.dispatch(setAuthToken(authToken));
+
   return {
     store,
     state: store.getState(),

--- a/tests/unit/core/components/TestAuthenticateButton.js
+++ b/tests/unit/core/components/TestAuthenticateButton.js
@@ -14,7 +14,7 @@ import {
   mapStateToProps,
 } from 'core/components/AuthenticateButton';
 import {
-  dispatchAnonymousActions,
+  dispatchClientMetadata,
   dispatchSignInActions,
 } from 'tests/unit/amo/helpers';
 import { getFakeI18nInst, userAuthToken } from 'tests/unit/helpers';
@@ -114,7 +114,7 @@ describe('<AuthenticateButton />', () => {
   });
 
   it('pulls isAuthenticated from state', () => {
-    const { store } = dispatchAnonymousActions();
+    const { store } = dispatchClientMetadata();
     expect(mapStateToProps(store.getState()).isAuthenticated).toEqual(false);
     store.dispatch(setAuthToken(userAuthToken({ user_id: 123 })));
     expect(mapStateToProps(store.getState()).isAuthenticated).toEqual(true);


### PR DESCRIPTION
Fixes #1904

This is frustrating but because the `<button>` element used for the "Log in to review this extension" button doesn't actually relate to anything the mobile browser will use its hover and focus states after first tap. It's a mess.

The easiest fix is to put a `href="#"` on it and turn it into a link. That isn't great but it's the best we can do for now.