### PR TITLE
Fix Search header doesn't mention type #3154

### DIFF
--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -60,6 +60,12 @@ export class SearchContextCardBase extends React.Component {
           '%(count)s themes found for "%(query)s"',
           count), { count: i18n.formatNumber(count), query }
         );
+      } else {
+        searchText = i18n.sprintf(i18n.ngettext(
+          '%(count)s result for "%(query)s"',
+          '%(count)s results for "%(query)s"',
+          count), { count: i18n.formatNumber(count), query }
+        );
       }
     } else if (!loading && query) {
       searchText = i18n.sprintf(i18n.ngettext(

--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -5,6 +5,12 @@ import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';
 import Card from 'ui/components/Card';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_DICT,
+  ADDON_TYPE_LANG,
+  ADDON_TYPE_THEME,
+} from 'core/constants';
 
 import './styles.scss';
 
@@ -28,15 +34,24 @@ export class SearchContextCardBase extends React.Component {
     const { addonType } = filters;
 
     let searchText;
+    let addOn;
+
+    if (addonType === ADDON_TYPE_EXTENSION) {
+      addOn = i18n.ngettext('extension', 'extensions', count);
+    } else if (addonType === ADDON_TYPE_DICT) {
+      addOn = i18n.ngettext('dictionary', 'dictionaries', count);
+    } else if (addonType === ADDON_TYPE_LANG) {
+      addOn = i18n.ngettext('language pack', 'language packs', count);
+    } else if (addonType === ADDON_TYPE_THEME) {
+      addOn = i18n.ngettext('theme', 'themes', count);
+    }
 
     if (!loading && query && addonType) {
-      const addon = addonType === 'persona' ? 'theme' : addonType;
-      searchText = i18n.sprintf(i18n.ngettext(
-        '%(count)s %(addon)s found for "%(query)s"',
-        '%(count)s %(addon)ss found for "%(query)s"',
-        count), { count: i18n.formatNumber(count), addon, query }
+      searchText = i18n.sprintf(i18n.gettext(
+        '%(count)s %(addOn)s found for "%(query)s"'
+      ), { count: i18n.formatNumber(count), addOn, query }
       );
-    } else if (!loading && query) {
+    } else if (!loading && query && !addonType) {
       searchText = i18n.sprintf(i18n.ngettext(
         '%(count)s result for "%(query)s"',
         '%(count)s results for "%(query)s"',

--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -34,24 +34,34 @@ export class SearchContextCardBase extends React.Component {
     const { addonType } = filters;
 
     let searchText;
-    let addOn;
-
-    if (addonType === ADDON_TYPE_EXTENSION) {
-      addOn = i18n.ngettext('extension', 'extensions', count);
-    } else if (addonType === ADDON_TYPE_DICT) {
-      addOn = i18n.ngettext('dictionary', 'dictionaries', count);
-    } else if (addonType === ADDON_TYPE_LANG) {
-      addOn = i18n.ngettext('language pack', 'language packs', count);
-    } else if (addonType === ADDON_TYPE_THEME) {
-      addOn = i18n.ngettext('theme', 'themes', count);
-    }
 
     if (!loading && query && addonType) {
-      searchText = i18n.sprintf(i18n.gettext(
-        '%(count)s %(addOn)s found for "%(query)s"'
-      ), { count: i18n.formatNumber(count), addOn, query }
-      );
-    } else if (!loading && query && !addonType) {
+      if (addonType === ADDON_TYPE_EXTENSION) {
+        searchText = i18n.sprintf(i18n.ngettext(
+          '%(count)s extension found for "%(query)s"',
+          '%(count)s extensions found for "%(query)s"',
+          count), { count: i18n.formatNumber(count), query }
+        );
+      } else if (addonType === ADDON_TYPE_DICT) {
+        searchText = i18n.sprintf(i18n.ngettext(
+          '%(count)s dictionary found for "%(query)s"',
+          '%(count)s dictionaries found for "%(query)s"',
+          count), { count: i18n.formatNumber(count), query }
+        );
+      } else if (addonType === ADDON_TYPE_LANG) {
+        searchText = i18n.sprintf(i18n.ngettext(
+          '%(count)s language pack found for "%(query)s"',
+          '%(count)s language packs found for "%(query)s"',
+          count), { count: i18n.formatNumber(count), query }
+        );
+      } else if (addonType === ADDON_TYPE_THEME) {
+        searchText = i18n.sprintf(i18n.ngettext(
+          '%(count)s theme found for "%(query)s"',
+          '%(count)s themes found for "%(query)s"',
+          count), { count: i18n.formatNumber(count), query }
+        );
+      }
+    } else if (!loading && query) {
       searchText = i18n.sprintf(i18n.ngettext(
         '%(count)s result for "%(query)s"',
         '%(count)s results for "%(query)s"',

--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -25,10 +25,18 @@ export class SearchContextCardBase extends React.Component {
   render() {
     const { count, filters, i18n, loading } = this.props;
     const { query } = filters;
+    const { addonType } = filters;
 
     let searchText;
 
-    if (!loading && query) {
+    if (!loading && query && addonType) {
+      const addon = addonType === 'persona' ? 'theme' : addonType;
+      searchText = i18n.sprintf(i18n.ngettext(
+        '%(count)s %(addon)s result for "%(query)s"',
+        '%(count)s %(addon)ss results for "%(query)s"',
+        count), { count: i18n.formatNumber(count), addon, query }
+      );
+    } else if (!loading && query) {
       searchText = i18n.sprintf(i18n.ngettext(
         '%(count)s result for "%(query)s"',
         '%(count)s results for "%(query)s"',

--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -62,8 +62,8 @@ export class SearchContextCardBase extends React.Component {
         );
       } else {
         searchText = i18n.sprintf(i18n.ngettext(
-          '%(count)s result for "%(query)s"',
-          '%(count)s results for "%(query)s"',
+          '%(count)s result found for "%(query)s"',
+          '%(count)s results found for "%(query)s"',
           count), { count: i18n.formatNumber(count), query }
         );
       }

--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -32,8 +32,8 @@ export class SearchContextCardBase extends React.Component {
     if (!loading && query && addonType) {
       const addon = addonType === 'persona' ? 'theme' : addonType;
       searchText = i18n.sprintf(i18n.ngettext(
-        '%(count)s %(addon)s result for "%(query)s"',
-        '%(count)s %(addon)ss results for "%(query)s"',
+        '%(count)s %(addon)s found for "%(query)s"',
+        '%(count)s %(addon)ss found for "%(query)s"',
         count), { count: i18n.formatNumber(count), addon, query }
       );
     } else if (!loading && query) {

--- a/tests/unit/amo/components/TestSearchContextCard.js
+++ b/tests/unit/amo/components/TestSearchContextCard.js
@@ -10,7 +10,12 @@ import {
   fakeAddon,
 } from 'tests/unit/amo/helpers';
 import { getFakeI18nInst, shallowUntilTarget } from 'tests/unit/helpers';
-
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_DICT,
+  ADDON_TYPE_LANG,
+  ADDON_TYPE_THEME,
+} from 'core/constants';
 
 describe('SearchContextCard', () => {
   let _store;
@@ -104,4 +109,125 @@ describe('SearchContextCard', () => {
     expect(root.find('.SearchContextCard-header'))
       .toIncludeText('No add-ons found');
   });
+
+  // addonType = ADDON_TYPE_THEME
+  it('should render singular form when only one result is found with addonType as ADDON_TYPE_THEME', () => {
+    const { store } = dispatchSearchResults({
+      addons: { [fakeAddon.slug]: fakeAddon },
+      filters: {
+        addonType: ADDON_TYPE_THEME,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('1 theme found for "test"');
+  });
+
+  it('should render plural form when multiple results are found with addonType as ADDON_TYPE_THEME', () => {
+    const { store } = dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_THEME,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('2 themes found for "test"');
+  });
+
+  // addonType = ADDON_TYPE_DICT
+  it('should render singular form when only one result is found with addonType as ADDON_TYPE_DICT', () => {
+    const { store } = dispatchSearchResults({
+      addons: { [fakeAddon.slug]: fakeAddon },
+      filters: {
+        addonType: ADDON_TYPE_DICT,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('1 dictionary found for "test"');
+  });
+
+  it('should render plural form when multipe results are found with addonType as ADDON_TYPE_DICT', () => {
+    const { store } = dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_DICT,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('2 dictionaries found for "test"');
+  });
+
+  // addonType = ADDON_TYPE_EXTENSION
+  it('should render singular form when only one result is found with addonType = ADDON_TYPE_EXTENSION', () => {
+    const { store } = dispatchSearchResults({
+      addons: { [fakeAddon.slug]: fakeAddon },
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('1 extension found for "test"');
+  });
+
+  it('should render plural form when multipe results are found with addonType as ADDON_TYPE_EXTENSION', () => {
+    const { store } = dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('2 extensions found for "test"');
+  });
+
+  // addonType = ADDON_TYPE_EXTENSION
+  it('should render singular form when only one result is found with addonType as ADDON_TYPE_LANG', () => {
+    const { store } = dispatchSearchResults({
+      addons: { [fakeAddon.slug]: fakeAddon },
+      filters: {
+        addonType: ADDON_TYPE_LANG,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('1 language pack found for "test"');
+  });
+
+  it('should render plural form when multipe results are found with addonType as ADDON_TYPE_LANG', () => {
+    const { store } = dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_LANG,
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('2 language packs found for "test"');
+  });
 });
+

--- a/tests/unit/amo/components/TestSearchContextCard.js
+++ b/tests/unit/amo/components/TestSearchContextCard.js
@@ -110,8 +110,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('No add-ons found');
   });
 
-  // addonType = ADDON_TYPE_THEME
-  it('should render singular form when only one result is found with addonType as ADDON_TYPE_THEME', () => {
+  it('should render singular form when only one result is found with addonType ADDON_TYPE_THEME', () => {
     const { store } = dispatchSearchResults({
       addons: { [fakeAddon.slug]: fakeAddon },
       filters: {
@@ -126,7 +125,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('1 theme found for "test"');
   });
 
-  it('should render plural form when multiple results are found with addonType as ADDON_TYPE_THEME', () => {
+  it('should render plural form when multiple results are found with addonType ADDON_TYPE_THEME', () => {
     const { store } = dispatchSearchResults({
       filters: {
         addonType: ADDON_TYPE_THEME,
@@ -140,8 +139,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('2 themes found for "test"');
   });
 
-  // addonType = ADDON_TYPE_DICT
-  it('should render singular form when only one result is found with addonType as ADDON_TYPE_DICT', () => {
+  it('should render singular form when only one result is found with addonType ADDON_TYPE_DICT', () => {
     const { store } = dispatchSearchResults({
       addons: { [fakeAddon.slug]: fakeAddon },
       filters: {
@@ -156,7 +154,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('1 dictionary found for "test"');
   });
 
-  it('should render plural form when multipe results are found with addonType as ADDON_TYPE_DICT', () => {
+  it('should render plural form when multiple results are found with addonType ADDON_TYPE_DICT', () => {
     const { store } = dispatchSearchResults({
       filters: {
         addonType: ADDON_TYPE_DICT,
@@ -170,8 +168,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('2 dictionaries found for "test"');
   });
 
-  // addonType = ADDON_TYPE_EXTENSION
-  it('should render singular form when only one result is found with addonType = ADDON_TYPE_EXTENSION', () => {
+  it('should render singular form when only one result is found with addonType ADDON_TYPE_EXTENSION', () => {
     const { store } = dispatchSearchResults({
       addons: { [fakeAddon.slug]: fakeAddon },
       filters: {
@@ -186,7 +183,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('1 extension found for "test"');
   });
 
-  it('should render plural form when multipe results are found with addonType as ADDON_TYPE_EXTENSION', () => {
+  it('should render plural form when multiple results are found with addonType ADDON_TYPE_EXTENSION', () => {
     const { store } = dispatchSearchResults({
       filters: {
         addonType: ADDON_TYPE_EXTENSION,
@@ -200,8 +197,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('2 extensions found for "test"');
   });
 
-  // addonType = ADDON_TYPE_EXTENSION
-  it('should render singular form when only one result is found with addonType as ADDON_TYPE_LANG', () => {
+  it('should render singular form when only one result is found with addonType ADDON_TYPE_LANG', () => {
     const { store } = dispatchSearchResults({
       addons: { [fakeAddon.slug]: fakeAddon },
       filters: {
@@ -216,7 +212,7 @@ describe('SearchContextCard', () => {
       .toIncludeText('1 language pack found for "test"');
   });
 
-  it('should render plural form when multipe results are found with addonType as ADDON_TYPE_LANG', () => {
+  it('should render plural form when multiple results are found with addonType ADDON_TYPE_LANG', () => {
     const { store } = dispatchSearchResults({
       filters: {
         addonType: ADDON_TYPE_LANG,

--- a/tests/unit/amo/components/TestSearchContextCard.js
+++ b/tests/unit/amo/components/TestSearchContextCard.js
@@ -225,5 +225,34 @@ describe('SearchContextCard', () => {
     expect(root.find('.SearchContextCard-header'))
       .toIncludeText('2 language packs found for "test"');
   });
+
+  it('should render singular form when only one result is found with addonType theme', () => {
+    const { store } = dispatchSearchResults({
+      addons: { [fakeAddon.slug]: fakeAddon },
+      filters: {
+        addonType: 'theme',
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('1 result found for "test"');
+  });
+
+  it('should render plural form when multiple results are found with addonType theme', () => {
+    const { store } = dispatchSearchResults({
+      filters: {
+        addonType: 'theme',
+        query: 'test',
+      },
+    });
+
+    const root = render({ store });
+
+    expect(root.find('.SearchContextCard-header'))
+      .toIncludeText('2 results found for "test"');
+  });
 });
 


### PR DESCRIPTION
Fixes #3154 
------------

This PR fixes the `Search Header mention type issue` which appears while searching a query.

I've updated the `SearchText` string by using `addonType` from `filters` which fixes this bug. Also, changed the `addonType` text to plural if search results are more than 1.

### Screenshots

* Test Case: **All Passed**

![screen shot 2017-09-15 at 10 18 47 pm](https://user-images.githubusercontent.com/9111111/30494284-2535580a-9a65-11e7-9609-d994e45553c4.png)

* Search Preview after the fix:

![screen shot 2017-09-15 at 10 19 35 pm](https://user-images.githubusercontent.com/9111111/30494302-2fa1a8b6-9a65-11e7-8bf2-9e3d4550d076.png)

![screen shot 2017-09-15 at 10 41 12 pm](https://user-images.githubusercontent.com/9111111/30494791-200a485c-9a67-11e7-8352-8e6971fb7df1.png)

* After updating test cases

![screen shot 2017-09-16 at 3 02 46 am](https://user-images.githubusercontent.com/9111111/30504302-9246c804-9a8b-11e7-9474-733e97d71880.png)


Thanks! 
