### PR TITLE
fix: Categories temporary 404 while loading

### DIFF
--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -67,23 +67,28 @@ export function mapStateToProps(state, ownProps) {
     { ...state.search.filters, page: parsePage(state.search.page) },
     { ...filters, page: queryParams.page },
   );
-  if (filtersMatchState) {
-    return {
-      addonType: filters.addonType,
-      category,
-      filters,
-      pathname,
-      queryParams,
-      ...state.search,
-    };
-  }
 
-  return {
+  const loading = state.categories.loading || state.search.loading;
+
+  const props = {
     addonType: filters.addonType,
     category,
+    loading,
     pathname,
     queryParams,
   };
+
+  if (filtersMatchState) {
+    return {
+      ...props,
+      filters,
+      count: state.search.count,
+      page: state.search.page,
+      results: state.search.results,
+    };
+  }
+
+  return props;
 }
 
 export default compose(


### PR DESCRIPTION
Fix #2846.

We weren't checking to see if we had *any* category data yet (or even did a proper loading check) so we'd hit a temporary 404 screen during the load. Because we fetch all categories at once this just marks whether or not we've fetched them and only renders a 404 for a non-existent category once we've compared it to the fetched categories.

### Before
![videotogif_2017 07 24_11 04 39](https://user-images.githubusercontent.com/15685960/28513760-08c84d14-7060-11e7-8323-7dd2cf64049d.gif)

### After
![2017-07-25 14 44 56](https://user-images.githubusercontent.com/90871/28588381-634c369a-7148-11e7-8ab4-04712c77d1e2.gif)
