### PR TITLE
Add reducer/saga/api for collection view

### DIFF
--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -20,13 +20,16 @@ export const getCollectionDetail = (
   }
 
   return callApi({
-    auth: Boolean(api && api.token),
+    auth: true,
     endpoint: `accounts/account/${user}/collections/${slug}`,
     state: api,
   });
 };
 
-type GetCollectionAddonsParams = GetCollectionParams & {| page?: number |};
+type GetCollectionAddonsParams = {|
+  ...GetCollectionParams,
+  page?: number,
+|};
 
 export const getCollectionAddons = (
   { api, page, slug, user }: GetCollectionAddonsParams
@@ -39,7 +42,7 @@ export const getCollectionAddons = (
   }
 
   return callApi({
-    auth: Boolean(api && api.token),
+    auth: true,
     endpoint: `accounts/account/${user}/collections/${slug}/addons`,
     params: { page },
     state: api,

--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -1,0 +1,47 @@
+/* @flow */
+import { callApi } from 'core/api';
+import type { ApiStateType } from 'core/reducers/api';
+
+
+type GetCollectionParams = {|
+  api: ApiStateType,
+  slug: string,
+  user: string | number,
+|};
+
+export const getCollectionDetail = (
+  { api, slug, user }: GetCollectionParams
+) => {
+  if (!slug) {
+    throw new Error('slug is required');
+  }
+  if (!user) {
+    throw new Error('user is required');
+  }
+
+  return callApi({
+    auth: Boolean(api && api.token),
+    endpoint: `accounts/account/${user}/collections/${slug}`,
+    state: api,
+  });
+};
+
+type GetCollectionAddonsParams = GetCollectionParams & {| page?: number |};
+
+export const getCollectionAddons = (
+  { api, page, slug, user }: GetCollectionAddonsParams
+) => {
+  if (!slug) {
+    throw new Error('slug is required');
+  }
+  if (!user) {
+    throw new Error('user is required');
+  }
+
+  return callApi({
+    auth: Boolean(api && api.token),
+    endpoint: `accounts/account/${user}/collections/${slug}/addons`,
+    params: { page },
+    state: api,
+  });
+};

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -37,7 +37,7 @@ type FetchCollectionParams = {|
 |};
 
 type FetchCollectionAction = {|
-  type: 'FETCH_COLLECTION',
+  type: typeof FETCH_COLLECTION,
   payload: FetchCollectionParams,
 |};
 
@@ -69,7 +69,7 @@ type FetchCollectionPageParams = {|
 |};
 
 type FetchCollectionPageAction = {|
-  type: 'FETCH_COLLECTION_PAGE',
+  type: typeof FETCH_COLLECTION_PAGE,
   payload: FetchCollectionPageParams,
 |};
 
@@ -136,7 +136,7 @@ type LoadCollectionParams = {|
 |};
 
 type LoadCollectionAction = {|
-  type: 'LOAD_COLLECTION',
+  type: typeof LOAD_COLLECTION,
   payload: LoadCollectionParams,
 |};
 
@@ -162,7 +162,7 @@ type LoadCollectionPageParams = {|
 |};
 
 type LoadCollectionPageAction = {|
-  type: 'LOAD_COLLECTION_PAGE',
+  type: typeof LOAD_COLLECTION_PAGE,
   payload: LoadCollectionPageParams,
 |};
 

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -1,0 +1,160 @@
+/* @flow */
+import { createInternalAddon } from 'core/reducers/addons';
+import type { AddonType, ExternalAddonType } from 'core/types/addons';
+
+export const FETCH_COLLECTION = 'FETCH_COLLECTION';
+export const LOAD_COLLECTION = 'LOAD_COLLECTION';
+
+export type CollectionType = {
+  addons: Array<AddonType>,
+  authorName: string,
+  description: string | null,
+  id: number,
+  lastUpdatedDate: string,
+  name: string,
+  numberOfAddons: number,
+};
+
+export type CollectionsState = {|
+  current: CollectionType | null,
+  loading: boolean,
+|};
+
+export const initialState: CollectionsState = {
+  current: null,
+  loading: false,
+};
+
+type FetchCollectionParams = {|
+  errorHandlerId: string,
+  page?: number,
+  slug: string,
+  user: number | string,
+|};
+
+export const fetchCollection = ({
+  errorHandlerId,
+  page,
+  slug,
+  user,
+}: FetchCollectionParams = {}) => {
+  if (!errorHandlerId) {
+    throw new Error('errorHandlerId is required');
+  }
+  if (!slug) {
+    throw new Error('slug is required');
+  }
+  if (!user) {
+    throw new Error('user is required');
+  }
+
+  return {
+    type: FETCH_COLLECTION,
+    payload: { errorHandlerId, page, slug, user },
+  };
+};
+
+type CollectionAddonsResults = Array<{|
+  addon: ExternalAddonType,
+  downloads: number,
+  notes: string | null,
+|}>;
+
+// The API returns more attributes than what is listed below.
+type CollectionDetail = {
+  addon_count: number,
+  author: {
+    name: string,
+  },
+  description: string | null,
+  id: number,
+  modified: string,
+  name: string,
+};
+
+type LoadCollectionParams = {|
+  addons: {
+    results: CollectionAddonsResults,
+  },
+  detail: CollectionDetail,
+  slug: string,
+  user: number | string,
+|};
+
+export const loadCollection = ({
+  addons,
+  detail,
+}: LoadCollectionParams = {}) => {
+  if (!addons) {
+    throw new Error('addons are required');
+  }
+  if (!detail) {
+    throw new Error('detail is required');
+  }
+
+  return {
+    type: LOAD_COLLECTION,
+    payload: { addons, detail },
+  };
+};
+
+type CreateInternalCollectionParams = {|
+  detail: CollectionDetail,
+  items: CollectionAddonsResults,
+|};
+
+export const createInternalCollection = ({
+  detail,
+  items,
+}: CreateInternalCollectionParams): CollectionType => ({
+  addons: items.map((item) => {
+    // This allows to have a consistent way to manipulate addons in the app.
+    return createInternalAddon(item.addon);
+  }),
+  authorName: detail.author.name,
+  description: detail.description,
+  id: detail.id,
+  lastUpdatedDate: detail.modified,
+  name: detail.name,
+  numberOfAddons: detail.addon_count,
+});
+
+const reducer = (
+  state: CollectionsState = initialState,
+  action: Object
+): CollectionsState => {
+  switch (action.type) {
+    case FETCH_COLLECTION:
+      return {
+        // Current collection can be null if state is the initial state,
+        // otherwise we have already loaded a collection. We cannot load
+        // another collection from the collection view, so we can keep the
+        // detail of the current collection and only use "loading indicator"
+        // for the add-ons.
+        current: state.current === null ? null : {
+          ...state.current,
+          // We reset the set of addons because they depend on pagination.
+          // Other information still hold though.
+          addons: [],
+        },
+        loading: true,
+      };
+
+    case LOAD_COLLECTION: {
+      const { addons, detail } = action.payload;
+
+      return {
+        current: createInternalCollection({
+          detail,
+          items: addons.results,
+        }),
+        loading: false,
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -1,0 +1,48 @@
+import { all, call, put, select, takeEvery } from 'redux-saga/effects';
+import {
+  FETCH_COLLECTION,
+  loadCollection,
+} from 'amo/reducers/collections';
+import * as api from 'amo/api/collections';
+import log from 'core/logger';
+import { createErrorHandler, getState } from 'core/sagas/utils';
+
+export function* fetchCollection({
+  payload: {
+    errorHandlerId,
+    page,
+    slug,
+    user,
+  },
+}) {
+  const errorHandler = createErrorHandler(errorHandlerId);
+
+  yield put(errorHandler.createClearingAction());
+
+  try {
+    const state = yield select(getState);
+
+    const { detail, addons } = yield all({
+      detail: call(api.getCollectionDetail, {
+        api: state.api,
+        slug,
+        user,
+      }),
+      addons: call(api.getCollectionAddons, {
+        api: state.api,
+        page,
+        slug,
+        user,
+      }),
+    });
+
+    yield put(loadCollection({ addons, detail }));
+  } catch (error) {
+    log.warn(`Collection failed to load: ${error}`);
+    yield put(errorHandler.createErrorAction(error));
+  }
+}
+
+export default function* collectionsSaga() {
+  yield takeEvery(FETCH_COLLECTION, fetchCollection);
+}

--- a/src/amo/sagas/index.js
+++ b/src/amo/sagas/index.js
@@ -6,6 +6,7 @@ import { all, fork } from 'redux-saga/effects';
 
 import addonsByAuthors from 'amo/sagas/addonsByAuthors';
 import categories from 'amo/sagas/categories';
+import collections from 'amo/sagas/collections';
 import featured from 'amo/sagas/featured';
 import landing from 'amo/sagas/landing';
 import reviews from 'amo/sagas/reviews';
@@ -24,6 +25,7 @@ export default function* rootSaga() {
     fork(addonsByAuthors),
     fork(autocomplete),
     fork(categories),
+    fork(collections),
     fork(featured),
     fork(landing),
     fork(reviews),

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -3,6 +3,7 @@ import { reducer as reduxAsyncConnect } from 'redux-connect';
 import createSagaMiddleware from 'redux-saga';
 
 import addonsByAuthors from 'amo/reducers/addonsByAuthors';
+import collections from 'amo/reducers/collections';
 import featured from 'amo/reducers/featured';
 import landing from 'amo/reducers/landing';
 import reviews from 'amo/reducers/reviews';
@@ -32,6 +33,7 @@ export default function createStore(initialState = {}) {
       api,
       autocomplete,
       categories,
+      collections,
       errors,
       errorPage,
       featured,

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -5,17 +5,14 @@ import {
 } from 'amo/api/collections';
 import { parsePage } from 'core/utils';
 import { createApiResponse } from 'tests/unit/helpers';
-import {
-  dispatchClientMetadata,
-  dispatchSignInActions,
-} from 'tests/unit/amo/helpers';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 
 
 describe(__filename, () => {
   let mockApi;
+  let apiState;
 
   const getParams = ({
-    apiState = dispatchClientMetadata().store.getState().api,
     ...otherParams
   } = {}) => {
     return {
@@ -28,6 +25,7 @@ describe(__filename, () => {
 
   beforeEach(() => {
     mockApi = sinon.mock(api);
+    apiState = dispatchClientMetadata().store.getState().api;
   });
 
   describe('getCollectionDetail', () => {
@@ -49,45 +47,21 @@ describe(__filename, () => {
       }).toThrow('user is required');
     });
 
-    it('calls the collection detail API', () => {
-      const apiState = dispatchClientMetadata().store.getState().api;
-      const params = getParams({ api: apiState });
+    it('calls the collection detail API', async () => {
+      const params = getParams();
 
       mockApi
         .expects('callApi')
         .withArgs({
-          auth: false,
+          auth: true,
           endpoint: 'accounts/account/user-id-or-name/collections/some-slug',
           state: apiState,
         })
         .once()
         .returns(createApiResponse());
 
-      return getCollectionDetail(params)
-        .then(() => {
-          mockApi.verify();
-        });
-    });
-
-    it('makes an authenticated request when API state allows it', () => {
-      const apiState = dispatchSignInActions().store.getState().api;
-      const params = getParams({ apiState });
-
-      mockApi
-        .expects('callApi')
-        .withArgs({
-          auth: true,
-          endpoint:
-          'accounts/account/user-id-or-name/collections/some-slug',
-          state: apiState,
-        })
-        .once()
-        .returns(createApiResponse());
-
-      return getCollectionDetail(params)
-        .then(() => {
-          mockApi.verify();
-        });
+      await getCollectionDetail(params);
+      mockApi.verify();
     });
   });
 
@@ -110,50 +84,24 @@ describe(__filename, () => {
       }).toThrow('user is required');
     });
 
-    it('calls the collection add-ons list API', () => {
-      const apiState = dispatchClientMetadata().store.getState().api;
+    it('calls the collection add-ons list API', async () => {
       const queryParams = { page: parsePage(1) };
-      const params = getParams({ apiState, ...queryParams });
-
-      mockApi
-        .expects('callApi')
-        .withArgs({
-          auth: false,
-          endpoint:
-          'accounts/account/user-id-or-name/collections/some-slug/addons',
-          params: queryParams,
-          state: apiState,
-        })
-        .once()
-        .returns(createApiResponse());
-
-      return getCollectionAddons(params)
-        .then(() => {
-          mockApi.verify();
-        });
-    });
-
-    it('makes an authenticated request when API state allows it', () => {
-      const apiState = dispatchSignInActions().store.getState().api;
-      const queryParams = { page: parsePage(1) };
-      const params = getParams({ apiState, ...queryParams });
+      const params = getParams({ ...queryParams });
 
       mockApi
         .expects('callApi')
         .withArgs({
           auth: true,
           endpoint:
-          'accounts/account/user-id-or-name/collections/some-slug/addons',
+            'accounts/account/user-id-or-name/collections/some-slug/addons',
           params: queryParams,
           state: apiState,
         })
         .once()
         .returns(createApiResponse());
 
-      return getCollectionAddons(params)
-        .then(() => {
-          mockApi.verify();
-        });
+      await getCollectionAddons(params);
+      mockApi.verify();
     });
   });
 });

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -1,0 +1,159 @@
+import * as api from 'core/api';
+import {
+  getCollectionAddons,
+  getCollectionDetail,
+} from 'amo/api/collections';
+import { parsePage } from 'core/utils';
+import { createApiResponse } from 'tests/unit/helpers';
+import {
+  dispatchClientMetadata,
+  dispatchSignInActions,
+} from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  let mockApi;
+
+  const getParams = ({
+    apiState = dispatchClientMetadata().store.getState().api,
+    ...otherParams
+  } = {}) => {
+    return {
+      api: apiState,
+      slug: 'some-slug',
+      user: 'user-id-or-name',
+      ...otherParams,
+    };
+  };
+
+  beforeEach(() => {
+    mockApi = sinon.mock(api);
+  });
+
+  describe('getCollectionDetail', () => {
+    it('throws an error when slug is missing', () => {
+      const params = getParams();
+      delete params.slug;
+
+      expect(() => {
+        getCollectionDetail(params);
+      }).toThrow('slug is required');
+    });
+
+    it('throws an error when user is missing', () => {
+      const params = getParams();
+      delete params.user;
+
+      expect(() => {
+        getCollectionDetail(params);
+      }).toThrow('user is required');
+    });
+
+    it('calls the collection detail API', () => {
+      const apiState = dispatchClientMetadata().store.getState().api;
+      const params = getParams({ api: apiState });
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          auth: false,
+          endpoint: 'accounts/account/user-id-or-name/collections/some-slug',
+          state: apiState,
+        })
+        .once()
+        .returns(createApiResponse());
+
+      return getCollectionDetail(params)
+        .then(() => {
+          mockApi.verify();
+        });
+    });
+
+    it('makes an authenticated request when API state allows it', () => {
+      const apiState = dispatchSignInActions().store.getState().api;
+      const params = getParams({ apiState });
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          auth: true,
+          endpoint:
+          'accounts/account/user-id-or-name/collections/some-slug',
+          state: apiState,
+        })
+        .once()
+        .returns(createApiResponse());
+
+      return getCollectionDetail(params)
+        .then(() => {
+          mockApi.verify();
+        });
+    });
+  });
+
+  describe('getCollectionAddons', () => {
+    it('throws an error when slug is missing', () => {
+      const params = getParams();
+      delete params.slug;
+
+      expect(() => {
+        getCollectionAddons(params);
+      }).toThrow('slug is required');
+    });
+
+    it('throws an error when user is missing', () => {
+      const params = getParams();
+      delete params.user;
+
+      expect(() => {
+        getCollectionAddons(params);
+      }).toThrow('user is required');
+    });
+
+    it('calls the collection add-ons list API', () => {
+      const apiState = dispatchClientMetadata().store.getState().api;
+      const queryParams = { page: parsePage(1) };
+      const params = getParams({ apiState, ...queryParams });
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          auth: false,
+          endpoint:
+          'accounts/account/user-id-or-name/collections/some-slug/addons',
+          params: queryParams,
+          state: apiState,
+        })
+        .once()
+        .returns(createApiResponse());
+
+      return getCollectionAddons(params)
+        .then(() => {
+          mockApi.verify();
+        });
+    });
+
+    it('makes an authenticated request when API state allows it', () => {
+      const apiState = dispatchSignInActions().store.getState().api;
+      const queryParams = { page: parsePage(1) };
+      const params = getParams({ apiState, ...queryParams });
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          auth: true,
+          endpoint:
+          'accounts/account/user-id-or-name/collections/some-slug/addons',
+          params: queryParams,
+          state: apiState,
+        })
+        .once()
+        .returns(createApiResponse());
+
+      return getCollectionAddons(params)
+        .then(() => {
+          mockApi.verify();
+        });
+    });
+  });
+});

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -281,3 +281,27 @@ export function dispatchAutocompleteResults({
 
   return { store };
 }
+
+export const createFakeCollectionDetail = ({ name = 'my-collection' } = {}) => {
+  return {
+    author: {
+      name: 'John Doe',
+    },
+    description: 'some description',
+    id: Date.now(),
+    public: true,
+    name,
+    addon_count: 123,
+  };
+};
+
+export const createFakeCollectionAddons = ({ addons = [fakeAddon] } = {}) => {
+  return {
+    count: addons.length,
+    results: addons.map((addon) => ({
+      addon,
+      downloads: 0,
+      notes: null,
+    })),
+  };
+};

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -282,16 +282,24 @@ export function dispatchAutocompleteResults({
   return { store };
 }
 
-export const createFakeCollectionDetail = ({ name = 'my-collection' } = {}) => {
+export const createFakeCollectionDetail = ({ name = 'My Addons' } = {}) => {
   return {
+    addon_count: 123,
     author: {
+      id: Date.now(),
       name: 'John Doe',
+      url: 'http://olympia.dev/en-US/firefox/user/johndoe/',
+      username: 'johndoe',
     },
+    default_locale: 'en-US',
     description: 'some description',
     id: Date.now(),
-    public: true,
+    modified: Date.now(),
     name,
-    addon_count: 123,
+    public: true,
+    slug: 'my-addons',
+    url: `https://example.org/en-US/firefox/collections/johndoe/my-addons/`,
+    uuid: 'ef7e1344-1c3d-4bbb-bbd8-df9d8c9020ec',
   };
 };
 

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -1,8 +1,11 @@
 import reducer, {
+  createInternalAddons,
   createInternalCollection,
   fetchCollection,
+  fetchCollectionPage,
   initialState,
   loadCollection,
+  loadCollectionPage,
 } from 'amo/reducers/collections';
 import { parsePage } from 'core/utils';
 import { createStubErrorHandler } from 'tests/unit/helpers';
@@ -39,6 +42,21 @@ describe(__filename, () => {
       expect(collectionsState.current).toEqual(null);
     });
 
+    it('indicates when fetching a collection page', () => {
+      const { store } = dispatchClientMetadata();
+
+      store.dispatch(fetchCollectionPage({
+        errorHandlerId: createStubErrorHandler().id,
+        page: parsePage(2),
+        slug: 'some-collection-slug',
+        user: 'some-user-id-or-name',
+      }));
+
+      const collectionsState = store.getState().collections;
+      expect(collectionsState.loading).toEqual(true);
+      expect(collectionsState.current.addons).toEqual([]);
+    });
+
     it('loads a collection', () => {
       const { store } = dispatchClientMetadata();
 
@@ -61,7 +79,32 @@ describe(__filename, () => {
       expect(collectionsState.loading).toEqual(false);
     });
 
-    it('only resets the add-ons when a current collection is loaded', () => {
+    it('resets the current collection when fetching a new collection', () => {
+      const { store } = dispatchClientMetadata();
+
+      const collectionAddons = createFakeCollectionAddons();
+      const collectionDetail = createFakeCollectionDetail();
+
+      // 1. User loads a collection.
+      store.dispatch(loadCollection({
+        addons: collectionAddons,
+        detail: collectionDetail,
+      }));
+
+      // 2. User navigates to another collection.
+      store.dispatch(fetchCollection({
+        errorHandlerId: createStubErrorHandler().id,
+        slug: 'some-collection-slug',
+        user: 'some-user-id-or-name',
+      }));
+
+      const collectionsState = store.getState().collections;
+
+      expect(collectionsState.loading).toEqual(true);
+      expect(collectionsState.current).toEqual(null);
+    });
+
+    it('resets the add-ons when fetching a new collection page', () => {
       const { store } = dispatchClientMetadata();
 
       const collectionAddons = createFakeCollectionAddons();
@@ -74,7 +117,7 @@ describe(__filename, () => {
       }));
 
       // 2. User clicks the "next" pagination link.
-      store.dispatch(fetchCollection({
+      store.dispatch(fetchCollectionPage({
         errorHandlerId: createStubErrorHandler().id,
         page: parsePage(2),
         slug: 'some-collection-slug',
@@ -82,16 +125,31 @@ describe(__filename, () => {
       }));
 
       const collectionsState = store.getState().collections;
-      const loadedCollection = collectionsState.current;
 
       expect(collectionsState.loading).toEqual(true);
-      expect(loadedCollection).toEqual({
+      expect(collectionsState.current).toEqual({
         ...createInternalCollection({
           detail: collectionDetail,
           items: collectionAddons.results,
         }),
         addons: [],
       });
+    });
+
+    it('loads a collection page', () => {
+      const { store } = dispatchClientMetadata();
+
+      const collectionAddons = createFakeCollectionAddons();
+
+      store.dispatch(loadCollectionPage({ addons: collectionAddons }));
+
+      const collectionsState = store.getState().collections;
+      const loadedCollection = collectionsState.current;
+
+      expect(loadedCollection).not.toEqual(null);
+      expect(loadedCollection.addons)
+        .toEqual(createInternalAddons(collectionAddons.results));
+      expect(collectionsState.loading).toEqual(false);
     });
   });
 
@@ -152,6 +210,59 @@ describe(__filename, () => {
       expect(() => {
         loadCollection(partialParams);
       }).toThrow('detail is required');
+    });
+  });
+
+  describe('fetchCollectionPage()', () => {
+    const defaultParams = {
+      errorHandlerId: 'some-error-handler-id',
+      page: 123,
+      slug: 'some-collection-slug',
+      user: 'some-user-id-or-name',
+    };
+
+    it('throws an error when errorHandlerId is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.errorHandlerId;
+
+      expect(() => {
+        fetchCollectionPage(partialParams);
+      }).toThrow('errorHandlerId is required');
+    });
+
+    it('throws an error when slug is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.slug;
+
+      expect(() => {
+        fetchCollectionPage(partialParams);
+      }).toThrow('slug is required');
+    });
+
+    it('throws an error when user is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.user;
+
+      expect(() => {
+        fetchCollectionPage(partialParams);
+      }).toThrow('user is required');
+    });
+
+    it('throws an error when page is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.page;
+
+      expect(() => {
+        fetchCollectionPage(partialParams);
+      }).toThrow('page is required');
+    });
+  });
+
+  describe('loadCollectionPage()', () => {
+    it('throws an error when addons are missing', () => {
+      expect(() => {
+        loadCollectionPage();
+      }).toThrow('addons are required');
     });
   });
 });

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -1,0 +1,157 @@
+import reducer, {
+  createInternalCollection,
+  fetchCollection,
+  initialState,
+  loadCollection,
+} from 'amo/reducers/collections';
+import { parsePage } from 'core/utils';
+import { createStubErrorHandler } from 'tests/unit/helpers';
+import {
+  createFakeCollectionAddons,
+  createFakeCollectionDetail,
+  dispatchClientMetadata,
+} from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  describe('reducer', () => {
+    it('initializes properly', () => {
+      const state = reducer(undefined, {});
+      expect(state).toEqual(initialState);
+    });
+
+    it('ignores unrelated actions', () => {
+      const state = reducer(initialState, { type: 'UNRELATED_ACTION' });
+      expect(state).toEqual(initialState);
+    });
+
+    it('indicates when fetching a collection', () => {
+      const { store } = dispatchClientMetadata();
+
+      store.dispatch(fetchCollection({
+        errorHandlerId: createStubErrorHandler().id,
+        slug: 'some-collection-slug',
+        user: 'some-user-id-or-name',
+      }));
+
+      const collectionsState = store.getState().collections;
+      expect(collectionsState.loading).toEqual(true);
+      expect(collectionsState.current).toEqual(null);
+    });
+
+    it('loads a collection', () => {
+      const { store } = dispatchClientMetadata();
+
+      const collectionAddons = createFakeCollectionAddons();
+      const collectionDetail = createFakeCollectionDetail();
+
+      store.dispatch(loadCollection({
+        addons: collectionAddons,
+        detail: collectionDetail,
+      }));
+
+      const collectionsState = store.getState().collections;
+      const loadedCollection = collectionsState.current;
+
+      expect(loadedCollection).not.toEqual(null);
+      expect(loadedCollection).toEqual(createInternalCollection({
+        detail: collectionDetail,
+        items: collectionAddons.results,
+      }));
+      expect(collectionsState.loading).toEqual(false);
+    });
+
+    it('only resets the add-ons when a current collection is loaded', () => {
+      const { store } = dispatchClientMetadata();
+
+      const collectionAddons = createFakeCollectionAddons();
+      const collectionDetail = createFakeCollectionDetail();
+
+      // 1. User loads a collection.
+      store.dispatch(loadCollection({
+        addons: collectionAddons,
+        detail: collectionDetail,
+      }));
+
+      // 2. User clicks the "next" pagination link.
+      store.dispatch(fetchCollection({
+        errorHandlerId: createStubErrorHandler().id,
+        page: parsePage(2),
+        slug: 'some-collection-slug',
+        user: 'some-user-id-or-name',
+      }));
+
+      const collectionsState = store.getState().collections;
+      const loadedCollection = collectionsState.current;
+
+      expect(collectionsState.loading).toEqual(true);
+      expect(loadedCollection).toEqual({
+        ...createInternalCollection({
+          detail: collectionDetail,
+          items: collectionAddons.results,
+        }),
+        addons: [],
+      });
+    });
+  });
+
+  describe('fetchCollection()', () => {
+    const defaultParams = {
+      errorHandlerId: 'some-error-handler-id',
+      slug: 'some-collection-slug',
+      user: 'some-user-id-or-name',
+    };
+
+    it('throws an error when errorHandlerId is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.errorHandlerId;
+
+      expect(() => {
+        fetchCollection(partialParams);
+      }).toThrow('errorHandlerId is required');
+    });
+
+    it('throws an error when slug is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.slug;
+
+      expect(() => {
+        fetchCollection(partialParams);
+      }).toThrow('slug is required');
+    });
+
+    it('throws an error when user is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.user;
+
+      expect(() => {
+        fetchCollection(partialParams);
+      }).toThrow('user is required');
+    });
+  });
+
+  describe('loadCollection()', () => {
+    const defaultParams = {
+      addons: createFakeCollectionAddons(),
+      detail: createFakeCollectionDetail(),
+    };
+
+    it('throws an error when addons are missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.addons;
+
+      expect(() => {
+        loadCollection(partialParams);
+      }).toThrow('addons are required');
+    });
+
+    it('throws an error when detail is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.detail;
+
+      expect(() => {
+        loadCollection(partialParams);
+      }).toThrow('detail is required');
+    });
+  });
+});

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -1,0 +1,112 @@
+import SagaTester from 'redux-saga-tester';
+
+import * as collectionsApi from 'amo/api/collections';
+import collectionsReducer, {
+  fetchCollection,
+  loadCollection,
+} from 'amo/reducers/collections';
+import collectionsSaga from 'amo/sagas/collections';
+import apiReducer from 'core/reducers/api';
+import { parsePage } from 'core/utils';
+import { createStubErrorHandler } from 'tests/unit/helpers';
+import {
+  createFakeCollectionAddons,
+  createFakeCollectionDetail,
+  dispatchClientMetadata,
+} from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  const user = 'user-id-or-name';
+  const slug = 'collection-slug';
+
+  let errorHandler;
+  let mockApi;
+  let sagaTester;
+
+  beforeEach(() => {
+    errorHandler = createStubErrorHandler();
+    mockApi = sinon.mock(collectionsApi);
+    sagaTester = new SagaTester({
+      initialState: dispatchClientMetadata().state,
+      reducers: {
+        api: apiReducer,
+        collections: collectionsReducer,
+      },
+    });
+    sagaTester.start(collectionsSaga);
+  });
+
+  function _fetchCollection(params) {
+    sagaTester.dispatch(fetchCollection({
+      errorHandlerId: errorHandler.id,
+      ...params,
+    }));
+  }
+
+  it('calls the API to fetch a collection', async () => {
+    const state = sagaTester.getState();
+
+    const collectionAddons = createFakeCollectionAddons();
+    const collectionDetail = createFakeCollectionDetail();
+
+    mockApi
+      .expects('getCollectionDetail')
+      .withArgs({
+        api: state.api,
+        slug,
+        user,
+      })
+      .once()
+      .returns(Promise.resolve(collectionDetail));
+
+    mockApi
+      .expects('getCollectionAddons')
+      .withArgs({
+        api: state.api,
+        page: parsePage(1),
+        slug,
+        user,
+      })
+      .once()
+      .returns(Promise.resolve(collectionAddons));
+
+    _fetchCollection({ page: parsePage(1), slug, user });
+
+    const expectedLoadAction = loadCollection({
+      addons: collectionAddons,
+      detail: collectionDetail,
+    });
+
+    await sagaTester.waitFor(expectedLoadAction.type);
+    mockApi.verify();
+
+    const loadAction = sagaTester.getCalledActions()[2];
+    expect(loadAction).toEqual(expectedLoadAction);
+  });
+
+  it('clears the error handler', async () => {
+    _fetchCollection({ slug, user });
+
+    const expectedAction = errorHandler.createClearingAction();
+
+    await sagaTester.waitFor(expectedAction.type);
+    expect(sagaTester.getCalledActions()[1])
+      .toEqual(errorHandler.createClearingAction());
+  });
+
+  it('dispatches an error', async () => {
+    const error = new Error('some API error maybe');
+
+    mockApi
+      .expects('getCollectionDetail')
+      .once()
+      .returns(Promise.reject(error));
+
+    _fetchCollection({ slug, user });
+
+    const errorAction = errorHandler.createErrorAction(error);
+    await sagaTester.waitFor(errorAction.type);
+    expect(sagaTester.getCalledActions()[2]).toEqual(errorAction);
+  });
+});

--- a/tests/unit/amo/test_store.js
+++ b/tests/unit/amo/test_store.js
@@ -10,6 +10,7 @@ describe('amo createStore', () => {
       'api',
       'autocomplete',
       'categories',
+      'collections',
       'errorPage',
       'errors',
       'featured',


### PR DESCRIPTION
Refs #3140

---

This PR adds the reducer, saga, and API needed to build the collection view. It has a simplified state that could be extended later but for now, I focus on getting this collection view up and running as part of our MVP.

I do not reset the whole `current` collection when fetching a collection because it is nicer in the UI: only the list of add-ons has a "loading indicator" but the card with the detail on the left side do not change. I can't think of any issue with this so far, since we do not list collections in a list view. See:

![2017-09-28 11 45 20](https://user-images.githubusercontent.com/217628/30960184-91264132-a442-11e7-8ca3-468f91e8e0df.gif)

I could maybe add a separate action for that, but I took the easy path.