### PR TITLE
Add display name to user state and use it in menu

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -9,7 +9,7 @@ import SectionLinks from 'amo/components/SectionLinks';
 import AuthenticateButton, {
   createHandleLogOutFunction,
 } from 'core/components/AuthenticateButton';
-import { isAuthenticated } from 'core/reducers/user';
+import { isAuthenticated, selectDisplayName } from 'core/reducers/user';
 import { VIEW_CONTEXT_HOME } from 'core/constants';
 import translate from 'core/i18n/translate';
 import Icon from 'ui/components/Icon';
@@ -22,6 +22,7 @@ import './styles.scss';
 export class HeaderBase extends React.Component {
   static propTypes = {
     api: PropTypes.object.isRequired,
+    displayName: PropTypes.string,
     handleLogOut: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
     isAuthenticated: PropTypes.bool.isRequired,
@@ -44,6 +45,7 @@ export class HeaderBase extends React.Component {
 
   render() {
     const {
+      displayName,
       i18n,
       isHomePage,
       location,
@@ -86,7 +88,7 @@ export class HeaderBase extends React.Component {
 
           {this.props.isAuthenticated ? (
             <DropdownMenu
-              text={username}
+              text={displayName}
               className="Header-authenticate-button Header-button"
             >
               <DropdownMenuItem>{i18n.gettext('My Account')}</DropdownMenuItem>
@@ -158,9 +160,10 @@ export class HeaderBase extends React.Component {
 export const mapStateToProps = (state) => {
   return {
     api: state.api,
+    displayName: selectDisplayName(state),
     isHomePage: state.viewContext.context === VIEW_CONTEXT_HOME,
-    username: state.user.username,
     isAuthenticated: isAuthenticated(state),
+    username: state.user.username,
   };
 };
 

--- a/src/core/reducers/user.js
+++ b/src/core/reducers/user.js
@@ -8,11 +8,13 @@ type Action = Object;
 export type UserStateType = {
   id: ?number,
   username: ?string,
+  displayName: ?string,
 };
 
 export const initialState: UserStateType = {
   id: null,
   username: null,
+  displayName: null,
 };
 
 export const loadUserProfile = ({ profile }: Object) => {
@@ -30,6 +32,17 @@ export const isAuthenticated = (state: { user: UserStateType }) => {
   return !!state.user.id;
 };
 
+export const selectDisplayName = (state: { user: UserStateType }) => {
+  const displayName = state.user.displayName;
+  if (displayName && displayName !== '') {
+    return displayName;
+  }
+
+  // We fallback to the username if no display name has been defined by the
+  // user.
+  return state.user.username;
+};
+
 export default function reducer(
   state: UserStateType = initialState,
   action: Action = {}
@@ -42,6 +55,7 @@ export default function reducer(
         ...state,
         id: payload.profile.id,
         username: payload.profile.username,
+        displayName: payload.profile.display_name,
       };
     case LOG_OUT_USER:
       return initialState;

--- a/src/core/reducers/user.js
+++ b/src/core/reducers/user.js
@@ -34,7 +34,7 @@ export const isAuthenticated = (state: { user: UserStateType }) => {
 
 export const selectDisplayName = (state: { user: UserStateType }) => {
   const displayName = state.user.displayName;
-  if (displayName && displayName !== '') {
+  if (displayName && displayName.length) {
     return displayName;
   }
 

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -41,6 +41,10 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 
+    @include respond-to(medium) {
+      max-width: 200px;
+    }
+
     @include respond-to(extraLarge) {
       max-width: 300px;
     }

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -65,7 +65,16 @@ describe(__filename, () => {
     expect(wrapper.find(DropdownMenu)).toHaveLength(0);
   });
 
-  it('displays a menu and the username when user is signed in', () => {
+  it('displays a menu and the display name when user is signed in', () => {
+    const displayName = 'King of the Elephants';
+    const { store } = dispatchSignInActions({ username: 'babar', displayName });
+    const wrapper = renderHeader({ store });
+
+    expect(wrapper.find(DropdownMenu)).toHaveLength(1);
+    expect(wrapper.find(DropdownMenu)).toHaveProp('text', displayName);
+  });
+
+  it('displays the username when user is signed in but has no display name', () => {
     const { store } = dispatchSignInActions({ username: 'babar' });
     const wrapper = renderHeader({ store });
 

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -171,13 +171,14 @@ export function dispatchSignInActions({
   authToken = userAuthToken(),
   userId = 12345,
   username = 'user-1234',
+  displayName = null,
   ...otherArgs
 } = {}) {
   const { store } = dispatchClientMetadata(otherArgs);
 
   store.dispatch(setAuthToken(authToken));
   store.dispatch(loadUserProfile({
-    profile: createUserProfileResponse({ id: userId, username }),
+    profile: createUserProfileResponse({ id: userId, username, displayName }),
   }));
 
   return {

--- a/tests/unit/core/reducers/test_user.js
+++ b/tests/unit/core/reducers/test_user.js
@@ -2,6 +2,7 @@ import { logOutUser } from 'core/actions';
 import reducer, {
   isAuthenticated,
   loadUserProfile,
+  selectDisplayName,
 } from 'core/reducers/user';
 import { createUserProfileResponse } from 'tests/unit/helpers';
 import {
@@ -13,9 +14,10 @@ import {
 describe(__filename, () => {
   describe('reducer', () => {
     it('initializes properly', () => {
-      const { id, username } = reducer(undefined);
+      const { displayName, id, username } = reducer(undefined);
       expect(id).toEqual(null);
       expect(username).toEqual(null);
+      expect(displayName).toEqual(null);
     });
 
     it('ignores unrelated actions', () => {
@@ -44,9 +46,10 @@ describe(__filename, () => {
       const state = reducer(undefined, loadUserProfile({
         profile: createUserProfileResponse({ id: 12345, username: 'john' }),
       }));
-      const { id, username } = reducer(state, logOutUser());
+      const { displayName, id, username } = reducer(state, logOutUser());
       expect(id).toEqual(null);
       expect(username).toEqual(null);
+      expect(displayName).toEqual(null);
     });
   });
 
@@ -61,6 +64,46 @@ describe(__filename, () => {
       const { state } = dispatchClientMetadata();
 
       expect(isAuthenticated(state)).toEqual(false);
+    });
+  });
+
+  describe('selectDisplayName selector', () => {
+    it('returns the display name when user has a display name', () => {
+      const displayName = 'King of the Elephants';
+      const { state } = dispatchSignInActions({ displayName });
+
+      expect(selectDisplayName(state)).toEqual(displayName);
+    });
+
+    it('returns the username when display name is null', () => {
+      const username = 'babar';
+      const displayName = null;
+      const { state } = dispatchSignInActions({ username, displayName });
+
+      expect(selectDisplayName(state)).toEqual(username);
+    });
+
+    it('returns the username when display name is undefined', () => {
+      const username = 'babar';
+      const displayName = undefined;
+      const { state } = dispatchSignInActions({ username, displayName });
+
+      expect(selectDisplayName(state)).toEqual(username);
+    });
+
+    it('returns the username when display name is an empty string', () => {
+      const username = 'babar';
+      const displayName = '';
+      const { state } = dispatchSignInActions({ username, displayName });
+
+      expect(selectDisplayName(state)).toEqual(username);
+    });
+
+    it('returns the username when user did not define a display name', () => {
+      const username = 'babar';
+      const { state } = dispatchSignInActions({ username });
+
+      expect(selectDisplayName(state)).toEqual(username);
     });
   });
 });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -287,11 +287,16 @@ export function createApiResponse({
   return Promise.resolve(response);
 }
 
-export function createUserProfileResponse({ id = 123456, username = 'user-1234' } = {}) {
+export function createUserProfileResponse({
+  id = 123456,
+  username = 'user-1234',
+  displayName = null,
+} = {}) {
   return {
     average_addon_rating: null,
     biography: '',
     created: '2017-08-15T12:01:13Z',
+    display_name: displayName,
     homepage: '',
     id,
     is_addon_developer: false,


### PR DESCRIPTION
Fix #3118

---

This PR adds the `displayName` to the `user` state and uses it in the menu when possible.

Before (or without a display name):

<img width="1392" alt="screen shot 2017-09-14 at 15 50 51" src="https://user-images.githubusercontent.com/217628/30433744-9157eb5c-9965-11e7-9706-d24780f6ffaf.png">

After (I usually don't use my second name but I needed it for testing 😛 ):

<img width="1392" alt="screen shot 2017-09-14 at 15 50 38" src="https://user-images.githubusercontent.com/217628/30433751-95b9ae10-9965-11e7-937e-fc9e15b080c0.png">
