### PR TITLE
fix: Use AddonsCard instead of SearchResults for featured (fix #2957)

### DIFF
--- a/src/amo/components/FeaturedAddons/index.js
+++ b/src/amo/components/FeaturedAddons/index.js
@@ -6,7 +6,7 @@ import { compose } from 'redux';
 
 import { getFeatured } from 'amo/actions/featured';
 import { setViewContext } from 'amo/actions/viewContext';
-import SearchResults from 'amo/components/SearchResults';
+import AddonsCard from 'amo/components/AddonsCard';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -87,10 +87,9 @@ export class FeaturedAddonsBase extends React.Component {
         <h2 className="FeaturedAddons-header">
           {this.headerForAddonType()}
         </h2>
-        <SearchResults
-          count={results && results.length}
+        <AddonsCard
+          addons={loading ? null : results}
           loading={loading}
-          results={loading ? null : results}
         />
       </div>
     );

--- a/src/amo/components/FeaturedAddons/styles.scss
+++ b/src/amo/components/FeaturedAddons/styles.scss
@@ -4,7 +4,7 @@
   margin: 10px;
 }
 
-.FeaturedAddons .SearchResults {
+.FeaturedAddons .AddonsCard {
   margin: 0 10px;
 }
 

--- a/tests/unit/amo/components/TestFeaturedAddons.js
+++ b/tests/unit/amo/components/TestFeaturedAddons.js
@@ -7,7 +7,7 @@ import {
   FeaturedAddonsBase,
   mapStateToProps,
 } from 'amo/components/FeaturedAddons';
-import SearchResults from 'amo/components/SearchResults';
+import AddonsCard from 'amo/components/AddonsCard';
 import {
   ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME,
 } from 'core/constants';
@@ -251,7 +251,7 @@ describe('<FeaturedAddons />', () => {
     store.dispatch(_getFeatured({ addonType: ADDON_TYPE_EXTENSION }));
     const root = render(mapStateToProps(store.getState()));
 
-    expect(root.find(SearchResults)).toHaveProp('loading', true);
+    expect(root.find(AddonsCard)).toHaveProp('loading', true);
   });
 
   it('does not render old results while loading', () => {
@@ -261,8 +261,8 @@ describe('<FeaturedAddons />', () => {
     store.dispatch(_getFeatured({ addonType: ADDON_TYPE_EXTENSION }));
     const root = render(mapStateToProps(store.getState()));
 
-    expect(root.find(SearchResults)).toHaveProp('loading', true);
-    expect(root.find(SearchResults)).toHaveProp('results', null);
+    expect(root.find(AddonsCard)).toHaveProp('loading', true);
+    expect(root.find(AddonsCard)).toHaveProp('addons', null);
   });
 
   it('renders each add-on when set', () => {
@@ -275,7 +275,7 @@ describe('<FeaturedAddons />', () => {
     const root = render(mapStateToProps(store.getState()));
 
     expect(
-      root.find(SearchResults).prop('results').map((result) => result.name)
+      root.find(AddonsCard).prop('addons').map((result) => result.name)
     ).toEqual(['Howdy', 'Howdy again']);
   });
 


### PR DESCRIPTION
### Before
![morefeatured](https://user-images.githubusercontent.com/1583842/29373129-e727e896-82b5-11e7-821c-16ca5d2efa56.gif)

### After
<img width="1181" alt="screenshot 2017-08-17 15 07 34" src="https://user-images.githubusercontent.com/90871/29416457-080879ba-835e-11e7-9059-85ee3448af66.png">
