### PR TITLE
Allow search results to load without add-on data

### DIFF
--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -33,7 +33,7 @@ export default class AddonsCard extends React.Component {
         {addons && addons.length ? (
           <ul className="AddonsCard-list">
             {addons.map((addon) => (
-              <SearchResult addon={null} key={addon.slug} />
+              <SearchResult addon={addon} key={addon.slug} />
             ))}
           </ul>
         ) : null}

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -33,7 +33,7 @@ export default class AddonsCard extends React.Component {
         {addons && addons.length ? (
           <ul className="AddonsCard-list">
             {addons.map((addon) => (
-              <SearchResult addon={addon} key={addon.slug} />
+              <SearchResult addon={null} key={addon.slug} />
             ))}
           </ul>
         ) : null}

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -9,6 +9,7 @@ import { ADDON_TYPE_THEME } from 'core/constants';
 import { isAllowedOrigin, sanitizeHTML } from 'core/utils';
 import { getAddonIconUrl } from 'core/imageUtils';
 import Icon from 'ui/components/Icon';
+import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
 
 import './styles.scss';
@@ -16,21 +17,25 @@ import './styles.scss';
 
 export class SearchResultBase extends React.Component {
   static propTypes = {
-    addon: PropTypes.object.isRequired,
+    addon: PropTypes.object,
     i18n: PropTypes.object.isRequired,
   }
 
-  render() {
+  addonIsTheme() {
+    const { addon } = this.props;
+    return addon && addon.type === ADDON_TYPE_THEME;
+  }
+
+  renderResult() {
     const { addon, i18n } = this.props;
-    const averageDailyUsers = addon.average_daily_users;
-    const isTheme = addon.type === ADDON_TYPE_THEME;
-    const resultClassnames = classNames('SearchResult', {
-      'SearchResult--theme': isTheme,
-    });
+
+    const isTheme = this.addonIsTheme();
+    const averageDailyUsers = addon && addon.average_daily_users;
 
     // Fall-back to default icon if invalid icon url.
     const iconURL = getAddonIconUrl(addon);
-    const themeURL = (addon.theme_data && isAllowedOrigin(addon.theme_data.previewURL)) ?
+    const themeURL = (addon && addon.theme_data &&
+      isAllowedOrigin(addon.theme_data.previewURL)) ?
       addon.theme_data.previewURL : null;
     const imageURL = isTheme ? themeURL : iconURL;
 
@@ -41,60 +46,91 @@ export class SearchResultBase extends React.Component {
       ),
     });
 
-    /* eslint-disable react/no-danger */
+    let addonAuthors = null;
+    const addonAuthorsData = addon && addon.authors && addon.authors.length ?
+      addon.authors : null;
+    if (!addon || addonAuthorsData) {
+      addonAuthors = (
+        <h3 className="SearchResult-author SearchResult--meta-section">
+          {addon ? addonAuthorsData[0].name : <LoadingText />}
+        </h3>
+      );
+    }
+
+    const summaryProps = {};
+    if (addon) {
+      summaryProps.dangerouslySetInnerHTML = sanitizeHTML(addon.summary);
+    } else {
+      summaryProps.children = <LoadingText />;
+    }
+
+    return (
+      <div className="SearchResult-result">
+        <div className={iconWrapperClassnames}>
+          {imageURL ? (
+            <img className="SearchResult-icon" src={imageURL} alt="" />
+          ) : (
+            <p className="SearchResult-notheme">
+              {i18n.gettext('No theme preview available')}
+            </p>
+          )}
+        </div>
+
+        <div className="SearchResult-contents">
+          <h2 className="SearchResult-name">
+            {addon ? addon.name : <LoadingText />}
+          </h2>
+          <p
+            className="SearchResult-summary"
+            {...summaryProps}
+          />
+
+          <div className="SearchResult-metadata">
+            <div className="SearchResult-rating">
+              <Rating
+                rating={addon ? addon.ratings.average : 0}
+                readOnly
+                styleName="small"
+              />
+            </div>
+            {addonAuthors}
+          </div>
+        </div>
+
+        <h3 className="SearchResult-users SearchResult--meta-section">
+          <Icon className="SearchResult-users-icon" name="user-fill" />
+          <span className="SearchResult-users-text">
+            {addon ? i18n.sprintf(i18n.ngettext(
+              '%(total)s user', '%(total)s users', averageDailyUsers),
+              { total: i18n.formatNumber(averageDailyUsers) },
+            ) : <LoadingText width={100} />}
+          </span>
+        </h3>
+      </div>
+    );
+  }
+
+  render() {
+    const { addon } = this.props;
+
+    const result = this.renderResult();
+    const isTheme = this.addonIsTheme();
+    const resultClassnames = classNames('SearchResult', {
+      'SearchResult--theme': isTheme,
+    });
+
     return (
       <li className={resultClassnames}>
-        <Link
-          to={`/addon/${addon.slug}/`}
-          className="SearchResult-link"
-          ref={(el) => { this.name = el; }}
-        >
-          <div className={iconWrapperClassnames}>
-            {imageURL ? (
-              <img className="SearchResult-icon" src={imageURL} alt="" />
-            ) : (
-              <p className="SearchResult-notheme">
-                {i18n.gettext('No theme preview available')}
-              </p>
-            )}
-          </div>
-
-          <div className="SearchResult-contents">
-            <h2 className="SearchResult-name">{addon.name}</h2>
-            <p
-              className="SearchResult-summary"
-              dangerouslySetInnerHTML={sanitizeHTML(addon.summary)}
-            />
-
-            <div className="SearchResult-metadata">
-              <div className="SearchResult-rating">
-                <Rating
-                  rating={addon.ratings.average}
-                  readOnly
-                  styleName="small"
-                />
-              </div>
-              { addon.authors && addon.authors.length ? (
-                <h3 className="SearchResult-author SearchResult--meta-section">
-                  {addon.authors[0].name}
-                </h3>
-              ) : null }
-            </div>
-          </div>
-
-          <h3 className="SearchResult-users SearchResult--meta-section">
-            <Icon className="SearchResult-users-icon" name="user-fill" />
-            <span className="SearchResult-users-text">
-              {i18n.sprintf(i18n.ngettext(
-                '%(total)s user', '%(total)s users', averageDailyUsers),
-                { total: i18n.formatNumber(averageDailyUsers) },
-              )}
-            </span>
-          </h3>
-        </Link>
+        {addon ?
+          <Link
+            to={`/addon/${addon.slug}/`}
+            className="SearchResult-link"
+            ref={(el) => { this.name = el; }}
+          >{result}</Link>
+          : result
+        }
       </li>
     );
-    /* eslint-enable react/no-danger */
   }
 }
 

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -9,11 +9,14 @@
 
 .SearchResult-link {
   color: $text-color-default;
+  text-decoration: none;
+}
+
+.SearchResult-result {
   display: flex;
   flex-flow: row wrap;
   margin: 0;
   padding: 0;
-  text-decoration: none;
   width: 100%;
 }
 

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -92,6 +92,9 @@
     color: $link-color;
     text-decoration: underline;
   }
