### PR TITLE
fix: Remove filters from categories

### DIFF
--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -9,6 +9,7 @@ import Search from 'amo/components/Search';
 import { categoriesFetch } from 'core/actions/categories';
 import { withErrorHandler } from 'core/errorHandler';
 import log from 'core/logger';
+import { convertFiltersToQueryParams } from 'core/searchUtils';
 import { apiAddonType, parsePage } from 'core/utils';
 
 import './styles.scss';
@@ -58,7 +59,9 @@ export class CategoryBase extends React.Component {
       page: parsePage(location.query.page),
     };
     const pathname = `/${params.visibleAddonType}/${categorySlug}/`;
-    const paginationQueryParams = { page: filters.page };
+    const paginationQueryParams = convertFiltersToQueryParams({
+      page: filters.page,
+    });
 
     let category;
     if (categories) {
@@ -76,7 +79,7 @@ export class CategoryBase extends React.Component {
         {errorHandler.renderErrorIfPresent()}
         <CategoryHeader category={category} />
         <Search
-          enableSearchSort={false}
+          enableSearchFilters={false}
           filters={filters}
           paginationQueryParams={paginationQueryParams}
           pathname={pathname}

--- a/src/amo/components/SearchPage/index.js
+++ b/src/amo/components/SearchPage/index.js
@@ -27,7 +27,7 @@ export const SearchPageBase = ({ filters, pathname, ...props }: PropTypes) => {
   return (
     <Search
       {...props}
-      enableSearchSort
+      enableSearchFilters
       filters={filters}
       paginationQueryParams={paginationQueryParams}
       pathname={pathname}

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -122,7 +122,7 @@ describe('Category', () => {
     });
     expect(search).toHaveProp('pathname',
       `/${params.visibleAddonType}/${fakeCategory.slug}/`);
-    expect(search).toHaveProp('enableSearchSort', false);
+    expect(search).toHaveProp('enableSearchFilters', false);
   });
 
   it('fetches categories when not yet loaded', () => {

--- a/tests/unit/amo/components/TestSearchPage.js
+++ b/tests/unit/amo/components/TestSearchPage.js
@@ -42,7 +42,7 @@ describe(__filename, () => {
   it('enables search filters', () => {
     const root = render();
 
-    expect(root.find(Search)).toHaveProp('enableSearchSort', true);
+    expect(root.find(Search)).toHaveProp('enableSearchFilters', true);
   });
 
   it("doesn't duplicate the clientApp in the URL in the queryParams", () => {


### PR DESCRIPTION
Fixes #3039.

This is sort of a stop-gap as we *should* eventually support filters here. But we didn't before so this at least prevents the bug.

### Before
<img width="1146" alt="screenshot 2017-09-01 02 43 25" src="https://user-images.githubusercontent.com/90871/29952173-9d75b6fe-8ebf-11e7-9613-5e64a1fa12c8.png">

### After
<img width="1146" alt="screenshot 2017-09-01 02 43 10" src="https://user-images.githubusercontent.com/90871/29952174-9edff1c6-8ebf-11e7-8e4d-5952c2d34919.png">