### PR TITLE
Add createStubErrorHandler() helper in test suite

### DIFF
--- a/tests/unit/amo/actions/test_featured.js
+++ b/tests/unit/amo/actions/test_featured.js
@@ -1,14 +1,11 @@
 import { getFeatured, loadFeatured } from 'amo/actions/featured';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 
 describe('amo/actions/featured/getFeatured', () => {
   function getActionArgs(args = {}) {
-    const errorHandler = new ErrorHandler({
-      id: 'some-error-handler',
-      dispatch: sinon.stub(),
-    });
+    const errorHandler = createStubErrorHandler();
     return {
       addonType: ADDON_TYPE_EXTENSION,
       errorHandlerId: errorHandler.id,

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -44,7 +44,10 @@ import {
   dispatchSignInActions, fakeAddon, signedInApiState,
 } from 'tests/unit/amo/helpers';
 import {
-  createFetchAddonResult, getFakeI18nInst, sampleUserAgentParsed,
+  createFetchAddonResult,
+  createStubErrorHandler,
+  getFakeI18nInst,
+  sampleUserAgentParsed,
 } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
@@ -62,10 +65,7 @@ function renderProps({
     addon,
     ...addonProps,
     dispatch: sinon.stub(),
-    errorHandler: new ErrorHandler({
-      id: 'some-id',
-      dispatch: sinon.stub(),
-    }),
+    errorHandler: createStubErrorHandler(),
     getClientCompatibility: () => ({ compatible: true, reason: null }),
     getBrowserThemeData: () => '{}',
     i18n,
@@ -166,10 +166,7 @@ describe('Addon', () => {
   });
 
   it('renders without an add-on', () => {
-    const errorHandler = new ErrorHandler({
-      id: 'no-addon-error-handler',
-      dispatch: sinon.stub(),
-    });
+    const errorHandler = createStubErrorHandler();
     const slugParam = 'some-addon'; // as passed through the URL.
     const fakeDispatch = sinon.stub();
 
@@ -204,11 +201,7 @@ describe('Addon', () => {
   });
 
   it('renders an error if there is one', () => {
-    const errorHandler = new ErrorHandler({
-      capturedError: new Error('some error'),
-      id: 'some-handler',
-      dispatch: sinon.stub(),
-    });
+    const errorHandler = createStubErrorHandler(new Error('some error'));
 
     const root = shallowRender({ errorHandler });
     expect(root.find(ErrorList)).toHaveLength(1);

--- a/tests/unit/amo/components/TestAddonReview.js
+++ b/tests/unit/amo/components/TestAddonReview.js
@@ -13,9 +13,8 @@ import * as coreUtils from 'core/utils';
 import {
   mapDispatchToProps, mapStateToProps, AddonReviewBase,
 } from 'amo/components/AddonReview';
-import { ErrorHandler } from 'core/errorHandler';
 import { fakeAddon, fakeReview, signedInApiState } from 'tests/unit/amo/helpers';
-import { getFakeI18nInst } from 'tests/unit/helpers';
+import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
 
 const defaultReview = {
   id: 3321, addonId: fakeAddon.id, addonSlug: fakeAddon.slug, rating: 5,
@@ -33,10 +32,7 @@ function fakeLocalState(overrides = {}) {
 function render({ ...customProps } = {}) {
   const props = {
     createLocalState: () => fakeLocalState(),
-    errorHandler: new ErrorHandler({
-      id: 'some-id',
-      dispatch: sinon.stub(),
-    }),
+    errorHandler: createStubErrorHandler(),
     i18n: getFakeI18nInst(),
     apiState: signedInApiState,
     onReviewSubmitted: () => {},
@@ -60,10 +56,7 @@ describe('AddonReview', () => {
     const setDenormalizedReview = sinon.spy(() => {});
     const refreshAddon = sinon.spy(() => Promise.resolve());
     const updateReviewText = sinon.spy(() => Promise.resolve());
-    const errorHandler = new ErrorHandler({
-      id: 'some-id',
-      dispatch: sinon.stub(),
-    });
+    const errorHandler = createStubErrorHandler();
     const root = render({
       onReviewSubmitted,
       setDenormalizedReview,

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -13,12 +13,15 @@ import Link from 'amo/components/Link';
 import Paginate from 'core/components/Paginate';
 import { loadEntities } from 'core/actions';
 import { fetchAddon } from 'core/actions/addons';
-import { ErrorHandler } from 'core/errorHandler';
 import { denormalizeAddon } from 'core/reducers/addons';
 import ErrorList from 'ui/components/ErrorList';
 import Rating from 'ui/components/Rating';
 import { fakeAddon, fakeReview } from 'tests/unit/amo/helpers';
-import { createFetchAddonResult, getFakeI18nInst } from 'tests/unit/helpers';
+import {
+  createFetchAddonResult,
+  createStubErrorHandler,
+  getFakeI18nInst,
+} from 'tests/unit/helpers';
 import LoadingText from 'ui/components/LoadingText';
 
 function getLoadedReviews({
@@ -34,10 +37,7 @@ describe('amo/components/AddonReviewList', () => {
     function render({
       addon = fakeAddon,
       dispatch = sinon.stub(),
-      errorHandler = new ErrorHandler({
-        id: 'some-error-handler',
-        dispatch: sinon.stub(),
-      }),
+      errorHandler = createStubErrorHandler(),
       params = {
         addonSlug: fakeAddon.slug,
       },
@@ -92,10 +92,7 @@ describe('amo/components/AddonReviewList', () => {
     it('fetches an addon if needed', () => {
       const addonSlug = 'some-addon-slug';
       const dispatch = sinon.stub();
-      const errorHandler = new ErrorHandler({
-        id: 'fetch-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler();
 
       render({
         addon: null, errorHandler, params: { addonSlug }, dispatch,
@@ -109,10 +106,7 @@ describe('amo/components/AddonReviewList', () => {
     it('fetches reviews if needed', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
       const dispatch = sinon.stub();
-      const errorHandler = new ErrorHandler({
-        id: 'fetch-reviews-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler();
 
       render({
         addon,
@@ -131,10 +125,7 @@ describe('amo/components/AddonReviewList', () => {
     it('fetches reviews if needed during an update', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
       const dispatch = sinon.stub();
-      const errorHandler = new ErrorHandler({
-        id: 'fetch-reviews-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler();
 
       const root = render({
         addon: null,
@@ -155,10 +146,7 @@ describe('amo/components/AddonReviewList', () => {
 
     it('fetches reviews by page', () => {
       const dispatch = sinon.stub();
-      const errorHandler = new ErrorHandler({
-        id: 'fetch-reviews-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler();
       const addonSlug = fakeAddon.slug;
       const page = 2;
 
@@ -179,10 +167,7 @@ describe('amo/components/AddonReviewList', () => {
 
     it('fetches reviews when the page changes', () => {
       const dispatch = sinon.stub();
-      const errorHandler = new ErrorHandler({
-        id: 'fetch-reviews-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler();
       const addonSlug = fakeAddon.slug;
 
       const root = render({
@@ -204,11 +189,7 @@ describe('amo/components/AddonReviewList', () => {
     it('does not fetch an addon if there is an error', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
       const dispatch = sinon.stub();
-      const errorHandler = new ErrorHandler({
-        capturedError: new Error('some error'),
-        id: 'fetch-addon-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler(new Error('some error'));
 
       render({
         addon: null,
@@ -222,11 +203,7 @@ describe('amo/components/AddonReviewList', () => {
 
     it('does not fetch reviews if there is an error', () => {
       const dispatch = sinon.stub();
-      const errorHandler = new ErrorHandler({
-        capturedError: new Error('some error'),
-        id: 'fetch-reviews-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler(new Error('some error'));
 
       render({
         reviews: null,
@@ -246,11 +223,7 @@ describe('amo/components/AddonReviewList', () => {
     });
 
     it('renders an error', () => {
-      const errorHandler = new ErrorHandler({
-        capturedError: new Error('some error'),
-        id: 'custom-error-handler',
-        dispatch: sinon.stub(),
-      });
+      const errorHandler = createStubErrorHandler(new Error('some error'));
 
       const root = render({ errorHandler });
       expect(root.find(ErrorList)).toHaveLength(1);

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -9,17 +9,14 @@ import { ErrorHandler } from 'core/errorHandler';
 import Button from 'ui/components/Button';
 import LoadingText from 'ui/components/LoadingText';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
-import { getFakeI18nInst } from 'tests/unit/helpers';
+import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
 
 describe('<Categories />', () => {
   function render({ ...props }) {
     const fakeDispatch = sinon.stub();
-    const errorHandler = new ErrorHandler({
-      id: 'some-error-handler',
-      dispatch: sinon.stub(),
-    });
+    const errorHandler = createStubErrorHandler();
 
     return shallow(
       <CategoriesBase
@@ -200,11 +197,9 @@ describe('<Categories />', () => {
   });
 
   it('reports errors', () => {
-    const errorHandler = new ErrorHandler({
-      capturedError: new Error('example of an error'),
-      id: 'some-id',
-      dispatch: sinon.stub(),
-    });
+    const errorHandler = createStubErrorHandler(
+      new Error('example of an error')
+    );
     const root = render({ categories: {}, errorHandler });
 
     expect(root.find(ErrorList)).toHaveLength(1);

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -11,7 +11,7 @@ import { ADDON_TYPE_THEME, CLIENT_APP_FIREFOX } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
 import I18nProvider from 'core/i18n/Provider';
 import { visibleAddonType } from 'core/utils';
-import { getFakeI18nInst } from 'tests/unit/helpers';
+import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
@@ -103,22 +103,18 @@ describe('Category', () => {
   });
 
   it('should render an error', () => {
-    const errorHandler = new ErrorHandler({
-      capturedError: new Error('example of an error'),
-      id: 'some-id',
-      dispatch: fakeDispatch,
-    });
+    const errorHandler = createStubErrorHandler(
+      new Error('example of an error')
+    );
     const root = render({ errorHandler });
 
     expect(root.find(ErrorList)).toHaveLength(1);
   });
 
   it('should render an error without a category too', () => {
-    const errorHandler = new ErrorHandler({
-      capturedError: new Error('example of an error'),
-      id: 'some-id',
-      dispatch: fakeDispatch,
-    });
+    const errorHandler = createStubErrorHandler(
+      new Error('example of an error')
+    );
     const root = render({ errorHandler, category: null, loading: false });
 
     expect(root.find(ErrorList)).toHaveLength(1);

--- a/tests/unit/amo/components/TestFeaturedAddons.js
+++ b/tests/unit/amo/components/TestFeaturedAddons.js
@@ -17,7 +17,7 @@ import { visibleAddonType } from 'core/utils';
 import {
   createAddonsApiResult, fakeAddon, signedInApiState,
 } from 'tests/unit/amo/helpers';
-import { getFakeI18nInst } from 'tests/unit/helpers';
+import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
 
 
 describe('<FeaturedAddons />', () => {
@@ -27,10 +27,7 @@ describe('<FeaturedAddons />', () => {
   beforeEach(() => {
     const initialState = { api: signedInApiState };
     store = createStore(initialState).store;
-    errorHandler = new ErrorHandler({
-      id: 'some-error-handler',
-      dispatch: sinon.stub(),
-    });
+    errorHandler = createStubErrorHandler();
   });
 
   function _getFeatured(args = {}) {

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -16,7 +16,7 @@ import I18nProvider from 'core/i18n/Provider';
 import { ErrorHandler } from 'core/errorHandler';
 import { visibleAddonType } from 'core/utils';
 import { dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
-import { getFakeI18nInst } from 'tests/unit/helpers';
+import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
 
@@ -24,10 +24,7 @@ describe('<LandingPage />', () => {
   function renderProps(props = {}) {
     return {
       dispatch: sinon.stub(),
-      errorHandler: new ErrorHandler({
-        id: 'some-handler',
-        dispatch: sinon.stub(),
-      }),
+      errorHandler: createStubErrorHandler(),
       i18n: getFakeI18nInst(),
       params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) },
       resultsLoaded: false,
@@ -165,11 +162,7 @@ describe('<LandingPage />', () => {
   });
 
   it('renders an error', () => {
-    const errorHandler = new ErrorHandler({
-      dispatch: sinon.stub(),
-      id: 'some-id',
-      capturedError: new Error('some error'),
-    });
+    const errorHandler = createStubErrorHandler(new Error('some error'));
     const root = render({ errorHandler });
 
     expect(root.find(ErrorList)).toHaveLength(1);

--- a/tests/unit/amo/components/TestSearch.js
+++ b/tests/unit/amo/components/TestSearch.js
@@ -8,13 +8,12 @@ import { setViewContext } from 'amo/actions/viewContext';
 import { searchStart } from 'core/actions/search';
 import Paginate from 'core/components/Paginate';
 import { ADDON_TYPE_EXTENSION, VIEW_CONTEXT_EXPLORE } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
 import ErrorList from 'ui/components/ErrorList';
 import {
   dispatchClientMetadata,
   dispatchSearchResults,
 } from 'tests/unit/amo/helpers';
-
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 describe('Search', () => {
   let props;
@@ -27,10 +26,7 @@ describe('Search', () => {
     props = {
       count: 80,
       dispatch: sinon.stub(),
-      errorHandler: new ErrorHandler({
-        id: 'Search-testing-123',
-        dispatch: sinon.stub(),
-      }),
+      errorHandler: createStubErrorHandler(),
       filters: { page: 3, query: 'foo' },
       pathname: '/search/',
       handleSearch: sinon.spy(),
@@ -149,11 +145,9 @@ describe('Search', () => {
   });
 
   it('should render an error', () => {
-    const errorHandler = new ErrorHandler({
-      capturedError: new Error('example of an error'),
-      id: 'some-id',
-      dispatch: sinon.stub(),
-    });
+    const errorHandler = createStubErrorHandler(
+      new Error('example of an error')
+    );
     const root = render({ errorHandler });
 
     expect(root.find(ErrorList)).toHaveLength(1);

--- a/tests/unit/amo/sagas/testCategories.js
+++ b/tests/unit/amo/sagas/testCategories.js
@@ -7,9 +7,9 @@ import { setClientApp, setLang } from 'core/actions';
 import * as actions from 'core/actions/categories';
 import * as api from 'core/api';
 import { CATEGORIES_LOAD } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
 import apiReducer from 'core/reducers/api';
 import categoriesReducer from 'core/reducers/categories';
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 
 describe('categoriesSaga', () => {
@@ -19,10 +19,7 @@ describe('categoriesSaga', () => {
   let store;
 
   beforeEach(() => {
-    errorHandler = new ErrorHandler({
-      id: 'some-error-handler',
-      dispatch: sinon.stub(),
-    });
+    errorHandler = createStubErrorHandler();
     store = createStore().store;
     store.dispatch(setClientApp('firefox'));
     store.dispatch(setLang('en-US'));

--- a/tests/unit/amo/sagas/testFeatured.js
+++ b/tests/unit/amo/sagas/testFeatured.js
@@ -6,12 +6,12 @@ import { getFeatured, loadFeatured } from 'amo/actions/featured';
 import { FEATURED_ADDONS_TO_LOAD } from 'amo/constants';
 import featuredReducer from 'amo/reducers/featured';
 import featuredSaga from 'amo/sagas/featured';
-import { ErrorHandler } from 'core/errorHandler';
 import apiReducer from 'core/reducers/api';
 import { ADDON_TYPE_EXTENSION, FEATURED_LOADED } from 'core/constants';
 import {
   createAddonsApiResult, dispatchSignInActions, fakeAddon,
 } from 'tests/unit/amo/helpers';
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 describe('amo/sagas/featured', () => {
   describe('fetchFeaturedAddons', () => {
@@ -21,10 +21,7 @@ describe('amo/sagas/featured', () => {
     let sagaTester;
 
     beforeEach(() => {
-      errorHandler = new ErrorHandler({
-        id: 'some-error-handler',
-        dispatch: sinon.stub(),
-      });
+      errorHandler = createStubErrorHandler();
       mockApi = sinon.mock(api);
 
       const { state } = dispatchSignInActions();

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -12,11 +12,11 @@ import {
   SEARCH_SORT_POPULAR,
   SEARCH_SORT_TOP_RATED,
 } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
 import apiReducer from 'core/reducers/api';
 import {
   createAddonsApiResult, dispatchSignInActions, fakeAddon,
 } from 'tests/unit/amo/helpers';
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 describe('amo/sagas/landing', () => {
   describe('fetchLandingAddons', () => {
@@ -26,10 +26,7 @@ describe('amo/sagas/landing', () => {
     let sagaTester;
 
     beforeEach(() => {
-      errorHandler = new ErrorHandler({
-        id: 'some-error-handler',
-        dispatch: sinon.stub(),
-      });
+      errorHandler = createStubErrorHandler();
       mockApi = sinon.mock(api);
 
       const { state } = dispatchSignInActions();

--- a/tests/unit/amo/sagas/testReviews.js
+++ b/tests/unit/amo/sagas/testReviews.js
@@ -6,12 +6,11 @@ import { fetchReviews, setAddonReviews } from 'amo/actions/reviews';
 import { SET_ADDON_REVIEWS } from 'amo/constants';
 import reviewsReducer from 'amo/reducers/reviews';
 import reviewsSaga from 'amo/sagas/reviews';
-import { ErrorHandler } from 'core/errorHandler';
 import apiReducer from 'core/reducers/api';
 import {
   dispatchSignInActions, fakeAddon, fakeReview,
 } from 'tests/unit/amo/helpers';
-import { apiResponsePage } from 'tests/unit/helpers';
+import { apiResponsePage, createStubErrorHandler } from 'tests/unit/helpers';
 
 describe('amo/sagas/reviews', () => {
   describe('fetchReviews', () => {
@@ -21,10 +20,7 @@ describe('amo/sagas/reviews', () => {
     let sagaTester;
 
     beforeEach(() => {
-      errorHandler = new ErrorHandler({
-        id: 'some-error-handler',
-        dispatch: sinon.stub(),
-      });
+      errorHandler = createStubErrorHandler();
       mockAmoApi = sinon.mock(amoApi);
 
       const { state } = dispatchSignInActions();

--- a/tests/unit/core/actions/test_addons.js
+++ b/tests/unit/core/actions/test_addons.js
@@ -1,14 +1,11 @@
 import { fetchAddon } from 'core/actions/addons';
-import { ErrorHandler } from 'core/errorHandler';
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 describe('core.actions.addons', () => {
   describe('fetchAddon', () => {
     const defaultParams = Object.freeze({
       slug: 'addon-slug',
-      errorHandler: new ErrorHandler({
-        id: 'some-handler',
-        dispatch: sinon.stub(),
-      }),
+      errorHandler: createStubErrorHandler(),
     });
 
     it('requires an error handler', () => {

--- a/tests/unit/core/api/test_api.js
+++ b/tests/unit/core/api/test_api.js
@@ -6,9 +6,9 @@ import utf8 from 'utf8';
 
 import * as api from 'core/api';
 import { ADDON_TYPE_THEME, CLIENT_APP_ANDROID } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
 import { parsePage } from 'core/utils';
 import {
+  createStubErrorHandler,
   signedInApiState,
   unexpectedSuccess,
   userAuthToken,
@@ -46,10 +46,6 @@ describe('api', () => {
   });
 
   describe('core.callApi', () => {
-    function newErrorHandler() {
-      return new ErrorHandler({ id: '123', dispatch: sinon.stub() });
-    }
-
     it('does not use remote host for api calls', () => {
       expect(apiHost).toEqual('https://localhost');
     });
@@ -79,7 +75,7 @@ describe('api', () => {
     it('clears an error handler before making a request', () => {
       mockWindow.expects('fetch').returns(createApiResponse());
 
-      const errorHandler = newErrorHandler();
+      const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'clear');
 
       return api.callApi({ endpoint: 'resource', errorHandler })
@@ -95,7 +91,7 @@ describe('api', () => {
         jsonData: { non_field_errors: nonFieldErrors },
       }));
 
-      const errorHandler = newErrorHandler();
+      const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'handle');
 
       return api.callApi({ endpoint: 'resource', errorHandler })
@@ -114,7 +110,7 @@ describe('api', () => {
         },
       }));
 
-      const errorHandler = newErrorHandler();
+      const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'handle');
 
       return api.callApi({ endpoint: 'resource' })
@@ -143,7 +139,7 @@ describe('api', () => {
         'this could be any error'
       )));
 
-      const errorHandler = newErrorHandler();
+      const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'handle');
 
       return api.callApi({ endpoint: 'resource', errorHandler })

--- a/tests/unit/core/sagas/testAddons.js
+++ b/tests/unit/core/sagas/testAddons.js
@@ -4,12 +4,11 @@ import SagaTester from 'redux-saga-tester';
 import { fetchAddon } from 'core/actions/addons';
 import * as api from 'core/api';
 import { ENTITIES_LOADED } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
 import addonsReducer from 'core/reducers/addons';
 import apiReducer from 'core/reducers/api';
 import addonsSaga from 'core/sagas/addons';
 import { dispatchSignInActions, fakeAddon } from 'tests/unit/amo/helpers';
-import { createFetchAddonResult } from 'tests/unit/helpers';
+import { createFetchAddonResult, createStubErrorHandler } from 'tests/unit/helpers';
 
 
 describe('core/sagas/addons', () => {
@@ -19,10 +18,7 @@ describe('core/sagas/addons', () => {
   let sagaTester;
 
   beforeEach(() => {
-    errorHandler = new ErrorHandler({
-      id: 'some-addon-handler',
-      dispatch: sinon.stub(),
-    });
+    errorHandler = createStubErrorHandler();
     mockApi = sinon.mock(api);
     const initialState = dispatchSignInActions().state;
     apiState = initialState.api;

--- a/tests/unit/core/sagas/testSearch.js
+++ b/tests/unit/core/sagas/testSearch.js
@@ -3,12 +3,12 @@ import SagaTester from 'redux-saga-tester';
 import { searchStart } from 'core/actions/search';
 import * as api from 'core/api';
 import { CLEAR_ERROR, SEARCH_LOADED } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
 import searchReducer from 'core/reducers/search';
 import apiReducer from 'core/reducers/api';
 import authReducer from 'core/reducers/authentication';
 import searchSaga from 'core/sagas/search';
 import { dispatchSignInActions } from 'tests/unit/amo/helpers';
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 
 describe('Search Saga', () => {
@@ -17,10 +17,7 @@ describe('Search Saga', () => {
   let sagaTester;
 
   beforeEach(() => {
-    errorHandler = new ErrorHandler({
-      id: 'some-search-handler',
-      dispatch: sinon.stub(),
-    });
+    errorHandler = createStubErrorHandler();
     mockApi = sinon.mock(api);
     const initialState = dispatchSignInActions().state;
     sagaTester = new SagaTester({
@@ -32,7 +29,7 @@ describe('Search Saga', () => {
 
   function _searchStart(params) {
     sagaTester.dispatch(searchStart({
-      errorHandlerId: 'some-search-handler',
+      errorHandlerId: 'create-stub-error-handler-id',
       ...params,
     }));
   }

--- a/tests/unit/disco/containers/TestDiscoPane.js
+++ b/tests/unit/disco/containers/TestDiscoPane.js
@@ -18,7 +18,10 @@ import {
 } from 'disco/constants';
 import * as helpers from 'disco/containers/DiscoPane';
 import {
-  createFakeEvent, getFakeI18nInst, MockedSubComponent,
+  createFakeEvent,
+  createStubErrorHandler,
+  getFakeI18nInst,
+  MockedSubComponent,
 } from 'tests/unit/helpers';
 import {
   fakeDiscoAddon,
@@ -59,9 +62,7 @@ describe('AddonPage', () => {
 
     return {
       AddonComponent: MockedSubComponent,
-      errorHandler: new ErrorHandler({
-        id: 'some-id', dispatch: sinon.stub(),
-      }),
+      errorHandler: createStubErrorHandler(),
       dispatch: sinon.stub(),
       i18n,
       results,
@@ -247,11 +248,7 @@ describe('AddonPage', () => {
 
   describe('errors', () => {
     it('renders errors', () => {
-      const errorHandler = new ErrorHandler({
-        id: 'some-handler',
-        dispatch: sinon.stub(),
-        capturedError: new Error('some error'),
-      });
+      const errorHandler = createStubErrorHandler(new Error('some error'));
       const root = render({ errorHandler });
 
       expect(root.find(ErrorList)).toHaveLength(1);

--- a/tests/unit/disco/sagas/testDisco.js
+++ b/tests/unit/disco/sagas/testDisco.js
@@ -1,7 +1,6 @@
 import SagaTester from 'redux-saga-tester';
 
 import { loadEntities } from 'core/actions';
-import { ErrorHandler } from 'core/errorHandler';
 import addonsReducer from 'core/reducers/addons';
 import apiReducer from 'core/reducers/api';
 import * as api from 'disco/api';
@@ -12,7 +11,7 @@ import { dispatchSignInActions } from 'tests/unit/amo/helpers';
 import {
   createFetchDiscoveryResult, fakeDiscoAddon,
 } from 'tests/unit/disco/helpers';
-
+import { createStubErrorHandler } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('fetchDiscoveryAddons', () => {
@@ -22,10 +21,7 @@ describe(__filename, () => {
     let sagaTester;
 
     beforeEach(() => {
-      errorHandler = new ErrorHandler({
-        id: 'some-error-handler',
-        dispatch: sinon.stub(),
-      });
+      errorHandler = createStubErrorHandler();
       mockApi = sinon.mock(api);
 
       const { state } = dispatchSignInActions();

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -12,6 +12,7 @@ import * as coreApi from 'core/api';
 import { ADDON_TYPE_EXTENSION } from 'core/constants';
 import { makeI18n } from 'core/i18n/utils';
 import { initialApiState } from 'core/reducers/api';
+import { ErrorHandler } from 'core/errorHandler';
 
 export const sampleUserAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1';
 export const sampleUserAgentParsed = UAParser(sampleUserAgent);
@@ -234,4 +235,12 @@ export function createFakeEvent(extraProps = {}) {
     preventDefault: sinon.stub(),
     ...extraProps,
   };
+}
+
+export function createStubErrorHandler(capturedError = null) {
+  return new ErrorHandler({
+    id: 'create-stub-error-handler-id',
+    dispatch: sinon.stub(),
+    capturedError,
+  });
 }


### PR DESCRIPTION
Fixes #2936 

---

This PR introduces a new test helper `createStubErrorHandler()`, which takes a `capturedError` optionally. I have left all `ErrorHandler` objects relying on a custom `dispatch` as is.