### PR TITLE
Make sure all apps set a default status code

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,7 +7,7 @@
 .*/node_modules/enzyme-matchers/.*
 .*/node_modules/jest-enzyme/.*
 .*/node_modules/eslint-plugin-jsx-a11y/.*
-.*/node_modules/react-nested-status
+.*/node_modules/react-nested-status/node_modules/.*
 .*/node_modules/stylelint
 
 [include]

--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -8,6 +8,7 @@ import cookie from 'react-cookie';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import LoadingBar from 'react-redux-loading-bar';
+import NestedStatus from 'react-nested-status';
 import { compose } from 'redux';
 
 import SearchForm from 'amo/components/SearchForm';
@@ -195,27 +196,29 @@ export class AppBase extends React.Component {
 
     const query = location.query ? location.query.q : null;
     return (
-      <div className="amo">
-        <LoadingBar className="App-loading-bar" />
-        <Helmet defaultTitle={i18n.gettext('Add-ons for Firefox')} />
-        <InfoDialogComponent />
-        <HeaderComponent
-          SearchFormComponent={SearchForm}
-          isHomePage={isHomePage}
-          location={location}
-          query={query}
-          ref={(ref) => { this.header = ref; }}
-        />
-        <div className="App-content">
-          <ErrorPage getErrorComponent={getErrorComponent}>
-            {children}
-          </ErrorPage>
+      <NestedStatus code={200}>
+        <div className="amo">
+          <LoadingBar className="App-loading-bar" />
+          <Helmet defaultTitle={i18n.gettext('Add-ons for Firefox')} />
+          <InfoDialogComponent />
+          <HeaderComponent
+            SearchFormComponent={SearchForm}
+            isHomePage={isHomePage}
+            location={location}
+            query={query}
+            ref={(ref) => { this.header = ref; }}
+          />
+          <div className="App-content">
+            <ErrorPage getErrorComponent={getErrorComponent}>
+              {children}
+            </ErrorPage>
+          </div>
+          <FooterComponent
+            handleViewDesktop={this.onViewDesktop}
+            location={location}
+          />
         </div>
-        <FooterComponent
-          handleViewDesktop={this.onViewDesktop}
-          location={location}
-        />
-      </div>
+      </NestedStatus>
     );
   }
 }

--- a/src/disco/containers/App.js
+++ b/src/disco/containers/App.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
+import NestedStatus from 'react-nested-status';
 import { compose } from 'redux';
 import classNames from 'classnames';
 
@@ -31,15 +32,17 @@ export class AppBase extends React.Component {
     });
 
     return (
-      <div className={classes}>
-        <Helmet defaultTitle={i18n.gettext('Discover Add-ons')}>
-          <meta name="robots" content="noindex" />
-        </Helmet>
-        <ErrorPage>
-          {children}
-        </ErrorPage>
-        <Footer />
-      </div>
+      <NestedStatus code={200}>
+        <div className={classes}>
+          <Helmet defaultTitle={i18n.gettext('Discover Add-ons')}>
+            <meta name="robots" content="noindex" />
+          </Helmet>
+          <ErrorPage>
+            {children}
+          </ErrorPage>
+          <Footer />
+        </div>
+      </NestedStatus>
     );
   }
 }

--- a/tests/unit/amo/containers/TestApp.js
+++ b/tests/unit/amo/containers/TestApp.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import { shallow } from 'enzyme';
 import { findDOMNode } from 'react-dom';
 import {
   renderIntoDocument,
   findRenderedComponentWithType,
 } from 'react-addons-test-utils';
+import NestedStatus from 'react-nested-status';
 import { Provider } from 'react-redux';
 import { loadFail } from 'redux-connect/lib/store';
 
