### PR TITLE
chore: Change Disco Pane background for Photon (fix #2938)

### DIFF
--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -1,5 +1,7 @@
+@import "~photon-colors/colors";
+
 $focus-outline-color: #0096dc;
-$page-background: #fbfbfb;
+$page-background: $grey-10;
 $primary-font-color: #000;
 $secondary-font-color: #6a6a6a;
 $header-copy-font-color: #444;


### PR DESCRIPTION
Heh, these colours are _very_ similar but this updates the Disco Pane's background colour for Photon styles.

fixes #2938

### Before
<img width="1276" alt="screenshot 2017-08-16 00 56 17" src="https://user-images.githubusercontent.com/90871/29341784-987d656e-821e-11e7-88e4-f529172dee57.png">

### After
<img width="1276" alt="screenshot 2017-08-16 00 54 06" src="https://user-images.githubusercontent.com/90871/29341778-9249fb4e-821e-11e7-9979-a737d3b3219f.png">
