### PR TITLE
Fix search input corners and autocomplete

### DIFF
--- a/src/core/reducers/autocomplete.js
+++ b/src/core/reducers/autocomplete.js
@@ -7,7 +7,6 @@ export const AUTOCOMPLETE_CANCELLED = 'AUTOCOMPLETE_CANCELLED';
 
 const initialState = {
   loading: false,
-  isOpen: false,
   suggestions: [],
 };
 
@@ -48,14 +47,12 @@ export default function reducer(state = initialState, action = {}) {
     case AUTOCOMPLETE_CANCELLED:
       return {
         ...state,
-        isOpen: false,
         loading: false,
       };
     case AUTOCOMPLETE_STARTED:
       return {
         ...initialState,
         loading: true,
-        isOpen: true,
       };
     case AUTOCOMPLETE_LOADED:
     {
@@ -72,7 +69,6 @@ export default function reducer(state = initialState, action = {}) {
       return {
         ...state,
         loading: false,
-        isOpen: suggestions.length > 0,
         suggestions,
       };
     }

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -430,6 +430,7 @@ describe(__filename, () => {
       wrapper.find('input').simulate('change', createFakeChangeEvent());
       sinon.assert.callCount(dispatch, 1);
       sinon.assert.calledWith(dispatch, autocompleteCancel());
+      expect(wrapper.state('autocompleteIsOpen')).toEqual(false);
     });
 
     it('displays suggestions when user is typing', () => {
@@ -442,14 +443,15 @@ describe(__filename, () => {
       const wrapper = mountComponent({
         query: 'foo',
         suggestions: autocompleteState.suggestions,
-        autocompleteIsOpen: autocompleteState.isOpen,
       });
       expect(wrapper.find(Suggestion)).toHaveLength(0);
       // this triggers Autosuggest
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(Suggestion)).toHaveLength(2);
       expect(wrapper.find(LoadingText)).toHaveLength(0);
-      expect(wrapper.find('form')).toHaveClassName('SearchForm--autocompleteIsOpen');
+      expect(wrapper.find('form'))
+        .toHaveClassName('SearchForm--autocompleteIsOpen');
+      expect(wrapper.state('autocompleteIsOpen')).toEqual(true);
     });
 
     it('does not display suggestions when search is empty', () => {
@@ -463,23 +465,45 @@ describe(__filename, () => {
       const wrapper = mountComponent({
         query: '',
         suggestions: autocompleteState.suggestions,
-        autocompleteIsOpen: autocompleteState.isOpen,
       });
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(Suggestion)).toHaveLength(0);
-      expect(wrapper.find('form')).not.toHaveClassName('SearchForm--autocompleteIsOpen');
+      expect(wrapper.find('form'))
+        .not.toHaveClassName('SearchForm--autocompleteIsOpen');
+      expect(wrapper.state('autocompleteIsOpen')).toEqual(false);
     });
 
     it('does not display suggestions when there is no suggestion', () => {
+      const wrapper = mountComponent({ suggestions: [] });
+
+      wrapper.find('input').simulate('focus');
+      expect(wrapper.find(Suggestion)).toHaveLength(0);
+      expect(wrapper.find(LoadingText)).toHaveLength(0);
+      expect(wrapper.find('form'))
+        .not.toHaveClassName('SearchForm--autocompleteIsOpen');
+      expect(wrapper.state('autocompleteIsOpen')).toEqual(false);
+    });
+
+    it('does not display suggestions when the API returns nothing', () => {
+      // Setting `query` to `fhghfhgfhhgfhghfhgfj` will trigger Autosuggest
+      // `onSuggestionsFetchRequested()` method, which normally opens the list
+      // of results when focused. Yet, this value does not return any result,
+      // which is another edge case.
       const wrapper = mountComponent({
+        query: 'fhghfhgfhhgfhghfhgfj',
         suggestions: [],
-        autocompleteIsOpen: false,
       });
 
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(Suggestion)).toHaveLength(0);
       expect(wrapper.find(LoadingText)).toHaveLength(0);
-      expect(wrapper.find('form')).not.toHaveClassName('SearchForm--autocompleteIsOpen');
+      expect(wrapper.find('form'))
+        .not.toHaveClassName('SearchForm--autocompleteIsOpen');
+      // This value is set to `true` because the autocomplete should be open
+      // and this value is controlled by Autosuggest. Because there is no
+      // results, Autosuggest does not display anything and we should make the
+      // `input` look like if there is no result too.
+      expect(wrapper.state('autocompleteIsOpen')).toEqual(true);
     });
 
     it('displays 10 loading bars when suggestions are loading', () => {
@@ -496,7 +520,8 @@ describe(__filename, () => {
       });
       wrapper.find('input').simulate('focus');
       expect(wrapper.find(LoadingText)).toHaveLength(10);
-      expect(wrapper.find('form')).toHaveClassName('SearchForm--autocompleteIsOpen');
+      expect(wrapper.find('form'))
+        .toHaveClassName('SearchForm--autocompleteIsOpen');
     });
 
     it('updates the state and push a new route when a suggestion is selected', () => {
@@ -604,7 +629,6 @@ describe(__filename, () => {
         },
       ]);
       expect(mapStateToProps(state).loadingSuggestions).toEqual(false);
-      expect(mapStateToProps(state).autocompleteIsOpen).toEqual(true);
     });
 
     it('passes the loading suggestions boolean through', () => {
@@ -618,18 +642,6 @@ describe(__filename, () => {
       const state = store.getState();
 
       expect(mapStateToProps(state).loadingSuggestions).toEqual(true);
-      expect(mapStateToProps(state).autocompleteIsOpen).toEqual(true);
-    });
-
-    it('passes the `isOpen` boolean through', () => {
-      const { store } = dispatchSignInActions();
-
-      store.dispatch(autocompleteCancel());
-
-      const state = store.getState();
-
-      expect(mapStateToProps(state).loadingSuggestions).toEqual(false);
-      expect(mapStateToProps(state).autocompleteIsOpen).toEqual(false);
     });
   });
 });

