### PR TITLE
Show loading indicators when switching between landing pages

### DIFF
--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -103,7 +103,7 @@ export class SearchResultBase extends React.Component {
             {addon ? i18n.sprintf(i18n.ngettext(
               '%(total)s user', '%(total)s users', averageDailyUsers),
               { total: i18n.formatNumber(averageDailyUsers) },
-            ) : <LoadingText width={100} />}
+            ) : <LoadingText width={90} />}
           </span>
         </h3>
       </div>

--- a/src/amo/reducers/landing.js
+++ b/src/amo/reducers/landing.js
@@ -18,7 +18,7 @@ export default function landing(state = initialState, action) {
   switch (action.type) {
     case LANDING_GET:
       return {
-        ...state,
+        ...initialState,
         addonType: payload.addonType,
         loading: true,
         resultsLoaded: false,

--- a/tests/unit/amo/reducers/testLanding.js
+++ b/tests/unit/amo/reducers/testLanding.js
@@ -1,6 +1,7 @@
 import { getLanding } from 'amo/actions/landing';
 import landing, { initialState } from 'amo/reducers/landing';
 import { ADDON_TYPE_THEME } from 'core/constants';
+import { fakeAddon } from 'tests/unit/amo/helpers';
 
 
 describe('landing reducer', () => {
@@ -52,6 +53,30 @@ describe('landing reducer', () => {
       }));
 
       expect(state.resultsLoaded).toEqual(false);
+    });
+
+    it('resets each set of add-ons', () => {
+      const entities = {
+        addons: {
+          bar: { ...fakeAddon, slug: 'bar' },
+          foo: { ...fakeAddon, slug: 'foo' },
+          food: { ...fakeAddon, slug: 'food' },
+        },
+      };
+      const state = landing({
+        ...initialState,
+        featured: {
+          entities,
+          result: { count: 2, results: ['foo', 'food'] },
+        },
+      }, getLanding({
+        addonType: ADDON_TYPE_THEME,
+        errorHandlerId: 'some-error-handler',
+      }));
+
+      expect(state.featured).toEqual(initialState.featured);
+      expect(state.highlyRated).toEqual(initialState.highlyRated);
+      expect(state.popular).toEqual(initialState.popular);
     });
   });
 


### PR DESCRIPTION
Fixes #2882 

---

This PR enables the loader when we change from one landing page to another by resetting the add-ons sets when a new request is triggered. In addition, I fixed a visual glitch by reducing the size of the loader related to the number of users (a width of `100%` put the loader on a new line).


## Gif

![2017-08-16 10 44 40](https://user-images.githubusercontent.com/217628/29355234-7e54d56c-8270-11e7-957f-30aeafc323dc.gif)
