### PR TITLE
Fix sign-in while running a server from amo:dev

### DIFF
--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -42,7 +42,7 @@ function unsecureCookie(req, res, proxyRes) {
 
 function getHost(req) {
   const useDesktop = req.headers.cookie && cookie.parse(req.headers.cookie).mamo === 'off';
-  if (useDesktop || req.url.startsWith('/api/') || req.url.startsWith('/fxa-authenticate')) {
+  if (useDesktop || req.url.startsWith('/api/')) {
     return apiHost;
   }
   return frontendHost;
@@ -50,16 +50,8 @@ function getHost(req) {
 
 const server = http.createServer((req, res) => {
   const host = getHost(req);
-  let target = host;
-  if (req.url.startsWith('/fxa-authenticate')) {
-    // This is just a temporary hack to try and see if changing the
-    // Redirect URI in the FxA client https://oauth-stable.dev.lcip.org/console/client/063dd7f1edaf1507
-    // will do what I want.
-    target = host + '/api/v3/accounts/authenticate/?' +
-      req.url.split('?')[1] + '&config=local';
-  }
   return proxy.web(req, res, {
-    target: target,
+    target: host,
     changeOrigin: true,
     autoRewrite: true,
     protocolRewrite: 'http',

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -42,7 +42,7 @@ function unsecureCookie(req, res, proxyRes) {
 
 function getHost(req) {
   const useDesktop = req.headers.cookie && cookie.parse(req.headers.cookie).mamo === 'off';
-  if (useDesktop || req.url.startsWith('/api/')) {
+  if (useDesktop || req.url.startsWith('/api/') || req.url.startsWith('/fxa-authenticate')) {
     return apiHost;
   }
   return frontendHost;
@@ -50,8 +50,16 @@ function getHost(req) {
 
 const server = http.createServer((req, res) => {
   const host = getHost(req);
+  let target = host;
+  if (req.url.startsWith('/fxa-authenticate')) {
+    // This is just a temporary hack to try and see if changing the
+    // Redirect URI in the FxA client https://oauth-stable.dev.lcip.org/console/client/063dd7f1edaf1507
+    // will do what I want.
+    target = host + '/api/v3/accounts/authenticate/?' +
+      req.url.split('?')[1] + '&config=local';
+  }
   return proxy.web(req, res, {
-    target: host,
+    target: target,
     changeOrigin: true,
     autoRewrite: true,
     protocolRewrite: 'http',

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -2,6 +2,7 @@
   "amoCDN": "AMO_CDN",
   "apiHost": "API_HOST",
   "CSP": "CSP",
+  "fxaConfig": "FXA_CONFIG",
   "proxyApiHost": "PROXY_API_HOST",
   "proxyEnabled": "PROXY_ENABLED",
   "proxyPort": "PROXY_PORT",

--- a/package.json
+++ b/package.json
@@ -67,10 +67,11 @@
       }
     },
     "amo:stage": {
-      "command": "better-npm-run start-dev",
+      "command": "better-npm-run start-dev-proxy",
       "env": {
         "AMO_CDN": "https://addons-stage-cdn.allizom.org",
-        "API_HOST": "https://addons.allizom.org",
+        "PROXY_API_HOST": "https://addons.allizom.org",
+        "FXA_CONFIG": "local",
         "CSP": false,
         "NODE_APP_INSTANCE": "amo"
       }

--- a/package.json
+++ b/package.json
@@ -50,10 +50,12 @@
       }
     },
     "amo:dev": {
-      "command": "better-npm-run start-dev",
+      "command": "better-npm-run start-dev-proxy",
       "env": {
         "AMO_CDN": "https://addons-amo-dev-cdn.allizom.org",
         "API_HOST": "https://addons-dev.allizom.org",
+        "PROXY_API_HOST": "https://addons-dev.allizom.org",
+        "FXA_CONFIG": "local",
         "CSP": false,
         "NODE_APP_INSTANCE": "amo"
       }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
       "command": "better-npm-run start-dev-proxy",
       "env": {
         "AMO_CDN": "https://addons-amo-dev-cdn.allizom.org",
-        "API_HOST": "https://addons-dev.allizom.org",
         "PROXY_API_HOST": "https://addons-dev.allizom.org",
         "FXA_CONFIG": "local",
         "CSP": false,


### PR DESCRIPTION
Fixes #2941 

This does a few things:
* Both `amo:dev` and `amo:stage` go through the proxy which means both the frontend site and the backend API are served on the same domain like production. This should help catch same origin issues locally.
* Sign-ins work on `amo:dev`
* Sign-ins do not work on `amo:stage` (like before) because we need to configure a new FxA client. I'll do that in a follow-up.