### PR TITLE
Add renderErrorIfPresent() method in ErrorHandler

### DIFF
--- a/src/amo/components/AddonReview.js
+++ b/src/amo/components/AddonReview.js
@@ -162,7 +162,7 @@ export class AddonReviewBase extends React.Component {
         <p ref={(ref) => { this.reviewPrompt = ref; }}>{prompt}</p>
         <form onSubmit={this.onSubmit} ref={(ref) => { this.reviewForm = ref; }}>
           <div className="AddonReview-form-input">
-            {errorHandler.hasError() ? errorHandler.renderError() : null}
+            {errorHandler.renderErrorIfPresent()}
             <label htmlFor="AddonReview-textarea" className="visually-hidden">
               {i18n.gettext('Review text')}
             </label>

--- a/src/amo/components/AddonReviewList.js
+++ b/src/amo/components/AddonReviewList.js
@@ -170,7 +170,7 @@ export class AddonReviewListBase extends React.Component {
 
     return (
       <div className="AddonReviewList">
-        {errorHandler.hasError() ? errorHandler.renderError() : null}
+        {errorHandler.renderErrorIfPresent()}
         <div className="AddonReviewList-header">
           <div className="AddonReviewList-header-icon">
             {addon ? <Link to={this.addonURL()}>{iconImage}</Link> : iconImage}

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -90,7 +90,7 @@ export class CategoriesBase extends React.Component {
 
     return (
       <Card className={classNameProp} header={i18n.gettext('Categories')}>
-        {errorHandler.hasError() ? errorHandler.renderError() : null}
+        {errorHandler.renderErrorIfPresent()}
         {loading ?
           <div className="Categories-loading">
             <span className="Categories-loading-info visually-hidden">

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -48,7 +48,7 @@ export class CategoryBase extends React.Component {
 
     return (
       <div className="Category">
-        {errorHandler.hasError() ? errorHandler.renderError() : null}
+        {errorHandler.renderErrorIfPresent()}
         <CategoryHeader category={category} />
         <Search
           enableSearchSort={false}

--- a/src/amo/components/FeaturedAddons/index.js
+++ b/src/amo/components/FeaturedAddons/index.js
@@ -83,7 +83,7 @@ export class FeaturedAddonsBase extends React.Component {
 
     return (
       <div className="FeaturedAddons">
-        {errorHandler.hasError() ? errorHandler.renderError() : null}
+        {errorHandler.renderErrorIfPresent()}
         <h2 className="FeaturedAddons-header">
           {this.headerForAddonType()}
         </h2>

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -199,7 +199,7 @@ export class LandingPageBase extends React.Component {
 
     return (
       <div className={classNames('LandingPage', `LandingPage--${addonType}`)}>
-        {errorHandler.hasError() ? errorHandler.renderError() : null}
+        {errorHandler.renderErrorIfPresent()}
         <div className="LandingPage-header">
           {this.icon(addonType)}
 

--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -122,7 +122,7 @@ export class SearchBase extends React.Component {
 
     return (
       <div className="Search">
-        {errorHandler.hasError() ? errorHandler.renderError() : null}
+        {errorHandler.renderErrorIfPresent()}
 
         <SearchContextCard />
 

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -42,6 +42,10 @@ export class ErrorHandler {
     return <ErrorList messages={messages} code={code} />;
   }
 
+  renderErrorIfPresent() {
+    return this.hasError() ? this.renderError() : null;
+  }
+
   createErrorAction(error) {
     return setError({ error, id: this.id });
   }

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -106,7 +106,7 @@ export class DiscoPaneBase extends React.Component {
 
     return (
       <div id="app-view" ref={(ref) => { this.container = ref; }}>
-        {errorHandler.hasError() ? errorHandler.renderError() : null}
+        {errorHandler.renderErrorIfPresent()}
         <header className={showVideo ? 'show-video' : ''}>
           <div className="disco-header">
             <div className="disco-content">

--- a/tests/unit/core/testErrorHandler.js
+++ b/tests/unit/core/testErrorHandler.js
@@ -4,6 +4,7 @@ import { findDOMNode } from 'react-dom';
 import { findRenderedComponentWithType, renderIntoDocument }
   from 'react-addons-test-utils';
 import { createStore, combineReducers } from 'redux';
+import { shallow } from 'enzyme';
 
 import I18nProvider from 'core/i18n/Provider';
 import { createApiError } from 'core/api/index';
@@ -262,6 +263,18 @@ describe('errorHandler', () => {
     it('tells you if it does not have an error', () => {
       const handler = new ErrorHandler();
       expect(handler.hasError()).toBe(false);
+    });
+
+    it('returns no component if it does not have an error', () => {
+      const handler = new ErrorHandler();
+      expect(handler.renderErrorIfPresent()).toBe(null);
+    });
+
+    it('returns a component if it has an error', () => {
+      const handler = new ErrorHandler({ capturedError: new Error('error message') });
+      const wrapper = shallow(<div>{handler.renderErrorIfPresent()}</div>);
+      expect(handler.renderErrorIfPresent()).not.toBe(null);
+      expect(wrapper.find(ErrorList)).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Fixes #2929

---

This PR introduces a `renderErrorIfPresent()` method to the `ErrorHandler` as requested in #2929.