### PR TITLE
fix: Limit 57+ autocomplete to compatible add-ons

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -10,7 +10,10 @@ import config from 'config';
 
 import { initialApiState } from 'core/reducers/api';
 import log from 'core/logger';
-import { convertFiltersToQueryParams } from 'core/searchUtils';
+import {
+  addVersionCompatibilityToFilters,
+  convertFiltersToQueryParams,
+} from 'core/searchUtils';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { ApiStateType } from 'core/reducers/api';
 import type { ReactRouterLocation } from 'core/types/router';
@@ -243,11 +246,16 @@ type AutocompleteParams = {|
 |};
 
 export function autocomplete({ api, filters }: AutocompleteParams) {
+  const filtersWithAppVersion = addVersionCompatibilityToFilters({
+    filters,
+    userAgentInfo: api.userAgentInfo,
+  });
+
   return callApi({
     endpoint: 'addons/autocomplete',
     params: {
       app: api.clientApp,
-      ...convertFiltersToQueryParams(filters),
+      ...convertFiltersToQueryParams(filtersWithAppVersion),
     },
     state: api,
   });

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -7,6 +7,10 @@ import utf8 from 'utf8';
 import * as api from 'core/api';
 import { ADDON_TYPE_THEME, CLIENT_APP_ANDROID } from 'core/constants';
 import {
+  createFakeAutocompleteResult,
+  dispatchClientMetadata,
+} from 'tests/unit/amo/helpers';
+import {
   createApiResponse,
   createStubErrorHandler,
   generateHeaders,
@@ -14,7 +18,6 @@ import {
   unexpectedSuccess,
   userAuthToken,
 } from 'tests/unit/helpers';
-import { createFakeAutocompleteResult } from 'tests/unit/amo/helpers';
 
 
 describe(__filename, () => {
@@ -235,8 +238,14 @@ describe(__filename, () => {
         .withArgs(`${apiHost}/api/v3/addons/featured/?app=android&type=persona&lang=en-US`)
         .once()
         .returns(mockResponse());
+
+      const { state } = dispatchClientMetadata({
+        clientApp: CLIENT_APP_ANDROID,
+        lang: 'en-US',
+      });
+
       return api.featured({
-        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
+        api: state.api,
         filters: { addonType: ADDON_TYPE_THEME },
       })
         .then((response) => {
@@ -448,8 +457,14 @@ describe(__filename, () => {
         .withArgs(`${apiHost}/api/v3/addons/autocomplete/?app=android&q=foo&lang=en-US`)
         .once()
         .returns(mockResponse());
+
+      const { state } = dispatchClientMetadata({
+        clientApp: CLIENT_APP_ANDROID,
+        lang: 'en-US',
+      });
+
       return api.autocomplete({
-        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
+        api: state.api,
         filters: {
           query: 'foo',
         },
@@ -462,8 +477,14 @@ describe(__filename, () => {
         .withArgs(`${apiHost}/api/v3/addons/autocomplete/?app=android&q=foo&type=persona&lang=en-US`)
         .once()
         .returns(mockResponse());
+
+      const { state } = dispatchClientMetadata({
+        clientApp: CLIENT_APP_ANDROID,
+        lang: 'en-US',
+      });
+
       return api.autocomplete({
-        api: { clientApp: CLIENT_APP_ANDROID, lang: 'en-US' },
+        api: state.api,
         filters: {
           query: 'foo',
           addonType: ADDON_TYPE_THEME,

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -1,14 +1,97 @@
+import { oneLine } from 'common-tags';
+
 import { ADDON_TYPE_THEME } from 'core/constants';
 import {
+  addVersionCompatibilityToFilters,
   convertFiltersToQueryParams,
   convertQueryParamsToFilters,
   convertOSToFilterValue,
 } from 'core/searchUtils';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
-import { userAgents } from 'tests/unit/helpers';
+import { userAgents, userAgentsByPlatform } from 'tests/unit/helpers';
 
 
 describe(__filename, () => {
+  describe('addVersionCompatibilityToFilters', () => {
+    it('returns unmodified filters if not Firefox', () => {
+      const { state } = dispatchClientMetadata({
+        userAgent: userAgentsByPlatform.mac.chrome41,
+      });
+
+      const newFilters = addVersionCompatibilityToFilters({
+        filters: { query: 'foo' },
+        userAgentInfo: state.api.userAgentInfo,
+      });
+
+      expect(newFilters).toEqual({ query: 'foo' });
+    });
+
+    it('returns unmodified filters if Firefox for iOS (even if 57+)', () => {
+      // HACK: This is not a real UA string; this version doesn't exist (yet).
+      // But it's useful to test theoretical future versions.
+      const fakeFirefoxForIOSUserAgent = oneLine`Mozilla/5.0 (iPad; CPU
+        iPhone OS 20_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko)
+        FxiOS/60.0 Mobile/12F69 Safari/600.1.4`;
+      const { state } = dispatchClientMetadata({
+        userAgent: fakeFirefoxForIOSUserAgent,
+      });
+
+      const newFilters = addVersionCompatibilityToFilters({
+        filters: { query: 'foo' },
+        userAgentInfo: state.api.userAgentInfo,
+      });
+
+      expect(newFilters).toEqual({ query: 'foo' });
+    });
+
+    it('returns unmodified filters if Firefox for iOS', () => {
+      const { state } = dispatchClientMetadata({
+        userAgent: userAgentsByPlatform.linux.firefox10,
+      });
+
+      const newFilters = addVersionCompatibilityToFilters({
+        filters: { query: 'foo' },
+        userAgentInfo: state.api.userAgentInfo,
+      });
+
+      expect(newFilters).toEqual({ query: 'foo' });
+    });
+
+    it('adds compatibleWithVersion if Firefox 57+', () => {
+      const { state } = dispatchClientMetadata({
+        userAgent: userAgentsByPlatform.mac.firefox57,
+      });
+
+      const newFilters = addVersionCompatibilityToFilters({
+        filters: { query: 'foo' },
+        userAgentInfo: state.api.userAgentInfo,
+      });
+
+      expect(newFilters).toEqual({
+        compatibleWithVersion: '57.1',
+        query: 'foo',
+      });
+    });
+
+    it('requires filters', () => {
+      const { state } = dispatchClientMetadata({
+        userAgent: userAgentsByPlatform.mac.firefox57,
+      });
+
+      expect(() => {
+        addVersionCompatibilityToFilters({
+          userAgentInfo: state.api.userAgentInfo,
+        });
+      }).toThrow('filters are required');
+    });
+
+    it('requires userAgentInfo', () => {
+      expect(() => {
+        addVersionCompatibilityToFilters({ filters: {} });
+      }).toThrow('userAgentInfo is required');
+    });
+  });
+
   describe('convertFiltersToQueryParams', () => {
     it('converts filters', () => {
       const queryParams = convertFiltersToQueryParams({

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -125,8 +125,12 @@ export const userAgentsByPlatform = {
       Gecko/20100101 Firefox/10.0`,
   },
   mac: {
+    chrome41: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1)
+      AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36`,
     firefox33: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10;
       rv:33.0) Gecko/20100101 Firefox/33.0`,
+    firefox57: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0)
+      Gecko/20100101 Firefox/57.1`,
   },
   windows: {
     firefox40: oneLine`Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0)
@@ -155,8 +159,7 @@ export const userAgents = {
   chrome: [
     oneLine`Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko)
       Chrome/41.0.2228.0 Safari/537.36`,
-    oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36
-      (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36`,
+    userAgentsByPlatform.mac.chrome41,
   ],
   firefox: [
     userAgentsByPlatform.linux.firefox10,
@@ -166,9 +169,7 @@ export const userAgents = {
     // Firefox ESR 52
     oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:52.2.1)
       Gecko/20100101 Firefox/52.2.1`,
-    // Firefox 57 (first version that is WebExtension-only) for Mac
-    oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0)
-      Gecko/20100101 Firefox/57.1`,
+    userAgentsByPlatform.mac.firefox57,
   ],
   firefoxOS: [
     userAgentsByPlatform.firefoxOS.firefox26,


### PR DESCRIPTION
Fix #3209

Creates a helper function to deal with adding version compatibility because we do this in two places now.

This just makes sure autcomplete results won't surface incompatible add-ons, because that's a bad UX.