### PR TITLE
Enter installing state after download ends

### DIFF
--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -23,6 +23,7 @@ import {
   INSTALL_ERROR,
   INSTALL_CANCELLED,
   INSTALL_FAILED,
+  INSTALLING,
   SET_ENABLE_NOT_AVAILABLE,
   SHOW_INFO,
   START_DOWNLOAD,
@@ -67,6 +68,8 @@ export function makeProgressHandler(dispatch, guid) {
         type: DOWNLOAD_PROGRESS,
         payload: { guid, downloadProgress },
       });
+    } else if (event.type === 'onDownloadEnded') {
+      dispatch(setInstallState({ guid, status: INSTALLING }));
     } else if (event.type === 'onDownloadFailed') {
       dispatch({
         type: INSTALL_ERROR,

--- a/tests/unit/core/TestInstallAddon.js
+++ b/tests/unit/core/TestInstallAddon.js
@@ -21,6 +21,7 @@ import {
   INSTALL_CANCELLED,
   INSTALL_FAILED,
   INSTALLED,
+  INSTALLING,
   SET_ENABLE_NOT_AVAILABLE,
   SHOW_INFO,
   START_DOWNLOAD,
@@ -456,6 +457,16 @@ describe('withInstallHelpers inner functions', () => {
         type: 'INSTALL_ERROR',
         payload: { guid, error: DOWNLOAD_FAILED },
       })).toBeTruthy();
+    });
+
+    it('sets status to installing onDownloadEnded', () => {
+      const dispatch = sinon.spy();
+      const guid = '{my-addon}';
+      const handler = makeProgressHandler(dispatch, guid);
+      handler({ state: 'STATE_SOMETHING' }, { type: 'onDownloadEnded' });
+      sinon.assert.calledWith(dispatch, setInstallState({
+        guid, status: INSTALLING,
+      }));
     });
 
     it('resets status to uninstalled on onInstallCancelled', () => {

--- a/tests/unit/core/TestInstallAddon.js
+++ b/tests/unit/core/TestInstallAddon.js
@@ -442,10 +442,10 @@ describe('withInstallHelpers inner functions', () => {
       const guid = 'foo@addon';
       const handler = makeProgressHandler(dispatch, guid);
       handler({ state: 'STATE_DOWNLOADING', progress: 300, maxProgress: 990 });
-      expect(dispatch.calledWith({
+      sinon.assert.calledWith(dispatch, {
         type: DOWNLOAD_PROGRESS,
         payload: { downloadProgress: 30, guid },
-      })).toBeTruthy();
+      });
     });
 
     it('sets status to error on onDownloadFailed', () => {
@@ -453,10 +453,10 @@ describe('withInstallHelpers inner functions', () => {
       const guid = '{my-addon}';
       const handler = makeProgressHandler(dispatch, guid);
       handler({ state: 'STATE_SOMETHING' }, { type: 'onDownloadFailed' });
-      expect(dispatch.calledWith({
+      sinon.assert.calledWith(dispatch, {
         type: 'INSTALL_ERROR',
         payload: { guid, error: DOWNLOAD_FAILED },
-      })).toBeTruthy();
+      });
     });
 
     it('sets status to installing onDownloadEnded', () => {
@@ -474,7 +474,7 @@ describe('withInstallHelpers inner functions', () => {
       const guid = '{my-addon}';
       const handler = makeProgressHandler(dispatch, guid);
       handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallCancelled' });
-      expect(dispatch.firstCall.args[0]).toEqual({
+      sinon.assert.calledWith(dispatch, {
         type: INSTALL_CANCELLED,
         payload: { guid },
       });
@@ -485,7 +485,7 @@ describe('withInstallHelpers inner functions', () => {
       const guid = '{my-addon}';
       const handler = makeProgressHandler(dispatch, guid);
       handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallFailed' });
-      expect(dispatch.firstCall.args[0]).toEqual({
+      sinon.assert.calledWith(dispatch, {
         type: 'INSTALL_ERROR',
         payload: { guid, error: INSTALL_FAILED },
       });
@@ -496,7 +496,7 @@ describe('withInstallHelpers inner functions', () => {
       const guid = 'foo@addon';
       const handler = makeProgressHandler(dispatch, guid);
       handler({ state: 'WAT' }, { type: 'onNothingPerformed' });
-      expect(dispatch.called).toBeFalsy();
+      sinon.assert.notCalled(dispatch);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2314

Before the fix:

![fix-install-before mov](https://user-images.githubusercontent.com/55398/28078984-5c59b488-662c-11e7-8506-f65e6e0ef79f.gif)

After the fix:

![fix-install-after-cancel mov](https://user-images.githubusercontent.com/55398/28078996-658d78b4-662c-11e7-8437-d93e734df18c.gif)

Here's another one after the fix that shows confirming the installation:

![fix-install-after-confirm mov](https://user-images.githubusercontent.com/55398/28079041-88156d42-662c-11e7-8056-5feb165d44ef.gif)
