### PR TITLE
fix: Put cards in proper order

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -511,29 +511,30 @@ export class AddonBase extends React.Component {
         </Card>
 
         <div className="Addon-details">
-          {addonPreviews.length > 0 ? (
-            <Card
-              className="Addon-screenshots"
-              header={i18n.gettext('Screenshots')}
-            >
-              <ScreenShots previews={addonPreviews} />
-            </Card>
-          ) : null}
-
           <div className="Addon-main-content">
             {addonType === ADDON_TYPE_THEME ?
               this.renderMoreAddonsByAuthors() : null}
+
+            {addonPreviews.length > 0 ? (
+              <Card
+                className="Addon-screenshots"
+                header={i18n.gettext('Screenshots')}
+              >
+                <ScreenShots previews={addonPreviews} />
+              </Card>
+            ) : null}
+
             {this.renderShowMoreCard()}
           </div>
 
+          <AddonMoreInfo addon={addon} />
+
           {this.renderRatingsCard()}
+
+          {this.renderVersionReleaseNotes()}
 
           {addonType !== ADDON_TYPE_THEME ?
             this.renderMoreAddonsByAuthors() : null}
-
-          <AddonMoreInfo addon={addon} />
-
-          {this.renderVersionReleaseNotes()}
         </div>
       </div>
     );

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -202,6 +202,7 @@
       // This span makes sure the left widget does not move vertically when
       // there is a long description.
       grid-row: 1 / span 100000;
+      overflow-x: hidden;
     }
 
     .AddonDescription-version-notes {
@@ -218,7 +219,6 @@
   }
 
   .Addon-screenshots {
-    grid-column: 1 / 2;
     // overflow required to fix content overlap in Safari.
     // See https://github.com/mozilla/addons-frontend/issues/2847
     overflow-x: hidden;


### PR DESCRIPTION
fix #3241 

Now looks like this, which matches the order in the mocks:

<img width="1539" alt="screenshot 2017-09-26 13 52 07" src="https://user-images.githubusercontent.com/90871/30861201-e6800a8c-a2c1-11e7-82c8-1378a6828459.png">
