### PR TITLE
Update category link colours

### DIFF
--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -137,7 +137,8 @@ export class CategoriesBase extends React.Component {
               return (
                 <li className="Categories-item" key={name}>
                   <Button
-                    className={`Categories-link Categories--category-color-${getCategoryColor(category)}`}
+                    className={`Categories-link
+                      Categories--category-color-${getCategoryColor(category)}`}
                     to={`/${visibleAddonType(addonType)}/${slug}/`}
                   >
                     {name}

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -137,9 +137,7 @@ export class CategoriesBase extends React.Component {
               return (
                 <li className="Categories-item" key={name}>
                   <Button
-                    className={`Categories-link Button--action
-                      Button--small
-                      Categories--category-color-${getCategoryColor(category)}`}
+                    className={`Categories-link Categories--category-color-${getCategoryColor(category)}`}
                     to={`/${visibleAddonType(addonType)}/${slug}/`}
                   >
                     {name}

--- a/src/amo/components/Categories/styles.scss
+++ b/src/amo/components/Categories/styles.scss
@@ -14,15 +14,34 @@
 }
 
 .Categories-item {
-  @include margin-end(5px);
+  @include margin-end(7px);
 
   display: inline-block;
-  margin: 0 0 5px;
+  margin: 0 0 7px;
   padding: 0;
+}
+
+.Categories-link,
+.Categories-link:link,
+.Categories-link:visited,
+.Categories-link:hover,
+.Categories-link:active {
+  border-radius: 5px;
+  color: #fff;
+  display: inline-block;
+  font-size: $font-size-s;
+  font-weight: normal;
+  padding: 10px 12px 8px;
+  text-decoration: none;
 }
 
 @for $i from 1 through 12 {
   .Categories--category-color-#{$i} {
-    background: desaturate(nth($category-colors, $i), 20);
+    background: nth($category-colors, $i);
+
+    &:focus,
+    &:hover {
+      background: darken(nth($category-colors, $i), 20);
+    }
   }
 }

--- a/src/amo/components/Categories/styles.scss
+++ b/src/amo/components/Categories/styles.scss
@@ -14,10 +14,11 @@
 }
 
 .Categories-item {
-  @include margin-end(7px);
+  $category-gutter: 7px;
+  @include margin-end($category-gutter);
 
   display: inline-block;
-  margin: 0 0 7px;
+  margin: 0 0 $category-gutter;
   padding: 0;
 }
 

--- a/src/amo/components/CategoryHeader/styles.scss
+++ b/src/amo/components/CategoryHeader/styles.scss
@@ -11,7 +11,7 @@
 .Card-contents {
   @for $i from 1 through 12 {
     .CategoryHeader--category-color-#{$i} & {
-      background: desaturate(nth($category-colors, $i), 20);
+      background: nth($category-colors, $i);
     }
   }
 }

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -1,49 +1,5 @@
 @import "~core/css/inc/vars";
-
-// Photon colors:
-$magenta-50: #ff1ad9;
-$magenta-60: #ed00b5;
-$magenta-70: #b5007f;
-$magenta-80: #7d004f;
-$magenta-90: #440027;
-$purple-50: #9400ff;
-$purple-60: #8000d7;
-$purple-70: #6200a4;
-$purple-80: #440071;
-$purple-90: #25003e;
-$blue-50: #0a84ff;
-$blue-60: #0060df;
-$blue-70: #003eaa;
-$blue-80: #002275;
-$blue-90: #000f40;
-$teal-50: #00feff;
-$teal-60: #00c8d7;
-$teal-70: #008ea4;
-$teal-80: #005a71;
-$teal-90: #002d3e;
-$green-50: #30e60b;
-$green-60: #12bc00;
-$green-70: #058b00;
-$green-80: #006504;
-$green-90: #003706;
-$yellow-50: #ffe900;
-$yellow-60: #d7b600;
-$yellow-70: #a47f00;
-$yellow-80: #715100;
-$yellow-90: #3e2800;
-$red-50: #ff0039;
-$red-60: #d70022;
-$red-70: #a4000f;
-$red-80: #5a0002;
-$red-90: #3e0200;
-$grey-10: #f9f9fa;
-$grey-30: #d7d7db;
-$grey-50: #737373;
-$grey-70: #4a4a4f;
-$grey-90: #0c0c0d;
-$ink-70: #363959;
-$ink-80: #202340;
-$ink-90: #0f1126;
+@import "~photon-colors/colors";
 
 // Desktop variables (from specs)
 $black: #343a40;
@@ -79,10 +35,7 @@ $header-accent-color: $link-color;
 $header-text-not-active-color: transparentize($white, 0.5);
 
 // Category Colors
-$category-colors: #ff6b6b, #f06595, #cc5de8, #845ef7, #5c7cfa, #329af0, #22b8cf, #20c997, #51cf66, #94d82d, #fcc419, #ff922b;
-
-// Extension Category Colors
-$category-colors-extensions: #ff66ed, #ff7466, #ffad66, #ffc866, #95e100, #67f74a, #00d1e6, #66bdff, #747eb3, #b366ff;
+$category-colors: #fa5252, #e64980, #be4bdb, #7950f2, #4c6ef5, #228ae6, #15aabf, #12b886, #40c057, #82c91e, #fab005, #fd7e14;
 
 // Fonts
 $font-size-s: 12px;

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -35,7 +35,8 @@ $header-accent-color: $link-color;
 $header-text-not-active-color: transparentize($white, 0.5);
 
 // Category Colors
-$category-colors: #fa5252, #e64980, #be4bdb, #7950f2, #4c6ef5, #228ae6, #15aabf, #12b886, #40c057, #82c91e, #fab005, #fd7e14;
+$category-colors: #fa5252, #e64980, #be4bdb, #7950f2, #4c6ef5, #228ae6,
+  #15aabf, #12b886, #40c057, #82c91e, #fab005, #fd7e14;
 
 // Fonts
 $font-size-s: 12px;


### PR DESCRIPTION
Fixes #3114 

This updates the category colours to match the current spec. Note the colours in the spec are not actually photon colours but they're photon-like hence not using the photon vars.

I removed the use of button default classes to reduce the specificity issues and make these links their own thing. This enabled dedicated hover/focus styling much more easily and avoiding the pale blue default.

The photon colours removal was to make sure we're using the packaged vars not hard-coded ones - despite me not using the vars in this patch the import was needed to expose the photon vars elsewhere.

I removed another un-used CSS variable here too.

Before: 

<img width="1391" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/30379031-207488b0-988d-11e7-8055-c0f28e149396.png">

After:

<img width="1393" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/30378917-b411d04c-988c-11e7-981e-c012b53e7ea8.png">

