### PR TITLE
Make palceholder text in header lighter

### DIFF
--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -16,7 +16,7 @@
 
 .SectionLinks-link,
 .SectionLinks-link:link {
-  color: transparentize($white, 0.5);
+  color: $header-text-not-active-color;
   margin: 0 15px;
   padding: 0 0 2px;
   text-decoration: none;
@@ -25,7 +25,7 @@
 
   &:focus,
   &:hover {
-    border-bottom: 3px solid transparentize($white, 0.5);
+    border-bottom: 3px solid $header-text-not-active-color;
   }
 
   &:active {

--- a/src/ui/components/SearchInput/style.scss
+++ b/src/ui/components/SearchInput/style.scss
@@ -1,5 +1,6 @@
 @import "~core/css/inc/mixins";
 @import "~ui/components/Icon/vars";
+@import "~ui/css/vars";
 
 $input-height: 48px;
 $icon-margin-start: 24px;
@@ -47,6 +48,7 @@ $icon-margin-end: 12px;
   // Include the start margin on the end so that icon and text is centred together.
   @include padding-end($icon-margin-start);
 
+  color: $header-text-not-active-color;
   display: inline-block;
   height: $input-height;
   line-height: $input-height;

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -43,6 +43,7 @@ $type-black: $black;
 $link-color: #0d96ff;
 
 $header-accent-color: $link-color;
+$header-text-not-active-color: transparentize($white, 0.5);
 
 // Fonts
 $font-size-s: 12px;


### PR DESCRIPTION
Fix #2189.

I opted for `#ffffff` at 50% opacity because it's what we're using in the section links right above the search form. I think it looks better as the "out of focus" colour in the header. @pwalm: let me know if that's okay or if I should still use `#dcdcdc` as the bug said.

### My version

<img width="714" alt="screenshot 2017-06-16 20 24 19" src="https://user-images.githubusercontent.com/90871/27241792-236f2634-52d2-11e7-88bb-7e20d8533cb2.png">

### `#dcdcdc` version

<img width="679" alt="screenshot 2017-06-16 20 24 39" src="https://user-images.githubusercontent.com/90871/27241795-28654ef2-52d2-11e7-8c74-cca89b3c4d15.png">
