### PR TITLE
Show description for themes

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -453,14 +453,15 @@ export class AddonBase extends React.Component {
       isRestartRequired = addon.isRestartRequired;
     }
 
-    const addonsByAuthorsLength = addonsByAuthors ? addonsByAuthors.length : 0;
-    const _classNames = classNames('Addon', `Addon-${addonType}`, {
-      'Addon--has-more-addons': addonsByAuthorsLength > 0,
-      'Addon--has-many-more-addons': addonsByAuthorsLength > 3,
-    });
+    const numberOfAddonsByAuthors = addonsByAuthors ? addonsByAuthors.length : 0;
 
     return (
-      <div className={_classNames}>
+      <div
+        className={classNames('Addon', `Addon-${addonType}`, {
+          'Addon--has-more-than-0-addons': numberOfAddonsByAuthors > 0,
+          'Addon--has-more-than-3-addons': numberOfAddonsByAuthors > 3,
+        })}
+      >
         {errorBanner}
         <Card className="" photonStyle>
           <header className="Addon-header">

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -385,6 +385,7 @@ export class AddonBase extends React.Component {
   render() {
     const {
       addon,
+      addonsByAuthors,
       clientApp,
       errorHandler,
       getClientCompatibility,
@@ -452,8 +453,14 @@ export class AddonBase extends React.Component {
       isRestartRequired = addon.isRestartRequired;
     }
 
+    const addonsByAuthorsLength = addonsByAuthors ? addonsByAuthors.length : 0;
+    const _classNames = classNames('Addon', `Addon-${addonType}`, {
+      'Addon--has-more-addons': addonsByAuthorsLength > 0,
+      'Addon--has-many-more-addons': addonsByAuthorsLength > 3,
+    });
+
     return (
-      <div className={classNames('Addon', `Addon-${addonType}`)}>
+      <div className={_classNames}>
         {errorBanner}
         <Card className="" photonStyle>
           <header className="Addon-header">

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -201,13 +201,13 @@
       grid-column: 2;
       grid-row: 1 / span 5;
 
-      .Addon--has-more-addons.Addon-persona & {
-        // This span makes sure the left widdget does not move vertically when
+      .Addon--has-more-than-0-addons.Addon-persona & {
+        // This span makes sure the left widget does not move vertically when
         // there is a long description.
-        grid-row: 2 / span 1000;
+        grid-row: 2 / span 50000;
       }
 
-      .Addon--has-many-more-addons.Addon-persona & {
+      .Addon--has-more-than-3-addons.Addon-persona & {
         grid-row: 3;
       }
     }
@@ -223,7 +223,7 @@
     .AddonDescription-more-addons--theme {
       grid-column: 2;
 
-      .Addon--has-many-more-addons & {
+      .Addon--has-more-than-3-addons & {
         grid-row: 1 / span 2;
       }
     }
@@ -243,11 +243,11 @@
   .Addon-overall-rating {
     grid-column: 1 / 2;
 
-    .Addon--has-more-addons.Addon-persona & {
+    .Addon--has-more-than-0-addons.Addon-persona & {
       grid-row: 1 / span 2;
     }
 
-    .Addon--has-many-more-addons.Addon-persona & {
+    .Addon--has-more-than-3-addons.Addon-persona & {
       grid-row: 1;
     }
   }
@@ -256,11 +256,11 @@
     grid-column: 1 / 2;
     grid-row: 4 / span 1;
 
-    .Addon--has-more-addons.Addon-persona & {
+    .Addon--has-more-than-0-addons.Addon-persona & {
       grid-row: 3 / span 1;
     }
 
-    .Addon--has-many-more-addons.Addon-persona & {
+    .Addon--has-more-than-3-addons.Addon-persona & {
       grid-row: 2 / span 2;
     }
   }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -193,13 +193,23 @@
   .Addon-details {
     display: grid;
     grid-auto-flow: column dense;
-    grid-gap: 10px;
+    grid-gap: 0 10px;
     grid-template-columns: minmax(300px, 35%) auto;
     margin: 10px 0 0;
 
     .AddonDescription {
       grid-column: 2;
       grid-row: 1 / span 5;
+
+      .Addon--has-more-addons.Addon-persona & {
+        // This span makes sure the left widdget does not move vertically when
+        // there is a long description.
+        grid-row: 2 / span 1000;
+      }
+
+      .Addon--has-many-more-addons.Addon-persona & {
+        grid-row: 3;
+      }
     }
 
     .AddonDescription-version-notes {
@@ -212,7 +222,10 @@
 
     .AddonDescription-more-addons--theme {
       grid-column: 2;
-      grid-row: 1 / span 5;
+
+      .Addon--has-many-more-addons & {
+        grid-row: 1 / span 2;
+      }
     }
 
     .AddonDescription-contents {
@@ -229,10 +242,27 @@
 
   .Addon-overall-rating {
     grid-column: 1 / 2;
+
+    .Addon--has-more-addons.Addon-persona & {
+      grid-row: 1 / span 2;
+    }
+
+    .Addon--has-many-more-addons.Addon-persona & {
+      grid-row: 1;
+    }
   }
 
   .AddonMoreInfo {
     grid-column: 1 / 2;
+    grid-row: 4 / span 1;
+
+    .Addon--has-more-addons.Addon-persona & {
+      grid-row: 3 / span 1;
+    }
+
+    .Addon--has-many-more-addons.Addon-persona & {
+      grid-row: 2 / span 2;
+    }
   }
 
   // We hide this "Read reviews" link on larger displays as we actually show

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1051,6 +1051,38 @@ describe(__filename, () => {
       expect(root).toHaveClassName('.AddonDescription-more-addons--theme');
       expect(root).toHaveProp('addons', addonsByAuthors);
     });
+
+    it('adds a css class to the main component when there are add-ons', () => {
+      const addon = fakeAddon;
+      const addonsByAuthors = [
+        { ...fakeAddon, slug: 'addon-1' },
+        { ...fakeAddon, slug: 'addon-2' },
+      ];
+      const { store } = dispatchAddonData({ addon, addonsByAuthors });
+
+      const root = renderComponent({ params: { slug: addon.slug }, store });
+
+      expect(root).toHaveClassName('.Addon--has-more-addons');
+      expect(root).not.toHaveClassName('.Addon--has-many-more-addons');
+    });
+
+    it('adds a css class when there many other add-ons by authors', () => {
+      const addon = fakeAddon;
+      // We need more than 3 add-ons to indicate that there are "many" other
+      // add-ons by authors.
+      const addonsByAuthors = [
+        { ...fakeAddon, slug: 'addon-1' },
+        { ...fakeAddon, slug: 'addon-2' },
+        { ...fakeAddon, slug: 'addon-3' },
+        { ...fakeAddon, slug: 'addon-4' },
+      ];
+      const { store } = dispatchAddonData({ addon, addonsByAuthors });
+
+      const root = renderComponent({ params: { slug: addon.slug }, store });
+
+      expect(root).toHaveClassName('.Addon--has-more-addons');
+      expect(root).toHaveClassName('.Addon--has-many-more-addons');
+    });
   });
 
   it('displays a badge when the addon is featured', () => {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1052,7 +1052,7 @@ describe(__filename, () => {
       expect(root).toHaveProp('addons', addonsByAuthors);
     });
 
-    it('adds a css class to the main component when there are add-ons', () => {
+    it('adds a CSS class to the main component when there are add-ons', () => {
       const addon = fakeAddon;
       const addonsByAuthors = [
         { ...fakeAddon, slug: 'addon-1' },
@@ -1062,14 +1062,12 @@ describe(__filename, () => {
 
       const root = renderComponent({ params: { slug: addon.slug }, store });
 
-      expect(root).toHaveClassName('.Addon--has-more-addons');
-      expect(root).not.toHaveClassName('.Addon--has-many-more-addons');
+      expect(root).toHaveClassName('.Addon--has-more-than-0-addons');
+      expect(root).not.toHaveClassName('.Addon--has-more-than-3-addons');
     });
 
-    it('adds a css class when there many other add-ons by authors', () => {
+    it('adds a CSS class when there are more than 3 other add-ons', () => {
       const addon = fakeAddon;
-      // We need more than 3 add-ons to indicate that there are "many" other
-      // add-ons by authors.
       const addonsByAuthors = [
         { ...fakeAddon, slug: 'addon-1' },
         { ...fakeAddon, slug: 'addon-2' },
@@ -1080,8 +1078,8 @@ describe(__filename, () => {
 
       const root = renderComponent({ params: { slug: addon.slug }, store });
 
-      expect(root).toHaveClassName('.Addon--has-more-addons');
-      expect(root).toHaveClassName('.Addon--has-many-more-addons');
+      expect(root).toHaveClassName('.Addon--has-more-than-0-addons');
+      expect(root).toHaveClassName('.Addon--has-more-than-3-addons');
     });
   });
 


### PR DESCRIPTION
Fix #3123

---

This PR fixes a CSS grid issue that prevented the theme description to be shown when other add-ons by the artists are displayed. It sticks to the mock-ups and works perfectly on FF 55, FF Nightly and Chrome/Opera. It should work with short/long description, and no/one/many other add-ons.

⚠️ This is a "better-than-nothing" yet pixel-perfect fix. I spent too much hours on it and @tofumatt helped a lot too! I don't know if there is a better "css grid way" of doing this but this works without `margin` hacks or similar. Please see all the screenshots to see all the edge cases.

## Screenshots

<img width="836" alt="screen shot 2017-09-15 at 14 38 56" src="https://user-images.githubusercontent.com/217628/30483082-d63ab432-9a25-11e7-8c0b-297eece3cff9.png">

<img width="836" alt="screen shot 2017-09-15 at 14 38 54" src="https://user-images.githubusercontent.com/217628/30483081-d63999f8-9a25-11e7-9992-6dd991b3172c.png">

<img width="836" alt="screen shot 2017-09-15 at 14 38 50" src="https://user-images.githubusercontent.com/217628/30483086-d64311d6-9a25-11e7-8060-64f621f2baa0.png">

![screen shot 2017-09-15 at 14 38 38](https://user-images.githubusercontent.com/217628/30483083-d63c71b4-9a25-11e7-9012-4317be76fcdf.png)

![screen shot 2017-09-15 at 14 38 34](https://user-images.githubusercontent.com/217628/30483084-d63d54da-9a25-11e7-9cf1-44e2e5bccf03.png)

![screen shot 2017-09-15 at 14 38 14](https://user-images.githubusercontent.com/217628/30483085-d63e5fc4-9a25-11e7-9bca-b5cf6582eda7.png)

<img width="1392" alt="screen shot 2017-09-15 at 14 38 01" src="https://user-images.githubusercontent.com/217628/30483088-d656953a-9a25-11e7-9256-d388c43a91b5.png">

<img width="1392" alt="screen shot 2017-09-15 at 14 37 54" src="https://user-images.githubusercontent.com/217628/30483087-d654ff36-9a25-11e7-93bb-0072c3af48a7.png">

<img width="1392" alt="screen shot 2017-09-15 at 14 37 39" src="https://user-images.githubusercontent.com/217628/30483090-d65b3bd0-9a25-11e7-877c-264193a16aab.png">

<img width="1392" alt="screen shot 2017-09-15 at 14 37 33" src="https://user-images.githubusercontent.com/217628/30483089-d6595630-9a25-11e7-98d6-4436354c1ae2.png">

<img width="1392" alt="screen shot 2017-09-15 at 15 01 27" src="https://user-images.githubusercontent.com/217628/30483305-c4926080-9a26-11e7-9558-cf80ae0bf0e3.png">

<img width="1392" alt="screen shot 2017-09-15 at 15 01 18" src="https://user-images.githubusercontent.com/217628/30483306-c4a2adbe-9a26-11e7-8e20-e24da71fbb1a.png">
