### PR TITLE
	Add badge for needs restart

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -315,7 +315,7 @@ export class AddonBase extends React.Component {
       });
       isCompatible = compatibility.compatible;
       isFeatured = addon.is_featured;
-      isRestartRequired = addon.is_restart_required;
+      isRestartRequired = addon.isRestartRequired;
     }
 
     return (

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -307,6 +307,7 @@ export class AddonBase extends React.Component {
 
     let isCompatible = false;
     let isFeatured = false;
+    let isRestartRequired = false;
     let compatibility;
     if (addon) {
       compatibility = getClientCompatibility({
@@ -314,6 +315,7 @@ export class AddonBase extends React.Component {
       });
       isCompatible = compatibility.compatible;
       isFeatured = addon.is_featured;
+      isRestartRequired = addon.is_restart_required;
     }
 
     return (
@@ -329,6 +331,12 @@ export class AddonBase extends React.Component {
                 <Badge
                   type="featured"
                   label={this.getFeaturedText(addonType)}
+                />
+              ) : null}
+              {isRestartRequired ? (
+                <Badge
+                  type="restart-required"
+                  label={i18n.gettext('Restart Required')}
                 />
               ) : null}
             </div>

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -131,7 +131,7 @@
 .Addon-badges {
   flex-basis: 100%;
   flex-grow: 1;
-  margin: 10px 0;
+  margin-bottom: 10px;
   order: 3;
 }
 

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -128,16 +128,9 @@
   }
 }
 
-.Addon-badges {
-  flex-basis: 100%;
-  flex-grow: 1;
-  margin-bottom: 10px;
-  order: 3;
-}
-
 .Addon .InstallButton {
   margin-top: auto;
-  order: 4;
+  order: 3;
 }
 
 .Addon .InstallButton {
@@ -146,6 +139,13 @@
 
     align-self: flex-end;
   }
+}
+
+.Addon-badges {
+  flex-basis: 100%;
+  flex-grow: 1;
+  margin-bottom: 10px;
+  order: 4;
 }
 
 // Details section with lots of grid stuff, on larger displays.

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -17,6 +17,7 @@ export function denormalizeAddon(apiAddon) {
       ...apiAddon,
       // Set iconUrl to be consistent between disco and amo.
       iconUrl: apiAddon.icon_url,
+      is_restart_required: apiAddon.is_restart_required || false,
     };
   }
   return apiAddon;
@@ -48,6 +49,7 @@ export default function addon(state = initialState, action) {
         newState[key] = {
           ...thisAddon,
           installURL: thisAddon.current_version.files[0].url,
+          is_restart_required: thisAddon.current_version.files[0].is_restart_required,
         };
       } else {
         newState[key] = thisAddon;

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -17,7 +17,6 @@ export function denormalizeAddon(apiAddon) {
       ...apiAddon,
       // Set iconUrl to be consistent between disco and amo.
       iconUrl: apiAddon.icon_url,
-      is_restart_required: apiAddon.is_restart_required || false,
     };
   }
   return apiAddon;
