### PR TITLE
chore: Fix current_version placement for #3265

### DIFF
--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -100,6 +100,10 @@ export const fakeTheme = Object.freeze({
     url: 'http://olympia.dev/en-US/firefox/user/madonna/',
     username: 'MaDonna',
   }],
+  current_version: {
+    ...fakeAddon.current_version,
+    version: '0',
+  },
   description: 'This is the add-on description',
   guid: 'dancing-daisies-theme@my-addons.firefox',
   id: 54321,
@@ -124,7 +128,6 @@ export const fakeTheme = Object.freeze({
     version: '1.0',
   },
   type: ADDON_TYPE_THEME,
-  version: '0',
 });
 
 export const fakeInstalledAddon = Object.freeze({


### PR DESCRIPTION
Just fixes https://github.com/mozilla/addons-frontend/pull/3271/files/898b68b8aaf607001ea88fd884b3fb91fb82947a#diff-54c8950d51a2194d71ef543a52684043.

Will merge if green but feel free to review if you like 😉 