### PR TITLE
Send platform in search and autocomplete

### DIFF
--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -26,7 +26,7 @@ import {
   autocompleteStart,
 } from 'core/reducers/autocomplete';
 import {
-  convertOperatingSystemToFilterName,
+  convertOSToFilterValue,
   convertFiltersToQueryParams,
 } from 'core/searchUtils';
 import Icon from 'ui/components/Icon';
@@ -101,7 +101,7 @@ export class SearchFormBase extends React.Component {
       filters.addonType = addonType;
     }
 
-    filters.operatingSystem = convertOperatingSystemToFilterName(
+    filters.operatingSystem = convertOSToFilterValue(
       userAgentInfo.os.name);
 
     return filters;

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -93,7 +93,7 @@ export class SearchFormBase extends React.Component {
     }));
   }
 
-  setFilters(newFilters) {
+  createFiltersFromQuery(newFilters) {
     const { addonType, userAgentInfo } = this.props;
     const filters = { ...newFilters };
 
@@ -109,7 +109,7 @@ export class SearchFormBase extends React.Component {
 
   goToSearch(query) {
     const { api, pathname, router } = this.props;
-    const filters = this.setFilters({ query });
+    const filters = this.createFiltersFromQuery({ query });
 
     router.push({
       pathname: `/${api.lang}/${api.clientApp}${pathname}`,
@@ -144,7 +144,7 @@ export class SearchFormBase extends React.Component {
       return;
     }
 
-    const filters = this.setFilters({ query: value });
+    const filters = this.createFiltersFromQuery({ query: value });
 
     this.setState({
       autocompleteIsOpen: true,

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -21,11 +21,14 @@ import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import { getAddonIconUrl } from 'core/imageUtils';
 import log from 'core/logger';
-import { convertFiltersToQueryParams } from 'core/searchUtils';
 import {
   autocompleteCancel,
   autocompleteStart,
 } from 'core/reducers/autocomplete';
+import {
+  convertOperatingSystemToFilterName,
+  convertFiltersToQueryParams,
+} from 'core/searchUtils';
 import Icon from 'ui/components/Icon';
 
 import './styles.scss';
@@ -49,6 +52,7 @@ export class SearchFormBase extends React.Component {
       url: PropTypes.string.isRequired,
       iconUrl: PropTypes.string.isRequired,
     })).isRequired,
+    userAgentInfo: PropTypes.object.isRequired,
   }
 
   static defaultProps = {
@@ -90,12 +94,14 @@ export class SearchFormBase extends React.Component {
   }
 
   goToSearch(query) {
-    const { addonType, api, pathname, router } = this.props;
+    const { addonType, api, pathname, router, userAgentInfo } = this.props;
     const filters = { query };
 
     if (addonType) {
       filters.addonType = addonType;
     }
+    filters.operatingSystem = convertOperatingSystemToFilterName(
+      userAgentInfo.os.name);
 
     router.push({
       pathname: `/${api.lang}/${api.clientApp}${pathname}`,
@@ -130,12 +136,14 @@ export class SearchFormBase extends React.Component {
       return;
     }
 
-    const { addonType } = this.props;
+    const { addonType, dispatch, errorHandler, userAgentInfo } = this.props;
     const filters = { query: value };
 
     if (addonType) {
       filters.addonType = addonType;
     }
+    filters.operatingSystem = convertOperatingSystemToFilterName(
+      userAgentInfo.os.name);
 
     this.setState({
       autocompleteIsOpen: true,
@@ -283,6 +291,7 @@ export function mapStateToProps(state) {
     api: state.api,
     suggestions: state.autocomplete.suggestions,
     loadingSuggestions: state.autocomplete.loading,
+    userAgentInfo: state.api.userAgentInfo,
   };
 }
 

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -144,7 +144,6 @@ export class SearchFormBase extends React.Component {
       return;
     }
 
-    const { dispatch, errorHandler } = this.props;
     const filters = this.setFilters({ query: value });
 
     this.setState({
@@ -227,8 +226,8 @@ export class SearchFormBase extends React.Component {
     };
 
     const autocompleteIsOpen = this.state.autocompleteIsOpen &&
-      // This prevents the input to look like Autosuggest is open when there is
-      // no result coming from the API.
+      // This prevents the input to look like Autosuggest is open when
+      // there is no result coming from the API.
       this.getSuggestions().length > 0;
 
     return (

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -93,15 +93,23 @@ export class SearchFormBase extends React.Component {
     }));
   }
 
-  goToSearch(query) {
-    const { addonType, api, pathname, router, userAgentInfo } = this.props;
-    const filters = { query };
+  setFilters(newFilters) {
+    const { addonType, userAgentInfo } = this.props;
+    const filters = { ...newFilters };
 
     if (addonType) {
       filters.addonType = addonType;
     }
+
     filters.operatingSystem = convertOperatingSystemToFilterName(
       userAgentInfo.os.name);
+
+    return filters;
+  }
+
+  goToSearch(query) {
+    const { api, pathname, router } = this.props;
+    const filters = this.setFilters({ query });
 
     router.push({
       pathname: `/${api.lang}/${api.clientApp}${pathname}`,
@@ -136,14 +144,8 @@ export class SearchFormBase extends React.Component {
       return;
     }
 
-    const { addonType, dispatch, errorHandler, userAgentInfo } = this.props;
-    const filters = { query: value };
-
-    if (addonType) {
-      filters.addonType = addonType;
-    }
-    filters.operatingSystem = convertOperatingSystemToFilterName(
-      userAgentInfo.os.name);
+    const { dispatch, errorHandler } = this.props;
+    const filters = this.setFilters({ query: value });
 
     this.setState({
       autocompleteIsOpen: true,

--- a/src/core/api/search.js
+++ b/src/core/api/search.js
@@ -3,7 +3,6 @@ import { oneLine } from 'common-tags';
 
 import { addon, callApi } from 'core/api';
 import {
-  ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
 } from 'core/constants';
@@ -57,25 +56,12 @@ export default function search(
     _filters.clientApp = 'firefox';
   }
 
-  // Themes are cross-platform and searching for them with an operatingSystem
-  // filter will result in no results, so we delete it for now.
-  // Can be deleted once https://github.com/mozilla/addons-server/issues/6206
-  // is fixed.
-  if (_filters.addonType === ADDON_TYPE_THEME) {
-    delete _filters.operatingSystem;
-  }
-
   // If the browser is Firefox or Firefox for Android and we're searching for
   // extensions, send the appversion param to get extensions marked as
   // compatible with this version.
   if (
     api.userAgentInfo.browser.name === 'Firefox' &&
-    api.userAgentInfo.os.name !== 'iOS' &&
-    // TODO: Remove this check once
-    // https://github.com/mozilla/addons-server/issues/6206 is fixed.
-    // Right now sending the `appversion` param to search will result
-    // in no themes being returned.
-    (!_filters.addonType || _filters.addonType === ADDON_TYPE_EXTENSION)
+    api.userAgentInfo.os.name !== 'iOS'
   ) {
     const browserVersion = parseInt(api.userAgentInfo.browser.version, 10);
 

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -1,3 +1,9 @@
+export const operatingSystems = {
+  Linux: 'linux',
+  'Mac OS': 'mac',
+  Windows: 'windows',
+};
+
 export const paramsToFilter = {
   app: 'clientApp',
   appversion: 'compatibleWithVersion',
@@ -33,6 +39,14 @@ export function convertQueryParamsToFilters(params) {
     }
     return object;
   }, {});
+}
+
+export function convertOperatingSystemToFilterName(name) {
+  if (name in operatingSystems) {
+    return operatingSystems[name];
+  }
+
+  return '';
 }
 
 export function hasSearchFilters(filters) {

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -1,3 +1,6 @@
+import log from 'core/logger';
+
+
 export const operatingSystems = {
   Linux: 'linux',
   'Mac OS': 'mac',
@@ -45,6 +48,9 @@ export function convertOSToFilterValue(name) {
   if (name in operatingSystems) {
     return operatingSystems[name];
   }
+
+  log.info(
+    `operatingSystem "${name}" not recognized so falling back to no OS.`);
 
   return '';
 }

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -41,7 +41,7 @@ export function convertQueryParamsToFilters(params) {
   }, {});
 }
 
-export function convertOperatingSystemToFilterName(name) {
+export function convertOSToFilterValue(name) {
   if (name in operatingSystems) {
     return operatingSystems[name];
   }

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -52,7 +52,7 @@ export function convertOSToFilterValue(name) {
   log.info(
     `operatingSystem "${name}" not recognized so falling back to no OS.`);
 
-  return '';
+  return undefined;
 }
 
 export function hasSearchFilters(filters) {

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -324,11 +324,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'a' },
-=======
-        filters: { operatingSystem: 'windows', query: 'a' },
->>>>>>> Fixup tests from rebase
       }));
     });
 
@@ -353,11 +349,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'a' },
-=======
-        filters: { operatingSystem: 'windows', query: 'a' },
->>>>>>> Fixup tests from rebase
       }));
       dispatch.reset();
 
@@ -379,11 +371,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: {
           addonType: ADDON_TYPE_THEME,
-<<<<<<< HEAD
           operatingSystem: OS_WINDOWS,
-=======
-          operatingSystem: 'windows',
->>>>>>> Fixup tests from rebase
           query: 'a',
         },
       }));
@@ -433,11 +421,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'ad' },
-=======
-        filters: { operatingSystem: 'windows', query: 'ad' },
->>>>>>> Fixup tests from rebase
       }));
     });
 
