### PR TITLE
fix: Padding on rtl horizontal cards

### DIFF
--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -30,9 +30,10 @@
       grid-template-columns: repeat(4, 25%);
 
       .SearchResult {
+        @include padding-start(0);
+
         grid-column: auto;
         margin-bottom: 0;
-        padding-left: 0;
       }
 
       .SearchResult-link {


### PR DESCRIPTION
Very minor fix, I didn't catch this in the new card PR.

Fixes #2645
Fixes #2605
Closes #2610 

### Before
<img width="981" alt="screenshot 2017-06-28 09 10 42" src="https://user-images.githubusercontent.com/90871/27647897-afcb4e4c-5be1-11e7-8acf-6aaada8225f2.png">

### After
<img width="981" alt="screenshot 2017-06-28 09 07 07" src="https://user-images.githubusercontent.com/90871/27647900-b408c1b0-5be1-11e7-8ba0-f474475fef3d.png">
