### PR TITLE
Add add-on DB ID to MoreInfoCard

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -516,7 +516,7 @@ export class AddonBase extends React.Component {
           {this.renderShowMoreCard()}
           {this.renderRatingsCard()}
 
-          {addon ? <AddonMoreInfo addon={addon} /> : null}
+          <AddonMoreInfo addon={addon} />
           {this.renderVersionReleaseNotes()}
           {this.renderMoreAddonsByAuthors()}
         </div>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -87,9 +87,7 @@ export class AddonMoreInfoBase extends React.Component {
             </dd>
           ) : null}
           {addon.has_privacy_policy ? (
-            <dt
-              className="AddonMoreInfo-privacy-policy-title"
-            >
+            <dt className="AddonMoreInfo-privacy-policy-title">
               {i18n.gettext('Privacy Policy')}
             </dt>
           ) : null}
@@ -104,9 +102,7 @@ export class AddonMoreInfoBase extends React.Component {
             </dd>
           ) : null}
           {addon.has_eula ? (
-            <dt
-              className="AddonMoreInfo-eula-title"
-            >
+            <dt className="AddonMoreInfo-eula-title">
               {i18n.gettext('End-User License Agreement')}
             </dt>
           ) : null}
@@ -118,6 +114,20 @@ export class AddonMoreInfoBase extends React.Component {
               >
                 {i18n.gettext('Read the license agreement for this add-on')}
               </Link>
+            </dd>
+          ) : null}
+          {addon.id ? (
+            <dt
+              className="AddonMoreInfo-database-id-title"
+              title={i18n.gettext(`This ID is useful for debugging and
+                identifying your add-on to site administrators.`)}
+            >
+              {i18n.gettext('Internal Database ID')}
+            </dt>
+          ) : null}
+          {addon.id ? (
+            <dd className="AddonMoreInfo-database-id-content">
+              {addon.id}
             </dd>
           ) : null}
         </dl>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -7,7 +7,7 @@ import translate from 'core/i18n/translate';
 import { trimAndAddProtocolToUrl } from 'core/utils';
 import Card from 'ui/components/Card';
 
