### PR TITLE
chore: Remove LoadingBar

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "react-onclickoutside": "6.6.0",
     "react-photoswipe": "1.3.0",
     "react-redux": "5.0.6",
-    "react-redux-loading-bar": "2.9.3",
     "react-router": "2.8.1",
     "react-router-scroll": "0.4.3",
     "react-textarea-autosize": "^5.1.0",

--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -7,7 +7,6 @@ import React from 'react';
 import cookie from 'react-cookie';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
-import LoadingBar from 'react-redux-loading-bar';
 import NestedStatus from 'react-nested-status';
 import { compose } from 'redux';
 
@@ -199,7 +198,6 @@ export class AppBase extends React.Component {
     return (
       <NestedStatus code={200}>
         <div className="amo">
-          <LoadingBar className="App-loading-bar" />
           <Helmet defaultTitle={i18n.gettext('Add-ons for Firefox')} />
           <InfoDialogComponent />
           <HeaderComponent

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -108,11 +108,3 @@ fieldset {
   margin: 0;
   padding: 0;
 }
-
-.App-loading-bar {
-  background: $loading-bar-color;
-  height: 2px;
-  position: fixed;
-  top: 0;
-  z-index: 10000;
-}

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -1,7 +1,6 @@
 @import "~core/css/inc/vars";
 
 $body-font-color: #000;
-$loading-bar-color: #329af0;
 
 // This is the color used for the Header and Footer background and the
 // basis of the SearchForm and Footer background colors.

--- a/src/amo/sagas/categories.js
+++ b/src/amo/sagas/categories.js
@@ -1,7 +1,6 @@
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import { call, put, select, takeEvery } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
@@ -15,15 +14,12 @@ import { createErrorHandler, getState } from 'core/sagas/utils';
 export function* fetchCategories({ payload: { errorHandlerId } }) {
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
-    yield put(showLoading());
     const state = yield select(getState);
     const response = yield call(categoriesApi, { api: state.api });
     yield put(categoriesLoad(response));
   } catch (error) {
     log.warn('Categories failed to load:', error);
     yield put(errorHandler.createErrorAction(error));
-  } finally {
-    yield put(hideLoading());
   }
 }
 

--- a/src/amo/sagas/featured.js
+++ b/src/amo/sagas/featured.js
@@ -1,7 +1,6 @@
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import { call, put, select, takeEvery } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
@@ -18,8 +17,6 @@ export function* fetchFeaturedAddons(
 ) {
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
-    yield put(showLoading());
-
     const state = yield select(getState);
     const filters = { addonType, page_size: FEATURED_ADDONS_TO_LOAD };
     const response = yield call(featuredApi, { api: state.api, filters });
@@ -34,8 +31,6 @@ export function* fetchFeaturedAddons(
       `Failed to fetch featured add-ons for addonType ${addonType}: ${error}`);
 
     yield put(errorHandler.createErrorAction(error));
-  } finally {
-    yield put(hideLoading());
   }
 }
 

--- a/src/amo/sagas/landing.js
+++ b/src/amo/sagas/landing.js
@@ -1,8 +1,7 @@
-import { oneLine } from 'common-tags';
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
+import { oneLine } from 'common-tags';
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
@@ -22,8 +21,6 @@ export function* fetchLandingAddons(
 ) {
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
-    yield put(showLoading());
-
     const state = yield select(getState);
     const { api } = state;
     const filters = { addonType, page_size: LANDING_PAGE_ADDON_COUNT };
@@ -50,8 +47,6 @@ export function* fetchLandingAddons(
       addonType ${addonType}: ${error}`);
 
     yield put(errorHandler.createErrorAction(error));
-  } finally {
-    yield put(hideLoading());
   }
 }
 

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -3,7 +3,6 @@
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import { call, put, select, takeEvery } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
@@ -22,7 +21,6 @@ export function* fetchReviews(
 ): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
-    yield put(showLoading());
     const state = yield select(getState);
     const response = yield call(getReviews, {
       // Hide star-only ratings (reviews that do not have a body).
@@ -34,8 +32,6 @@ export function* fetchReviews(
   } catch (error) {
     log.warn(`Failed to load reviews for add-on slug ${addonSlug}: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-  } finally {
-    yield put(hideLoading());
   }
 }
 

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -1,4 +1,3 @@
-import { loadingBarReducer } from 'react-redux-loading-bar';
 import { createStore as _createStore, combineReducers } from 'redux';
 import { reducer as reduxAsyncConnect } from 'redux-connect';
 import createSagaMiddleware from 'redux-saga';
