### PR TITLE
fix: RTL arrow for search filters

### DIFF
--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -1,5 +1,6 @@
 @import "~photon-colors/colors";
 
+@import "~core/css/inc/mixins";
 @import "~ui/css/vars";
 
 .SearchFilters-label {
@@ -8,6 +9,9 @@
 }
 
 .SearchFilters-select {
+  @include padding-end(10px);
+  @include padding-start(5px);
+
   appearance: none;
   background: $grey-30 url("~ui/components/Icon/triangle-down-black.svg") no-repeat calc(100% - 10px) 50%;
   background-size: 12px;
@@ -16,6 +20,11 @@
   display: block;
   line-height: 1.2;
   margin: 0 0 5px;
-  padding: 10px 10px 10px 5px;
+  padding-bottom: 10px;
+  padding-top: 10px;
   width: 100%;
+
+  [dir=rtl] & {
+    background-position: 10px 50%;
+  }
 }


### PR DESCRIPTION
fixes #3040

### Before
![rtl](https://user-images.githubusercontent.com/15685960/29915804-9c32a63c-8e45-11e7-981e-438bdd5b4cba.png)

### After
<img width="412" alt="screenshot 2017-08-31 17 11 18" src="https://user-images.githubusercontent.com/90871/29933720-92ff5dd2-8e70-11e7-945e-48b512197486.png">
