### PR TITLE
fix: Disable docker log for now to fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 - if [ $GUI ]; then export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3; fi
 script:
 - if [[ $TOXENV == 'discopane-ui-tests' ]]; then
-    docker run --cidfile=./docker-container.txt -d -p 4000:4000 -e NODE_APP_INSTANCE=disco -e NODE_ENV=uitests $(docker build -q .) /bin/sh -c "npm run build && npm run start" && sleep 60 && docker logs --tail=all $(cat ./docker-container.txt);
+    docker run --cidfile=./docker-container.txt -d -p 4000:4000 -e NODE_APP_INSTANCE=disco -e NODE_ENV=uitests $(docker build -q .) /bin/sh -c "npm run build && npm run start" && sleep 60;
   fi
 - if [ $TOXENV ]; then tox; fi
 - if [ $TASK ]; then yarn $TASK; fi


### PR DESCRIPTION
Trying this to see what happens, because these constantly "failing" tests are annoying and a bad thing–they're gonna make me think something is fine when it isn't soon.