-import './AddonMoreInfo.scss';
+import './styles.scss';
 
 
 export class AddonMoreInfoBase extends React.Component {
@@ -22,38 +22,42 @@ export class AddonMoreInfoBase extends React.Component {
     let homepage = trimAndAddProtocolToUrl(addon.homepage);
     if (homepage) {
       homepage = (
-        <li><a href={homepage} ref={(ref) => { this.homepageLink = ref; }}>
+        <li><a className="AddonMoreInfo-homepage-link" href={homepage}>
           {i18n.gettext('Homepage')}
         </a></li>
       );
     }
+
     let supportUrl = trimAndAddProtocolToUrl(addon.support_url);
     if (supportUrl) {
       supportUrl = (
-        <li><a href={supportUrl} ref={(ref) => { this.supportLink = ref; }}>
+        <li><a className="AddonMoreInfo-support-link" href={supportUrl}>
           {i18n.gettext('Support Site')}
         </a></li>
       );
     }
 
     return (
-      <Card className="AddonMoreInfo" header={i18n.gettext('More information')}>
+      <Card
+        className="AddonMoreInfo"
+        header={i18n.gettext('More information')}
+      >
         <dl className="AddonMoreInfo-contents">
           {homepage || supportUrl ? (
-            <dt ref={(ref) => { this.linkTitle = ref; }}>
+            <dt className="AddonMoreInfo-links-title">
               {i18n.gettext('Add-on Links')}
             </dt>
           ) : null}
           {homepage || supportUrl ? (
-            <dd className="AddonMoreInfo-contents-links">
-              <ul className="AddonMoreInfo-contents-links-list">
+            <dd className="AddonMoreInfo-links-contents">
+              <ul className="AddonMoreInfo-links-contents-list">
                 {homepage}
                 {supportUrl}
               </ul>
             </dd>
           ) : null}
           <dt>{i18n.gettext('Version')}</dt>
-          <dd ref={(ref) => { this.version = ref; }}>
+          <dd className="AddonMoreInfo-version">
             {addon.current_version.version}
           </dd>
           <dt>{i18n.gettext('Last updated')}</dt>
@@ -68,40 +72,49 @@ export class AddonMoreInfoBase extends React.Component {
             )}
           </dd>
           {addon.current_version.license ? (
-            <dt ref={(ref) => { this.licenseHeader = ref; }}>
+            <dt className="AddonMoreInfo-license-title">
               {i18n.gettext('License')}
             </dt>
           ) : null}
           {addon.current_version.license ? (
             <dd>
               <a
+                className="AddonMoreInfo-license-link"
                 href={addon.current_version.license.url}
-                ref={(ref) => { this.licenseLink = ref; }}
               >
-                {addon.current_version.license.name}</a>
+                {addon.current_version.license.name}
+              </a>
             </dd>
           ) : null}
           {addon.has_privacy_policy ? (
-            <dt>{i18n.gettext('Privacy Policy')}</dt>
+            <dt
+              className="AddonMoreInfo-privacy-policy-title"
+            >
+              {i18n.gettext('Privacy Policy')}
+            </dt>
           ) : null}
           {addon.has_privacy_policy ? (
             <dd>
               <Link
+                className="AddonMoreInfo-privacy-policy-link"
                 href={`/addon/${addon.slug}/privacy/`}
-                ref={(ref) => { this.privacyPolicyLink = ref; }}
               >
                 {i18n.gettext('Read the privacy policy for this add-on')}
               </Link>
             </dd>
           ) : null}
           {addon.has_eula ? (
-            <dt>{i18n.gettext('End-User License Agreement')}</dt>
+            <dt
+              className="AddonMoreInfo-eula-title"
+            >
+              {i18n.gettext('End-User License Agreement')}
+            </dt>
           ) : null}
           {addon.has_eula ? (
             <dd>
               <Link
+                className="AddonMoreInfo-eula-link"
                 href={`/addon/${addon.slug}/eula/`}
-                ref={(ref) => { this.eulaLink = ref; }}
               >
                 {i18n.gettext('Read the license agreement for this add-on')}
               </Link>
@@ -114,5 +127,5 @@ export class AddonMoreInfoBase extends React.Component {
 }
 
 export default compose(
-  translate({ withRef: true }),
+  translate(),
 )(AddonMoreInfoBase);

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -24,15 +24,15 @@ export class AddonMoreInfoBase extends React.Component {
       return (
         <dl className="AddonMoreInfo-contents">
           <dt className="AddonMoreInfo-loading-title">
-            <LoadingText width={55} />
+            <LoadingText maxWidth={40} />
           </dt>
-          <dd className="AddonMoreInfo-loading-title">
+          <dd className="AddonMoreInfo-loading-content">
             <LoadingText width={25} />
           </dd>
           <dt className="AddonMoreInfo-loading-title">
-            <LoadingText width={55} />
+            <LoadingText maxWidth={40} />
           </dt>
-          <dd className="AddonMoreInfo-loading-title">
+          <dd className="AddonMoreInfo-loading-content">
             <LoadingText width={25} />
           </dd>
         </dl>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -17,22 +17,25 @@ export class AddonMoreInfoBase extends React.Component {
     i18n: PropTypes.object.isRequired,
   }
 
-  render() {
+  listContent() {
     const { addon, i18n } = this.props;
 
     if (!addon) {
       return (
-        <Card
-          className="AddonMoreInfo"
-          header={i18n.gettext('More information')}
-        >
-          <dl className="AddonMoreInfo-contents">
-            <dt><LoadingText width={55} /></dt>
-            <dd><LoadingText width={25} /></dd>
-            <dt><LoadingText width={55} /></dt>
-            <dd><LoadingText width={25} /></dd>
-          </dl>
-        </Card>
+        <dl className="AddonMoreInfo-contents">
+          <dt className="AddonMoreInfo-loading-title">
+            <LoadingText width={55} />
+          </dt>
+          <dd className="AddonMoreInfo-loading-title">
+            <LoadingText width={25} />
+          </dd>
+          <dt className="AddonMoreInfo-loading-title">
+            <LoadingText width={55} />
+          </dt>
+          <dd className="AddonMoreInfo-loading-title">
+            <LoadingText width={25} />
+          </dd>
+        </dl>
       );
     }
 
@@ -55,99 +58,107 @@ export class AddonMoreInfoBase extends React.Component {
     }
 
     return (
+      <dl className="AddonMoreInfo-contents">
+        {homepage || supportUrl ? (
+          <dt className="AddonMoreInfo-links-title">
+            {i18n.gettext('Add-on Links')}
+          </dt>
+        ) : null}
+        {homepage || supportUrl ? (
+          <dd className="AddonMoreInfo-links-contents">
+            <ul className="AddonMoreInfo-links-contents-list">
+              {homepage}
+              {supportUrl}
+            </ul>
+          </dd>
+        ) : null}
+        <dt>{i18n.gettext('Version')}</dt>
+        <dd className="AddonMoreInfo-version">
+          {addon.current_version.version}
+        </dd>
+        <dt>{i18n.gettext('Last updated')}</dt>
+        <dd>
+          {i18n.sprintf(
+            // L10n: This will output, in English:
+            // "2 months ago (Dec 12 2016)"
+            i18n.gettext('%(timeFromNow)s (%(date)s)'), {
+              timeFromNow: i18n.moment(addon.last_updated).fromNow(),
+              date: i18n.moment(addon.last_updated).format('ll'),
+            }
+          )}
+        </dd>
+        {addon.current_version.license ? (
+          <dt className="AddonMoreInfo-license-title">
+            {i18n.gettext('License')}
+          </dt>
+        ) : null}
+        {addon.current_version.license ? (
+          <dd>
+            <a
+              className="AddonMoreInfo-license-link"
+              href={addon.current_version.license.url}
+            >
+              {addon.current_version.license.name}
+            </a>
+          </dd>
+        ) : null}
+        {addon.has_privacy_policy ? (
+          <dt className="AddonMoreInfo-privacy-policy-title">
+            {i18n.gettext('Privacy Policy')}
+          </dt>
+        ) : null}
+        {addon.has_privacy_policy ? (
+          <dd>
+            <Link
+              className="AddonMoreInfo-privacy-policy-link"
+              href={`/addon/${addon.slug}/privacy/`}
+            >
+              {i18n.gettext('Read the privacy policy for this add-on')}
+            </Link>
+          </dd>
+        ) : null}
+        {addon.has_eula ? (
+          <dt className="AddonMoreInfo-eula-title">
+            {i18n.gettext('End-User License Agreement')}
+          </dt>
+        ) : null}
+        {addon.has_eula ? (
+          <dd>
+            <Link
+              className="AddonMoreInfo-eula-link"
+              href={`/addon/${addon.slug}/eula/`}
+            >
+              {i18n.gettext('Read the license agreement for this add-on')}
+            </Link>
+          </dd>
+        ) : null}
+        {addon.id ? (
+          <dt
+            className="AddonMoreInfo-database-id-title"
+            title={i18n.gettext(`This ID is useful for debugging and
+              identifying your add-on to site administrators.`)}
+          >
+            {i18n.gettext('Internal Database ID')}
+          </dt>
+        ) : null}
+        {addon.id ? (
+          <dd className="AddonMoreInfo-database-id-content">
+            {addon.id}
+          </dd>
+        ) : null}
+      </dl>
+    );
+  }
+
+  render() {
+    const { i18n } = this.props;
+
+    return (
       <Card
         className="AddonMoreInfo"
         header={i18n.gettext('More information')}
       >
-        <dl className="AddonMoreInfo-contents">
-          {homepage || supportUrl ? (
-            <dt className="AddonMoreInfo-links-title">
-              {i18n.gettext('Add-on Links')}
-            </dt>
-          ) : null}
-          {homepage || supportUrl ? (
-            <dd className="AddonMoreInfo-links-contents">
-              <ul className="AddonMoreInfo-links-contents-list">
-                {homepage}
-                {supportUrl}
-              </ul>
-            </dd>
-          ) : null}
-          <dt>{i18n.gettext('Version')}</dt>
-          <dd className="AddonMoreInfo-version">
-            {addon.current_version.version}
-          </dd>
-          <dt>{i18n.gettext('Last updated')}</dt>
-          <dd>
-            {i18n.sprintf(
-              // L10n: This will output, in English:
-              // "2 months ago (Dec 12 2016)"
-              i18n.gettext('%(timeFromNow)s (%(date)s)'), {
-                timeFromNow: i18n.moment(addon.last_updated).fromNow(),
-                date: i18n.moment(addon.last_updated).format('ll'),
-              }
-            )}
-          </dd>
-          {addon.current_version.license ? (
-            <dt className="AddonMoreInfo-license-title">
-              {i18n.gettext('License')}
-            </dt>
-          ) : null}
-          {addon.current_version.license ? (
-            <dd>
-              <a
-                className="AddonMoreInfo-license-link"
-                href={addon.current_version.license.url}
-              >
-                {addon.current_version.license.name}
-              </a>
-            </dd>
-          ) : null}
-          {addon.has_privacy_policy ? (
-            <dt className="AddonMoreInfo-privacy-policy-title">
-              {i18n.gettext('Privacy Policy')}
-            </dt>
-          ) : null}
-          {addon.has_privacy_policy ? (
-            <dd>
-              <Link
-                className="AddonMoreInfo-privacy-policy-link"
-                href={`/addon/${addon.slug}/privacy/`}
-              >
-                {i18n.gettext('Read the privacy policy for this add-on')}
-              </Link>
-            </dd>
-          ) : null}
-          {addon.has_eula ? (
-            <dt className="AddonMoreInfo-eula-title">
-              {i18n.gettext('End-User License Agreement')}
-            </dt>
-          ) : null}
-          {addon.has_eula ? (
-            <dd>
-              <Link
-                className="AddonMoreInfo-eula-link"
-                href={`/addon/${addon.slug}/eula/`}
-              >
-                {i18n.gettext('Read the license agreement for this add-on')}
-              </Link>
-            </dd>
-          ) : null}
-          {addon.id ? (
-            <dt
-              className="AddonMoreInfo-database-id-title"
-              title={i18n.gettext(`This ID is useful for debugging and
-                identifying your add-on to site administrators.`)}
-            >
-              {i18n.gettext('Internal Database ID')}
-            </dt>
-          ) : null}
-          {addon.id ? (
-            <dd className="AddonMoreInfo-database-id-content">
-              {addon.id}
-            </dd>
-          ) : null}
-        </dl>
+        {this.listContent()}
       </Card>
     );
   }

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -79,7 +79,7 @@ export class AddonMoreInfoBase extends React.Component {
         <dt>{i18n.gettext('Last updated')}</dt>
         <dd>
           {i18n.sprintf(
-            // L10n: This will output, in English:
+            // translators: This will output, in English:
             // "2 months ago (Dec 12 2016)"
             i18n.gettext('%(timeFromNow)s (%(date)s)'), {
               timeFromNow: i18n.moment(addon.last_updated).fromNow(),
@@ -138,7 +138,7 @@ export class AddonMoreInfoBase extends React.Component {
             title={i18n.gettext(`This ID is useful for debugging and
               identifying your add-on to site administrators.`)}
           >
-            {i18n.gettext('Internal Database ID')}
+            {i18n.gettext('Site Identifier')}
           </dt>
         ) : null}
         {addon.id ? (

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -6,6 +6,7 @@ import Link from 'amo/components/Link';
 import translate from 'core/i18n/translate';
 import { trimAndAddProtocolToUrl } from 'core/utils';
 import Card from 'ui/components/Card';
+import LoadingText from 'ui/components/LoadingText';
 
 import './styles.scss';
 
@@ -18,6 +19,22 @@ export class AddonMoreInfoBase extends React.Component {
 
   render() {
     const { addon, i18n } = this.props;
+
+    if (!addon) {
+      return (
+        <Card
+          className="AddonMoreInfo"
+          header={i18n.gettext('More information')}
+        >
+          <dl className="AddonMoreInfo-contents">
+            <dt><LoadingText width={55} /></dt>
+            <dd><LoadingText width={25} /></dd>
+            <dt><LoadingText width={55} /></dt>
+            <dd><LoadingText width={25} /></dd>
+          </dl>
+        </Card>
+      );
+    }
 
     let homepage = trimAndAddProtocolToUrl(addon.homepage);
     if (homepage) {

--- a/src/amo/components/AddonMoreInfo/styles.scss
+++ b/src/amo/components/AddonMoreInfo/styles.scss
@@ -24,7 +24,7 @@
   }
 }
 
-.AddonMoreInfo-contents-links-list {
+.AddonMoreInfo-links-content-list {
   list-style: none;
   margin: 0;
   padding: 0;

--- a/src/amo/components/AddonMoreInfo/styles.scss
+++ b/src/amo/components/AddonMoreInfo/styles.scss
@@ -24,8 +24,16 @@
   }
 }
 
-.AddonMoreInfo-links-content-list {
+.AddonMoreInfo-links-contents-list {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+.AddonMoreInfo-loading-title .LoadingText {
+  margin-bottom: 3px;
+}
+
+.AddonMoreInfo-loading-content .LoadingText {
+  margin-bottom: 5px;
 }

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -237,7 +237,6 @@ describe(__filename, () => {
     // These should be empty:
     expect(root.find(InstallButton)).toHaveLength(0);
     expect(root.find(AddonCompatibilityError)).toHaveLength(0);
-    expect(root.find(AddonMoreInfo)).toHaveLength(0);
     expect(root.find(RatingManager)).toHaveLength(0);
 
     // These should show LoadingText
@@ -248,8 +247,11 @@ describe(__filename, () => {
     expect(root.find('.Addon-overall-rating').shallow().find(LoadingText))
       .toHaveLength(1);
 
-    // These should render with an empty addon.
-    expect(root.find(AddonMeta).prop('addon')).toEqual(null);
+    // These should render with an empty addon (they will show their own
+    // loading state).
+    expect(root.find(AddonMeta)).toHaveProp('addon', null);
+    expect(root.find(AddonMoreInfo)).toHaveProp('addon', null);
+    expect(root.find(AddonMoreInfo)).toHaveLength(1);
   });
 
   it('does not dispatch fetchAddon action when slug is the same', () => {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -7,6 +7,7 @@ import AddonMoreInfo, {
 } from 'amo/components/AddonMoreInfo';
 import { dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
 import { getFakeI18nInst, shallowUntilTarget } from 'tests/unit/helpers';
+import LoadingText from 'ui/components/LoadingText';
 
 
 describe(__filename, () => {
@@ -23,6 +24,12 @@ describe(__filename, () => {
       AddonMoreInfoBase
     );
   }
+
+  it('renders LoadingText if no add-on is present', () => {
+    const root = render({ addon: null });
+
+    expect(root.find(LoadingText)).toHaveLength(4);
+  });
 
   it('does renders a link <dt> if links exist', () => {
     const partialAddon = {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -175,7 +175,7 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-database-id-title'))
-      .toHaveText('Internal Database ID');
+      .toHaveText('Site Identifier');
     expect(root.find('.AddonMoreInfo-database-id-title'))
       .toHaveProp('title', oneLine`This ID is useful for debugging and
         identifying your add-on to site administrators.`);

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -1,3 +1,4 @@
+import { oneLine } from 'common-tags';
 import deepcopy from 'deepcopy';
 import React from 'react';
 
@@ -132,5 +133,26 @@ describe(__filename, () => {
       .toHaveProp('children', 'Read the license agreement for this add-on');
     expect(root.find('.AddonMoreInfo-eula-link'))
       .toHaveProp('href', '/addon/chill-out/eula/');
+  });
+
+  it('does not render an add-on ID if none exists', () => {
+    const partialAddon = { ...fakeAddon, id: undefined };
+    const root = render({ addon: partialAddon });
+
+    expect(root.find('.AddonMoreInfo-database-id-title')).toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-database-id-content')).toHaveLength(0);
+  });
+
+  it('renders the ID and title attribute', () => {
+    const addon = { ...fakeAddon, id: 9001 };
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-database-id-title'))
+      .toHaveText('Internal Database ID');
+    expect(root.find('.AddonMoreInfo-database-id-title'))
+      .toHaveProp('title', oneLine`This ID is useful for debugging and
+        identifying your add-on to site administrators.`);
+    expect(root.find('.AddonMoreInfo-database-id-content'))
+      .toHaveText('9001');
   });
 });

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -32,12 +32,12 @@ describe(__filename, () => {
   });
 
   it('does renders a link <dt> if links exist', () => {
-    const partialAddon = {
+    const addon = {
       ...fakeAddon,
       homepage: null,
       support_url: 'foo.com',
     };
-    const root = render({ addon: partialAddon });
+    const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-links-title'))
       .toIncludeText('Add-on Links');
@@ -61,7 +61,8 @@ describe(__filename, () => {
   });
 
   it('renders the homepage of an add-on', () => {
-    const root = render();
+    const addon = { ...fakeAddon, homepage: 'http://hamsterdance.com/' };
+    const root = render({ addon });
     const link = root.find('.AddonMoreInfo-homepage-link');
 
     expect(link).toIncludeText('Homepage');
@@ -77,7 +78,11 @@ describe(__filename, () => {
   });
 
   it('renders the support link of an add-on', () => {
-    const root = render();
+    const addon = {
+      ...fakeAddon,
+      support_url: 'http://support.hampsterdance.com/',
+    };
+    const root = render({ addon });
     const link = root.find('.AddonMoreInfo-support-link');
 
     expect(link).toIncludeText('Support Site');
@@ -85,13 +90,27 @@ describe(__filename, () => {
   });
 
   it('renders the version number of an add-on', () => {
-    const root = render();
+    const addon = {
+      ...fakeAddon,
+      current_version: {
+        ...fakeAddon.current_version,
+        version: '2.0.1',
+      },
+    };
+    const root = render({ addon });
 
-    expect(root.find('.AddonMoreInfo-version')).toHaveText('2.0.0');
+    expect(root.find('.AddonMoreInfo-version')).toHaveText('2.0.1');
   });
 
   it('renders the license and link', () => {
-    const root = render();
+    const addon = {
+      ...fakeAddon,
+      current_version: {
+        ...fakeAddon.current_version,
+        license: { name: 'tofulicense', url: 'http://license.com/' },
+      },
+    };
+    const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-license-title')).toHaveText('License');
     expect(root.find('.AddonMoreInfo-license-link'))
@@ -101,8 +120,8 @@ describe(__filename, () => {
   });
 
   it('does not render a privacy policy if none exists', () => {
-    const partialAddon = { ...fakeAddon, has_privacy_policy: false };
-    const root = render({ addon: partialAddon });
+    const addon = { ...fakeAddon, has_privacy_policy: false };
+    const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-privacy-policy-title'))
       .toHaveLength(0);
@@ -116,15 +135,15 @@ describe(__filename, () => {
 
     expect(root.find('.AddonMoreInfo-privacy-policy-title'))
       .toHaveText('Privacy Policy');
-    expect(root.find('.AddonMoreInfo-privacy-policy-link'))
-      .toHaveProp('children', 'Read the privacy policy for this add-on');
+    expect(root.find('.AddonMoreInfo-privacy-policy-link').children())
+      .toHaveText('Read the privacy policy for this add-on');
     expect(root.find('.AddonMoreInfo-privacy-policy-link'))
       .toHaveProp('href', '/addon/chill-out/privacy/');
   });
 
   it('does not render a EULA if none exists', () => {
-    const partialAddon = { ...fakeAddon, has_eula: false };
-    const root = render({ addon: partialAddon });
+    const addon = { ...fakeAddon, has_eula: false };
+    const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-eula-title')).toHaveLength(0);
     expect(root.find('.AddonMoreInfo-eula-link')).toHaveLength(0);
@@ -136,14 +155,15 @@ describe(__filename, () => {
 
     expect(root.find('.AddonMoreInfo-eula-title'))
       .toHaveText('End-User License Agreement');
-    expect(root.find('.AddonMoreInfo-eula-link'))
-      .toHaveProp('children', 'Read the license agreement for this add-on');
+    expect(root.find('.AddonMoreInfo-eula-link').children())
+      .toHaveText('Read the license agreement for this add-on');
     expect(root.find('.AddonMoreInfo-eula-link'))
       .toHaveProp('href', '/addon/chill-out/eula/');
   });
 
   it('does not render an add-on ID if none exists', () => {
-    const partialAddon = { ...fakeAddon, id: undefined };
+    const partialAddon = { ...fakeAddon };
+    delete partialAddon.id;
     const root = render({ addon: partialAddon });
 
     expect(root.find('.AddonMoreInfo-database-id-title')).toHaveLength(0);


### PR DESCRIPTION
This PR looks huge because I moved the tests to enzyme (and thus had to change from using `ref` because `shallow` won't find refs. I like putting classNames on stuff anyway.

* Fixes #2750
* Fixes #3127 

Adds the add-on's database ID to the more info card. Useful for admins/debugging/etc.

Check out 62b85c0a607a35f0459425e0c51b47acdb1edb1f for the meat of the change.

### Before
<img width="495" alt="screenshot 2017-09-13 22 28 59" src="https://user-images.githubusercontent.com/90871/30401659-f698ca4c-98d2-11e7-8864-769298ff3215.png">

### After
<img width="480" alt="screenshot 2017-09-13 22 25 57" src="https://user-images.githubusercontent.com/90871/30401663-faadfc1a-98d2-11e7-9ade-d35995031332.png">

------

While I was here it was super-easy to add LoadingText support to this component so I did:

### Before
![2017-09-13 22 48 10](https://user-images.githubusercontent.com/90871/30402447-b549bb7a-98d5-11e7-8399-a1b90de3ab04.gif)

### After
![2017-09-13 22 46 07](https://user-images.githubusercontent.com/90871/30402495-d0f77150-98d5-11e7-90ef-5b55b3dbc583.gif)
