### PR TITLE
Fixes #2821 hide vertical scrollbar in Screenshots section from add-ons detail page

### DIFF
--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -17,6 +17,7 @@ $screenshot-width: 320px;
   list-style-type: none;
   margin: 0;
   overflow-x: scroll;
+  overflow-y: hidden;
   padding: 0;
   width: auto;
 }


### PR DESCRIPTION
Fixes #2821  hide vertical scrollbar in Screenshots section from add-ons detail page


