### PR TITLE
Send telemetry-client-id to the Discovery API

### DIFF
--- a/src/disco/actions.js
+++ b/src/disco/actions.js
@@ -1,12 +1,14 @@
 import { GET_DISCO_RESULTS, LOAD_DISCO_RESULTS } from 'disco/constants';
 
-export function getDiscoResults({ errorHandlerId } = {}) {
+export function getDiscoResults({
+  errorHandlerId, telemetryClientId = undefined,
+} = {}) {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
   return {
     type: GET_DISCO_RESULTS,
-    payload: { errorHandlerId },
+    payload: { errorHandlerId, telemetryClientId },
   };
 }
 

--- a/src/disco/api.js
+++ b/src/disco/api.js
@@ -11,9 +11,10 @@ export const discoResult = new schema.Entity(
   { idAttribute: (result) => getGuid(result.addon) }
 );
 
-export function getDiscoveryAddons({ api }) {
+export function getDiscoveryAddons({ api, telemetryClientId }) {
   return callApi({
     endpoint: 'discovery',
+    params: { 'telemetry-client-id': telemetryClientId },
     schema: { results: [discoResult] },
     state: api,
   });

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -55,7 +55,7 @@ export class DiscoPaneBase extends React.Component {
     // TODO: fix this; it's not the right way to detect whether a
     // dispatch is needed. This should look for an undefined value
     // instead of an empty list because an empty list could be a valid
-    // API response.
+    // (yet unlikley) API response.
     if (!errorHandler.hasError() && !results.length) {
       dispatch(getDiscoResults({
         errorHandlerId: errorHandler.id,

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -31,6 +31,7 @@ export class DiscoPaneBase extends React.Component {
     errorHandler: PropTypes.object.isRequired,
     handleGlobalEvent: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
     mozAddonManager: PropTypes.object,
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     _addChangeListeners: PropTypes.func,
@@ -50,9 +51,16 @@ export class DiscoPaneBase extends React.Component {
     super(props);
     this.state = { showVideo: false };
 
-    const { dispatch, errorHandler, results } = props;
+    const { dispatch, errorHandler, location, results } = props;
+    // TODO: fix this; it's not the right way to detect whether a
+    // dispatch is needed. This should look for an undefined value
+    // instead of an empty list because an empty list could be a valid
+    // API response.
     if (!errorHandler.hasError() && !results.length) {
-      dispatch(getDiscoResults({ errorHandlerId: errorHandler.id }));
+      dispatch(getDiscoResults({
+        errorHandlerId: errorHandler.id,
+        telemetryClientId: location.query.clientId,
+      }));
     }
   }
 

--- a/src/disco/sagas/disco.js
+++ b/src/disco/sagas/disco.js
@@ -12,12 +12,14 @@ import { GET_DISCO_RESULTS } from 'disco/constants';
 import { getDiscoveryAddons } from 'disco/api';
 
 
-export function* fetchDiscoveryAddons({ payload: { errorHandlerId } }) {
+export function* fetchDiscoveryAddons({
+  payload: { errorHandlerId, telemetryClientId },
+}) {
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
     const state = yield select(getState);
     const { entities, result } = yield call(getDiscoveryAddons, {
-      api: state.api,
+      api: state.api, telemetryClientId,
     });
 
     yield put(loadAddons(entities));

--- a/tests/unit/disco/containers/TestDiscoPane.js
+++ b/tests/unit/disco/containers/TestDiscoPane.js
@@ -33,7 +33,7 @@ import ErrorList from 'ui/components/ErrorList';
 const { DiscoPaneBase } = helpers;
 
 
-describe('AddonPage', () => {
+describe(__filename, () => {
   let fakeEvent;
   let fakeVideo;
   let fakeTracking;
@@ -65,6 +65,7 @@ describe('AddonPage', () => {
       errorHandler: createStubErrorHandler(),
       dispatch: sinon.stub(),
       i18n,
+      location: { query: {} },
       results,
       _tracking: fakeTracking,
       _video: fakeVideo,
@@ -202,7 +203,26 @@ describe('AddonPage', () => {
       render({ errorHandler, dispatch, ...props });
 
       sinon.assert.calledWith(dispatch, getDiscoResults({
+        errorHandlerId: errorHandler.id, telemetryClientId: undefined,
+      }));
+    });
+
+    it('sends a telemetry client ID if there is one', () => {
+      const location = {
+        query: {
+          clientId: 'telemetry-client-id',
+        },
+      };
+      const dispatch = sinon.stub();
+      const errorHandler = new ErrorHandler({ id: 'some-id', dispatch });
+      // Set up some empty results so that the component fetches new ones.
+      const props = helpers.mapStateToProps(loadDiscoResultsIntoState([]));
+
+      render({ errorHandler, dispatch, location, ...props });
+
+      sinon.assert.calledWith(dispatch, getDiscoResults({
         errorHandlerId: errorHandler.id,
+        telemetryClientId: location.query.clientId,
       }));
     });
 

--- a/tests/unit/disco/sagas/testDisco.js
+++ b/tests/unit/disco/sagas/testDisco.js
@@ -44,7 +44,7 @@ describe(__filename, () => {
       }));
     }
 
-    it('fetches landing page addons from the API', async () => {
+    it('fetches discovery addons from the API', async () => {
       const addon1 = {
         heading: 'Discovery Addon 1',
         description: 'informative text',
@@ -66,7 +66,7 @@ describe(__filename, () => {
       const addonResponse = createFetchDiscoveryResult([addon1, addon2]);
       mockApi
         .expects('getDiscoveryAddons')
-        .withArgs({ api: apiState })
+        .withArgs({ api: apiState, telemetryClientId: undefined })
         .returns(Promise.resolve(addonResponse));
 
       const { entities, result } = addonResponse;
@@ -81,6 +81,29 @@ describe(__filename, () => {
 
       expect(calledActions[1]).toEqual(loadAddons(entities));
       expect(calledActions[2]).toEqual(expectedLoadAction);
+    });
+
+    it('includes a telemetry client ID in the API request', async () => {
+      const telemetryClientId = 'client-id';
+      const addon = {
+        heading: 'Discovery Addon',
+        description: 'informative text',
+        addon: { ...fakeDiscoAddon },
+      };
+      const addonResponse = createFetchDiscoveryResult([addon]);
+
+      mockApi
+        .expects('getDiscoveryAddons')
+        .withArgs({ api: apiState, telemetryClientId })
+        .returns(Promise.resolve(addonResponse));
+
+      const { entities, result } = addonResponse;
+      const expectedLoadAction = loadDiscoResults({ entities, result });
+
+      _getDiscoResults({ telemetryClientId });
+
+      await sagaTester.waitFor(expectedLoadAction.type);
+      mockApi.verify();
     });
 
     it('dispatches an error', async () => {

--- a/tests/unit/disco/test_actions.js
+++ b/tests/unit/disco/test_actions.js
@@ -31,10 +31,10 @@ describe('disco/actions/loadDiscoResults', () => {
 
 describe('disco/actions/getDiscoResults', () => {
   function defaultParams() {
-    return { errorHandlerId: 'some-id' };
+    return { errorHandlerId: 'some-id', telemetryClientId: 'client-id' };
   }
 
-  it('requires an error handler ID', () => {
+  it('requires errorHandlerId', () => {
     const params = defaultParams();
     delete params.errorHandlerId;
     expect(() => getDiscoResults(params))


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2823

This isn't very exciting because it doesn't do anything yet. We still need to figure out how to test it. All it does is prep us for when the Discopane gets loaded with a telemetry client ID. We pass that ID to the API request so that `addons-server` can mix in results from the add-on recommendation engine.