### PR TITLE
Quick fix to cachebust favicon

### DIFF
--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -91,7 +91,7 @@ export default class ServerHtml extends Component {
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <link rel="shortcut icon" href="/favicon.ico" />
+          <link rel="shortcut icon" href="/favicon.ico?v=1" />
           {head.title.toComponent()}
           {head.meta.toComponent()}
           {this.getStyle()}

--- a/tests/unit/core/containers/TestServerHtml.js
+++ b/tests/unit/core/containers/TestServerHtml.js
@@ -113,7 +113,7 @@ describe('<ServerHtml />', () => {
   it('renders favicon', () => {
     const html = findRenderedDOMComponentWithTag(render(), 'html');
     const favicon = html.querySelector('link[rel="shortcut icon"]');
-    expect(favicon.getAttribute('href')).toEqual('/favicon.ico');
+    expect(favicon.getAttribute('href')).toEqual('/favicon.ico?v=1');
   });
 
   it('renders title', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-server/issues/6431

This is a quick fix to cache-bust the favicon on the frontend. 

Longer term we may as well point directly to the resource to save on a redirect. I'll file a separate issue for doing that if we don't have one already.