### PR TITLE
Rating Star Alignment Issue

### DIFF
--- a/src/amo/css/AddonMeta.scss
+++ b/src/amo/css/AddonMeta.scss
@@ -27,4 +27,12 @@
   justify-content: flex-start;
   margin: 0;
   padding: 0;
+
+  @include respond-to(medium) {
+    justify-content: flex-end;
+
+    [dir=rtl] & {
+      justify-content: flex-start;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #2587 
For some Languages the character length for translation of `User` and `reviews` is long hence breaking alignment of review starts. This fixes them.