### PR TITLE
Make the loading indicators more subtle

### DIFF
--- a/src/ui/components/LoadingText/styles.scss
+++ b/src/ui/components/LoadingText/styles.scss
@@ -1,4 +1,5 @@
 @import "~amo/css/inc/vars";
+@import "~photon-colors/colors";
 
 @keyframes placeHolderShimmer {
   0% {
@@ -6,7 +7,7 @@
   }
 
   25% {
-    opacity: 0.15;
+    opacity: 0.25;
   }
 
   50% {
@@ -14,7 +15,7 @@
   }
 
   75% {
-    opacity: 0.15;
+    opacity: 0.25;
   }
 
   100% {
@@ -24,7 +25,7 @@
 
 .LoadingText {
   animation: placeHolderShimmer 3s infinite cubic-bezier(0.65, 0.05, 0.36, 1);
-  background: $text-color-default;
+  background: $grey-40;
   display: inline-block;
   height: 1rem;
   line-height: 1;

--- a/src/ui/components/LoadingText/styles.scss
+++ b/src/ui/components/LoadingText/styles.scss
@@ -25,7 +25,7 @@
 
 .LoadingText {
   animation: placeHolderShimmer 3s infinite cubic-bezier(0.65, 0.05, 0.36, 1);
-  background: $grey-40;
+  background: $grey-30;
   display: inline-block;
   height: 1rem;
   line-height: 1;


### PR DESCRIPTION
Fixes #2899

This makes use of a photon grey which is lighter than the current grey used as the base colour for the loading indicator animations. I've reduced the lightest opacity so it doesn't get too light. 

Before (ignore the arrow it's not relevant to this)

<img width="883" alt="untitled_2" src="https://user-images.githubusercontent.com/1514/30426592-7d30467c-9944-11e7-92b7-b3e631513917.png">

After (updated to grey-30 after feedback)

<img width="842" alt="untitled_3" src="https://user-images.githubusercontent.com/1514/30438028-0f721646-9968-11e7-9a1c-b61ed11baec1.png">


