### PR TITLE
Cancel autocomplete saga on AUTOCOMPLETE_CANCELLED

### DIFF
--- a/src/core/sagas/autocomplete.js
+++ b/src/core/sagas/autocomplete.js
@@ -1,10 +1,14 @@
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */
-import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { call, put, race, select, take, takeLatest } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
-import { AUTOCOMPLETE_STARTED, autocompleteLoad } from 'core/reducers/autocomplete';
+import {
+  AUTOCOMPLETE_CANCELLED,
+  AUTOCOMPLETE_STARTED,
+  autocompleteLoad,
+} from 'core/reducers/autocomplete';
 import { autocomplete as autocompleteApi } from 'core/api';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
@@ -35,5 +39,10 @@ export function* fetchAutocompleteResults({ payload }) {
 }
 
 export default function* autocompleteSaga() {
-  yield takeLatest(AUTOCOMPLETE_STARTED, fetchAutocompleteResults);
+  yield takeLatest(AUTOCOMPLETE_STARTED, function* fetchOrCancel(...args) {
+    yield race({
+      fetch: call(fetchAutocompleteResults, ...args),
+      cancel: take(AUTOCOMPLETE_CANCELLED),
+    });
+  });
 }


### PR DESCRIPTION
Fix #3031 

---

This PR cancels the autocomplete saga when `AUTOCOMPLETE_CANCELLED` is fired.

According to the [redux-saga doc (bottom)](https://redux-saga.js.org/docs/advanced/TaskCancellation.html), `race` should be used for automatic cancellation and that's why I used it. I made sure that the saga could be run again, even after cancellation (my first attempt was to use `cancel` but that cancelled the whole saga, and I could not run it again...).

![2017-08-31 15 43 49](https://user-images.githubusercontent.com/217628/29926509-f2b87f22-8e63-11e7-87fe-219085cc6d8d.gif)
