### PR TITLE
Fix header on iOS 11

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -8,6 +8,7 @@
   background: $ink-90;
   display: grid;
   grid-template-columns: min-content auto;
+  max-width: 100vw;
   min-height: 112px;
   padding: 0 12px;
 


### PR DESCRIPTION
This fixes the header on iOS 11 by setting `max-width` to the display width.

## Issue checklist

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [ ] Add `Fixes #ISSUENUM` at the top of your PR. (#3079, only fixes iOS 11, not iOS 10)
* [x] Add a description of the the changes introduced in this PR.
* [ ] The change has been successfully run locally. (I can’t run `yarn amo` for some reason, I use Windows 10)
* [ ] Add tests to cover the changes added in this PR.
* [ ] Add before and after screenshots (Only for changes that impact the UI). (Before available at https://github.com/mozilla/addons-frontend/issues/3079#issuecomment-331026857, after unavailable because of `yarn` issues)