### PR TITLE
fix: Do not uppercase login text

### DIFF
--- a/src/amo/components/AddonReview/styles.scss
+++ b/src/amo/components/AddonReview/styles.scss
@@ -56,6 +56,5 @@
   // for the rounded corners of the overlay.
   padding: 15px 0 5px;
   text-align: center;
-  text-transform: uppercase;
   vertical-align: bottom;
 }

--- a/src/amo/components/Home/styles.scss
+++ b/src/amo/components/Home/styles.scss
@@ -118,7 +118,6 @@
   padding: 10px;
   text-align: center;
   text-decoration: none;
-  text-transform: uppercase;
   width: calc(100% - 40px);
 
   &:hover,

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -18,6 +18,5 @@ $button-height:
   margin-top: $rating-top-margin + $button-margin;
   padding: 0;
   position: absolute;
-  text-transform: uppercase;
   width: 100%;
 }


### PR DESCRIPTION
Fix #3322

### Before
![image](https://user-images.githubusercontent.com/31961530/31121135-afcbea8c-a83f-11e7-93b6-cd9d1578cb3d.png)

### After
<img width="459" alt="screenshot 2017-10-03 16 37 50" src="https://user-images.githubusercontent.com/90871/31134206-5d0552b0-a859-11e7-8e94-e4e4042ed53e.png">
