### PR TITLE
Fix screenshots overlap in safari

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -162,6 +162,9 @@
 
   .Addon-screenshots {
     grid-column: 1 / 2;
+    // overflow required to fix content overlap in Safari.
+    // See https://github.com/mozilla/addons-frontend/issues/2847
+    overflow-x: hidden;
   }
 
   .Addon-overall-rating {


### PR DESCRIPTION
Fixes #2847

Before: 

<img width="1613" alt="before" src="https://user-images.githubusercontent.com/1514/28668133-6f93eeb4-72c6-11e7-953c-712997ca6b15.png">

After:

<img width="1071" alt="after" src="https://user-images.githubusercontent.com/1514/28668137-74765c6e-72c6-11e7-84f6-a46073966a1d.png">
