### PR TITLE
fix(package): update react-onclickoutside to version 6.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "react-dom": "15.6.1",
     "react-helmet": "5.1.3",
     "react-nested-status": "0.1.2",
-    "react-onclickoutside": "6.1.1",
+    "react-onclickoutside": "6.3.1",
     "react-photoswipe": "1.2.0",
     "react-redux": "5.0.5",
     "react-redux-loading-bar": "2.9.2",


### PR DESCRIPTION
Closes #2731 
Closes #2732