### PR TITLE
Use photon colors for log in button

### DIFF
--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -253,16 +253,16 @@ $default-arrow-margin: 3px;
 
   &.Button--outline-only {
     background: transparent;
-    border-color: $background;
+    border-color: $teal-50;
     color: $color;
 
     &:hover {
-      border-color: $background-hover;
+      border-color: $teal-70;
     }
 
     &:active,
     &:focus {
-      border-color: $background-active;
+      border-color: $teal-70;
     }
   }
 

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -1,7 +1,7 @@
 @import "./vars";
+@import "~photon-colors/colors";
 
 /* Font mixins. Changes here affect *all* apps */
-
 @mixin font-light() {
   font-family: "Fira Sans", sans-serif;
   font-style: normal;


### PR DESCRIPTION
Fixes #3112

Before:

<img width="245" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/30372293-496018ce-9875-11e7-96e7-c46cfb7fc0e5.png">


After:

<img width="264" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/30372285-4047f40a-9875-11e7-9984-4bc5f7f1da2a.png">
