### PR TITLE
Fetch addon on slug update

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -90,11 +90,16 @@ export class AddonBase extends React.Component {
     }
   }
 
-  componentWillReceiveProps({ addon: newAddon }) {
-    const { addon: oldAddon, dispatch } = this.props;
+  componentWillReceiveProps({ addon: newAddon, params: newParams }) {
+    const { addon: oldAddon, dispatch, errorHandler, params } = this.props;
+
     const oldAddonType = oldAddon ? oldAddon.type : null;
     if (newAddon && newAddon.type !== oldAddonType) {
       dispatch(setViewContext(newAddon.type));
+    }
+
+    if (params.slug !== newParams.slug) {
+      dispatch(fetchAddon({ slug: newParams.slug, errorHandler }));
     }
   }
 

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -200,6 +200,32 @@ describe('Addon', () => {
     expect(root.find(AddonMeta).prop('addon')).toEqual(null);
   });
 
+  it('does not dispatch fetchAddon action when slug is the same', () => {
+    const fakeDispatch = sinon.stub();
+    const errorHandler = createStubErrorHandler();
+    const addon = fakeAddon;
+    const root = shallowRender({ addon, errorHandler, dispatch: fakeDispatch });
+
+    fakeDispatch.reset();
+    // Update with the same slug.
+    root.setProps({ params: { slug: addon.slug } });
+
+    sinon.assert.notCalled(fakeDispatch);
+  });
+
+  it('dispatches fetchAddon action when updating with a new slug', () => {
+    const fakeDispatch = sinon.stub();
+    const errorHandler = createStubErrorHandler();
+    const root = shallowRender({ errorHandler, dispatch: fakeDispatch });
+    const slug = 'some-new-slug';
+
+    fakeDispatch.reset();
+    // Update with a new slug.
+    root.setProps({ params: { slug } });
+
+    sinon.assert.calledWith(fakeDispatch, fetchAddonAction({ errorHandler, slug }));
+  });
+
   it('renders an error if there is one', () => {
     const errorHandler = createStubErrorHandler(new Error('some error'));
 


### PR DESCRIPTION
Fix #3017

---

This PR updates an addon page whenever its slug changes.

![2017-08-29 11 44 05](https://user-images.githubusercontent.com/217628/29815021-8d44ca98-8caf-11e7-929e-91773f58fda9.gif)
