### PR TITLE
fix: Limit width of addon description

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -154,6 +154,10 @@
       grid-column: 2;
       grid-row: 1 / 5;
     }
+
+    .AddonDescription-contents {
+      max-width: 550px;
+    }
   }
 
   .Addon-screenshots {


### PR DESCRIPTION
Fixes #2654

Really simple, just prevents huge displays from stretching the text across hundreds of pixels.

### Before
<img width="1386" alt="screenshot 2017-06-30 14 21 38" src="https://user-images.githubusercontent.com/90871/27754514-ba7c19d8-5d9f-11e7-8b85-8d76a22bc5eb.png">

### After
<img width="1386" alt="screenshot 2017-06-30 14 21 32" src="https://user-images.githubusercontent.com/90871/27754517-be0c2e9e-5d9f-11e7-8963-67f119f0a1b9.png">
