### PR TITLE
chore: Reorganise API code and tests

### DIFF
--- a/src/core/api/addon.js
+++ b/src/core/api/addon.js
@@ -1,0 +1,22 @@
+import { schema as normalizrSchema } from 'normalizr';
+
+import { callApi } from 'core/api';
+import type { ApiStateType } from 'core/reducers/api';
+
+
+export const addonSchema = new normalizrSchema.Entity(
+  'addons', {}, { idAttribute: 'slug' });
+
+type FetchAddonParams = {|
+  api: ApiStateType,
+  slug: string,
+|};
+
+export function fetchAddon({ api, slug }: FetchAddonParams) {
+  return callApi({
+    endpoint: `addons/addon/${slug}`,
+    schema: addonSchema,
+    auth: true,
+    state: api,
+  });
+}

--- a/src/core/api/authentication.js
+++ b/src/core/api/authentication.js
@@ -1,0 +1,55 @@
+import url from 'url';
+
+import config from 'config';
+
+import { API_BASE, callApi, makeQueryString } from 'core/api';
+import type { ApiStateType } from 'core/reducers/api';
+import type { ReactRouterLocation } from 'core/types/router';
+
+
+type LoginParams = {|
+  api: ApiStateType,
+  code: string,
+  state: string,
+|};
+
+export function login({ api, code, state }: LoginParams) {
+  const params = { config: undefined };
+  const configName = config.get('fxaConfig');
+  if (configName) {
+    params.config = configName;
+  }
+  return callApi({
+    endpoint: 'accounts/login',
+    method: 'POST',
+    body: { code, state },
+    params,
+    state: api,
+    credentials: true,
+  });
+}
+
+export function logOutFromServer({ api }: {| api: ApiStateType |}) {
+  return callApi({
+    auth: true,
+    credentials: true,
+    endpoint: 'accounts/session',
+    method: 'DELETE',
+    state: api,
+  });
+}
+
+export function startLoginUrl(
+  { location }: {| location: ReactRouterLocation |},
+) {
+  const configName = config.get('fxaConfig');
+  const params = {
+    config: undefined,
+    to: url.format({ ...location }),
+  };
+  if (configName) {
+    params.config = configName;
+  }
+  const query = makeQueryString(params);
+  return `${API_BASE}/accounts/login/start/${query}`;
+}

--- a/src/core/api/categories.js
+++ b/src/core/api/categories.js
@@ -1,0 +1,16 @@
+import { schema as normalizrSchema } from 'normalizr';
+
+import { callApi } from 'core/api';
+import type { ApiStateType } from 'core/reducers/api';
+
+
+export const categorySchema = new normalizrSchema.Entity(
+  'categories', {}, { idAttribute: 'slug' });
+
+export function categories({ api }: {| api: ApiStateType |}) {
+  return callApi({
+    endpoint: 'addons/categories',
+    schema: { results: [categorySchema] },
+    state: api,
+  });
+}

--- a/src/core/api/featured.js
+++ b/src/core/api/featured.js
@@ -1,0 +1,24 @@
+import { callApi } from 'core/api';
+import { addonSchema } from 'core/api/addon';
+import type { ApiStateType } from 'core/reducers/api';
+import { convertFiltersToQueryParams } from 'core/searchUtils';
+
+
+type FeaturedParams = {|
+  api: ApiStateType,
+  filters: Object,
+  page: number,
+|};
+
+export function featured({ api, filters, page }: FeaturedParams) {
+  return callApi({
+    endpoint: 'addons/featured',
+    params: {
+      app: api.clientApp,
+      ...convertFiltersToQueryParams(filters),
+      page,
+    },
+    schema: { results: [addonSchema] },
+    state: api,
+  });
+}

--- a/src/core/api/search.js
+++ b/src/core/api/search.js
@@ -1,7 +1,8 @@
 /* @flow */
 import { oneLine } from 'common-tags';
 
-import { addon, callApi } from 'core/api';
+import { callApi } from 'core/api';
+import { addonSchema } from 'core/api/addon';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -11,6 +12,25 @@ import log from 'core/logger';
 import type { ApiStateType } from 'core/reducers/api';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 
+
+type AutocompleteParams = {|
+  api: ApiStateType,
+  filters: {|
+    query: string,
+    addonType?: string,
+  |},
+|};
+
+export function autocomplete({ api, filters }: AutocompleteParams) {
+  return callApi({
+    endpoint: 'addons/autocomplete',
+    params: {
+      app: api.clientApp,
+      ...convertFiltersToQueryParams(filters),
+    },
+    state: api,
+  });
+}
 
 export type SearchParams = {|
   api: ApiStateType,
@@ -30,7 +50,7 @@ export type SearchParams = {|
   |},
 |};
 
