### PR TITLE
Add new addonsByAuthors reducer/saga to retrieve other add-ons by these authors

### DIFF
--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -1,0 +1,135 @@
+/* @flow */
+import type { AddonType } from 'core/types/addons';
+
+
+type State = {
+  byAddonSlug: { [string]: AddonType },
+};
+
+export const initialState: State = {
+  byAddonSlug: {},
+};
+
+export const OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE = 6;
+
+// For further information about this notation, see:
+// https://github.com/mozilla/addons-frontend/pull/3027#discussion_r137661289
+export const FETCH_OTHER_ADDONS_BY_AUTHORS: 'FETCH_OTHER_ADDONS_BY_AUTHORS'
+  = 'FETCH_OTHER_ADDONS_BY_AUTHORS';
+export const LOAD_OTHER_ADDONS_BY_AUTHORS: 'LOAD_OTHER_ADDONS_BY_AUTHORS'
+  = 'LOAD_OTHER_ADDONS_BY_AUTHORS';
+
+type FetchOtherAddonsByAuthorsParams = {|
+  addonType: string,
+  authors: Array<string>,
+  errorHandlerId: string,
+  slug: string,
+|};
+
+type FetchOtherAddonsByAuthorsAction = {|
+  type: typeof FETCH_OTHER_ADDONS_BY_AUTHORS,
+  payload: FetchOtherAddonsByAuthorsParams,
+|};
+
+export const fetchOtherAddonsByAuthors = (
+  { addonType, authors, errorHandlerId, slug }: FetchOtherAddonsByAuthorsParams
+): FetchOtherAddonsByAuthorsAction => {
+  if (!errorHandlerId) {
+    throw new Error('An errorHandlerId is required');
+  }
+
+  if (!slug) {
+    throw new Error('An add-on slug is required.');
+  }
+
+  if (!addonType) {
+    throw new Error('An add-on type is required.');
+  }
+
+  if (!authors) {
+    throw new Error('Authors are required.');
+  }
+
+  if (!Array.isArray(authors)) {
+    throw new Error('The authors parameter must be an array.');
+  }
+
+  return {
+    type: FETCH_OTHER_ADDONS_BY_AUTHORS,
+    payload: {
+      addonType,
+      authors,
+      errorHandlerId,
+      slug,
+    },
+  };
+};
+
+type LoadOtherAddonsByAuthorsParams = {|
+  slug: string,
+  addons: Array<AddonType>,
+|};
+
+type LoadOtherAddonsByAuthorsAction = {|
+  type: typeof LOAD_OTHER_ADDONS_BY_AUTHORS,
+  payload: LoadOtherAddonsByAuthorsParams,
+|};
+
+export const loadOtherAddonsByAuthors = (
+  { addons, slug }: LoadOtherAddonsByAuthorsParams
+): LoadOtherAddonsByAuthorsAction => {
+  if (!slug) {
+    throw new Error('An add-on slug is required.');
+  }
+
+  if (!addons) {
+    throw new Error('A set of add-ons is required.');
+  }
+
+  return {
+    type: LOAD_OTHER_ADDONS_BY_AUTHORS,
+    payload: { slug, addons },
+  };
+};
+
+type Action =
+  | FetchOtherAddonsByAuthorsAction
+  | LoadOtherAddonsByAuthorsAction;
+
+const reducer = (
+  state: State = initialState,
+  action: Action
+): State => {
+  switch (action.type) {
+    case FETCH_OTHER_ADDONS_BY_AUTHORS: {
+      const payload = action.payload;
+
+      return {
+        ...state,
+        byAddonSlug: {
+          ...state.byAddonSlug,
+          [payload.slug]: undefined,
+        },
+      };
+    }
+    case LOAD_OTHER_ADDONS_BY_AUTHORS: {
+      const payload = action.payload;
+
+      return {
+        ...state,
+        byAddonSlug: {
+          ...state.byAddonSlug,
+          [payload.slug]: payload.addons
+            // This ensures we do not display the main add-on in the list of
+            // "add-ons by these authors".
+            .filter((addon) => addon.slug !== payload.slug)
+            .slice(0, OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE),
+        },
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -101,32 +101,26 @@ const reducer = (
   action: Action
 ): State => {
   switch (action.type) {
-    case FETCH_OTHER_ADDONS_BY_AUTHORS: {
-      const payload = action.payload;
-
+    case FETCH_OTHER_ADDONS_BY_AUTHORS:
       return {
         ...state,
         byAddonSlug: {
           ...state.byAddonSlug,
-          [payload.slug]: undefined,
+          [action.payload.slug]: undefined,
         },
       };
-    }
-    case LOAD_OTHER_ADDONS_BY_AUTHORS: {
-      const payload = action.payload;
-
+    case LOAD_OTHER_ADDONS_BY_AUTHORS:
       return {
         ...state,
         byAddonSlug: {
           ...state.byAddonSlug,
-          [payload.slug]: payload.addons
+          [action.payload.slug]: action.payload.addons
             // This ensures we do not display the main add-on in the list of
             // "add-ons by these authors".
-            .filter((addon) => addon.slug !== payload.slug)
+            .filter((addon) => addon.slug !== action.payload.slug)
             .slice(0, OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE),
         },
       };
-    }
     default:
       return state;
   }

--- a/src/amo/sagas/addonsByAuthors.js
+++ b/src/amo/sagas/addonsByAuthors.js
@@ -1,0 +1,47 @@
+import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { SEARCH_SORT_POPULAR } from 'core/constants';
+import {
+  FETCH_OTHER_ADDONS_BY_AUTHORS,
+  OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
+  loadOtherAddonsByAuthors,
+} from 'amo/reducers/addonsByAuthors';
+import { search as searchApi } from 'core/api/search';
+import log from 'core/logger';
+import { createErrorHandler, getState } from 'core/sagas/utils';
+
+
+export function* fetchOtherAddonsByAuthors({ payload }) {
+  const { errorHandlerId, authors, slug, addonType } = payload;
+  const errorHandler = createErrorHandler(errorHandlerId);
+
+  yield put(errorHandler.createClearingAction());
+
+  try {
+    const state = yield select(getState);
+
+    const response = yield call(searchApi, {
+      api: state.api,
+      filters: {
+        addonType,
+        author: authors.join(','),
+        // We need one more add-on than the number to display because the API
+        // may return the main add-on and we cannot tell the API to exclude it.
+        page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 1,
+        sort: SEARCH_SORT_POPULAR,
+      },
+    });
+
+    // TODO: remove the line below and pass `response.addons` directly once
+    // https://github.com/mozilla/addons-frontend/issues/2917 is done.
+    const addons = Object.values(response.entities.addons || {});
+
+    yield put(loadOtherAddonsByAuthors({ addons, slug }));
+  } catch (error) {
+    log.warn(`Search for addons by authors results failed to load: ${error}`);
+    yield put(errorHandler.createErrorAction(error));
+  }
+}
+
+export default function* addonsByAuthorsSaga() {
+  yield takeLatest(FETCH_OTHER_ADDONS_BY_AUTHORS, fetchOtherAddonsByAuthors);
+}

--- a/src/amo/sagas/index.js
+++ b/src/amo/sagas/index.js
@@ -4,6 +4,7 @@
 import { all, fork } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
+import addonsByAuthors from 'amo/sagas/addonsByAuthors';
 import categories from 'amo/sagas/categories';
 import featured from 'amo/sagas/featured';
 import landing from 'amo/sagas/landing';
@@ -18,6 +19,7 @@ import user from 'core/sagas/user';
 export default function* rootSaga() {
   yield all([
     fork(addons),
+    fork(addonsByAuthors),
     fork(autocomplete),
     fork(categories),
     fork(featured),

--- a/src/amo/sagas/landing.js
+++ b/src/amo/sagas/landing.js
@@ -8,7 +8,8 @@ import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 
 import { loadLanding } from 'amo/actions/landing';
 import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
-import { featured as featuredApi, search as searchApi } from 'core/api';
+import { featured as featuredApi } from 'core/api';
+import { search as searchApi } from 'core/api/search';
 import {
   LANDING_GET, SEARCH_SORT_POPULAR, SEARCH_SORT_TOP_RATED,
 } from 'core/constants';

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -3,6 +3,7 @@ import { createStore as _createStore, combineReducers } from 'redux';
 import { reducer as reduxAsyncConnect } from 'redux-connect';
 import createSagaMiddleware from 'redux-saga';
 
+import addonsByAuthors from 'amo/reducers/addonsByAuthors';
 import featured from 'amo/reducers/featured';
 import landing from 'amo/reducers/landing';
 import reviews from 'amo/reducers/reviews';
@@ -26,6 +27,7 @@ export default function createStore(initialState = {}) {
   const store = _createStore(
     combineReducers({
       addons,
+      addonsByAuthors,
       api,
       autocomplete,
       categories,

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -10,7 +10,6 @@ import config from 'config';
 
 import { initialApiState } from 'core/reducers/api';
 import log from 'core/logger';
-import searchApi from 'core/api/search';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { ApiStateType } from 'core/reducers/api';
@@ -268,5 +267,3 @@ export function autocomplete({ api, filters }: AutocompleteParams) {
     state: api,
   });
 }
-
-export const search = searchApi;

--- a/src/core/api/search.js
+++ b/src/core/api/search.js
@@ -19,6 +19,7 @@ export type SearchParams = {|
   // for convertFiltersToQueryParams.
   filters: {|
     addonType?: string,
+    author?: string,
     clientApp?: string,
     category?: string,
     compatibleWithVersion?: number|string,
@@ -30,7 +31,7 @@ export type SearchParams = {|
   |},
 |};
 
-export default function search(
+export function search(
   { api, auth = false, filters = {} }: SearchParams
 ) {
   const _filters = { ...filters };

--- a/src/core/sagas/search.js
+++ b/src/core/sagas/search.js
@@ -5,7 +5,7 @@ import { call, put, select, takeLatest } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
 import { searchLoad } from 'core/actions/search';
-import { search as searchApi } from 'core/api';
+import { search as searchApi } from 'core/api/search';
 import { SEARCH_STARTED } from 'core/constants';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -1,6 +1,7 @@
 export const paramsToFilter = {
   app: 'clientApp',
   appversion: 'compatibleWithVersion',
+  author: 'author',
   category: 'category',
   page: 'page',
   // TODO: Change our filter to `pageSize`, for consistency.

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -15,7 +15,7 @@ describe(__filename, () => {
       expect(state).toEqual(initialState);
     });
 
-    it('ignore unrelated actions', () => {
+    it('ignores unrelated actions', () => {
       // Load some initial state to be sure that an unrelated action does not
       // change it.
       const state = reducer(undefined, loadOtherAddonsByAuthors({
@@ -26,69 +26,65 @@ describe(__filename, () => {
       expect(newState).toEqual(state);
     });
 
-    describe('loadOtherAddonsByAuthors()', () => {
-      it('allows an empty list of add-ons', () => {
-        const state = reducer(undefined, loadOtherAddonsByAuthors({
-          slug: 'addon-slug',
-          addons: [],
-        }));
-        expect(state.byAddonSlug).toEqual({
-          'addon-slug': [],
-        });
-      });
-
-      it('adds related add-ons by slug', () => {
-        const state = reducer(undefined, loadOtherAddonsByAuthors({
-          slug: 'addon-slug',
-          addons: [fakeAddon],
-        }));
-        expect(state.byAddonSlug).toEqual({
-          'addon-slug': [fakeAddon],
-        });
-      });
-
-      it('excludes the main add-on from the list of add-ons', () => {
-        const state = reducer(undefined, loadOtherAddonsByAuthors({
-          slug: fakeAddon.slug,
-          addons: [fakeAddon],
-        }));
-        expect(state.byAddonSlug).toEqual({
-          [fakeAddon.slug]: [],
-        });
-      });
-
-      it('always ensures the page size is consistent', () => {
-        const slug = 'addon-slug';
-        const state = reducer(undefined, loadOtherAddonsByAuthors({
-          slug,
-          // This is the case where there are more add-ons loaded than needed.
-          addons: Array(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
-        }));
-        expect(state.byAddonSlug[slug])
-          .toHaveLength(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE);
+    it('allows an empty list of add-ons', () => {
+      const state = reducer(undefined, loadOtherAddonsByAuthors({
+        slug: 'addon-slug',
+        addons: [],
+      }));
+      expect(state.byAddonSlug).toEqual({
+        'addon-slug': [],
       });
     });
 
-    describe('fetchOtherAddonsByAuthors()', () => {
-      it('resets the loaded add-ons', () => {
-        const slug = 'addon-slug';
-
-        const previousState = reducer(undefined, loadOtherAddonsByAuthors({
-          addons: [fakeAddon],
-          slug,
-        }));
-        expect(previousState.byAddonSlug)
-          .toEqual({ 'addon-slug': [fakeAddon] });
-
-        const state = reducer(previousState, fetchOtherAddonsByAuthors({
-          authors: ['author1'],
-          addonType: ADDON_TYPE_THEME,
-          errorHandlerId: 'error-handler-id',
-          slug,
-        }));
-        expect(state.byAddonSlug)
-          .toEqual({ 'addon-slug': undefined });
+    it('adds related add-ons by slug', () => {
+      const state = reducer(undefined, loadOtherAddonsByAuthors({
+        slug: 'addon-slug',
+        addons: [fakeAddon],
+      }));
+      expect(state.byAddonSlug).toEqual({
+        'addon-slug': [fakeAddon],
       });
+    });
+
+    it('excludes the main add-on from the list of add-ons', () => {
+      const state = reducer(undefined, loadOtherAddonsByAuthors({
+        slug: fakeAddon.slug,
+        addons: [fakeAddon],
+      }));
+      expect(state.byAddonSlug).toEqual({
+        [fakeAddon.slug]: [],
+      });
+    });
+
+    it('always ensures the page size is consistent', () => {
+      const slug = 'addon-slug';
+      const state = reducer(undefined, loadOtherAddonsByAuthors({
+        slug,
+        // This is the case where there are more add-ons loaded than needed.
+        addons: Array(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
+      }));
+      expect(state.byAddonSlug[slug])
+        .toHaveLength(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE);
+    });
+
+    it('resets the loaded add-ons', () => {
+      const slug = 'addon-slug';
+
+      const previousState = reducer(undefined, loadOtherAddonsByAuthors({
+        addons: [fakeAddon],
+        slug,
+      }));
+      expect(previousState.byAddonSlug)
+        .toEqual({ 'addon-slug': [fakeAddon] });
+
+      const state = reducer(previousState, fetchOtherAddonsByAuthors({
+        authors: ['author1'],
+        addonType: ADDON_TYPE_THEME,
+        errorHandlerId: 'error-handler-id',
+        slug,
+      }));
+      expect(state.byAddonSlug)
+        .toEqual({ 'addon-slug': undefined });
     });
   });
 

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -1,0 +1,170 @@
+import { ADDON_TYPE_THEME } from 'core/constants';
+import reducer, {
+  OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
+  fetchOtherAddonsByAuthors,
+  initialState,
+  loadOtherAddonsByAuthors,
+} from 'amo/reducers/addonsByAuthors';
+import { fakeAddon } from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  describe('reducer', () => {
+    it('initializes properly', () => {
+      const state = reducer(undefined, {});
+      expect(state).toEqual(initialState);
+    });
+
+    it('ignore unrelated actions', () => {
+      // Load some initial state to be sure that an unrelated action does not
+      // change it.
+      const state = reducer(undefined, loadOtherAddonsByAuthors({
+        slug: fakeAddon.slug,
+        addons: [fakeAddon],
+      }));
+      const newState = reducer(state, { type: 'UNRELATED' });
+      expect(newState).toEqual(state);
+    });
+
+    describe('loadOtherAddonsByAuthors()', () => {
+      it('allows an empty list of add-ons', () => {
+        const state = reducer(undefined, loadOtherAddonsByAuthors({
+          slug: 'addon-slug',
+          addons: [],
+        }));
+        expect(state.byAddonSlug).toEqual({
+          'addon-slug': [],
+        });
+      });
+
+      it('adds related add-ons by slug', () => {
+        const state = reducer(undefined, loadOtherAddonsByAuthors({
+          slug: 'addon-slug',
+          addons: [fakeAddon],
+        }));
+        expect(state.byAddonSlug).toEqual({
+          'addon-slug': [fakeAddon],
+        });
+      });
+
+      it('excludes the main add-on from the list of add-ons', () => {
+        const state = reducer(undefined, loadOtherAddonsByAuthors({
+          slug: fakeAddon.slug,
+          addons: [fakeAddon],
+        }));
+        expect(state.byAddonSlug).toEqual({
+          [fakeAddon.slug]: [],
+        });
+      });
+
+      it('always ensures the page size is consistent', () => {
+        const slug = 'addon-slug';
+        const state = reducer(undefined, loadOtherAddonsByAuthors({
+          slug,
+          // This is the case where there are more add-ons loaded than needed.
+          addons: Array(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
+        }));
+        expect(state.byAddonSlug[slug])
+          .toHaveLength(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE);
+      });
+    });
+
+    describe('fetchOtherAddonsByAuthors()', () => {
+      it('resets the loaded add-ons', () => {
+        const slug = 'addon-slug';
+
+        const previousState = reducer(undefined, loadOtherAddonsByAuthors({
+          addons: [fakeAddon],
+          slug,
+        }));
+        expect(previousState.byAddonSlug)
+          .toEqual({ 'addon-slug': [fakeAddon] });
+
+        const state = reducer(previousState, fetchOtherAddonsByAuthors({
+          authors: ['author1'],
+          addonType: ADDON_TYPE_THEME,
+          errorHandlerId: 'error-handler-id',
+          slug,
+        }));
+        expect(state.byAddonSlug)
+          .toEqual({ 'addon-slug': undefined });
+      });
+    });
+  });
+
+  describe('fetchOtherAddonsByAuthors()', () => {
+    const getParams = () => {
+      return {
+        authors: ['user1', 'user2'],
+        addonType: ADDON_TYPE_THEME,
+        errorHandlerId: 'error-handler-id',
+        slug: 'addon-slug',
+      };
+    };
+
+    it('requires an error id', () => {
+      const params = getParams();
+      delete params.errorHandlerId;
+      expect(() => {
+        fetchOtherAddonsByAuthors(params);
+      }).toThrow(/An errorHandlerId is required/);
+    });
+
+    it('requires a slug', () => {
+      const params = getParams();
+      delete params.slug;
+      expect(() => {
+        fetchOtherAddonsByAuthors(params);
+      }).toThrow(/An add-on slug is required/);
+    });
+
+    it('requires an add-on type', () => {
+      const params = getParams();
+      delete params.addonType;
+      expect(() => {
+        fetchOtherAddonsByAuthors(params);
+      }).toThrow(/An add-on type is required/);
+    });
+
+    it('requires some authors', () => {
+      const params = getParams();
+      delete params.authors;
+      expect(() => {
+        fetchOtherAddonsByAuthors(params);
+      }).toThrow(/Authors are required/);
+    });
+
+    it('requires an array of authors', () => {
+      const params = getParams();
+      params.authors = 'invalid-type';
+      expect(() => {
+        fetchOtherAddonsByAuthors(params);
+      }).toThrow(/The authors parameter must be an array/);
+    });
+  });
+
+  describe('loadOtherAddonsByAuthors()', () => {
+    const getParams = () => {
+      return {
+        addons: [fakeAddon],
+        slug: 'addon-slug',
+      };
+    };
+
+    it('requires an add-on slug', () => {
+      const params = getParams();
+      delete params.slug;
+      expect(() => {
+        loadOtherAddonsByAuthors(params);
+      }).toThrow(/An add-on slug is required/);
+    });
+
+    it('requires an array of add-ons', () => {
+      const params = getParams();
+      delete params.addons;
+      expect(() => {
+        loadOtherAddonsByAuthors(params);
+      }).toThrow(/A set of add-ons is required/);
+    });
+  });
+});

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -2,6 +2,7 @@ import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import SagaTester from 'redux-saga-tester';
 
 import * as api from 'core/api';
+import * as searchApi from 'core/api/search';
 import { getLanding, loadLanding } from 'amo/actions/landing';
 import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import landingReducer from 'amo/reducers/landing';
@@ -23,11 +24,13 @@ describe('amo/sagas/landing', () => {
     let apiState;
     let errorHandler;
     let mockApi;
+    let mockSearchApi;
     let sagaTester;
 
     beforeEach(() => {
       errorHandler = createStubErrorHandler();
       mockApi = sinon.mock(api);
+      mockSearchApi = sinon.mock(searchApi);
 
       const { state } = dispatchSignInActions();
       apiState = state.api;
@@ -65,7 +68,7 @@ describe('amo/sagas/landing', () => {
       const highlyRated = createAddonsApiResult([{
         ...fakeAddon, slug: 'highly-rated-addon',
       }]);
-      mockApi
+      mockSearchApi
         .expects('search')
         .withArgs({
           ...baseArgs,
@@ -79,7 +82,7 @@ describe('amo/sagas/landing', () => {
       const popular = createAddonsApiResult([{
         ...fakeAddon, slug: 'popular-addon',
       }]);
-      mockApi
+      mockSearchApi
         .expects('search')
         .withArgs({
           ...baseArgs,

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -8,7 +8,6 @@ import addonsByAuthorsReducer, {
 import addonsByAuthorsSaga from 'amo/sagas/addonsByAuthors';
 import {
   ADDON_TYPE_THEME,
-  CLEAR_ERROR,
   SEARCH_SORT_POPULAR,
 } from 'core/constants';
 import * as searchApi from 'core/api/search';
@@ -81,7 +80,9 @@ describe(__filename, () => {
   it('clears the error handler', async () => {
     _fetchOtherAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
 
-    await sagaTester.waitFor(CLEAR_ERROR);
+    const expectedAction = errorHandler.createClearingAction();
+
+    await sagaTester.waitFor(expectedAction.type);
     expect(sagaTester.getCalledActions()[1])
       .toEqual(errorHandler.createClearingAction());
   });

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -1,0 +1,133 @@
+import SagaTester from 'redux-saga-tester';
+
+import addonsByAuthorsReducer, {
+  OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
+  fetchOtherAddonsByAuthors,
+  loadOtherAddonsByAuthors,
+} from 'amo/reducers/addonsByAuthors';
+import addonsByAuthorsSaga from 'amo/sagas/addonsByAuthors';
+import {
+  ADDON_TYPE_THEME,
+  CLEAR_ERROR,
+  SEARCH_SORT_POPULAR,
+} from 'core/constants';
+import * as searchApi from 'core/api/search';
+import apiReducer from 'core/reducers/api';
+import {
+  createAddonsApiResult,
+  dispatchClientMetadata,
+  fakeAddon,
+} from 'tests/unit/amo/helpers';
+import { createStubErrorHandler } from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  let errorHandler;
+  let mockApi;
+  let sagaTester;
+
+  beforeEach(() => {
+    errorHandler = createStubErrorHandler();
+    mockApi = sinon.mock(searchApi);
+    sagaTester = new SagaTester({
+      initialState: dispatchClientMetadata().state,
+      reducers: {
+        api: apiReducer,
+        addonsByAuthors: addonsByAuthorsReducer,
+      },
+    });
+    sagaTester.start(addonsByAuthorsSaga);
+  });
+
+  function _fetchOtherAddonsByAuthors(params) {
+    sagaTester.dispatch(fetchOtherAddonsByAuthors({
+      errorHandlerId: errorHandler.id,
+      addonType: ADDON_TYPE_THEME,
+      ...params,
+    }));
+  }
+
+  it('calls the API to retrieve other add-ons', async () => {
+    const addons = [fakeAddon];
+    const authors = ['mozilla', 'johnedoe'];
+    const slug = fakeAddon.slug;
+    const state = sagaTester.getState();
+
+    mockApi
+      .expects('search')
+      .withArgs({
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_THEME,
+          author: authors.join(','),
+          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 1,
+          sort: SEARCH_SORT_POPULAR,
+        },
+      })
+      .once()
+      .returns(Promise.resolve(createAddonsApiResult(addons)));
+
+    _fetchOtherAddonsByAuthors({ authors, slug });
+
+    const expectedLoadAction = loadOtherAddonsByAuthors({ addons, slug });
+
+    await sagaTester.waitFor(expectedLoadAction.type);
+    mockApi.verify();
+
+    const loadAction = sagaTester.getCalledActions()[2];
+    expect(loadAction).toEqual(expectedLoadAction);
+  });
+
+  it('clears the error handler', async () => {
+    _fetchOtherAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
+
+    await sagaTester.waitFor(CLEAR_ERROR);
+    expect(sagaTester.getCalledActions()[1])
+      .toEqual(errorHandler.createClearingAction());
+  });
+
+  it('dispatches an error', async () => {
+    const error = new Error('some API error maybe');
+    mockApi
+      .expects('search')
+      .once()
+      .returns(Promise.reject(error));
+
+    _fetchOtherAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
+
+    const errorAction = errorHandler.createErrorAction(error);
+    await sagaTester.waitFor(errorAction.type);
+    expect(sagaTester.getCalledActions()[2]).toEqual(errorAction);
+  });
+
+  it('handles no API results', async () => {
+    const addons = [];
+    const authors = ['mozilla', 'johnedoe'];
+    const slug = fakeAddon.slug;
+    const state = sagaTester.getState();
+
+    mockApi
+      .expects('search')
+      .withArgs({
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_THEME,
+          author: authors.join(','),
+          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 1,
+          sort: SEARCH_SORT_POPULAR,
+        },
+      })
+      .once()
+      .returns(Promise.resolve(createAddonsApiResult(addons)));
+
+    _fetchOtherAddonsByAuthors({ authors, slug });
+
+    const expectedLoadAction = loadOtherAddonsByAuthors({ addons, slug });
+
+    await sagaTester.waitFor(expectedLoadAction.type);
+    mockApi.verify();
+
+    const loadAction = sagaTester.getCalledActions()[2];
+    expect(loadAction).toEqual(expectedLoadAction);
+  });
+});

--- a/tests/unit/amo/test_store.js
+++ b/tests/unit/amo/test_store.js
@@ -5,6 +5,7 @@ describe('amo createStore', () => {
     const { store } = createStore();
     expect(Object.keys(store.getState()).sort()).toEqual([
       'addons',
+      'addonsByAuthors',
       'api',
       'autocomplete',
       'categories',

--- a/tests/unit/core/api/test_search.js
+++ b/tests/unit/core/api/test_search.js
@@ -1,7 +1,7 @@
 /* global window */
 import config from 'config';
 
-import search from 'core/api/search';
+import { search } from 'core/api/search';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,

--- a/tests/unit/core/sagas/testSearch.js
+++ b/tests/unit/core/sagas/testSearch.js
@@ -1,7 +1,7 @@
 import SagaTester from 'redux-saga-tester';
 
 import { searchStart } from 'core/actions/search';
-import * as api from 'core/api';
+import * as api from 'core/api/search';
 import { CLEAR_ERROR, SEARCH_LOADED } from 'core/constants';
 import searchReducer from 'core/reducers/search';
 import apiReducer from 'core/reducers/api';

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -13,6 +13,7 @@ describe(__filename, () => {
         compatibleWithVersion: '57.0',
         page: 4,
         query: 'Cool things',
+        author: 'johndoe',
       });
 
       expect(queryParams).toEqual({
@@ -20,6 +21,7 @@ describe(__filename, () => {
         page: 4,
         q: 'Cool things',
         type: ADDON_TYPE_THEME,
+        author: 'johndoe',
       });
     });
   });


### PR DESCRIPTION
Refs #2767

---

This PR adds a new reducer (`addonsByAuthors`) to deal with other add-ons by developers (see #2767). ~~It would make sense to put it into the `addons` reducer but I think we should not touch it anymore until #3024 is resolved.~~ That is why I created a new reducer.

There is also a saga to retrieve add-ons based on a set of authors. I set the number of results to retrieve for each author to `6` because it is the number of add-ons displayed [on the existing website](https://addons.mozilla.org/en-US/firefox/addon/english-gb-language-pack/). It is configurable in the reducer though.

I reused the same principle as in the [`reviews` reducer](https://github.com/mozilla/addons-frontend/blob/master/src/amo/reducers/reviews.js) and exposed a `byAddon` map.

It can be used as follows:

<details>
<summary>patch</summary>

``` diff
diff --git a/src/amo/components/Addon/index.js b/src/amo/components/Addon/index.js
index 45d468d..8b60362 100644
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -13,6 +13,7 @@ import NotFound from 'amo/components/ErrorPage/NotFound';
 import DefaultRatingManager from 'amo/components/RatingManager';
 import ScreenShots from 'amo/components/ScreenShots';
 import Link from 'amo/components/Link';
+import { fetchOtherAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
 import { fetchAddon } from 'core/reducers/addons';
 import { withErrorHandler } from 'core/errorHandler';
 import InstallButton from 'core/components/InstallButton';
@@ -57,6 +58,7 @@ export class AddonBase extends React.Component {
     installStatus: PropTypes.string.isRequired,
     toggleThemePreview: PropTypes.func.isRequired,
     userAgentInfo: PropTypes.object.isRequired,
+    addonsByAuthors: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
@@ -69,12 +71,19 @@ export class AddonBase extends React.Component {
 
     if (addon) {
       dispatch(setViewContext(addon.type));
+      dispatch(fetchOtherAddonsByAuthors({
+        errorHandlerId: errorHandler.id,
+        addonType: addon.type,
+        authors: addon.authors.map((author) => author.name),
+        slug: addon.slug,
+      }));
     } else {
       dispatch(fetchAddon({ slug: params.slug, errorHandler }));
     }
   }
 
-  componentWillReceiveProps({ addon: newAddon, params: newParams }) {
+  componentWillReceiveProps(nextProps) {
+    const { addon: newAddon, params: newParams } = nextProps;
     const { addon: oldAddon, dispatch, errorHandler, params } = this.props;
 
     const oldAddonType = oldAddon ? oldAddon.type : null;
@@ -85,6 +94,16 @@ export class AddonBase extends React.Component {
     if (params.slug !== newParams.slug) {
       dispatch(fetchAddon({ slug: newParams.slug, errorHandler }));
     }
+
+    // TODO: also check when addonsByAuthors is not empty to avoid extra API calls
+    if (newAddon && oldAddon !== newAddon) {
+      dispatch(fetchOtherAddonsByAuthors({
+        errorHandlerId: errorHandler.id,
+        addonType: newAddon.type,
+        authors: newAddon.authors.map((author) => author.name),
+        slug: newAddon.slug,
+      }));
+    }
   }
 
   componentWillUnmount() {
@@ -408,9 +427,13 @@ export class AddonBase extends React.Component {
 export function mapStateToProps(state, ownProps) {
   const { slug } = ownProps.params;
   const addon = state.addons[slug];
+
   let installedAddon = {};
+  let addonsByAuthors = {};
+
   if (addon) {
     installedAddon = state.installations[addon.guid] || {};
+    addonsByAuthors = state.addonsByAuthors.byAddon[addon.slug] || {};
   }
 
   return {
@@ -431,6 +454,7 @@ export function mapStateToProps(state, ownProps) {
     installStatus: installedAddon.status || UNKNOWN,
     clientApp: state.api.clientApp,
     userAgentInfo: state.api.userAgentInfo,
+    addonsByAuthors,
   };
 }
```

</details>