### PR TITLE
chore: Add error handler output to ReportAbuseButton

### DIFF
--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -94,7 +94,7 @@ export class ReportAbuseButtonBase extends React.Component {
   props: PropTypes;
 
   render() {
-    const { abuseReport, addon, i18n, loading } = this.props;
+    const { abuseReport, addon, errorHandler, i18n, loading } = this.props;
 
     if (!addon) {
       return null;
@@ -167,6 +167,9 @@ export class ReportAbuseButtonBase extends React.Component {
             features; this report will be sent to Mozilla and not to the
             add-on developer.`
           )}</p>
+
+          {errorHandler.renderErrorIfPresent()}
+
           <Textarea
             className="ReportAbuseButton-textarea"
             disabled={loading}


### PR DESCRIPTION
Fix #3262

Add error handler to the report abuse button.

Looks like this:

<img width="279" alt="screenshot 2017-09-28 00 57 25" src="https://user-images.githubusercontent.com/90871/30943664-60e4160a-a3ea-11e7-91ee-b87c7e77eecc.png">
