### PR TITLE
chore: Remove prefix from AddonReviewList and AddonReview

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -56,7 +56,7 @@ export const setDenormalizedReview = (
   return { type: SET_REVIEW, payload: review };
 };
 
-export type SetAddonReviewsAction = {|
+export type SetReviewsAction = {|
   type: string,
   payload: {|
     addonSlug: string,
@@ -65,15 +65,15 @@ export type SetAddonReviewsAction = {|
   |},
 |};
 
-type SetAddonReviewsParams = {|
+type SetReviewsParams = {|
   addonSlug: string,
   reviewCount: number,
   reviews: Array<ApiReviewType>,
 |};
 
-export const setAddonReviews = (
-  { addonSlug, reviewCount, reviews }: SetAddonReviewsParams
-): SetAddonReviewsAction => {
+export const setReviews = (
+  { addonSlug, reviewCount, reviews }: SetReviewsParams
+): SetReviewsAction => {
   if (!addonSlug) {
     throw new Error('addonSlug cannot be empty');
   }

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -8,7 +8,7 @@ import { compose } from 'redux';
 import { withErrorHandling } from 'core/errorHandler';
 import { setReview } from 'amo/actions/reviews';
 import { getLatestUserReview, submitReview } from 'amo/api';
-import DefaultAddonReview from 'amo/components/AddonReview';
+import DefaultReview from 'amo/components/Review';
 import DefaultAuthenticateButton from 'core/components/AuthenticateButton';
 import {
   ADDON_TYPE_DICT,
@@ -41,7 +41,7 @@ type LoadSavedReviewFunc = ({|
 type SubmitReviewFunc = (SubmitReviewParams) => Promise<void>;
 
 type RatingManagerProps = {|
-  AddonReview: typeof DefaultAddonReview,
+  Review: typeof DefaultReview,
   AuthenticateButton: typeof DefaultAuthenticateButton,
   Rating: typeof DefaultRating,
   addon: AddonType,
@@ -62,7 +62,7 @@ export class RatingManagerBase extends React.Component {
   state: {| showTextEntry: boolean |};
 
   static defaultProps = {
-    AddonReview: DefaultAddonReview,
+    Review: DefaultReview,
     AuthenticateButton: DefaultAuthenticateButton,
     Rating: DefaultRating,
   }
@@ -154,7 +154,7 @@ export class RatingManagerBase extends React.Component {
   }
 
   render() {
-    const { AddonReview, Rating, i18n, addon, userId, userReview } = this.props;
+    const { Review, Rating, i18n, addon, userId, userReview } = this.props;
     const { showTextEntry } = this.state;
     const isLoggedIn = Boolean(userId);
 
@@ -169,7 +169,7 @@ export class RatingManagerBase extends React.Component {
     return (
       <div className="RatingManager">
         {showTextEntry && isLoggedIn ?
-          <AddonReview
+          <Review
             onReviewSubmitted={onReviewSubmitted}
             review={userReview}
           /> : null

--- a/src/amo/components/Review/index.js
+++ b/src/amo/components/Review/index.js
@@ -22,9 +22,9 @@ import type { ErrorHandler as ErrorHandlerType } from 'core/errorHandler';
 import type { ElementEvent } from 'core/types/dom';
 import type { DispatchFunc } from 'core/types/redux';
 
-import 'amo/css/AddonReview.scss';
+import './styles.scss';
 
-type AddonReviewProps = {|
+type ReviewProps = {|
   apiState?: ApiStateType,
   createLocalState: typeof defaultLocalStateCreator,
   debounce: typeof defaultDebounce,
@@ -37,33 +37,38 @@ type AddonReviewProps = {|
   updateReviewText: (review: $Shape<SubmitReviewParams>) => Promise<void>,
 |};
 
-type AddonReviewState = {|
+type ReviewState = {|
   reviewBody: ?string,
 |};
 
-export class AddonReviewBase extends React.Component {
+// Changing this will invalidate any saved add-ons for users because it
+// changes the prefix we use in our offline storage key.
+const LOCALSTATE_PREFIX = 'AddonReview';
+
+export class ReviewBase extends React.Component {
   localState: LocalState;
-  props: AddonReviewProps;
+  props: ReviewProps;
   reviewForm: Node;
   reviewPrompt: Node;
   reviewTextarea: Node;
-  state: AddonReviewState;
+  state: ReviewState;
 
   static defaultProps = {
     createLocalState: defaultLocalStateCreator,
     debounce: defaultDebounce,
   };
 
-  constructor(props: AddonReviewProps) {
+  constructor(props: ReviewProps) {
     super(props);
     this.state = {
       reviewBody: props.review.body,
     };
-    this.localState = props.createLocalState(`AddonReview:${props.review.id}`);
+    this.localState = props.createLocalState(
+      `${LOCALSTATE_PREFIX}:${props.review.id}`);
     this.checkForStoredState();
   }
 
-  componentWillReceiveProps(nextProps: AddonReviewProps) {
+  componentWillReceiveProps(nextProps: ReviewProps) {
     const { review } = nextProps;
     if (review) {
       this.setState({ reviewBody: review.body });
@@ -74,7 +79,7 @@ export class AddonReviewBase extends React.Component {
     return this.localState.load()
       .then((storedState) => {
         if (storedState) {
-          log.debug(oneLine`Initializing AddonReview state from LocalState
+          log.debug(oneLine`Initializing Review state from LocalState
             ${this.localState.id}`, storedState);
           this.setState(storedState);
         }
@@ -157,19 +162,19 @@ export class AddonReviewBase extends React.Component {
     }
 
     return (
-      <OverlayCard visibleOnLoad className="AddonReview">
-        <h2 className="AddonReview-header">{i18n.gettext('Write a review')}</h2>
+      <OverlayCard visibleOnLoad className="Review">
+        <h2 className="Review-header">{i18n.gettext('Write a review')}</h2>
         <p ref={(ref) => { this.reviewPrompt = ref; }}>{prompt}</p>
         <form onSubmit={this.onSubmit} ref={(ref) => { this.reviewForm = ref; }}>
-          <div className="AddonReview-form-input">
+          <div className="Review-form-input">
             {errorHandler.hasError() ? errorHandler.renderError() : null}
-            <label htmlFor="AddonReview-textarea" className="visually-hidden">
+            <label htmlFor="Review-textarea" className="visually-hidden">
               {i18n.gettext('Review text')}
             </label>
             <textarea
-              id="AddonReview-textarea"
+              id="Review-textarea"
               ref={(ref) => { this.reviewTextarea = ref; }}
-              className="AddonReview-textarea"
+              className="Review-textarea"
               onInput={this.onBodyInput}
               name="review"
               value={reviewBody}
@@ -177,7 +182,7 @@ export class AddonReviewBase extends React.Component {
             />
           </div>
           <input
-            className="AddonReview-submit"
+            className="Review-submit"
             type="submit" value={i18n.gettext('Submit review')}
           />
         </form>
@@ -206,7 +211,7 @@ export const mapDispatchToProps = (dispatch: DispatchFunc) => ({
 });
 
 export default compose(
-  withErrorHandler({ name: 'AddonReview' }),
+  withErrorHandler({ name: 'Review' }),
   connect(mapStateToProps, mapDispatchToProps),
   translate({ withRef: true }),
-)(AddonReviewBase);
+)(ReviewBase);

--- a/src/amo/components/Review/styles.scss
+++ b/src/amo/components/Review/styles.scss
@@ -1,24 +1,24 @@
 @import "~amo/css/inc/vars";
 
-.AddonReview .Card-contents {
+.Review .Card-contents {
   padding-left: 0;
   padding-right: 0;
 }
 
-.AddonReview-form-input {
+.Review-form-input {
   display: flex;
   flex-direction: column;
   margin: 0;
   padding: 0 10px;
 }
 
-.AddonReview-header {
+.Review-header {
   font-size: $font-size-form-header;
   margin-bottom: 0.3em;
 }
 
-.AddonReview-textarea,
-.AddonReview-submit {
+.Review-textarea,
+.Review-submit {
   margin-bottom: 12px;
   text-align: left;
   width: 100%;
@@ -28,11 +28,11 @@
   box-shadow: none;
 }
 
-.AddonReview-textarea {
+.Review-textarea {
   min-height: 200px;
 }
 
-.AddonReview-submit {
+.Review-submit {
   font-size: $font-size-s;
   text-align: center;
   color: $link-color;

--- a/src/amo/components/ReviewList/index.js
+++ b/src/amo/components/ReviewList/index.js
@@ -1,5 +1,4 @@
 /* @flow */
-/* eslint-disable react/no-unused-prop-types */
 import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -25,23 +24,24 @@ import type { AddonType } from 'core/types/addons';
 import type { DispatchFunc, ReduxStore } from 'core/types/redux';
 import type { ReactRouterLocation } from 'core/types/router';
 
-import 'amo/css/AddonReviewList.scss';
+import './styles.scss';
 
-type AddonReviewListRouteParams = {|
+type ReviewListRouteParams = {|
+  // eslint-disable-next-line react/no-unused-prop-types
   addonSlug: string,
 |}
 
-type AddonReviewListProps = {|
+type ReviewListProps = {|
   i18n: Object,
   addon?: AddonType,
   location: ReactRouterLocation,
-  params: AddonReviewListRouteParams,
+  params: ReviewListRouteParams,
   reviewCount?: number,
   reviews?: Array<UserReviewType>,
 |};
 
-export class AddonReviewListBase extends React.Component {
-  props: AddonReviewListProps;
+export class ReviewListBase extends React.Component {
+  props: ReviewListProps;
 
   addonURL() {
     const { addon } = this.props;
@@ -59,10 +59,10 @@ export class AddonReviewListBase extends React.Component {
     const { i18n } = this.props;
     const timestamp = i18n.moment(review.created).fromNow();
     return (
-      <li className="AddonReviewList-li">
+      <li className="ReviewList-li">
         <h3>{review.title}</h3>
         <p>{review.body}</p>
-        <div className="AddonReviewList-by-line">
+        <div className="ReviewList-by-line">
           <Rating styleName="small" rating={review.rating} readOnly />
           {/* L10n: Example: "from Jose, last week" */}
           {i18n.sprintf(i18n.gettext('from %(authorName)s, %(timestamp)s'),
@@ -87,14 +87,14 @@ export class AddonReviewListBase extends React.Component {
       fallbackIcon;
 
     return (
-      <div className="AddonReviewList">
-        <div className="AddonReviewList-header">
-          <div className="AddonReviewList-header-icon">
+      <div className="ReviewList">
+        <div className="ReviewList-header">
+          <div className="ReviewList-header-icon">
             <Link to={this.addonURL()}>
               <img src={iconUrl} alt={i18n.gettext('Add-on icon')} />
             </Link>
           </div>
-          <div className="AddonReviewList-header-text">
+          <div className="ReviewList-header-text">
             <h1 className="visually-hidden">
               {i18n.sprintf(i18n.gettext('Reviews for %(addonName)s'),
                             { addonName: addon.name })}
@@ -147,7 +147,7 @@ export function loadInitialData(
     location, params, store,
   }: {|
     location: ReactRouterLocation,
-    params: AddonReviewListRouteParams,
+    params: ReviewListRouteParams,
     store: ReduxStore,
   |}
 ) {
@@ -168,7 +168,7 @@ export function loadInitialData(
 }
 
 export function mapStateToProps(
-  state: {| reviews: ReviewState |}, ownProps: AddonReviewListProps,
+  state: {| reviews: ReviewState |}, ownProps: ReviewListProps,
 ) {
   if (!ownProps || !ownProps.params || !ownProps.params.addonSlug) {
     throw new Error('The component had a falsey params.addonSlug parameter');
@@ -184,9 +184,9 @@ export function mapStateToProps(
 
 export default compose(
   safeAsyncConnect([{
-    key: 'AddonReviewList',
+    key: 'ReviewList',
     promise: loadInitialData,
   }]),
   connect(mapStateToProps),
   translate({ withRef: true }),
-)(AddonReviewListBase);
+)(ReviewListBase);

--- a/src/amo/components/ReviewList/index.js
+++ b/src/amo/components/ReviewList/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import Rating from 'ui/components/Rating';
-import { setAddonReviews } from 'amo/actions/reviews';
+import { setReviews } from 'amo/actions/reviews';
 import { getReviews } from 'amo/api';
 import fallbackIcon from 'amo/img/icons/default-64.png';
 import Paginate from 'core/components/Paginate';
@@ -119,7 +119,7 @@ export class ReviewListBase extends React.Component {
   }
 }
 
-export function loadAddonReviews(
+export function loadReviews(
   {
     addonId, addonSlug, dispatch, page = 1,
   }: {|
@@ -136,7 +136,7 @@ export function loadAddonReviews(
       // For example, the user selected a star rating but hasn't submitted
       // review text yet.
       const reviews = allReviews.filter((review) => Boolean(review.body));
-      dispatch(setAddonReviews({
+      dispatch(setReviews({
         addonSlug, reviews, reviewCount: response.count,
       }));
     });
@@ -162,7 +162,7 @@ export function loadInitialData(
   })
     .then(() => loadAddonIfNeeded({ store, params: { slug: addonSlug } }))
     .then(() => findAddon(store.getState(), addonSlug))
-    .then((addon) => loadAddonReviews({
+    .then((addon) => loadReviews({
       addonId: addon.id, addonSlug, dispatch: store.dispatch, page,
     }));
 }

--- a/src/amo/components/ReviewList/styles.scss
+++ b/src/amo/components/ReviewList/styles.scss
@@ -1,6 +1,6 @@
 @import "~amo/css/inc/vars";
 
-.AddonReviewList {
+.ReviewList {
   padding: 10px;
 
   .CardList {
@@ -8,11 +8,11 @@
   }
 }
 
-.AddonReviewList-header {
+.ReviewList-header {
   margin: 15px 0;
   display: flex;
 
-  .AddonReviewList-header-text {
+  .ReviewList-header-text {
     > h2,
     > h3 {
       font-size: 1.1em;
@@ -38,12 +38,12 @@
     }
   }
 
-  .AddonReviewList-header-icon {
+  .ReviewList-header-icon {
     margin: 0 20px;
   }
 }
 
-.AddonReviewList-li {
+.ReviewList-li {
   word-wrap: break-word;
 
   > h3 {
@@ -56,7 +56,7 @@
     font-size: $font-size-default;
   }
 
-  .AddonReviewList-by-line {
+  .ReviewList-by-line {
     display: flex;
     color: $sub-text-color;
     font-size: $font-size-s;

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -10,7 +10,7 @@ import SimulateSyncError from
   'core/containers/error-simulation/SimulateSyncError';
 import HandleLogin from 'core/containers/HandleLogin';
 
-import AddonReviewList from './components/AddonReviewList';
+import ReviewList from './components/ReviewList';
 import App from './components/App';
 import Categories from './components/Categories';
 import CategoryPage from './containers/CategoryPage';
@@ -31,7 +31,7 @@ export default (
   <Route path="/:lang/:application" component={App}>
     <IndexRoute component={Home} />
     <Route path="addon/:slug/" component={Addon} />
-    <Route path="addon/:addonSlug/reviews/" component={AddonReviewList} />
+    <Route path="addon/:addonSlug/reviews/" component={ReviewList} />
     <Route path=":visibleAddonType/categories/" component={Categories} />
     <Route path=":visibleAddonType/featured/" component={FeaturedAddons} />
     <Route path=":visibleAddonType/:slug/" component={CategoryPage} />

--- a/tests/unit/amo/actions/testReviews.js
+++ b/tests/unit/amo/actions/testReviews.js
@@ -2,7 +2,7 @@ import {
   denormalizeReview,
   setDenormalizedReview,
   setReview,
-  setAddonReviews,
+  setReviews,
 } from 'amo/actions/reviews';
 import { SET_REVIEW } from 'amo/constants';
 import { fakeAddon, fakeReview } from 'tests/unit/amo/helpers';
@@ -42,7 +42,7 @@ describe('amo.actions.reviews', () => {
     });
   });
 
-  describe('setAddonReviews', () => {
+  describe('setReviews', () => {
     const defaultParams = {
       reviews: [fakeReview],
       reviewCount: 1,
@@ -52,19 +52,19 @@ describe('amo.actions.reviews', () => {
     it('requires an addonSlug', () => {
       const params = { ...defaultParams };
       delete params.addonSlug;
-      expect(() => setAddonReviews(params)).toThrowError(/addonSlug cannot be empty/);
+      expect(() => setReviews(params)).toThrowError(/addonSlug cannot be empty/);
     });
 
     it('requires a list of reviews', () => {
       const params = { ...defaultParams };
       delete params.reviews;
-      expect(() => setAddonReviews(params)).toThrowError(/reviews must be an Array/);
+      expect(() => setReviews(params)).toThrowError(/reviews must be an Array/);
     });
 
     it('requires a count of reviews', () => {
       const params = { ...defaultParams };
       delete params.reviewCount;
-      expect(() => setAddonReviews(params)).toThrowError(/reviewCount must be set/);
+      expect(() => setReviews(params)).toThrowError(/reviewCount must be set/);
     });
   });
 });

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -28,7 +28,7 @@ import { getFakeI18nInst, userAuthToken } from 'tests/unit/helpers';
 
 function render(customProps = {}) {
   const props = {
-    AddonReview: () => <div />,
+    Review: () => <div />,
     AuthenticateButton: () => <div />,
     addon: fakeAddon,
     apiState: signedInApiState,
@@ -159,39 +159,39 @@ describe('RatingManager', () => {
       });
   });
 
-  it('renders and configures AddonReview after submitting a rating', () => {
+  it('renders and configures Review after submitting a rating', () => {
     const userReview = setReview(fakeReview).payload;
-    const FakeAddonReview = sinon.spy(() => <div />);
-    const root = render({ AddonReview: FakeAddonReview, userReview });
+    const FakeReview = sinon.spy(() => <div />);
+    const root = render({ Review: FakeReview, userReview });
 
-    expect(FakeAddonReview.called).toEqual(false);
+    expect(FakeReview.called).toEqual(false);
 
     return root.onSelectRating(5)
       .then(() => {
-        expect(FakeAddonReview.called).toBeTruthy();
+        expect(FakeReview.called).toBeTruthy();
 
-        const props = FakeAddonReview.firstCall.args[0];
+        const props = FakeReview.firstCall.args[0];
         expect(props.review).toEqual(userReview);
 
         // Now make sure the callback is configured.
         expect(root.state.showTextEntry).toEqual(true);
-        // Trigger the callback just like AddonReview would after completion.
+        // Trigger the callback just like Review would after completion.
         props.onReviewSubmitted();
         expect(root.state.showTextEntry).toEqual(false);
       });
   });
 
-  it('does not render an AddonReview when logged out', () => {
+  it('does not render an Review when logged out', () => {
     const userReview = setReview(fakeReview).payload;
-    const FakeAddonReview = sinon.spy(() => <div />);
+    const FakeReview = sinon.spy(() => <div />);
     const userId = null; // logged out
-    const root = render({ AddonReview: FakeAddonReview, userReview, userId });
+    const root = render({ Review: FakeReview, userReview, userId });
 
-    expect(FakeAddonReview.called).toEqual(false);
+    expect(FakeReview.called).toEqual(false);
 
     return root.onSelectRating(5)
       .then(() => {
-        expect(FakeAddonReview.called).toBeFalsy();
+        expect(FakeReview.called).toBeFalsy();
       });
   });
 

--- a/tests/unit/amo/components/TestReview.js
+++ b/tests/unit/amo/components/TestReview.js
@@ -11,8 +11,8 @@ import { setReview } from 'amo/actions/reviews';
 import * as amoApi from 'amo/api';
 import * as coreUtils from 'core/utils';
 import {
-  mapDispatchToProps, mapStateToProps, AddonReviewBase,
-} from 'amo/components/AddonReview';
+  mapDispatchToProps, mapStateToProps, ReviewBase,
+} from 'amo/components/Review';
 import { ErrorHandler } from 'core/errorHandler';
 import { fakeAddon, fakeReview, signedInApiState } from 'tests/unit/amo/helpers';
 import { getFakeI18nInst } from 'tests/unit/helpers';
@@ -46,15 +46,15 @@ function render({ ...customProps } = {}) {
     updateReviewText: () => Promise.resolve(),
     ...customProps,
   };
-  const AddonReview = translate({ withRef: true })(AddonReviewBase);
+  const Review = translate({ withRef: true })(ReviewBase);
   const root = findRenderedComponentWithType(renderIntoDocument(
-    <AddonReview {...props} />
-  ), AddonReview);
+    <Review {...props} />
+  ), Review);
 
   return root.getWrappedInstance();
 }
 
-describe('AddonReview', () => {
+describe('Review', () => {
   it('can update a review', () => {
     const onReviewSubmitted = sinon.spy(() => {});
     const setDenormalizedReview = sinon.spy(() => {});

--- a/tests/unit/amo/components/TestReviewList.js
+++ b/tests/unit/amo/components/TestReviewList.js
@@ -12,11 +12,11 @@ import fallbackIcon from 'amo/img/icons/default-64.png';
 import createStore from 'amo/store';
 import { setAddonReviews } from 'amo/actions/reviews';
 import {
-  AddonReviewListBase,
+  ReviewListBase,
   loadAddonReviews,
   loadInitialData,
   mapStateToProps,
-} from 'amo/components/AddonReviewList';
+} from 'amo/components/ReviewList';
 import Link from 'amo/components/Link';
 import Paginate from 'core/components/Paginate';
 import translate from 'core/i18n/translate';
@@ -39,8 +39,8 @@ function getLoadedReviews({
   return action.payload.reviews;
 }
 
-describe('amo/components/AddonReviewList', () => {
-  describe('<AddonReviewListBase/>', () => {
+describe('amo/components/ReviewList', () => {
+  describe('<ReviewListBase/>', () => {
     function render({
       addon = fakeAddon,
       params = {
@@ -60,11 +60,11 @@ describe('amo/components/AddonReviewList', () => {
         ...customProps,
       };
 
-      const AddonReviewList = translate({ withRef: true })(AddonReviewListBase);
+      const ReviewList = translate({ withRef: true })(ReviewListBase);
       const tree = renderIntoDocument(
         <Provider store={store}>
           <I18nProvider i18n={getFakeI18nInst()}>
-            <AddonReviewList {...props} />
+            <ReviewList {...props} />
           </I18nProvider>
         </Provider>
       );
@@ -104,20 +104,20 @@ describe('amo/components/AddonReviewList', () => {
     it('renders a review', () => {
       const root = renderToDOM({ reviews: [fakeReview] });
 
-      const title = root.querySelector('.AddonReviewList-li h3');
+      const title = root.querySelector('.ReviewList-li h3');
       expect(title.textContent).toEqual(fakeReview.title);
 
-      const body = root.querySelector('.AddonReviewList-li p');
+      const body = root.querySelector('.ReviewList-li p');
       expect(body.textContent).toEqual(fakeReview.body);
 
       const byLine =
-        root.querySelector('.AddonReviewList-by-line').textContent;
+        root.querySelector('.ReviewList-by-line').textContent;
       expect(byLine).toContain(fakeReview.user.name);
     });
 
     it("renders the add-on's icon in the header", () => {
       const root = renderToDOM({ addon: fakeAddon });
-      const img = root.querySelector('.AddonReviewList-header-icon img');
+      const img = root.querySelector('.ReviewList-header-icon img');
       expect(img.src).toEqual(fakeAddon.icon_url);
     });
 
@@ -128,39 +128,39 @@ describe('amo/components/AddonReviewList', () => {
           icon_url: 'http://foo.com/hax.png',
         },
       });
-      const img = root.querySelector('.AddonReviewList-header-icon img');
+      const img = root.querySelector('.ReviewList-header-icon img');
       expect(img.src).toEqual(fallbackIcon);
     });
 
     it('renders a hidden h1 for SEO', () => {
       const root = renderToDOM({ addon: fakeAddon });
-      const h1 = root.querySelector('.AddonReviewList-header h1');
+      const h1 = root.querySelector('.ReviewList-header h1');
       expect(h1.className).toEqual('visually-hidden');
       expect(h1.textContent).toEqual(`Reviews for ${fakeAddon.name}`);
     });
 
     it('produces an addon URL', () => {
       const root = findRenderedComponentWithType(
-        render(), AddonReviewListBase);
+        render(), ReviewListBase);
       expect(root.addonURL()).toEqual(`/addon/${fakeAddon.slug}/`);
     });
 
     it('produces a URL to itself', () => {
       const root = findRenderedComponentWithType(
-        render(), AddonReviewListBase);
+        render(), ReviewListBase);
       expect(root.url()).toEqual(`/addon/${fakeAddon.slug}/reviews/`);
     });
 
     it('requires an addon prop to produce a URL', () => {
       const root = findRenderedComponentWithType(render({
         addon: null,
-      }), AddonReviewListBase);
+      }), ReviewListBase);
       expect(() => root.addonURL()).toThrowError(/cannot access addonURL/);
     });
 
     it('configures a paginator with the right URL', () => {
       const tree = render();
-      const root = findRenderedComponentWithType(tree, AddonReviewListBase);
+      const root = findRenderedComponentWithType(tree, ReviewListBase);
       const paginator = findRenderedComponentWithType(tree, Paginate);
 
       expect(paginator.props.pathname).toEqual(root.url());

--- a/tests/unit/amo/components/TestReviewList.js
+++ b/tests/unit/amo/components/TestReviewList.js
@@ -10,10 +10,10 @@ import { findDOMNode } from 'react-dom';
 import * as amoApi from 'amo/api';
 import fallbackIcon from 'amo/img/icons/default-64.png';
 import createStore from 'amo/store';
-import { setAddonReviews } from 'amo/actions/reviews';
+import { setReviews } from 'amo/actions/reviews';
 import {
   ReviewListBase,
-  loadAddonReviews,
+  loadReviews,
   loadInitialData,
   mapStateToProps,
 } from 'amo/components/ReviewList';
@@ -34,7 +34,7 @@ import {
 function getLoadedReviews({
   addonSlug = fakeAddon.slug, reviews = [fakeReview], reviewCount = 1 } = {},
 ) {
-  const action = setAddonReviews({ addonSlug, reviewCount, reviews });
+  const action = setReviews({ addonSlug, reviewCount, reviews });
   // This is how reviews look after they have been loaded.
   return action.payload.reviews;
 }
@@ -191,7 +191,7 @@ describe('amo/components/ReviewList', () => {
     });
   });
 
-  describe('loadAddonReviews', () => {
+  describe('loadReviews', () => {
     let mockAmoApi;
 
     beforeEach(() => {
@@ -210,14 +210,14 @@ describe('amo/components/ReviewList', () => {
         .withArgs({ addon: fakeAddon.id, page })
         .returns(apiResponsePage({ results: reviews }));
 
-      return loadAddonReviews({
+      return loadReviews({
         addonId: fakeAddon.id, addonSlug, dispatch, page,
       })
         .then(() => {
           mockAmoApi.verify();
 
           expect(dispatch.called).toBeTruthy();
-          const expectedAction = setAddonReviews({
+          const expectedAction = setReviews({
             addonSlug, reviewCount: reviews.length, reviews,
           });
           expect(dispatch.firstCall.args[0]).toEqual(expectedAction);
@@ -233,11 +233,11 @@ describe('amo/components/ReviewList', () => {
         .expects('getReviews')
         .returns(apiResponsePage({ results: reviews }));
 
-      return loadAddonReviews({ addonId: fakeAddon.id, addonSlug, dispatch })
+      return loadReviews({ addonId: fakeAddon.id, addonSlug, dispatch })
         .then(() => {
           // Expect an action with a filtered review array.
           // However, the count will not take into account the filtering.
-          const expectedAction = setAddonReviews({
+          const expectedAction = setReviews({
             addonSlug, reviews: [fakeReview], reviewCount: 2,
           });
           expect(dispatch.called).toBeTruthy();
@@ -283,7 +283,7 @@ describe('amo/components/ReviewList', () => {
 
     it('loads all reviews from state', () => {
       const reviews = [{ ...fakeReview, id: 1 }, { ...fakeReview, id: 2 }];
-      const action = setAddonReviews({
+      const action = setReviews({
         addonSlug: fakeAddon.slug, reviews, reviewCount: reviews.length,
       });
       store.dispatch(action);
@@ -299,7 +299,7 @@ describe('amo/components/ReviewList', () => {
     });
 
     it('sets reviewCount prop from from state', () => {
-      store.dispatch(setAddonReviews({
+      store.dispatch(setReviews({
         addonSlug: fakeAddon.slug, reviews: [fakeReview], reviewCount: 1,
       }));
 

--- a/tests/unit/amo/reducers/testReviews.js
+++ b/tests/unit/amo/reducers/testReviews.js
@@ -1,4 +1,4 @@
-import { setAddonReviews, setReview } from 'amo/actions/reviews';
+import { setReviews, setReview } from 'amo/actions/reviews';
 import reviews, { initialState } from 'amo/reducers/reviews';
 import { fakeAddon, fakeReview } from 'tests/unit/amo/helpers';
 
@@ -159,11 +159,11 @@ describe('amo.reducers.reviews', () => {
     expect(state[userId][addonId][2].isLatest).toEqual(false);
   });
 
-  describe('setAddonReviews', () => {
+  describe('setReviews', () => {
     it('stores multiple user reviews for an add-on', () => {
       const review1 = fakeReview;
       const review2 = { ...fakeReview, id: 3 };
-      const action = setAddonReviews({
+      const action = setReviews({
         addonSlug: fakeAddon.slug, reviews: [review1, review2], reviewCount: 2,
       });
       const state = reviews(undefined, action);
@@ -181,10 +181,10 @@ describe('amo.reducers.reviews', () => {
       const review3 = { ...fakeReview, id: 4 };
 
       let state;
-      state = reviews(state, setAddonReviews({
+      state = reviews(state, setReviews({
         addonSlug: addon1.slug, reviews: [review1], reviewCount: 1,
       }));
-      state = reviews(state, setAddonReviews({
+      state = reviews(state, setReviews({
         addonSlug: addon2.slug, reviews: [review2, review3], reviewCount: 2,
       }));
 
@@ -194,10 +194,10 @@ describe('amo.reducers.reviews', () => {
     });
 
     it('stores review counts', () => {
-      const state = reviews(undefined, setAddonReviews({
+      const state = reviews(undefined, setReviews({
         addonSlug: 'slug1', reviews: [fakeReview], reviewCount: 1,
       }));
-      const newState = reviews(state, setAddonReviews({
+      const newState = reviews(state, setReviews({
         addonSlug: 'slug2', reviews: [fakeReview, fakeReview], reviewCount: 2,
       }));
 


### PR DESCRIPTION
This patch literally just renames `AddonReview` to `Review` and `AddonReviewList` to `ReviewList`. (It also moves them and their CSS into a folder (`index.js` and `styles.scss`).

I am about to do the desktop review page but found it harder to remember that the review components always had the `Addon` prefix which I think is unneeded: we only have reviews for addons so the namespacing just creates more typing and a harder-to-find component in alphabetical lists.

I figured I'd do this outside the style patch so it was less likely to cause conflicts, as I know @kumar303 wants to work on review sagas soon too.