### PR TITLE
Avoid encoding the slug twice on the client

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -113,8 +113,12 @@ export function callApi({
     }
   }
 
-  // Workaround for https://github.com/bitinn/node-fetch/issues/245
-  const apiURL = utf8.encode(`${API_BASE}/${endpoint}/${queryString}`);
+  let apiURL = `${API_BASE}/${endpoint}/${queryString}`;
+  if (_config.get('server')) {
+    log.debug('Encoding `apiURL` in UTF8 before fetch().');
+    // Workaround for https://github.com/bitinn/node-fetch/issues/245
+    apiURL = utf8.encode(apiURL);
+  }
 
   // $FLOW_FIXME: once everything uses Flow we won't have to use toUpperCase
   return fetch(apiURL, options)

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -73,6 +73,7 @@ type CallApiParams = {|
   params?: Object,
   schema?: Object,
   state?: ApiStateType,
+  _config?: config,
 |};
 
 export function callApi({
@@ -85,6 +86,7 @@ export function callApi({
   body,
   credentials,
   errorHandler,
+  _config = config,
 }: CallApiParams): Promise<any> {
   if (errorHandler) {
     errorHandler.clear();
@@ -110,8 +112,12 @@ export function callApi({
       options.headers.authorization = `Bearer ${state.token}`;
     }
   }
-  // Workaround for https://github.com/bitinn/node-fetch/issues/245
-  const apiURL = utf8.encode(`${API_BASE}/${endpoint}/${queryString}`);
+
+  let apiURL = `${API_BASE}/${endpoint}/${queryString}`;
+  if (_config.get('server')) {
+    // Workaround for https://github.com/bitinn/node-fetch/issues/245
+    apiURL = utf8.encode(`${API_BASE}/${endpoint}/${queryString}`);
+  }
 
   // $FLOW_FIXME: once everything uses Flow we won't have to use toUpperCase
   return fetch(apiURL, options)

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -73,7 +73,7 @@ type CallApiParams = {|
   params?: Object,
   schema?: Object,
   state?: ApiStateType,
-  _config?: config,
+  _config?: typeof config,
 |};
 
 export function callApi({
@@ -115,8 +115,9 @@ export function callApi({
 
   let apiURL = `${API_BASE}/${endpoint}/${queryString}`;
   if (_config.get('server')) {
+    log.debug('Encoding `apiURL` in UTF8 before fetch().');
     // Workaround for https://github.com/bitinn/node-fetch/issues/245
-    apiURL = utf8.encode(`${API_BASE}/${endpoint}/${queryString}`);
+    apiURL = utf8.encode(apiURL);
   }
 
   // $FLOW_FIXME: once everything uses Flow we won't have to use toUpperCase

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -113,12 +113,8 @@ export function callApi({
     }
   }
 
-  let apiURL = `${API_BASE}/${endpoint}/${queryString}`;
-  if (_config.get('server')) {
-    log.debug('Encoding `apiURL` in UTF8 before fetch().');
-    // Workaround for https://github.com/bitinn/node-fetch/issues/245
-    apiURL = utf8.encode(apiURL);
-  }
+  // Workaround for https://github.com/bitinn/node-fetch/issues/245
+  const apiURL = utf8.encode(`${API_BASE}/${endpoint}/${queryString}`);
 
   // $FLOW_FIXME: once everything uses Flow we won't have to use toUpperCase
   return fetch(apiURL, options)

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -1,7 +1,7 @@
 /* global window */
 import querystring from 'querystring';
 
-import config from 'config';
+import config, { util as configUtil } from 'config';
 import utf8 from 'utf8';
 
 import * as api from 'core/api';
@@ -41,7 +41,28 @@ describe(__filename, () => {
         .then(() => mockWindow.verify());
     });
 
-    it('encodes non-ascii URLs in UTF8', () => {
+    it('does not encode non-ascii URLs in UTF8 on the client', () => {
+      const endpoint = 'project-ă-ă-â-â-日本語';
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/${endpoint}/`, {
+          body: undefined, credentials: undefined, method: 'GET', headers: {},
+        })
+        .once()
+        .returns(createApiResponse());
+
+      // We use `cloneDeep()` to allow modifications on the `config` object,
+      // since a call to `get()` makes it immutable.
+      const clientConfig = configUtil.cloneDeep(config);
+      clientConfig.client = true;
+      clientConfig.server = false;
+
+      return api.callApi({
+        _config: clientConfig,
+        endpoint,
+      }).then(() => mockWindow.verify());
+    });
+
+    it('encodes non-ascii URLs in UTF8 on the server', () => {
       const endpoint = 'diccionario-español-venezuela';
       mockWindow.expects('fetch')
         .withArgs(utf8.encode(`${apiHost}/api/v3/${endpoint}/`), {

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -70,7 +70,16 @@ describe(__filename, () => {
         })
         .once()
         .returns(createApiResponse());
-      return api.callApi({ endpoint }).then(() => mockWindow.verify());
+
+      // We use `cloneDeep()` to allow modifications on the `config` object,
+      // since a call to `get()` makes it immutable.
+      const serverConfig = configUtil.cloneDeep(config);
+      serverConfig.server = true;
+
+      return api.callApi({
+        _config: serverConfig,
+        endpoint,
+      }).then(() => mockWindow.verify());
     });
 
     it('clears an error handler before making a request', () => {


### PR DESCRIPTION
Fix #3138

---

This PR prevents the client to call the API with URLs encoded twice. Encoding should only be forced on the server, see #1920.