### PR TITLE
chore: Use constants for screenshots

### DIFF
--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -8,8 +8,8 @@ import 'react-photoswipe/lib/photoswipe.css';
 
 import 'amo/css/ScreenShots.scss';
 
-const HEIGHT = 1024;
-const WIDTH = 1366; // This is the same as our $max-content-width;
+export const HEIGHT = 1024;
+export const WIDTH = 1366; // This is the same as our $max-content-width;
 const PHOTO_SWIPE_OPTIONS = {
   closeEl: true,
   captionEl: true,

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -3,7 +3,11 @@ import React from 'react';
 import { renderIntoDocument } from 'react-addons-test-utils';
 import { PhotoSwipeGallery } from 'react-photoswipe';
 
-import ScreenShots, { thumbnailContent } from 'amo/components/ScreenShots';
+import ScreenShots, {
+  HEIGHT,
+  WIDTH,
+  thumbnailContent,
+} from 'amo/components/ScreenShots';
 
 describe('<ScreenShots />', () => {
   const previews = [
@@ -25,15 +29,15 @@ describe('<ScreenShots />', () => {
         title: 'A screenshot',
         src: 'http://img.com/one',
         thumbnail_src: 'http://img.com/1',
-        h: 1024,
-        w: 1366,
+        h: HEIGHT,
+        w: WIDTH,
       },
       {
         title: 'Another screenshot',
         src: 'http://img.com/two',
         thumbnail_src: 'http://img.com/2',
-        h: 1024,
-        w: 1366,
+        h: HEIGHT,
+        w: WIDTH,
       },
     ];
     const root = shallow(<ScreenShots previews={previews} />);
@@ -50,8 +54,8 @@ describe('<ScreenShots />', () => {
 
     expect(thumbnail.type()).toEqual('img');
     expect(thumbnail.prop('src')).toEqual('https://foo.com/img.png');
-    expect(thumbnail.prop('height')).toEqual(1024);
-    expect(thumbnail.prop('width')).toEqual(1366);
+    expect(thumbnail.prop('height')).toEqual(HEIGHT);
+    expect(thumbnail.prop('width')).toEqual(WIDTH);
     expect(thumbnail.prop('alt')).toEqual('');
   });
 


### PR DESCRIPTION
I forgot to commit @willdurand's suggestion that I export constants in #3163. If this passes I'll merge it as it's just a fixup from r+wc'd code.