### PR TITLE
fix: Text entered in the Search field appears cut

### DIFF
--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -21,9 +21,8 @@
   border-radius: $border-radius-s;
   color: $black;
   height: 27px;
+  line-height: 27px;
   outline: 0;
-  padding-bottom: 6px;
-  padding-top: 6px;
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;


### PR DESCRIPTION
Fixes #3357 
Before:
<img width="316" alt="screen shot 2017-10-05 at 5 57 04 pm" src="https://user-images.githubusercontent.com/5318732/31227323-1098ab1c-a9f7-11e7-988c-796ab11226ae.png">

After:
<img width="334" alt="screen shot 2017-10-05 at 5 57 33 pm" src="https://user-images.githubusercontent.com/5318732/31227326-17b51188-a9f7-11e7-9abd-9c7959451fe8.png">
