### PR TITLE
Collection view

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -1,0 +1,202 @@
+/* @flow */
+import React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import { withErrorHandler } from 'core/errorHandler';
+import log from 'core/logger';
+import translate from 'core/i18n/translate';
+import { parsePage } from 'core/utils';
+import { fetchCollection, fetchCollectionPage } from 'amo/reducers/collections';
+import type {
+  CollectionsState,
+  CollectionType,
+} from 'amo/reducers/collections';
+import AddonsCard from 'amo/components/AddonsCard';
+import Link from 'amo/components/Link';
+import NotFound from 'amo/components/ErrorPage/NotFound';
+import Paginate from 'core/components/Paginate';
+import Card from 'ui/components/Card';
+import LoadingText from 'ui/components/LoadingText';
+import type { ErrorHandlerType } from 'core/errorHandler';
+import type { ReactRouterLocation } from 'core/types/router';
+
+import './styles.scss';
+
+
+type Props = {|
+  collection: CollectionType | null,
+  dispatch: Function,
+  errorHandler: ErrorHandlerType,
+  i18n: Object,
+  loading: boolean,
+  location: ReactRouterLocation,
+  params: {|
+    slug: string,
+    user: string,
+  |},
+|};
+
+export class CollectionBase extends React.Component {
+  componentWillMount() {
+    this.loadDataIfNeeded();
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    this.loadDataIfNeeded(nextProps);
+  }
+
+  loadDataIfNeeded(nextProps?: Props) {
+    const { collection, errorHandler, loading, params } = {
+      ...this.props,
+      ...nextProps,
+    };
+
+    if (errorHandler.hasError()) {
+      log.warn('Not loading data because of an error.');
+      return;
+    }
+
+    if (loading) {
+      return;
+    }
+
+    let collectionChanged = false;
+    let addonsPageChanged = false;
+    let location = this.props.location;
+
+    if (nextProps && nextProps.location) {
+      const nextLocation = nextProps.location;
+
+      if (location.pathname !== nextLocation.pathname) {
+        collectionChanged = true;
+        location = nextLocation;
+      }
+
+      if (location.query.page !== nextLocation.query.page) {
+        addonsPageChanged = true;
+        location = nextLocation;
+      }
+    }
+
+    if (!collection || collectionChanged) {
+      this.props.dispatch(fetchCollection({
+        errorHandlerId: errorHandler.id,
+        page: parsePage(location.query.page),
+        slug: params.slug,
+        user: params.user,
+      }));
+
+      return;
+    }
+
+    if (collection && addonsPageChanged) {
+      this.props.dispatch(fetchCollectionPage({
+        errorHandlerId: errorHandler.id,
+        page: parsePage(location.query.page),
+        slug: params.slug,
+        user: params.user,
+      }));
+    }
+  }
+
+  props: Props;
+
+  url() {
+    const { params } = this.props;
+
+    return `/collections/${params.user}/${params.slug}/`;
+  }
+
+  renderCollection() {
+    const { collection, i18n, loading, location } = this.props;
+
+    const addons = collection ? collection.addons : [];
+
+    return (
+      <div className="Collection-wrapper">
+        <Card className="Collection-detail">
+          <h1 className="Collection-title">
+            {collection ? collection.name : <LoadingText />}
+          </h1>
+          <p className="Collection-description">
+            {collection ? collection.description : <LoadingText />}
+          </p>
+          <div className="Collection-metadata">
+            <dl className="Collection-number-of-addons">
+              <dd>
+                {collection ? collection.numberOfAddons : <LoadingText />}
+              </dd>
+              <dt>{i18n.gettext('Addons')}</dt>
+            </dl>
+            <dl className="Collection-author-name">
+              <dd className="Collection-author-name-value">
+                {collection ? collection.authorName : <LoadingText />}
+              </dd>
+              <dt>{i18n.gettext('Creator')}</dt>
+            </dl>
+            <dl className="Collection-last-updated">
+              <dd>
+                {collection ?
+                  i18n.moment(collection.lastUpdatedDate).format('ll')
+                  : <LoadingText />}
+              </dd>
+              <dt>{i18n.gettext('Last updated')}</dt>
+            </dl>
+          </div>
+        </Card>
+        <div className="Collection-items">
+          <AddonsCard
+            addons={addons}
+            loading={!collection || loading}
+          />
+          {collection && (
+            <Paginate
+              LinkComponent={Link}
+              count={collection.numberOfAddons}
+              currentPage={parsePage(location.query.page)}
+              pathname={this.url()}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    const { errorHandler } = this.props;
+
+    if (errorHandler.hasError()) {
+      log.warn('Captured API Error:', errorHandler.capturedError);
+      // 401 and 403 are for an add-on lookup is made to look like a 404 on
+      // purpose. See: https://github.com/mozilla/addons-frontend/issues/3061.
+      if (errorHandler.capturedError.responseStatusCode === 401 ||
+        errorHandler.capturedError.responseStatusCode === 403 ||
+        errorHandler.capturedError.responseStatusCode === 404
+      ) {
+        return <NotFound />;
+      }
+    }
+
+    return (
+      <div className="Collection">
+        {errorHandler.renderErrorIfPresent()}
+
+        {this.renderCollection()}
+      </div>
+    );
+  }
+}
+
+export const mapStateToProps = (state: { collections: CollectionsState }) => {
+  return {
+    collection: state.collections.current,
+    loading: state.collections.loading,
+  };
+};
+
+export default compose(
+  translate(),
+  withErrorHandler({ name: 'Collection' }),
+  connect(mapStateToProps),
+)(CollectionBase);

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -200,6 +200,7 @@ export default compose(
   withErrorHandler({
     // This allows to sync the client and the server error handler ids, thus
     // allowing the client side to be aware of errors thrown on the server.
+    // See: https://github.com/mozilla/addons-frontend/issues/3313
     id: 'Collection-001',
     name: 'Collection',
   }),

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -3,28 +3,28 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import AddonsCard from 'amo/components/AddonsCard';
+import Link from 'amo/components/Link';
+import NotFound from 'amo/components/ErrorPage/NotFound';
+import { fetchCollection, fetchCollectionPage } from 'amo/reducers/collections';
+import Paginate from 'core/components/Paginate';
 import { withErrorHandler } from 'core/errorHandler';
 import log from 'core/logger';
 import translate from 'core/i18n/translate';
 import { parsePage } from 'core/utils';
-import { fetchCollection, fetchCollectionPage } from 'amo/reducers/collections';
+import Card from 'ui/components/Card';
+import LoadingText from 'ui/components/LoadingText';
 import type {
   CollectionsState,
   CollectionType,
 } from 'amo/reducers/collections';
-import AddonsCard from 'amo/components/AddonsCard';
-import Link from 'amo/components/Link';
-import NotFound from 'amo/components/ErrorPage/NotFound';
-import Paginate from 'core/components/Paginate';
-import Card from 'ui/components/Card';
-import LoadingText from 'ui/components/LoadingText';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { ReactRouterLocation } from 'core/types/router';
 
 import './styles.scss';
 
 
-type Props = {|
+type PropTypes = {|
   collection: CollectionType | null,
   dispatch: Function,
   errorHandler: ErrorHandlerType,
@@ -42,11 +42,11 @@ export class CollectionBase extends React.Component {
     this.loadDataIfNeeded();
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  componentWillReceiveProps(nextProps: PropTypes) {
     this.loadDataIfNeeded(nextProps);
   }
 
-  loadDataIfNeeded(nextProps?: Props) {
+  loadDataIfNeeded(nextProps?: PropTypes) {
     const { collection, errorHandler, loading, params } = {
       ...this.props,
       ...nextProps,
@@ -100,7 +100,7 @@ export class CollectionBase extends React.Component {
     }
   }
 
-  props: Props;
+  props: PropTypes;
 
   url() {
     const { params } = this.props;
@@ -197,6 +197,11 @@ export const mapStateToProps = (state: { collections: CollectionsState }) => {
 
 export default compose(
   translate(),
-  withErrorHandler({ name: 'Collection' }),
+  withErrorHandler({
+    // This allows to sync the client and the server error handler ids, thus
+    // allowing the client side to be aware of errors thrown on the server.
+    id: 'Collection-001',
+    name: 'Collection',
+  }),
   connect(mapStateToProps),
 )(CollectionBase);

--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -1,0 +1,73 @@
+@import "~amo/css/inc/vars";
+@import "~core/css/inc/mixins";
+@import "~photon-colors/colors";
+@import "~ui/css/vars";
+
+.Collection {
+  padding: 20px 10px;
+}
+
+.Collection-title {
+  @include font-light();
+
+  font-size: $font-size-l;
+}
+
+.Collection-description {
+  font-size: $font-size-s;
+}
+
+.Collection-metadata {
+  background-color: $grey-10;
+  border-radius: $border-radius-m;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.Collection-number-of-addons,
+.Collection-author-name,
+.Collection-last-updated {
+  @include text-align-start();
+
+  flex: 1;
+  margin: 10px 15px;
+  max-width: 30%;
+
+  dd {
+    margin: 0;
+  }
+
+  dt {
+    color: $grey-50;
+  }
+}
+
+.Collection-author-name-value {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@include respond-to(large) {
+  .Collection-wrapper {
+    display: grid;
+    grid-auto-flow: column dense;
+    grid-gap: 0 10px;
+    grid-template-columns: minmax(300px, 35%) auto;
+    margin: 10px 0 0;
+
+    .Collection-detail {
+      grid-column: 1;
+    }
+
+    .Collection-items {
+      grid-column: 2;
+
+      .CardList {
+        margin-top: 0;
+      }
+    }
+  }
+}

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -21,6 +21,7 @@ import NotAuthorized from './components/ErrorPage/NotAuthorized';
 import NotFound from './components/ErrorPage/NotFound';
 import SearchPage from './components/SearchPage';
 import ServerError from './components/ErrorPage/ServerError';
+import Collection from './components/Collection';
 
 // If you add a new route here, check that the nginx rules maintained by ops
 // are in sync. See:
@@ -31,6 +32,7 @@ export default (
     <IndexRoute component={Home} />
     <Route path="addon/:slug/" component={Addon} />
     <Route path="addon/:addonSlug/reviews/" component={AddonReviewList} />
+    <Route path="collections/:user/:slug/" component={Collection} />
     <Route path=":visibleAddonType/categories/" component={CategoriesPage} />
     <Route path=":visibleAddonType/featured/" component={FeaturedAddons} />
     <Route path=":visibleAddonType/:slug/" component={Category} />


### PR DESCRIPTION
Fix #3140 
~~⚠️ depends on #3256~~

---

This PR adds a new page: collection view. I reuse the `AddonsCard` component that displays a list of add-ons. It does not match the mock-ups yet because this component needs some love but I believe this should be done in a separate PR. Same for the pagination (see #3100).

## Gifs

![2017-09-28 14 01 37](https://user-images.githubusercontent.com/217628/30965621-4d7ca566-a456-11e7-9493-27c60bb4233a.gif)

## Screenshots

Loading:

<img width="1394" alt="screen shot 2017-09-29 at 15 59 55" src="https://user-images.githubusercontent.com/217628/31019244-54479138-a52f-11e7-9726-f644a56616c3.png">

Pagination:

<img width="1392" alt="screen shot 2017-09-28 at 13 58 32" src="https://user-images.githubusercontent.com/217628/30965637-5a141e1c-a456-11e7-9e50-a34e8cd844e1.png">

Extensions:

<img width="1392" alt="screen shot 2017-09-28 at 13 58 29" src="https://user-images.githubusercontent.com/217628/30965636-5a041698-a456-11e7-90b5-94d911858544.png">

Themes:

<img width="1392" alt="screen shot 2017-09-28 at 13 58 26" src="https://user-images.githubusercontent.com/217628/30965635-5a03f1ae-a456-11e7-907d-761ffe0a2812.png">

<details>
<summary>Smaller screens (more screenshots!)</summary>

![screen shot 2017-09-28 at 13 59 17](https://user-images.githubusercontent.com/217628/30965706-a0156ae2-a456-11e7-8af4-4fd44fcf1600.png)

![screen shot 2017-09-28 at 13 59 13](https://user-images.githubusercontent.com/217628/30965703-a00fa274-a456-11e7-8859-fdb1066a9578.png)

![screen shot 2017-09-28 at 13 59 08](https://user-images.githubusercontent.com/217628/30965704-a010f35e-a456-11e7-85fc-4e1bb7db2186.png)

![screen shot 2017-09-28 at 13 59 01](https://user-images.githubusercontent.com/217628/30965705-a014d3ca-a456-11e7-9e77-2d11b6dcb008.png)

</details>
