### PR TITLE
Remove confusing/redundant title attribute on search button

### DIFF
--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -213,7 +213,6 @@ export class SearchFormBase extends React.Component {
           className="visually-hidden"
           onClick={this.handleSearch}
           ref={(ref) => { this.submitButton = ref; }}
-          title={i18n.gettext('Enter')}
           type="submit"
         >
           {i18n.gettext('Search')}


### PR DESCRIPTION
Fix #3028 

---

Because there is already a textual content on this button, I do not think the `title` attribute adds anything meaningful.