@@ -465,11 +449,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'ad' },
-=======
-        filters: { operatingSystem: 'windows', query: 'ad' },
->>>>>>> Fixup tests from rebase
       }));
       dispatch.reset();
 
@@ -484,11 +464,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'adb' },
-=======
-        filters: { operatingSystem: 'windows', query: 'adb' },
->>>>>>> Fixup tests from rebase
       }));
     });
 

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -324,7 +324,11 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
+<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'a' },
+=======
+        filters: { operatingSystem: 'windows', query: 'a' },
+>>>>>>> Fixup tests from rebase
       }));
     });
 
@@ -349,7 +353,11 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
+<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'a' },
+=======
+        filters: { operatingSystem: 'windows', query: 'a' },
+>>>>>>> Fixup tests from rebase
       }));
       dispatch.reset();
 
@@ -371,7 +379,11 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: {
           addonType: ADDON_TYPE_THEME,
+<<<<<<< HEAD
           operatingSystem: OS_WINDOWS,
+=======
+          operatingSystem: 'windows',
+>>>>>>> Fixup tests from rebase
           query: 'a',
         },
       }));
@@ -421,7 +433,11 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
+<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'ad' },
+=======
+        filters: { operatingSystem: 'windows', query: 'ad' },
+>>>>>>> Fixup tests from rebase
       }));
     });
 
