### PR TITLE
fix: Read more link doesn't show more content for release notes

### DIFF
--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -13,7 +13,7 @@ import './ShowMoreCard.scss';
 
 // This refers to height of `Card-contents` CSS class,
 // beyond which it will add read more link.
-export const MAX_HEIGHT = 145;
+export const MAX_HEIGHT = 150;
 
 export class ShowMoreCardBase extends React.Component {
   static propTypes = {
@@ -40,7 +40,7 @@ export class ShowMoreCardBase extends React.Component {
   truncateToMaxHeight = (contents) => {
     // If the contents are short enough they don't need a "show more" link; the
     // contents are expanded by default.
-    if (contents.clientHeight > MAX_HEIGHT) {
+    if (contents.clientHeight >= MAX_HEIGHT) {
       this.setState({ expanded: false });
     } else {
       this.setState({ expanded: true });

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -12,7 +12,7 @@ import Card from 'ui/components/Card';
 import './ShowMoreCard.scss';
 
 
-const MAX_HEIGHT = 100;
+const MAX_HEIGHT = 145;
 
 export class ShowMoreCardBase extends React.Component {
   static propTypes = {

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -11,7 +11,8 @@ import Card from 'ui/components/Card';
 
 import './ShowMoreCard.scss';
 
-// This refers to height of Card-contents class, beyond which it will add read more link
+// This refers to height of `Card-contents` CSS class,
+// beyond which it will add read more link.
 export const MAX_HEIGHT = 145;
 
 export class ShowMoreCardBase extends React.Component {

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -11,8 +11,8 @@ import Card from 'ui/components/Card';
 
 import './ShowMoreCard.scss';
 
-
-const MAX_HEIGHT = 145;
+// This refers to height of Card-contents class, beyond which it will add read more link
+export const MAX_HEIGHT = 145;
 
 export class ShowMoreCardBase extends React.Component {
   static propTypes = {

--- a/tests/unit/ui/components/TestShowMoreCard.js
+++ b/tests/unit/ui/components/TestShowMoreCard.js
@@ -40,7 +40,7 @@ describe(__filename, () => {
 
   it('truncates the contents if they are too long', () => {
     const root = render({ children: 'Hello I am description' });
-    root.truncateToMaxHeight({ clientHeight: 101 });
+    root.truncateToMaxHeight({ clientHeight: 146 });
     expect(root.state.expanded).toEqual(false);
   });
 

--- a/tests/unit/ui/components/TestShowMoreCard.js
+++ b/tests/unit/ui/components/TestShowMoreCard.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { findDOMNode } from 'react-dom';
 import { Simulate, renderIntoDocument } from 'react-addons-test-utils';
 
-import { ShowMoreCardBase } from 'ui/components/ShowMoreCard';
+import { ShowMoreCardBase, MAX_HEIGHT } from 'ui/components/ShowMoreCard';
 import { getFakeI18nInst } from 'tests/unit/helpers';
 
 
@@ -40,7 +40,7 @@ describe(__filename, () => {
 
   it('truncates the contents if they are too long', () => {
     const root = render({ children: 'Hello I am description' });
-    root.truncateToMaxHeight({ clientHeight: 146 });
+    root.truncateToMaxHeight({ clientHeight: MAX_HEIGHT + 1 });
     expect(root.state.expanded).toEqual(false);
   });
 


### PR DESCRIPTION
Fixes: #3148 

**Before:** 

<img width="1114" alt="screen shot 2017-09-17 at 4 45 36 pm" src="https://user-images.githubusercontent.com/5318732/30520481-6fef217e-9bcc-11e7-87a9-a110076f3eec.png">

**After:**

<img width="1119" alt="screen shot 2017-09-17 at 4 44 37 pm" src="https://user-images.githubusercontent.com/5318732/30520488-84015dd0-9bcc-11e7-9307-4e18001888a4.png">

