### PR TITLE
Extensions page title is not correctly aligned in RTL #2689

### DIFF
--- a/src/amo/components/LandingPage/styles.scss
+++ b/src/amo/components/LandingPage/styles.scss
@@ -9,6 +9,7 @@
   @include margin-end(20px);
 }
 
+// In LTR, the spacing actually looks correct because of the icon itself has built-in margins in its design.
 .LandingPage-icon--extension {
   [dir=rtl] & {
     margin-left: 20px;

--- a/src/amo/components/LandingPage/styles.scss
+++ b/src/amo/components/LandingPage/styles.scss
@@ -5,10 +5,6 @@
   padding: $padding-page;
 }
 
-.LandingPage-icon--persona {
-  @include margin-end(20px);
-}
-
 .LandingPage-header {
   align-items: center;
   display: flex;
@@ -30,6 +26,8 @@
 .LandingPage-icon {
   height: 89px;
   width: 225px;
+
+  @include margin-end(20px);
 
   @include respond-to(medium) {
     height: 178px;

--- a/src/amo/components/LandingPage/styles.scss
+++ b/src/amo/components/LandingPage/styles.scss
@@ -5,6 +5,16 @@
   padding: $padding-page;
 }
 
+.LandingPage-icon--persona {
+  @include margin-end(20px);
+}
+
+.LandingPage-icon--extension {
+  [dir=rtl] & {
+    margin-left: 20px;
+  }
+}
+
 .LandingPage-header {
   align-items: center;
   display: flex;
@@ -26,8 +36,6 @@
 .LandingPage-icon {
   height: 89px;
   width: 225px;
-
-  @include margin-end(20px);
 
   @include respond-to(medium) {
     height: 178px;


### PR DESCRIPTION
Fixes #2689 

**Before:**
<img width="665" alt="screen shot 2017-07-06 at 4 01 35 pm" src="https://user-images.githubusercontent.com/5318732/27907702-5096fc10-6266-11e7-92db-bd50175a98a8.png">

**After:**
<img width="785" alt="screen shot 2017-07-06 at 4 13 19 pm" src="https://user-images.githubusercontent.com/5318732/27907739-7bf8f6a6-6266-11e7-9a16-34d40ccef97e.png">