+  .LoadingText {
+    margin-bottom: 5px;
+  }
 }
 
 .SearchResult-summary {

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -92,6 +92,7 @@
     color: $link-color;
     text-decoration: underline;
   }
+
   .LoadingText {
     margin-bottom: 5px;
   }

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -5,6 +5,8 @@ import { SearchResultBase } from 'amo/components/SearchResult';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 import { getFakeI18nInst } from 'tests/unit/helpers';
 import { ADDON_TYPE_THEME } from 'core/constants';
+import LoadingText from 'ui/components/LoadingText';
+import Rating from 'ui/components/Rating';
 
 
 describe('<SearchResult />', () => {
@@ -117,5 +119,24 @@ describe('<SearchResult />', () => {
 
     expect(root.find('.SearchResult-notheme'))
       .toIncludeText('No theme preview available');
+  });
+
+  it('renders placeholders without an addon', () => {
+    const root = render({ addon: null });
+
+    // Since there's no add-on, there shouldn't be a link.
+    expect(root.find('.SearchResult-link')).toHaveLength(0);
+
+    expect(root.find('.SearchResult-icon'))
+      .toHaveProp('src', 'default-64.png');
+    expect(root.find('.SearchResult-name').find(LoadingText))
+      .toHaveLength(1);
+    expect(root.find('.SearchResult-summary').find(LoadingText))
+      .toHaveLength(1);
+    expect(root.find(Rating)).toHaveProp('rating', 0);
+    expect(root.find('.SearchResult-author').find(LoadingText))
+      .toHaveLength(1);
+    expect(root.find('.SearchResult-users-text').find(LoadingText))
+      .toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2742

This patch doesn't apply it anywhere but here's an example of what's possible:

![search-results-loading mov](https://user-images.githubusercontent.com/55398/28092718-12fdd264-665a-11e7-85bb-8ad4677bf9c0.gif)
