### PR TITLE
fix: Render carousel on client to fix CSP errors (fix #3349)

### DIFF
--- a/src/ui/components/Carousel/index.js
+++ b/src/ui/components/Carousel/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import classNames from 'classnames';
 import React from 'react';
 import { compose } from 'redux';
 import NukaCarousel from 'nuka-carousel';
@@ -54,7 +55,11 @@ export class CarouselBase extends React.Component {
     }
 
     return (
-      <Card className="Carousel">
+      <Card
+        className={classNames('Carousel', {
+          'Carousel--first-render-wrapper': !this.state.hasRendered,
+        })}
+      >
         {this.state.hasRendered ? (
           <NukaCarousel
             autoplay
@@ -72,7 +77,7 @@ export class CarouselBase extends React.Component {
             }))}
           </NukaCarousel>
         ) : (
-          <div className="Carousel--server-render">
+          <div className="Carousel--first-render">
             {/*
               We render the sections here to keep the server-side content
               similar to the client-side content so the re-render isn't as

--- a/src/ui/components/Carousel/index.js
+++ b/src/ui/components/Carousel/index.js
@@ -1,7 +1,8 @@
 /* @flow */
-import NukaCarousel from 'nuka-carousel';
+import defaultConfig from 'config';
 import React from 'react';
 import { compose } from 'redux';
+import NukaCarousel from 'nuka-carousel';
 
 import translate from 'core/i18n/translate';
 import { getDirection } from 'core/i18n/utils';
@@ -12,35 +13,84 @@ import './styles.scss';
 
 
 type PropTypes = {|
+  config: Object,
   i18n: Object,
   sections: Array<React.Element<typeof CarouselSection>>,
 |};
 
-export const CarouselBase = ({ i18n, sections }: PropTypes) => {
-  if (!sections) {
-    throw new Error('sections are required for a Carousel component');
+type StateTypes = {|
+  client: boolean,
+|};
+
+export class CarouselBase extends React.Component {
+  static defaultProps = {
+    config: defaultConfig,
   }
 
-  return (
-    <Card className="Carousel">
-      <NukaCarousel
-        autoplay
-        autoplayInterval={4000}
-        cellAlign={getDirection(i18n.lang) === 'ltr' ? 'left' : 'right'}
-        cellSpacing={10}
-        framePadding="0 10%"
-        frameOverflow="visible"
-        slidesToShow={1}
-        slidesToScroll={1}
-        slideWidth={1}
-      >
-        {(sections.map((section) => {
-          return section;
-        }))}
-      </NukaCarousel>
-    </Card>
-  );
-};
+  constructor(props: PropTypes) {
+    super(props);
+
+    this.state = { client: !this.props.config.get('server') };
+  }
+
+  state: StateTypes;
+
+  // HACK: NukaCarousel uses inline styles to create the carousel effect, which
+  // work fine on the client but cause CSP issues during initial server render.
+  // To get around this, we re-render the component on the client side.
+  // We use componentDidMount to cause it to update on the client because this
+  // lifecycle method is only called on the client.
+  // See: https://github.com/mozilla/addons-frontend/issues/3349
+  componentDidMount() {
+    if (!this.state.client) {
+      // eslint-disable-next-line react/no-did-mount-set-state
+      this.setState({ client: true });
+    }
+  }
+
+  props: PropTypes;
+
+  render() {
+    const { i18n, sections } = this.props;
+
+    if (!sections) {
+      throw new Error('sections are required for a Carousel component');
+    }
+
+    return (
+      <Card className="Carousel">
+        {this.state.client ? (
+          <NukaCarousel
+            autoplay
+            autoplayInterval={4000}
+            cellAlign={getDirection(i18n.lang) === 'ltr' ? 'left' : 'right'}
+            cellSpacing={10}
+            framePadding="0 10%"
+            frameOverflow="visible"
+            slidesToShow={1}
+            slidesToScroll={1}
+            slideWidth={1}
+          >
+            {(sections.map((section) => {
+              return section;
+            }))}
+          </NukaCarousel>
+        ) : (
+          <div className="Carousel--server-render">
+            {/*
+              We render the sections here to keep the server-side content
+              similar to the client-side content so the re-render isn't as
+              jarring–and so non-JS clients can still see the carousel.
+            */}
+            {(sections.map((section) => {
+              return section;
+            }))}
+          </div>
+        )}
+      </Card>
+    );
+  }
+}
 
 export default compose(
   translate(),

--- a/src/ui/components/Carousel/index.js
+++ b/src/ui/components/Carousel/index.js
@@ -1,9 +1,9 @@
 /* @flow */
-import defaultConfig from 'config';
 import React from 'react';
 import { compose } from 'redux';
 import NukaCarousel from 'nuka-carousel';
 
+import log from 'core/logger';
 import translate from 'core/i18n/translate';
 import { getDirection } from 'core/i18n/utils';
 import Card from 'ui/components/Card';
@@ -13,24 +13,19 @@ import './styles.scss';
 
 
 type PropTypes = {|
-  config: Object,
   i18n: Object,
   sections: Array<React.Element<typeof CarouselSection>>,
 |};
 
 type StateTypes = {|
-  client: boolean,
+  hasRendered: boolean,
 |};
 
 export class CarouselBase extends React.Component {
-  static defaultProps = {
-    config: defaultConfig,
-  }
-
   constructor(props: PropTypes) {
     super(props);
 
-    this.state = { client: !this.props.config.get('server') };
+    this.state = { hasRendered: false };
   }
 
   state: StateTypes;
@@ -42,9 +37,10 @@ export class CarouselBase extends React.Component {
   // lifecycle method is only called on the client.
   // See: https://github.com/mozilla/addons-frontend/issues/3349
   componentDidMount() {
-    if (!this.state.client) {
+    if (!this.state.hasRendered) {
+      log.debug('Re-rendering Carousel to avoid CSP issues.');
       // eslint-disable-next-line react/no-did-mount-set-state
-      this.setState({ client: true });
+      this.setState({ hasRendered: true });
     }
   }
 
@@ -59,7 +55,7 @@ export class CarouselBase extends React.Component {
 
     return (
       <Card className="Carousel">
-        {this.state.client ? (
+        {this.state.hasRendered ? (
           <NukaCarousel
             autoplay
             autoplayInterval={4000}

--- a/src/ui/components/Carousel/styles.scss
+++ b/src/ui/components/Carousel/styles.scss
@@ -48,6 +48,26 @@ $extraHeightForCard: 28px;
   }
 }
 
+.Carousel--server-render {
+  display: flex;
+  height: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0 10%;
+  // This is set really high so even a lot of carousel items don't get cramped
+  // by the `flex` display.
+  width: 50000px;
+
+  .slider-list {
+    margin: 0 -5px;
+  }
+
+  .slider-slide {
+    display: inline-block;
+    list-style: none;
+  }
+}
+
 .Carousel .Card-contents {
   height: $carousel-height-default + $extraHeightForCard;
   overflow-y: hidden;

--- a/src/ui/components/Carousel/styles.scss
+++ b/src/ui/components/Carousel/styles.scss
@@ -49,6 +49,7 @@ $extraHeightForCard: 28px;
 }
 
 .Carousel--server-render {
+  direction: ltr;
   display: flex;
   height: 100%;
   overflow-x: auto;
@@ -58,13 +59,9 @@ $extraHeightForCard: 28px;
   // by the `flex` display.
   width: 50000px;
 
-  .slider-list {
-    margin: 0 -5px;
-  }
-
-  .slider-slide {
-    display: inline-block;
-    list-style: none;
+  [dir=rtl] & .CarouselSection {
+    direction: rtl;
+    text-align: right;
   }
 }
 

--- a/src/ui/components/Carousel/styles.scss
+++ b/src/ui/components/Carousel/styles.scss
@@ -49,11 +49,14 @@ $extraHeightForCard: 28px;
 }
 
 .Carousel--first-render-wrapper .Card-contents {
+  // HACK: This fixes RTL glitches in the NukaCarousel we will eventually
+  // fix properly. This means te content in RTL doesn't change order after
+  // the client re-render.
+  direction: ltr;
   overflow-x: auto;
 }
 
 .Carousel--first-render {
-  direction: ltr;
   display: flex;
   height: 100%;
   margin: 0 10%;

--- a/src/ui/components/Carousel/styles.scss
+++ b/src/ui/components/Carousel/styles.scss
@@ -48,20 +48,32 @@ $extraHeightForCard: 28px;
   }
 }
 
-.Carousel--server-render {
+.Carousel--first-render-wrapper .Card-contents {
+  overflow-x: auto;
+}
+
+.Carousel--first-render {
   direction: ltr;
   display: flex;
   height: 100%;
-  overflow-x: auto;
+  margin: 0 10%;
   overflow-y: hidden;
-  padding: 0 10%;
   // This is set really high so even a lot of carousel items don't get cramped
   // by the `flex` display.
-  width: 50000px;
+  width: 303vw;
 
   [dir=rtl] & .CarouselSection {
     direction: rtl;
     text-align: right;
+  }
+
+  .CarouselSection {
+    margin: 0 17px;
+    width: 75.75vw;
+
+    &:first-of-type {
+      @include margin-start(1%);
+    }
   }
 }
 

--- a/tests/unit/ui/components/TestCarousel.js
+++ b/tests/unit/ui/components/TestCarousel.js
@@ -7,7 +7,6 @@ import Carousel, { CarouselBase } from 'ui/components/Carousel';
 
 
 describe(__filename, () => {
-  let fakeConfig;
   const defaultProps = {
     i18n: fakeI18n(),
   };
@@ -26,13 +25,6 @@ describe(__filename, () => {
     return mount(<Carousel {...defaultProps} {...props} />);
   }
 
-  beforeEach(() => {
-    fakeConfig = {
-      get: sinon.stub(),
-    };
-    fakeConfig.get.withArgs('server').returns(false);
-  });
-
   it('throws an error if sections are not supplied', () => {
     expect(() => {
       shallowRender();
@@ -40,7 +32,7 @@ describe(__filename, () => {
   });
 
   it('renders a Carousel on the client', () => {
-    const root = shallowRender({ config: fakeConfig, sections: [] });
+    const root = mountRender({ sections: [] });
 
     expect(root.find('.Carousel')).toHaveLength(1);
     expect(root.find(NukaCarousel)).toHaveProp('cellAlign', 'left');
@@ -49,7 +41,7 @@ describe(__filename, () => {
   });
 
   it('renders a Carousel with cellAlign=right for RTL langs', () => {
-    const root = shallowRender({
+    const root = mountRender({
       i18n: fakeI18n({ lang: 'ar' }),
       sections: [],
     });
@@ -57,25 +49,17 @@ describe(__filename, () => {
     expect(root.find(NukaCarousel)).toHaveProp('cellAlign', 'right');
   });
 
-  it('renders sections', () => {
-    const root = shallowRender({
-      config: fakeConfig,
+  it('renders sections inside NukaCarousel on re-render', () => {
+    const root = mountRender({
       sections: [
         <p className="something" key="1">Howdy!</p>,
         <p className="something-else" key="2">Bonjour !</p>,
       ],
     });
 
-    expect(root.find('p')).toHaveLength(2);
-    expect(root.find('.something')).toHaveLength(1);
-    expect(root.find('.something-else')).toHaveLength(1);
-  });
-
-  it('does render a NukaCarousel component immediately if on client', () => {
-    const root = shallowRender({ config: fakeConfig, sections: [] });
-
-    expect(root.find(NukaCarousel)).toHaveLength(1);
-    expect(root.find('.Carousel--server-render')).toHaveLength(0);
+    expect(root.find(NukaCarousel).find('p')).toHaveLength(2);
+    expect(root.find(NukaCarousel).find('.something')).toHaveLength(1);
+    expect(root.find(NukaCarousel).find('.something-else')).toHaveLength(1);
   });
 
   it('does not render a NukaCarousel component on the server', () => {
@@ -86,9 +70,8 @@ describe(__filename, () => {
     expect(root.find('.Carousel--server-render')).toHaveLength(1);
   });
 
-  it('updates state on componentDidMount', () => {
-    fakeConfig.get.withArgs('server').returns(true);
-    const root = mountRender({ config: fakeConfig, sections: [] });
+  it('updates state on componentDidMount and renders a NukaCarousel', () => {
+    const root = mountRender({ sections: [] });
 
     expect(root.find('.Carousel')).toHaveLength(1);
     expect(root.find(NukaCarousel)).toHaveLength(1);

--- a/tests/unit/ui/components/TestCarousel.js
+++ b/tests/unit/ui/components/TestCarousel.js
@@ -36,7 +36,8 @@ describe(__filename, () => {
 
     expect(root.find('.Carousel')).toHaveLength(1);
     expect(root.find(NukaCarousel)).toHaveProp('cellAlign', 'left');
-    expect(root.find('.Carousel--server-render')).toHaveLength(0);
+    expect(root.find('.Carousel--first-render-wrapper')).toHaveLength(0);
+    expect(root.find('.Carousel--first-render')).toHaveLength(0);
     expect(root.find('.Carousel-section-wrapper')).toHaveLength(0);
   });
 
@@ -67,7 +68,8 @@ describe(__filename, () => {
 
     expect(root.find('.Carousel')).toHaveLength(1);
     expect(root.find(NukaCarousel)).toHaveLength(0);
-    expect(root.find('.Carousel--server-render')).toHaveLength(1);
+    expect(root.find('.Carousel--first-render-wrapper')).toHaveLength(1);
+    expect(root.find('.Carousel--first-render')).toHaveLength(1);
   });
 
   it('updates state on componentDidMount and renders a NukaCarousel', () => {
@@ -75,7 +77,8 @@ describe(__filename, () => {
 
     expect(root.find('.Carousel')).toHaveLength(1);
     expect(root.find(NukaCarousel)).toHaveLength(1);
-    expect(root.find('.Carousel--server-render')).toHaveLength(0);
+    expect(root.find('.Carousel--first-render-wrapper')).toHaveLength(0);
+    expect(root.find('.Carousel--first-render')).toHaveLength(0);
   });
 
   it('renders sections inside server render on the server', () => {
@@ -86,7 +89,8 @@ describe(__filename, () => {
       ],
     });
 
-    expect(root.find('.Carousel--server-render')).toHaveLength(1);
+    expect(root.find('.Carousel--first-render-wrapper')).toHaveLength(1);
+    expect(root.find('.Carousel--first-render')).toHaveLength(1);
     expect(root.find('p')).toHaveLength(2);
     expect(root.find('.something')).toHaveLength(1);
     expect(root.find('.something-else')).toHaveLength(1);

--- a/tests/unit/ui/components/TestCarousel.js
+++ b/tests/unit/ui/components/TestCarousel.js
@@ -1,27 +1,51 @@
-import NukaCarousel from 'nuka-carousel';
+import { mount } from 'enzyme';
 import React from 'react';
+import NukaCarousel from 'nuka-carousel';
 
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 import Carousel, { CarouselBase } from 'ui/components/Carousel';
 
 
 describe(__filename, () => {
-  function shallowRender({
-    i18n = fakeI18n(),
-    ...props
-  } = {}) {
+  let fakeConfig;
+  const defaultProps = {
+    i18n: fakeI18n(),
+  };
+
+  function shallowRender({ ...props } = {}) {
     return shallowUntilTarget(
-      <Carousel i18n={i18n} {...props} />,
+      <Carousel {...defaultProps} {...props} />,
       CarouselBase
     );
   }
 
-  it('renders a Carousel', () => {
-    const root = shallowRender({ sections: [] });
+  // We mount certain tests to ensure lifecycle methods like componentDidMount
+  // are called.
+  // See: https://github.com/mozilla/addons-frontend/issues/3349
+  function mountRender({ ...props } = {}) {
+    return mount(<Carousel {...defaultProps} {...props} />);
+  }
+
+  beforeEach(() => {
+    fakeConfig = {
+      get: sinon.stub(),
+    };
+    fakeConfig.get.withArgs('server').returns(false);
+  });
+
+  it('throws an error if sections are not supplied', () => {
+    expect(() => {
+      shallowRender();
+    }).toThrow('sections are required for a Carousel component');
+  });
+
+  it('renders a Carousel on the client', () => {
+    const root = shallowRender({ config: fakeConfig, sections: [] });
 
     expect(root.find('.Carousel')).toHaveLength(1);
     expect(root.find(NukaCarousel)).toHaveProp('cellAlign', 'left');
-    expect(root.find('div.Carousel-section-wrapper')).toHaveLength(0);
+    expect(root.find('.Carousel--server-render')).toHaveLength(0);
+    expect(root.find('.Carousel-section-wrapper')).toHaveLength(0);
   });
 
   it('renders a Carousel with cellAlign=right for RTL langs', () => {
@@ -33,13 +57,45 @@ describe(__filename, () => {
     expect(root.find(NukaCarousel)).toHaveProp('cellAlign', 'right');
   });
 
-  it('throws an error if sections are not supplied', () => {
-    expect(() => {
-      shallowRender();
-    }).toThrow('sections are required for a Carousel component');
+  it('renders sections', () => {
+    const root = shallowRender({
+      config: fakeConfig,
+      sections: [
+        <p className="something" key="1">Howdy!</p>,
+        <p className="something-else" key="2">Bonjour !</p>,
+      ],
+    });
+
+    expect(root.find('p')).toHaveLength(2);
+    expect(root.find('.something')).toHaveLength(1);
+    expect(root.find('.something-else')).toHaveLength(1);
   });
 
-  it('renders sections', () => {
+  it('does render a NukaCarousel component immediately if on client', () => {
+    const root = shallowRender({ config: fakeConfig, sections: [] });
+
+    expect(root.find(NukaCarousel)).toHaveLength(1);
+    expect(root.find('.Carousel--server-render')).toHaveLength(0);
+  });
+
+  it('does not render a NukaCarousel component on the server', () => {
+    const root = shallowRender({ sections: [] });
+
+    expect(root.find('.Carousel')).toHaveLength(1);
+    expect(root.find(NukaCarousel)).toHaveLength(0);
+    expect(root.find('.Carousel--server-render')).toHaveLength(1);
+  });
+
+  it('updates state on componentDidMount', () => {
+    fakeConfig.get.withArgs('server').returns(true);
+    const root = mountRender({ config: fakeConfig, sections: [] });
+
+    expect(root.find('.Carousel')).toHaveLength(1);
+    expect(root.find(NukaCarousel)).toHaveLength(1);
+    expect(root.find('.Carousel--server-render')).toHaveLength(0);
+  });
+
+  it('renders sections inside server render on the server', () => {
     const root = shallowRender({
       sections: [
         <p className="something" key="1">Howdy!</p>,
@@ -47,6 +103,7 @@ describe(__filename, () => {
       ],
     });
 
+    expect(root.find('.Carousel--server-render')).toHaveLength(1);
     expect(root.find('p')).toHaveLength(2);
     expect(root.find('.something')).toHaveLength(1);
     expect(root.find('.something-else')).toHaveLength(1);


### PR DESCRIPTION
fix #3349 

No need for two reviews, just whoever gets to it first (feel free to clear the other person once you start reviewing it).

This fixes the CSP error on the carousel by rendering it on the client after `componentDidMount` runs. It's not lovely but it looks nice enough without huge jumps and it works. Pretty much any carousel, by their nature modifying style props, would require this 😢

### Before
![2017-10-05 01 36 07](https://user-images.githubusercontent.com/90871/31206089-a50157a2-a96d-11e7-837d-87745ca6d635.gif)

### After
![2017-10-05 00 59 25](https://user-images.githubusercontent.com/90871/31206087-a1da6fdc-a96d-11e7-9d31-8ef2ff98260e.gif)
