### PR TITLE
Fixes category loading problem (server side)

### DIFF
--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -13,7 +13,7 @@ export default class AddonsCard extends React.Component {
     addons: PropTypes.array.isRequired,
     children: PropTypes.node,
     className: PropTypes.string,
-    loading: PropTypes.boolean,
+    loading: PropTypes.bool,
     // When loading, this is the number of placeholders
     // that will be rendered.
     placeholderCount: PropTypes.number,

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+/* global $PropertyType */
 import classnames from 'classnames';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -88,7 +89,7 @@ export class CategoriesBase extends React.Component {
       categoriesState[clientApp][addonType]
     ) {
       categories = Object.values(categoriesState[clientApp][addonType]);
-    };
+    }
     const classNameProp = classnames('Categories', className);
 
     if (!errorHandler.hasError() && !loading && !categories.length) {

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -52,9 +52,11 @@ type CategoriesProps = {
 
 export class CategoriesBase extends React.Component {
   componentWillMount() {
-    const { addonType, categories, dispatch, errorHandler } = this.props;
+    const {
+      addonType, categories, dispatch, errorHandler, loading,
+    } = this.props;
 
-    if (!categories) {
+    if (!loading && !categories) {
       dispatch(categoriesFetch({ errorHandlerId: errorHandler.id }));
     }
 

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -43,7 +43,7 @@ type CategoriesProps = {
   addonType: string,
   className: string,
   clientApp: string,
-  categories?: $PropertyType<CategoriesStateType, 'categories'>,
+  categoriesState?: $PropertyType<CategoriesStateType, 'categories'>,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: Object,
@@ -53,10 +53,10 @@ type CategoriesProps = {
 export class CategoriesBase extends React.Component {
   componentWillMount() {
     const {
-      addonType, categories, dispatch, errorHandler, loading,
+      addonType, categoriesState, dispatch, errorHandler, loading,
     } = this.props;
 
-    if (!loading && !categories) {
+    if (!loading && !categoriesState) {
       dispatch(categoriesFetch({ errorHandlerId: errorHandler.id }));
     }
 
@@ -76,7 +76,7 @@ export class CategoriesBase extends React.Component {
     /* eslint-disable react/no-array-index-key */
     const {
       addonType,
-      categories: categoriesState,
+      categoriesState,
       className,
       clientApp,
       errorHandler,
@@ -158,7 +158,7 @@ export function mapStateToProps(
   state: {| api: ApiStateType, categories: CategoriesStateType |}
 ) {
   return {
-    categories: state.categories.categories,
+    categoriesState: state.categories.categories,
     clientApp: state.api.clientApp,
     loading: state.categories.loading,
   };

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -19,7 +19,7 @@ export class CategoryBase extends React.Component {
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
     filters: PropTypes.object,
-    loading: PropTypes.boolean,
+    loading: PropTypes.bool,
     paginationQueryParams: PropTypes.object,
     pathname: PropTypes.string,
   }

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -86,7 +86,7 @@ export class CategoryBase extends React.Component {
   }
 }
 
-export function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state) {
   const loading = state.categories.loading || state.search.loading;
 
   return {

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -87,12 +87,10 @@ export class CategoryBase extends React.Component {
 }
 
 export function mapStateToProps(state) {
-  const loading = state.categories.loading || state.search.loading;
-
   return {
     categories: state.categories.categories,
     clientApp: state.api.clientApp,
-    loading,
+    loading: state.categories.loading,
   };
 }
 

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -8,6 +8,7 @@ import NotFound from 'amo/components/ErrorPage/NotFound';
 import Search from 'amo/components/Search';
 import { categoriesFetch } from 'core/actions/categories';
 import { withErrorHandler } from 'core/errorHandler';
+import log from 'core/logger';
 import { apiAddonType, getCategoryFromState, parsePage } from 'core/utils';
 
 import './styles.scss';
@@ -15,35 +16,59 @@ import './styles.scss';
 
 export class CategoryBase extends React.Component {
   static propTypes = {
-    category: PropTypes.object,
+    categories: PropTypes.object,
+    clientApp: PropTypes.string,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
-    filters: PropTypes.object,
     loading: PropTypes.bool,
-    paginationQueryParams: PropTypes.object,
-    pathname: PropTypes.string,
+    location: PropTypes.object.isRequired,
+    params: PropTypes.object.isRequired,
   }
 
   componentWillMount() {
-    const { category, dispatch, errorHandler } = this.props;
+    const { categories, dispatch, errorHandler, loading } = this.props;
 
-    if (!category) {
+    if (!loading && !categories) {
       dispatch(categoriesFetch({ errorHandlerId: errorHandler.id }));
     }
   }
 
   render() {
     const {
-      category,
+      categories,
+      clientApp,
       errorHandler,
-      filters,
       loading,
-      paginationQueryParams,
-      pathname,
+      location,
+      params,
     } = this.props;
 
-    if (!errorHandler.hasError() && loading === false && !category) {
+    let addonType;
+    try {
+      addonType = apiAddonType(params.visibleAddonType);
+    } catch (error) {
+      log.info(
+        `addonType ${params.visibleAddonType} threw an error: ${error}`);
       return <NotFound />;
+    }
+    const categorySlug = params.slug;
+    const filters = {
+      addonType,
+      category: categorySlug,
+      page: parsePage(location.query.page),
+    };
+    const pathname = `/${params.visibleAddonType}/${categorySlug}/`;
+    const paginationQueryParams = { page: filters.page };
+
+    let category;
+    if (categories) {
+      if (categories[clientApp] && categories[clientApp][addonType]) {
+        category = categories[clientApp][addonType][categorySlug];
+      }
+
+      if (!errorHandler.hasError() && !loading && !category) {
+        return <NotFound />;
+      }
     }
 
     return (
@@ -62,30 +87,12 @@ export class CategoryBase extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const filters = {
-    addonType: apiAddonType(ownProps.params.visibleAddonType),
-    category: ownProps.params.slug,
-    page: parsePage(ownProps.location.query.page),
-  };
-  const pathname = `/${ownProps.params.visibleAddonType}/${filters.category}/`;
-  const paginationQueryParams = { page: filters.page };
-
-  const category = getCategoryFromState({
-    addonType: filters.addonType,
-    categorySlug: filters.category,
-    clientApp: state.api.clientApp,
-    state,
-  });
-
   const loading = state.categories.loading || state.search.loading;
 
   return {
-    addonType: filters.addonType,
-    category,
-    filters,
+    categories: state.categories.categories,
+    clientApp: state.api.clientApp,
     loading,
-    pathname,
-    paginationQueryParams,
   };
 }
 

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -9,7 +9,7 @@ import Search from 'amo/components/Search';
 import { categoriesFetch } from 'core/actions/categories';
 import { withErrorHandler } from 'core/errorHandler';
 import log from 'core/logger';
-import { apiAddonType, getCategoryFromState, parsePage } from 'core/utils';
+import { apiAddonType, parsePage } from 'core/utils';
 
 import './styles.scss';
 

--- a/src/amo/components/CategoryHeader/index.js
+++ b/src/amo/components/CategoryHeader/index.js
@@ -14,7 +14,7 @@ import './styles.scss';
 
 export class CategoryHeaderBase extends React.Component {
   static propTypes = {
-    category: PropTypes.object.isRequired,
+    category: PropTypes.object,
     i18n: PropTypes.object.isRequired,
   }
 

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -18,7 +18,7 @@ function makePageNumbers({ start, end }) {
 
 export class PaginateBase extends React.Component {
   static propTypes = {
-    LinkComponent: PropTypes.object,
+    LinkComponent: PropTypes.func,
     count: PropTypes.number.isRequired,
     currentPage: PropTypes.number.isRequired,
     i18n: PropTypes.object.isRequired,

--- a/src/core/components/PaginatorLink/index.js
+++ b/src/core/components/PaginatorLink/index.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router';
 
 export default class PaginatorLink extends React.Component {
   static propTypes = {
-    LinkComponent: PropTypes.object,
+    LinkComponent: PropTypes.func,
     className: PropTypes.string,
     currentPage: PropTypes.number.isRequired,
     pathname: PropTypes.string.isRequired,

--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -23,7 +23,6 @@ export function emptyCategoryList() {
 }
 
 export const initialState = {
-  // TODO: fix Categories component.
   categories: null,
   loading: false,
 };

--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -22,8 +22,9 @@ export function emptyCategoryList() {
     }, {});
 }
 
-const initialState = {
-  categories: emptyCategoryList(),
+export const initialState = {
+  // TODO: fix Categories component.
+  categories: null,
   loading: false,
 };
 
@@ -32,7 +33,7 @@ export default function categories(state = initialState, action) {
 
   switch (action.type) {
     case CATEGORIES_FETCH:
-      return { ...state, loading: true };
+      return { ...initialState, loading: true };
     case CATEGORIES_LOAD:
       {
         const categoryList = emptyCategoryList();

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -298,8 +298,10 @@ function baseServer(routes, createStore, { appSagas, appInstanceName = appName }
             sagas = require(`${appName}/sagas`).default;
           }
           const runningSagas = sagaMiddleware.run(sagas);
-          // We need to render once because it will force components
-          // with sagas to call the sagas and load their data.
+
+          // We need to render once because it will force components to
+          // dispatch data loading actions which get processed by sagas.
+          log.info('First component render to dispatch loading actions');
           ReactDOM.renderToString(<ServerHtml {...pageProps} {...props} />);
 
           // Send the redux-saga END action to stop sagas from running
@@ -308,6 +310,7 @@ function baseServer(routes, createStore, { appSagas, appInstanceName = appName }
 
           // Once all sagas have completed, we load the page.
           return runningSagas.done.then(() => {
+            log.info('Second component render after sagas have finished');
             return hydrateOnClient({ props, pageProps, res });
           });
         })

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -424,21 +424,6 @@ export function getCategoryColor(category) {
   return category.id;
 }
 
-export function getCategoryFromState(
-  { addonType, clientApp, categorySlug, state } = {}
-) {
-  const categories = state.categories.categories;
-
-  if (
-    categories && categories[clientApp] && categories[clientApp][addonType] &&
-    categories[clientApp][addonType][categorySlug]
-  ) {
-    return categories[clientApp][addonType][categorySlug];
-  }
-
-  return null;
-}
-
 export function parsePage(page) {
   const parsed = parseInt(page, 10);
   return Number.isNaN(parsed) || parsed < 1 ? 1 : parsed;

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -17,7 +17,7 @@ export class RatingBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     onSelectRating: PropTypes.func,
     rating: PropTypes.number,
-    readOnly: PropTypes.boolean,
+    readOnly: PropTypes.bool,
     styleName: PropTypes.oneOf(RATING_STYLES),
   }
 

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -60,6 +60,26 @@ describe('<Categories />', () => {
     sinon.assert.calledOnce(dispatch);
   });
 
+  it('does not fetch categories if already loaded', () => {
+    store.dispatch(categoriesLoad({ result: [fakeCategory] }));
+    const dispatch = sinon.stub();
+    render({ addonType: ADDON_TYPE_EXTENSION, dispatch });
+
+    // Make sure only the viewContext was dispatched, not a fetch action.
+    sinon.assert.calledWith(dispatch, setViewContext(ADDON_TYPE_EXTENSION));
+    sinon.assert.calledOnce(dispatch);
+  });
+
+  it('does not fetch categories if an empty set was loaded', () => {
+    store.dispatch(categoriesLoad({ result: [] }));
+    const dispatch = sinon.stub();
+    render({ addonType: ADDON_TYPE_EXTENSION, dispatch });
+
+    // Make sure only the viewContext was dispatched, not a fetch action.
+    sinon.assert.calledWith(dispatch, setViewContext(ADDON_TYPE_EXTENSION));
+    sinon.assert.calledOnce(dispatch);
+  });
+
   it('changes viewContext if addonType changes', () => {
     const dispatch = sinon.stub();
     const root = render({

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -24,7 +24,6 @@ describe('<Categories />', () => {
   function render({ ...props }) {
     const errorHandler = createStubErrorHandler();
 
-    // TODO: move to shallowUntilTarget
     return shallow(
       <CategoriesBase
         addonType={ADDON_TYPE_EXTENSION}

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -7,7 +7,6 @@ import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
 import {
   ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME, CLIENT_APP_ANDROID,
 } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
 import Button from 'ui/components/Button';
 import LoadingText from 'ui/components/LoadingText';
 import { dispatchClientMetadata, fakeCategory } from 'tests/unit/amo/helpers';
@@ -40,10 +39,7 @@ describe('<Categories />', () => {
 
   it('fetches categories if needed', () => {
     const dispatch = sinon.stub();
-    const errorHandler = new ErrorHandler({
-      id: 'custom-error-handler',
-      dispatch,
-    });
+    const errorHandler = createStubErrorHandler();
     render({
       addonType: ADDON_TYPE_EXTENSION, dispatch, errorHandler,
     });
@@ -51,6 +47,18 @@ describe('<Categories />', () => {
     sinon.assert.calledWith(dispatch, categoriesFetch({
       errorHandlerId: errorHandler.id,
     }));
+  });
+
+  it('does not fetch categories if already loading them', () => {
+    store.dispatch(categoriesFetch({
+      errorHandlerId: createStubErrorHandler().id,
+    }));
+    const dispatch = sinon.stub();
+    render({ addonType: ADDON_TYPE_EXTENSION, dispatch });
+
+    // Make sure only the viewContext was dispatched, not a fetch action.
+    sinon.assert.calledWith(dispatch, setViewContext(ADDON_TYPE_EXTENSION));
+    sinon.assert.calledOnce(dispatch);
   });
 
   it('changes viewContext if addonType changes', () => {

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -4,26 +4,35 @@ import React from 'react';
 import { setViewContext } from 'amo/actions/viewContext';
 import { CategoriesBase, mapStateToProps } from 'amo/components/Categories';
 import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
-import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
+import {
+  ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME, CLIENT_APP_ANDROID,
+} from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
 import Button from 'ui/components/Button';
 import LoadingText from 'ui/components/LoadingText';
-import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
+import { dispatchClientMetadata, fakeCategory } from 'tests/unit/amo/helpers';
 import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
 
 describe('<Categories />', () => {
+  let store;
+
+  beforeEach(() => {
+    store = dispatchClientMetadata().store;
+  });
+
   function render({ ...props }) {
-    const fakeDispatch = sinon.stub();
     const errorHandler = createStubErrorHandler();
 
+    // TODO: move to shallowUntilTarget
     return shallow(
       <CategoriesBase
         addonType={ADDON_TYPE_EXTENSION}
-        dispatch={fakeDispatch}
+        dispatch={store.dispatch}
         errorHandler={errorHandler}
         i18n={getFakeI18nInst()}
+        {...mapStateToProps(store.getState())}
         {...props}
       />
     );
@@ -36,7 +45,7 @@ describe('<Categories />', () => {
       dispatch,
     });
     render({
-      addonType: ADDON_TYPE_EXTENSION, categories: {}, dispatch, errorHandler,
+      addonType: ADDON_TYPE_EXTENSION, dispatch, errorHandler,
     });
 
     sinon.assert.calledWith(dispatch, categoriesFetch({
@@ -48,7 +57,6 @@ describe('<Categories />', () => {
     const dispatch = sinon.stub();
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      categories: {},
       dispatch,
     });
 
@@ -61,7 +69,6 @@ describe('<Categories />', () => {
     const dispatch = sinon.stub();
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      categories: {},
       dispatch,
     });
 
@@ -76,7 +83,7 @@ describe('<Categories />', () => {
   });
 
   it('renders Categories', () => {
-    const root = render({ addonType: ADDON_TYPE_EXTENSION, categories: {} });
+    const root = render({ addonType: ADDON_TYPE_EXTENSION });
 
     expect(root).toHaveClassName('Categories');
   });
@@ -84,7 +91,6 @@ describe('<Categories />', () => {
   it('renders loading text when loading', () => {
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      categories: {},
       loading: true,
     });
 
@@ -95,7 +101,6 @@ describe('<Categories />', () => {
   it('renders LoadingText components when loading', () => {
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      categories: {},
       loading: true,
     });
 
@@ -107,13 +112,15 @@ describe('<Categories />', () => {
     const categoriesResponse = {
       result: [
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Games',
           slug: 'Games',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Travel',
           slug: 'Travel',
           type: ADDON_TYPE_EXTENSION,
@@ -121,13 +128,10 @@ describe('<Categories />', () => {
       ],
     };
 
-    const { store } = dispatchClientMetadata();
     store.dispatch(categoriesLoad(categoriesResponse));
-    const { categories } = mapStateToProps(store.getState());
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      categories,
     });
 
     expect(root.find('.Categories-list').childAt(0).find(Button))
@@ -140,25 +144,29 @@ describe('<Categories />', () => {
     const categoriesResponse = {
       result: [
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Travel',
           slug: 'travel',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Music',
           slug: 'music',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Nature',
           slug: 'nature',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Games',
           slug: 'Games',
           type: ADDON_TYPE_EXTENSION,
@@ -166,13 +174,10 @@ describe('<Categories />', () => {
       ],
     };
 
-    const { store } = dispatchClientMetadata();
     store.dispatch(categoriesLoad(categoriesResponse));
-    const props = mapStateToProps(store.getState());
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      ...props,
     });
 
     expect(root.find('.Categories-list').childAt(0).find(Button))
@@ -187,10 +192,8 @@ describe('<Categories />', () => {
 
   it('renders a no categories found message', () => {
     const categoriesResponse = { result: [] };
-    const { store } = dispatchClientMetadata();
     store.dispatch(categoriesLoad(categoriesResponse));
-    const props = mapStateToProps(store.getState());
-    const root = render(props);
+    const root = render();
 
     expect(root.find('.Categories-none-loaded-message'))
       .toIncludeText('No categories found.');
@@ -200,7 +203,7 @@ describe('<Categories />', () => {
     const errorHandler = createStubErrorHandler(
       new Error('example of an error')
     );
-    const root = render({ categories: {}, errorHandler });
+    const root = render({ errorHandler });
 
     expect(root.find(ErrorList)).toHaveLength(1);
   });

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -49,7 +49,6 @@ describe('Category', () => {
     }
     const state = store.getState();
 
-    // TODO: move to shallowUntilTarget
     return {
       ...mapStateToProps(state),
       dispatch: store.dispatch,

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -18,18 +18,9 @@ import { ErrorHandler } from 'core/errorHandler';
 import I18nProvider from 'core/i18n/Provider';
 import { visibleAddonType } from 'core/utils';
 import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
-import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
+import { dispatchClientMetadata, fakeCategory } from 'tests/unit/amo/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
-
-const fakeCategory = {
-  id: 5,
-  application: CLIENT_APP_FIREFOX,
-  description: 'I am a cool category for doing things',
-  name: 'Testing category',
-  slug: 'test',
-  type: ADDON_TYPE_THEME,
-};
 
 describe('Category', () => {
   let category;

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -50,9 +50,9 @@ describe('Category', () => {
     }
     const state = store.getState();
 
+    // TODO: move to shallowUntilTarget
     return {
       ...mapStateToProps(state),
-      // TODO: remove when switching to shallowUntil
       dispatch: store.dispatch,
       errorHandler,
       i18n: getFakeI18nInst(),

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -1,6 +1,5 @@
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
-import { Provider } from 'react-redux';
 
 import { CategoryBase, mapStateToProps } from 'amo/components/Category';
 import CategoryHeader from 'amo/components/CategoryHeader';
@@ -14,8 +13,6 @@ import {
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
 } from 'core/constants';
-import { ErrorHandler } from 'core/errorHandler';
-import I18nProvider from 'core/i18n/Provider';
 import { visibleAddonType } from 'core/utils';
 import { createStubErrorHandler, getFakeI18nInst } from 'tests/unit/helpers';
 import { dispatchClientMetadata, fakeCategory } from 'tests/unit/amo/helpers';
@@ -23,7 +20,6 @@ import ErrorList from 'ui/components/ErrorList';
 
 
 describe('Category', () => {
-  let category;
   let errorHandler;
   let store;
 
@@ -33,13 +29,6 @@ describe('Category', () => {
     });
     errorHandler = createStubErrorHandler();
     store = clientData.store;
-    category = {
-      id: 5,
-      description: 'I am a cool category for doing things',
-      name: 'Testing category',
-      slug: 'test',
-      type: ADDON_TYPE_THEME,
-    };
   });
 
   function _categoriesLoad(actionParams = {}) {
@@ -96,19 +85,6 @@ describe('Category', () => {
     }));
   }
 
-  function mountRender(props = { loading: false }) {
-    const { store } = dispatchClientMetadata();
-    return mount(
-      <Provider store={store}>
-        <I18nProvider i18n={getFakeI18nInst()}>
-          <CategoryBase
-            {...renderProps({ category: null, ...props })}
-          />
-        </I18nProvider>
-      </Provider>
-    );
-  }
-
   it('outputs a category page', () => {
     const root = render();
 
@@ -116,10 +92,12 @@ describe('Category', () => {
   });
 
   it('should render an error', () => {
-    const errorHandler = createStubErrorHandler(
-      new Error('example of an error')
-    );
-    const root = render({ errorHandler });
+    const root = render();
+    root.setProps({
+      errorHandler: createStubErrorHandler(
+        new Error('example of an error')
+      ),
+    });
 
     expect(root.find(ErrorList)).toHaveLength(1);
   });

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -77,14 +77,6 @@ describe('Category', () => {
     }));
   }
 
-  function _searchStart(overrides = {}) {
-    store.dispatch(searchStart({
-      errorHandlerId: errorHandler.id,
-      filters: { addonType: ADDON_TYPE_EXTENSION },
-      ...overrides,
-    }));
-  }
-
   it('outputs a category page', () => {
     const root = render();
 

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -3,11 +3,17 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import { CategoryBase, mapStateToProps } from 'amo/components/Category';
+import CategoryHeader from 'amo/components/CategoryHeader';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Search from 'amo/components/Search';
 import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
 import { searchStart } from 'core/actions/search';
-import { ADDON_TYPE_THEME, CLIENT_APP_FIREFOX } from 'core/constants';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
+} from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
 import I18nProvider from 'core/i18n/Provider';
 import { visibleAddonType } from 'core/utils';
@@ -16,19 +22,26 @@ import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
 
-function _categoriesFetch(overrides = {}) {
-  return categoriesFetch({
-    errorHandlerId: 'some-handler-id',
-    ...overrides,
-  });
-}
+const fakeCategory = {
+  id: 5,
+  application: CLIENT_APP_FIREFOX,
+  description: 'I am a cool category for doing things',
+  name: 'Testing category',
+  slug: 'test',
+  type: ADDON_TYPE_THEME,
+};
 
 describe('Category', () => {
   let category;
-  let fakeDispatch;
+  let errorHandler;
+  let store;
 
   beforeEach(() => {
-    fakeDispatch = sinon.stub();
+    const clientData = dispatchClientMetadata({
+      clientApp: CLIENT_APP_FIREFOX,
+    });
+    errorHandler = createStubErrorHandler();
+    store = clientData.store;
     category = {
       id: 5,
       description: 'I am a cool category for doing things',
@@ -38,22 +51,58 @@ describe('Category', () => {
     };
   });
 
-  function renderProps(customProps = {}) {
-    const errorHandler = new ErrorHandler({
-      id: 'some-handler-id',
-      dispatch: fakeDispatch,
-    });
+  function _categoriesLoad(actionParams = {}) {
+    store.dispatch(categoriesLoad({
+      result: [fakeCategory],
+      ...actionParams,
+    }));
+  }
+
+  function renderProps(
+    customProps = {},
+    {
+      autoDispatchCategories = true,
+      paramOverrides = {},
+    } = {}
+  ) {
+    if (autoDispatchCategories) {
+      _categoriesLoad();
+    }
+    const state = store.getState();
+
     return {
-      category,
-      dispatch: fakeDispatch,
+      ...mapStateToProps(state),
+      // TODO: remove when switching to shallowUntil
+      dispatch: store.dispatch,
       errorHandler,
       i18n: getFakeI18nInst(),
+      location: { query: {} },
+      params: {
+        slug: fakeCategory.slug,
+        visibleAddonType: visibleAddonType(fakeCategory.type),
+        ...paramOverrides,
+      },
       ...customProps,
     };
   }
 
-  function render(props = {}) {
-    return shallow(<CategoryBase {...renderProps(props)} />);
+  function render(props = {}, options = {}) {
+    return shallow(<CategoryBase {...renderProps(props, options)} />);
+  }
+
+  function _categoriesFetch(overrides = {}) {
+    store.dispatch(categoriesFetch({
+      errorHandlerId: errorHandler.id,
+      ...overrides,
+    }));
+  }
+
+  function _searchStart(overrides = {}) {
+    store.dispatch(searchStart({
+      errorHandlerId: errorHandler.id,
+      filters: { addonType: ADDON_TYPE_EXTENSION },
+      ...overrides,
+    }));
   }
 
   function mountRender(props = { loading: false }) {
@@ -75,33 +124,6 @@ describe('Category', () => {
     expect(root).toHaveClassName('Category');
   });
 
-  it('fetches categories when needed', () => {
-    const errorHandler = new ErrorHandler({
-      id: 'some-id',
-      dispatch: fakeDispatch,
-    });
-    render({ category: null, errorHandler });
-
-    sinon.assert.calledWithMatch(fakeDispatch, _categoriesFetch({
-      errorHandlerId: 'some-id',
-    }));
-  });
-
-  it('should return 404 if no category was found and loading is false', () => {
-    const root = mountRender({
-      category: null,
-      loading: false,
-    });
-
-    expect(root.find(NotFound)).toHaveLength(1);
-  });
-
-  it('should not return 404 if category is falsy and loading is true', () => {
-    const root = mountRender({ loading: true });
-
-    expect(root.find(NotFound)).toHaveLength(0);
-  });
-
   it('should render an error', () => {
     const errorHandler = createStubErrorHandler(
       new Error('example of an error')
@@ -112,126 +134,233 @@ describe('Category', () => {
   });
 
   it('should render an error without a category too', () => {
-    const errorHandler = createStubErrorHandler(
-      new Error('example of an error')
-    );
-    const root = render({ errorHandler, category: null, loading: false });
+    const root = render({}, {
+      paramOverrides: { slug: 'unknown-category' },
+    });
+    root.setProps({
+      errorHandler: createStubErrorHandler(new Error('example')),
+    });
 
     expect(root.find(ErrorList)).toHaveLength(1);
   });
 
-  it('disables the sort component in Search', () => {
+  it('configures a Search component', () => {
+    const location = { query: { page: 2 } };
+    const params = {
+      slug: fakeCategory.slug,
+      visibleAddonType: visibleAddonType(fakeCategory.type),
+    };
+    const root = render({ location, params });
+    const search = root.find(Search);
+
+    expect(search).toHaveProp('filters', {
+      addonType: fakeCategory.type,
+      category: fakeCategory.slug,
+      page: location.query.page,
+    });
+    expect(search).toHaveProp('paginationQueryParams', {
+      page: location.query.page,
+    });
+    expect(search).toHaveProp('pathname',
+      `/${params.visibleAddonType}/${fakeCategory.slug}/`);
+    expect(search).toHaveProp('enableSearchSort', false);
+  });
+
+  it('fetches categories when not yet loaded', () => {
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    render({}, { autoDispatchCategories: false });
+
+    sinon.assert.calledWithMatch(fakeDispatch, categoriesFetch({
+      errorHandlerId: errorHandler.id,
+    }));
+  });
+
+  it('does not fetch categories when already loaded', () => {
+    _categoriesLoad();
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    render({}, { autoDispatchCategories: false });
+
+    sinon.assert.notCalled(fakeDispatch);
+  });
+
+  it('does not fetch categories while already loading them', () => {
+    _categoriesFetch();
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    render({}, { autoDispatchCategories: false });
+
+    sinon.assert.notCalled(fakeDispatch);
+  });
+
+  it('passes a category to the header', () => {
     const root = render();
 
-    expect(root.find(Search)).toHaveProp('enableSearchSort', false);
+    expect(root.find(CategoryHeader)).toHaveProp('category', fakeCategory);
   });
-});
 
-describe('Category.mapStateToProps()', () => {
-  const fakeCategory = {
-    id: 5,
-    application: CLIENT_APP_FIREFOX,
-    description: 'I am a cool category for doing things',
-    name: 'Testing category',
-    slug: 'test',
-    type: ADDON_TYPE_THEME,
-  };
-  let filters;
-  let ownProps;
-  let store;
-
-  beforeAll(() => {
-    filters = {
-      addonType: ADDON_TYPE_THEME,
-      category: 'ad-block',
+  describe('category lookup', () => {
+    const decoyCategory = {
+      ...fakeCategory,
+      application: CLIENT_APP_FIREFOX,
+      type: ADDON_TYPE_THEME,
+      slug: 'decoy-slug',
     };
-    ownProps = {
-      location: { query: {} },
-      params: {
-        application: CLIENT_APP_FIREFOX,
-        visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
-        slug: 'ad-block',
-      },
+    const targetCategory = {
+      ...fakeCategory,
+      application: CLIENT_APP_ANDROID,
+      type: ADDON_TYPE_EXTENSION,
+      slug: 'target-slug',
     };
-  });
 
-  beforeEach(() => {
-    store = dispatchClientMetadata().store;
-    store.dispatch(categoriesLoad({ result: [fakeCategory] }));
-  });
+    const _dispatchClientApp = (clientApp) => dispatchClientMetadata({
+      store, clientApp,
+    });
 
-  function _searchStart(props = {}) {
-    store.dispatch(searchStart({
-      errorHandlerId: 'Search',
-      ...props,
-    }));
-  }
+    function _render(
+      props = {}, { autoDispatchCategories = true, ...options } = {}
+    ) {
+      if (autoDispatchCategories) {
+        _categoriesLoad({ result: [decoyCategory, targetCategory] });
+      }
+      return render(props, {
+        // Since we loaded our own, tell the parent helper not to.
+        autoDispatchCategories: false,
+        ...options,
+      });
+    }
 
-  it('passes category filters', () => {
-    _searchStart({ filters });
-    const props = mapStateToProps(store.getState(), ownProps);
+    it('looks for a category by slug, addonType, and clientApp', () => {
+      _dispatchClientApp(targetCategory.application);
 
-    expect(props).toEqual({
-      addonType: ADDON_TYPE_THEME,
-      category: null,
-      filters: { ...filters, page: 1 },
-      loading: true,
-      pathname: '/themes/ad-block/',
-      paginationQueryParams: { page: 1 },
+      const root = _render({
+        params: {
+          slug: targetCategory.slug,
+          visibleAddonType: visibleAddonType(targetCategory.type),
+        },
+      });
+
+      expect(root.find(CategoryHeader))
+        .toHaveProp('category', targetCategory);
+    });
+
+    it('renders a 404 for unknown category', () => {
+      const root = _render({}, {
+        paramOverrides: { slug: 'unknown-category' },
+      });
+
+      expect(root.find(NotFound)).toHaveLength(1);
+    });
+
+    it('renders 404 for mismatched clientApp', () => {
+      _dispatchClientApp(decoyCategory.application);
+
+      const root = _render({
+        params: {
+          slug: targetCategory.slug,
+          visibleAddonType: visibleAddonType(targetCategory.type),
+        },
+      });
+
+      expect(root.find(NotFound)).toHaveLength(1);
+    });
+
+    it('renders 404 for mismatched addonType', () => {
+      _dispatchClientApp(targetCategory.application);
+
+      const root = _render({
+        params: {
+          slug: targetCategory.slug,
+          visibleAddonType: visibleAddonType(decoyCategory.type),
+        },
+      });
+
+      expect(root.find(NotFound)).toHaveLength(1);
+    });
+
+    it('renders 404 for bogus addonType', () => {
+      _dispatchClientApp(targetCategory.application);
+
+      const root = _render({
+        params: {
+          slug: targetCategory.slug,
+          visibleAddonType: 'bogus-addon-type',
+        },
+      });
+
+      expect(root.find(NotFound)).toHaveLength(1);
+    });
+
+    it('renders 404 for bogus clientApp', () => {
+      _dispatchClientApp('not-a-valid-client-app');
+
+      const root = _render({
+        params: {
+          slug: targetCategory.slug,
+          visibleAddonType: visibleAddonType(targetCategory.type),
+        },
+      });
+
+      expect(root.find(NotFound)).toHaveLength(1);
+    });
+
+    it('does not render missing category 404 when error is present', () => {
+      const root = _render({}, {
+        paramOverrides: { slug: 'unknown-category' },
+      });
+      root.setProps({
+        errorHandler: createStubErrorHandler(new Error('example')),
+      });
+
+      expect(root.find(NotFound)).toHaveLength(0);
+    });
+
+    it('does not render missing category 404 while loading', () => {
+      _searchStart();
+      const root = _render({}, {
+        paramOverrides: { slug: 'unknown-category' },
+      });
+
+      expect(root.find(NotFound)).toHaveLength(0);
+      // Make sure the header is still rendered.
+      expect(root.find(CategoryHeader)).toHaveProp('category', undefined);
+    });
+
+    it('does not render missing category 404 before loading categories', () => {
+      const root = _render({}, {
+        autoDispatchCategories: false,
+        paramOverrides: { slug: 'unknown-category' },
+      });
+
+      expect(root.find(NotFound)).toHaveLength(0);
     });
   });
 
-  it('gets category from filters/state/etc.', () => {
-    const filtersWithSlug = {
-      ...filters,
-      category: 'test',
-    };
-    const ownPropsWithSlug = {
-      location: { query: {} },
-      params: {
-        application: CLIENT_APP_FIREFOX,
-        visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
-        slug: 'test',
-      },
-    };
-    _searchStart({ filters: filtersWithSlug });
-    const props = mapStateToProps(store.getState(), ownPropsWithSlug);
+  describe('loading', () => {
+    it('sets loading to true if categories and search are loading', () => {
+      _categoriesFetch();
+      _searchStart();
+      const root = render({}, { autoDispatchCategories: false });
 
-    expect(props).toEqual({
-      addonType: ADDON_TYPE_THEME,
-      category: fakeCategory,
-      filters: { ...filtersWithSlug, page: 1 },
-      loading: true,
-      pathname: '/themes/test/',
-      paginationQueryParams: { page: 1 },
+      expect(root.instance().props.loading).toEqual(true);
     });
-  });
 
-  it('sets loading to true if categories and search are loading', () => {
-    store.dispatch(_categoriesFetch());
-    _searchStart({ filters });
-    const props = mapStateToProps(store.getState(), ownProps);
+    it('sets loading to true if only categories are loading', () => {
+      _categoriesFetch();
+      const root = render({}, { autoDispatchCategories: false });
 
-    expect(props).toMatchObject({ loading: true });
-  });
+      expect(root.instance().props.loading).toEqual(true);
+    });
 
-  it('sets loading to true if only categories are loading', () => {
-    store.dispatch(_categoriesFetch());
-    const props = mapStateToProps(store.getState(), ownProps);
+    it('sets loading to true if only search is loading', () => {
+      _searchStart();
+      const root = render({}, { autoDispatchCategories: false });
 
-    expect(props).toMatchObject({ loading: true });
-  });
+      expect(root.instance().props.loading).toEqual(true);
+    });
 
-  it('sets loading to true if only search is loading', () => {
-    _searchStart({ filters });
-    const props = mapStateToProps(store.getState(), ownProps);
+    it('sets loading to false if nothing is loading', () => {
+      const root = render({}, { autoDispatchCategories: false });
 
-    expect(props).toMatchObject({ loading: true });
-  });
-
-  it('sets loading to false if nothing is loading', () => {
-    const props = mapStateToProps(store.getState(), ownProps);
-
-    expect(props).toMatchObject({ loading: false });
+      expect(root.instance().props.loading).toEqual(false);
+    });
   });
 });

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -142,6 +142,14 @@ describe('Category', () => {
     sinon.assert.notCalled(fakeDispatch);
   });
 
+  it('does not fetch categories when an empty set was loaded', () => {
+    _categoriesLoad({ result: [] });
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    render({}, { autoDispatchCategories: false });
+
+    sinon.assert.notCalled(fakeDispatch);
+  });
+
   it('does not fetch categories while already loading them', () => {
     _categoriesFetch();
     const fakeDispatch = sinon.stub(store, 'dispatch');

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -6,7 +6,6 @@ import CategoryHeader from 'amo/components/CategoryHeader';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Search from 'amo/components/Search';
 import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
-import { searchStart } from 'core/actions/search';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -166,6 +166,19 @@ describe('Category', () => {
     expect(root.find(CategoryHeader)).toHaveProp('category', fakeCategory);
   });
 
+  it('sets loading to true if categories are loading', () => {
+    _categoriesFetch();
+    const root = render({}, { autoDispatchCategories: false });
+
+    expect(root.instance().props.loading).toEqual(true);
+  });
+
+  it('sets loading to false if nothing is loading', () => {
+    const root = render({}, { autoDispatchCategories: false });
+
+    expect(root.instance().props.loading).toEqual(false);
+  });
+
   describe('category lookup', () => {
     const decoyCategory = {
       ...fakeCategory,
@@ -283,8 +296,9 @@ describe('Category', () => {
     });
 
     it('does not render missing category 404 while loading', () => {
-      _searchStart();
+      _categoriesFetch();
       const root = _render({}, {
+        autoDispatchCategories: false,
         paramOverrides: { slug: 'unknown-category' },
       });
 
@@ -300,36 +314,6 @@ describe('Category', () => {
       });
 
       expect(root.find(NotFound)).toHaveLength(0);
-    });
-  });
-
-  describe('loading', () => {
-    it('sets loading to true if categories and search are loading', () => {
-      _categoriesFetch();
-      _searchStart();
-      const root = render({}, { autoDispatchCategories: false });
-
-      expect(root.instance().props.loading).toEqual(true);
-    });
-
-    it('sets loading to true if only categories are loading', () => {
-      _categoriesFetch();
-      const root = render({}, { autoDispatchCategories: false });
-
-      expect(root.instance().props.loading).toEqual(true);
-    });
-
-    it('sets loading to true if only search is loading', () => {
-      _searchStart();
-      const root = render({}, { autoDispatchCategories: false });
-
-      expect(root.instance().props.loading).toEqual(true);
-    });
-
-    it('sets loading to false if nothing is loading', () => {
-      const root = render({}, { autoDispatchCategories: false });
-
-      expect(root.instance().props.loading).toEqual(false);
     });
   });
 });

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -5,6 +5,7 @@ import {
   setClientApp, setLang, setAuthToken, setUserAgent,
 } from 'core/actions';
 import { addon as addonSchema } from 'core/api';
+import { ADDON_TYPE_THEME, CLIENT_APP_FIREFOX } from 'core/constants';
 import { searchLoad, searchStart } from 'core/actions/search';
 
 import {
@@ -61,6 +62,17 @@ export const fakeReview = Object.freeze({
   body: 'It is Okay',
   title: 'Review Title',
 });
+
+const fakeCategory = {
+  application: CLIENT_APP_FIREFOX,
+  description: 'I am a cool category for doing things',
+  id: 5,
+  misc: false,
+  name: 'Testing category',
+  slug: 'test',
+  type: ADDON_TYPE_THEME,
+  weight: 1,
+};
 
 /*
  * Redux store state for when a user has signed in.

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -63,7 +63,7 @@ export const fakeReview = Object.freeze({
   title: 'Review Title',
 });
 
-const fakeCategory = {
+export const fakeCategory = Object.freeze({
   application: CLIENT_APP_FIREFOX,
   description: 'I am a cool category for doing things',
   id: 5,
@@ -72,7 +72,7 @@ const fakeCategory = {
   slug: 'test',
   type: ADDON_TYPE_THEME,
   weight: 1,
-};
+});
 
 /*
  * Redux store state for when a user has signed in.

--- a/tests/unit/core/reducers/test_categories.js
+++ b/tests/unit/core/reducers/test_categories.js
@@ -5,19 +5,20 @@ import {
   ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
 } from 'core/constants';
-import { categoriesFetch } from 'core/actions/categories';
-import categories, { emptyCategoryList } from 'core/reducers/categories';
+import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
+import categories, {
+  initialState, emptyCategoryList,
+} from 'core/reducers/categories';
+import { fakeCategory } from 'tests/unit/amo/helpers';
 
 
 describe('categories reducer', () => {
-  const initialState = {
-    categories: emptyCategoryList(), loading: true,
-  };
-
   it('defaults to an empty set of categories', () => {
-    const state = categories(initialState, { type: 'unrelated' });
-    expect(state.categories).toEqual(emptyCategoryList());
+    const state = categories(undefined, { type: 'unrelated' });
+    expect(state.categories).toEqual(null);
   });
 
   it('defaults to not loading', () => {
@@ -29,7 +30,7 @@ describe('categories reducer', () => {
     it('sets loading', () => {
       const state = categories(initialState,
         categoriesFetch({ errorHandlerId: 'some-handler' }));
-      expect(state.categories).toEqual(emptyCategoryList());
+      expect(state.categories).toEqual(null);
       expect(state.loading).toEqual(true);
     });
   });
@@ -40,127 +41,139 @@ describe('categories reducer', () => {
     beforeAll(() => {
       const result = [
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Alerts & Update',
           slug: 'alert-update',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Games',
           slug: 'Games',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Blogging',
           slug: 'blogging',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Naturé',
           slug: 'naturé',
           type: ADDON_TYPE_THEME,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Painting',
           slug: 'painting',
           type: ADDON_TYPE_THEME,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Anime',
           slug: 'anime',
           type: ADDON_TYPE_THEME,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Alerts & Update',
           slug: 'alert-update',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Security',
           slug: 'security',
           type: ADDON_TYPE_EXTENSION,
         },
         {
+          ...fakeCategory,
           application: 'netscape',
           name: 'I should not appear',
           slug: 'i-should-not-appear',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'I should also not appear',
           slug: 'i-should-also-not-appear',
           type: 'FAKE_TYPE',
         },
       ];
-      state = categories(initialState, {
-        type: 'CATEGORIES_LOAD',
-        payload: { result },
-      });
+      state = categories(initialState, categoriesLoad({ result }));
     });
 
     it('sets the categories in a sorted order', () => {
       const result = [
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Alerts & Update',
           slug: 'alert-update',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Blogging',
           slug: 'blogging',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'android',
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
           name: 'Games',
           slug: 'Games',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Alerts & Update',
           slug: 'alert-update',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Security',
           slug: 'security',
           type: ADDON_TYPE_EXTENSION,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Anime',
           slug: 'anime',
           type: ADDON_TYPE_THEME,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Naturé',
           slug: 'naturé',
           type: ADDON_TYPE_THEME,
         },
         {
-          application: 'firefox',
+          ...fakeCategory,
+          application: CLIENT_APP_FIREFOX,
           name: 'Painting',
           slug: 'painting',
           type: ADDON_TYPE_THEME,
         },
       ];
-      state = categories(initialState, {
-        type: 'CATEGORIES_LOAD',
-        payload: { result },
-      });
+      state = categories(initialState, categoriesLoad({ result }));
 
       // Notice all Firefox theme categories are also set as Android theme
       // categories and no Android categories are returned. This reflects the
@@ -175,13 +188,15 @@ describe('categories reducer', () => {
           [ADDON_TYPE_DICT]: {},
           [ADDON_TYPE_EXTENSION]: {
             'alert-update': {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Alerts & Update',
               slug: 'alert-update',
               type: ADDON_TYPE_EXTENSION,
             },
             security: {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Security',
               slug: 'security',
               type: ADDON_TYPE_EXTENSION,
@@ -191,19 +206,22 @@ describe('categories reducer', () => {
           [ADDON_TYPE_OPENSEARCH]: {},
           [ADDON_TYPE_THEME]: {
             anime: {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Anime',
               slug: 'anime',
               type: ADDON_TYPE_THEME,
             },
             naturé: {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Naturé',
               slug: 'naturé',
               type: ADDON_TYPE_THEME,
             },
             painting: {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Painting',
               slug: 'painting',
               type: ADDON_TYPE_THEME,
@@ -215,19 +233,22 @@ describe('categories reducer', () => {
           [ADDON_TYPE_DICT]: {},
           [ADDON_TYPE_EXTENSION]: {
             'alert-update': {
-              application: 'android',
+              ...fakeCategory,
+              application: CLIENT_APP_ANDROID,
               name: 'Alerts & Update',
               slug: 'alert-update',
               type: ADDON_TYPE_EXTENSION,
             },
             blogging: {
-              application: 'android',
+              ...fakeCategory,
+              application: CLIENT_APP_ANDROID,
               name: 'Blogging',
               slug: 'blogging',
               type: ADDON_TYPE_EXTENSION,
             },
             Games: {
-              application: 'android',
+              ...fakeCategory,
+              application: CLIENT_APP_ANDROID,
               name: 'Games',
               slug: 'Games',
               type: ADDON_TYPE_EXTENSION,
@@ -237,19 +258,22 @@ describe('categories reducer', () => {
           [ADDON_TYPE_OPENSEARCH]: {},
           [ADDON_TYPE_THEME]: {
             anime: {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Anime',
               slug: 'anime',
               type: ADDON_TYPE_THEME,
             },
             naturé: {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Naturé',
               slug: 'naturé',
               type: ADDON_TYPE_THEME,
             },
             painting: {
-              application: 'firefox',
+              ...fakeCategory,
+              application: CLIENT_APP_FIREFOX,
               name: 'Painting',
               slug: 'painting',
               type: ADDON_TYPE_THEME,

--- a/tests/unit/core/reducers/test_categories.js
+++ b/tests/unit/core/reducers/test_categories.js
@@ -9,9 +9,7 @@ import {
   CLIENT_APP_FIREFOX,
 } from 'core/constants';
 import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
-import categories, {
-  initialState, emptyCategoryList,
-} from 'core/reducers/categories';
+import categories, { initialState } from 'core/reducers/categories';
 import { fakeCategory } from 'tests/unit/amo/helpers';
 
 

--- a/tests/unit/core/test_utils.js
+++ b/tests/unit/core/test_utils.js
@@ -12,14 +12,12 @@ import { compose } from 'redux';
 import UAParser from 'ua-parser-js';
 
 import * as actions from 'core/actions';
-import { categoriesLoad } from 'core/actions/categories';
 import * as api from 'core/api';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
   CATEGORY_COLORS,
-  CLIENT_APP_FIREFOX,
   INCOMPATIBLE_FIREFOX_FOR_IOS,
   INCOMPATIBLE_NO_OPENSEARCH,
   INCOMPATIBLE_NOT_FIREFOX,
@@ -55,7 +53,6 @@ import NotFound from 'core/components/ErrorPage/NotFound';
 import I18nProvider from 'core/i18n/Provider';
 import {
   fakeAddon,
-  dispatchClientMetadata,
   signedInApiState,
 } from 'tests/unit/amo/helpers';
 import {

--- a/tests/unit/core/test_utils.js
+++ b/tests/unit/core/test_utils.js
@@ -33,7 +33,6 @@ import {
   convertBoolean,
   findAddon,
   getCategoryColor,
-  getCategoryFromState,
   getClientApp,
   getClientCompatibility,
   getClientConfig,
@@ -1026,65 +1025,6 @@ describe('getCategoryColor', () => {
     const categoryColor = getCategoryColor(category);
 
     expect(categoryColor).toEqual(1);
-  });
-});
-
-describe('getCategoryFromState', () => {
-  it('handles missing category', () => {
-    const addonType = ADDON_TYPE_EXTENSION;
-    const categorySlug = 'foo';
-    const clientApp = CLIENT_APP_FIREFOX;
-    const { state } = dispatchClientMetadata();
-
-    const category = getCategoryFromState({
-      addonType, clientApp, categorySlug, state });
-
-    expect(category).toBeNull();
-  });
-
-  it('handles unknown clientApp', () => {
-    const addonType = ADDON_TYPE_EXTENSION;
-    const categorySlug = 'foo';
-    const clientApp = 'not a real thing';
-    const { state } = dispatchClientMetadata();
-
-    const category = getCategoryFromState({
-      addonType, clientApp, categorySlug, state });
-
-    expect(category).toBeNull();
-  });
-
-  it('handles unknown addonType', () => {
-    const addonType = 'not real';
-    const categorySlug = 'foo';
-    const clientApp = CLIENT_APP_FIREFOX;
-    const { state } = dispatchClientMetadata();
-
-    const category = getCategoryFromState({
-      addonType, clientApp, categorySlug, state });
-
-    expect(category).toBeNull();
-  });
-
-  it('returns a category', () => {
-    const addonType = ADDON_TYPE_THEME;
-    const fakeCategory = {
-      id: 5,
-      application: CLIENT_APP_FIREFOX,
-      description: 'I am a cool category for doing things',
-      name: 'Testing category',
-      slug: 'test',
-      type: ADDON_TYPE_THEME,
-    };
-    const categorySlug = 'test';
-    const clientApp = CLIENT_APP_FIREFOX;
-    const { store } = dispatchClientMetadata();
-    store.dispatch(categoriesLoad({ result: [fakeCategory] }));
-
-    const category = getCategoryFromState({
-      addonType, clientApp, categorySlug, state: store.getState() });
-
-    expect(category).toMatchObject(fakeCategory);
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2949

Notes:
* `Category` loads data only when needed now
* `Search` is rendered while loading which is necessary so it can dispatch its own loading actions
* Category state is initialized properly but that required some re-design of a few things
* I spent extra time making sure the test coverage was right since this fixed a serious bug
* I was relying server logging to track this down so I cleaned up a bunch of PropType typos
* Since we need to cherry-pick this ASAP, I can address minor change requests in a follow-up