### PR TITLE
feat: Add more section to header

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -17,7 +17,7 @@
     padding: 0 $header-footer-gutter 10px;
   }
 
-  @include respond-to(large) {
+  @include respond-to(extraLarge) {
     grid-template-columns: max-content auto auto;
     grid-template-rows: 46px auto;
     margin: 0 auto;
@@ -46,7 +46,7 @@
     margin: 24px 0 0;
   }
 
-  @include respond-to(large) {
+  @include respond-to(extraLarge) {
     @include margin-end(24px);
 
     align-self: center;
@@ -67,7 +67,7 @@
     vertical-align: middle;
   }
 
-  @include respond-to(large) {
+  @include respond-to(extraLarge) {
     vertical-align: bottom;
   }
 }
@@ -105,7 +105,7 @@
     grid-row: 1 / 2;
   }
 
-  @include respond-to(large) {
+  @include respond-to(extraLarge) {
     grid-column: 2 / -1;
     grid-row: 1 / 2;
   }
@@ -113,7 +113,6 @@
 
 .Header-button {
   margin-bottom: 12px;
-  vertical-align: top;
 }
 
 .Header-developer-hub-link {
@@ -157,7 +156,7 @@
     margin: 0;
   }
 
-  @include respond-to(large) {
+  @include respond-to(extraLarge) {
     @include margin-end(12px);
 
     align-self: center;
@@ -183,7 +182,7 @@
     max-width: 250px;
   }
 
-  @include respond-to(large) {
+  @include respond-to(extraLarge) {
     align-self: center;
     margin-top: 6px;
     max-width: 284px;

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -1,41 +1,73 @@
+/* @flow */
 import classNames from 'classnames';
 import React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 
 import Link from 'amo/components/Link';
-import type { ViewContextType } from 'amo/reducers/viewContext';
+import { setClientApp } from 'core/actions';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
   VIEW_CONTEXT_EXPLORE,
   VIEW_CONTEXT_HOME,
+  VIEW_CONTEXT_LANGUAGE_TOOLS,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { visibleAddonType } from 'core/utils';
+import DropdownMenu from 'ui/components/DropdownMenu';
+import DropdownMenuItem from 'ui/components/DropdownMenuItem';
+import type { ViewContextType } from 'amo/reducers/viewContext';
+import type { ApiStateType } from 'core/reducers/api';
 
 import './styles.scss';
 
 
-type SectionLinksProps = {
+type SectionLinksProps = {|
   className?: string,
+  clientApp: string,
+  dispatch: Function,
   i18n: Object,
+  router: Object,
   viewContext: ViewContextType,
-}
+|};
 
 export class SectionLinksBase extends React.Component {
+  setClientApp = (event: Object) => {
+    event.preventDefault();
+
+    const { dispatch, router } = this.props;
+
+    const clientApp = event.currentTarget.getAttribute('data-clientapp');
+
+    dispatch(setClientApp(clientApp));
+    router.push(event.currentTarget.getAttribute('href'));
+  }
+
   props: SectionLinksProps;
 
   render() {
-    const { className, i18n, viewContext } = this.props;
+    const { className, clientApp, i18n, viewContext } = this.props;
     const isExploring = [VIEW_CONTEXT_EXPLORE, VIEW_CONTEXT_HOME]
       .includes(viewContext);
+
+    let forBrowserNameText;
+    if (clientApp === CLIENT_APP_FIREFOX) {
+      forBrowserNameText = i18n.gettext('for Firefox');
+    } else if (clientApp === CLIENT_APP_ANDROID) {
+      forBrowserNameText = i18n.gettext('for Android');
+    }
 
     return (
       <ul className={classNames('SectionLinks', className)}>
         <li>
           <Link
-            className={classNames('SectionLinks-link', { 'SectionLinks-link--active': isExploring })}
+            className={classNames('SectionLinks-link', 'SectionLinks-explore', {
+              'SectionLinks-link--active': isExploring,
+            })}
             to="/"
           >
             {i18n.gettext('Explore')}
@@ -44,7 +76,8 @@ export class SectionLinksBase extends React.Component {
         <li>
           <Link
             className={classNames('SectionLinks-link', {
-              'SectionLinks-link--active': viewContext === ADDON_TYPE_EXTENSION,
+              'SectionLinks-link--active': viewContext ===
+                ADDON_TYPE_EXTENSION,
             })}
             to={`/${visibleAddonType(ADDON_TYPE_EXTENSION)}/`}
           >
@@ -61,16 +94,84 @@ export class SectionLinksBase extends React.Component {
             {i18n.gettext('Themes')}
           </Link>
         </li>
+        <li>
+          <DropdownMenu
+            className="SectionLinks-link SectionLinks-dropdown"
+            text={i18n.gettext('More…')}
+          >
+            <DropdownMenuItem className="SectionLinks-subheader">
+              {forBrowserNameText}
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <Link
+                className={classNames('SectionLinks-dropdownlink', {
+                  'SectionLinks-dropdownlink--active': viewContext ===
+                    VIEW_CONTEXT_LANGUAGE_TOOLS,
+                })}
+                to="/language-tools/"
+              >
+                {i18n.gettext('Dictionaries & Language Packs')}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <Link
+                className="SectionLinks-dropdownlink"
+                href="/search-tools/"
+              >
+                {i18n.gettext('Search Tools')}
+              </Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem className="SectionLinks-subheader">
+              {i18n.gettext('Other Browser Sites')}
+            </DropdownMenuItem>
+            {clientApp !== CLIENT_APP_ANDROID ? (
+              <DropdownMenuItem>
+                <Link
+                  className={`SectionLinks-clientApp-${CLIENT_APP_ANDROID}`}
+                  data-clientapp={CLIENT_APP_ANDROID}
+                  onClick={this.setClientApp}
+                  prependClientApp={false}
+                  to={`/${CLIENT_APP_ANDROID}/`}
+                >
+                  {i18n.gettext('Add-ons for Android')}
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+            {clientApp !== CLIENT_APP_FIREFOX ? (
+              <DropdownMenuItem>
+                <Link
+                  className={`SectionLinks-clientApp-${CLIENT_APP_FIREFOX}`}
+                  data-clientapp={CLIENT_APP_FIREFOX}
+                  onClick={this.setClientApp}
+                  prependClientApp={false}
+                  to={`/${CLIENT_APP_FIREFOX}/`}
+                >
+                  {i18n.gettext('Add-ons for Firefox')}
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenu>
+        </li>
       </ul>
     );
   }
 }
 
-export function mapStateToProps(state: { viewContext: ViewContextType }) {
-  return { viewContext: state.viewContext.context };
+export function mapStateToProps(
+  state: {
+    api: ApiStateType,
+    viewContext: ViewContextType,
+  }
+) {
+  return {
+    clientApp: state.api.clientApp,
+    viewContext: state.viewContext.context,
+  };
 }
 
 export default compose(
+  withRouter,
   connect(mapStateToProps),
   translate(),
 )(SectionLinksBase);

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -44,3 +44,38 @@
     border-bottom: 3px solid $white;
   }
 }
+
+.SectionLinks-explore {
+  display: none;
+
+  @include respond-to(large) {
+    display: inline-block;
+  }
+}
+
+.SectionLinks-dropdown {
+  padding: 0;
+  white-space: nowrap;
+
+  &,
+  &:active,
+  &:focus,
+  &:hover {
+    border-bottom: 0;
+  }
+
+  .DropdownMenu-button {
+    display: block;
+    margin-top: 2px;
+    padding: 0;
+  }
+
+  .DropdownMenu-button-text {
+    color: $grey-40;
+    font-size: $font-size-m-smaller;
+  }
+
+  .DropdownMenu-items {
+    top: 22px;
+  }
+}

--- a/src/amo/reducers/viewContext.js
+++ b/src/amo/reducers/viewContext.js
@@ -4,13 +4,14 @@ import {
   ADDON_TYPE_THEME,
   VIEW_CONTEXT_EXPLORE,
   VIEW_CONTEXT_HOME,
+  VIEW_CONTEXT_LANGUAGE_TOOLS,
   SET_VIEW_CONTEXT,
 } from 'core/constants';
 
 
 export type ViewContextType = {|
   context: ADDON_TYPE_EXTENSION | ADDON_TYPE_THEME | VIEW_CONTEXT_EXPLORE |
-    VIEW_CONTEXT_HOME,
+    VIEW_CONTEXT_HOME | VIEW_CONTEXT_LANGUAGE_TOOLS,
 |}
 
 export type ViewContextActionType = {|

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -92,6 +92,9 @@ export const TRACKING_TYPE_INVALID = 'invalid';
 // View Contexts that aren't an addonType
 export const VIEW_CONTEXT_EXPLORE = 'VIEW_CONTEXT_EXPLORE';
 export const VIEW_CONTEXT_HOME = 'VIEW_CONTEXT_HOME';
+// Language tools contain both ADDON_TYPE_DICT and ADDON_TYPE_LANG so
+// we share a custom view context for both add-on types.
+export const VIEW_CONTEXT_LANGUAGE_TOOLS = 'VIEW_CONTEXT_LANGUAGE_TOOLS';
 
 // Add-on Search Sort Values
 export const SEARCH_SORT_POPULAR = 'hotness';

--- a/tests/unit/amo/components/TestSectionLinks.js
+++ b/tests/unit/amo/components/TestSectionLinks.js
@@ -2,17 +2,26 @@ import React from 'react';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import SectionLinks, { SectionLinksBase } from 'amo/components/SectionLinks';
+import { setClientApp } from 'core/actions';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
   VIEW_CONTEXT_EXPLORE,
   VIEW_CONTEXT_HOME,
+  VIEW_CONTEXT_LANGUAGE_TOOLS,
 } from 'core/constants';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
-import { getFakeI18nInst, shallowUntilTarget } from 'tests/unit/helpers';
+import {
+  createFakeEvent,
+  getFakeI18nInst,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+import DropdownMenu from 'ui/components/DropdownMenu';
 
 
-describe('SectionLinks Component', () => {
+describe(__filename, () => {
   let _store;
 
   beforeEach(() => {
@@ -28,10 +37,32 @@ describe('SectionLinks Component', () => {
     return shallowUntilTarget(<SectionLinks {...props} />, SectionLinksBase);
   }
 
-  it('renders three sections', () => {
+  it('renders four sections', () => {
     const root = render({ viewContext: ADDON_TYPE_EXTENSION });
 
-    expect(root.find('.SectionLinks-link').length).toEqual(3);
+    expect(root.find('.SectionLinks-link')).toHaveLength(4);
+  });
+
+  it('renders a DropdownMenu for the "More" section', () => {
+    const root = render({ viewContext: ADDON_TYPE_EXTENSION });
+
+    expect(root.find(DropdownMenu)).toHaveLength(1);
+  });
+
+  it('renders a link to the Language Tools page', () => {
+    const root = render({ viewContext: ADDON_TYPE_EXTENSION });
+
+    expect(root.find('.SectionLinks-dropdownlink').findWhere((element) => {
+      return element.prop('to') === '/language-tools/';
+    })).toHaveProp('children', 'Dictionaries & Language Packs');
+  });
+
+  it('renders a link to the Search Tools page', () => {
+    const root = render({ viewContext: ADDON_TYPE_EXTENSION });
+
+    expect(root.find('.SectionLinks-dropdownlink').findWhere((element) => {
+      return element.prop('href') === '/search-tools/';
+    })).toHaveProp('children', 'Search Tools');
   });
 
   it('renders Explore active on homepage', () => {
@@ -63,5 +94,68 @@ describe('SectionLinks Component', () => {
 
     expect(root.find('.SectionLinks-link--active').children())
       .toIncludeText('Themes');
+  });
+
+  it('renders Language Tools active when viewContext is languageTools', () => {
+    _store.dispatch(setViewContext(VIEW_CONTEXT_LANGUAGE_TOOLS));
+    const root = render();
+
+    expect(root.find('.SectionLinks-dropdownlink--active').children())
+      .toIncludeText('Dictionaries & Language Packs');
+  });
+
+  it('shows Firefox name and hides link in header on Desktop', () => {
+    _store.dispatch(setClientApp(CLIENT_APP_FIREFOX));
+    const root = render();
+
+    expect(root.find('.SectionLinks-subheader').at(0).children())
+      .toIncludeText('for Firefox');
+    expect(root.find(`.SectionLinks-clientApp-${CLIENT_APP_ANDROID}`))
+      .toHaveLength(1);
+    expect(root.find(`.SectionLinks-clientApp-${CLIENT_APP_FIREFOX}`))
+      .toHaveLength(0);
+  });
+
+  it('shows Android name and hides link in header on Android', () => {
+    _store.dispatch(setClientApp(CLIENT_APP_ANDROID));
+    const root = render();
+
+    expect(root.find('.SectionLinks-subheader').at(0).children())
+      .toIncludeText('for Android');
+    expect(root.find(`.SectionLinks-clientApp-${CLIENT_APP_ANDROID}`))
+      .toHaveLength(0);
+    expect(root.find(`.SectionLinks-clientApp-${CLIENT_APP_FIREFOX}`))
+      .toHaveLength(1);
+  });
+
+  it('changes clientApp when different site link clicked', () => {
+    const dispatchSpy = sinon.spy(_store, 'dispatch');
+    const fakeEvent = createFakeEvent({
+      currentTarget: {
+        getAttribute: (attribute) => {
+          if (attribute === 'data-clientapp') {
+            return CLIENT_APP_ANDROID;
+          }
+          if (attribute === 'href') {
+            return `/en-US/${CLIENT_APP_ANDROID}/`;
+          }
+
+          return undefined;
+        },
+      },
+    });
+    const getAttributeSpy = sinon.spy(fakeEvent.currentTarget, 'getAttribute');
+    const fakeRouter = { push: sinon.stub() };
+    _store.dispatch(setClientApp(CLIENT_APP_FIREFOX));
+    const root = render({ router: fakeRouter });
+
+    root.find(`.SectionLinks-clientApp-android`)
+      .simulate('click', fakeEvent);
+
+    sinon.assert.called(fakeEvent.preventDefault);
+    sinon.assert.calledWith(getAttributeSpy, 'data-clientapp');
+    sinon.assert.calledWith(getAttributeSpy, 'href');
+    sinon.assert.calledWith(dispatchSpy, setClientApp(CLIENT_APP_ANDROID));
+    sinon.assert.calledWith(fakeRouter.push, `/en-US/${CLIENT_APP_ANDROID}/`);
   });
 });


### PR DESCRIPTION
fix #3281.

This adds links to Language Tools, Search Tools, and other apps to the header. This is in advance of language tools page.

The Explore link is the same as the home link, so we hide it on smaller screens because otherwise the header gets too crammed.

### Screenshots

<img width="767" alt="screenshot 2017-09-30 01 29 56" src="https://user-images.githubusercontent.com/90871/31040525-305fd4fa-a580-11e7-9989-25a62824f992.png">
<img width="341" alt="screenshot 2017-09-30 01 29 50" src="https://user-images.githubusercontent.com/90871/31040524-30587282-a580-11e7-8ed7-8574e888e75f.png">
<img width="655" alt="screenshot 2017-09-30 01 29 25" src="https://user-images.githubusercontent.com/90871/31040522-3055ac46-a580-11e7-83d5-5c22d1645544.png">
<img width="741" alt="screenshot 2017-09-30 01 29 19" src="https://user-images.githubusercontent.com/90871/31040523-3055df36-a580-11e7-955a-565d73760e41.png">


----


I know we argued again the "More" link but using "Extensions" as both a link and a dropdown was awkward UX and inconsistent. Putting the link inside that dropdown seemed like bad UX because then it was extra work (and two taps on a touch device) to get to Extensions landing page which is a very important page. So I settled on the more link, especially because I think the Dropdown @willdurand added is quite nice 😄 