### PR TITLE
fix: Remove small-caps

### DIFF
--- a/src/core/components/Paginate/Paginate.scss
+++ b/src/core/components/Paginate/Paginate.scss
@@ -27,7 +27,6 @@
 
   display: inline-block;
   font-size: $font-size-s;
-  font-variant: small-caps;
   font-weight: normal;
   line-height: 2;
   min-width: 48%;

--- a/src/ui/components/Card/Card.scss
+++ b/src/ui/components/Card/Card.scss
@@ -41,7 +41,6 @@ $footer-padding: 10px;
 
   border-bottom-left-radius: $border-radius-default;
   border-bottom-right-radius: $border-radius-default;
-  font-variant: all-small-caps;
   margin-top: 1px;
   padding: 0;
   text-align: center;


### PR DESCRIPTION
Fix #3190.

This removes the small-caps on all of our `Card` elements. Small-caps are very bad for accessibility.

I know we need to update the pagination styles (#3100) but I removed the small-caps for now, anyway.

### Before
<img width="451" alt="screenshot 2017-09-20 13 31 05" src="https://user-images.githubusercontent.com/90871/30643741-0d045e6a-9e08-11e7-9d1a-1887f083029a.png">
<img width="810" alt="screenshot 2017-09-20 13 31 03" src="https://user-images.githubusercontent.com/90871/30643740-0d031884-9e08-11e7-967a-31dd4f680a52.png">

### After
![screen shot 2017-10-02 at 15 14 07](https://user-images.githubusercontent.com/90871/31081709-a3a56a6e-a784-11e7-9b5a-3847e1bd3267.png)
![screen shot 2017-10-02 at 15 13 49](https://user-images.githubusercontent.com/90871/31081711-a3e23732-a784-11e7-916b-a84dc4fb392d.png)
![screen shot 2017-10-02 at 15 13 46](https://user-images.githubusercontent.com/90871/31081710-a3c8833c-a784-11e7-8ff4-aa6e0ddd39ea.png)
