### PR TITLE
fix: Make screenshots big

### DIFF
--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -8,8 +8,8 @@ import 'react-photoswipe/lib/photoswipe.css';
 
 import 'amo/css/ScreenShots.scss';
 
-const HEIGHT = 200;
-const WIDTH = 320;
+const HEIGHT = 1024;
+const WIDTH = 1366; // This is the same as our $max-content-width;
 const PHOTO_SWIPE_OPTIONS = {
   closeEl: true,
   captionEl: true,

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -25,15 +25,15 @@ describe('<ScreenShots />', () => {
         title: 'A screenshot',
         src: 'http://img.com/one',
         thumbnail_src: 'http://img.com/1',
-        h: 200,
-        w: 320,
+        h: 1024,
+        w: 1366,
       },
       {
         title: 'Another screenshot',
         src: 'http://img.com/two',
         thumbnail_src: 'http://img.com/2',
-        h: 200,
-        w: 320,
+        h: 1024,
+        w: 1366,
       },
     ];
     const root = shallow(<ScreenShots previews={previews} />);
@@ -50,8 +50,8 @@ describe('<ScreenShots />', () => {
 
     expect(thumbnail.type()).toEqual('img');
     expect(thumbnail.prop('src')).toEqual('https://foo.com/img.png');
-    expect(thumbnail.prop('height')).toEqual(200);
-    expect(thumbnail.prop('width')).toEqual(320);
+    expect(thumbnail.prop('height')).toEqual(1024);
+    expect(thumbnail.prop('width')).toEqual(1366);
     expect(thumbnail.prop('alt')).toEqual('');
   });
 


### PR DESCRIPTION
Fix #2571.

Well, this wasn't hard.

The `Screenshots` component we're using frustratingly *requires* height and width params so I couldn't just leave this blank or set them to `100%`, but this works well enough as it's as big as the max size of the size and are basically as big as the screenshots come down the wire from AMO anyway, for now.

### Mobile
![2017-09-16 00 47 12](https://user-images.githubusercontent.com/90871/30507082-15ff2122-9a79-11e7-9f29-8c632da73654.gif)

### Desktop
![2017-09-16 00 52 22](https://user-images.githubusercontent.com/90871/30507137-77f3560a-9a79-11e7-8b96-f1827af5e121.gif)