### PR TITLE
fix: Add copy to landing page

### DIFF
--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -190,11 +190,10 @@ export class LandingPageBase extends React.Component {
       [ADDON_TYPE_EXTENSION]: i18n.gettext('Extensions'),
     };
     const contentText = {
-      [ADDON_TYPE_THEME]: i18n.gettext(oneLine`Change your browser's
-        appearance. Choose from thousands of themes to give Firefox the look
-        you want.`),
-      [ADDON_TYPE_EXTENSION]: i18n.gettext(oneLine`Install powerful tools that
-        make browsing faster and safer, add-ons make your browser yours.`),
+      [ADDON_TYPE_THEME]: i18n.gettext(`Change your browser's appearance.
+        Choose from thousands of themes to give Firefox the look you want.`),
+      [ADDON_TYPE_EXTENSION]: i18n.gettext(`Explore powerful tools and features
+        to customize Firefox and make the browser all your own.`),
     };
 
     return (


### PR DESCRIPTION
Also fixes a `oneLine` `i18n` bug.

Fixes #3282

### Before

![ext_h](https://user-images.githubusercontent.com/15685960/31069291-8436e2f4-a764-11e7-8f4c-1e650e922000.png)

### After

<img width="1539" alt="screenshot 2017-10-02 11 46 16" src="https://user-images.githubusercontent.com/90871/31074205-6b95ac1e-a767-11e7-9405-6dfb93c6e3cb.png">
