### PR TITLE
fix: Show search results for categories

### DIFF
--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import CategoryHeader from 'amo/components/CategoryHeader';
-import Search from 'amo/components/Search';
+import { SearchBase } from 'amo/components/Search';
 import { categoriesFetch } from 'core/actions/categories';
 import { loadByCategoryIfNeeded, parsePage } from 'core/searchUtils';
 import {
@@ -35,7 +35,7 @@ export class CategoryBase extends React.Component {
     return (
       <div className="Category">
         <CategoryHeader category={category} />
-        <Search enableSearchSort={false} {...searchProps} />
+        <SearchBase enableSearchSort={false} hasSearchParams {...searchProps} />
       </div>
     );
   }
@@ -65,7 +65,6 @@ export function mapStateToProps(state, ownProps) {
     return {
       addonType: filters.addonType,
       category,
-      hasSearchParams: true,
       filters,
       pathname,
       queryParams,
@@ -76,7 +75,6 @@ export function mapStateToProps(state, ownProps) {
   return {
     addonType: filters.addonType,
     category,
-    hasSearchParams: true,
     pathname,
     queryParams,
   };

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 
 import { CategoryBase, mapStateToProps } from 'amo/components/Category';
-import Search from 'amo/components/Search';
+import { SearchBase } from 'amo/components/Search';
 import createStore from 'amo/store';
 import { categoriesFetch } from 'core/actions/categories';
 import { searchStart } from 'core/actions/search';
@@ -50,7 +50,16 @@ describe('Category', () => {
 
   it('disables the sort component in Search', () => {
     const root = render();
-    expect(root.find(Search)).toHaveProp('enableSearchSort', false);
+
+    expect(root.find(SearchBase)).toHaveProp('enableSearchSort', false);
+  });
+
+  it('forces hasSearchParams for the Search component', () => {
+    // This prevents search results not appearing because the search
+    // component doesn't recognise a valid search param.
+    const root = render();
+
+    expect(root.find(SearchBase)).toHaveProp('hasSearchParams', true);
   });
 });
 
@@ -84,7 +93,6 @@ describe('Category.mapStateToProps()', () => {
       category: null,
       count: 0,
       filters,
-      hasSearchParams: true,
       loading: true,
       page: undefined,
       pathname: '/themes/ad-block/',
@@ -103,7 +111,6 @@ describe('Category.mapStateToProps()', () => {
     expect(props).toEqual({
       addonType: ADDON_TYPE_THEME,
       category: null,
-      hasSearchParams: true,
       pathname: '/themes/ad-block/',
       queryParams: { page: 1 },
     });


### PR DESCRIPTION
Fix #2650.

Looks like we should improve the `hasSearchParams` in general, but this came about because we were still including a component named `Search` but it was changed to include `mapStateToProps` and was overriding our overrides 😒

Added a test to make sure that component is the right one and the flag is set.

### Before
<img width="1386" alt="screenshot 2017-06-30 14 41 56" src="https://user-images.githubusercontent.com/90871/27755078-73309006-5da2-11e7-923a-6f822e9f8265.png">

### After
<img width="1386" alt="screenshot 2017-06-30 14 40 11" src="https://user-images.githubusercontent.com/90871/27755082-76555c62-5da2-11e7-848f-afdce67f23ba.png">
