### PR TITLE
Workaround transparency issue in Safari

### DIFF
--- a/src/ui/components/ShowMoreCard/ShowMoreCard.scss
+++ b/src/ui/components/ShowMoreCard/ShowMoreCard.scss
@@ -2,7 +2,10 @@
 
 .ShowMoreCard-contents {
   &::after {
-    background: linear-gradient(transparent, $base-color);
+    // rgba(255, 255, 255, 0) instead of transparent prevents
+    // grey line in Safari.
+    // See: https://github.com/mozilla/addons-frontend/issues/2865
+    background: linear-gradient(rgba(255, 255, 255, 0), $base-color);
     bottom: 0;
     content: "";
     height: 20px;


### PR DESCRIPTION
Fixes #2865

Before:

<img width="553" alt="add-ons_for_firefox 2" src="https://user-images.githubusercontent.com/1514/28671283-0e8fe132-72d4-11e7-986a-d75941559035.png">


After:
<img width="670" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/28671316-21022a00-72d4-11e7-9e07-83dace93422c.png">
