### PR TITLE
feat: Disable tracking/Google Analytics when DNT is enabled

### DIFF
--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -79,7 +79,10 @@ export function getPageProps({ noScriptStyles = '', store, req, res }) {
     noScriptStyles,
     sriData,
     store,
-    trackingEnabled: convertBoolean(config.get('trackingEnabled')),
+    trackingEnabled: (
+      convertBoolean(config.get('trackingEnabled')) &&
+      req.header('dnt') !== '1' // A DNT header set to "1" means Do Not Track
+    ),
   };
 }
 


### PR DESCRIPTION
Fix #2792.

This patch disables the GA script from being included and sets Tracking as being off when DNT is set. It respects this on both the server and client.

Works for both AMO and the Disco Pane, so that's cool 👍 

Tested locally with tracking set to enabled and DNT on/off and things worked as expected.

One review for this should be fine, whoever can get to it first 😄 