### PR TITLE
fix: Prevent grid issues on Addon Details page

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -323,7 +323,6 @@ export class AddonBase extends React.Component {
           authorNames.length
         );
         break;
-
       case ADDON_TYPE_EXTENSION:
         header = i18n.ngettext(
           i18n.sprintf(
@@ -334,7 +333,6 @@ export class AddonBase extends React.Component {
           authorNames.length
         );
         break;
-
       case ADDON_TYPE_LANG:
         header = i18n.ngettext(
           i18n.sprintf(
@@ -345,7 +343,6 @@ export class AddonBase extends React.Component {
           authorNames.length
         );
         break;
-
       case ADDON_TYPE_THEME:
         header = i18n.ngettext(
           i18n.sprintf(
@@ -356,7 +353,6 @@ export class AddonBase extends React.Component {
           authorNames.length
         );
         break;
-
       default:
         header = i18n.ngettext(
           i18n.sprintf(
@@ -524,12 +520,20 @@ export class AddonBase extends React.Component {
             </Card>
           ) : null}
 
-          {this.renderShowMoreCard()}
+          <div className="Addon-main-content">
+            {addonType === ADDON_TYPE_THEME ?
+              this.renderMoreAddonsByAuthors() : null}
+            {this.renderShowMoreCard()}
+          </div>
+
           {this.renderRatingsCard()}
 
+          {addonType !== ADDON_TYPE_THEME ?
+            this.renderMoreAddonsByAuthors() : null}
+
           <AddonMoreInfo addon={addon} />
+
           {this.renderVersionReleaseNotes()}
-          {this.renderMoreAddonsByAuthors()}
         </div>
       </div>
     );

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -197,19 +197,11 @@
     grid-template-columns: minmax(300px, 35%) auto;
     margin: 10px 0 0;
 
-    .AddonDescription {
+    .Addon-main-content {
       grid-column: 2;
-      grid-row: 1 / span 5;
-
-      .Addon--has-more-than-0-addons.Addon-persona & {
-        // This span makes sure the left widget does not move vertically when
-        // there is a long description.
-        grid-row: 2 / span 50000;
-      }
-
-      .Addon--has-more-than-3-addons.Addon-persona & {
-        grid-row: 3;
-      }
+      // This span makes sure the left widget does not move vertically when
+      // there is a long description.
+      grid-row: 1 / span 100000;
     }
 
     .AddonDescription-version-notes {
@@ -218,14 +210,6 @@
 
     .AddonDescription-more-addons {
       grid-column: 1;
-    }
-
-    .AddonDescription-more-addons--theme {
-      grid-column: 2;
-
-      .Addon--has-more-than-3-addons & {
-        grid-row: 1 / span 2;
-      }
     }
 
     .AddonDescription-contents {
@@ -242,27 +226,10 @@
 
   .Addon-overall-rating {
     grid-column: 1 / 2;
-
-    .Addon--has-more-than-0-addons.Addon-persona & {
-      grid-row: 1 / span 2;
-    }
-
-    .Addon--has-more-than-3-addons.Addon-persona & {
-      grid-row: 1;
-    }
   }
 
   .AddonMoreInfo {
     grid-column: 1 / 2;
-    grid-row: 5 / span 1;
-
-    .Addon--has-more-than-0-addons.Addon-persona & {
-      grid-row: 3 / span 1;
-    }
-
-    .Addon--has-more-than-3-addons.Addon-persona & {
-      grid-row: 2 / span 2;
-    }
   }
 
   // We hide this "Read reviews" link on larger displays as we actually show

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -947,6 +947,33 @@ describe(__filename, () => {
       }));
     });
 
+    it('puts "add-ons by author" in main content if type is theme', () => {
+      const addon = fakeTheme;
+      const { store } = dispatchAddonData({
+        addon,
+        addonsByAuthors: [{ ...fakeTheme, slug: 'another-slug' }],
+      });
+
+      const root = renderComponent({ params: { slug: addon.slug }, store });
+
+      expect(root.find('.Addon-main-content .AddonDescription-more-addons'))
+        .toHaveLength(1);
+    });
+
+    it('puts "add-ons by author" outside main if type is not theme', () => {
+      const addon = fakeAddon;
+      const { store } = dispatchAddonData({
+        addon,
+        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+      });
+
+      const root = renderComponent({ params: { slug: addon.slug }, store });
+
+      expect(root.find('.Addon-main-content .AddonDescription-more-addons'))
+        .toHaveLength(0);
+      expect(root.find('.AddonDescription-more-addons')).toHaveLength(1);
+    });
+
     it('is hidden when an add-on has not loaded yet', () => {
       // We use shallowRender because we cannot dispatch a `undefined` add-on.
       const root = shallowRender({ addon: undefined });


### PR DESCRIPTION
Fix #3226

This fixes a lot of issues with the addon detail's page grid. As we add more content (generally to the left side) we get weird mismatches.

Maybe we shouldn't even be really using grid here as we seem to nearly always have one huge item off to the right and a bunch of smaller ones to the left. For now this fixes the layout issues we hit.

Here are a tonne of screenshots showing it working:

<img width="1510" alt="screenshot 2017-09-26 03 31 57" src="https://user-images.githubusercontent.com/90871/30839718-90ae5394-a26b-11e7-954d-e8879e7a3183.png">
<img width="1510" alt="screenshot 2017-09-26 03 31 52" src="https://user-images.githubusercontent.com/90871/30839720-90b1599a-a26b-11e7-9431-870770148e46.png">
<img width="1510" alt="screenshot 2017-09-26 03 31 44" src="https://user-images.githubusercontent.com/90871/30839724-90d26482-a26b-11e7-8912-2e216def434a.png">
<img width="1510" alt="screenshot 2017-09-26 03 31 38" src="https://user-images.githubusercontent.com/90871/30839717-90ad693e-a26b-11e7-887a-2bb45d21dbc9.png">
<img width="1510" alt="screenshot 2017-09-26 03 31 24" src="https://user-images.githubusercontent.com/90871/30839719-90ae7356-a26b-11e7-8ce3-b6143b3d5e2c.png">
<img width="1510" alt="screenshot 2017-09-26 03 31 14" src="https://user-images.githubusercontent.com/90871/30839716-90aae8bc-a26b-11e7-95c1-4a102b7adb92.png">
<img width="1510" alt="screenshot 2017-09-26 03 31 02" src="https://user-images.githubusercontent.com/90871/30839721-90c046e4-a26b-11e7-872c-e68898abbce2.png">
<img width="1280" alt="screenshot 2017-09-26 03 29 49" src="https://user-images.githubusercontent.com/90871/30839722-90c48574-a26b-11e7-8849-7bc9e56c2e78.png">
<img width="1280" alt="screenshot 2017-09-26 03 29 45" src="https://user-images.githubusercontent.com/90871/30839723-90c4f4be-a26b-11e7-8afe-e4e7cdb090f0.png">