-export default function search(
+export function search(
   { api, auth = false, filters = {} }: SearchParams
 ) {
   const _filters = { ...filters };
@@ -92,7 +112,7 @@ export default function search(
 
   return callApi({
     endpoint: 'addons/search',
-    schema: { results: [addon] },
+    schema: { results: [addonSchema] },
     params: convertFiltersToQueryParams(_filters),
     state: api,
     auth,

--- a/tests/unit/core/api/test_addon.js
+++ b/tests/unit/core/api/test_addon.js
@@ -1,0 +1,93 @@
+/* global window */
+import config from 'config';
+
+import { fetchAddon } from 'core/api/addon';
+import {
+  createApiResponse,
+  unexpectedSuccess,
+  userAuthToken,
+} from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  const apiHost = config.get('apiHost');
+  let mockWindow;
+
+  beforeEach(() => {
+    mockWindow = sinon.mock(window);
+  });
+
+  function mockResponse(responseProps = {}) {
+    return createApiResponse({
+      jsonData: {
+        name: 'Foo!',
+        slug: 'foo',
+      },
+      ...responseProps,
+    });
+  }
+
+  it('sets the lang and slug', () => {
+    mockWindow.expects('fetch')
+      .withArgs(`${apiHost}/api/v3/addons/addon/foo/?lang=en-US`, {
+        body: undefined,
+        credentials: undefined,
+        headers: {},
+        method: 'GET',
+      })
+      .once()
+      .returns(mockResponse());
+    return fetchAddon({ api: { lang: 'en-US' }, slug: 'foo' })
+      .then(() => mockWindow.verify());
+  });
+
+  it('normalizes the response', () => {
+    mockWindow.expects('fetch').once().returns(mockResponse());
+    return fetchAddon('foo')
+      .then((results) => {
+        const foo = { slug: 'foo', name: 'Foo!' };
+        expect(results.result).toEqual('foo');
+        expect(results.entities).toEqual({ addons: { foo } });
+      });
+  });
+
+  it('fails when the add-on is not found', () => {
+    mockWindow
+      .expects('fetch')
+      .withArgs(`${apiHost}/api/v3/addons/addon/foo/?lang=en-US`, {
+        body: undefined,
+        credentials: undefined,
+        headers: {},
+        method: 'GET',
+      })
+      .once()
+      .returns(mockResponse({ ok: false }));
+    return fetchAddon({ api: { lang: 'en-US' }, slug: 'foo' })
+      .then(unexpectedSuccess,
+        (error) => {
+          expect(error.message)
+            .toMatch(new RegExp('Error calling: /api/v3/addons/addon/foo/'));
+        });
+  });
+
+  it('includes the authorization token if available', () => {
+    const token = userAuthToken();
+    mockWindow
+      .expects('fetch')
+      .withArgs(`${apiHost}/api/v3/addons/addon/bar/?lang=en-US`, {
+        body: undefined,
+        credentials: undefined,
+        headers: { authorization: `Bearer ${token}` },
+        method: 'GET',
+      })
+      .once()
+      .returns(mockResponse());
+    return fetchAddon({ api: { lang: 'en-US', token }, slug: 'bar' })
+      .then((results) => {
+        const foo = { slug: 'foo', name: 'Foo!' };
+        expect(results.result).toEqual('foo');
+        expect(results.entities).toEqual({ addons: { foo } });
+        mockWindow.verify();
+      });
+  });
+});

--- a/tests/unit/core/api/test_authentication.js
+++ b/tests/unit/core/api/test_authentication.js
@@ -1,0 +1,94 @@
+/* global window */
+import querystring from 'querystring';
+
+import config from 'config';
+
+import {
+  login,
+  logOutFromServer,
+  startLoginUrl,
+} from 'core/api/authentication';
+import {
+  createApiResponse,
+  signedInApiState,
+  userAuthToken,
+} from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  const apiHost = config.get('apiHost');
+  let mockWindow;
+
+  beforeEach(() => {
+    mockWindow = sinon.mock(window);
+  });
+
+  describe('login', () => {
+    const response = { token: userAuthToken() };
+    const mockResponse = () => createApiResponse({
+      jsonData: response,
+    });
+
+    it('sends the code and state', () => {
+      mockWindow
+        .expects('fetch')
+        .withArgs(`${apiHost}/api/v3/accounts/login/?lang=en-US`, {
+          body: '{"code":"my-code","state":"my-state"}',
+          credentials: 'include',
+          headers: { 'Content-type': 'application/json' },
+          method: 'POST',
+        })
+        .once()
+        .returns(mockResponse());
+      return login({ api: { lang: 'en-US' }, code: 'my-code', state: 'my-state' })
+        .then((apiResponse) => {
+          expect(apiResponse).toBe(response);
+          mockWindow.verify();
+        });
+    });
+
+    it('sends the config when set', () => {
+      sinon.stub(config, 'get').withArgs('fxaConfig').returns('my-config');
+      mockWindow
+        .expects('fetch')
+        .withArgs(`${apiHost}/api/v3/accounts/login/?config=my-config&lang=fr`)
+        .once()
+        .returns(mockResponse());
+      return login({ api: { lang: 'fr' }, code: 'my-code', state: 'my-state' })
+        .then(() => mockWindow.verify());
+    });
+  });
+
+  describe('startLoginUrl', () => {
+    const getStartLoginQs = (location) =>
+      querystring.parse(startLoginUrl({ location }).split('?')[1]);
+
+    it('includes the next path', () => {
+      const location = { pathname: '/foo', query: { bar: 'BAR' } };
+      expect(getStartLoginQs(location)).toEqual({ to: '/foo?bar=BAR' });
+    });
+
+    it('includes the next path the config if set', () => {
+      sinon.stub(config, 'get').withArgs('fxaConfig').returns('my-config');
+      const location = { pathname: '/foo' };
+      expect(getStartLoginQs(location)).toEqual({ to: '/foo', config: 'my-config' });
+    });
+  });
+
+  describe('logOutFromServer', () => {
+    it('makes a delete request to the session endpoint', () => {
+      const mockResponse = createApiResponse({ jsonData: { ok: true } });
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/accounts/session/?lang=en-US`, {
+          body: undefined,
+          credentials: 'include',
+          headers: { authorization: 'Bearer secret-token' },
+          method: 'DELETE',
+        })
+        .once()
+        .returns(mockResponse);
+      return logOutFromServer({ api: signedInApiState })
+        .then(() => mockWindow.verify());
+    });
+  });
+});

--- a/tests/unit/core/api/test_categories.js
+++ b/tests/unit/core/api/test_categories.js
@@ -1,0 +1,41 @@
+/* global window */
+import config from 'config';
+
+import { categories } from 'core/api/categories';
+import { CLIENT_APP_ANDROID } from 'core/constants';
+import { createApiResponse } from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  let mockWindow;
+  const apiHost = config.get('apiHost');
+
+  beforeEach(() => {
+    mockWindow = sinon.mock(window);
+  });
+
+  function mockResponse(responseProps = {}) {
+    return createApiResponse({
+      jsonData: {
+        results: [
+          { slug: 'foo' },
+          { slug: 'food' },
+          { slug: 'football' },
+        ],
+      },
+      ...responseProps,
+    });
+  }
+
+  it('sets the lang and calls the right API endpoint', () => {
+    mockWindow.expects('fetch')
+      .withArgs(
+        `${apiHost}/api/v3/addons/categories/?lang=en-US`)
+      .once()
+      .returns(mockResponse());
+    return categories({
+      api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
+    })
+      .then(() => mockWindow.verify());
+  });
+});

--- a/tests/unit/core/api/test_featured.js
+++ b/tests/unit/core/api/test_featured.js
@@ -1,0 +1,52 @@
+/* global window */
+import config from 'config';
+
+import { featured } from 'core/api/featured';
+import { ADDON_TYPE_THEME, CLIENT_APP_ANDROID } from 'core/constants';
+import { createApiResponse } from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  const apiHost = config.get('apiHost');
+  let mockWindow;
+
+  beforeEach(() => {
+    mockWindow = sinon.mock(window);
+  });
+
+  const mockResponse = () => createApiResponse({
+    jsonData: {
+      results: [
+        { slug: 'foo' },
+        { slug: 'food' },
+        { slug: 'football' },
+      ],
+    },
+  });
+
+  it('sets the app, lang, and type query', () => {
+    mockWindow.expects('fetch')
+      .withArgs(`${apiHost}/api/v3/addons/featured/?app=android&type=persona&lang=en-US`)
+      .once()
+      .returns(mockResponse());
+    return featured({
+      api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
+      filters: { addonType: ADDON_TYPE_THEME },
+    })
+      .then((response) => {
+        expect(response).toEqual({
+          entities: {
+            addons: {
+              foo: { slug: 'foo' },
+              food: { slug: 'food' },
+              football: { slug: 'football' },
+            },
+          },
+          result: {
+            results: ['foo', 'food', 'football'],
+          },
+        });
+        return mockWindow.verify();
+      });
+  });
+});

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -1,20 +1,14 @@
 /* global window */
-import querystring from 'querystring';
-
 import config from 'config';
 import utf8 from 'utf8';
 
-import * as api from 'core/api';
-import { ADDON_TYPE_THEME, CLIENT_APP_ANDROID } from 'core/constants';
+import { callApi, createApiError, makeQueryString } from 'core/api';
 import {
   createApiResponse,
   createStubErrorHandler,
   generateHeaders,
-  signedInApiState,
   unexpectedSuccess,
-  userAuthToken,
 } from 'tests/unit/helpers';
-import { createFakeAutocompleteResult } from 'tests/unit/amo/helpers';
 
 
 describe(__filename, () => {
@@ -37,7 +31,7 @@ describe(__filename, () => {
         })
         .once()
         .returns(createApiResponse());
-      return api.callApi({ endpoint: 'resource', method: 'get' })
+      return callApi({ endpoint: 'resource', method: 'get' })
         .then(() => mockWindow.verify());
     });
 
@@ -49,7 +43,7 @@ describe(__filename, () => {
         })
         .once()
         .returns(createApiResponse());
-      return api.callApi({ endpoint }).then(() => mockWindow.verify());
+      return callApi({ endpoint }).then(() => mockWindow.verify());
     });
 
     it('clears an error handler before making a request', () => {
@@ -58,7 +52,7 @@ describe(__filename, () => {
       const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'clear');
 
-      return api.callApi({ endpoint: 'resource', errorHandler })
+      return callApi({ endpoint: 'resource', errorHandler })
         .then(() => {
           expect(errorHandler.clear.called).toBeTruthy();
         });
@@ -74,7 +68,7 @@ describe(__filename, () => {
       const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'handle');
 
-      return api.callApi({ endpoint: 'resource', errorHandler })
+      return callApi({ endpoint: 'resource', errorHandler })
         .then(unexpectedSuccess, () => {
           expect(errorHandler.handle.called).toBeTruthy();
           const args = errorHandler.handle.firstCall.args;
@@ -93,7 +87,7 @@ describe(__filename, () => {
       const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'handle');
 
-      return api.callApi({ endpoint: 'resource' })
+      return callApi({ endpoint: 'resource' })
         .then(unexpectedSuccess, (err) => {
           expect(err.message).toEqual('pretend this was a response with invalid JSON');
         });
@@ -107,7 +101,7 @@ describe(__filename, () => {
         },
       }));
 
-      return api.callApi({ endpoint: 'resource' })
+      return callApi({ endpoint: 'resource' })
         .then((responseData) => {
           mockWindow.verify();
           expect(responseData).toEqual({});
@@ -122,7 +116,7 @@ describe(__filename, () => {
       const errorHandler = createStubErrorHandler();
       sinon.stub(errorHandler, 'handle');
 
-      return api.callApi({ endpoint: 'resource', errorHandler })
+      return callApi({ endpoint: 'resource', errorHandler })
         .then(unexpectedSuccess, () => {
           expect(errorHandler.handle.called).toBeTruthy();
           const args = errorHandler.handle.firstCall.args;
@@ -141,165 +135,51 @@ describe(__filename, () => {
         })
         .once()
         .returns(response);
-      return api.callApi({ endpoint: 'resource', method: 'GET' })
+      return callApi({ endpoint: 'resource', method: 'GET' })
         .then(() => mockWindow.verify());
     });
   });
 
   describe('makeQueryString', () => {
     it('transforms an object to a query string', () => {
-      const query = api.makeQueryString({ user: 123, addon: 321 });
+      const query = makeQueryString({ user: 123, addon: 321 });
       expect(query).toContain('user=123');
       expect(query).toContain('addon=321');
     });
 
     it('ignores undefined query string values', () => {
-      const query = api.makeQueryString({ user: undefined, addon: 321 });
+      const query = makeQueryString({ user: undefined, addon: 321 });
       expect(query).toEqual('?addon=321');
     });
 
     it('ignores null query string values', () => {
-      const query = api.makeQueryString({ user: null, addon: 321 });
+      const query = makeQueryString({ user: null, addon: 321 });
       expect(query).toEqual('?addon=321');
     });
 
     it('ignores empty string query string values', () => {
-      const query = api.makeQueryString({ user: '', addon: 321 });
+      const query = makeQueryString({ user: '', addon: 321 });
       expect(query).toEqual('?addon=321');
     });
 
     it('handles falsey integers', () => {
-      const query = api.makeQueryString({ some_flag: 0 });
+      const query = makeQueryString({ some_flag: 0 });
       expect(query).toEqual('?some_flag=0');
     });
 
     it('handles truthy integers', () => {
-      const query = api.makeQueryString({ some_flag: 1 });
+      const query = makeQueryString({ some_flag: 1 });
       expect(query).toEqual('?some_flag=1');
     });
 
     it('handles false values', () => {
-      const query = api.makeQueryString({ some_flag: false });
+      const query = makeQueryString({ some_flag: false });
       expect(query).toEqual('?some_flag=false');
     });
 
     it('handles true values', () => {
-      const query = api.makeQueryString({ some_flag: true });
+      const query = makeQueryString({ some_flag: true });
       expect(query).toEqual('?some_flag=true');
-    });
-  });
-
-  describe('featured add-ons api', () => {
-    const mockResponse = () => createApiResponse({
-      jsonData: {
-        results: [
-          { slug: 'foo' },
-          { slug: 'food' },
-          { slug: 'football' },
-        ],
-      },
-    });
-
-    it('sets the app, lang, and type query', () => {
-      mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/featured/?app=android&type=persona&lang=en-US`)
-        .once()
-        .returns(mockResponse());
-      return api.featured({
-        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
-        filters: { addonType: ADDON_TYPE_THEME },
-      })
-        .then((response) => {
-          expect(response).toEqual({
-            entities: {
-              addons: {
-                foo: { slug: 'foo' },
-                food: { slug: 'food' },
-                football: { slug: 'football' },
-              },
-            },
-            result: {
-              results: ['foo', 'food', 'football'],
-            },
-          });
-          return mockWindow.verify();
-        });
-    });
-  });
-
-  describe('add-on api', () => {
-    function mockResponse(responseProps = {}) {
-      return createApiResponse({
-        jsonData: {
-          name: 'Foo!',
-          slug: 'foo',
-        },
-        ...responseProps,
-      });
-    }
-
-    it('sets the lang and slug', () => {
-      mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/addon/foo/?lang=en-US`, {
-          body: undefined,
-          credentials: undefined,
-          headers: {},
-          method: 'GET',
-        })
-        .once()
-        .returns(mockResponse());
-      return api.fetchAddon({ api: { lang: 'en-US' }, slug: 'foo' })
-        .then(() => mockWindow.verify());
-    });
-
-    it('normalizes the response', () => {
-      mockWindow.expects('fetch').once().returns(mockResponse());
-      return api.fetchAddon('foo')
-        .then((results) => {
-          const foo = { slug: 'foo', name: 'Foo!' };
-          expect(results.result).toEqual('foo');
-          expect(results.entities).toEqual({ addons: { foo } });
-        });
-    });
-
-    it('fails when the add-on is not found', () => {
-      mockWindow
-        .expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/addon/foo/?lang=en-US`, {
-          body: undefined,
-          credentials: undefined,
-          headers: {},
-          method: 'GET',
-        })
-        .once()
-        .returns(mockResponse({ ok: false }));
-      return api.fetchAddon({ api: { lang: 'en-US' }, slug: 'foo' })
-        .then(unexpectedSuccess,
-          (error) => {
-            expect(error.message)
-              .toMatch(new RegExp('Error calling: /api/v3/addons/addon/foo/'));
-          });
-    });
-
-    it('includes the authorization token if available', () => {
-      const token = userAuthToken();
-      mockWindow
-        .expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/addon/bar/?lang=en-US`, {
-          body: undefined,
-          credentials: undefined,
-          headers: { authorization: `Bearer ${token}` },
-          method: 'GET',
-        })
-        .once()
-        .returns(mockResponse());
-      return api.fetchAddon({ api: { lang: 'en-US', token }, slug: 'bar' })
-        .then((results) => {
-          const foo = { slug: 'foo', name: 'Foo!' };
-          expect(results.result).toEqual('foo');
-          expect(results.entities).toEqual({ addons: { foo } });
-          mockWindow.verify();
-        });
     });
   });
 
@@ -307,7 +187,7 @@ describe(__filename, () => {
     function _createApiError({
       response = { status: 500 }, ...params } = {}
     ) {
-      return api.createApiError({ response, ...params });
+      return createApiError({ response, ...params });
     }
 
     it('includes an abbreviated URL', () => {
@@ -339,143 +219,6 @@ describe(__filename, () => {
       });
       expect(error.message)
         .toEqual('Error calling: /api/resource/ (status: 422)');
-    });
-  });
-
-  describe('login', () => {
-    const response = { token: userAuthToken() };
-    const mockResponse = () => createApiResponse({
-      jsonData: response,
-    });
-
-    it('sends the code and state', () => {
-      mockWindow
-        .expects('fetch')
-        .withArgs(`${apiHost}/api/v3/accounts/login/?lang=en-US`, {
-          body: '{"code":"my-code","state":"my-state"}',
-          credentials: 'include',
-          headers: { 'Content-type': 'application/json' },
-          method: 'POST',
-        })
-        .once()
-        .returns(mockResponse());
-      return api.login({ api: { lang: 'en-US' }, code: 'my-code', state: 'my-state' })
-        .then((apiResponse) => {
-          expect(apiResponse).toBe(response);
-          mockWindow.verify();
-        });
-    });
-
-    it('sends the config when set', () => {
-      sinon.stub(config, 'get').withArgs('fxaConfig').returns('my-config');
-      mockWindow
-        .expects('fetch')
-        .withArgs(`${apiHost}/api/v3/accounts/login/?config=my-config&lang=fr`)
-        .once()
-        .returns(mockResponse());
-      return api.login({ api: { lang: 'fr' }, code: 'my-code', state: 'my-state' })
-        .then(() => mockWindow.verify());
-    });
-  });
-
-  describe('startLoginUrl', () => {
-    const getStartLoginQs = (location) =>
-      querystring.parse(api.startLoginUrl({ location }).split('?')[1]);
-
-    it('includes the next path', () => {
-      const location = { pathname: '/foo', query: { bar: 'BAR' } };
-      expect(getStartLoginQs(location)).toEqual({ to: '/foo?bar=BAR' });
-    });
-
-    it('includes the next path the config if set', () => {
-      sinon.stub(config, 'get').withArgs('fxaConfig').returns('my-config');
-      const location = { pathname: '/foo' };
-      expect(getStartLoginQs(location)).toEqual({ to: '/foo', config: 'my-config' });
-    });
-  });
-
-  describe('categories api', () => {
-    function mockResponse(responseProps = {}) {
-      return createApiResponse({
-        jsonData: {
-          results: [
-            { slug: 'foo' },
-            { slug: 'food' },
-            { slug: 'football' },
-          ],
-        },
-        ...responseProps,
-      });
-    }
-
-    it('sets the lang and calls the right API endpoint', () => {
-      mockWindow.expects('fetch')
-        .withArgs(
-          `${apiHost}/api/v3/addons/categories/?lang=en-US`)
-        .once()
-        .returns(mockResponse());
-      return api.categories({
-        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
-      })
-        .then(() => mockWindow.verify());
-    });
-  });
-
-  describe('logOutFromServer', () => {
-    it('makes a delete request to the session endpoint', () => {
-      const mockResponse = createApiResponse({ jsonData: { ok: true } });
-      mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/accounts/session/?lang=en-US`, {
-          body: undefined,
-          credentials: 'include',
-          headers: { authorization: 'Bearer secret-token' },
-          method: 'DELETE',
-        })
-        .once()
-        .returns(mockResponse);
-      return api.logOutFromServer({ api: signedInApiState })
-        .then(() => mockWindow.verify());
-    });
-  });
-
-  describe('autocomplete api', () => {
-    const mockResponse = () => createApiResponse({
-      jsonData: {
-        results: [
-          createFakeAutocompleteResult({ name: 'foo' }),
-          createFakeAutocompleteResult({ name: 'food' }),
-          createFakeAutocompleteResult({ name: 'football' }),
-        ],
-      },
-    });
-
-    it('sets the app, lang, and query', () => {
-      mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/autocomplete/?app=android&q=foo&lang=en-US`)
-        .once()
-        .returns(mockResponse());
-      return api.autocomplete({
-        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
-        filters: {
-          query: 'foo',
-        },
-      })
-        .then(() => mockWindow.verify());
-    });
-
-    it('optionally takes addon type as filter', () => {
-      mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/autocomplete/?app=android&q=foo&type=persona&lang=en-US`)
-        .once()
-        .returns(mockResponse());
-      return api.autocomplete({
-        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
-        filters: {
-          query: 'foo',
-          addonType: ADDON_TYPE_THEME,
-        },
-      })
-        .then(() => mockWindow.verify());
     });
   });
 });

