### PR TITLE
Fix link colours in description

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -21,6 +21,20 @@ $addon-padding: 20px;
     color: $header-copy-font-color;
     font-size: 12px;
     margin: 0.75em 0;
+
+    a:link,
+    a:visited,
+    a:focus,
+    a:hover,
+    a:active {
+      color: $header-copy-font-color;
+      text-decoration: underline;
+    }
+
+    a:focus,
+    a:hover {
+      color: $link-hover-color;
+    }
   }
 
   &.theme {


### PR DESCRIPTION
Fixes #3245

## Before:

<img width="737" alt="discover_add-ons" src="https://user-images.githubusercontent.com/1514/30874050-26749c1e-a2e7-11e7-89ab-37593270a42e.png">

## Post fix:

Unfocused:
<img width="747" alt="discover_add-ons" src="https://user-images.githubusercontent.com/1514/30874758-361598ec-a2e9-11e7-961a-9b77297db8c9.png">

Hover:
<img width="773" alt="discover_add-ons" src="https://user-images.githubusercontent.com/1514/30874814-5f54c66a-a2e9-11e7-8bdb-b52c1d6c7f19.png">

Focus:
<img width="758" alt="discover_add-ons" src="https://user-images.githubusercontent.com/1514/30874791-4af052c0-a2e9-11e7-84f9-76960592a7a3.png">


