### PR TITLE
Make sure menu is on top of the autocompletion panel

### DIFF
--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -62,7 +62,7 @@
   padding: 0;
   position: absolute;
   width: 100%;
-  z-index: 100;
+  z-index: 5;
 }
 
 .SearchForm-suggestions-item {


### PR DESCRIPTION
Fix #3120 

---

The `z-index` for the autocompletion was a bit too high.

<img width="1392" alt="screen shot 2017-09-13 at 18 40 08" src="https://user-images.githubusercontent.com/217628/30389529-5e931ba4-98b3-11e7-9305-cfd04977c753.png">
