### PR TITLE
Add dropdown menu and display username (when logged in)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,8 @@
     "CLIENT_CONFIG": true,
     "webpackIsomorphicTools": true,
     "ga": true,
+    // See: https://github.com/facebook/flow/issues/1609
+    "SyntheticEvent": true,
   },
   "parser": "babel-eslint",
   "plugins": [

--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -89,15 +89,15 @@ export class HeaderBase extends React.Component {
               text={username}
               className="Header-authenticate-button Header-button"
             >
-              <DropdownMenuItem>{i18n.gettext('Account')}</DropdownMenuItem>
+              <DropdownMenuItem>{i18n.gettext('My Account')}</DropdownMenuItem>
               <DropdownMenuItem>
                 <Link href={`/user/${username}/`}>
-                  {i18n.gettext('My profile')}
+                  {i18n.gettext('View Profile')}
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem>
                 <Link href="/users/edit">
-                  {i18n.gettext('Account settings')}
+                  {i18n.gettext('Edit Profile')}
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem onClick={this.handleLogOut} detached>

--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -6,28 +6,51 @@ import DownloadFirefoxButton from 'amo/components/DownloadFirefoxButton';
 import Link from 'amo/components/Link';
 import SearchForm from 'amo/components/SearchForm';
 import SectionLinks from 'amo/components/SectionLinks';
-import AuthenticateButton from 'core/components/AuthenticateButton';
+import AuthenticateButton, {
+  createHandleLogOutFunction,
+} from 'core/components/AuthenticateButton';
+import { isAuthenticated } from 'core/reducers/user';
 import { VIEW_CONTEXT_HOME } from 'core/constants';
 import translate from 'core/i18n/translate';
 import Icon from 'ui/components/Icon';
+import DropdownMenu from 'ui/components/DropdownMenu';
+import DropdownMenuItem from 'ui/components/DropdownMenuItem';
 
 import './styles.scss';
 
 
 export class HeaderBase extends React.Component {
   static propTypes = {
+    api: PropTypes.object.isRequired,
+    handleLogOut: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
+    isAuthenticated: PropTypes.bool.isRequired,
     isHomePage: PropTypes.bool.isRequired,
     location: PropTypes.object.isRequired,
-    query: PropTypes.string,
+    query: PropTypes.string.isRequired,
+    username: PropTypes.string,
   }
 
-  static defaultPropTypes = {
+  static defaultProps = {
     isHomePage: false,
+    query: '',
+  }
+
+  handleLogOut = (event) => {
+    event.preventDefault();
+
+    this.props.handleLogOut({ api: this.props.api });
   }
 
   render() {
-    const { i18n, isHomePage, location, query } = this.props;
+    const {
+      i18n,
+      isHomePage,
+      location,
+      query,
+      username,
+    } = this.props;
+
     const headerLink = (
       <Link className="Header-title" to="/">
         <Icon className="Header-addons-icon" name="fox" />
@@ -60,12 +83,35 @@ export class HeaderBase extends React.Component {
           <DownloadFirefoxButton
             className="Header-download-button Header-button"
           />
-          <AuthenticateButton
-            className="Header-authenticate-button Header-button Button--action
+
+          {this.props.isAuthenticated ? (
+            <DropdownMenu
+              text={username}
+              className="Header-authenticate-button Header-button"
+            >
+              <DropdownMenuItem>{i18n.gettext('Account')}</DropdownMenuItem>
+              <DropdownMenuItem>
+                <Link href={`/user/${username}/`}>
+                  {i18n.gettext('My profile')}
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <Link href="/users/edit">
+                  {i18n.gettext('Account settings')}
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={this.handleLogOut} detached>
+                {i18n.gettext('Log out')}
+              </DropdownMenuItem>
+            </DropdownMenu>
+          ) : (
+            <AuthenticateButton
+              className="Header-authenticate-button Header-button Button--action
               Button--outline-only Button--small"
-            location={location}
-            noIcon
-          />
+              location={location}
+              noIcon
+            />
+          )}
         </div>
 
         <SearchForm
@@ -78,11 +124,20 @@ export class HeaderBase extends React.Component {
   }
 }
 
-export function mapStateToProps(state) {
-  return { isHomePage: state.viewContext.context === VIEW_CONTEXT_HOME };
-}
+export const mapStateToProps = (state) => {
+  return {
+    api: state.api,
+    isHomePage: state.viewContext.context === VIEW_CONTEXT_HOME,
+    username: state.user.username,
+    isAuthenticated: isAuthenticated(state),
+  };
+};
+
+export const mapDispatchToProps = (dispatch) => ({
+  handleLogOut: createHandleLogOutFunction(dispatch),
+});
 
 export default compose(
-  connect(mapStateToProps),
+  connect(mapStateToProps, mapDispatchToProps),
   translate(),
 )(HeaderBase);

--- a/src/amo/components/Link.js
+++ b/src/amo/components/Link.js
@@ -10,6 +10,7 @@ import Icon from 'ui/components/Icon';
 
 export class LinkBase extends React.Component {
   static propTypes = {
+    className: PropTypes.string,
     clientApp: PropTypes.string.isRequired,
     children: PropTypes.node,
     external: PropTypes.bool,
@@ -18,6 +19,7 @@ export class LinkBase extends React.Component {
     prependClientApp: PropTypes.bool,
     prependLang: PropTypes.bool,
     to: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+    dispatch: PropTypes.func.isRequired,
   }
 
   static defaultProps = {
@@ -48,6 +50,7 @@ export class LinkBase extends React.Component {
       clientApp,
       children,
       external,
+      dispatch,
       href,
       lang,
       prependClientApp,

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -71,7 +71,7 @@ export class AuthenticateButtonBase extends React.Component {
     // https://github.com/mozilla/addons-frontend/issues/1904
     return (
       <Button
-        href={`#log-${isAuthenticated ? 'out' : 'in'}`}
+        href={`#${isAuthenticated ? 'logout' : 'login'}`}
         className={className}
         onClick={this.onClick}
       >

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -21,13 +21,13 @@ type HandleLogInFunc = (
   location: ReactRouterLocation, options?: {| _window: typeof window |}
 ) => void;
 
-type HandleLogOutFunc = ({| api: ApiStateType |}) => Promise<void>;
+type HandleLogOutFunction = ({| api: ApiStateType |}) => Promise<void>;
 
 type AuthenticateButtonProps = {|
   api: ApiStateType,
   className?: string,
   handleLogIn: HandleLogInFunc,
-  handleLogOut: HandleLogOutFunc,
+  handleLogOut: HandleLogOutFunction,
   i18n: Object,
   isAuthenticated: boolean,
   location: ReactRouterLocation,
@@ -58,7 +58,7 @@ export class AuthenticateButtonBase extends React.Component {
 
   render() {
     const {
-      i18n, isAuthenticated, logInText, logOutText, noIcon, ...otherProps
+      i18n, isAuthenticated, logInText, logOutText, noIcon, className,
     } = this.props;
     const buttonText = isAuthenticated ?
       logOutText || i18n.gettext('Log out') :
@@ -70,7 +70,11 @@ export class AuthenticateButtonBase extends React.Component {
     // mobile browser. This is the cause of
     // https://github.com/mozilla/addons-frontend/issues/1904
     return (
-      <Button onClick={this.onClick} href="#" {...otherProps}>
+      <Button
+        href={`#log-${isAuthenticated ? 'out' : 'in'}`}
+        className={className}
+        onClick={this.onClick}
+      >
         {noIcon ? null : <Icon name="user-dark" />}
         {buttonText}
       </Button>
@@ -99,16 +103,21 @@ export const mapStateToProps = (
 });
 
 type DispatchMappedProps = {|
-  handleLogOut: HandleLogOutFunc,
+  handleLogOut: HandleLogOutFunction,
 |};
+
+export const createHandleLogOutFunction = (
+  dispatch: DispatchFunc
+): HandleLogOutFunction => {
+  return ({ api }) => {
+    return logOutFromServer({ api }).then(() => dispatch(logOutUser()));
+  };
+};
 
 export const mapDispatchToProps = (
   dispatch: DispatchFunc
 ): DispatchMappedProps => ({
-  handleLogOut({ api }) {
-    return logOutFromServer({ api })
-      .then(() => dispatch(logOutUser()));
-  },
+  handleLogOut: createHandleLogOutFunction(dispatch),
 });
 
 export default compose(

--- a/src/ui/components/DropdownMenu/index.js
+++ b/src/ui/components/DropdownMenu/index.js
@@ -1,0 +1,67 @@
+/* @flow */
+import React from 'react';
+import classNames from 'classnames';
+import onClickOutside from 'react-onclickoutside';
+
+import Icon from 'ui/components/Icon';
+import DropdownMenuItem from 'ui/components/DropdownMenuItem';
+
+import './styles.scss';
+
+
+type Props = {|
+  text: string,
+  children: Array<DropdownMenuItem>,
+  className?: string,
+|};
+
+export class DropdownMenuBase extends React.Component {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = { buttonIsActive: false };
+  }
+
+  state: {| buttonIsActive: bool |};
+  props: Props;
+
+  handleOnClick = (event: SyntheticEvent) => {
+    event.preventDefault();
+
+    this.setState((previousState) => ({
+      buttonIsActive: !previousState.buttonIsActive,
+    }));
+  }
+
+  handleClickOutside = () => {
+    this.setState({ buttonIsActive: false });
+  }
+
+  render() {
+    const { children, className, text } = this.props;
+
+    return (
+      <div
+        className={classNames('DropdownMenu', className, {
+          'DropdownMenu--active': this.state.buttonIsActive,
+        })}
+      >
+        <button
+          className="DropdownMenu-text"
+          onClick={this.handleOnClick}
+        >
+          {text}
+          <Icon name="inverted-caret" />
+        </button>
+
+        {children && (
+          <ul className="DropdownMenu-items">
+            {children}
+          </ul>
+        )}
+      </div>
+    );
+  }
+}
+
+export default onClickOutside(DropdownMenuBase);

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -9,6 +9,22 @@
   padding-bottom: 6px;
   padding-top: 6px;
   position: relative;
+
+  // This is needed because `:hover` on mobile prevents the main button to
+  // close the dropdown menu. On mobile, `.DropdownMenu--active` controls the
+  // visibility of the menu. On "large" devices (and above), `:hover` also
+  // opens the menu.
+  @include respond-to(large) {
+    &:hover {
+      .DropdownMenu-items {
+        display: block;
+      }
+
+      .Icon-inverted-caret {
+        opacity: 1;
+      }
+    }
+  }
 }
 
 .DropdownMenu-text {
@@ -26,30 +42,8 @@
     opacity: 0.6;
     transition: opacity $transition-short ease-in-out;
     width: 9px;
-  }
-}
 
-.DropdownMenu--active {
-  .DropdownMenu-items {
-    display: block;
-  }
-
-  .Icon-inverted-caret {
-    opacity: 1;
-  }
-}
-
-// This is needed because `:hover` on mobile prevents the main button to close
-// the dropdown menu. On mobile, `.DropdownMenu--active` controls the
-// visibility of the menu. On "large" devices (and above), `:hover` also opens
-// the menu.
-@include respond-to(large) {
-  .DropdownMenu:hover {
-    .DropdownMenu-items {
-      display: block;
-    }
-
-    .Icon-inverted-caret {
+    .DropdownMenu--active & {
       opacity: 1;
     }
   }
@@ -84,5 +78,9 @@
     top: -4px;
     transform: rotate(45deg);
     width: 8px;
+  }
+
+  .DropdownMenu--active & {
+    display: block;
   }
 }

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -7,7 +7,7 @@
 
   display: inline-block;
   padding-bottom: 6px;
-  padding-top: 6px;
+  padding-top: 5px;
   position: relative;
 
   // This is needed because `:hover` on mobile prevents the main button to
@@ -38,7 +38,7 @@
   .Icon-inverted-caret {
     @include margin-start(5px);
 
-    height: 10px;
+    height: 8px;
     opacity: 0.6;
     transition: opacity $transition-short ease-in-out;
     width: 9px;

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -1,0 +1,88 @@
+@import "~core/css/inc/mixins";
+@import "~amo/css/inc/vars";
+@import "~ui/css/vars";
+
+.DropdownMenu {
+  @include text-align-start();
+
+  display: inline-block;
+  padding-bottom: 6px;
+  padding-top: 6px;
+  position: relative;
+}
+
+.DropdownMenu-text {
+  @include font-regular();
+
+  color: $white;
+  cursor: pointer;
+  font-size: $font-size-s;
+  font-weight: normal;
+  text-decoration: none;
+
+  .Icon-inverted-caret {
+    @include margin-start(5px);
+
+    height: 10px;
+    opacity: 0.6;
+    width: 9px;
+  }
+}
+
+.DropdownMenu--active {
+  .DropdownMenu-items {
+    display: block;
+  }
+
+  .Icon-inverted-caret {
+    opacity: 1;
+  }
+}
+
+// This is needed because `:hover` on mobile prevents the main button to close
+// the dropdown menu. On mobile, `.DropdownMenu--active` controls the
+// visibility of the menu. On "large" devices (and above), `:hover` also opens
+// the menu.
+@include respond-to(large) {
+  .DropdownMenu:hover {
+    .DropdownMenu-items {
+      display: block;
+    }
+
+    .Icon-inverted-caret {
+      opacity: 1;
+    }
+  }
+}
+
+.DropdownMenu-items {
+  @include font-regular();
+  @include end(0);
+
+  background: $white;
+  border: 0;
+  border-radius: $border-radius-default;
+  box-shadow: 0 0 2px transparentize($black, 0.5);
+  display: none;
+  list-style-type: none;
+  margin: 0;
+  padding: 4px 24px 20px;
+  position: absolute;
+  top: 30px;
+  white-space: nowrap;
+  width: auto;
+  z-index: 10;
+
+  &::after {
+    @include end(36px);
+
+    background-color: $white;
+    content: "";
+    display: block;
+    height: 8px;
+    position: absolute;
+    top: -4px;
+    transform: rotate(45deg);
+    width: 8px;
+  }
+}

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -15,7 +15,6 @@
   @include font-regular();
 
   color: $white;
-  cursor: pointer;
   font-size: $font-size-s;
   font-weight: normal;
   text-decoration: none;
@@ -25,6 +24,7 @@
 
     height: 10px;
     opacity: 0.6;
+    transition: opacity $transition-short ease-in-out;
     width: 9px;
   }
 }

--- a/src/ui/components/DropdownMenuItem/index.js
+++ b/src/ui/components/DropdownMenuItem/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 import React from 'react';
 import classNames from 'classnames';
-import { oneLine } from 'common-tags';
 
 import Link from 'amo/components/Link';
 
@@ -16,15 +15,6 @@ type Props = {|
 
 const DropdownMenuItem = ({ children, onClick, detached = false }: Props) => {
   const childIsComponent = typeof children === 'object';
-
-  if (
-    childIsComponent &&
-    children.type && children.type.displayName !== 'Connect(LinkBase)'
-  ) {
-    throw new Error(oneLine`Only the "Link" component is supported as a child
-      of "DropdownMenuItem", got: ${children.type.displayName}`);
-  }
-
   const classnames = classNames('DropdownMenuItem', {
     'DropdownMenuItem-section': !childIsComponent && !onClick,
     'DropdownMenuItem-link': childIsComponent || onClick,

--- a/src/ui/components/DropdownMenuItem/index.js
+++ b/src/ui/components/DropdownMenuItem/index.js
@@ -25,31 +25,19 @@ const DropdownMenuItem = ({ children, onClick, detached = false }: Props) => {
       of "DropdownMenuItem", got: ${children.type.displayName}`);
   }
 
-  if (!childIsComponent && !onClick) {
-    return (
-      <li className="DropdownMenuItem DropdownMenuItem-section">
-        {children}
-      </li>
-    );
-  }
-
-  const classnames = classNames('DropdownMenuItem-link', {
-    'DropdownMenuItem-link--detached': detached,
+  const classnames = classNames('DropdownMenuItem', {
+    'DropdownMenuItem-section': !childIsComponent && !onClick,
+    'DropdownMenuItem-link': childIsComponent || onClick,
+    'DropdownMenuItem--detached': detached,
   });
 
-  if (childIsComponent) {
-    return (
-      <li className="DropdownMenuItem">
-        {React.cloneElement((children: Link), { className: classnames })}
-      </li>
-    );
-  }
-
   return (
-    <li className="DropdownMenuItem">
-      <button className={classnames} onClick={onClick}>
-        {children}
-      </button>
+    <li className={classnames}>
+      {onClick ? (
+        <button onClick={onClick}>{children}</button>
+      ) : (
+        children
+      )}
     </li>
   );
 };

--- a/src/ui/components/DropdownMenuItem/index.js
+++ b/src/ui/components/DropdownMenuItem/index.js
@@ -1,0 +1,57 @@
+/* @flow */
+import React from 'react';
+import classNames from 'classnames';
+import { oneLine } from 'common-tags';
+
+import Link from 'amo/components/Link';
+
+import './styles.scss';
+
+
+type Props = {|
+  children: string | Link,
+  detached?: boolean,
+  onClick?: Function,
+|};
+
+const DropdownMenuItem = ({ children, onClick, detached = false }: Props) => {
+  const childIsComponent = typeof children === 'object';
+
+  if (
+    childIsComponent &&
+    children.type && children.type.displayName !== 'Connect(LinkBase)'
+  ) {
+    throw new Error(oneLine`Only the "Link" component is supported as a child
+      of "DropdownMenuItem", got: ${children.type.displayName}`);
+  }
+
+  if (!childIsComponent && !onClick) {
+    return (
+      <li className="DropdownMenuItem DropdownMenuItem-section">
+        {children}
+      </li>
+    );
+  }
+
+  const classnames = classNames('DropdownMenuItem-link', {
+    'DropdownMenuItem-link--detached': detached,
+  });
+
+  if (childIsComponent) {
+    return (
+      <li className="DropdownMenuItem">
+        {React.cloneElement((children: Link), { className: classnames })}
+      </li>
+    );
+  }
+
+  return (
+    <li className="DropdownMenuItem">
+      <button className={classnames} onClick={onClick}>
+        {children}
+      </button>
+    </li>
+  );
+};
+
+export default DropdownMenuItem;

--- a/src/ui/components/DropdownMenuItem/styles.scss
+++ b/src/ui/components/DropdownMenuItem/styles.scss
@@ -1,25 +1,22 @@
 @import "~core/css/inc/mixins";
 @import "~ui/css/vars";
 
-$section-font-size: 11px;
-$link-font-size: 15px;
-
 .DropdownMenuItem-section {
   color: $grey-50;
-  font-size: $section-font-size;
+  font-size: $font-size-s;
   line-height: 1.6;
   margin: 16px 0 0;
-  text-transform: uppercase;
 }
 
-.DropdownMenuItem-link {
+.DropdownMenuItem-link a,
+.DropdownMenuItem-link button {
   @include font-medium();
 
   &,
   &:link {
     color: $grey-90;
     cursor: pointer;
-    font-size: $link-font-size;
+    font-size: $font-size-m-smaller;
     line-height: 1.6;
     margin: 0;
     padding: 0;
@@ -33,6 +30,6 @@ $link-font-size: 15px;
   }
 }
 
-.DropdownMenuItem-link--detached {
+.DropdownMenuItem--detached {
   margin-top: 8px;
 }

--- a/src/ui/components/DropdownMenuItem/styles.scss
+++ b/src/ui/components/DropdownMenuItem/styles.scss
@@ -1,0 +1,38 @@
+@import "~core/css/inc/mixins";
+@import "~ui/css/vars";
+
+$section-font-size: 11px;
+$link-font-size: 15px;
+
+.DropdownMenuItem-section {
+  color: $grey-50;
+  font-size: $section-font-size;
+  line-height: 1.6;
+  margin: 16px 0 0;
+  text-transform: uppercase;
+}
+
+.DropdownMenuItem-link {
+  @include font-medium();
+
+  &,
+  &:link {
+    color: $grey-90;
+    cursor: pointer;
+    font-size: $link-font-size;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    text-decoration: none;
+  }
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: $blue-50;
+  }
+}
+
+.DropdownMenuItem-link--detached {
+  margin-top: 8px;
+}

--- a/src/ui/components/DropdownMenuItem/styles.scss
+++ b/src/ui/components/DropdownMenuItem/styles.scss
@@ -1,5 +1,6 @@
 @import "~core/css/inc/mixins";
 @import "~ui/css/vars";
+@import "~photon-colors/colors";
 
 .DropdownMenuItem-section {
   color: $grey-50;

--- a/src/ui/components/Icon/inverted-caret.svg
+++ b/src/ui/components/Icon/inverted-caret.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="6px" viewBox="0 0 10 6" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <title>Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Icon/Arrow/Down/White" transform="translate(1.000000, 1.000000)" stroke-width="2" stroke="#FFFFFF">
+            <polyline id="Shape" points="8 0 4 4 0 0"></polyline>
+        </g>
+    </g>
+</svg>

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -144,3 +144,7 @@
 .Icon-restart {
   @include icon($name: "restart");
 }
+
+.Icon-inverted-caret {
+  @include icon($name: "inverted-caret");
+}

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -60,14 +60,14 @@ describe(__filename, () => {
       .toContain('Firefox Add-ons');
   });
 
-  it('displays `login` text when user is not connected', () => {
+  it('displays `login` text when user is not signed in', () => {
     const wrapper = renderHeader();
 
     expect(wrapper.find(AuthenticateButton)).toHaveLength(1);
     expect(wrapper.find(DropdownMenu)).toHaveLength(0);
   });
 
-  it('displays a menu and the username when user is logged in', () => {
+  it('displays a menu and the username when user is signed in', () => {
     const { store } = dispatchSignInActions({ username: 'babar' });
     const wrapper = renderHeader({ store });
 
@@ -75,7 +75,7 @@ describe(__filename, () => {
     expect(wrapper.find(DropdownMenu)).toHaveProp('text', 'babar');
   });
 
-  it('allows to log out a logged user', () => {
+  it('allows a signed-in user to log out', () => {
     const { store } = dispatchSignInActions({ username: 'babar' });
     const wrapper = renderHeader({ store });
     const mockApi = sinon.mock(api);

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -21,6 +21,7 @@ import {
   signedInApiState as coreSignedInApiState,
 } from '../helpers';
 
+
 export const fakeAddon = Object.freeze({
   authors: [{
     name: 'Krupa',
@@ -167,13 +168,14 @@ export function dispatchClientMetadata({
 export function dispatchSignInActions({
   authToken = userAuthToken(),
   userId = 12345,
+  username = 'user-1234',
   ...otherArgs
 } = {}) {
   const { store } = dispatchClientMetadata(otherArgs);
 
   store.dispatch(setAuthToken(authToken));
   store.dispatch(loadUserProfile({
-    profile: createUserProfileResponse({ id: userId }),
+    profile: createUserProfileResponse({ id: userId, username }),
   }));
 
   return {

--- a/tests/unit/core/components/TestAuthenticateButton.js
+++ b/tests/unit/core/components/TestAuthenticateButton.js
@@ -59,11 +59,13 @@ describe('<AuthenticateButton />', () => {
   it('lets you customize the log in text', () => {
     const root = render({ isAuthenticated: false, logInText: 'Maybe log in?' });
     expect(root.textContent).toEqual('Maybe log in?');
+    expect(root.href).toContain('#log-in');
   });
 
   it('lets you customize the log out text', () => {
     const root = render({ isAuthenticated: true, logOutText: 'Maybe log out?' });
     expect(root.textContent).toEqual('Maybe log out?');
+    expect(root.href).toContain('#log-out');
   });
 
   it('shows a log in button when unauthenticated', () => {

--- a/tests/unit/core/components/TestAuthenticateButton.js
+++ b/tests/unit/core/components/TestAuthenticateButton.js
@@ -59,13 +59,13 @@ describe('<AuthenticateButton />', () => {
   it('lets you customize the log in text', () => {
     const root = render({ isAuthenticated: false, logInText: 'Maybe log in?' });
     expect(root.textContent).toEqual('Maybe log in?');
-    expect(root.href).toContain('#log-in');
+    expect(root.href).toContain('#login');
   });
 
   it('lets you customize the log out text', () => {
     const root = render({ isAuthenticated: true, logOutText: 'Maybe log out?' });
     expect(root.textContent).toEqual('Maybe log out?');
-    expect(root.href).toContain('#log-out');
+    expect(root.href).toContain('#logout');
   });
 
   it('shows a log in button when unauthenticated', () => {

--- a/tests/unit/ui/components/TestDropdownMenu.js
+++ b/tests/unit/ui/components/TestDropdownMenu.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import DropdownMenu, { DropdownMenuBase } from 'ui/components/DropdownMenu';
+import DropdownMenuItem from 'ui/components/DropdownMenuItem';
+import Icon from 'ui/components/Icon';
+import { createFakeEvent, shallowUntilTarget } from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  it('renders a menu', () => {
+    const menu = shallowUntilTarget(
+      <DropdownMenu text="Menu" />,
+      DropdownMenuBase
+    );
+
+    expect(menu).toHaveClassName('DropdownMenu');
+    expect(menu.find('.DropdownMenu-text')).toIncludeText('Menu');
+    expect(menu.find(Icon)).toHaveLength(1);
+    expect(menu.find('.DropdownMenu-items')).toHaveLength(0);
+  });
+
+  it('renders items passed as children', () => {
+    const menu = shallowUntilTarget(
+      <DropdownMenu text="Menu">
+        <DropdownMenuItem>A section</DropdownMenuItem>
+      </DropdownMenu>,
+      DropdownMenuBase
+    );
+
+    expect(menu.find('.DropdownMenu-items')).toHaveLength(1);
+    expect(menu.find(DropdownMenuItem)).toHaveLength(1);
+  });
+
+  it('toggles the menu state when button is clicked', () => {
+    const menu = shallowUntilTarget(
+      <DropdownMenu text="Menu" />,
+      DropdownMenuBase
+    );
+    expect(menu).not.toHaveClassName('DropdownMenu--active');
+
+    // User clicks the menu main button.
+    menu.find('.DropdownMenu-text').simulate('click', createFakeEvent());
+    expect(menu).toHaveClassName('DropdownMenu--active');
+
+    // User clicks the menu main button, again.
+    menu.find('.DropdownMenu-text').simulate('click', createFakeEvent());
+    expect(menu).not.toHaveClassName('DropdownMenu--active');
+  });
+
+  it('resets the menu state on blur', () => {
+    const root = mount(<DropdownMenu text="Menu" />);
+    const menu = root.find('.DropdownMenu');
+
+    // User clicks the menu main button.
+    menu.find('.DropdownMenu-text').simulate('click', createFakeEvent());
+    expect(menu).toHaveClassName('DropdownMenu--active');
+
+    // User clicks somewhere else.
+    // The first `instance()` call is Enzyme API, the second `getInstance()`
+    // call is react-onclickoutside API. See:
+    // https://github.com/Pomax/react-onclickoutside#but-how-can-i-access-my-component-it-has-an-api-that-i-rely-on
+    root.instance().getInstance().handleClickOutside();
+    expect(menu).not.toHaveClassName('DropdownMenu--active');
+  });
+
+  it('optionally takes a class name', () => {
+    const menu = shallowUntilTarget(
+      <DropdownMenu text="Menu" className="my-class" />,
+      DropdownMenuBase
+    );
+
+    expect(menu).toHaveClassName('DropdownMenu');
+    expect(menu).toHaveClassName('my-class');
+  });
+});

--- a/tests/unit/ui/components/TestDropdownMenuItem.js
+++ b/tests/unit/ui/components/TestDropdownMenuItem.js
@@ -69,14 +69,4 @@ describe(__filename, () => {
     expect(item).toHaveClassName('DropdownMenuItem-link');
     expect(item).toHaveClassName('DropdownMenuItem--detached');
   });
-
-  it('throws an error if child component is not a `Link`', () => {
-    expect(() => {
-      shallow(
-        <DropdownMenuItem>
-          <input />
-        </DropdownMenuItem>
-      );
-    }).toThrowError(/Only the "Link" component is supported as a child/);
-  });
 });

--- a/tests/unit/ui/components/TestDropdownMenuItem.js
+++ b/tests/unit/ui/components/TestDropdownMenuItem.js
@@ -6,7 +6,7 @@ import Link from 'amo/components/Link';
 
 
 describe(__filename, () => {
-  it('renders a section when only `title` is specified', () => {
+  it('renders a section when only `children` prop is supplied', () => {
     const item = shallow(
       <DropdownMenuItem>A section</DropdownMenuItem>
     );
@@ -24,11 +24,9 @@ describe(__filename, () => {
     );
 
     expect(item).toHaveClassName('DropdownMenuItem');
+    expect(item).toHaveClassName('DropdownMenuItem-link');
     expect(item.find(Link)).toHaveLength(1);
     expect(item.find(Link)).toHaveProp('to', '/');
-    // This assertion makes sure the given `Link` is cloned with the right
-    // `className` prop.
-    expect(item.find(Link)).toHaveClassName('DropdownMenuItem-link');
   });
 
   it('can visually detach a link item', () => {
@@ -41,9 +39,8 @@ describe(__filename, () => {
     );
 
     expect(item).toHaveClassName('DropdownMenuItem');
-    expect(item.find(Link)).toHaveLength(1);
-    expect(item.find(Link)).toHaveClassName('DropdownMenuItem-link');
-    expect(item.find(Link)).toHaveClassName('DropdownMenuItem-link--detached');
+    expect(item).toHaveClassName('DropdownMenuItem-link');
+    expect(item).toHaveClassName('DropdownMenuItem--detached');
   });
 
   it('renders a `button` when `onClick` prop is supplied', () => {
@@ -55,22 +52,22 @@ describe(__filename, () => {
     );
 
     expect(item).toHaveClassName('DropdownMenuItem');
+    expect(item).toHaveClassName('DropdownMenuItem-link');
     expect(item.find('button')).toHaveLength(1);
-    expect(item.find('button')).toHaveClassName('DropdownMenuItem-link');
     expect(item.find('button')).toHaveProp('onClick', stub);
   });
 
   it('can visually detach a button item', () => {
     const stub = sinon.stub();
-    const button = shallow(
+    const item = shallow(
       <DropdownMenuItem onClick={stub} detached>
         A button that is detached from the rest of the menu
       </DropdownMenuItem>
-    ).find('button');
+    );
 
-    expect(button).toHaveLength(1);
-    expect(button).toHaveClassName('DropdownMenuItem-link');
-    expect(button).toHaveClassName('DropdownMenuItem-link--detached');
+    expect(item).toHaveClassName('DropdownMenuItem');
+    expect(item).toHaveClassName('DropdownMenuItem-link');
+    expect(item).toHaveClassName('DropdownMenuItem--detached');
   });
 
   it('throws an error if child component is not a `Link`', () => {

--- a/tests/unit/ui/components/TestDropdownMenuItem.js
+++ b/tests/unit/ui/components/TestDropdownMenuItem.js
@@ -1,0 +1,85 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import DropdownMenuItem from 'ui/components/DropdownMenuItem';
+import Link from 'amo/components/Link';
+
+
+describe(__filename, () => {
+  it('renders a section when only `title` is specified', () => {
+    const item = shallow(
+      <DropdownMenuItem>A section</DropdownMenuItem>
+    );
+
+    expect(item).toHaveClassName('DropdownMenuItem');
+    expect(item).toHaveClassName('DropdownMenuItem-section');
+    expect(item).toIncludeText('A section');
+  });
+
+  it('renders a `Link` passed in children', () => {
+    const item = shallow(
+      <DropdownMenuItem>
+        <Link to="/">a link</Link>
+      </DropdownMenuItem>
+    );
+
+    expect(item).toHaveClassName('DropdownMenuItem');
+    expect(item.find(Link)).toHaveLength(1);
+    expect(item.find(Link)).toHaveProp('to', '/');
+    // This assertion makes sure the given `Link` is cloned with the right
+    // `className` prop.
+    expect(item.find(Link)).toHaveClassName('DropdownMenuItem-link');
+  });
+
+  it('can visually detach a link item', () => {
+    const item = shallow(
+      <DropdownMenuItem detached>
+        <Link to="/">
+          a link detached from the rest of the menu
+        </Link>
+      </DropdownMenuItem>
+    );
+
+    expect(item).toHaveClassName('DropdownMenuItem');
+    expect(item.find(Link)).toHaveLength(1);
+    expect(item.find(Link)).toHaveClassName('DropdownMenuItem-link');
+    expect(item.find(Link)).toHaveClassName('DropdownMenuItem-link--detached');
+  });
+
+  it('renders a `button` when `onClick` prop is supplied', () => {
+    const stub = sinon.stub();
+    const item = shallow(
+      <DropdownMenuItem onClick={stub}>
+        A button
+      </DropdownMenuItem>
+    );
+
+    expect(item).toHaveClassName('DropdownMenuItem');
+    expect(item.find('button')).toHaveLength(1);
+    expect(item.find('button')).toHaveClassName('DropdownMenuItem-link');
+    expect(item.find('button')).toHaveProp('onClick', stub);
+  });
+
+  it('can visually detach a button item', () => {
+    const stub = sinon.stub();
+    const button = shallow(
+      <DropdownMenuItem onClick={stub} detached>
+        A button that is detached from the rest of the menu
+      </DropdownMenuItem>
+    ).find('button');
+
+    expect(button).toHaveLength(1);
+    expect(button).toHaveClassName('DropdownMenuItem-link');
+    expect(button).toHaveClassName('DropdownMenuItem-link--detached');
+  });
+
+  it('throws an error if child component is not a `Link`', () => {
+    expect(() => {
+      shallow(
+        <DropdownMenuItem>
+          <input />
+        </DropdownMenuItem>
+      );
+    }).toThrowError(/Only the "Link" component is supported as a child/);
+  });
+});


### PR DESCRIPTION
Fix #1751 
Refs #2745
~~⚠️  depends on #2989~~

---

This PR introduces a new `DropdownMenu` component according to the recent mock-ups. It displays the username if she is logged in, and a simple menu linking to account view/edit and providing the "log out" action. This PR also fixes warnings related to the `Header` and `Link` components.

## Screenshots

<img width="1392" alt="screen shot 2017-09-08 at 13 34 30" src="https://user-images.githubusercontent.com/217628/30209934-8f4bb318-949a-11e7-94cb-e9014b25c02c.png">
<img width="1392" alt="screen shot 2017-09-08 at 13 34 28" src="https://user-images.githubusercontent.com/217628/30209932-8f4897aa-949a-11e7-9d9d-1ceac0d9c062.png">
<img width="1392" alt="screen shot 2017-09-08 at 13 34 26" src="https://user-images.githubusercontent.com/217628/30209933-8f4ad984-949a-11e7-9f08-442e445531e6.png">

![capture d ecran - 2017-09-08 a 13 34 48](https://user-images.githubusercontent.com/217628/30209943-9816ef6c-949a-11e7-84f9-fb602689f92c.png)

![capture d ecran - 2017-09-08 a 13 34 53](https://user-images.githubusercontent.com/217628/30209946-9b4a4954-949a-11e7-8033-5f304467500c.png)
