### PR TITLE
add in line under themes

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -37,6 +37,7 @@ $addon-padding: 20px;
   }
 
   .theme-image {
+    border-bottom: 2px solid #f5f5f5;
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
     display: block;


### PR DESCRIPTION
Fixes #2197

<img width="724" alt="screenshot 2017-09-15 16 56 03" src="https://user-images.githubusercontent.com/74699/30507307-e335d6f0-9a37-11e7-96c2-0b87ec98a608.png">
<img width="738" alt="screenshot 2017-09-15 16 55 43" src="https://user-images.githubusercontent.com/74699/30507308-e4a77aac-9a37-11e7-8f22-4e167229b1f4.png">

It's subtle.