### PR TITLE
Rename withErrorHandling() to withRenderedErrorHandler()

### DIFF
--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { oneLine } from 'common-tags';
 
-import { withErrorHandling } from 'core/errorHandler';
+import { withRenderedErrorHandler } from 'core/errorHandler';
 import { setReview } from 'amo/actions/reviews';
 import { getLatestUserReview, submitReview } from 'amo/api';
 import DefaultAddonReview from 'amo/components/AddonReview';
@@ -257,6 +257,6 @@ export const RatingManagerWithI18n = compose(
 )(RatingManagerBase);
 
 export default compose(
-  withErrorHandling({ name: 'RatingManager' }),
+  withRenderedErrorHandler({ name: 'RatingManager' }),
   connect(mapStateToProps, mapDispatchToProps),
 )(RatingManagerWithI18n);

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -59,13 +59,8 @@ export class ErrorHandler {
 export type ErrorHandlerType = typeof ErrorHandler;
 
 /*
- * This is a decorator that gives a component the ability to handle errors.
- *
- * The decorator will assign an ErrorHandler instance to the errorHandler
- * property.
- *
- * For convenience, you can use withErrorHandling() instead which will
- * additionally renders the error automatically.
+ * For convenience, you can use `withRenderedErrorHandler()` which renders the
+ * error automatically at the beginning of the component's output.
  *
  * Example:
  *
@@ -77,7 +72,7 @@ export type ErrorHandlerType = typeof ErrorHandler;
  *     const { errorHandler } = this.props;
  *     return (
  *       <div>
- *         {errorHandler.hasError() ? errorHandler.renderError() : null}
+ *         {errorHandler.hasErrorIfPresent()}
  *         <div>some content</div>
  *       </div>
  *     );
@@ -141,10 +136,10 @@ export function withErrorHandler({ name, id }) {
  * }
  *
  * export default compose(
- *   withErrorHandling({ name: 'SomeComponent' }),
+ *   withRenderedErrorHandler({ name: 'SomeComponent' }),
  * )(SomeComponent);
  */
-export function withErrorHandling({ name, id } = {}) {
+export function withRenderedErrorHandler({ name, id } = {}) {
   return (WrappedComponent) => {
     function ErrorBanner(props) {
       // eslint-disable-next-line react/prop-types

--- a/tests/unit/core/testErrorHandler.js
+++ b/tests/unit/core/testErrorHandler.js
@@ -11,7 +11,7 @@ import { createApiError } from 'core/api/index';
 import { ERROR_UNKNOWN } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { clearError, setError } from 'core/actions/errors';
-import { ErrorHandler, withErrorHandler, withErrorHandling }
+import { ErrorHandler, withErrorHandler, withRenderedErrorHandler }
   from 'core/errorHandler';
 import errors from 'core/reducers/errors';
 import { getFakeI18nInst } from 'tests/unit/helpers';
@@ -105,7 +105,7 @@ describe('errorHandler', () => {
     });
   });
 
-  describe('withErrorHandling', () => {
+  describe('withRenderedErrorHandler', () => {
     it('renders a generic error above component content', () => {
       const id = 'some-handler-id';
 
@@ -113,7 +113,7 @@ describe('errorHandler', () => {
       store.dispatch(setError({ id, error: new Error() }));
 
       const { dom, tree } = createWrappedComponent({
-        store, id, decorator: withErrorHandling,
+        store, id, decorator: withRenderedErrorHandler,
       });
       const errorList = findRenderedComponentWithType(tree, ErrorList);
       expect(errorList.props.code).toEqual(ERROR_UNKNOWN);
@@ -138,7 +138,7 @@ describe('errorHandler', () => {
       store.dispatch(setError({ id, error }));
 
       const { tree } = createWrappedComponent({
-        store, id, decorator: withErrorHandling,
+        store, id, decorator: withRenderedErrorHandler,
       });
       const errorList = findRenderedComponentWithType(tree, ErrorList);
       expect(errorList.props.messages).toEqual([nestedMessage]);
@@ -146,7 +146,7 @@ describe('errorHandler', () => {
 
     it('renders component content when there is no error', () => {
       const { dom, tree } = createWrappedComponent({
-        decorator: withErrorHandling,
+        decorator: withRenderedErrorHandler,
       });
       expect(() => findRenderedComponentWithType(tree, ErrorList))
         .toThrowError(/Did not find exactly one match/);
@@ -163,7 +163,7 @@ describe('errorHandler', () => {
       store.dispatch(setError({ id, error }));
 
       const { tree } = createWrappedComponent({
-        store, id, decorator: withErrorHandling,
+        store, id, decorator: withRenderedErrorHandler,
       });
 
       const errorList = findRenderedComponentWithType(tree, ErrorList);
@@ -178,7 +178,7 @@ describe('errorHandler', () => {
       store.dispatch(clearError(id));
 
       const { tree } = createWrappedComponent({
-        store, id, decorator: withErrorHandling,
+        store, id, decorator: withRenderedErrorHandler,
       });
       expect(() => findRenderedComponentWithType(tree, ErrorList))
         .toThrowError(/Did not find exactly one match/);
@@ -191,7 +191,7 @@ describe('errorHandler', () => {
       }));
 
       const { tree } = createWrappedComponent({
-        store, id: 'this-handler-id', decorator: withErrorHandling,
+        store, id: 'this-handler-id', decorator: withRenderedErrorHandler,
       });
       expect(() => findRenderedComponentWithType(tree, ErrorList))
         .toThrowError(/Did not find exactly one match/);
@@ -199,7 +199,7 @@ describe('errorHandler', () => {
 
     it('passes through wrapped component properties without an error', () => {
       const { component } = createWrappedComponent({
-        decorator: withErrorHandling,
+        decorator: withRenderedErrorHandler,
         customProps: { color: 'red' },
       });
       expect(component.props.color).toEqual('red');
@@ -213,7 +213,7 @@ describe('errorHandler', () => {
       const { component } = createWrappedComponent({
         id,
         store,
-        decorator: withErrorHandling,
+        decorator: withRenderedErrorHandler,
         customProps: { color: 'red' },
       });
       expect(component.props.color).toEqual('red');


### PR DESCRIPTION
Fixes #2931 

---

Rename a HOC to avoid confusion, cf. #2931.