### PR TITLE
chore(package): update babel-jest to version 21.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-gettext-extractor": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6",
-    "babel-jest": "^20.0.3",
+    "babel-jest": "^21.0.2",
     "babel-loader": "^7.0.0",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",


### PR DESCRIPTION
Closes #3066 