### PR TITLE
Add most popular extensions shelf to the homepage

### DIFF
--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -1,0 +1,99 @@
+/* @flow */
+import { createInternalAddon } from 'core/reducers/addons';
+import type { AddonType, ExternalAddonType } from 'core/types/addons';
+
+export const FETCH_HOME_ADDONS: 'FETCH_HOME_ADDONS' = 'FETCH_HOME_ADDONS';
+export const LOAD_HOME_ADDONS: 'LOAD_HOME_ADDONS' = 'LOAD_HOME_ADDONS';
+
+export type HomeState = {
+  popularExtensions: Array<AddonType>,
+};
+
+export const initialState: HomeState = {
+  popularExtensions: [],
+};
+
+type FetchHomeAddonsParams = {|
+  errorHandlerId: string,
+|};
+
+type FetchHomeAddonsAction = {|
+  type: typeof FETCH_HOME_ADDONS,
+  payload: FetchHomeAddonsParams,
+|};
+
+export const fetchHomeAddons = ({
+  errorHandlerId,
+}: FetchHomeAddonsParams): FetchHomeAddonsAction => {
+  if (!errorHandlerId) {
+    throw new Error('errorHandlerId is required');
+  }
+
+  return {
+    type: FETCH_HOME_ADDONS,
+    payload: { errorHandlerId },
+  };
+};
+
+type ExternalAddonMap = {
+  [addonSlug: string]: ExternalAddonType,
+};
+
+type LoadHomeAddonsParams = {|
+  popularExtensions: {|
+    result: {|
+      count: number,
+      results: Array<string>,
+    |},
+    entities: {|
+      addons: ExternalAddonMap,
+    |},
+  |},
+|};
+
+type LoadHomeAddonsAction = {|
+  type: typeof LOAD_HOME_ADDONS,
+  payload: LoadHomeAddonsParams,
+|};
+
+export const loadHomeAddons = ({
+  popularExtensions,
+}: LoadHomeAddonsParams): LoadHomeAddonsAction => {
+  if (!popularExtensions) {
+    throw new Error('popularExtensions is required');
+  }
+
+  return {
+    type: LOAD_HOME_ADDONS,
+    payload: {
+      popularExtensions,
+    },
+  };
+};
+
+type Action =
+  | FetchHomeAddonsAction
+  | LoadHomeAddonsAction;
+
+const reducer = (
+  state: HomeState = initialState,
+  action: Action
+): HomeState => {
+  switch (action.type) {
+    case LOAD_HOME_ADDONS: {
+      const { popularExtensions } = action.payload;
+
+      return {
+        ...state,
+        popularExtensions: popularExtensions.result.results.map((slug) => (
+          createInternalAddon(popularExtensions.entities.addons[slug])
+        )),
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -1,0 +1,49 @@
+import { all, call, put, select, takeLatest } from 'redux-saga/effects';
+import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import {
+  FETCH_HOME_ADDONS,
+  loadHomeAddons,
+} from 'amo/reducers/home';
+import {
+  ADDON_TYPE_EXTENSION,
+  SEARCH_SORT_POPULAR,
+} from 'core/constants';
+import { search as searchApi } from 'core/api/search';
+import log from 'core/logger';
+import { createErrorHandler, getState } from 'core/sagas/utils';
+
+
+export function* fetchHomeAddons({ payload: { errorHandlerId } }) {
+  const errorHandler = createErrorHandler(errorHandlerId);
+
+  yield put(errorHandler.createClearingAction());
+
+  try {
+    const state = yield select(getState);
+
+    const {
+      popularExtensions,
+    } = yield all({
+      popularExtensions: call(searchApi, {
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_EXTENSION,
+          page_size: LANDING_PAGE_ADDON_COUNT,
+          sort: SEARCH_SORT_POPULAR,
+        },
+        page: 1,
+      }),
+    });
+
+    yield put(loadHomeAddons({
+      popularExtensions,
+    }));
+  } catch (error) {
+    log.warn(`Home add-ons failed to load: ${error}`);
+    yield put(errorHandler.createErrorAction(error));
+  }
+}
+
+export default function* homeSaga() {
+  yield takeLatest(FETCH_HOME_ADDONS, fetchHomeAddons);
+}

--- a/src/amo/sagas/index.js
+++ b/src/amo/sagas/index.js
@@ -8,6 +8,7 @@ import addonsByAuthors from 'amo/sagas/addonsByAuthors';
 import categories from 'amo/sagas/categories';
 import collections from 'amo/sagas/collections';
 import featured from 'amo/sagas/featured';
+import home from 'amo/sagas/home';
 import landing from 'amo/sagas/landing';
 import reviews from 'amo/sagas/reviews';
 import abuse from 'core/sagas/abuse';
@@ -27,6 +28,7 @@ export default function* rootSaga() {
     fork(categories),
     fork(collections),
     fork(featured),
+    fork(home),
     fork(landing),
     fork(reviews),
     fork(search),

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -5,6 +5,7 @@ import createSagaMiddleware from 'redux-saga';
 import addonsByAuthors from 'amo/reducers/addonsByAuthors';
 import collections from 'amo/reducers/collections';
 import featured from 'amo/reducers/featured';
+import home from 'amo/reducers/home';
 import landing from 'amo/reducers/landing';
 import reviews from 'amo/reducers/reviews';
 import viewContext from 'amo/reducers/viewContext';
@@ -37,6 +38,7 @@ export default function createStore(initialState = {}) {
       errors,
       errorPage,
       featured,
+      home,
       infoDialog,
       installations,
       landing,

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -20,6 +20,7 @@ import {
   SEARCH_SORT_POPULAR,
   VIEW_CONTEXT_HOME,
 } from 'core/constants';
+import { createInternalAddon } from 'core/reducers/addons';
 import {
   createStubErrorHandler,
   fakeI18n,
@@ -173,18 +174,23 @@ describe(__filename, () => {
   it('does not fetch the add-ons when results are already loaded', () => {
     const store = dispatchClientMetadata().store;
 
-    const popularExtensions = createAddonsApiResult([{
-      ...fakeAddon, slug: 'popular-addon',
-    }]);
+    const addons = [{ ...fakeAddon, slug: 'popular-addon' }];
+    const popularExtensions = createAddonsApiResult(addons);
 
     store.dispatch(loadHomeAddons({
       popularExtensions,
     }));
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
-    render({ store });
+    const root = render({ store });
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, setViewContext(VIEW_CONTEXT_HOME));
+
+    const shelf = root.find(LandingAddonsCard);
+    expect(shelf).toHaveProp('loading', false);
+    expect(shelf).toHaveProp('addons', addons.map((addon) => (
+      createInternalAddon(addon)
+    )));
   });
 });

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -1,7 +1,8 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import {
+import { setViewContext } from 'amo/actions/viewContext';
+import Home, {
   CategoryLink,
   ExtensionLink,
   HomeBase,
@@ -9,24 +10,49 @@ import {
   mapStateToProps,
 } from 'amo/components/Home';
 import HomeCarousel from 'amo/components/HomeCarousel';
+import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
-import { CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX } from 'core/constants';
-import { dispatchSignInActions } from 'tests/unit/amo/helpers';
-import { fakeI18n } from 'tests/unit/helpers';
+import { fetchHomeAddons, loadHomeAddons } from 'amo/reducers/home';
+import {
+  ADDON_TYPE_EXTENSION,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
+  SEARCH_SORT_POPULAR,
+  VIEW_CONTEXT_HOME,
+} from 'core/constants';
+import {
+  createStubErrorHandler,
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+import {
+  createAddonsApiResult,
+  dispatchClientMetadata,
+  fakeAddon,
+} from 'tests/unit/amo/helpers';
 
 
-describe('Home', () => {
-  function render(props) {
-    const fakeDispatch = sinon.stub();
+describe(__filename, () => {
+  const getProps = () => {
+    const store = dispatchClientMetadata({
+      clientApp: CLIENT_APP_FIREFOX,
+    }).store;
 
-    return shallow(
-      <HomeBase
-        clientApp={CLIENT_APP_FIREFOX}
-        dispatch={fakeDispatch}
-        i18n={fakeI18n()}
-        {...props}
-      />
-    );
+    return {
+      dispatch: store.dispatch,
+      errorHandler: createStubErrorHandler(),
+      i18n: fakeI18n(),
+      store,
+    };
+  };
+
+  function render(otherProps) {
+    const allProps = {
+      ...getProps(),
+      ...otherProps,
+    };
+
+    return shallowUntilTarget(<Home {...allProps} />, HomeBase);
   }
 
   it('renders a carousel', () => {
@@ -66,7 +92,11 @@ describe('Home', () => {
   });
 
   it('renders Android URLs for categories', () => {
-    const root = render({ clientApp: CLIENT_APP_ANDROID });
+    const store = dispatchClientMetadata({
+      clientApp: CLIENT_APP_ANDROID,
+    }).store;
+
+    const root = render({ store });
     const links = shallow(root.instance().extensionsCategoriesForClientApp());
 
     expect(links.find(ExtensionLink).find('[name="block-ads"]'))
@@ -104,8 +134,57 @@ describe('Home', () => {
   });
 
   it('maps clientApp to props from state', () => {
-    const { state } = dispatchSignInActions({ clientApp: CLIENT_APP_ANDROID });
+    const { state } = dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID });
 
     expect(mapStateToProps(state).clientApp).toEqual(CLIENT_APP_ANDROID);
+  });
+
+  it('renders a popular extensions shelf', () => {
+    const root = render();
+
+    const shelf = root.find(LandingAddonsCard);
+    expect(shelf).toHaveLength(1);
+    expect(shelf).toHaveProp('header', 'Most popular extensions');
+    expect(shelf).toHaveProp('footerText', 'More popular extensions');
+    expect(shelf).toHaveProp('footerLink', {
+      pathname: '/search/',
+      query: {
+        addonType: ADDON_TYPE_EXTENSION,
+        sort: SEARCH_SORT_POPULAR,
+      },
+    });
+    expect(shelf).toHaveProp('loading', true);
+  });
+
+  it('dispatches an action to fetch the add-ons to display', () => {
+    const errorHandler = createStubErrorHandler();
+    const store = dispatchClientMetadata().store;
+
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    render({ errorHandler, store });
+
+    sinon.assert.callCount(fakeDispatch, 2);
+    sinon.assert.calledWith(fakeDispatch, setViewContext(VIEW_CONTEXT_HOME));
+    sinon.assert.calledWith(fakeDispatch, fetchHomeAddons({
+      errorHandlerId: errorHandler.id,
+    }));
+  });
+
+  it('does not fetch the add-ons when results are already loaded', () => {
+    const store = dispatchClientMetadata().store;
+
+    const popularExtensions = createAddonsApiResult([{
+      ...fakeAddon, slug: 'popular-addon',
+    }]);
+
+    store.dispatch(loadHomeAddons({
+      popularExtensions,
+    }));
+
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    render({ store });
+
+    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.calledWith(fakeDispatch, setViewContext(VIEW_CONTEXT_HOME));
   });
 });

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -1,0 +1,70 @@
+import reducer, {
+  fetchHomeAddons,
+  initialState,
+  loadHomeAddons,
+} from 'amo/reducers/home';
+import { createInternalAddon } from 'core/reducers/addons';
+import {
+  createAddonsApiResult,
+  dispatchClientMetadata,
+  fakeAddon,
+} from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  describe('reducer', () => {
+    it('initializes properly', () => {
+      const state = reducer(undefined, {});
+      expect(state).toEqual(initialState);
+    });
+
+    it('ignores unrelated actions', () => {
+      const state = reducer(initialState, { type: 'UNRELATED_ACTION' });
+      expect(state).toEqual(initialState);
+    });
+
+    it('loads the add-ons to display on homepage', () => {
+      const { store } = dispatchClientMetadata();
+
+      store.dispatch(loadHomeAddons({
+        popularExtensions: createAddonsApiResult([fakeAddon]),
+      }));
+
+      const homeState = store.getState().home;
+
+      expect(homeState.popularExtensions).toEqual([
+        createInternalAddon(fakeAddon),
+      ]);
+    });
+  });
+
+  describe('fetchHomeAddons()', () => {
+    const defaultParams = {
+      errorHandlerId: 'some-error-handler-id',
+    };
+
+    it('throws an error when errorHandlerId is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.errorHandlerId;
+
+      expect(() => {
+        fetchHomeAddons(partialParams);
+      }).toThrow('errorHandlerId is required');
+    });
+  });
+
+  describe('loadHomeAddons()', () => {
+    const defaultParams = {
+      popularExtensions: {},
+    };
+
+    it('throws an error when popular extensions are missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.popularExtensions;
+
+      expect(() => {
+        loadHomeAddons(partialParams);
+      }).toThrow('popularExtensions is required');
+    });
+  });
+});

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -1,4 +1,4 @@
-import reducer, {
+import homeReducer, {
   fetchHomeAddons,
   initialState,
   loadHomeAddons,
@@ -14,12 +14,12 @@ import {
 describe(__filename, () => {
   describe('reducer', () => {
     it('initializes properly', () => {
-      const state = reducer(undefined, {});
+      const state = homeReducer(undefined, {});
       expect(state).toEqual(initialState);
     });
 
     it('ignores unrelated actions', () => {
-      const state = reducer(initialState, { type: 'UNRELATED_ACTION' });
+      const state = homeReducer(initialState, { type: 'UNRELATED_ACTION' });
       expect(state).toEqual(initialState);
     });
 

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -1,0 +1,112 @@
+import SagaTester from 'redux-saga-tester';
+
+import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import homeReducer, {
+  fetchHomeAddons,
+  loadHomeAddons,
+} from 'amo/reducers/home';
+import homeSaga from 'amo/sagas/home';
+import * as searchApi from 'core/api/search';
+import {
+  ADDON_TYPE_EXTENSION,
+  SEARCH_SORT_POPULAR,
+} from 'core/constants';
+import apiReducer from 'core/reducers/api';
+import { createStubErrorHandler } from 'tests/unit/helpers';
+import {
+  createAddonsApiResult,
+  dispatchClientMetadata,
+  fakeAddon,
+} from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  let errorHandler;
+  let mockSearchApi;
+  let sagaTester;
+
+  beforeEach(() => {
+    errorHandler = createStubErrorHandler();
+    mockSearchApi = sinon.mock(searchApi);
+    sagaTester = new SagaTester({
+      initialState: dispatchClientMetadata().state,
+      reducers: {
+        api: apiReducer,
+        home: homeReducer,
+      },
+    });
+    sagaTester.start(homeSaga);
+  });
+
+  describe('fetchHomeAddons', () => {
+    function _fetchHomeAddons(params) {
+      sagaTester.dispatch(fetchHomeAddons({
+        errorHandlerId: errorHandler.id,
+        ...params,
+      }));
+    }
+
+    it('calls the API to fetch the add-ons to display on home', async () => {
+      const state = sagaTester.getState();
+
+      const baseArgs = { api: state.api };
+      const baseFilters = {
+        page_size: LANDING_PAGE_ADDON_COUNT,
+      };
+
+      const popularExtensions = createAddonsApiResult([{
+        ...fakeAddon, slug: 'popular-addon',
+      }]);
+      mockSearchApi
+        .expects('search')
+        .withArgs({
+          ...baseArgs,
+          filters: {
+            ...baseFilters,
+            addonType: ADDON_TYPE_EXTENSION,
+            sort: SEARCH_SORT_POPULAR,
+          },
+          page: 1,
+        })
+        .returns(Promise.resolve(popularExtensions));
+
+      _fetchHomeAddons();
+
+      const expectedLoadAction = loadHomeAddons({
+        popularExtensions,
+      });
+
+      await sagaTester.waitFor(expectedLoadAction.type);
+      mockSearchApi.verify();
+
+      const calledActions = sagaTester.getCalledActions();
+      const loadAction = calledActions[2];
+      expect(loadAction).toEqual(expectedLoadAction);
+    });
+
+    it('clears the error handler', async () => {
+      _fetchHomeAddons();
+
+      const expectedAction = errorHandler.createClearingAction();
+
+      await sagaTester.waitFor(expectedAction.type);
+      expect(sagaTester.getCalledActions()[1])
+        .toEqual(errorHandler.createClearingAction());
+    });
+
+    it('dispatches an error', async () => {
+      const error = new Error('some API error maybe');
+
+      mockSearchApi
+        .expects('search')
+        .once()
+        .returns(Promise.reject(error));
+
+      _fetchHomeAddons();
+
+      const errorAction = errorHandler.createErrorAction(error);
+      await sagaTester.waitFor(errorAction.type);
+      expect(sagaTester.getCalledActions()[2]).toEqual(errorAction);
+    });
+  });
+});

--- a/tests/unit/amo/test_store.js
+++ b/tests/unit/amo/test_store.js
@@ -14,6 +14,7 @@ describe('amo createStore', () => {
       'errorPage',
       'errors',
       'featured',
+      'home',
       'infoDialog',
       'installations',
       'landing',


### PR DESCRIPTION
Fix #3308

---

This PR adds the "most popular extensions" shelf to the homepage. It also adds all we need to add the other shelves. I have created a new reducer/saga to be able to fetch all the data in one round.

For example: here is the code to add the second shelf (#3309): https://gist.github.com/willdurand/88a24904de4e6b2567fb2e5ab7f63676 (no test and I used `happyholidays` because dev/stage does not have the required collection).

## Screenshot

<img width="1392" alt="screen shot 2017-10-05 at 18 00 51" src="https://user-images.githubusercontent.com/217628/31237519-7d0ba3d0-a9f7-11e7-9d05-dab4f5090d8c.png">
