### PR TITLE
Report add-on abuse UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "react-redux-loading-bar": "2.9.2",
     "react-router": "2.8.1",
     "react-router-scroll": "0.4.2",
+    "react-textarea-autosize": "^5.1.0",
     "redux": "3.7.2",
     "redux-connect": "4.0.2",
     "redux-logger": "3.0.6",

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import Link from 'amo/components/Link';
+import ReportAbuseButton from 'amo/components/ReportAbuseButton';
 import translate from 'core/i18n/translate';
 import { trimAndAddProtocolToUrl } from 'core/utils';
 import Card from 'ui/components/Card';
@@ -151,7 +152,7 @@ export class AddonMoreInfoBase extends React.Component {
   }
 
   render() {
-    const { i18n } = this.props;
+    const { addon, i18n } = this.props;
 
     return (
       <Card
@@ -159,6 +160,8 @@ export class AddonMoreInfoBase extends React.Component {
         header={i18n.gettext('More information')}
       >
         {this.listContent()}
+
+        <ReportAbuseButton addon={addon} />
       </Card>
     );
   }

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -1,0 +1,221 @@
+import classNames from 'classnames';
+import { oneLine } from 'common-tags';
+import React from 'react';
+import { connect } from 'react-redux';
+import Textarea from 'react-textarea-autosize';
+import { compose } from 'redux';
+
+import { withErrorHandler } from 'core/errorHandler';
+import type { ErrorHandlerType } from 'core/errorHandler';
+import translate from 'core/i18n/translate';
+import log from 'core/logger';
+import {
+  disableAbuseButtonUI,
+  enableAbuseButtonUI,
+  hideAddonAbuseReportUI,
+  sendAddonAbuseReport,
+  showAddonAbuseReportUI,
+} from 'core/reducers/abuse';
+import { sanitizeHTML } from 'core/utils';
+import Button from 'ui/components/Button';
+
+import './styles.scss';
+
+
+type PropTypes = {
+  abuseReport: {|
+    message: string,
+    reporter: Object | null,
+  |},
+  addon: Object | null,
+  dispatch: Function,
+  errorHandler: ErrorHandlerType,
+  loading: bool,
+  i18n: Object,
+};
+
+export class ReportAbuseButtonBase extends React.Component {
+  dismissReportUI = (event) => {
+    event.preventDefault();
+
+    const { addon, dispatch, loading } = this.props;
+
+    if (loading) {
+      log.debug(
+        "Ignoring dismiss click because we're submitting the abuse report");
+      return;
+    }
+
+    dispatch(hideAddonAbuseReportUI({ addon }));
+  }
+
+  sendReport = (event) => {
+    event.preventDefault();
+
+    // The button isn't clickable if there is no content, but just in case:
+    // we verify there's a message to send.
+    if (!this.textarea.value.length) {
+      log.debug(oneLine`User managed to click submit button while textarea
+        was empty. Ignoring this onClick/sendReport event.`);
+      return;
+    }
+
+    const { addon, dispatch, errorHandler } = this.props;
+
+    dispatch(sendAddonAbuseReport({
+      addonSlug: addon.slug,
+      errorHandlerId: errorHandler.id,
+      message: this.textarea.value,
+    }));
+  }
+
+  showReportUI = (event) => {
+    event.preventDefault();
+
+    const { addon, dispatch } = this.props;
+
+    dispatch(showAddonAbuseReportUI({ addon }));
+    this.textarea.focus();
+  }
+
+  textareaChange = () => {
+    const { abuseReport, addon, dispatch } = this.props;
+
+    // Don't dispatch the UI update if the button is already visible.
+    // We also test for `value.trim()` so the user can't submit an
+    // empty report full of spaces.
+    if (this.textarea.value.trim().length && !abuseReport.buttonEnabled) {
+      dispatch(enableAbuseButtonUI({ addon }));
+    } else if (!this.textarea.value.trim().length) {
+      dispatch(disableAbuseButtonUI({ addon }));
+    }
+  }
+
+  props: PropTypes;
+
+  render() {
+    const { abuseReport, addon, i18n, loading } = this.props;
+
+    if (!addon) {
+      return null;
+    }
+
+    if (abuseReport && abuseReport.message) {
+      return (
+        <div className="ReportAbuseButton ReportAbuseButton--report-sent">
+          <h3 className="ReportAbuseButton-header">
+            {i18n.gettext('You reported this add-on for abuse')}
+          </h3>
+
+          <p className="ReportAbuseButton-first-paragraph">
+            {i18n.gettext(
+              `We have received your report. Thanks for letting us know about
+              your concerns with this add-on.`
+            )}
+          </p>
+
+          <p>
+            {i18n.gettext(
+              `We can't respond to every abuse report but we'll look into
+              this issue.`
+            )}
+          </p>
+        </div>
+      );
+    }
+
+    const sendButtonIsDisabled = loading || !abuseReport.buttonEnabled;
+
+    const prefaceText = i18n.sprintf(i18n.gettext(
+      `If you think this add-on violates
+      %(linkTagStart)sMozilla's add-on policies%(linkTagEnd)s or has
+      security or privacy issues, please report these issues to Mozilla using
+      this form.`
+    ), {
+      linkTagStart: '<a href="https://developer.mozilla.org/en-US/Add-ons/AMO/Policy">',
+      linkTagEnd: '</a>',
+    });
+
+    /* eslint-disable react/no-danger */
+    return (
+      <div
+        className={classNames('ReportAbuseButton', {
+          'ReportAbuseButton--is-expanded': abuseReport.uiVisible,
+        })}
+      >
+        <div className="ReportAbuseButton--preview">
+          <Button
+            className="ReportAbuseButton-show-more Button--report"
+            onClick={this.showReportUI}
+          >
+            {i18n.gettext('Report this add-on for abuse')}
+          </Button>
+        </div>
+
+        <div className="ReportAbuseButton--expanded">
+          <h3 className="ReportAbuseButton-header">
+            {i18n.gettext('Report this add-on for abuse')}
+          </h3>
+
+          <p
+            className="ReportAbuseButton-first-paragraph"
+            dangerouslySetInnerHTML={sanitizeHTML(prefaceText, ['a'])}
+          />
+
+          <p>{i18n.gettext(
+            `Please don't use this form to report bugs or request add-on
+            features; this report will be sent to Mozilla and not to the
+            add-on developer.`
+          )}</p>
+          <Textarea
+            className="ReportAbuseButton-textarea"
+            disabled={loading}
+            inputRef={(ref) => { this.textarea = ref; }}
+            onChange={this.textareaChange}
+            placeholder={i18n.gettext(
+              'Explain how this add-on is violating our policies.'
+            )}
+          />
+
+          <div className="ReportAbuseButton-buttons">
+            <a
+              className={classNames('ReportAbuseButton-dismiss-report', {
+                'ReportAbuseButton-dismiss-report--disabled': loading,
+              })}
+              href="#cancel"
+              onClick={this.dismissReportUI}
+            >
+              {i18n.gettext('Dismiss')}
+            </a>
+            <Button
+              className="ReportAbuseButton-send-report Button--report Button--small"
+              disabled={sendButtonIsDisabled}
+              onClick={this.sendReport}
+            >
+              {loading ?
+                i18n.gettext('Sending abuse report') :
+                i18n.gettext('Send abuse report')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+    /* eslint-enable react/no-danger */
+  }
+}
+
+export const mapStateToProps = (state, ownProps) => {
+  const addon = ownProps.addon;
+
+  return {
+    abuseReport: addon && state.abuse.bySlug[addon.slug] ?
+      state.abuse.bySlug[addon.slug] : {},
+    loading: state.abuse.loading,
+  };
+};
+
+export default compose(
+  connect(mapStateToProps),
+  translate(),
+  withErrorHandler({ name: 'ReportAbuseButton' }),
+)(ReportAbuseButtonBase);

--- a/src/amo/components/ReportAbuseButton/styles.scss
+++ b/src/amo/components/ReportAbuseButton/styles.scss
@@ -1,0 +1,62 @@
+@import "~ui/css/vars";
+
+.ReportAbuseButton {
+  margin: 10px auto;
+}
+
+.ReportAbuseButton-header {
+  margin-bottom: 0;
+}
+
+.ReportAbuseButton-first-paragraph {
+  margin-top: 6px;
+}
+
+.ReportAbuseButton--preview {
+  display: block;
+
+  .ReportAbuseButton--is-expanded & {
+    display: none;
+  }
+}
+
+.ReportAbuseButton--expanded {
+  display: none;
+
+  .ReportAbuseButton--is-expanded & {
+    display: block;
+  }
+}
+
+.ReportAbuseButton-show-more {
+  width: 100%;
+}
+
+.ReportAbuseButton-textarea {
+  font-size: $font-size-m-smaller;
+  line-height: 1.4;
+  margin: 5px auto;
+  // This is the height of two lines of text. Often the placeholder text
+  // will span two lines–because this element will grow/shrink based on
+  // the contents of the text inside it, we set a minimum height so it
+  // won't shrink when the two-line placeholder is replaced with a single
+  // character when the user starts typing.
+  min-height: 51px;
+  padding: 5px;
+  resize: none;
+  width: 100%;
+}
+
+.ReportAbuseButton-buttons {
+  display: flex;
+  justify-content: space-between;
+}
+
+.ReportAbuseButton-dismiss-report {
+  align-self: center;
+}
+
+.ReportAbuseButton-dismiss-report--disabled:link {
+  color: $neutral-base-color;
+  cursor: not-allowed;
+}

--- a/src/core/api/abuse.js
+++ b/src/core/api/abuse.js
@@ -16,7 +16,7 @@ export function reportAddon(
     auth: true,
     endpoint: 'abuse/report/addon',
     method: 'POST',
-    params: { addon: addonSlug, message },
+    body: { addon: addonSlug, message },
     state: api,
   });
 }

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -176,6 +176,7 @@ $default-arrow-margin: 3px;
   background: $background;
   border: 1px solid $border-color;
   border-radius: $border-radius;
+  cursor: pointer;
   display: inline-block;
   margin: 0;
   min-height: 39px;

--- a/src/core/reducers/abuse.js
+++ b/src/core/reducers/abuse.js
@@ -1,6 +1,57 @@
 /* @flow */
+import type { AddonType } from 'core/types/addons';
+
+export const DISABLE_ADDON_ABUSE_BUTTON_UI = 'DISABLE_ADDON_ABUSE_BUTTON_UI';
+export const ENABLE_ADDON_ABUSE_BUTTON_UI = 'ENABLE_ADDON_ABUSE_BUTTON_UI';
+export const HIDE_ADDON_ABUSE_REPORT_UI = 'HIDE_ADDON_ABUSE_REPORT_UI';
 export const LOAD_ADDON_ABUSE_REPORT = 'LOAD_ADDON_ABUSE_REPORT';
 export const SEND_ADDON_ABUSE_REPORT = 'SEND_ADDON_ABUSE_REPORT';
+export const SHOW_ADDON_ABUSE_REPORT_UI = 'SHOW_ADDON_ABUSE_REPORT_UI';
+
+type DisableAddonAbuseButtonUIType = {| addon: AddonType |};
+
+export function disableAbuseButtonUI(
+  { addon }: DisableAddonAbuseButtonUIType = {}
+) {
+  if (!addon) {
+    throw new Error('addon is required');
+  }
+
+  return {
+    type: DISABLE_ADDON_ABUSE_BUTTON_UI,
+    payload: { addon },
+  };
+}
+
+type EnableAddonAbuseButtonUIType = { addon: AddonType };
+
+export function enableAbuseButtonUI(
+  { addon }: EnableAddonAbuseButtonUIType = {}
+) {
+  if (!addon) {
+    throw new Error('addon is required');
+  }
+
+  return {
+    type: ENABLE_ADDON_ABUSE_BUTTON_UI,
+    payload: { addon },
+  };
+}
+
+type HideAddonAbuseReportUIType = { addon: AddonType };
+
+export function hideAddonAbuseReportUI(
+  { addon }: HideAddonAbuseReportUIType = {}
+) {
+  if (!addon) {
+    throw new Error('addon is required');
+  }
+
+  return {
+    type: HIDE_ADDON_ABUSE_REPORT_UI,
+    payload: { addon },
+  };
+}
 
 type LoadAddonAbuseReportType = {
   addon: {|
@@ -13,7 +64,7 @@ type LoadAddonAbuseReportType = {
 };
 
 export function loadAddonAbuseReport(
-  { addon, message, reporter }: LoadAddonAbuseReportType
+  { addon, message, reporter }: LoadAddonAbuseReportType = {}
 ) {
   if (!addon) {
     throw new Error('addon is required');
@@ -38,7 +89,7 @@ type SendAddonAbuseReportAction = {|
 |};
 
 export function sendAddonAbuseReport(
-  { addonSlug, errorHandlerId, message }: SendAddonAbuseReportAction
+  { addonSlug, errorHandlerId, message }: SendAddonAbuseReportAction = {}
 ) {
   if (!addonSlug) {
     throw new Error('addonSlug is required');
@@ -56,14 +107,36 @@ export function sendAddonAbuseReport(
   };
 }
 
+type ShowAddonAbuseReportUIType = { addon: AddonType };
+
+export function showAddonAbuseReportUI(
+  { addon }: ShowAddonAbuseReportUIType = {}
+) {
+  if (!addon) {
+    throw new Error('addon is required');
+  }
+
+  return {
+    type: SHOW_ADDON_ABUSE_REPORT_UI,
+    payload: { addon },
+  };
+}
+
 export const initialState = {
   bySlug: {},
+  loading: false,
 };
 
 type ReducerState = {|
   bySlug: {
-    [addonSlug: string]: {| message: string, reporter: Object | null |},
+    [addonSlug: string]: {|
+      buttonEnabled?: bool,
+      message: string,
+      reporter: Object | null,
+      uiVisible?: bool,
+    |},
   },
+  loading: bool,
 |};
 
 export default function abuseReducer(
@@ -71,13 +144,60 @@ export default function abuseReducer(
   action: Object
 ) {
   switch (action.type) {
+    case DISABLE_ADDON_ABUSE_BUTTON_UI: {
+      const { addon } = action.payload;
+
+      return {
+        ...state,
+        bySlug: {
+          ...state.bySlug,
+          [addon.slug]: { ...state.bySlug[addon.slug], buttonEnabled: false },
+        },
+      };
+    }
+    case ENABLE_ADDON_ABUSE_BUTTON_UI: {
+      const { addon } = action.payload;
+
+      return {
+        ...state,
+        bySlug: {
+          ...state.bySlug,
+          [addon.slug]: { ...state.bySlug[addon.slug], buttonEnabled: true },
+        },
+      };
+    }
+    case HIDE_ADDON_ABUSE_REPORT_UI: {
+      const { addon } = action.payload;
+
+      return {
+        ...state,
+        bySlug: {
+          ...state.bySlug,
+          [addon.slug]: { ...state.bySlug[addon.slug], uiVisible: false },
+        },
+      };
+    }
     case LOAD_ADDON_ABUSE_REPORT: {
       const { addon, message, reporter } = action.payload;
       return {
         ...state,
         bySlug: {
           ...state.bySlug,
-          [addon.slug]: { message, reporter },
+          [addon.slug]: { message, reporter, uiVisible: false },
+        },
+        loading: false,
+      };
+    }
+    case SEND_ADDON_ABUSE_REPORT:
+      return { ...state, loading: true };
+    case SHOW_ADDON_ABUSE_REPORT_UI: {
+      const { addon } = action.payload;
+
+      return {
+        ...state,
+        bySlug: {
+          ...state.bySlug,
+          [addon.slug]: { ...state.bySlug[addon.slug], uiVisible: true },
         },
       };
     }

--- a/src/core/sagas/abuse.js
+++ b/src/core/sagas/abuse.js
@@ -28,9 +28,8 @@ export function* reportAddon({
     const state = yield select(getState);
 
     const response = yield call(reportAddonApi, {
-      addon: addonSlug,
+      addonSlug,
       api: state.api,
-      auth: true,
       message,
     });
 

--- a/src/ui/components/Button/Button.scss
+++ b/src/ui/components/Button/Button.scss
@@ -48,8 +48,8 @@
 
 .Button--report {
   @include button(
-    $background: $action-base-color,
-    $background-active: $action-active-color,
-    $background-hover: $action-hover-color
+    $background: $report-base-color,
+    $background-active: $report-active-color,
+    $background-hover: $report-hover-color
   );
 }

--- a/tests/unit/amo/components/TestReportAbuseButton.js
+++ b/tests/unit/amo/components/TestReportAbuseButton.js
@@ -1,0 +1,307 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import ReportAbuseButton from 'amo/components/ReportAbuseButton';
+import {
+  disableAbuseButtonUI,
+  enableAbuseButtonUI,
+  loadAddonAbuseReport,
+  sendAddonAbuseReport,
+} from 'core/reducers/abuse';
+import { dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
+import {
+  createFakeAddonAbuseReport,
+  createFakeEvent,
+  createStubErrorHandler,
+  getFakeI18nInst,
+} from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  function renderMount({
+    addon = { ...fakeAddon, slug: 'my-addon' },
+    errorHandler = createStubErrorHandler(),
+    store = dispatchClientMetadata().store,
+    ...props
+  } = {}) {
+    return mount(
+      <ReportAbuseButton
+        addon={addon}
+        errorHandler={errorHandler}
+        i18n={getFakeI18nInst()}
+        store={store}
+        {...props}
+      />
+    );
+  }
+
+  it('renders nothing if no add-on exists', () => {
+    const root = renderMount({ addon: null });
+
+    expect(root.find('.ReportAbuseButton')).toHaveLength(0);
+  });
+
+  it('renders a button to report an add-on', () => {
+    const root = renderMount();
+
+    expect(root.find('.ReportAbuseButton')).toHaveLength(1);
+    expect(root.find('.ReportAbuseButton-show-more').prop('children'))
+      .toEqual('Report this add-on for abuse');
+    expect(root.find('.ReportAbuseButton-send-report').prop('children'))
+      .toEqual('Send abuse report');
+  });
+
+  it('renders a textarea with placeholder for the add-on message', () => {
+    const root = renderMount();
+
+    expect(root.find('.ReportAbuseButton-textarea')).toHaveLength(1);
+    expect(
+      root
+        .find('.ReportAbuseButton-textarea')
+        .render()
+        .find('textarea')
+        .attr('placeholder')
+    ).toEqual('Explain how this add-on is violating our policies.');
+  });
+
+  it('shows the preview content when first rendered', () => {
+    const root = renderMount();
+
+    expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(0);
+  });
+
+  it('shows more content when the "report" button is clicked', () => {
+    const fakeEvent = createFakeEvent();
+    const root = renderMount();
+
+    root.find('.ReportAbuseButton-show-more').simulate('click', fakeEvent);
+
+    sinon.assert.called(fakeEvent.preventDefault);
+    expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(1);
+  });
+
+  it('dismisses more content when the "dismiss" button is clicked', () => {
+    const fakeEvent = createFakeEvent();
+    const root = renderMount();
+
+    root.find('.ReportAbuseButton-show-more').simulate('click');
+
+    root.find('.ReportAbuseButton-dismiss-report')
+      .simulate('click', fakeEvent);
+
+    sinon.assert.called(fakeEvent.preventDefault);
+    expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(0);
+  });
+
+  it('disables the submit button if there is no abuse report', () => {
+    const root = renderMount();
+
+    expect(root.find('.ReportAbuseButton-send-report')).toHaveProp('disabled');
+  });
+
+  it('disables the submit button if text in the textarea is removed', () => {
+    const root = renderMount();
+
+    // This simulates entering text into the textarea.
+    const textarea = root.find('.ReportAbuseButton-textarea textarea');
+    textarea.node.value = 'add-on ate my homework!';
+    textarea.simulate('change');
+
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(false);
+
+    textarea.node.value = '';
+    textarea.simulate('change');
+
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(true);
+  });
+
+  it('disables the buttons while sending the abuse report', () => {
+    const addon = { ...fakeAddon, slug: 'bank-machine-skimmer' };
+    const fakeEvent = createFakeEvent();
+    const { store } = dispatchClientMetadata();
+    store.dispatch(sendAddonAbuseReport({
+      addonSlug: addon.slug,
+      errorHandlerId: 'my-error',
+      message: 'All my money is gone',
+    }));
+    const root = renderMount({ addon, store });
+
+    // Expand the view so we can test that it wasn't contracted when
+    // clicking on the disabled "dismiss" link.
+    root.find('.ReportAbuseButton-show-more').simulate('click');
+    expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(1);
+
+    const dismissButton = root.find('.ReportAbuseButton-dismiss-report');
+    const sendButton = root.find('.ReportAbuseButton-send-report');
+
+    expect(dismissButton)
+      .toHaveClassName('ReportAbuseButton-dismiss-report--disabled');
+    expect(sendButton.prop('disabled')).toEqual(true);
+    expect(sendButton.prop('children')).toEqual('Sending abuse report');
+
+    dismissButton.simulate('click', fakeEvent);
+    sinon.assert.called(fakeEvent.preventDefault);
+    expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(1);
+  });
+
+  it('shows a success message and hides the button if report was sent', () => {
+    const addon = { ...fakeAddon, slug: 'bank-machine-skimmer' };
+    const { store } = dispatchClientMetadata();
+    const abuseResponse = createFakeAddonAbuseReport({
+      addon,
+      message: 'Seriously, where is my money?!',
+    });
+    store.dispatch(loadAddonAbuseReport(abuseResponse));
+    const root = renderMount({ addon, store });
+
+    expect(root.find('.ReportAbuseButton--report-sent')).toHaveLength(1);
+    expect(root.find('.ReportAbuseButton-show-more')).toHaveLength(0);
+    expect(root.find('.ReportAbuseButton-send-report')).toHaveLength(0);
+  });
+
+  it('dispatches when the send button is clicked if textarea has text', () => {
+    const addon = { ...fakeAddon, slug: 'which-browser' };
+    const fakeEvent = createFakeEvent();
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const root = renderMount({ addon, store });
+
+    // This simulates entering text into the textarea.
+    const textarea = root.find('.ReportAbuseButton-textarea textarea');
+    textarea.node.value = 'Opera did it first!';
+    textarea.simulate('change');
+
+    root.find('.ReportAbuseButton-send-report').simulate('click', fakeEvent);
+    sinon.assert.calledWith(dispatchSpy, sendAddonAbuseReport({
+      addonSlug: addon.slug,
+      errorHandlerId: 'create-stub-error-handler-id',
+      message: 'Opera did it first!',
+    }));
+    sinon.assert.called(fakeEvent.preventDefault);
+  });
+
+  it('enables the submit button if there is text in the textarea', () => {
+    const addon = { ...fakeAddon, slug: 'which-browser' };
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const root = renderMount({ addon, store });
+
+    // Make sure it's disabled by default.
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(true);
+
+    // This simulates entering text into the textarea.
+    const textarea = root.find('.ReportAbuseButton-textarea textarea');
+    textarea.node.value = 'Opera did it first!';
+    textarea.simulate('change');
+
+    sinon.assert.calledWith(dispatchSpy, enableAbuseButtonUI({ addon }));
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(false);
+  });
+
+  it('does not dispatch enableAbuseButtonUI if button already enabled', () => {
+    const addon = { ...fakeAddon, slug: 'which-browser' };
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const root = renderMount({ addon, store });
+
+    // This simulates entering text into the textarea.
+    const textarea = root.find('.ReportAbuseButton-textarea textarea');
+    textarea.node.value = 'Opera did it first!';
+    textarea.simulate('change');
+
+    sinon.assert.calledWith(dispatchSpy, enableAbuseButtonUI({ addon }));
+
+    // Ensure `enableAbuseButtonUI()` isn't called again.
+    dispatchSpy.reset();
+
+    // This simulates entering text into the textarea.
+    textarea.node.value = 'Opera did it first! Adding some text!';
+    textarea.simulate('change');
+
+    sinon.assert.neverCalledWith(dispatchSpy, enableAbuseButtonUI({ addon }));
+  });
+
+  it('does not dispatch enableAbuseButtonUI if textarea is whitespace', () => {
+    const addon = { ...fakeAddon, slug: 'which-browser' };
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const root = renderMount({ addon, store });
+
+    // This simulates entering text into the textarea.
+    const textarea = root.find('.ReportAbuseButton-textarea textarea');
+    textarea.node.value = '      ';
+    textarea.simulate('change');
+
+    sinon.assert.neverCalledWith(dispatchSpy, enableAbuseButtonUI({ addon }));
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(true);
+  });
+
+  it('disables the submit button if there is no text in the textarea', () => {
+    const addon = { ...fakeAddon, slug: 'which-browser' };
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const root = renderMount({ addon, store });
+
+    // This simulates entering text into the textarea.
+    const textarea = root.find('.ReportAbuseButton-textarea textarea');
+    textarea.node.value = 'Opera did it first!';
+    textarea.simulate('change');
+
+    textarea.node.value = '';
+    textarea.simulate('change');
+
+    sinon.assert.calledWith(dispatchSpy, disableAbuseButtonUI({ addon }));
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(true);
+  });
+
+  it('disables the submit button if there is empty text in the textarea', () => {
+    const addon = { ...fakeAddon, slug: 'which-browser' };
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const root = renderMount({ addon, store });
+
+    // This simulates entering text into the textarea.
+    const textarea = root.find('.ReportAbuseButton-textarea textarea');
+    textarea.node.value = 'Opera did it first!';
+    textarea.simulate('change');
+
+    textarea.node.value = '        ';
+    textarea.simulate('change');
+
+    sinon.assert.calledWith(dispatchSpy, disableAbuseButtonUI({ addon }));
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(true);
+  });
+
+  // This is a bit of a belt-and-braces approach, as the button that
+  // activates this function is disabled when the textarea is empty.
+  it('does not allow dispatch if there is no content in the textarea', () => {
+    const addon = { ...fakeAddon, slug: 'this-should-not-happen' };
+    const fakeEvent = createFakeEvent();
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const root = renderMount({ addon, store });
+
+    // We enable the button with an empty textarea; this never happens
+    // normally but we can force it here for testing.
+    store.dispatch(enableAbuseButtonUI({ addon }));
+    dispatchSpy.reset();
+    fakeEvent.preventDefault.reset();
+
+    // Make sure the button isn't disabled.
+    expect(root.find('.ReportAbuseButton-send-report').prop('disabled'))
+      .toEqual(false);
+    root.find('.ReportAbuseButton-send-report').simulate('click', fakeEvent);
+
+    sinon.assert.notCalled(dispatchSpy);
+    // Make sure preventDefault was called; we then know the sendReport()
+    // method was called.
+    sinon.assert.called(fakeEvent.preventDefault);
+  });
+});

--- a/tests/unit/core/api/test_abuse.js
+++ b/tests/unit/core/api/test_abuse.js
@@ -34,7 +34,7 @@ describe(__filename, () => {
           auth: true,
           endpoint: 'abuse/report/addon',
           method: 'POST',
-          params: { addon: 'cool-addon', message },
+          body: { addon: 'cool-addon', message },
           state: apiState,
         })
         .once()

--- a/tests/unit/core/reducers/test_abuse.js
+++ b/tests/unit/core/reducers/test_abuse.js
@@ -1,8 +1,12 @@
 import abuseReducer, {
   SEND_ADDON_ABUSE_REPORT,
+  disableAbuseButtonUI,
+  enableAbuseButtonUI,
+  hideAddonAbuseReportUI,
   initialState,
   loadAddonAbuseReport,
   sendAddonAbuseReport,
+  showAddonAbuseReportUI,
 } from 'core/reducers/abuse';
 import { dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
 import { createFakeAddonAbuseReport } from 'tests/unit/helpers';
@@ -38,6 +42,86 @@ describe(__filename, () => {
             message: 'This add-on is malwaré.',
           },
         },
+      });
+    });
+
+    describe('disableAbuseButtonUI', () => {
+      it('sets the buttonEnabled state to false', () => {
+        const state = abuseReducer(
+          initialState, disableAbuseButtonUI({ addon: fakeAddon }));
+
+        expect(state).toEqual({
+          bySlug: {
+            [fakeAddon.slug]: { buttonEnabled: false },
+          },
+          loading: false,
+        });
+      });
+
+      it('requires an addon param', () => {
+        expect(() => {
+          disableAbuseButtonUI();
+        }).toThrow('addon is required');
+      });
+    });
+
+    describe('enableAbuseButtonUI', () => {
+      it('sets the buttonEnabled state to true', () => {
+        const state = abuseReducer(
+          initialState, enableAbuseButtonUI({ addon: fakeAddon }));
+
+        expect(state).toEqual({
+          bySlug: {
+            [fakeAddon.slug]: { buttonEnabled: true },
+          },
+          loading: false,
+        });
+      });
+
+      it('requires an addon param', () => {
+        expect(() => {
+          enableAbuseButtonUI();
+        }).toThrow('addon is required');
+      });
+    });
+
+    describe('hideAddonAbuseReportUI', () => {
+      it('sets the uiVisible state to false', () => {
+        const state = abuseReducer(
+          initialState, hideAddonAbuseReportUI({ addon: fakeAddon }));
+
+        expect(state).toEqual({
+          bySlug: {
+            [fakeAddon.slug]: { uiVisible: false },
+          },
+          loading: false,
+        });
+      });
+
+      it('requires an addon param', () => {
+        expect(() => {
+          hideAddonAbuseReportUI();
+        }).toThrow('addon is required');
+      });
+    });
+
+    describe('showAddonAbuseReportUI', () => {
+      it('sets the uiVisible state to true', () => {
+        const state = abuseReducer(
+          initialState, showAddonAbuseReportUI({ addon: fakeAddon }));
+
+        expect(state).toEqual({
+          bySlug: {
+            [fakeAddon.slug]: { uiVisible: true },
+          },
+          loading: false,
+        });
+      });
+
+      it('requires an addon param', () => {
+        expect(() => {
+          showAddonAbuseReportUI();
+        }).toThrow('addon is required');
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -403,6 +403,14 @@ axobject-query@^0.1.0:
   dependencies:
     ast-types-flow "0.0.7"
 
+babel-code-frame@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz#418a7b5f3f7dc9a4670e61b1158b4c5661bec98d"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -435,14 +443,14 @@ babel-core@^6.0.0, babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-eslint@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+babel-eslint@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.0.tgz#ce06f385bdfb5b6d7e603f06222f891abd14c240"
   dependencies:
-    babel-code-frame "^6.22.0"
-    babel-traverse "^6.23.1"
-    babel-types "^6.23.0"
-    babylon "^6.17.0"
+    babel-code-frame "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
 
 babel-generator@^6.18.0, babel-generator@^6.25.0:
   version "6.25.0"
@@ -523,6 +531,15 @@ babel-helper-explode-class@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
+babel-helper-function-name@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz#d1b6779b647e5c5c31ebeb05e13b998e4d352d56"
+  dependencies:
+    babel-helper-get-function-arity "7.0.0-beta.0"
+    babel-template "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
@@ -532,6 +549,12 @@ babel-helper-function-name@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
+
+babel-helper-get-function-arity@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz#9d1ab7213bb5efe1ef1638a8ea1489969b5a8b6e"
+  dependencies:
+    babel-types "7.0.0-beta.0"
 
 babel-helper-get-function-arity@^6.24.1:
   version "6.24.1"
@@ -604,6 +627,10 @@ babel-loader@^7.0.0:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
+
+babel-messages@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-7.0.0-beta.0.tgz#6df01296e49fc8fbd0637394326a167f36da817b"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -1054,6 +1081,15 @@ babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
+babel-template@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-7.0.0-beta.0.tgz#85083cf9e4395d5e48bf5154d7a8d6991cafecfb"
+  dependencies:
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    lodash "^4.2.0"
+
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.3.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -1064,7 +1100,21 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0, babel-te
     babylon "^6.17.2"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
+babel-traverse@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz#da14be9b762f62a2f060db464eaafdd8cd072a41"
+  dependencies:
+    babel-code-frame "7.0.0-beta.0"
+    babel-helper-function-name "7.0.0-beta.0"
+    babel-messages "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
@@ -1078,7 +1128,15 @@ babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
+babel-types@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-7.0.0-beta.0.tgz#eb8b6e556470e6dcc4aef982d79ad229469b5169"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -1087,7 +1145,11 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.17.0, babylon@^6.17.2, babylon@^6.17.4:
+babylon@7.0.0-beta.22:
+  version "7.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.22.tgz#74f0ad82ed7c7c3cfeab74cf684f815104161b65"
+
+babylon@^6.17.2, babylon@^6.17.4:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -2136,6 +2198,12 @@ debug@2.6.1:
 debug@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.0.1.tgz#0564c612b521dc92d9f2988f0549e34f9c98db64"
   dependencies:
     ms "2.0.0"
 
@@ -3426,6 +3494,10 @@ global@^4.3.0:
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
+
+globals@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.1.0.tgz#4425a1881be0d336b4a823a82a7be725d5dd987c"
 
 globals@^9.0.0, globals@^9.17.0:
   version "9.18.0"
@@ -6539,6 +6611,12 @@ react-test-renderer@^15.5.4:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
+react-textarea-autosize@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.1.0.tgz#ffbf8164fce217c79443c1c17dedf730592df224"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-themeable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
@@ -7955,6 +8033,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 topo@1.x.x:
   version "1.1.0"


### PR DESCRIPTION
Fixes #2759.

Allows a user to report an add-on for abuse. This uses a new inline form that I didn't bother to abstract for now, but it should be pretty easy to do if we use this UI elsewhere. It could be tweaked a bit but the UX is a lot nicer than a modal.

It logs reported add-ons in the reducer so once you've reported an add-on, at least for the current session (until a full page reload, because abuse reports are stored in a database/accessible via an API), it appears as reported and you can't submit another one.

Sorry for the big PR; it's mostly tests. I wanted to get the interaction quite nice and it's very tested, but it meant a lot of tests.

### Desktop
![2017-09-21 22 53 07](https://user-images.githubusercontent.com/90871/30720551-e307a2de-9f1f-11e7-9add-1ff6f86fe2f1.gif)

### Mobile
![2017-09-21 22 58 48](https://user-images.githubusercontent.com/90871/30720693-80b83e8a-9f20-11e7-9809-9ca30868017d.gif)
