### PR TITLE
fix(package): update redux-logger to version 3.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "react-router-scroll": "0.4.2",
     "redux": "3.6.0",
     "redux-connect": "4.0.2",
-    "redux-logger": "2.8.1",
+    "redux-logger": "3.0.6",
     "redux-saga": "0.14.3",
     "serialize-javascript": "1.3.0",
     "simple-debounce": "0.0.3",


### PR DESCRIPTION
Closes #2209.

Just changed `import createLogger from 'react-redux';` to `import { createLogger } from 'react-redux';` as https://github.com/evgenyrodionov/redux-logger/releases/tag/3.0.0 recommends. Tested and it passes tests and logs in browser 👍 