--- a/tests/unit/core/reducers/test_autocomplete.js
+++ b/tests/unit/core/reducers/test_autocomplete.js
@@ -23,13 +23,11 @@ describe(__filename, () => {
       const results = [createFakeAutocompleteResult({ name: 'foo' })];
       const previousState = reducer(undefined, autocompleteLoad({ results }));
       const {
-        isOpen,
         loading,
         suggestions,
       } = reducer(previousState, autocompleteCancel());
 
       expect(loading).toEqual(false);
-      expect(isOpen).toEqual(false);
       expect(suggestions).toEqual(previousState.suggestions);
     });
 
@@ -51,23 +49,14 @@ describe(__filename, () => {
 
       const {
         loading,
-        isOpen,
         suggestions,
       } = reducer(undefined, autocompleteLoad({ results }));
 
       expect(loading).toBe(false);
-      expect(isOpen).toEqual(true);
       expect(suggestions).toHaveLength(3);
       expect(suggestions[0]).toHaveProperty('name', 'foo');
       expect(suggestions[1]).toHaveProperty('name', 'bar');
       expect(suggestions[2]).toHaveProperty('name', 'baz');
-    });
-
-    it('sets isOpen to false if no suggestions are found', () => {
-      const results = [];
-      const { isOpen } = reducer(undefined, autocompleteLoad({ results }));
-
-      expect(isOpen).toEqual(false);
     });
 
     it('sets the icon_url as iconUrl', () => {


### PR DESCRIPTION
Fix #3078
Refs #3077

---

This PR reverts the trailing edge debouncing implementation introduced in #3065. It also get rid of the async `setState` callback. Last but not the least, it provides a different fix for the search input corners.

Having a `isOpen` in the reducer was misleading: with the recent `autocompleteCancel()` change (cancelling the API call and everything else), the input could be desynchronized. Now, the `SearchForm` is synchronized with `Autosuggest` at the component level and it works better.