--- a/tests/unit/core/api/test_search.js
+++ b/tests/unit/core/api/test_search.js
@@ -1,7 +1,7 @@
 /* global window */
 import config from 'config';
 
-import search from 'core/api/search';
+import { autocomplete, search } from 'core/api/search';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -9,7 +9,11 @@ import {
   CLIENT_APP_FIREFOX,
 } from 'core/constants';
 import { parsePage } from 'core/utils';
-import { dispatchSignInActions, fakeAddon } from 'tests/unit/amo/helpers';
+import {
+  createFakeAutocompleteResult,
+  dispatchSignInActions,
+  fakeAddon,
+} from 'tests/unit/amo/helpers';
 import {
   createApiResponse,
   unexpectedSuccess,
@@ -18,11 +22,11 @@ import {
 
 
 describe(__filename, () => {
-  let api;
-  let mockWindow;
   const apiHost = config.get('apiHost');
   const firefox57 = userAgents.firefox[5];
   const firefoxESR52 = userAgents.firefox[4];
+  let api;
+  let mockWindow;
 
   beforeEach(() => {
     api = dispatchSignInActions({
@@ -31,224 +35,267 @@ describe(__filename, () => {
     mockWindow = sinon.mock(window);
   });
 
-  function _search(extraArguments = {}) {
-    return search({
-      api,
-      auth: true,
-      filters: { page: parsePage(3), query: 'foo' },
-      ...extraArguments,
-    });
-  }
+  describe('search API', () => {
+    function _search(extraArguments = {}) {
+      return search({
+        api,
+        auth: true,
+        filters: { page: parsePage(3), query: 'foo' },
+        ...extraArguments,
+      });
+    }
 
-  function mockResponse(responseProps = {}) {
-    return createApiResponse({
+    function mockResponse(responseProps = {}) {
+      return createApiResponse({
+        jsonData: {
+          results: [
+            { ...fakeAddon, slug: 'foo' },
+            { ...fakeAddon, slug: 'food' },
+            { ...fakeAddon, slug: 'football' },
+          ],
+        },
+        ...responseProps,
+      });
+    }
+
+    it('sets the lang, limit, page and query', () => {
+      // FIXME: This shouldn't fail if the args are in a different order.
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+      return _search().then(() => mockWindow.verify());
+    });
+
+    it('sets appversion if Firefox version is 57 or above', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgent: firefox57,
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&appversion=57.1&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search().then(() => mockWindow.verify());
+    });
+
+    // See: https://github.com/mozilla/addons-frontend/pull/2969#issuecomment-323551742
+    it('does not set appversion if version is below 57', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgent: firefoxESR52,
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search().then(() => mockWindow.verify());
+    });
+
+    it('sets appversion if Firefox for Android', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_ANDROID,
+        userAgent: userAgents.firefoxAndroid[4],
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=android&appversion=57.0&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search().then(() => mockWindow.verify());
+    });
+
+    it('does not set appversion if Firefox for iOS', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgent: userAgents.firefoxIOS[3],
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search().then(() => mockWindow.verify());
+    });
+
+    it('does not set appversion if browser is not Firefox', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgent: 'Lynx Beta',
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search().then(() => mockWindow.verify());
+    });
+
+    it('sets appversion if browser is Firefox 57+', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgent: firefox57,
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&appversion=57.1&page=3&q=foo&type=extension&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search({
+        filters: {
+          addonType: ADDON_TYPE_EXTENSION,
+          page: parsePage(3),
+          query: 'foo',
+        },
+      })
+        .then(() => mockWindow.verify());
+    });
+
+    it('sets appversion if addonType is not set', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgent: firefox57,
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&appversion=57.1&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search().then(() => mockWindow.verify());
+    });
+
+    it('does not set appversion if addonType is set but not extension', () => {
+      api = dispatchSignInActions({
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgent: firefox57,
+      }).store.getState().api;
+
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&type=persona&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search({
+        filters: {
+          addonType: ADDON_TYPE_THEME,
+          page: parsePage(3),
+          query: 'foo',
+        },
+      })
+        .then(() => mockWindow.verify());
+    });
+
+    it('normalizes the response', () => {
+      mockWindow.expects('fetch').once().returns(mockResponse());
+
+      return _search({ filters: { query: 'foo' } })
+        .then((results) => {
+          expect(results.result.results).toEqual(['foo', 'food', 'football']);
+          expect(results.entities).toEqual({
+            addons: {
+              foo: { ...fakeAddon, slug: 'foo' },
+              food: { ...fakeAddon, slug: 'food' },
+              football: { ...fakeAddon, slug: 'football' },
+            },
+          });
+        });
+    });
+
+    it('surfaces status and apiURL on Error instance', () => {
+      const url = `${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`;
+      mockWindow.expects('fetch')
+        .withArgs(url)
+        .once()
+        .returns(mockResponse({ ok: false, status: 401 }));
+
+      return _search()
+        .then(unexpectedSuccess, (err) => {
+          expect(err.response.status).toEqual(401);
+          expect(err.response.apiURL).toEqual(url);
+        });
+    });
+
+    it('changes theme requests for android to firefox results', () => {
+      // FIXME: This shouldn't fail if the args are in a different order.
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&type=persona&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      return _search({
+        filters: {
+          addonType: ADDON_TYPE_THEME,
+          clientApp: CLIENT_APP_ANDROID,
+          page: parsePage(3),
+        },
+      })
+        .then(() => mockWindow.verify());
+    });
+
+    it('allows overrides to clientApp', () => {
+      // FIXME: This shouldn't fail if the args are in a different order.
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/search/?app=android&page=3&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+      return _search({
+        filters: {
+          clientApp: CLIENT_APP_ANDROID,
+          page: parsePage(3),
+          query: 'foo',
+        },
+      })
+        .then(() => mockWindow.verify());
+    });
+  });
+
+  describe('autocomplete api', () => {
+    const mockResponse = () => createApiResponse({
       jsonData: {
         results: [
-          { ...fakeAddon, slug: 'foo' },
-          { ...fakeAddon, slug: 'food' },
-          { ...fakeAddon, slug: 'football' },
+          createFakeAutocompleteResult({ name: 'foo' }),
+          createFakeAutocompleteResult({ name: 'food' }),
+          createFakeAutocompleteResult({ name: 'football' }),
         ],
       },
-      ...responseProps,
     });
-  }
 
-  it('sets the lang, limit, page and query', () => {
-    // FIXME: This shouldn't fail if the args are in a different order.
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-    return _search().then(() => mockWindow.verify());
-  });
+    it('sets the app, lang, and query', () => {
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/autocomplete/?app=android&q=foo&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+      return autocomplete({
+        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
+        filters: {
+          query: 'foo',
+        },
+      })
+        .then(() => mockWindow.verify());
+    });
 
-  it('sets appversion if Firefox version is 57 or above', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: firefox57,
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&appversion=57.1&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search().then(() => mockWindow.verify());
-  });
-
-  // See: https://github.com/mozilla/addons-frontend/pull/2969#issuecomment-323551742
-  it('does not set appversion if version is below 57', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: firefoxESR52,
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search().then(() => mockWindow.verify());
-  });
-
-  it('sets appversion if Firefox for Android', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_ANDROID,
-      userAgent: userAgents.firefoxAndroid[4],
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=android&appversion=57.0&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search().then(() => mockWindow.verify());
-  });
-
-  it('does not set appversion if Firefox for iOS', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: userAgents.firefoxIOS[3],
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search().then(() => mockWindow.verify());
-  });
-
-  it('does not set appversion if browser is not Firefox', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: 'Lynx Beta',
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search().then(() => mockWindow.verify());
-  });
-
-  it('sets appversion if browser is Firefox 57+', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: firefox57,
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&appversion=57.1&page=3&q=foo&type=extension&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search({
-      filters: {
-        addonType: ADDON_TYPE_EXTENSION,
-        page: parsePage(3),
-        query: 'foo',
-      },
-    })
-      .then(() => mockWindow.verify());
-  });
-
-  it('sets appversion if addonType is not set', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: firefox57,
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&appversion=57.1&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search().then(() => mockWindow.verify());
-  });
-
-  it('does not set appversion if addonType is set but not extension', () => {
-    api = dispatchSignInActions({
-      clientApp: CLIENT_APP_FIREFOX,
-      userAgent: firefox57,
-    }).store.getState().api;
-
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&type=persona&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search({
-      filters: {
-        addonType: ADDON_TYPE_THEME,
-        page: parsePage(3),
-        query: 'foo',
-      },
-    })
-      .then(() => mockWindow.verify());
-  });
-
-  it('normalizes the response', () => {
-    mockWindow.expects('fetch').once().returns(mockResponse());
-
-    return _search({ filters: { query: 'foo' } })
-      .then((results) => {
-        expect(results.result.results).toEqual(['foo', 'food', 'football']);
-        expect(results.entities).toEqual({
-          addons: {
-            foo: { ...fakeAddon, slug: 'foo' },
-            food: { ...fakeAddon, slug: 'food' },
-            football: { ...fakeAddon, slug: 'football' },
-          },
-        });
-      });
-  });
-
-  it('surfaces status and apiURL on Error instance', () => {
-    const url = `${apiHost}/api/v3/addons/search/?app=firefox&page=3&q=foo&lang=en-US`;
-    mockWindow.expects('fetch')
-      .withArgs(url)
-      .once()
-      .returns(mockResponse({ ok: false, status: 401 }));
-
-    return _search()
-      .then(unexpectedSuccess, (err) => {
-        expect(err.response.status).toEqual(401);
-        expect(err.response.apiURL).toEqual(url);
-      });
-  });
-
-  it('changes theme requests for android to firefox results', () => {
-    // FIXME: This shouldn't fail if the args are in a different order.
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&type=persona&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-
-    return _search({
-      filters: {
-        addonType: ADDON_TYPE_THEME,
-        clientApp: CLIENT_APP_ANDROID,
-        page: parsePage(3),
-      },
-    })
-      .then(() => mockWindow.verify());
-  });
-
-  it('allows overrides to clientApp', () => {
-    // FIXME: This shouldn't fail if the args are in a different order.
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=android&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-    return _search({
-      filters: {
-        clientApp: CLIENT_APP_ANDROID,
-        page: parsePage(3),
-        query: 'foo',
-      },
-    })
-      .then(() => mockWindow.verify());
+    it('optionally takes addon type as filter', () => {
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/autocomplete/?app=android&q=foo&type=persona&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+      return autocomplete({
+        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
+        filters: {
+          query: 'foo',
+          addonType: ADDON_TYPE_THEME,
+        },
+      })
+        .then(() => mockWindow.verify());
+    });
   });
 });


### PR DESCRIPTION
This just separates out a lot of the code in core/api. I was finding it a real pain to read that file and while we've moved to using separate files for new code I wanted to separate it out because the tests and API code is hard to make sense of right now.

This didn't take too long and is solely reorganising. If you think it's not worth the time though just say so and you can close this, it's not the hugest deal.