@@ -56,8 +58,8 @@ describe('App', () => {
 
   const FakeInfoDialogComponent = () => <div />;
 
-  function render({ children = [], ...customProps } = {}) {
-    const props = {
+  function renderProps(customProps = {}) {
+    return {
       i18n: getFakeI18nInst(),
       logOutUser: sinon.stub(),
       location: sinon.stub(),
@@ -65,6 +67,10 @@ describe('App', () => {
       store: createStore().store,
       ...customProps,
     };
+  }
+
+  function render({ children = [], ...customProps } = {}) {
+    const props = renderProps(customProps);
     return findRenderedComponentWithType(renderIntoDocument(
       <Provider store={props.store}>
         <I18nProvider i18n={props.i18n}>
@@ -177,6 +183,11 @@ describe('App', () => {
     const rootNode = findDOMNode(root);
 
     expect(rootNode.textContent).toContain('Page not found');
+  });
+
+  it('renders a response with a 200 status', () => {
+    const root = shallow(<AppBase {...renderProps()} />);
+    expect(root.find(NestedStatus)).toHaveProp('code', 200);
   });
 
   describe('handling expired auth tokens', () => {

--- a/tests/unit/core/server/testServer.js
+++ b/tests/unit/core/server/testServer.js
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet';
 import { Router, Route } from 'react-router';
 import { createStore, combineReducers } from 'redux';
 import { reducer as reduxAsyncConnect } from 'redux-connect';
+import NestedStatus from 'react-nested-status';
 import supertest from 'supertest';
 
 import baseServer from 'core/server/base';
@@ -10,6 +11,11 @@ import FakeApp, { fakeAssets } from 'tests/unit/core/server/fakeApp';
 
 describe('core/server/base', () => {
   const _helmentCanUseDOM = Helmet.canUseDOM;
+  const defaultStubRoutes = (
+    <Router>
+      <Route path="*" component={FakeApp} />
+    </Router>
+  );
 
   beforeEach(() => {
     Helmet.canUseDOM = false;
@@ -23,13 +29,7 @@ describe('core/server/base', () => {
     delete global.webpackIsomorphicTools;
   });
 
-  function testClient() {
-    const stubRoutes = (
-      <Router>
-        <Route path="*" component={FakeApp} />
-      </Router>
-    );
-
+  function testClient({ stubRoutes = defaultStubRoutes } = {}) {
     function createStoreAndSagas() {
       return {
         store: createStore(combineReducers({ reduxAsyncConnect })),
@@ -49,6 +49,32 @@ describe('core/server/base', () => {
 
       expect(response.headers).toMatchObject({ vary: 'DNT' });
       expect(response.statusCode).toEqual(200);
+    });
+
+    it('returns the status code of NestedStatus', async () => {
+      // This is an example of implementing a NotFound component
+      // using NestedStatus which exercises the server's logic for
+      // getting the response status code from the rendered component.
+      class NotFound extends React.Component {
+        render() {
+          return (
+            <NestedStatus code={404}>
+              <h1>Not Found</h1>
+            </NestedStatus>
+          );
+        }
+      }
+
+      const stubRoutes = (
+        <Router>
+          <Route path="*" component={NotFound} />
+        </Router>
+      );
+
+      const response = await testClient({ stubRoutes })
+        .get('/en-US/firefox/simulation-of-a-non-existent-page').end();
+
+      expect(response.statusCode).toEqual(404);
     });
   });
 });

--- a/tests/unit/disco/containers/TestApp.js
+++ b/tests/unit/disco/containers/TestApp.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import { shallow } from 'enzyme';
 import { findDOMNode } from 'react-dom';
 import {
   findRenderedComponentWithType,
   renderIntoDocument,
 } from 'react-addons-test-utils';
+import NestedStatus from 'react-nested-status';
 import { Provider } from 'react-redux';
 import { loadFail } from 'redux-connect/lib/store';
 
@@ -20,14 +22,19 @@ class MyComponent extends React.Component {
   }
 }
 
-function renderApp(extraProps = {}, store = createStore().store) {
-  const props = {
+function renderProps(customProps = {}) {
+  return {
     browserVersion: '50',
     i18n: getFakeI18nInst(),
-    ...extraProps,
+    store: createStore().store,
+    ...customProps,
   };
+}
+
+function renderApp(customProps = {}) {
+  const props = renderProps(customProps);
   const root = findRenderedComponentWithType(renderIntoDocument(
-    <Provider store={store}>
+    <Provider store={props.store}>
       <I18nProvider i18n={props.i18n}>
         <AppBase {...props}>
           <MyComponent />
@@ -69,6 +76,11 @@ describe('App', () => {
     const rootNode = renderApp({ browserVersion: '52.0a1' });
     expect(rootNode.className).not.toContain('padding-compensation');
   });
+
+  it('renders a response with a 200 status', () => {
+    const root = shallow(<AppBase {...renderProps()} />);
+    expect(root.find(NestedStatus)).toHaveProp('code', 200);
+  });
 });
 
 describe('App errors', () => {
@@ -80,7 +92,7 @@ describe('App errors', () => {
     });
     store.dispatch(loadFail('ReduxKey', error));
 
-    const rootNode = renderApp({}, store);
+    const rootNode = renderApp({ store });
     expect(rootNode.textContent).not.toContain('The component');
     expect(rootNode.textContent).toContain('Page not found');
   });
@@ -93,7 +105,7 @@ describe('App errors', () => {
     });
     store.dispatch(loadFail('ReduxKey', error));
 
-    const rootNode = renderApp({}, store);
+    const rootNode = renderApp({ store });
     expect(rootNode.textContent).not.toContain('The component');
     expect(rootNode.textContent).toContain('Server Error');
   });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2886

**The problem:**

The [fix for Category 404s](https://github.com/mozilla/addons-frontend/pull/2684/files#diff-4623346018e51a6970a0e7b3ffb9e325R38) introduced a scenario where the [first render](https://github.com/mozilla/addons-frontend/blob/a1ccd6fde1b87c536046f69b9ec32f3888262e31/src/core/server/base.js#L312-L314) of the app declares a 404 status code but [later](https://github.com/mozilla/addons-frontend/blob/a1ccd6fde1b87c536046f69b9ec32f3888262e31/src/core/server/base.js#L320-L323) it does not. In the final successful render, nothing was declaring a 200 status code.

This bug was probably happening in a few other parts of the app too.

**The solution:**

Both AMO and Discopane will now always declare a 200 status code by default. This will get overidden by error responses because in those cases, the default `App` is not rendered.

We should also stop using `NestedStatus`: https://github.com/mozilla/addons-frontend/issues/2892