### PR TITLE
Revert "fix(package): update dompurify to version 1.0.1 (#2974)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "common-tags": "1.4.0",
     "config": "1.26.2",
     "deep-eql": "3.0.0",
-    "dompurify": "1.0.1",
+    "dompurify": "0.9.0",
     "es6-error": "4.0.2",
     "express": "4.15.2",
     "extract-text-webpack-plugin": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,9 +2337,9 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-dompurify@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-1.0.1.tgz#a7dae8a6b0719c80d7d639fe44f834b81e9b02b8"
+dompurify@0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-0.9.0.tgz#470f9dd95657a644a84be1ed950677946259d055"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -4505,9 +4505,9 @@ jschardet@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.0.tgz#a61f310306a5a71188e1b1acd08add3cfbb08b1e"
 
-jsdom@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.1.0.tgz#6c48d7a48ffc5c300283c312904d15da8360509b"
+jsdom@11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.2.0.tgz#4f6b8736af3357c3af7227a3b54a5bda1c513fd6"
   dependencies:
     abab "^1.0.3"
     acorn "^4.0.4"


### PR DESCRIPTION
This reverts commit ea532fc095269de702bf4f68fecfe00de063dea8.

Fixes #2981.

[Looks like this will be fixed in `1.0.2`](https://github.com/cure53/DOMPurify/issues/249) but that isn't out yet. For now we'll revert things so we can run stuff on -dev and can tag later today without needing to cherry-pick the 1.0.2 release.