### PR TITLE
fix: Categories titles are not correctly aligned

### DIFF
--- a/src/amo/components/CategoryHeader/styles.scss
+++ b/src/amo/components/CategoryHeader/styles.scss
@@ -3,7 +3,6 @@
 @import "~ui/css/vars";
 
 .CategoryHeader {
-  background: $white;
   border-radius: $border-radius-default;
   padding: 10px 10px 0;
   width: 100%;


### PR DESCRIPTION
Fixes: #2688 
Removed white background to align category header correctly

After background removal -

![screenshot from 2017-07-06 08-42-52](https://user-images.githubusercontent.com/19590302/27894018-3658588e-61f9-11e7-975f-1fb5ccf67fb0.png)
