### PR TITLE
Link to Version History / Development Channel

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -27,7 +27,6 @@ export class AddonMoreInfoBase extends React.Component {
         versionLicense: <LoadingText minWidth={20} />,
         addonId: <LoadingText minWidth={20} />,
         versionHistoryLink: <LoadingText minWidth={20} />,
-        betaVersionsLink: <LoadingText minWidth={20} />,
       });
     }
 
@@ -159,10 +158,12 @@ export class AddonMoreInfoBase extends React.Component {
           {i18n.gettext('Version History')}
         </dt>
         <dd>{versionHistoryLink}</dd>
-        <dt className="AddonMoreInfo-beta-versions-title">
-          {i18n.gettext('Beta Versions')}
-        </dt>
-        <dd>{betaVersionsLink}</dd>
+        {betaVersionsLink ? (
+          <dt className="AddonMoreInfo-beta-versions-title">
+            {i18n.gettext('Beta Versions')}
+          </dt>
+        ) : null}
+        {betaVersionsLink ? <dd>{betaVersionsLink}</dd> : null}
         <dt
           className="AddonMoreInfo-database-id-title"
           title={i18n.gettext(`This ID is useful for debugging and

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -132,9 +132,13 @@ export class AddonMoreInfoBase extends React.Component {
             </ul>
           </dd>
         ) : null}
-        <dt>{i18n.gettext('Version')}</dt>
+        <dt className="AddonMoreInfo-version-title">
+          {i18n.gettext('Version')}
+        </dt>
         <dd className="AddonMoreInfo-version">{version}</dd>
-        <dt>{i18n.gettext('Last updated')}</dt>
+        <dt className="AddonMoreInfo-last-updated-title">
+          {i18n.gettext('Last updated')}
+        </dt>
         <dd>{versionLastUpdated}</dd>
         {versionLicenseLink ? (
           <dt className="AddonMoreInfo-license-title">

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -146,6 +146,28 @@ export class AddonMoreInfoBase extends React.Component {
             {addon.id}
           </dd>
         ) : null}
+        <dt className="AddonMoreInfo-version-history-title">
+          {i18n.gettext('Version History')}
+        </dt>
+        <dd>
+          <Link
+            className="AddonMoreInfo-version-history-link"
+            href={`/addon/${addon.slug}/versions/`}
+          >
+            {i18n.gettext('See all versions')}
+          </Link>
+        </dd>
+        <dt className="AddonMoreInfo-dev-channel-title">
+          {i18n.gettext('Development Channel')}
+        </dt>
+        <dd>
+          <Link
+            className="AddonMoreInfo-dev-channel-link"
+            href={`/addon/${addon.slug}/versions/beta`}
+          >
+            {i18n.gettext('See experimental versions')}
+          </Link>
+        </dd>
       </dl>
     );
   }

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -155,6 +155,14 @@ export class AddonMoreInfoBase extends React.Component {
           </dt>
         ) : null}
         {eulaLink ? <dd>{eulaLink}</dd> : null}
+        <dt className="AddonMoreInfo-version-history-title">
+          {i18n.gettext('Version History')}
+        </dt>
+        <dd>{versionHistoryLink}</dd>
+        <dt className="AddonMoreInfo-dev-channel-title">
+          {i18n.gettext('Development Channel')}
+        </dt>
+        <dd>{versionDevChannelLink}</dd>
         <dt
           className="AddonMoreInfo-database-id-title"
           title={i18n.gettext(`This ID is useful for debugging and
@@ -165,14 +173,6 @@ export class AddonMoreInfoBase extends React.Component {
         <dd className="AddonMoreInfo-database-id-content">
           {addonId}
         </dd>
-        <dt className="AddonMoreInfo-version-history-title">
-          {i18n.gettext('Version History')}
-        </dt>
-        <dd>{versionHistoryLink}</dd>
-        <dt className="AddonMoreInfo-dev-channel-title">
-          {i18n.gettext('Development Channel')}
-        </dt>
-        <dd>{versionDevChannelLink}</dd>
       </dl>
     );
   }

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -27,7 +27,7 @@ export class AddonMoreInfoBase extends React.Component {
         versionLicense: <LoadingText minWidth={20} />,
         addonId: <LoadingText minWidth={20} />,
         versionHistoryLink: <LoadingText minWidth={20} />,
-        versionDevChannelLink: <LoadingText minWidth={20} />,
+        betaVersionsLink: <LoadingText minWidth={20} />,
       });
     }
 