@@ -449,7 +465,11 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
+<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'ad' },
+=======
+        filters: { operatingSystem: 'windows', query: 'ad' },
+>>>>>>> Fixup tests from rebase
       }));
       dispatch.reset();
 
@@ -464,7 +484,11 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
+<<<<<<< HEAD
         filters: { operatingSystem: OS_WINDOWS, query: 'adb' },
+=======
+        filters: { operatingSystem: 'windows', query: 'adb' },
+>>>>>>> Fixup tests from rebase
       }));
     });
 

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -471,14 +471,16 @@ describe(__filename, () => {
     });
 
     it('clears suggestions when input is cleared', () => {
-      const { store } = dispatchSignInActions();
-      const dispatchSpy = sinon.spy(store, 'dispatch');
-      const wrapper = mountBaseComponent({ query: 'foo', store });
+      const fakeDispatch = sinon.stub();
+      const wrapper = mountBaseComponent({
+        dispatch: fakeDispatch,
+        query: 'foo',
+      });
 
       // Clearing the input calls `handleSuggestionsClearRequested()`.
       wrapper.find('input').simulate('change', createFakeChangeEvent());
-      sinon.assert.callCount(dispatchSpy, 1);
-      sinon.assert.calledWith(dispatchSpy, autocompleteCancel());
+      sinon.assert.callCount(fakeDispatch, 1);
+      sinon.assert.calledWith(fakeDispatch, autocompleteCancel());
       expect(wrapper.state('autocompleteIsOpen')).toEqual(false);
     });
 
