### PR TITLE
chore: Ignore nsp issue for JSDom

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/525"]
+}


### PR DESCRIPTION
See #3195.

As discussed because we don't use `FetchExternalResources` for JSDom it seems we're all good here.