@@ -39,7 +38,6 @@ export default function createStore(initialState = {}) {
       infoDialog,
       installations,
       landing,
-      loadingBar: loadingBarReducer,
       reduxAsyncConnect,
       reviews,
       search,

--- a/src/core/sagas/addons.js
+++ b/src/core/sagas/addons.js
@@ -3,7 +3,6 @@
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import { call, put, select, takeEvery } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
@@ -21,15 +20,12 @@ export function* fetchAddon(
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
   try {
-    yield put(showLoading());
     const state = yield select(getState);
     const response = yield call(fetchAddonFromApi, { api: state.api, slug });
     yield put(loadAddons(response.entities));
   } catch (error) {
     log.warn(`Failed to load add-on with slug ${slug}: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-  } finally {
-    yield put(hideLoading());
   }
 }
 

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -1,25 +1,8 @@
 /* global window */
-
-import { applyMiddleware, compose } from 'redux';
-import { loadingBarMiddleware } from 'react-redux-loading-bar';
-import { createLogger } from 'redux-logger';
 import config from 'config';
+import { applyMiddleware, compose } from 'redux';
+import { createLogger } from 'redux-logger';
 
-
-// These are the actions the loading indicator will respond to for showing
-// or hiding the loading bar.
-// These are existing reduxConnect actions that we hook into to dispatch
-// the loading bar actions.
-// This can probably go away when we move to something like redux-saga.
-const PROMISE_PREFIXES = {
-  promiseTypeSuffixes: [
-    // Dispatching this action shows the loading bar and starts its animation.
-    'BEGIN_GLOBAL_LOAD',
-    // Dispatching either of the following actions stop/hide the loading bar.
-    'END_GLOBAL_LOAD',
-    'LOAD_FAIL',
-  ],
-};
 
 /*
  * Enhance a redux store with common middleware.
@@ -43,7 +26,6 @@ export function middleware({
   if (sagaMiddleware) {
     callbacks.push(sagaMiddleware);
   }
-  callbacks.push(loadingBarMiddleware(PROMISE_PREFIXES));
 
   return compose(
     applyMiddleware(...callbacks),

--- a/tests/unit/amo/sagas/testCategories.js
+++ b/tests/unit/amo/sagas/testCategories.js
@@ -1,4 +1,3 @@
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import SagaTester from 'redux-saga-tester';
 
 import categoriesSaga from 'amo/sagas/categories';
@@ -72,14 +71,8 @@ describe('categoriesSaga', () => {
     // First action is CATEGORIES_FETCH.
     expect(calledActions[0]).toEqual(_categoriesFetch());
 
-    // Next action is showing the loading bar.
-    expect(calledActions[1]).toEqual(showLoading());
-
     // Next action is loading the categories returned by the API.
-    expect(calledActions[2]).toEqual(actions.categoriesLoad({ result }));
-
-    // Last action is to hide the loading bar.
-    expect(calledActions[3]).toEqual(hideLoading());
+    expect(calledActions[1]).toEqual(actions.categoriesLoad({ result }));
 
     mockApi.verify();
   });
@@ -97,8 +90,7 @@ describe('categoriesSaga', () => {
     await sagaTester.waitFor(errorAction.type);
 
     const calledActions = sagaTester.getCalledActions();
-    expect(calledActions[2]).toEqual(errorAction);
-    expect(calledActions[3]).toEqual(hideLoading());
+    expect(calledActions[1]).toEqual(errorAction);
   });
 
   it('should respond to all CATEGORIES_FETCH actions', async () => {

--- a/tests/unit/amo/sagas/testFeatured.js
+++ b/tests/unit/amo/sagas/testFeatured.js
@@ -1,4 +1,3 @@
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import SagaTester from 'redux-saga-tester';
 
 import * as api from 'core/api';
@@ -58,11 +57,9 @@ describe('amo/sagas/featured', () => {
       mockApi.verify();
 
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[1]).toEqual(showLoading());
-      expect(calledActions[2]).toEqual(loadFeatured({
+      expect(calledActions[1]).toEqual(loadFeatured({
         addonType, entities, result,
       }));
-      expect(calledActions[3]).toEqual(hideLoading());
     });
 
     it('dispatches an error', async () => {
@@ -74,8 +71,7 @@ describe('amo/sagas/featured', () => {
       const errorAction = errorHandler.createErrorAction(error);
       await sagaTester.waitFor(errorAction.type);
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[2]).toEqual(errorAction);
-      expect(calledActions[3]).toEqual(hideLoading());
+      expect(calledActions[1]).toEqual(errorAction);
     });
   });
 });

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -1,4 +1,3 @@
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import SagaTester from 'redux-saga-tester';
 
 import * as api from 'core/api';
@@ -99,11 +98,9 @@ describe('amo/sagas/landing', () => {
       mockApi.verify();
 
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[1]).toEqual(showLoading());
-      expect(calledActions[2]).toEqual(loadLanding({
+      expect(calledActions[1]).toEqual(loadLanding({
         addonType, featured, highlyRated, popular,
       }));
-      expect(calledActions[3]).toEqual(hideLoading());
     });
 
     it('dispatches an error', async () => {
@@ -116,8 +113,7 @@ describe('amo/sagas/landing', () => {
       await sagaTester.waitFor(errorAction.type);
 
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[2]).toEqual(errorAction);
-      expect(calledActions[3]).toEqual(hideLoading());
+      expect(calledActions[1]).toEqual(errorAction);
     });
   });
 });

--- a/tests/unit/amo/sagas/testReviews.js
+++ b/tests/unit/amo/sagas/testReviews.js
@@ -1,4 +1,3 @@
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import SagaTester from 'redux-saga-tester';
 
 import * as amoApi from 'amo/api';
@@ -60,11 +59,9 @@ describe('amo/sagas/reviews', () => {
       mockAmoApi.verify();
 
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[1]).toEqual(showLoading());
-      expect(calledActions[2]).toEqual(setAddonReviews({
+      expect(calledActions[1]).toEqual(setAddonReviews({
         addonSlug: fakeAddon.slug, reviews, reviewCount: 1,
       }));
-      expect(calledActions[3]).toEqual(hideLoading());
     });
 
     it('dispatches an error', async () => {
@@ -76,8 +73,7 @@ describe('amo/sagas/reviews', () => {
       const errorAction = errorHandler.createErrorAction(error);
       await sagaTester.waitFor(errorAction.type);
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[2]).toEqual(errorAction);
-      expect(calledActions[3]).toEqual(hideLoading());
+      expect(calledActions[1]).toEqual(errorAction);
     });
   });
 });

--- a/tests/unit/amo/test_store.js
+++ b/tests/unit/amo/test_store.js
@@ -16,7 +16,6 @@ describe('amo createStore', () => {
       'infoDialog',
       'installations',
       'landing',
-      'loadingBar',
       'reduxAsyncConnect',
       'reviews',
       'search',

--- a/tests/unit/core/sagas/testAddons.js
+++ b/tests/unit/core/sagas/testAddons.js
@@ -1,4 +1,3 @@
-import { hideLoading, showLoading } from 'react-redux-loading-bar';
 import SagaTester from 'redux-saga-tester';
 
 import * as api from 'core/api';
@@ -51,18 +50,6 @@ describe('core/sagas/addons', () => {
     mockApi.verify();
   });
 
-  it('shows a progress bar', async () => {
-    mockApi
-      .expects('fetchAddon')
-      .returns(Promise.resolve(createFetchAddonResult(fakeAddon)));
-
-    _fetchAddon();
-
-    await sagaTester.waitFor(LOAD_ADDONS);
-    expect(sagaTester.getCalledActions()[2]).toEqual(showLoading());
-    expect(sagaTester.getCalledActions()[4]).toEqual(hideLoading());
-  });
-
   it('clears the error handler', async () => {
     mockApi
       .expects('fetchAddon')
@@ -83,7 +70,6 @@ describe('core/sagas/addons', () => {
 
     const errorAction = errorHandler.createErrorAction(error);
     await sagaTester.waitFor(errorAction.type);
-    expect(sagaTester.getCalledActions()[3]).toEqual(errorAction);
-    expect(sagaTester.getCalledActions()[4]).toEqual(hideLoading());
+    expect(sagaTester.getCalledActions()[2]).toEqual(errorAction);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6625,12 +6625,6 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-redux-loading-bar@2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-2.9.2.tgz#f0e604ee35af5ecb25addb10bf24ca3d478c95a8"
-  dependencies:
-    prop-types "^15.5.6"
-
 react-redux@5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"


### PR DESCRIPTION
Close #1156
Close #2179
Close #3291

This removes the blue LoadingBar from the top of all pages and from our saga code. This tidies up the tests, sagas, and UI. Yay! 🎉 