### PR TITLE
Rename Invalid category slugs in Homepage

### DIFF
--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -90,7 +90,7 @@ export class HomeBase extends React.Component {
           <ExtensionLink name="block-ads" slug="privacy-security">
             {i18n.gettext('Block ads')}
           </ExtensionLink>
-          <ExtensionLink name="screenshot" slug="photos-media">
+          <ExtensionLink name="screenshot" slug="photos-music-videos">
             {i18n.gettext('Screenshot')}
           </ExtensionLink>
           <ExtensionLink name="find-news" slug="feeds-news-blogging">
@@ -99,10 +99,10 @@ export class HomeBase extends React.Component {
           <ExtensionLink name="shop-online" slug="shopping">
             {i18n.gettext('Shop online')}
           </ExtensionLink>
-          <ExtensionLink name="be-social" slug="social-networking">
+          <ExtensionLink name="be-social" slug="social-communication">
             {i18n.gettext('Be social')}
           </ExtensionLink>
-          <ExtensionLink name="play-games" slug="sports-games">
+          <ExtensionLink name="play-games" slug="games-entertainment">
             {i18n.gettext('Play games')}
           </ExtensionLink>
         </ul>


### PR DESCRIPTION
Fixes #2685: Renaming slugs as per categories slug

**Before**
<img width="1280" alt="screen shot 2017-07-04 at 1 24 59 pm" src="https://user-images.githubusercontent.com/5318732/27820469-5f92eae0-60bc-11e7-98f6-d8a31cab8984.png">

**After**
<img width="1280" alt="screen shot 2017-07-04 at 1 24 32 pm" src="https://user-images.githubusercontent.com/5318732/27820488-6efd5254-60bc-11e7-9fe2-8cebea2649d8.png">