@@ -94,12 +94,12 @@ export class AddonMoreInfoBase extends React.Component {
           {i18n.gettext('See all versions')}
         </a>
       ),
-      versionDevChannelLink: (
+      betaVersionsLink: (
         <a
-          className="AddonMoreInfo-dev-channel-link"
+          className="AddonMoreInfo-beta-versions-link"
           href={`/addon/${addon.slug}/versions/beta`}
         >
-          {i18n.gettext('See experimental versions')}
+          {i18n.gettext('See all beta versions')}
         </a>
       ),
     });
@@ -114,7 +114,7 @@ export class AddonMoreInfoBase extends React.Component {
     versionLastUpdated,
     versionLicenseLink = null,
     versionHistoryLink,
-    versionDevChannelLink,
+    betaVersionsLink = null,
     addonId,
   }) {
     const { i18n } = this.props;
@@ -159,10 +159,10 @@ export class AddonMoreInfoBase extends React.Component {
           {i18n.gettext('Version History')}
         </dt>
         <dd>{versionHistoryLink}</dd>
-        <dt className="AddonMoreInfo-dev-channel-title">
-          {i18n.gettext('Development Channel')}
+        <dt className="AddonMoreInfo-beta-versions-title">
+          {i18n.gettext('Beta Versions')}
         </dt>
-        <dd>{versionDevChannelLink}</dd>
+        <dd>{betaVersionsLink}</dd>
         <dt
           className="AddonMoreInfo-database-id-title"
           title={i18n.gettext(`This ID is useful for debugging and

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -21,22 +21,14 @@ export class AddonMoreInfoBase extends React.Component {
     const { addon, i18n } = this.props;
 
     if (!addon) {
-      return (
-        <dl className="AddonMoreInfo-contents">
-          <dt className="AddonMoreInfo-loading-title">
-            <LoadingText maxWidth={40} />
-          </dt>
-          <dd className="AddonMoreInfo-loading-content">
-            <LoadingText width={25} />
-          </dd>
-          <dt className="AddonMoreInfo-loading-title">
-            <LoadingText maxWidth={40} />
-          </dt>
-          <dd className="AddonMoreInfo-loading-content">
-            <LoadingText width={25} />
-          </dd>
-        </dl>
-      );
+      return this.renderDefinitions({
+        version: <LoadingText minWidth={20} />,
+        versionLastUpdated: <LoadingText minWidth={20} />,
+        versionLicense: <LoadingText minWidth={20} />,
+        addonId: <LoadingText minWidth={20} />,
+        versionHistoryLink: <LoadingText minWidth={20} />,
+        versionDevChannelLink: <LoadingText minWidth={20} />,
+      });
     }
 
     let homepage = trimAndAddProtocolToUrl(addon.homepage);
@@ -57,6 +49,75 @@ export class AddonMoreInfoBase extends React.Component {
       );
     }
 
+    return this.renderDefinitions({
+      homepage,
+      supportUrl,
+      version: addon.current_version.version,
+      versionLastUpdated: i18n.sprintf(
+        // translators: This will output, in English:
+        // "2 months ago (Dec 12 2016)"
+        i18n.gettext('%(timeFromNow)s (%(date)s)'), {
+          timeFromNow: i18n.moment(addon.last_updated).fromNow(),
+          date: i18n.moment(addon.last_updated).format('ll'),
+        }
+      ),
+      versionLicenseLink: addon.current_version.license ? (
+        <a
+          className="AddonMoreInfo-license-link"
+          href={addon.current_version.license.url}
+        >
+          {addon.current_version.license.name}
+        </a>
+      ) : null,
+      privacyPolicyLink: addon.has_privacy_policy ? (
+        <Link
+          className="AddonMoreInfo-privacy-policy-link"
+          href={`/addon/${addon.slug}/privacy/`}
+        >
+          {i18n.gettext('Read the privacy policy for this add-on')}
+        </Link>
+      ) : null,
+      eulaLink: addon.has_eula ? (
+        <Link
+          className="AddonMoreInfo-eula-link"
+          href={`/addon/${addon.slug}/eula/`}
+        >
+          {i18n.gettext('Read the license agreement for this add-on')}
+        </Link>
+      ) : null,
+      addonId: addon.id,
+      versionHistoryLink: (
+        <a
+          className="AddonMoreInfo-version-history-link"
+          href={`/addon/${addon.slug}/versions/`}
+        >
+          {i18n.gettext('See all versions')}
+        </a>
+      ),
+      versionDevChannelLink: (
+        <a
+          className="AddonMoreInfo-dev-channel-link"
+          href={`/addon/${addon.slug}/versions/beta`}
+        >
+          {i18n.gettext('See experimental versions')}
+        </a>
+      ),
+    });
+  }
+
+  renderDefinitions({
+    homepage = null,
+    supportUrl = null,
+    privacyPolicyLink = null,
+    eulaLink = null,
+    version,
+    versionLastUpdated,
+    versionLicenseLink = null,
+    versionHistoryLink,
+    versionDevChannelLink,
+    addonId,
+  }) {
+    const { i18n } = this.props;
     return (
       <dl className="AddonMoreInfo-contents">
         {homepage || supportUrl ? (
@@ -73,101 +134,45 @@ export class AddonMoreInfoBase extends React.Component {
           </dd>
         ) : null}
         <dt>{i18n.gettext('Version')}</dt>
-        <dd className="AddonMoreInfo-version">
-          {addon.current_version.version}
-        </dd>
+        <dd className="AddonMoreInfo-version">{version}</dd>
         <dt>{i18n.gettext('Last updated')}</dt>
-        <dd>
-          {i18n.sprintf(
-            // translators: This will output, in English:
-            // "2 months ago (Dec 12 2016)"
-            i18n.gettext('%(timeFromNow)s (%(date)s)'), {
-              timeFromNow: i18n.moment(addon.last_updated).fromNow(),
-              date: i18n.moment(addon.last_updated).format('ll'),
-            }
-          )}
-        </dd>
-        {addon.current_version.license ? (
+        <dd>{versionLastUpdated}</dd>
+        {versionLicenseLink ? (
           <dt className="AddonMoreInfo-license-title">
             {i18n.gettext('License')}
           </dt>
         ) : null}
-        {addon.current_version.license ? (
-          <dd>
-            <a
-              className="AddonMoreInfo-license-link"
-              href={addon.current_version.license.url}
-            >
-              {addon.current_version.license.name}
-            </a>
-          </dd>
-        ) : null}
-        {addon.has_privacy_policy ? (
+        {versionLicenseLink ? <dd>{versionLicenseLink}</dd> : null}
+        {privacyPolicyLink ? (
           <dt className="AddonMoreInfo-privacy-policy-title">
             {i18n.gettext('Privacy Policy')}
           </dt>
         ) : null}
-        {addon.has_privacy_policy ? (
-          <dd>
-            <Link
-              className="AddonMoreInfo-privacy-policy-link"
-              href={`/addon/${addon.slug}/privacy/`}
-            >
-              {i18n.gettext('Read the privacy policy for this add-on')}
-            </Link>
-          </dd>
-        ) : null}
-        {addon.has_eula ? (
+        {privacyPolicyLink ? <dd>{privacyPolicyLink}</dd> : null}
+        {eulaLink ? (
           <dt className="AddonMoreInfo-eula-title">
             {i18n.gettext('End-User License Agreement')}
           </dt>
         ) : null}
-        {addon.has_eula ? (
-          <dd>
-            <Link
-              className="AddonMoreInfo-eula-link"
-              href={`/addon/${addon.slug}/eula/`}
-            >
-              {i18n.gettext('Read the license agreement for this add-on')}
-            </Link>
-          </dd>
-        ) : null}
-        {addon.id ? (
-          <dt
-            className="AddonMoreInfo-database-id-title"
-            title={i18n.gettext(`This ID is useful for debugging and
-              identifying your add-on to site administrators.`)}
-          >
-            {i18n.gettext('Site Identifier')}
-          </dt>
-        ) : null}
-        {addon.id ? (
-          <dd className="AddonMoreInfo-database-id-content">
-            {addon.id}
-          </dd>
-        ) : null}
+        {eulaLink ? <dd>{eulaLink}</dd> : null}
+        <dt
+          className="AddonMoreInfo-database-id-title"
+          title={i18n.gettext(`This ID is useful for debugging and
+            identifying your add-on to site administrators.`)}
+        >
+          {i18n.gettext('Site Identifier')}
+        </dt>
+        <dd className="AddonMoreInfo-database-id-content">
+          {addonId}
+        </dd>
         <dt className="AddonMoreInfo-version-history-title">
           {i18n.gettext('Version History')}
         </dt>
-        <dd>
-          <Link
-            className="AddonMoreInfo-version-history-link"
-            href={`/addon/${addon.slug}/versions/`}
-          >
-            {i18n.gettext('See all versions')}
-          </Link>
-        </dd>
+        <dd>{versionHistoryLink}</dd>
         <dt className="AddonMoreInfo-dev-channel-title">
           {i18n.gettext('Development Channel')}
         </dt>
-        <dd>
-          <Link
-            className="AddonMoreInfo-dev-channel-link"
-            href={`/addon/${addon.slug}/versions/beta`}
-          >
-            {i18n.gettext('See experimental versions')}
-          </Link>
-        </dd>
+        <dd>{versionDevChannelLink}</dd>
       </dl>
     );
   }

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -93,14 +93,16 @@ export class AddonMoreInfoBase extends React.Component {
           {i18n.gettext('See all versions')}
         </a>
       ),
-      betaVersionsLink: (
+      // Since current_beta_version is just an alias to the latest beta,
+      // we can assume that no betas exist at all if it is null.
+      betaVersionsLink: addon.current_beta_version ? (
         <a
           className="AddonMoreInfo-beta-versions-link"
           href={`/addon/${addon.slug}/versions/beta`}
         >
           {i18n.gettext('See all beta versions')}
         </a>
-      ),
+      ) : null,
     });
   }
 

--- a/src/amo/components/AddonMoreInfo/styles.scss
+++ b/src/amo/components/AddonMoreInfo/styles.scss
@@ -29,11 +29,3 @@
   margin: 0;
   padding: 0;
 }
-
-.AddonMoreInfo-loading-title .LoadingText {
-  margin-bottom: 3px;
-}
-
-.AddonMoreInfo-loading-content .LoadingText {
-  margin-bottom: 5px;
-}

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -5,6 +5,7 @@ import React from 'react';
 import AddonMoreInfo, {
   AddonMoreInfoBase,
 } from 'amo/components/AddonMoreInfo';
+import { createInternalAddon } from 'core/reducers/addons';
 import { dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
 import { getFakeI18nInst, shallowUntilTarget } from 'tests/unit/helpers';
 import LoadingText from 'ui/components/LoadingText';
@@ -16,7 +17,7 @@ describe(__filename, () => {
   function render(props) {
     return shallowUntilTarget(
       <AddonMoreInfo
-        addon={fakeAddon}
+        addon={props.addon || createInternalAddon(fakeAddon)}
         i18n={getFakeI18nInst()}
         store={store}
         {...props}
@@ -32,11 +33,11 @@ describe(__filename, () => {
   });
 
   it('does renders a link <dt> if links exist', () => {
-    const addon = {
+    const addon = createInternalAddon({
       ...fakeAddon,
       homepage: null,
       support_url: 'foo.com',
-    };
+    });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-links-title'))
@@ -47,7 +48,7 @@ describe(__filename, () => {
     const partialAddon = deepcopy(fakeAddon);
     delete partialAddon.homepage;
     delete partialAddon.support_url;
-    const root = render({ addon: partialAddon });
+    const root = render({ addon: createInternalAddon(partialAddon) });
 
     expect(root.find('.AddonMoreInfo-links-title')).toHaveLength(0);
   });
@@ -55,13 +56,15 @@ describe(__filename, () => {
   it('does not render a homepage if none exists', () => {
     const partialAddon = deepcopy(fakeAddon);
     delete partialAddon.homepage;
-    const root = render({ addon: partialAddon });
+    const root = render({ addon: createInternalAddon(partialAddon) });
 
     expect(root.find('.AddonMoreInfo-homepage-link')).toHaveLength(0);
   });
 
   it('renders the homepage of an add-on', () => {
-    const addon = { ...fakeAddon, homepage: 'http://hamsterdance.com/' };
+    const addon = createInternalAddon({
+      ...fakeAddon, homepage: 'http://hamsterdance.com/',
+    });
     const root = render({ addon });
     const link = root.find('.AddonMoreInfo-homepage-link');
 
@@ -72,16 +75,16 @@ describe(__filename, () => {
   it('does not render a support link if none exists', () => {
     const partialAddon = deepcopy(fakeAddon);
     delete partialAddon.support_url;
-    const root = render({ addon: partialAddon });
+    const root = render({ addon: createInternalAddon(partialAddon) });
 
     expect(root.find('.AddonMoreInfo-support-link')).toHaveLength(0);
   });
 
   it('renders the support link of an add-on', () => {
-    const addon = {
+    const addon = createInternalAddon({
       ...fakeAddon,
       support_url: 'http://support.hampsterdance.com/',
-    };
+    });
     const root = render({ addon });
     const link = root.find('.AddonMoreInfo-support-link');
 
@@ -90,26 +93,26 @@ describe(__filename, () => {
   });
 
   it('renders the version number of an add-on', () => {
-    const addon = {
+    const addon = createInternalAddon({
       ...fakeAddon,
       current_version: {
         ...fakeAddon.current_version,
         version: '2.0.1',
       },
-    };
+    });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-version')).toHaveText('2.0.1');
   });
 
   it('renders the license and link', () => {
-    const addon = {
+    const addon = createInternalAddon({
       ...fakeAddon,
       current_version: {
         ...fakeAddon.current_version,
         license: { name: 'tofulicense', url: 'http://license.com/' },
       },
-    };
+    });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-license-title')).toHaveText('License');
@@ -120,7 +123,9 @@ describe(__filename, () => {
   });
 
   it('does not render a privacy policy if none exists', () => {
-    const addon = { ...fakeAddon, has_privacy_policy: false };
+    const addon = createInternalAddon({
+      ...fakeAddon, has_privacy_policy: false,
+    });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-privacy-policy-title'))
@@ -130,7 +135,9 @@ describe(__filename, () => {
   });
 
   it('renders the privacy policy and link', () => {
-    const addon = { ...fakeAddon, has_privacy_policy: true };
+    const addon = createInternalAddon({
+      ...fakeAddon, has_privacy_policy: true,
+    });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-privacy-policy-title'))
@@ -142,7 +149,7 @@ describe(__filename, () => {
   });
 
   it('does not render a EULA if none exists', () => {
-    const addon = { ...fakeAddon, has_eula: false };
+    const addon = createInternalAddon({ ...fakeAddon, has_eula: false });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-eula-title')).toHaveLength(0);
@@ -150,7 +157,7 @@ describe(__filename, () => {
   });
 
   it('renders the EULA and link', () => {
-    const addon = { ...fakeAddon, has_eula: true };
+    const addon = createInternalAddon({ ...fakeAddon, has_eula: true });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-eula-title'))
@@ -164,14 +171,14 @@ describe(__filename, () => {
   it('does not render an add-on ID if none exists', () => {
     const partialAddon = { ...fakeAddon };
     delete partialAddon.id;
-    const root = render({ addon: partialAddon });
+    const root = render({ addon: createInternalAddon(partialAddon) });
 
     expect(root.find('.AddonMoreInfo-database-id-title')).toHaveLength(0);
     expect(root.find('.AddonMoreInfo-database-id-content')).toHaveLength(0);
   });
 
   it('renders the ID and title attribute', () => {
-    const addon = { ...fakeAddon, id: 9001 };
+    const addon = createInternalAddon({ ...fakeAddon, id: 9001 });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-database-id-title'))
@@ -184,7 +191,7 @@ describe(__filename, () => {
   });
 
   it('links to version history', () => {
-    const addon = { ...fakeAddon, slug: 'some-slug' };
+    const addon = createInternalAddon({ ...fakeAddon, slug: 'some-slug' });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-version-history-title'))
@@ -194,7 +201,7 @@ describe(__filename, () => {
   });
 
   it('links to development channel versions', () => {
-    const addon = { ...fakeAddon, slug: 'some-slug' };
+    const addon = createInternalAddon({ ...fakeAddon, slug: 'some-slug' });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-dev-channel-title'))

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -182,4 +182,24 @@ describe(__filename, () => {
     expect(root.find('.AddonMoreInfo-database-id-content'))
       .toHaveText('9001');
   });
+
+  it('links to version history', () => {
+    const addon = { ...fakeAddon, slug: 'some-slug' };
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-version-history-title'))
+      .toHaveLength(1);
+    const link = root.find('.AddonMoreInfo-version-history-link');
+    expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/`);
+  });
+
+  it('links to development channel versions', () => {
+    const addon = { ...fakeAddon, slug: 'some-slug' };
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-dev-channel-title'))
+      .toHaveLength(1);
+    const link = root.find('.AddonMoreInfo-dev-channel-link');
+    expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/beta`);
+  });
 });

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -195,9 +195,9 @@ describe(__filename, () => {
     const addon = createInternalAddon({ ...fakeAddon, slug: 'some-slug' });
     const root = render({ addon });
 
-    expect(root.find('.AddonMoreInfo-dev-channel-title'))
+    expect(root.find('.AddonMoreInfo-beta-versions-title'))
       .toHaveLength(1);
-    const link = root.find('.AddonMoreInfo-dev-channel-link');
+    const link = root.find('.AddonMoreInfo-beta-versions-link');
     expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/beta`);
   });
 });

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -206,13 +206,32 @@ describe(__filename, () => {
     expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/`);
   });
 
-  it('links to development channel versions', () => {
-    const addon = createInternalAddon({ ...fakeAddon, slug: 'some-slug' });
+  it('links to beta versions', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      slug: 'some-slug',
+      current_beta_version: {
+        ...fakeAddon.current_version,
+        version: '3.0.0-beta',
+      },
+    });
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-beta-versions-title'))
       .toHaveLength(1);
     const link = root.find('.AddonMoreInfo-beta-versions-link');
     expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/beta`);
+  });
+
+  it('does not link to beta versions without a current beta', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon, current_beta_version: null,
+    });
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-beta-versions-title'))
+      .toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-beta-versions-link'))
+      .toHaveLength(0);
   });
 });

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -29,7 +29,7 @@ describe(__filename, () => {
   it('renders LoadingText if no add-on is present', () => {
     const root = render({ addon: null });
 
-    expect(root.find(LoadingText)).toHaveLength(5);
+    expect(root.find(LoadingText)).toHaveLength(4);
   });
 
   it('does renders a link <dt> if links exist', () => {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -29,7 +29,7 @@ describe(__filename, () => {
   it('renders LoadingText if no add-on is present', () => {
     const root = render({ addon: null });
 
-    expect(root.find(LoadingText)).toHaveLength(4);
+    expect(root.find(LoadingText)).toHaveLength(5);
   });
 
   it('does renders a link <dt> if links exist', () => {
@@ -166,15 +166,6 @@ describe(__filename, () => {
       .toHaveText('Read the license agreement for this add-on');
     expect(root.find('.AddonMoreInfo-eula-link'))
       .toHaveProp('href', '/addon/chill-out/eula/');
-  });
-
-  it('does not render an add-on ID if none exists', () => {
-    const partialAddon = { ...fakeAddon };
-    delete partialAddon.id;
-    const root = render({ addon: createInternalAddon(partialAddon) });
-
-    expect(root.find('.AddonMoreInfo-database-id-title')).toHaveLength(0);
-    expect(root.find('.AddonMoreInfo-database-id-content')).toHaveLength(0);
   });
 
   it('renders the ID and title attribute', () => {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -29,7 +29,22 @@ describe(__filename, () => {
   it('renders LoadingText if no add-on is present', () => {
     const root = render({ addon: null });
 
+    // These fields will be visible during loading since
+    // they will always exist for the loaded add-on.
+    expect(root.find('.AddonMoreInfo-version-title')).toHaveLength(1);
+    expect(root.find('.AddonMoreInfo-last-updated-title')).toHaveLength(1);
+    expect(root.find('.AddonMoreInfo-version-history-title')).toHaveLength(1);
+    expect(root.find('.AddonMoreInfo-database-id-title')).toHaveLength(1);
+
     expect(root.find(LoadingText)).toHaveLength(4);
+
+    // These fields will not be visible during loading
+    // since they may not exist.
+    expect(root.find('.AddonMoreInfo-links-title')).toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-license-title')).toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-privacy-policy-title')).toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-eula-title')).toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-beta-versions-title')).toHaveLength(0);
   });
 
   it('does renders a link <dt> if links exist', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3229

This adds two external links to the More Info card for viewing and installing alternative versions.

<img width="321" alt="screenshot 2017-09-25 16 49 33" src="https://user-images.githubusercontent.com/55398/30832673-8eb114aa-a211-11e7-80c4-7105585421cf.png">


I also made the loading screen match the final rendered card more closely which should make the loading transition less jarring.


<img width="320" alt="screenshot 2017-09-25 12 55 39" src="https://user-images.githubusercontent.com/55398/30823335-71f14508-a1f1-11e7-9a5c-ad870fe00ba9.png">
