### PR TITLE
Tighten up header spec

### DIFF
--- a/src/amo/components/Footer/styles.scss
+++ b/src/amo/components/Footer/styles.scss
@@ -10,6 +10,7 @@
   @include respond-to(medium) {
     display: flex;
     justify-content: space-between;
+    padding: 20px $header-footer-gutter;
   }
 
   @include respond-to(large) {
@@ -48,8 +49,6 @@
   margin-top: 10px;
 
   @include respond-to(medium) {
-    @include margin-end(10px);
-
     margin-top: auto;
   }
 }

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -14,6 +14,7 @@
   @include respond-to(medium) {
     grid-template-columns: auto auto;
     min-height: 98px;
+    padding: 0 $header-footer-gutter 10px;
   }
 
   @include respond-to(large) {
@@ -22,6 +23,7 @@
     margin: 0 auto;
     max-width: $max-content-width;
     min-height: 112px;
+    padding-bottom: 20px;
     width: 100%;
   }
 }
@@ -151,7 +153,7 @@
     align-self: end;
     grid-column: 1 / 3;
     grid-row: 2 / 2;
-    margin: 0 0 6px;
+    margin: 0;
   }
 
   @include respond-to(large) {
@@ -160,7 +162,8 @@
     align-self: center;
     grid-column: 2;
     grid-row: 2 / 2;
-    margin-top: 24px;
+    margin: 20px 0 6px;
+    padding: 0;
   }
 }
 

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -31,3 +31,7 @@ $vertical-space-xl: 128px;
 
 // Restrict content to this width on large screens.
 $max-content-width: 1366px;
+
+// Control the gutter to the left and right of the header and footer.
+// Mainly relevant to non-mobile screen-sizes.
+$header-footer-gutter: 24px;


### PR DESCRIPTION
A few tweaks to tighten up the spec on the header. There's some ambiguity in the mocks/specs re:  the gutter size. I've gone for the smaller one represented in the mocks. We can always adjust with the var later. 

Overall this gives the logo more room to breath. I quite like how the intended design has the header and footer on a different grid to the main content.

Before large:
![screen shot 2017-09-12 at 10 43 44](https://user-images.githubusercontent.com/1514/30319915-0e71060a-97a9-11e7-9729-8f9ce752f805.png)

Before medium:
![screen shot 2017-09-12 at 10 44 11](https://user-images.githubusercontent.com/1514/30319932-1bee9cca-97a9-11e7-8bc1-68ca7264ee7f.png)

After large:
![screen shot 2017-09-12 at 10 43 29](https://user-images.githubusercontent.com/1514/30319938-229fb64e-97a9-11e7-816c-7d49602c0ab9.png)

After medium (updated)
![screen shot 2017-09-12 at 11 28 59](https://user-images.githubusercontent.com/1514/30321403-d48c4dd2-97ad-11e7-880d-372bd4188091.png)