@@ -517,9 +519,7 @@ describe(__filename, () => {
       });
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(Suggestion)).toHaveLength(0);
-      expect(wrapper.find('form'))
-        .not.toHaveClassName('SearchForm--autocompleteIsOpen');
-      expect(wrapper.state('autocompleteIsOpen')).toEqual(false);
+      expect(wrapper.find('.SearchForm--autocompleteIsOpen')).toHaveLength(0);
     });
 
     it('does not display suggestions when there is no suggestion', () => {
@@ -528,9 +528,7 @@ describe(__filename, () => {
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(Suggestion)).toHaveLength(0);
       expect(wrapper.find(LoadingText)).toHaveLength(0);
-      expect(wrapper.find('form'))
-        .not.toHaveClassName('SearchForm--autocompleteIsOpen');
-      expect(wrapper.state('autocompleteIsOpen')).toEqual(false);
+      expect(wrapper.find('.SearchForm--autocompleteIsOpen')).toHaveLength(0);
     });
 
     it('does not display suggestions when the API returns nothing', () => {

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -37,7 +37,6 @@ import {
 
 describe(__filename, () => {
   let errorHandler;
-  // let fakeDispatch;
   let fakeRouter;
 
   function mountComponent({
@@ -60,6 +59,9 @@ describe(__filename, () => {
     );
   }
 
+  // We use `mount` and the base version of this component for these tests
+  // because we need to check the state of the component and the only way
+  // to do that is to mount it directly without HOC.
   function mountBaseComponent({
     pathname = '/search/',
     query = 'foo',

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import { setViewContext } from 'amo/actions/viewContext';
-import {
+import SearchForm, {
   SearchFormBase,
   mapStateToProps,
 } from 'amo/components/SearchForm';
@@ -12,13 +12,20 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_LANG,
   ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
+  OS_WINDOWS,
+  VIEW_CONTEXT_EXPLORE,
   VIEW_CONTEXT_HOME,
 } from 'core/constants';
 import LoadingText from 'ui/components/LoadingText';
 import {
+  autocompleteCancel,
+  autocompleteStart,
+} from 'core/reducers/autocomplete';
+import {
   createFakeAutocompleteResult,
   dispatchAutocompleteResults,
-  dispatchClientMetadata,
   dispatchSignInActions,
 } from 'tests/unit/amo/helpers';
 import {
@@ -26,38 +33,53 @@ import {
   createStubErrorHandler,
   getFakeI18nInst,
 } from 'tests/unit/helpers';
-import {
-  autocompleteCancel,
-  autocompleteStart,
-} from 'core/reducers/autocomplete';
 
 
 describe(__filename, () => {
-  const pathname = '/search/';
-  const api = { clientApp: 'firefox', lang: 'de' };
   let errorHandler;
-  let router;
+  // let fakeDispatch;
+  let fakeRouter;
 
-  const mountComponent = ({
-    store = dispatchClientMetadata().store,
+  function mountComponent({
+    pathname = '/search/',
+    query = 'foo',
+    store = dispatchSignInActions().store,
     ...props
-  } = {}) => {
+  } = {}) {
     return mount(
-      <SearchFormBase
-        api={api}
+      <SearchForm
         debounce={(callback) => (...args) => callback(...args)}
-        dispatch={() => {}}
         errorHandler={errorHandler}
         i18n={getFakeI18nInst()}
-        loadingSuggestions={false}
         pathname={pathname}
+        query={query}
+        router={fakeRouter}
         store={store}
-        suggestions={[]}
-        router={router}
         {...props}
       />
     );
-  };
+  }
+
+  function mountBaseComponent({
+    pathname = '/search/',
+    query = 'foo',
+    store = dispatchSignInActions().store,
+    ...props
+  } = {}) {
+    return mount(
+      <SearchFormBase
+        debounce={(callback) => (...args) => callback(...args)}
+        dispatch={sinon.stub()}
+        errorHandler={errorHandler}
+        i18n={getFakeI18nInst()}
+        pathname={pathname}
+        query={query}
+        router={fakeRouter}
+        {...mapStateToProps(store.getState())}
+        {...props}
+      />
+    );
+  }
 
   const createFakeChangeEvent = (value = '') => {
     return createFakeEvent({
@@ -68,7 +90,7 @@ describe(__filename, () => {
   describe('render/UI', () => {
     beforeEach(() => {
       errorHandler = createStubErrorHandler();
-      router = { push: sinon.spy() };
+      fakeRouter = { push: sinon.spy() };
     });
 
     it('renders a form', () => {
@@ -78,7 +100,9 @@ describe(__filename, () => {
     });
 
     it('renders a search input with Explore placeholder', () => {
-      const wrapper = mountComponent();
+      const { store } = dispatchSignInActions();
+      store.dispatch(setViewContext(VIEW_CONTEXT_EXPLORE));
+      const wrapper = mountComponent({ store });
       const input = wrapper.find('input');
 
       expect(input).toHaveProp('placeholder', 'Find add-ons');
@@ -86,9 +110,9 @@ describe(__filename, () => {
     });
 
     it('renders Dictionary placeholder', () => {
-      const wrapper = mountComponent({
-        addonType: ADDON_TYPE_DICT,
-      });
+      const { store } = dispatchSignInActions();
+      store.dispatch(setViewContext(ADDON_TYPE_DICT));
+      const wrapper = mountComponent({ store });
       const input = wrapper.find('input');
 
       expect(input).toHaveProp('placeholder', 'Find dictionary');
@@ -96,9 +120,9 @@ describe(__filename, () => {
     });
 
     it('renders Extensions placeholder', () => {
-      const wrapper = mountComponent({
-        addonType: ADDON_TYPE_EXTENSION,
-      });
+      const { store } = dispatchSignInActions();
+      store.dispatch(setViewContext(ADDON_TYPE_EXTENSION));
+      const wrapper = mountComponent({ store });
       const input = wrapper.find('input');
 
       expect(input).toHaveProp('placeholder', 'Find extensions');
@@ -106,9 +130,9 @@ describe(__filename, () => {
     });
 
     it('renders Language Pack placeholder', () => {
-      const wrapper = mountComponent({
-        addonType: ADDON_TYPE_LANG,
-      });
+      const { store } = dispatchSignInActions();
+      store.dispatch(setViewContext(ADDON_TYPE_LANG));
+      const wrapper = mountComponent({ store });
       const input = wrapper.find('input');
 
       expect(input).toHaveProp('placeholder', 'Find language pack');
@@ -116,9 +140,9 @@ describe(__filename, () => {
     });
 
     it('renders Themes placeholder', () => {
-      const wrapper = mountComponent({
-        addonType: ADDON_TYPE_THEME,
-      });
+      const { store } = dispatchSignInActions();
+      store.dispatch(setViewContext(ADDON_TYPE_THEME));
+      const wrapper = mountComponent({ store });
       const input = wrapper.find('input');
 
       expect(input).toHaveProp('placeholder', 'Find themes');
@@ -134,17 +158,17 @@ describe(__filename, () => {
     it('changes the URL on submit', () => {
       const wrapper = mountComponent();
 
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
       wrapper.find('.SearchForm-query').simulate(
         'change', createFakeChangeEvent('adblock'));
       wrapper.find('form').simulate('submit');
-      sinon.assert.called(router.push);
+      sinon.assert.called(fakeRouter.push);
     });
 
     it('blurs the form on submit', () => {
       const wrapper = mountComponent();
       const blurSpy = sinon.spy(
-        wrapper.instance().autosuggest.input, 'blur');
+        wrapper.find(SearchFormBase).getNode().autosuggest.input, 'blur');
 
       sinon.assert.notCalled(blurSpy);
       wrapper.find('input').simulate('change', createFakeChangeEvent('something'));
@@ -155,69 +179,89 @@ describe(__filename, () => {
     it('does nothing on non-Enter keydowns', () => {
       const wrapper = mountComponent();
 
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
       wrapper.find('input').simulate('change', createFakeChangeEvent('adblock'));
       wrapper.find('input').simulate('keydown', { key: 'A', shiftKey: true });
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
     });
 
     it('updates the location on form submit', () => {
       const wrapper = mountComponent();
 
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
       wrapper.find('input').simulate('change', createFakeChangeEvent('adblock'));
       wrapper.find('button').simulate('click');
-      sinon.assert.called(router.push);
+      sinon.assert.called(fakeRouter.push);
     });
 
     it('passes addonType when set', () => {
-      const wrapper = mountComponent({
-        addonType: ADDON_TYPE_EXTENSION,
+      const { store } = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        lang: 'de',
       });
+      store.dispatch(setViewContext(ADDON_TYPE_EXTENSION));
+      const wrapper = mountComponent({ store });
 
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
       wrapper.find('input').simulate('change', createFakeChangeEvent('& 26 %'));
       wrapper.find('button').simulate('click');
-      sinon.assert.calledWith(router.push, {
+      sinon.assert.calledWith(fakeRouter.push, {
         pathname: '/de/firefox/search/',
-        query: { q: '& 26 %', type: ADDON_TYPE_EXTENSION },
+        query: {
+          platform: OS_WINDOWS,
+          q: '& 26 %',
+          type: ADDON_TYPE_EXTENSION,
+        },
       });
     });
 
     it('does not set type when it is not defined', () => {
-      const wrapper = mountComponent();
+      const { store } = dispatchSignInActions({
+        clientApp: CLIENT_APP_ANDROID,
+        lang: 'fr',
+      });
+      store.dispatch(setViewContext(VIEW_CONTEXT_EXPLORE));
+      const wrapper = mountComponent({ store });
 
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
       wrapper.find('input').simulate('change', createFakeChangeEvent('searching'));
       wrapper.find('button').simulate('click');
-      sinon.assert.calledWith(router.push, {
-        pathname: '/de/firefox/search/',
-        query: { q: 'searching' },
+      sinon.assert.calledWith(fakeRouter.push, {
+        pathname: '/fr/android/search/',
+        query: { platform: OS_WINDOWS, q: 'searching' },
       });
     });
 
     it('encodes the value of the search text', () => {
       const wrapper = mountComponent();
 
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
       wrapper.find('input').simulate('change', createFakeChangeEvent('& 26 %'));
       wrapper.find('button').simulate('click');
-      sinon.assert.calledWith(router.push, {
-        pathname: '/de/firefox/search/',
-        query: { q: '& 26 %' },
+      sinon.assert.calledWith(fakeRouter.push, {
+        pathname: '/en-US/android/search/',
+        query: { platform: OS_WINDOWS, q: '& 26 %' },
       });
     });
 
     it('updates the state when props update', () => {
-      const wrapper = mountComponent({ query: '' });
-      expect(wrapper.state('searchValue')).toEqual('');
-
-      wrapper.setProps({ query: 'foo' });
+      // We can't access the state of components composed with higher order
+      // components (HOCs) so we need to mount `SearchFormBase` for the this
+      // test.
+      const { store } = dispatchSignInActions({
+        clientApp: CLIENT_APP_ANDROID,
+        lang: 'fr',
+      });
+      store.dispatch(setViewContext(VIEW_CONTEXT_EXPLORE));
+      const wrapper = mountBaseComponent({ store });
       expect(wrapper.state('searchValue')).toEqual('foo');
+
+      wrapper.setProps({ query: 'bar' });
+      expect(wrapper.state('searchValue')).toEqual('bar');
     });
 
     it('updates the state when user is typing', () => {
-      const wrapper = mountComponent({ query: '' });
+      const wrapper = mountBaseComponent({ query: '' });
       expect(wrapper.state('searchValue')).toEqual('');
 
       wrapper.find('input').simulate('change', createFakeChangeEvent('foo'));
@@ -228,21 +272,21 @@ describe(__filename, () => {
     });
 
     it('fetches suggestions on focus', () => {
-      const dispatch = sinon.spy();
-      const wrapper = mountComponent({
-        query: 'foo',
-        dispatch,
-      });
-      // Expect no call to to handleSuggestionsFetchRequested() until the input
-      // has focus, even if there is already a `searchValue`
-      sinon.assert.notCalled(dispatch);
-      // This is needed to trigger handleSuggestionsFetchRequested()
+      const { store } = dispatchSignInActions();
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      const wrapper = mountComponent({ query: 'foo', store });
+      // Expect no call to to `handleSuggestionsFetchRequested()` until
+      // the input has focus, even if there is already a `searchValue`.
+      sinon.assert.notCalled(dispatchSpy);
+      // This is needed to trigger `handleSuggestionsFetchRequested()`.
       wrapper.find('input').simulate('focus');
-      sinon.assert.callCount(dispatch, 1);
-      sinon.assert.calledWith(dispatch, autocompleteStart({
+
+      sinon.assert.callCount(dispatchSpy, 1);
+      sinon.assert.calledWith(dispatchSpy, autocompleteStart({
         errorHandlerId: errorHandler.id,
         filters: {
           query: 'foo',
+          operatingSystem: OS_WINDOWS,
         },
       }));
     });
@@ -255,7 +299,7 @@ describe(__filename, () => {
       const { autocomplete: autocompleteState } = store.getState();
 
       const dispatch = sinon.spy();
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         dispatch,
         suggestions: autocompleteState.suggestions,
       });
@@ -280,11 +324,11 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-        filters: { query: 'a' },
+        filters: { operatingSystem: OS_WINDOWS, query: 'a' },
       }));
     });
 
-    it('fetches suggestions twice on focus when search has not changed but add-type changed', () => {
+    it('fetches suggestions twice on focus when search has not changed but add-on type changed', () => {
       const { store } = dispatchAutocompleteResults({ results: [
         createFakeAutocompleteResult(),
         createFakeAutocompleteResult(),
@@ -292,7 +336,7 @@ describe(__filename, () => {
       const { autocomplete: autocompleteState } = store.getState();
 
       const dispatch = sinon.spy();
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         dispatch,
         suggestions: autocompleteState.suggestions,
       });
@@ -305,7 +349,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-        filters: { query: 'a' },
+        filters: { operatingSystem: OS_WINDOWS, query: 'a' },
       }));
       dispatch.reset();
 
@@ -325,7 +369,11 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-        filters: { query: 'a', addonType: ADDON_TYPE_THEME },
+        filters: {
+          addonType: ADDON_TYPE_THEME,
+          operatingSystem: OS_WINDOWS,
+          query: 'a',
+        },
       }));
     });
 
@@ -341,7 +389,7 @@ describe(__filename, () => {
       const { autocomplete: autocompleteState } = store.getState();
 
       const dispatch = sinon.spy();
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         dispatch,
         query: 'ad',
         suggestions: autocompleteState.suggestions,
@@ -373,7 +421,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-        filters: { query: 'ad' },
+        filters: { operatingSystem: OS_WINDOWS, query: 'ad' },
       }));
     });
 
@@ -386,7 +434,7 @@ describe(__filename, () => {
       const { autocomplete: autocompleteState } = store.getState();
 
       const dispatch = sinon.spy();
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         dispatch,
         query: 'ad',
         suggestions: autocompleteState.suggestions,
@@ -401,7 +449,7 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-        filters: { query: 'ad' },
+        filters: { operatingSystem: OS_WINDOWS, query: 'ad' },
       }));
       dispatch.reset();
 
@@ -416,20 +464,19 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteStart({
         errorHandlerId: errorHandler.id,
-        filters: { query: 'adb' },
+        filters: { operatingSystem: OS_WINDOWS, query: 'adb' },
       }));
     });
 
     it('clears suggestions when input is cleared', () => {
-      const dispatch = sinon.spy();
-      const wrapper = mountComponent({
-        query: 'foo',
-        dispatch,
-      });
-      // clearing the input calls handleSuggestionsClearRequested()
+      const { store } = dispatchSignInActions();
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      const wrapper = mountBaseComponent({ query: 'foo', store });
+
+      // Clearing the input calls `handleSuggestionsClearRequested()`.
       wrapper.find('input').simulate('change', createFakeChangeEvent());
-      sinon.assert.callCount(dispatch, 1);
-      sinon.assert.calledWith(dispatch, autocompleteCancel());
+      sinon.assert.callCount(dispatchSpy, 1);
+      sinon.assert.calledWith(dispatchSpy, autocompleteCancel());
       expect(wrapper.state('autocompleteIsOpen')).toEqual(false);
     });
 
@@ -440,7 +487,7 @@ describe(__filename, () => {
       ] });
       const { autocomplete: autocompleteState } = store.getState();
 
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         query: 'foo',
         suggestions: autocompleteState.suggestions,
       });
@@ -462,7 +509,7 @@ describe(__filename, () => {
       const { autocomplete: autocompleteState } = store.getState();
 
       // setting the `query` prop to empty also sets the input state to empty.
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         query: '',
         suggestions: autocompleteState.suggestions,
       });
@@ -474,7 +521,7 @@ describe(__filename, () => {
     });
 
     it('does not display suggestions when there is no suggestion', () => {
-      const wrapper = mountComponent({ suggestions: [] });
+      const wrapper = mountBaseComponent({ suggestions: [] });
 
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(Suggestion)).toHaveLength(0);
@@ -489,7 +536,7 @@ describe(__filename, () => {
       // `onSuggestionsFetchRequested()` method, which normally opens the list
       // of results when focused. Yet, this value does not return any result,
       // which is another edge case.
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         query: 'fhghfhgfhhgfhghfhgfj',
         suggestions: [],
       });
@@ -514,10 +561,7 @@ describe(__filename, () => {
         filters: { query: 'test' },
       }));
 
-      const wrapper = mountComponent({
-        ...mapStateToProps(store.getState()),
-        query: 'test',
-      });
+      const wrapper = mountComponent({ query: 'test', store });
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(LoadingText)).toHaveLength(10);
       expect(wrapper.find('form'))
@@ -529,7 +573,7 @@ describe(__filename, () => {
       const { store } = dispatchAutocompleteResults({ results: [result] });
       const { autocomplete: autocompleteState } = store.getState();
 
-      const wrapper = mountComponent({
+      const wrapper = mountBaseComponent({
         query: 'foo',
         suggestions: autocompleteState.suggestions,
       });
@@ -538,8 +582,8 @@ describe(__filename, () => {
       wrapper.find('input').simulate('focus');
       wrapper.find(Suggestion).simulate('click');
       expect(wrapper.state('searchValue')).toEqual('');
-      sinon.assert.callCount(router.push, 1);
-      sinon.assert.calledWith(router.push, result.url);
+      sinon.assert.callCount(fakeRouter.push, 1);
+      sinon.assert.calledWith(fakeRouter.push, result.url);
     });
 
     it('ignores loading suggestions that are selected', () => {
@@ -547,7 +591,7 @@ describe(__filename, () => {
       const { store } = dispatchAutocompleteResults({ results: [result] });
       const { autocomplete: autocompleteState } = store.getState();
 
-      const wrapper = mountComponent({ query: 'baz' });
+      const wrapper = mountBaseComponent({ query: 'baz' });
       expect(wrapper.state('searchValue')).toEqual('baz');
 
       wrapper.instance().handleSuggestionSelected(createFakeEvent(), {
@@ -557,32 +601,32 @@ describe(__filename, () => {
         },
       });
       expect(wrapper.state('searchValue')).toEqual('baz');
-      sinon.assert.notCalled(router.push);
+      sinon.assert.notCalled(fakeRouter.push);
     });
 
-    it('does not fetch suggestions when there is not value', () => {
+    it('does not fetch suggestions when there is no search value', () => {
       const dispatch = sinon.spy();
-      const wrapper = mountComponent({ dispatch });
+      const wrapper = mountBaseComponent({ dispatch });
 
       wrapper.instance().handleSuggestionsFetchRequested({});
       sinon.assert.notCalled(dispatch);
     });
 
     it('adds addonType to the filters used to fetch suggestions', () => {
-      const dispatch = sinon.spy();
-      const wrapper = mountComponent({
-        addonType: ADDON_TYPE_EXTENSION,
-        dispatch,
-      });
+      const { store } = dispatchSignInActions();
+      store.dispatch(setViewContext(ADDON_TYPE_EXTENSION));
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      const wrapper = mountComponent({ query: 'ad', store });
 
       wrapper.find('input').simulate('change', createFakeChangeEvent('ad'));
 
-      sinon.assert.callCount(dispatch, 1);
-      sinon.assert.calledWith(dispatch, autocompleteStart({
+      sinon.assert.callCount(dispatchSpy, 1);
+      sinon.assert.calledWith(dispatchSpy, autocompleteStart({
         errorHandlerId: errorHandler.id,
         filters: {
-          query: 'ad',
           addonType: ADDON_TYPE_EXTENSION,
+          operatingSystem: OS_WINDOWS,
+          query: 'ad',
         },
       }));
     });
@@ -636,7 +680,7 @@ describe(__filename, () => {
 
       store.dispatch(autocompleteStart({
         errorHandlerId: errorHandler.id,
-        filters: { query: 'test' },
+        filters: { operatingSystem: OS_WINDOWS, query: 'test' },
       }));
 
       const state = store.getState();

--- a/tests/unit/core/api/test_search.js
+++ b/tests/unit/core/api/test_search.js
@@ -168,27 +168,6 @@ describe(__filename, () => {
     return _search().then(() => mockWindow.verify());
   });
 
-  it('does not set appversion if addonType is set but not extension', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: firefox57,
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&type=persona&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search({
-      filters: {
-        addonType: ADDON_TYPE_THEME,
-        page: parsePage(3),
-        query: 'foo',
-      },
-    })
-      .then(() => mockWindow.verify());
-  });
-
   it('normalizes the response', () => {
     mockWindow.expects('fetch').once().returns(mockResponse());
 

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -2,7 +2,10 @@ import { ADDON_TYPE_THEME } from 'core/constants';
 import {
   convertFiltersToQueryParams,
   convertQueryParamsToFilters,
+  convertOperatingSystemToFilterName,
 } from 'core/searchUtils';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
+import { userAgents } from 'tests/unit/helpers';
 
 
 describe(__filename, () => {
@@ -39,6 +42,48 @@ describe(__filename, () => {
         page: 4,
         query: 'Cool things',
       });
+    });
+  });
+
+  describe('convertOperatingSystemToFilterName', () => {
+    function getOSNameFromUserAgent(userAgent) {
+      const { store } = dispatchClientMetadata({ userAgent });
+      return store.getState().api.userAgentInfo.os.name;
+    }
+
+    it('converts Windows to filter', () => {
+      const osName = getOSNameFromUserAgent(userAgents.firefox[1]);
+      const filterName = convertOperatingSystemToFilterName(osName);
+
+      expect(filterName).toEqual('windows');
+    });
+
+    it('converts Mac to filter', () => {
+      const osName = getOSNameFromUserAgent(userAgents.firefox[2]);
+      const filterName = convertOperatingSystemToFilterName(osName);
+
+      expect(filterName).toEqual('mac');
+    });
+
+    it('converts Linux to filter', () => {
+      const osName = getOSNameFromUserAgent(userAgents.firefox[0]);
+      const filterName = convertOperatingSystemToFilterName(osName);
+
+      expect(filterName).toEqual('linux');
+    });
+
+    it('converts Android to nothing (we use clientApp for Android)', () => {
+      const osName = getOSNameFromUserAgent(userAgents.firefoxAndroid[0]);
+      const filterName = convertOperatingSystemToFilterName(osName);
+
+      expect(filterName).toEqual('');
+    });
+
+    it('converts an unexpected value to nothing', () => {
+      const osName = getOSNameFromUserAgent(userAgents.firefoxOS[0]);
+      const filterName = convertOperatingSystemToFilterName(osName);
+
+      expect(filterName).toEqual('');
     });
   });
 });

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -53,37 +53,37 @@ describe(__filename, () => {
 
     it('converts Windows to filter', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefox[1]);
-      const filterName = convertOSToFilterValue(osName);
+      const osFilterValue = convertOSToFilterValue(osName);
 
-      expect(filterName).toEqual('windows');
+      expect(osFilterValue).toEqual('windows');
     });
 
     it('converts Mac to filter', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefox[2]);
-      const filterName = convertOSToFilterValue(osName);
+      const osFilterValue = convertOSToFilterValue(osName);
 
-      expect(filterName).toEqual('mac');
+      expect(osFilterValue).toEqual('mac');
     });
 
     it('converts Linux to filter', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefox[0]);
-      const filterName = convertOSToFilterValue(osName);
+      const osFilterValue = convertOSToFilterValue(osName);
 
-      expect(filterName).toEqual('linux');
+      expect(osFilterValue).toEqual('linux');
     });
 
     it('converts Android to undefined (we use clientApp for Android)', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefoxAndroid[0]);
-      const filterName = convertOSToFilterValue(osName);
+      const osFilterValue = convertOSToFilterValue(osName);
 
-      expect(filterName).toEqual(undefined);
+      expect(osFilterValue).toEqual(undefined);
     });
 
     it('converts an unexpected value to undefined', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefoxOS[0]);
-      const filterName = convertOSToFilterValue(osName);
+      const osFilterValue = convertOSToFilterValue(osName);
 
-      expect(filterName).toEqual(undefined);
+      expect(osFilterValue).toEqual(undefined);
     });
   });
 });

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -72,18 +72,18 @@ describe(__filename, () => {
       expect(filterName).toEqual('linux');
     });
 
-    it('converts Android to nothing (we use clientApp for Android)', () => {
+    it('converts Android to undefined (we use clientApp for Android)', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefoxAndroid[0]);
       const filterName = convertOSToFilterValue(osName);
 
-      expect(filterName).toEqual('');
+      expect(filterName).toEqual(undefined);
     });
 
-    it('converts an unexpected value to nothing', () => {
+    it('converts an unexpected value to undefined', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefoxOS[0]);
       const filterName = convertOSToFilterValue(osName);
 
-      expect(filterName).toEqual('');
+      expect(filterName).toEqual(undefined);
     });
   });
 });

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -2,7 +2,7 @@ import { ADDON_TYPE_THEME } from 'core/constants';
 import {
   convertFiltersToQueryParams,
   convertQueryParamsToFilters,
-  convertOperatingSystemToFilterName,
+  convertOSToFilterValue,
 } from 'core/searchUtils';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import { userAgents } from 'tests/unit/helpers';
@@ -45,7 +45,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('convertOperatingSystemToFilterName', () => {
+  describe('convertOSToFilterValue', () => {
     function getOSNameFromUserAgent(userAgent) {
       const { store } = dispatchClientMetadata({ userAgent });
       return store.getState().api.userAgentInfo.os.name;
@@ -53,35 +53,35 @@ describe(__filename, () => {
 
     it('converts Windows to filter', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefox[1]);
-      const filterName = convertOperatingSystemToFilterName(osName);
+      const filterName = convertOSToFilterValue(osName);
 
       expect(filterName).toEqual('windows');
     });
 
     it('converts Mac to filter', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefox[2]);
-      const filterName = convertOperatingSystemToFilterName(osName);
+      const filterName = convertOSToFilterValue(osName);
 
       expect(filterName).toEqual('mac');
     });
 
     it('converts Linux to filter', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefox[0]);
-      const filterName = convertOperatingSystemToFilterName(osName);
+      const filterName = convertOSToFilterValue(osName);
 
       expect(filterName).toEqual('linux');
     });
 
     it('converts Android to nothing (we use clientApp for Android)', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefoxAndroid[0]);
-      const filterName = convertOperatingSystemToFilterName(osName);
+      const filterName = convertOSToFilterValue(osName);
 
       expect(filterName).toEqual('');
     });
 
     it('converts an unexpected value to nothing', () => {
       const osName = getOSNameFromUserAgent(userAgents.firefoxOS[0]);
-      const filterName = convertOperatingSystemToFilterName(osName);
+      const filterName = convertOSToFilterValue(osName);
 
       expect(filterName).toEqual('');
     });


### PR DESCRIPTION
Fixes #2706 by sending the operating system (basically only for desktop searches right now, as we filter for android compatibility with `clientApp` instead).