### PR TITLE
fix: Handles 403 for addons and reviews

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -399,9 +399,10 @@ export class AddonBase extends React.Component {
     let errorBanner = null;
     if (errorHandler.hasError()) {
       log.warn('Captured API Error:', errorHandler.capturedError);
-      // A 401 is made to look like a 404 on purpose.
+      // 401 and 403 are made to look like a 404 on purpose.
       // See https://github.com/mozilla/addons-frontend/issues/3061
       if (errorHandler.capturedError.responseStatusCode === 401 ||
+          errorHandler.capturedError.responseStatusCode === 403 ||
           errorHandler.capturedError.responseStatusCode === 404
       ) {
         return <NotFound />;

--- a/src/amo/components/AddonReviewList.js
+++ b/src/amo/components/AddonReviewList.js
@@ -151,9 +151,10 @@ export class AddonReviewListBase extends React.Component {
       // TODO: support multiple error handlers, see
       // https://github.com/mozilla/addons-frontend/issues/3101
       //
-      // A 401 for an add-on lookup is made to look like a 404 on purpose.
+      // 401 and 403 are for an add-on lookup is made to look like a 404 on purpose.
       // See https://github.com/mozilla/addons-frontend/issues/3061
       if (errorHandler.capturedError.responseStatusCode === 401 ||
+          errorHandler.capturedError.responseStatusCode === 403 ||
           errorHandler.capturedError.responseStatusCode === 404
       ) {
         return <NotFound />;

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -338,6 +338,26 @@ describe(__filename, () => {
     expect(root.find(NotFound)).toHaveLength(1);
   });
 
+  it('renders NotFound page for forbidden add-on - 403 error', () => {
+    const id = 'error-handler-id';
+    const { store } = dispatchClientMetadata();
+
+    const error = createApiError({
+      response: { status: 403 },
+      apiURL: 'https://some/api/endpoint',
+      jsonResponse: { message: 'You do not have permission.' },
+    });
+    store.dispatch(setError({ id, error }));
+    const capturedError = store.getState().errors[id];
+    // This makes sure the error was dispatched to state correctly.
+    expect(capturedError).toBeTruthy();
+
+    const errorHandler = createStubErrorHandler(capturedError);
+
+    const root = shallowRender({ errorHandler });
+    expect(root.find(NotFound)).toHaveLength(1);
+  });
+
   it('renders a single author', () => {
     const authorUrl = 'http://olympia.dev/en-US/firefox/user/krupa/';
     const root = shallowRender({

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -239,7 +239,27 @@ describe('amo/components/AddonReviewList', () => {
       const error = createApiError({
         response: { status: 401 },
         apiURL: 'https://some/api/endpoint',
-        jsonResponse: { message: 'Not Found.' },
+        jsonResponse: { message: 'Authentication Failed.' },
+      });
+      store.dispatch(setError({ id, error }));
+      const capturedError = store.getState().errors[id];
+      // This makes sure the error was dispatched to state correctly.
+      expect(capturedError).toBeTruthy();
+
+      const errorHandler = createStubErrorHandler(capturedError);
+
+      const root = render({ errorHandler });
+      expect(root.find(NotFound)).toHaveLength(1);
+    });
+
+    it('renders NotFound page if API returns 403 error', () => {
+      const id = 'error-handler-id';
+      const { store } = dispatchClientMetadata();
+
+      const error = createApiError({
+        response: { status: 403 },
+        apiURL: 'https://some/api/endpoint',
+        jsonResponse: { message: 'Not Permitted.' },
       });
       store.dispatch(setError({ id, error }));
       const capturedError = store.getState().errors[id];


### PR DESCRIPTION
Fix #3218

Adds to #2769 
This deals with 403 errors, and shows them as 404 errors for addons and addon-review pages.