### PR TITLE
More add-ons by authors UI

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -125,10 +125,6 @@ export class AddonBase extends React.Component {
     this.props.toggleThemePreview(event.currentTarget);
   }
 
-  getAuthorUsernames(addon) {
-    return addon.authors.map((author) => author.username);
-  }
-
   getFeaturedText(addonType) {
     const { i18n } = this.props;
 
@@ -147,7 +143,7 @@ export class AddonBase extends React.Component {
 
     dispatch(fetchOtherAddonsByAuthors({
       addonType: addon.type,
-      authors: this.getAuthorUsernames(addon),
+      authors: addon.authors.map((author) => author.username),
       errorHandlerId: errorHandler.id,
       slug: addon.slug,
     }));

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -13,6 +13,7 @@ import NotFound from 'amo/components/ErrorPage/NotFound';
 import DefaultRatingManager from 'amo/components/RatingManager';
 import ScreenShots from 'amo/components/ScreenShots';
 import Link from 'amo/components/Link';
+import { fetchOtherAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
 import { fetchAddon } from 'core/reducers/addons';
 import { withErrorHandler } from 'core/errorHandler';
 import InstallButton from 'core/components/InstallButton';
@@ -34,6 +35,7 @@ import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import ShowMoreCard from 'ui/components/ShowMoreCard';
 import Badge from 'ui/components/Badge';
+import AddonsCard from 'amo/components/AddonsCard';
 
 import './styles.scss';
 
@@ -57,6 +59,7 @@ export class AddonBase extends React.Component {
     installStatus: PropTypes.string.isRequired,
     toggleThemePreview: PropTypes.func.isRequired,
     userAgentInfo: PropTypes.object.isRequired,
+    addonsByAuthors: PropTypes.array.isRequired,
   }
 
   static defaultProps = {
@@ -65,17 +68,33 @@ export class AddonBase extends React.Component {
   }
 
   componentWillMount() {
-    const { addon, dispatch, errorHandler, params } = this.props;
+    const {
+      addon,
+      dispatch,
+      errorHandler,
+      params,
+    } = this.props;
 
     if (addon) {
       dispatch(setViewContext(addon.type));
+      dispatch(fetchOtherAddonsByAuthors({
+        addonType: addon.type,
+        authors: this.getAuthorUsernames(addon),
+        errorHandlerId: errorHandler.id,
+        slug: addon.slug,
+      }));
     } else {
       dispatch(fetchAddon({ slug: params.slug, errorHandler }));
     }
   }
 
-  componentWillReceiveProps({ addon: newAddon, params: newParams }) {
+  componentWillReceiveProps(nextProps) {
     const { addon: oldAddon, dispatch, errorHandler, params } = this.props;
+    const {
+      addon: newAddon,
+      addonsByAuthors: newAddonsByAuthors,
+      params: newParams,
+    } = nextProps;
 
     const oldAddonType = oldAddon ? oldAddon.type : null;
     if (newAddon && newAddon.type !== oldAddonType) {
@@ -84,6 +103,15 @@ export class AddonBase extends React.Component {
 
     if (params.slug !== newParams.slug) {
       dispatch(fetchAddon({ slug: newParams.slug, errorHandler }));
+    }
+
+    if (newAddon && oldAddon !== newAddon && !newAddonsByAuthors) {
+      dispatch(fetchOtherAddonsByAuthors({
+        addonType: newAddon.type,
+        authors: this.getAuthorUsernames(newAddon),
+        errorHandlerId: errorHandler.id,
+        slug: newAddon.slug,
+      }));
     }
   }
 
@@ -101,6 +129,10 @@ export class AddonBase extends React.Component {
 
   onClick = (event) => {
     this.props.toggleThemePreview(event.currentTarget);
+  }
+
+  getAuthorUsernames(addon) {
+    return addon.authors.map((author) => author.username);
   }
 
   getFeaturedText(addonType) {
@@ -266,6 +298,67 @@ export class AddonBase extends React.Component {
     /* eslint-enable react/no-danger */
   }
 
+  renderMoreAddonsByAuthors = () => {
+    const { addon, addonsByAuthors, i18n } = this.props;
+
+    if (!addon || !addonsByAuthors || addonsByAuthors.length === 0) {
+      return null;
+    }
+
+    const addonType = addon.type;
+    const authorNames = addon.authors.map((author) => author.name);
+
+    let header;
+    switch (addonType) {
+      case ADDON_TYPE_EXTENSION:
+        header = i18n.ngettext(
+          i18n.sprintf(
+            i18n.gettext('More extensions by %(author)s'),
+            { author: authorNames[0] }
+          ),
+          i18n.gettext('More extensions by these authors'),
+          authorNames.length
+        );
+        break;
+
+      case ADDON_TYPE_THEME:
+        header = i18n.ngettext(
+          i18n.sprintf(
+            i18n.gettext('More themes by %(author)s'),
+            { author: authorNames[0] }
+          ),
+          i18n.gettext('More themes by these authors'),
+          authorNames.length
+        );
+        break;
+
+      default:
+        header = i18n.ngettext(
+          i18n.sprintf(
+            i18n.gettext('More add-ons by %(author)s'),
+            { author: authorNames[0] }
+          ),
+          i18n.gettext('More add-ons by these authors'),
+          authorNames.length
+        );
+    }
+
+    const classnames = classNames('AddonDescription-more-addons', {
+      'AddonDescription-more-addons--theme': addonType === ADDON_TYPE_THEME,
+    });
+
+    return (
+      <AddonsCard
+        addons={addonsByAuthors}
+        className={classnames}
+        header={header}
+        showMetadata={false}
+        showSummary={false}
+        type="horizontal"
+      />
+    );
+  }
+
   render() {
     const {
       addon,
@@ -402,6 +495,7 @@ export class AddonBase extends React.Component {
 
           {addon ? <AddonMoreInfo addon={addon} /> : null}
           {this.renderVersionReleaseNotes()}
+          {this.renderMoreAddonsByAuthors()}
         </div>
       </div>
     );
@@ -412,9 +506,13 @@ export class AddonBase extends React.Component {
 export function mapStateToProps(state, ownProps) {
   const { slug } = ownProps.params;
   const addon = state.addons[slug];
+
   let installedAddon = {};
+  let addonsByAuthors = [];
+
   if (addon) {
     installedAddon = state.installations[addon.guid] || {};
+    addonsByAuthors = state.addonsByAuthors.byAddonSlug[addon.slug];
   }
 
   return {
@@ -435,6 +533,7 @@ export function mapStateToProps(state, ownProps) {
     installStatus: installedAddon.status || UNKNOWN,
     clientApp: state.api.clientApp,
     userAgentInfo: state.api.userAgentInfo,
+    addonsByAuthors,
   };
 }
 

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -148,6 +148,46 @@
   order: 4;
 }
 
+.AddonDescription-more-addons {
+  margin-top: 0;
+
+  .Card-contents .AddonsCard-list {
+    background-color: $white;
+    display: grid;
+    grid-auto-flow: initial;
+    grid-template-columns: repeat(2, 1fr);
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.AddonDescription-more-addons--theme {
+  .Card-contents .AddonsCard-list {
+    .SearchResult-result {
+      width: 100%;
+    }
+
+    .SearchResult-icon-wrapper {
+      margin: 0 0 10px;
+      width: 100%;
+    }
+
+    .SearchResult-icon {
+      border-radius: $border-radius-default;
+    }
+
+    @include respond-to(large) {
+      .SearchResult.SearchResult--theme {
+        margin: 0 5px;
+      }
+    }
+
+    @include respond-to(desktop) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+}
+
 // Details section with lots of grid stuff, on larger displays.
 @include respond-to(large) {
   .Addon-details {
@@ -164,6 +204,15 @@
 
     .AddonDescription-version-notes {
       grid-column: 1;
+    }
+
+    .AddonDescription-more-addons {
+      grid-column: 1;
+    }
+
+    .AddonDescription-more-addons--theme {
+      grid-column: 2;
+      grid-row: 1 / span 5;
     }
 
     .AddonDescription-contents {

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -182,7 +182,7 @@
       }
     }
 
-    @include respond-to(desktop) {
+    @include respond-to(extraLarge) {
       grid-template-columns: repeat(3, 1fr);
     }
   }

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -18,6 +18,8 @@ export default class AddonsCard extends React.Component {
     // that will be rendered.
     placeholderCount: PropTypes.number,
     type: PropTypes.string,
+    showMetadata: PropTypes.bool,
+    showSummary: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -34,6 +36,8 @@ export default class AddonsCard extends React.Component {
       className,
       loading,
       placeholderCount,
+      showMetadata,
+      showSummary,
       type,
       ...otherProps
     } = this.props;
@@ -43,7 +47,12 @@ export default class AddonsCard extends React.Component {
     if (addons && addons.length) {
       addons.forEach((addon) => {
         searchResults.push(
-          <SearchResult addon={addon} key={addon.slug} />
+          <SearchResult
+            addon={addon}
+            key={addon.slug}
+            showMetadata={showMetadata}
+            showSummary={showSummary}
+          />
         );
       });
     } else if (loading) {

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -19,7 +19,14 @@ export class SearchResultBase extends React.Component {
   static propTypes = {
     addon: PropTypes.object,
     i18n: PropTypes.object.isRequired,
+    showMetadata: PropTypes.bool,
+    showSummary: PropTypes.bool,
   }
+
+  static defaultProps = {
+    showMetadata: true,
+    showSummary: true,
+  };
 
   addonIsTheme() {
     const { addon } = this.props;
@@ -27,7 +34,7 @@ export class SearchResultBase extends React.Component {
   }
 
   renderResult() {
-    const { addon, i18n } = this.props;
+    const { addon, i18n, showMetadata, showSummary } = this.props;
 
     const isTheme = this.addonIsTheme();
     const averageDailyUsers = addon && addon.average_daily_users;
@@ -57,11 +64,16 @@ export class SearchResultBase extends React.Component {
       );
     }
 
-    const summaryProps = {};
-    if (addon) {
-      summaryProps.dangerouslySetInnerHTML = sanitizeHTML(addon.summary);
-    } else {
-      summaryProps.children = <LoadingText />;
+    let summary = null;
+    if (showSummary) {
+      const summaryProps = {};
+      if (addon) {
+        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(addon.summary);
+      } else {
+        summaryProps.children = <LoadingText />;
+      }
+
+      summary = <p className="SearchResult-summary" {...summaryProps} />;
     }
 
     return (
@@ -80,21 +92,20 @@ export class SearchResultBase extends React.Component {
           <h2 className="SearchResult-name">
             {addon ? addon.name : <LoadingText />}
           </h2>
-          <p
-            className="SearchResult-summary"
-            {...summaryProps}
-          />
+          {summary}
 
-          <div className="SearchResult-metadata">
-            <div className="SearchResult-rating">
-              <Rating
-                rating={addon ? addon.ratings.average : 0}
-                readOnly
-                styleName="small"
-              />
+          {showMetadata ? (
+            <div className="SearchResult-metadata">
+              <div className="SearchResult-rating">
+                <Rating
+                  rating={addon ? addon.ratings.average : 0}
+                  readOnly
+                  styleName="small"
+                />
+              </div>
+              {addonAuthors}
             </div>
-            {addonAuthors}
-          </div>
+          ) : null}
         </div>
 
         <h3 className="SearchResult-users SearchResult--meta-section">

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -18,7 +18,6 @@ $breakpoints: (
   medium: only screen and (min-width: 500px),
   large: only screen and (min-width: 720px),
   extraLarge: only screen and (min-width: 900px),
-  desktop: only screen and (min-width: 1025px),
 );
 $page-margin: 20px 10px;
 

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -18,6 +18,7 @@ $breakpoints: (
   medium: only screen and (min-width: 500px),
   large: only screen and (min-width: 720px),
   extraLarge: only screen and (min-width: 900px),
+  desktop: only screen and (min-width: 1025px),
 );
 $page-margin: 20px 10px;
 

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -18,6 +18,7 @@ export type AddonVersionType = {|
 export type AddonAuthorType = {|
   name: string,
   url: string,
+  username: string,
 |};
 
 type ThemeData = {|

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -861,14 +861,16 @@ describe(__filename, () => {
 
     it('does not fetch the other add-ons when add-on is the same', () => {
       const addon = fakeAddon;
+      const ownProps = { params: { slug: addon.slug } };
+
       const { store } = dispatchAddonData({ addon });
       const fakeDispatch = sinon.spy(store, 'dispatch');
 
-      const root = renderComponent({ params: { slug: addon.slug }, store });
+      const root = renderComponent(store, ...ownProps);
       // `fakeAddon` is the API representation of an add-on, which is slightly
       // different than the representation of an add-on in the state. That is
-      // we need to retreive the add-on from the state.
-      const addonFromState = store.getState().addons[addon.slug];
+      // why we need to retrieve the add-on from the state.
+      const addonFromState = mapStateToProps(store.getState(), ownProps).addon;
       fakeDispatch.reset();
 
       root.setProps({ addon: addonFromState });
@@ -885,7 +887,13 @@ describe(__filename, () => {
       fakeDispatch.reset();
 
       const newAddon = { ...fakeAddon, slug: 'new-addon-slug' };
-      root.setProps({ addon: newAddon });
+      store.dispatch(_loadAddons({ addon: newAddon }));
+
+      const addonFromState = mapStateToProps(
+        store.getState(),
+        { params: { slug: newAddon.slug } }
+      ).addon;
+      root.setProps({ addon: addonFromState });
 
       sinon.assert.calledWith(fakeDispatch, fetchOtherAddonsByAuthors({
         addonType: newAddon.type,

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import {
@@ -19,7 +19,6 @@ import AddonMeta from 'amo/components/AddonMeta';
 import AddonMoreInfo from 'amo/components/AddonMoreInfo';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Link from 'amo/components/Link';
-import SearchResult from 'amo/components/SearchResult';
 import routes from 'amo/routes';
 import RatingManager, {
   RatingManagerWithI18n,
@@ -28,13 +27,18 @@ import createStore from 'amo/store';
 import {
   fetchAddon as fetchAddonAction, loadAddons,
 } from 'core/reducers/addons';
-import { fetchOtherAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
+import {
+  fetchOtherAddonsByAuthors,
+  loadOtherAddonsByAuthors,
+} from 'amo/reducers/addonsByAuthors';
 import { setError } from 'core/actions/errors';
 import { setInstallState } from 'core/actions/installations';
 import { createApiError } from 'core/api/index';
 import {
-  ADDON_TYPE_THEME,
+  ADDON_TYPE_DICT,
+  ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
+  ADDON_TYPE_THEME,
   ENABLED,
   INCOMPATIBLE_NOT_FIREFOX,
   INSTALLED,
@@ -108,28 +112,29 @@ function shallowRender(...args) {
   return shallow(<AddonBase {...props} />, { context: { i18n: props.i18n } });
 }
 
-// We use `mount` to test the i18n logic on the Addon component.
-function mountRender(...args) {
-  const { store, i18n, ...props } = renderProps(...args);
-  props.i18n = i18n;
-
-  return mount(
-    <Provider store={store}>
-      <I18nProvider i18n={i18n}>
-        <AddonBase store={store} {...props} />
-      </I18nProvider>
-    </Provider>
-  );
-}
-
-describe('Addon', () => {
+describe(__filename, () => {
   const incompatibleClientResult = {
     compatible: false,
     maxVersion: null,
     minVersion: null,
     reason: INCOMPATIBLE_NOT_FIREFOX,
   };
+
   const getClientCompatibilityFalse = () => incompatibleClientResult;
+
+  const _loadAddon = ({ addon = fakeAddon }) => {
+    return loadAddons(createFetchAddonResult(addon).entities);
+  };
+
+  const _loadOtherAddonsByAuthors = ({
+    addon = fakeAddon,
+    addonsByAuthors = [],
+  }) => {
+    return loadOtherAddonsByAuthors({
+      slug: addon.slug,
+      addons: addonsByAuthors,
+    });
+  };
 
   it('dispatches setViewContext with addonType', () => {
     const fakeDispatch = sinon.stub();
@@ -794,15 +799,6 @@ describe('Addon', () => {
   });
 
   describe('more add-ons by authors', () => {
-    function mountMoreAddonsByAuthors({ addon = fakeAddon, ...others }) {
-      const root = mountRender({
-        addon,
-        ...others,
-      });
-
-      return root.find('.AddonDescription-more-addons');
-    }
-
     it('fetches the other add-ons by authors', () => {
       const addon = fakeAddon;
       const fakeDispatch = sinon.stub();
@@ -843,26 +839,6 @@ describe('Addon', () => {
       }));
     });
 
-    it('does not fetch the other add-ons when they are already loaded', () => {
-      const fakeDispatch = sinon.stub();
-      const root = shallowRender({ addon: fakeAddon, dispatch: fakeDispatch });
-      fakeDispatch.reset();
-
-      const newAddon = { ...fakeAddon, slug: 'new-addon-slug' };
-      // These `addonsByAuthors` are related to the `newAddon` above, and it
-      // simulates the case when user has previously browsed this `newAddon`
-      // and navigates to it again.
-      const addonsByAuthors = [
-        { ...fakeAddon, slug: 'addon-1' },
-        { ...fakeAddon, slug: 'addon-2' },
-        { ...fakeAddon, slug: 'addon-3' },
-      ];
-
-      root.setProps({ addon: newAddon, addonsByAuthors });
-
-      sinon.assert.notCalled(fakeDispatch);
-    });
-
     it('is hidden when an add-on has not loaded yet', () => {
       const root = shallowRender({ addon: undefined });
       expect(root.find('.AddonDescription-more-addons'))
@@ -875,67 +851,117 @@ describe('Addon', () => {
         .toHaveLength(0);
     });
 
-    it('is hidden when there is no other addon', () => {
+    it('is hidden when there are no other add-ons', () => {
       const root = shallowRender({ addonsByAuthors: [] });
       expect(root.find('.AddonDescription-more-addons'))
         .toHaveLength(0);
     });
 
     it('displays the developer name when add-on is an extension', () => {
-      const root = mountMoreAddonsByAuthors({
+      const root = shallowRender({
         addonsByAuthors: [fakeAddon],
       });
-      expect(root.find('.Card-header'))
-        .toIncludeText('More extensions by Krupa');
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More extensions by Krupa');
+    });
+
+    it('displays the translator name when add-on is a dictionary', () => {
+      const root = shallowRender({
+        addon: {
+          ...fakeAddon,
+          type: ADDON_TYPE_DICT,
+        },
+        addonsByAuthors: [fakeAddon],
+      });
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More dictionaries by Krupa');
+    });
+
+    it('displays the translator name when add-on is a language pack', () => {
+      const root = shallowRender({
+        addon: {
+          ...fakeAddon,
+          type: ADDON_TYPE_LANG,
+        },
+        addonsByAuthors: [fakeAddon],
+      });
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More language packs by Krupa');
     });
 
     it('displays the artist name when add-on is a theme', () => {
-      const root = mountMoreAddonsByAuthors({
+      const root = shallowRender({
         addon: fakeTheme,
         addonsByAuthors: [fakeTheme],
       });
-      expect(root.find('.Card-header'))
-        .toIncludeText('More themes by Madonna');
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More themes by MaDonna');
     });
 
-    it('displays the author name when add-on is not extension or theme', () => {
-      const root = mountMoreAddonsByAuthors({
+    it('displays the author name in any other cases', () => {
+      const root = shallowRender({
         addon: {
           ...fakeAddon,
           type: ADDON_TYPE_OPENSEARCH,
         },
         addonsByAuthors: [fakeAddon],
       });
-      expect(root.find('.Card-header'))
-        .toIncludeText('More add-ons by Krupa');
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More add-ons by Krupa');
     });
 
     it('displays a plural form when extension has multiple authors', () => {
-      const root = mountMoreAddonsByAuthors({
+      const root = shallowRender({
         addon: {
           ...fakeAddon,
           authors: Array(2).fill(fakeAddon.authors[0]),
         },
         addonsByAuthors: [fakeAddon],
       });
-      expect(root.find('.Card-header'))
-        .toIncludeText('More extensions by these authors');
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More extensions by these developers');
     });
 
     it('displays a plural form when theme has multiple authors', () => {
-      const root = mountMoreAddonsByAuthors({
+      const root = shallowRender({
         addon: {
           ...fakeTheme,
           authors: Array(2).fill(fakeTheme.authors[0]),
         },
         addonsByAuthors: [fakeTheme],
       });
-      expect(root.find('.Card-header'))
-        .toIncludeText('More themes by these authors');
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More themes by these artists');
+    });
+
+    it('displays a plural form when language pack has multiple authors', () => {
+      const root = shallowRender({
+        addon: {
+          ...fakeAddon,
+          authors: Array(2).fill(fakeAddon.authors[0]),
+          type: ADDON_TYPE_LANG,
+        },
+        addonsByAuthors: [fakeAddon],
+      });
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More language packs by these translators');
+    });
+
+    it('displays a plural form when dictionary has multiple authors', () => {
+      const root = shallowRender({
+        addon: {
+          ...fakeAddon,
+          authors: Array(2).fill(fakeAddon.authors[0]),
+          type: ADDON_TYPE_DICT,
+        },
+        addonsByAuthors: [fakeAddon],
+      });
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More dictionaries by these translators');
     });
 
     it('displays a plural form when add-on has multiple authors', () => {
-      const root = mountMoreAddonsByAuthors({
+      const root = shallowRender({
         addon: {
           ...fakeAddon,
           authors: Array(2).fill(fakeAddon.authors[0]),
@@ -943,37 +969,58 @@ describe('Addon', () => {
         },
         addonsByAuthors: [fakeAddon],
       });
-      expect(root.find('.Card-header'))
-        .toIncludeText('More add-ons by these authors');
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('header', 'More add-ons by these developers');
     });
 
     it('displays more add-ons by authors', () => {
+      const { store } = dispatchClientMetadata();
+
+      const addon = fakeAddon;
       const addonsByAuthors = [
         { ...fakeAddon, slug: 'addon-1' },
         { ...fakeAddon, slug: 'addon-2' },
         { ...fakeAddon, slug: 'addon-3' },
       ];
-      const root = mountMoreAddonsByAuthors({ addonsByAuthors });
+
+      store.dispatch(_loadAddon({ addon }));
+      store.dispatch(_loadOtherAddonsByAuthors({ addon, addonsByAuthors }));
+
+      const mappedProps = mapStateToProps(
+        store.getState(), { params: { slug: addon.slug } }
+      );
+
+      const root = shallowRender({ ...mappedProps });
 
       expect(root.find('.AddonDescription-more-addons--theme'))
         .toHaveLength(0);
-      expect(root.find(SearchResult)).toHaveLength(addonsByAuthors.length);
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('addons', addonsByAuthors);
     });
 
     it('indicates when other add-ons are themes', () => {
+      const { store } = dispatchClientMetadata();
+
+      const addon = fakeTheme;
       const addonsByAuthors = [
         { ...fakeTheme, slug: 'addon-1' },
         { ...fakeTheme, slug: 'addon-2' },
         { ...fakeTheme, slug: 'addon-3' },
       ];
-      const root = mountMoreAddonsByAuthors({
-        addon: fakeTheme,
-        addonsByAuthors,
-      });
+
+      store.dispatch(_loadAddon({ addon }));
+      store.dispatch(_loadOtherAddonsByAuthors({ addon, addonsByAuthors }));
+
+      const mappedProps = mapStateToProps(
+        store.getState(), { params: { slug: addon.slug } }
+      );
+
+      const root = shallowRender({ ...mappedProps });
 
       expect(root.find('.AddonDescription-more-addons--theme'))
         .toHaveLength(1);
-      expect(root.find(SearchResult)).toHaveLength(addonsByAuthors.length);
+      expect(root.find('.AddonDescription-more-addons'))
+        .toHaveProp('addons', addonsByAuthors);
     });
   });
 

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -9,7 +9,7 @@ import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
 
 
-describe('<SearchResult />', () => {
+describe(__filename, () => {
   const baseAddon = {
     ...fakeAddon,
     authors: [
@@ -91,6 +91,18 @@ describe('<SearchResult />', () => {
     expect(root.find('.SearchResult-rating')).toHaveLength(1);
   });
 
+  it('renders the summary', () => {
+    const root = render();
+
+    expect(root.find('.SearchResult-summary')).toHaveLength(1);
+  });
+
+  it('renders the metadata', () => {
+    const root = render();
+
+    expect(root.find('.SearchResult-metadata')).toHaveLength(1);
+  });
+
   it('displays a placeholder if the icon is malformed', () => {
     const addon = { ...fakeAddon, icon_url: 'whatevs' };
     const root = render({ addon });
@@ -138,5 +150,17 @@ describe('<SearchResult />', () => {
       .toHaveLength(1);
     expect(root.find('.SearchResult-users-text').find(LoadingText))
       .toHaveLength(1);
+  });
+
+  it('can hide the summary section', () => {
+    const root = render({ showSummary: false });
+
+    expect(root.find('.SearchResult-summary')).toHaveLength(0);
+  });
+
+  it('can hide the metadata section', () => {
+    const root = render({ showMetadata: false });
+
+    expect(root.find('.SearchResult-metadata')).toHaveLength(0);
   });
 });

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -26,6 +26,7 @@ export const fakeAddon = Object.freeze({
   authors: [{
     name: 'Krupa',
     url: 'http://olympia.dev/en-US/firefox/user/krupa/',
+    username: 'krupa',
   }],
   average_daily_users: 100,
   categories: { firefox: ['other'] },
@@ -83,6 +84,7 @@ export const fakeTheme = Object.freeze({
   authors: [{
     name: 'Madonna',
     url: 'http://olympia.dev/en-US/firefox/user/madonna/',
+    username: 'madonna',
   }],
   description: 'This is the add-on description',
   guid: 'dancing-daisies-theme@my-addons.firefox',

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -82,9 +82,9 @@ export const fakeAddon = Object.freeze({
 export const fakeTheme = Object.freeze({
   ...fakeAddon,
   authors: [{
-    name: 'Madonna',
+    name: 'MaDonna',
     url: 'http://olympia.dev/en-US/firefox/user/madonna/',
-    username: 'madonna',
+    username: 'MaDonna',
   }],
   description: 'This is the add-on description',
   guid: 'dancing-daisies-theme@my-addons.firefox',


### PR DESCRIPTION
Fix #2767
~~⚠️ depends on #3027~~

---

This PR adds a new section on the add-on detail page to show related add-ons (made by any of the authors).

~~⚠️  I am waiting for https://github.com/mozilla/addons-server/issues/6346 to get more add-ons by authors. Right now, it does not work well (user `name` must be her `username`).~~ => available in `dev`.

The card is not displayed if there is no "other add-ons", which is the same behavior as the old website.

## Screenshots

### Themes

<img width="1392" alt="screen shot 2017-09-08 at 18 38 12" src="https://user-images.githubusercontent.com/217628/30221860-20d2e822-94c5-11e7-92c0-7028b9427063.png">
<img width="808" alt="screen shot 2017-09-08 at 18 38 27" src="https://user-images.githubusercontent.com/217628/30221861-20d3607c-94c5-11e7-8025-60b09d22b497.png">
<img width="447" alt="screen shot 2017-09-08 at 18 38 21" src="https://user-images.githubusercontent.com/217628/30221862-20d62f82-94c5-11e7-9228-b3f828900e6d.png">


### Extensions

<img width="1392" alt="screen shot 2017-09-08 at 18 38 53" src="https://user-images.githubusercontent.com/217628/30221871-294f847e-94c5-11e7-9803-2261ef929735.png">
<img width="695" alt="screen shot 2017-09-08 at 18 39 05" src="https://user-images.githubusercontent.com/217628/30221869-2900b060-94c5-11e7-883c-9071794d5b17.png">
<img width="447" alt="screen shot 2017-09-08 at 18 39 01" src="https://user-images.githubusercontent.com/217628/30221870-292e72ca-94c5-11e7-963e-4c2552719119.png">
