### PR TITLE
fix:Handles 401 error for unathuorized addons

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -280,8 +280,8 @@ export class AddonBase extends React.Component {
     let errorBanner = null;
     if (errorHandler.hasError()) {
       log.error('Captured API Error:', errorHandler.capturedError);
-      if (errorHandler.capturedError.responseStatusCode === 404 ||
-          errorHandler.capturedError.responseStatusCode === 401
+      if (errorHandler.capturedError.responseStatusCode === 401 ||
+          errorHandler.capturedError.responseStatusCode === 404
       ) {
         return <NotFound />;
       }

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -279,7 +279,9 @@ export class AddonBase extends React.Component {
 
     let errorBanner = null;
     if (errorHandler.hasError()) {
-      log.error('Captured API Error:', errorHandler.capturedError);
+      log.warn('Captured API Error:', errorHandler.capturedError);
+      // A 401 is made to look like a 404 on purpose.
+      // See https://github.com/mozilla/addons-frontend/issues/3061
       if (errorHandler.capturedError.responseStatusCode === 401 ||
           errorHandler.capturedError.responseStatusCode === 404
       ) {

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -280,7 +280,9 @@ export class AddonBase extends React.Component {
     let errorBanner = null;
     if (errorHandler.hasError()) {
       log.error('Captured API Error:', errorHandler.capturedError);
-      if (errorHandler.capturedError.responseStatusCode === 404) {
+      if (errorHandler.capturedError.responseStatusCode === 404 ||
+          errorHandler.capturedError.responseStatusCode === 401
+      ) {
         return <NotFound />;
       }
       // Show a list of errors at the top of the add-on section.

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -41,7 +41,7 @@ import {
 import InstallButton from 'core/components/InstallButton';
 import { ErrorHandler } from 'core/errorHandler';
 import I18nProvider from 'core/i18n/Provider';
-import { dispatchSignInActions, fakeAddon } from 'tests/unit/amo/helpers';
+import { dispatchSignInActions, dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
 import {
   createFetchAddonResult,
   createStubErrorHandler,
@@ -257,7 +257,7 @@ describe('Addon', () => {
 
   it('renders NotFound page for unauthorized add-on - 401 error', () => {
     const id = 'error-handler-id';
-    const { store } = createStore();
+    const store = dispatchClientMetadata().store;
 
     const error = createApiError({
       response: { status: 401 },
@@ -266,12 +266,8 @@ describe('Addon', () => {
     });
     store.dispatch(setError({ id, error }));
     const capturedError = store.getState().errors[id];
-    expect(capturedError).toBeTruthy();
 
-    // Set up an error handler from state like withErrorHandler().
-    const errorHandler = new ErrorHandler({
-      id, dispatch: sinon.stub(), capturedError,
-    });
+    const errorHandler = createStubErrorHandler(capturedError);
 
     const root = shallowRender({ errorHandler });
     expect(root.find(NotFound)).toHaveLength(1);

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -255,6 +255,28 @@ describe('Addon', () => {
     expect(root.find(NotFound)).toHaveLength(1);
   });
 
+  it('renders NotFound page for unauthorized add-on - 401 error', () => {
+    const id = 'error-handler-id';
+    const { store } = createStore();
+
+    const error = createApiError({
+      response: { status: 401 },
+      apiURL: 'https://some/api/endpoint',
+      jsonResponse: { message: 'Authentication credentials were not provided.' },
+    });
+    store.dispatch(setError({ id, error }));
+    const capturedError = store.getState().errors[id];
+    expect(capturedError).toBeTruthy();
+
+    // Set up an error handler from state like withErrorHandler().
+    const errorHandler = new ErrorHandler({
+      id, dispatch: sinon.stub(), capturedError,
+    });
+
+    const root = shallowRender({ errorHandler });
+    expect(root.find(NotFound)).toHaveLength(1);
+  });
+
   it('renders a single author', () => {
     const authorUrl = 'http://olympia.dev/en-US/firefox/user/krupa/';
     const root = shallowRender({

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -257,7 +257,7 @@ describe('Addon', () => {
 
   it('renders NotFound page for unauthorized add-on - 401 error', () => {
     const id = 'error-handler-id';
-    const store = dispatchClientMetadata().store;
+    const { store } = dispatchClientMetadata();
 
     const error = createApiError({
       response: { status: 401 },
@@ -266,6 +266,8 @@ describe('Addon', () => {
     });
     store.dispatch(setError({ id, error }));
     const capturedError = store.getState().errors[id];
+    // This makes sure the error was dispatched to state correctly.
+    expect(capturedError).toBeTruthy();
 
     const errorHandler = createStubErrorHandler(capturedError);
 


### PR DESCRIPTION
Fixes: #3061 

Unable to have screenshot as no addon gives `401` at local (or may be I am just unaware)

But I got 401 error from `addons.mozilla.org`
<img width="1280" alt="screen shot 2017-09-12 at 6 11 24 pm" src="https://user-images.githubusercontent.com/5318732/30326324-da66ad1e-97e5-11e7-9737-c83949e2a28e.png">


