### PR TITLE
Workaround erroneous span focus and outline user button on focus.

### DIFF
--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -34,6 +34,13 @@
 }
 
 .DropdownMenu-button {
+  &:focus {
+    // Fix outline for Firefox (see #3110)
+    outline: 1px dotted $white;
+    // Restore default outline for webkit.
+    outline: auto 5px -webkit-focus-ring-color;
+  }
+
   .DropdownMenu-button-text {
     @include font-regular();
 


### PR DESCRIPTION
Fixes #3110

~~This is a workaround for #3110 - I can't find a root cause as to why the span is focusable. Since it doesn't need to be focused adding an explicit attribute fixes the problem.~~

~~At some point it would be nice to understand what the root cause of the span being focusable even when it's tabIndex property says it's -1 already.~~

~~Trying to reproduce it in isolation doesn't appear to be easy.~~

~~This also adds the outline so that the button is outlined on focus.~~

The fix to prevent the span focus was to remove the `overflow:hidden` which was done in a different PR.

This  PR adds the outline for FF and the default webkit focus back for chrome etc:

## Firefox:

<img width="1357" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31681562-9a4747fe-b345-11e7-9361-00c918a6448c.png">

<img width="1405" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31681583-a99009d0-b345-11e7-9f20-ffcd1c683f71.png">

## Chrome

<img width="1382" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31681644-dff74858-b345-11e7-93ea-77c176a65d66.png">

<img width="1352" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31681670-f253b342-b345-11e7-8ec7-1a34bc2ab728.png">
#