@@ -28,7 +27,10 @@ export default function addon(state = initialState, action) {
   if (payload && payload.entities && payload.entities.addons) {
     const newState = { ...state };
     Object.keys(payload.entities.addons).forEach((key) => {
-      const thisAddon = payload.entities.addons[key];
+      const thisAddon = {
+        ...payload.entities.addons[key],
+        isRestartRequired: false,
+      };
       if (thisAddon.theme_data) {
         newState[key] = {
           ...thisAddon,
@@ -48,8 +50,10 @@ export default function addon(state = initialState, action) {
       } else if (thisAddon.current_version && thisAddon.current_version.files.length > 0) {
         newState[key] = {
           ...thisAddon,
-          installURL: thisAddon.current_version.files[0].url,
-          is_restart_required: thisAddon.current_version.files[0].is_restart_required,
+          installURL: thisAddon.current_version.files[0].url || '',
+          isRestartRequired: thisAddon.current_version.files.some(
+            (file) => !!file.is_restart_required
+          ),
         };
       } else {
         newState[key] = thisAddon;

--- a/src/ui/components/Badge/index.js
+++ b/src/ui/components/Badge/index.js
@@ -7,11 +7,11 @@ import './styles.scss';
 
 type Props = {|
   label: string,
-  type?: 'featured',
+  type?: 'featured' | 'restart-required',
 |};
 
 const Badge = ({ label, type }: Props) => {
-  if (type && !['featured'].includes(type)) {
+  if (type && !['featured', 'restart-required'].includes(type)) {
     throw new Error(`Invalid badge type given: "${type}"`);
   }
 

--- a/src/ui/components/Badge/index.js
+++ b/src/ui/components/Badge/index.js
@@ -5,10 +5,21 @@ import Icon from 'ui/components/Icon';
 
 import './styles.scss';
 
+
 type Props = {|
   label: string,
   type?: 'featured' | 'restart-required',
 |};
+
+const getIconNameForType = (type) => {
+  switch (type) {
+    case 'restart-required':
+      return 'restart';
+    default:
+  }
+
+  return type;
+};
 
 const Badge = ({ label, type }: Props) => {
   if (type && !['featured', 'restart-required'].includes(type)) {
@@ -17,7 +28,7 @@ const Badge = ({ label, type }: Props) => {
 
   return (
     <span className={type ? `Badge Badge-${type}` : 'Badge'}>
-      {type && <Icon alt={label} name={type} />}
+      {type && <Icon alt={label} name={getIconNameForType(type)} />}
       {label}
     </span>
   );

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -28,7 +28,7 @@
 .Badge-restart-required {
   background-color: $yellow-50;
 
-  .Icon-restart-required {
+  .Icon-restart {
     margin-top: -2px;
   }
 }

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -10,16 +10,25 @@
   display: inline-block;
   font-size: $font-size-s;
   line-height: 1.3;
+  margin-top: 10px;
   padding: 8px 12px 6px;
   text-align: center;
+
+  .Icon {
+    @include margin-end(10px);
+
+    vertical-align: middle;
+  }
 }
 
 .Badge-featured {
   background-color: $teal-50;
+}
 
-  .Icon-featured {
-    @include margin-end(10px);
+.Badge-restart-required {
+  background-color: $yellow-50;
 
-    vertical-align: middle;
+  .Icon-restart-required {
+    margin-top: -2px;
   }
 }

--- a/src/ui/components/Icon/restart.svg
+++ b/src/ui/components/Icon/restart.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="15px" height="16px" viewBox="0 0 15 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <title>Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Screens" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Extension-Detail---1366px" transform="translate(-402.000000, -465.000000)" fill-rule="nonzero" fill="#000000">
+            <g id="Group-130" transform="translate(389.000000, 456.000000)">
+                <path d="M20.5,23 C17.5,23 15,20.5 15,17.5 C15,14.5 17.5,12 20.5,12 C21.7,12 22.7,12.4 23.7,13 L21,13 L21,15 L27,15 L27,9 L25,9 L25,11.5 C23.7,10.5 22.2,10 20.5,10 C16.4,10 13,13.4 13,17.5 C13,21.6 16.4,25 20.5,25 C24.6,25 28,21.6 28,17.5 L26,17.5 C26,20.5 23.5,23 20.5,23 Z" id="Shape"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -116,6 +116,6 @@
   @include icon($name: "featured");
 }
 
-.Icon-restart-required {
+.Icon-restart {
   @include icon($name: "restart");
 }

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -115,3 +115,8 @@
 .Icon-featured {
   @include icon($name: "featured");
 }
+
+.Icon-restart,
+.Icon-restart-required {
+  @include icon($name: "restart");
+}

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -116,7 +116,6 @@
   @include icon($name: "featured");
 }
 
-.Icon-restart,
 .Icon-restart-required {
   @include icon($name: "restart");
 }

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -780,7 +780,7 @@ describe('mapStateToProps', () => {
   });
 
   it('displays a badge when the addon needs restart', () => {
-    const addon = { ...fakeAddon, is_restart_required: true };
+    const addon = { ...fakeAddon, isRestartRequired: true };
     const root = shallowRender({ addon });
 
     expect(root.find(Badge)).toHaveProp('type', 'restart-required');
@@ -788,13 +788,13 @@ describe('mapStateToProps', () => {
   });
 
   it('does not display the "restart required" badge when addon does not need restart', () => {
-    const addon = { ...fakeAddon, is_restart_required: false };
+    const addon = { ...fakeAddon, isRestartRequired: false };
     const root = shallowRender({ addon });
 
     expect(root.find(Badge)).toHaveLength(0);
   });
 
-  it('does not display the "restart required" badge when is_restart_required is not true', () => {
+  it('does not display the "restart required" badge when isRestartRequired is not true', () => {
     const root = shallowRender({ addon: fakeAddon });
 
     expect(root.find(Badge)).toHaveLength(0);

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -778,4 +778,25 @@ describe('mapStateToProps', () => {
 
     expect(root.find(Badge)).toHaveLength(0);
   });
+
+  it('displays a badge when the addon needs restart', () => {
+    const addon = { ...fakeAddon, is_restart_required: true };
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'restart-required');
+    expect(root.find(Badge)).toHaveProp('label', 'Restart Required');
+  });
+
+  it('does not display the "restart required" badge when addon does not need restart', () => {
+    const addon = { ...fakeAddon, is_restart_required: false };
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
+
+  it('does not display the "restart required" badge when is_restart_required is not true', () => {
+    const root = shallowRender({ addon: fakeAddon });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
 });

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -347,7 +347,11 @@ describe('amo/components/AddonReviewList', () => {
     it('loads addon from state', () => {
       store.dispatch(loadEntities(createFetchAddonResult(fakeAddon).entities));
       const props = getMappedProps();
-      expect(props.addon).toEqual(denormalizeAddon(fakeAddon));
+      expect(props.addon).toEqual(denormalizeAddon({
+        ...fakeAddon,
+        installURL: '',
+        isRestartRequired: false,
+      }));
     });
 
     it('ignores other add-ons', () => {

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -149,3 +149,16 @@ export function createFakeAutocompleteResult({ name = 'suggestion-result' } = {}
     url: `https://example.org/en-US/firefox/addons/${name}/`,
   };
 }
+
+export function createFakeAddon({ extraFileProps = {} } = {}) {
+  return {
+    ...fakeAddon,
+    current_version: {
+      ...fakeAddon.current_version,
+      files: [{
+        ...fakeAddon.current_version.files[0],
+        ...extraFileProps,
+      }],
+    },
+  };
+}

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -150,15 +150,12 @@ export function createFakeAutocompleteResult({ name = 'suggestion-result' } = {}
   };
 }
 
-export function createFakeAddon({ extraFileProps = {} } = {}) {
+export function createFakeAddon({ files = {} } = {}) {
   return {
     ...fakeAddon,
     current_version: {
       ...fakeAddon.current_version,
-      files: [{
-        ...fakeAddon.current_version.files[0],
-        ...extraFileProps,
-      }],
+      files,
     },
   };
 }

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -2,7 +2,7 @@ import { loadEntities } from 'core/actions';
 import { ADDON_TYPE_THEME } from 'core/constants';
 import addons, { denormalizeAddon } from 'core/reducers/addons';
 import { createFetchAddonResult } from 'tests/unit/helpers';
-import { fakeAddon } from 'tests/unit/amo/helpers';
+import { createFakeAddon, fakeAddon } from 'tests/unit/amo/helpers';
 
 
 describe('addon reducer', () => {
@@ -29,7 +29,11 @@ describe('addon reducer', () => {
       loadEntities(createFetchAddonResult(anotherFakeAddon).entities));
     expect(newAddonsState).toEqual({
       ...addonsState,
-      [anotherFakeAddon.slug]: denormalizeAddon(anotherFakeAddon),
+      [anotherFakeAddon.slug]: denormalizeAddon({
+        ...anotherFakeAddon,
+        installURL: '',
+        isRestartRequired: false,
+      }),
     });
   });
 
@@ -49,11 +53,12 @@ describe('addon reducer', () => {
       installable: denormalizeAddon({
         ...addon,
         installURL: 'https://a.m.o/download.xpi',
+        isRestartRequired: false,
       }),
     });
   });
 
-  it('sets the icon_url as iconUrl and adds is_restart_required', () => {
+  it('sets the icon_url as iconUrl', () => {
     const addon = {
       ...fakeAddon,
       slug: 'installable',
@@ -66,7 +71,8 @@ describe('addon reducer', () => {
       installable: {
         ...addon,
         iconUrl: addon.icon_url,
-        is_restart_required: false,
+        installURL: '',
+        isRestartRequired: false,
       },
     });
   });
@@ -107,22 +113,16 @@ describe('addon reducer', () => {
     });
   });
 
-  it('reads "is_restart_required" attribute from the file', () => {
-    const addon = {
-      ...fakeAddon,
-      slug: 'installable',
-      current_version: {
-        ...fakeAddon.current_version,
-        files: [{ is_restart_required: true }, { file: 'data' }],
-      },
-    };
+  it('exposes "isRestartRequired" attribute from current version files', () => {
+    const addon = createFakeAddon({ extraFileProps: { is_restart_required: true } });
 
     expect(
       addons(undefined, loadEntities(createFetchAddonResult(addon).entities))
     ).toEqual({
-      installable: denormalizeAddon({
+      [addon.slug]: denormalizeAddon({
         ...addon,
-        is_restart_required: true,
+        installURL: '',
+        isRestartRequired: true,
       }),
     });
   });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -33,7 +33,7 @@ describe('addon reducer', () => {
     });
   });
 
-  it('pulls down the install URL from the file', () => {
+  it('reads the install URL from the file', () => {
     const addon = {
       ...fakeAddon,
       slug: 'installable',
@@ -53,7 +53,7 @@ describe('addon reducer', () => {
     });
   });
 
-  it('sets the icon_url as iconUrl', () => {
+  it('sets the icon_url as iconUrl and adds is_restart_required', () => {
     const addon = {
       ...fakeAddon,
       slug: 'installable',
@@ -66,6 +66,7 @@ describe('addon reducer', () => {
       installable: {
         ...addon,
         iconUrl: addon.icon_url,
+        is_restart_required: false,
       },
     });
   });
@@ -103,6 +104,26 @@ describe('addon reducer', () => {
 
     expect(state).toMatchObject({
       baz: { description: null },
+    });
+  });
+
+  it('reads "is_restart_required" attribute from the file', () => {
+    const addon = {
+      ...fakeAddon,
+      slug: 'installable',
+      current_version: {
+        ...fakeAddon.current_version,
+        files: [{ is_restart_required: true }, { file: 'data' }],
+      },
+    };
+
+    expect(
+      addons(undefined, loadEntities(createFetchAddonResult(addon).entities))
+    ).toEqual({
+      installable: denormalizeAddon({
+        ...addon,
+        is_restart_required: true,
+      }),
     });
   });
 });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -113,7 +113,7 @@ describe('addon reducer', () => {
     });
   });
 
-  it('exposes "isRestartRequired" attribute from current version files', () => {
+  it('exposes `isRestartRequired` attribute from current version files', () => {
     const addon = createFakeAddon({
       files: [
         { ...fakeAddon.current_version.files[0], is_restart_required: true },
@@ -131,7 +131,7 @@ describe('addon reducer', () => {
     });
   });
 
-  it('sets "isRestartRequired" to "false" when addon does not need restart', () => {
+  it('sets `isRestartRequired` to `false` when addon does not need restart', () => {
     const addon = createFakeAddon({
       files: [
         { ...fakeAddon.current_version.files[0], is_restart_required: false },
@@ -149,7 +149,7 @@ describe('addon reducer', () => {
     });
   });
 
-  it('sets "isRestartRequired" to "false" when addon does not have any files', () => {
+  it('sets `isRestartRequired` to `false` when addon does not have any files', () => {
     const addon = createFakeAddon({ files: [] });
 
     expect(
@@ -162,7 +162,7 @@ describe('addon reducer', () => {
     });
   });
 
-  it('sets "isRestartRequired" to "true" when at least one of the files declares it', () => {
+  it('sets `isRestartRequired` to `true` when at least one of the files declares it', () => {
     const addon = createFakeAddon({
       files: [
         { ...fakeAddon.current_version.files[0], is_restart_required: false },

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -114,7 +114,61 @@ describe('addon reducer', () => {
   });
 
   it('exposes "isRestartRequired" attribute from current version files', () => {
-    const addon = createFakeAddon({ extraFileProps: { is_restart_required: true } });
+    const addon = createFakeAddon({
+      files: [
+        { ...fakeAddon.current_version.files[0], is_restart_required: true },
+      ],
+    });
+
+    expect(
+      addons(undefined, loadEntities(createFetchAddonResult(addon).entities))
+    ).toEqual({
+      [addon.slug]: denormalizeAddon({
+        ...addon,
+        installURL: '',
+        isRestartRequired: true,
+      }),
+    });
+  });
+
+  it('sets "isRestartRequired" to "false" when addon does not need restart', () => {
+    const addon = createFakeAddon({
+      files: [
+        { ...fakeAddon.current_version.files[0], is_restart_required: false },
+      ],
+    });
+
+    expect(
+      addons(undefined, loadEntities(createFetchAddonResult(addon).entities))
+    ).toEqual({
+      [addon.slug]: denormalizeAddon({
+        ...addon,
+        installURL: '',
+        isRestartRequired: false,
+      }),
+    });
+  });
+
+  it('sets "isRestartRequired" to "false" when addon does not have any files', () => {
+    const addon = createFakeAddon({ files: [] });
+
+    expect(
+      addons(undefined, loadEntities(createFetchAddonResult(addon).entities))
+    ).toEqual({
+      [addon.slug]: denormalizeAddon({
+        ...addon,
+        isRestartRequired: false,
+      }),
+    });
+  });
+
+  it('sets "isRestartRequired" to "true" when at least one of the files declares it', () => {
+    const addon = createFakeAddon({
+      files: [
+        { ...fakeAddon.current_version.files[0], is_restart_required: false },
+        { ...fakeAddon.current_version.files[0], is_restart_required: true },
+      ],
+    });
 
     expect(
       addons(undefined, loadEntities(createFetchAddonResult(addon).entities))

--- a/tests/unit/disco/containers/TestDiscoPane.js
+++ b/tests/unit/disco/containers/TestDiscoPane.js
@@ -139,7 +139,7 @@ describe('AddonPage', () => {
         description: 'editorial text',
         heading: 'The Add-on',
         iconUrl: addon.icon_url,
-        is_restart_required: false,
+        isRestartRequired: false,
       }]);
     });
 
@@ -169,7 +169,7 @@ describe('AddonPage', () => {
         description: undefined,
         heading: 'The Theme',
         iconUrl: addon.icon_url,
-        is_restart_required: false,
+        isRestartRequired: false,
       }]);
     });
   });

--- a/tests/unit/disco/containers/TestDiscoPane.js
+++ b/tests/unit/disco/containers/TestDiscoPane.js
@@ -139,6 +139,7 @@ describe('AddonPage', () => {
         description: 'editorial text',
         heading: 'The Add-on',
         iconUrl: addon.icon_url,
+        is_restart_required: false,
       }]);
     });
 
@@ -168,6 +169,7 @@ describe('AddonPage', () => {
         description: undefined,
         heading: 'The Theme',
         iconUrl: addon.icon_url,
+        is_restart_required: false,
       }]);
     });
   });

--- a/tests/unit/ui/components/TestBadge.js
+++ b/tests/unit/ui/components/TestBadge.js
@@ -21,7 +21,19 @@ describe(__filename, () => {
     expect(badge).toHaveClassName('Badge-featured');
     expect(badge.find(Icon)).toHaveLength(1);
     expect(badge.find(Icon)).toHaveProp('alt', 'foo');
+    expect(badge.find(Icon)).toHaveProp('name', 'featured');
     expect(badge.text()).toContain('foo');
+  });
+
+  it('displays the restart icon for type `restart-required`', () => {
+    const badge = shallow(<Badge type="restart-required" label="restart required" />);
+
+    expect(badge).toHaveClassName('Badge');
+    expect(badge).toHaveClassName('Badge-restart-required');
+    expect(badge.find(Icon)).toHaveLength(1);
+    expect(badge.find(Icon)).toHaveProp('alt', 'restart required');
+    expect(badge.find(Icon)).toHaveProp('name', 'restart');
+    expect(badge.text()).toContain('restart required');
   });
 
   it('throws an error if invalid type is supplied', () => {


### PR DESCRIPTION
Fix #2753 
Fix #2990 

~~⚠️  depends on #2972~~

---

Adds a new badge for addons that need restart. Note: I used the same tip as for the `installURL` field to expose `is_restart_required`.

## Screenshots

![screen shot 2017-08-23 at 17 23 54](https://user-images.githubusercontent.com/217628/29623845-ee523a64-8827-11e7-95ec-781699d7114b.png)

![screen shot 2017-08-23 at 17 28 44](https://user-images.githubusercontent.com/217628/29624101-8c957376-8828-11e7-9873-c5c66ae7af38.png)
