### PR TITLE
fix: Improve compatibility warning

### DIFF
--- a/src/amo/components/AddonCompatibilityError/style.scss
+++ b/src/amo/components/AddonCompatibilityError/style.scss
@@ -1,14 +1,16 @@
 @import "~amo/css/inc/vars";
+@import "~ui/css/vars";
 
 .AddonCompatibilityError {
-  background: $error-background-color;
+  background: $report-base-color;
   border-radius: $border-radius-default;
-  color: $error-text-color;
-  padding: 5px;
+  margin-top: 10px;
+  padding: 10px;
   text-align: center;
 
+  &,
   a,
   a:link {
-    color: $error-text-color;
+    color: $white;
   }
 }

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -9,10 +9,6 @@ $text-color-headings: $text-color-default;
 $text-color-message: #fff;
 $sub-text-color: #6a6a6a;
 $form-border-color: $primary-font-color;
-$error-text-color: $text-color-message;
-$error-background-color: #f03e3e;
-$error-button-background-color: $error-text-color;
-$error-button-text-color: $error-background-color;
 
 $button-background-color: #0095dd;
 

--- a/src/ui/components/ErrorList/styles.scss
+++ b/src/ui/components/ErrorList/styles.scss
@@ -1,10 +1,11 @@
 @import "~core/css/inc/vars";
+@import "~ui/css/vars";
 
 .ErrorList {
   text-align: center;
   border-radius: $border-radius-default;
-  background-color: $error-background-color;
-  color: $error-text-color;
+  background-color: $report-base-color;
+  color: $white;
   padding: 10px;
   margin: 0;
   margin-bottom: 10px;
@@ -12,14 +13,7 @@
 
 .ErrorList-item {
   list-style: none;
-  margin-bottom: 8px;
-
-  .Button {
-    color: $error-button-text-color;
-    background-color: $error-button-background-color;
-    border-radius: $border-radius-s;
-    font-size: $font-size-s;
-  }
+  margin-bottom: 10px;
 
   &:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
Fix #2577

Improves the compatibility styling.

### Before
<img width="633" alt="screenshot 2017-06-16 15 52 39" src="https://user-images.githubusercontent.com/90871/27231853-ea6c75f6-52ab-11e7-97e0-c27b3012d506.png">

### After
<img width="630" alt="screenshot 2017-06-16 15 51 34" src="https://user-images.githubusercontent.com/90871/27231859-ef0fa8a8-52ab-11e7-84ec-65237101d03c.png">
