### PR TITLE
fix: Restore grid styles to horizontal addons card

### DIFF
--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -36,7 +36,7 @@
         margin-bottom: 0;
       }
 
-      .SearchResult-link {
+      .SearchResult-result {
         display: grid;
         grid-column-gap: 8px;
         grid-template-columns: 32px auto;
@@ -76,7 +76,7 @@
         padding: 10px 0;
 
         // stylelint-disable max-nesting-depth
-        .SearchResult-link {
+        .SearchResult-result {
           display: block;
         }
 


### PR DESCRIPTION
Fix #2814

### Before
![2017-07-17_1050](https://user-images.githubusercontent.com/15685960/28259894-348a8e5a-6ae1-11e7-960e-aa236be04f1c.png)

### After
<img width="1250" alt="screenshot 2017-07-17 17 31 20" src="https://user-images.githubusercontent.com/90871/28278742-04a9e53e-6b16-11e7-94ac-91690f9bb515.png">
<img width="1250" alt="screenshot 2017-07-17 17 31 09" src="https://user-images.githubusercontent.com/90871/28278743-04ab7e30-6b16-11e7-909a-19eeea4895e9.png">
