### PR TITLE
fix: Uncentre categories (fix #2660)

### DIFF
--- a/src/amo/components/CategoriesHeader/styles.scss
+++ b/src/amo/components/CategoriesHeader/styles.scss
@@ -2,10 +2,6 @@
 @import "~core/css/inc/mixins";
 @import "~ui/css/vars";
 
-.CategoriesHeader .Card-contents {
-  display: flex;
-}
-
 .CategoriesHeader-loadingText {
   @include margin-end(5px);
 }


### PR DESCRIPTION
This is a bit of a stop-gap if we end up implementing #2662, but it was easy so why not?

### Before
<img width="1134" alt="screenshot 2017-07-01 20 24 34" src="https://user-images.githubusercontent.com/90871/27764842-70966c9a-5e9b-11e7-81a3-d04350a8e786.png">

### After
<img width="1131" alt="screenshot 2017-07-01 20 24 24" src="https://user-images.githubusercontent.com/90871/27764844-7428ea90-5e9b-11e7-853e-615bfbdb8983.png">
