### PR TITLE
Show 'Rate your experience' placeholder on Addon detail

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -163,7 +163,7 @@ export class AddonBase extends React.Component {
   renderRatingsCard() {
     const { RatingManager, addon, i18n, location } = this.props;
     let content;
-    let footerPropName;
+    let footerPropName = 'footerText';
 
     if (addon && addon.ratings.count) {
       const count = addon.ratings.count;
@@ -179,8 +179,9 @@ export class AddonBase extends React.Component {
           {linkText}
         </Link>
       );
+    } else if (!addon) {
+      content = <LoadingText width={100} />;
     } else {
-      footerPropName = 'footerText';
       content = i18n.gettext('No reviews yet');
     }
 

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -197,6 +197,8 @@ describe('Addon', () => {
       .toHaveLength(1);
     expect(root.find('.Addon-summary').find(LoadingText)).toHaveLength(1);
     expect(root.find('.Addon-title').find(LoadingText)).toHaveLength(1);
+    expect(root.find('.Addon-overall-rating').shallow().find(LoadingText))
+      .toHaveLength(1);
 
     // These should render with an empty addon.
     expect(root.find(AddonMeta).prop('addon')).toEqual(null);


### PR DESCRIPTION
Fixes #2630

@tofumatt whoops, turns out there were two instances of 'No reviews yet' so I missed one. Here it is fixed:

<img width="745" alt="screenshot 2017-06-23 15 36 29" src="https://user-images.githubusercontent.com/55398/27499614-4476d7b6-582a-11e7-85f0-6295acbf5d2e.png">
