### PR TITLE
fix: Tweak rating star alignment in addon detail header

### DIFF
--- a/src/amo/css/AddonMeta.scss
+++ b/src/amo/css/AddonMeta.scss
@@ -36,3 +36,8 @@
     }
   }
 }
+
+.AddonMeta .Rating-star-group {
+  @include margin-end(-2.5px);
+  @include margin-start(-2.5px);
+}


### PR DESCRIPTION
Fix #2587

### Before
![dev](https://user-images.githubusercontent.com/15685960/28111781-4fe2a54c-66ff-11e7-8506-302179f0fe92.png)

### After
![screen shot 2017-07-24 at 18 22 30](https://user-images.githubusercontent.com/90871/28547522-3c8a9b1a-709d-11e7-9566-88e689312a0a.png)
![screen shot 2017-07-24 at 18 22 35](https://user-images.githubusercontent.com/90871/28547521-3c89ec1a-709d-11e7-8806-15475d831e49.png)
![screen shot 2017-07-24 at 18 22 47](https://user-images.githubusercontent.com/90871/28547523-3c8adf9e-709d-11e7-8a6d-602175846125.png)
![screen shot 2017-07-24 at 18 22 51](https://user-images.githubusercontent.com/90871/28547520-3c897c94-709d-11e7-9d8a-c825db49c526.png)
