### PR TITLE
fix: Do not show version or history for themes

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -7,7 +7,11 @@ import Link from 'amo/components/Link';
 import ReportAbuseButton from 'amo/components/ReportAbuseButton';
 import translate from 'core/i18n/translate';
 import type { AddonType } from 'core/types/addons';
-import { isAddonAuthor, trimAndAddProtocolToUrl } from 'core/utils';
+import {
+  addonHasVersionHistory,
+  isAddonAuthor,
+  trimAndAddProtocolToUrl,
+} from 'core/utils';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
 
@@ -28,11 +32,9 @@ export class AddonMoreInfoBase extends React.Component {
 
     if (!addon) {
       return this.renderDefinitions({
-        version: <LoadingText minWidth={20} />,
         versionLastUpdated: <LoadingText minWidth={20} />,
         versionLicense: <LoadingText minWidth={20} />,
         addonId: <LoadingText minWidth={20} />,
-        versionHistoryLink: <LoadingText minWidth={20} />,
       });
     }
 
@@ -65,7 +67,8 @@ export class AddonMoreInfoBase extends React.Component {
           {i18n.gettext('Visit stats dashboard')}
         </Link>
       ) : null,
-      version: addon.current_version.version,
+      version: addonHasVersionHistory(addon) ?
+        addon.current_version.version : null,
       versionLastUpdated: i18n.sprintf(
         // translators: This will output, in English:
         // "2 months ago (Dec 12 2016)"
@@ -99,14 +102,14 @@ export class AddonMoreInfoBase extends React.Component {
         </Link>
       ) : null,
       addonId: addon.id,
-      versionHistoryLink: (
+      versionHistoryLink: addonHasVersionHistory(addon) ? (
         <Link
           className="AddonMoreInfo-version-history-link"
           href={`/addon/${addon.slug}/versions/`}
         >
           {i18n.gettext('See all versions')}
         </Link>
-      ),
+      ) : null,
       // Since current_beta_version is just an alias to the latest beta,
       // we can assume that no betas exist at all if it is null.
       betaVersionsLink: addon.current_beta_version ? (
@@ -126,10 +129,10 @@ export class AddonMoreInfoBase extends React.Component {
     statsLink = null,
     privacyPolicyLink = null,
     eulaLink = null,
-    version,
+    version = null,
     versionLastUpdated,
     versionLicenseLink = null,
-    versionHistoryLink,
+    versionHistoryLink = null,
     betaVersionsLink = null,
     addonId,
   }: Object) {
@@ -149,10 +152,12 @@ export class AddonMoreInfoBase extends React.Component {
             </ul>
           </dd>
         ) : null}
-        <dt className="AddonMoreInfo-version-title">
-          {i18n.gettext('Version')}
-        </dt>
-        <dd className="AddonMoreInfo-version">{version}</dd>
+        {version ? (
+          <dt className="AddonMoreInfo-version-title">
+            {i18n.gettext('Version')}
+          </dt>
+        ) : null}
+        {version ? <dd className="AddonMoreInfo-version">{version}</dd> : null}
         <dt className="AddonMoreInfo-last-updated-title">
           {i18n.gettext('Last updated')}
         </dt>
@@ -175,10 +180,12 @@ export class AddonMoreInfoBase extends React.Component {
           </dt>
         ) : null}
         {eulaLink ? <dd>{eulaLink}</dd> : null}
-        <dt className="AddonMoreInfo-version-history-title">
-          {i18n.gettext('Version History')}
-        </dt>
-        <dd>{versionHistoryLink}</dd>
+        {versionHistoryLink ? (
+          <dt className="AddonMoreInfo-version-history-title">
+            {i18n.gettext('Version History')}
+          </dt>
+        ) : null}
+        {versionHistoryLink ? <dd>{versionHistoryLink}</dd> : null}
         {betaVersionsLink ? (
           <dt className="AddonMoreInfo-beta-versions-title">
             {i18n.gettext('Beta Versions')}

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -38,6 +38,10 @@ export type AddonVersionType = {|
   // The `text` property is omitted from addon.current_version.license.
   license: { name: string, url: string },
   reviewed: Date,
+  // This is the developer-defined version number.
+  // It could, for example, be set to "0".
+  // See:
+  // https://github.com/mozilla/addons-frontend/pull/3271#discussion_r142159199
   version: string,
 |};
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -13,7 +13,9 @@ import { fetchAddon } from 'core/api';
 import GenericError from 'core/components/ErrorPage/GenericError';
 import NotFound from 'core/components/ErrorPage/NotFound';
 import {
+  ADDON_TYPE_COMPLETE_THEME,
   ADDON_TYPE_OPENSEARCH,
+  ADDON_TYPE_THEME,
   API_ADDON_TYPES_MAPPING,
   CATEGORY_COLORS,
   VISIBLE_ADDON_TYPES_MAPPING,
@@ -462,4 +464,16 @@ export function getCategoryColor(category) {
 export function parsePage(page) {
   const parsed = parseInt(page, 10);
   return Number.isNaN(parsed) || parsed < 1 ? 1 : parsed;
+}
+
+export function addonHasVersionHistory(addon) {
+  if (!addon) {
+    throw new Error('addon is required');
+  }
+
+  return ![
+    ADDON_TYPE_COMPLETE_THEME,
+    ADDON_TYPE_OPENSEARCH,
+    ADDON_TYPE_THEME,
+  ].includes(addon.type);
 }

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -4,11 +4,18 @@ import React from 'react';
 import AddonMoreInfo, {
   AddonMoreInfoBase,
 } from 'amo/components/AddonMoreInfo';
+import {
+  ADDON_TYPE_DICT,
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_LANG,
+  ADDON_TYPE_OPENSEARCH,
+} from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
   dispatchClientMetadata,
   dispatchSignInActions,
   fakeAddon,
+  fakeTheme,
 } from 'tests/unit/amo/helpers';
 import { getFakeI18nInst, shallowUntilTarget } from 'tests/unit/helpers';
 import LoadingText from 'ui/components/LoadingText';
@@ -34,18 +41,18 @@ describe(__filename, () => {
 
     // These fields will be visible during loading since
     // they will always exist for the loaded add-on.
-    expect(root.find('.AddonMoreInfo-version-title')).toHaveLength(1);
     expect(root.find('.AddonMoreInfo-last-updated-title')).toHaveLength(1);
-    expect(root.find('.AddonMoreInfo-version-history-title')).toHaveLength(1);
     expect(root.find('.AddonMoreInfo-database-id-title')).toHaveLength(1);
 
-    expect(root.find(LoadingText)).toHaveLength(4);
+    expect(root.find(LoadingText)).toHaveLength(2);
 
     // These fields will not be visible during loading
     // since they may not exist.
     expect(root.find('.AddonMoreInfo-links-title')).toHaveLength(0);
     expect(root.find('.AddonMoreInfo-license-title')).toHaveLength(0);
     expect(root.find('.AddonMoreInfo-privacy-policy-title')).toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-version-title')).toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-version-history-title')).toHaveLength(0);
     expect(root.find('.AddonMoreInfo-eula-title')).toHaveLength(0);
     expect(root.find('.AddonMoreInfo-beta-versions-title')).toHaveLength(0);
   });
@@ -254,14 +261,84 @@ describe(__filename, () => {
     expect(statsLink).toHaveProp('href', '/addon/coolio/statistics/');
   });
 
-  it('links to version history', () => {
-    const addon = createInternalAddon({ ...fakeAddon, slug: 'some-slug' });
+  it('links to version history if add-on is extension', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_EXTENSION,
+    });
+
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-version-history-title'))
       .toHaveLength(1);
     const link = root.find('.AddonMoreInfo-version-history-link');
     expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/`);
+  });
+
+  it('links to version history if add-on is a dictionary', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_DICT,
+    });
+
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-version-history-title'))
+      .toHaveLength(1);
+    const link = root.find('.AddonMoreInfo-version-history-link');
+    expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/`);
+  });
+
+  it('links to version history if add-on is a language pack', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_LANG,
+    });
+
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-version-history-title'))
+      .toHaveLength(1);
+    const link = root.find('.AddonMoreInfo-version-history-link');
+    expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/`);
+  });
+
+  it('omits version history for search plugins', () => {
+    // Search plugins only have one listed version so showing their
+    // version history is useless–we just omit it.
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_OPENSEARCH,
+    });
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-version-history-title'))
+      .toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-version-history-link'))
+      .toHaveLength(0);
+  });
+
+  it('omits version history for search tool', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_OPENSEARCH,
+    });
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-version-history-title'))
+      .toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-version-history-link'))
+      .toHaveLength(0);
+  });
+
+  it('omits version history for themes', () => {
+    const addon = createInternalAddon({ ...fakeTheme });
+    const root = render({ addon });
+
+    expect(root.find('.AddonMoreInfo-version-history-title'))
+      .toHaveLength(0);
+    expect(root.find('.AddonMoreInfo-version-history-link'))
+      .toHaveLength(0);
   });
 
   it('links to beta versions', () => {

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -124,6 +124,7 @@ export const fakeTheme = Object.freeze({
     version: '1.0',
   },
   type: ADDON_TYPE_THEME,
+  version: '0',
 });
 
 export const fakeInstalledAddon = Object.freeze({

--- a/tests/unit/core/test_utils.js
+++ b/tests/unit/core/test_utils.js
@@ -12,9 +12,11 @@ import { compose } from 'redux';
 import UAParser from 'ua-parser-js';
 
 import * as api from 'core/api';
-import { loadAddons } from 'core/reducers/addons';
 import {
+  ADDON_TYPE_COMPLETE_THEME,
+  ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
   CATEGORY_COLORS,
@@ -30,6 +32,7 @@ import {
 import {
   apiAddonTypeIsValid,
   addQueryParams,
+  addonHasVersionHistory,
   apiAddonType,
   convertBoolean,
   findAddon,
@@ -56,6 +59,7 @@ import {
 } from 'core/utils';
 import NotFound from 'core/components/ErrorPage/NotFound';
 import I18nProvider from 'core/i18n/Provider';
+import { createInternalAddon, loadAddons } from 'core/reducers/addons';
 import {
   fakeAddon,
   signedInApiState,
@@ -67,6 +71,57 @@ import {
   userAgents,
 } from 'tests/unit/helpers';
 
+
+describe('addonHasVersionHistory', () => {
+  function createAddonWithType(type) {
+    return createInternalAddon({ ...fakeAddon, type });
+  }
+
+  it('requires an addon', () => {
+    expect(() => {
+      addonHasVersionHistory();
+    }).toThrow('addon is required');
+  });
+
+  it('returns false for complete (legacy/XUL) theme', () => {
+    const addon = createAddonWithType(ADDON_TYPE_COMPLETE_THEME);
+
+    expect(addonHasVersionHistory(addon)).toEqual(false);
+  });
+
+  it('returns true for dictionary', () => {
+    const addon = createAddonWithType(ADDON_TYPE_DICT);
+
+    expect(addonHasVersionHistory(addon)).toEqual(true);
+  });
+
+  it('returns true for extension', () => {
+    const addon = createAddonWithType(ADDON_TYPE_EXTENSION);
+
+    expect(addonHasVersionHistory(addon)).toEqual(true);
+  });
+
+  it('returns true for language pack', () => {
+    const addon = createAddonWithType(ADDON_TYPE_LANG);
+
+    expect(addonHasVersionHistory(addon)).toEqual(true);
+  });
+
+  it('returns false for search tool', () => {
+    // Search plugins only have one listed version so showing their
+    // version history is useless. It's best to just say they don't
+    // have a history.
+    const addon = createAddonWithType(ADDON_TYPE_OPENSEARCH);
+
+    expect(addonHasVersionHistory(addon)).toEqual(false);
+  });
+
+  it('returns false for theme', () => {
+    const addon = createAddonWithType(ADDON_TYPE_THEME);
+
+    expect(addonHasVersionHistory(addon)).toEqual(false);
+  });
+});
 
 describe('apiAddonType', () => {
   it('maps plural/visible addonTypes to internal types', () => {


### PR DESCRIPTION
Fix #3265

Prevents showing version info is the version is "0" and only show versions for add-ons that support version history.

Themes more info cards now look like:

<img width="586" alt="screenshot 2017-09-28 17 34 17" src="https://user-images.githubusercontent.com/90871/30979491-af26000e-a475-11e7-97fc-48a52a1029c0.png">
