### PR TITLE
fix: Make the search look more obviously focused

### DIFF
--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -28,6 +28,11 @@
   white-space: nowrap;
   width: 100%;
 
+  &:focus {
+    border: 1px solid;
+    @include focus();
+  }
+
   @include respond-to(medium) {
     @include padding-end(28px);
   }

--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -17,7 +17,7 @@
   @include padding-end(6px);
   @include padding-start(28px);
 
-  border: 1px solid $teal-50;
+  border: 1px solid $white;
   border-radius: $border-radius-s;
   color: $black;
   height: 28px;
@@ -28,8 +28,11 @@
   white-space: nowrap;
   width: 100%;
 
-  &:focus {
+  &:focus,
+  &:hover {
     @include focus();
+
+    border-color: $teal-50;
   }
 
   @include respond-to(medium) {

--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -29,7 +29,7 @@
   width: 100%;
 
   &:hover {
-    border-color: $teal-70;
+    border-color: $teal-50;
   }
 
   &:focus {

--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -28,8 +28,11 @@
   white-space: nowrap;
   width: 100%;
 
-  &:focus,
   &:hover {
+    border-color: $teal-70;
+  }
+
+  &:focus {
     @include focus();
 
     border-color: $teal-50;

--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -17,7 +17,7 @@
   @include padding-end(6px);
   @include padding-start(28px);
 
-  border: 0;
+  border: 1px solid $teal-50;
   border-radius: $border-radius-s;
   color: $black;
   height: 28px;
@@ -29,7 +29,6 @@
   width: 100%;
 
   &:focus {
-    border: 1px solid;
     @include focus();
   }
 


### PR DESCRIPTION
Fixes: #3184 

**Before:**
<img width="394" alt="screen shot 2017-09-20 at 3 32 44 pm" src="https://user-images.githubusercontent.com/5318732/30638515-4f65da34-9e19-11e7-91b5-a1675021b72e.png">

**After:**
<img width="359" alt="screen shot 2017-09-20 at 3 35 32 pm" src="https://user-images.githubusercontent.com/5318732/30638547-6519c9e4-9e19-11e7-98fd-8f660d9a9ac3.png">
