### PR TITLE
Ignore Node security advisory for `mime`

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,8 @@
 {
-  "exceptions": ["https://nodesecurity.io/advisories/525"]
+  "exceptions": [
+    // https://github.com/mozilla/addons-frontend/issues/3195
+    "https://nodesecurity.io/advisories/525",
+    // https://github.com/mozilla/addons-frontend/issues/3260
+    "https://nodesecurity.io/advisories/535"
+  ]
 }


### PR DESCRIPTION
See https://github.com/mozilla/addons-frontend/issues/3260