### PR TITLE
Fixes #2855 Categories are not alphabetically sorted 

### DIFF
--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -51,12 +51,6 @@ export class CategoriesBase extends React.Component {
     const { addonType, className, error, loading, i18n } = this.props;
     const categories = this.props.categories[addonType] ?
       Object.values(this.props.categories[addonType]) : [];
-    categories.sort(function(a,b){
-          let x = a.name.toLowerCase();
-          let y = b.name.toLowerCase();
-       return x < y ? -1 : x > y ? 1 : 0;
-
-     });  
     const classNameProp = classnames('Categories', className);
 
     if (error) {

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -51,6 +51,12 @@ export class CategoriesBase extends React.Component {
     const { addonType, className, error, loading, i18n } = this.props;
     const categories = this.props.categories[addonType] ?
       Object.values(this.props.categories[addonType]) : [];
+    categories.sort(function(a,b){
+          let x = a.name.toLowerCase();
+          let y = b.name.toLowerCase();
+       return x < y ? -1 : x > y ? 1 : 0;
+
+     });  
     const classNameProp = classnames('Categories', className);
 
     if (error) {
@@ -91,7 +97,7 @@ export class CategoriesBase extends React.Component {
               );
             })}
           </div>
-        :
+          :
           <ul className="Categories-list">
             {categories.map((category) => (
               <li className="Categories-item" key={category.name}>

--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -68,12 +68,10 @@ export default function categories(state = initialState, action) {
           Object.keys(categoryList[appName]).forEach((addonType) => {
             categoryList[appName][addonType] = categoryList[appName][addonType]
               .sort((a, b) => {
-                const x = a.slug;
-                const y = b.slug;
-                if (x < y) {
+                if (a.name.toLowerCase() < b.name.toLowerCase()) {
                   return -1;
                 }
-                if (x > y) {
+                if (a.name.toLowerCase() > b.name.toLowerCase()) {
                   return 1;
                 }
                 return 0;

--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -67,7 +67,17 @@ export default function categories(state = initialState, action) {
         Object.keys(categoryList).forEach((appName) => {
           Object.keys(categoryList[appName]).forEach((addonType) => {
             categoryList[appName][addonType] = categoryList[appName][addonType]
-              .sort((a, b) => a.name >= b.name)
+              .sort((a, b) => {
+                const x = a.slug;
+                const y = b.slug;
+                if (x < y) {
+                  return -1;
+                }
+                if (x > y) {
+                  return 1;
+                }
+                return 0;
+              })
               .reduce((object, value) => (
                 { ...object, [value.slug]: value }
               ), {});

--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -67,15 +67,7 @@ export default function categories(state = initialState, action) {
         Object.keys(categoryList).forEach((appName) => {
           Object.keys(categoryList[appName]).forEach((addonType) => {
             categoryList[appName][addonType] = categoryList[appName][addonType]
-              .sort((a, b) => {
-                if (a.name.toLowerCase() < b.name.toLowerCase()) {
-                  return -1;
-                }
-                if (a.name.toLowerCase() > b.name.toLowerCase()) {
-                  return 1;
-                }
-                return 0;
-              })
+              .sort((a, b) => a.name.localeCompare(b.name))
               .reduce((object, value) => (
                 { ...object, [value.slug]: value }
               ), {});

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -70,14 +70,14 @@ describe('<Categories />', () => {
       result: [
         {
           application: 'android',
-          name: 'Games',
-          slug: 'Games',
+          name: 'Travel',
+          slug: 'travel',
           type: ADDON_TYPE_EXTENSION,
         },
         {
           application: 'android',
-          name: 'Travel',
-          slug: 'travel',
+          name: 'Games',
+          slug: 'Games',
           type: ADDON_TYPE_EXTENSION,
         },
       ],

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -70,8 +70,53 @@ describe('<Categories />', () => {
       result: [
         {
           application: 'android',
+          name: 'Games',
+          slug: 'Games',
+          type: ADDON_TYPE_EXTENSION,
+        },
+        {
+          application: 'android',
+          name: 'Travel',
+          slug: 'Travel',
+          type: ADDON_TYPE_EXTENSION,
+        },
+      ],
+    };
+
+    const { store } = dispatchClientMetadata();
+    store.dispatch(categoriesLoad(categoriesResponse));
+    const { categories } = mapStateToProps(store.getState());
+
+    const root = render({
+      addonType: ADDON_TYPE_EXTENSION,
+      categories,
+    });
+
+    expect(root.find('.Categories-list').childAt(0).find(Button))
+      .toHaveProp('children', 'Games');
+    expect(root.find('.Categories-list').childAt(1).find(Button))
+      .toHaveProp('children', 'Travel');
+  });
+
+  it('sorts and renders the sorted categories', () => {
+    const categoriesResponse = {
+      result: [
+        {
+          application: 'android',
           name: 'Travel',
           slug: 'travel',
+          type: ADDON_TYPE_EXTENSION,
+        },
+        {
+          application: 'android',
+          name: 'Music',
+          slug: 'music',
+          type: ADDON_TYPE_EXTENSION,
+        },
+        {
+          application: 'android',
+          name: 'Nature',
+          slug: 'nature',
           type: ADDON_TYPE_EXTENSION,
         },
         {
@@ -95,6 +140,10 @@ describe('<Categories />', () => {
     expect(root.find('.Categories-list').childAt(0).find(Button))
       .toHaveProp('children', 'Games');
     expect(root.find('.Categories-list').childAt(1).find(Button))
+      .toHaveProp('children', 'Music');
+    expect(root.find('.Categories-list').childAt(2).find(Button))
+      .toHaveProp('children', 'Nature');
+    expect(root.find('.Categories-list').childAt(3).find(Button))
       .toHaveProp('children', 'Travel');
   });
 });

--- a/tests/unit/core/reducers/test_categories.js
+++ b/tests/unit/core/reducers/test_categories.js
@@ -111,7 +111,7 @@ describe('categories reducer', () => {
       });
     });
 
-    it('sets the categories', () => {
+    it('sets the categories in a sorted order', () => {
       const result = [
         {
           application: 'android',


### PR DESCRIPTION
#2855 Categories were not alphabetically sorted. 

- Added a sorting function. 
- This can be added as a helper function if it's going to be reused. 

![screen shot 2017-07-26 at 23 04 52](https://user-images.githubusercontent.com/432669/28635102-0835a5e2-7257-11e7-9203-606912a0c573.png)
![screen shot 2017-07-26 at 23 05 18](https://user-images.githubusercontent.com/432669/28635101-082ee28e-7257-11e7-92b5-3236210270c6.png)

