### PR TITLE
Add collection based shelf to Homepage

### DIFF
--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -166,7 +166,7 @@ export class HomeBase extends React.Component {
 
         <LandingAddonsCard
           addons={popularExtensions}
-          className="PopularExtensions"
+          className="Home-PopularExtensions"
           header={i18n.gettext('Most popular extensions')}
           footerText={i18n.gettext('More popular extensions')}
           footerLink={{
@@ -181,7 +181,7 @@ export class HomeBase extends React.Component {
 
         <LandingAddonsCard
           addons={featuredCollection}
-          className="FeaturedCollection"
+          className="Home-FeaturedCollection"
           header={i18n.gettext('Change your tabs')}
           footerText={i18n.gettext('Browse this collection')}
           footerLink={{ pathname:

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -48,22 +48,31 @@ export const ThemeLink = (props) => {
   return <CategoryLink type="themes" {...props} />;
 };
 
+export const FEATURED_COLLECTION_SLUG = 'change-up-your-tabs';
+export const FEATURED_COLLECTION_USER = 'mozilla';
+
 export class HomeBase extends React.Component {
   static propTypes = {
     clientApp: PropTypes.string.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
+    featuredCollection: PropTypes.array.isRequired,
     i18n: PropTypes.object.isRequired,
     popularExtensions: PropTypes.array.isRequired,
+    resultsLoaded: PropTypes.bool.isRequired,
   }
 
   componentWillMount() {
-    const { dispatch, errorHandler, popularExtensions } = this.props;
+    const { dispatch, errorHandler, resultsLoaded } = this.props;
 
     dispatch(setViewContext(VIEW_CONTEXT_HOME));
 
-    if (popularExtensions === null) {
-      dispatch(fetchHomeAddons({ errorHandlerId: errorHandler.id }));
+    if (!resultsLoaded) {
+      dispatch(fetchHomeAddons({
+        errorHandlerId: errorHandler.id,
+        featuredCollectionSlug: FEATURED_COLLECTION_SLUG,
+        featuredCollectionUser: FEATURED_COLLECTION_USER,
+      }));
     }
   }
 
@@ -141,10 +150,18 @@ export class HomeBase extends React.Component {
   }
 
   render() {
-    const { i18n, popularExtensions } = this.props;
+    const {
+      errorHandler,
+      featuredCollection,
+      i18n,
+      popularExtensions,
+      resultsLoaded,
+    } = this.props;
 
     return (
       <div className="Home">
+        {errorHandler.renderErrorIfPresent()}
+
         <HomeCarousel />
 
         <LandingAddonsCard
@@ -159,7 +176,18 @@ export class HomeBase extends React.Component {
               sort: SEARCH_SORT_POPULAR,
             },
           }}
-          loading={popularExtensions === null}
+          loading={resultsLoaded === false}
+        />
+
+        <LandingAddonsCard
+          addons={featuredCollection}
+          className="FeaturedCollection"
+          header={i18n.gettext('Change your tabs')}
+          footerText={i18n.gettext('Browse this collection')}
+          footerLink={{ pathname:
+            `/collections/${FEATURED_COLLECTION_USER}/${FEATURED_COLLECTION_SLUG}/`,
+          }}
+          loading={resultsLoaded === false}
         />
 
         <Card
@@ -207,7 +235,9 @@ export class HomeBase extends React.Component {
 export function mapStateToProps(state) {
   return {
     clientApp: state.api.clientApp,
+    featuredCollection: state.home.featuredCollection,
     popularExtensions: state.home.popularExtensions,
+    resultsLoaded: state.home.resultsLoaded,
   };
 }
 

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -123,7 +123,7 @@ type ExternalCollectionDetail = {|
   uuid: string,
 |};
 
-type CollectionAddonsListResponse = {|
+export type CollectionAddonsListResponse = {|
   count: number,
   next: string,
   previous: string,

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -122,9 +122,9 @@ const reducer = (
         ...state,
         featuredCollection: featuredCollection.results
           .slice(0, LANDING_PAGE_ADDON_COUNT)
-          .map((item) => (
-            createInternalAddon(item.addon)
-          )),
+          .map((item) => {
+            return createInternalAddon(item.addon);
+          }),
         popularExtensions: popularExtensions.result.results.map((slug) => (
           createInternalAddon(popularExtensions.entities.addons[slug])
         )),

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -1,20 +1,28 @@
 /* @flow */
+import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import { createInternalAddon } from 'core/reducers/addons';
+import type { CollectionAddonsListResponse } from 'amo/reducers/collections';
 import type { AddonType, ExternalAddonType } from 'core/types/addons';
 
 export const FETCH_HOME_ADDONS: 'FETCH_HOME_ADDONS' = 'FETCH_HOME_ADDONS';
 export const LOAD_HOME_ADDONS: 'LOAD_HOME_ADDONS' = 'LOAD_HOME_ADDONS';
 
 export type HomeState = {
-  popularExtensions: Array<AddonType>| null,
+  featuredCollection: Array<AddonType>,
+  popularExtensions: Array<AddonType>,
+  resultsLoaded: boolean,
 };
 
 export const initialState: HomeState = {
-  popularExtensions: null,
+  featuredCollection: [],
+  popularExtensions: [],
+  resultsLoaded: false,
 };
 
 type FetchHomeAddonsParams = {|
   errorHandlerId: string,
+  featuredCollectionSlug: string,
+  featuredCollectionUser: string,
 |};
 
 type FetchHomeAddonsAction = {|
@@ -24,14 +32,26 @@ type FetchHomeAddonsAction = {|
 
 export const fetchHomeAddons = ({
   errorHandlerId,
+  featuredCollectionSlug,
+  featuredCollectionUser,
 }: FetchHomeAddonsParams): FetchHomeAddonsAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
+  if (!featuredCollectionSlug) {
+    throw new Error('featuredCollectionSlug is required');
+  }
+  if (!featuredCollectionUser) {
+    throw new Error('featuredCollectionUser is required');
+  }
 
   return {
     type: FETCH_HOME_ADDONS,
-    payload: { errorHandlerId },
+    payload: {
+      errorHandlerId,
+      featuredCollectionSlug,
+      featuredCollectionUser,
+    },
   };
 };
 
@@ -40,6 +60,7 @@ type ExternalAddonMap = {
 };
 
 type LoadHomeAddonsParams = {|
+  featuredCollection: CollectionAddonsListResponse,
   popularExtensions: {|
     result: {|
       count: number,
@@ -57,8 +78,12 @@ type LoadHomeAddonsAction = {|
 |};
 
 export const loadHomeAddons = ({
+  featuredCollection,
   popularExtensions,
 }: LoadHomeAddonsParams): LoadHomeAddonsAction => {
+  if (!featuredCollection) {
+    throw new Error('featuredCollection is required');
+  }
   if (!popularExtensions) {
     throw new Error('popularExtensions is required');
   }
@@ -66,6 +91,7 @@ export const loadHomeAddons = ({
   return {
     type: LOAD_HOME_ADDONS,
     payload: {
+      featuredCollection,
       popularExtensions,
     },
   };
@@ -80,14 +106,29 @@ const reducer = (
   action: Action
 ): HomeState => {
   switch (action.type) {
+    case FETCH_HOME_ADDONS:
+      return {
+        ...state,
+        resultsLoaded: false,
+      };
+
     case LOAD_HOME_ADDONS: {
-      const { popularExtensions } = action.payload;
+      const {
+        featuredCollection,
+        popularExtensions,
+      } = action.payload;
 
       return {
         ...state,
+        featuredCollection: featuredCollection.results
+          .slice(0, LANDING_PAGE_ADDON_COUNT)
+          .map((item) => (
+            createInternalAddon(item.addon)
+          )),
         popularExtensions: popularExtensions.result.results.map((slug) => (
           createInternalAddon(popularExtensions.entities.addons[slug])
         )),
+        resultsLoaded: true,
       };
     }
 

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -1,4 +1,5 @@
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
+import { getCollectionAddons } from 'amo/api/collections';
 import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import {
   FETCH_HOME_ADDONS,
@@ -13,7 +14,13 @@ import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 
 
-export function* fetchHomeAddons({ payload: { errorHandlerId } }) {
+export function* fetchHomeAddons({
+  payload: {
+    errorHandlerId,
+    featuredCollectionSlug,
+    featuredCollectionUser,
+  },
+}) {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -23,6 +30,7 @@ export function* fetchHomeAddons({ payload: { errorHandlerId } }) {
 
     const {
       popularExtensions,
+      featuredCollection,
     } = yield all({
       popularExtensions: call(searchApi, {
         api: state.api,
@@ -33,10 +41,17 @@ export function* fetchHomeAddons({ payload: { errorHandlerId } }) {
         },
         page: 1,
       }),
+      featuredCollection: call(getCollectionAddons, {
+        api: state.api,
+        page: 1,
+        slug: featuredCollectionSlug,
+        user: featuredCollectionUser,
+      }),
     });
 
     yield put(loadHomeAddons({
       popularExtensions,
+      featuredCollection,
     }));
   } catch (error) {
     log.warn(`Home add-ons failed to load: ${error}`);

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -1,3 +1,4 @@
+import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import homeReducer, {
   fetchHomeAddons,
   initialState,
@@ -6,6 +7,7 @@ import homeReducer, {
 import { createInternalAddon } from 'core/reducers/addons';
 import {
   createAddonsApiResult,
+  createFakeCollectionAddons,
   dispatchClientMetadata,
   fakeAddon,
 } from 'tests/unit/amo/helpers';
@@ -27,20 +29,43 @@ describe(__filename, () => {
       const { store } = dispatchClientMetadata();
 
       store.dispatch(loadHomeAddons({
+        featuredCollection: createFakeCollectionAddons({
+          addons: Array(10).fill(fakeAddon),
+        }),
         popularExtensions: createAddonsApiResult([fakeAddon]),
       }));
 
       const homeState = store.getState().home;
 
+      expect(homeState.resultsLoaded).toEqual(true);
       expect(homeState.popularExtensions).toEqual([
         createInternalAddon(fakeAddon),
       ]);
+      expect(homeState.featuredCollection)
+        .toHaveLength(LANDING_PAGE_ADDON_COUNT);
+      expect(homeState.featuredCollection).toEqual(
+        Array(LANDING_PAGE_ADDON_COUNT).fill(createInternalAddon(fakeAddon))
+      );
+    });
+
+    it('sets `resultsLoaded` to `false` when fetching home add-ons', () => {
+      const loadedState = { ...initialState, resultsLoaded: true };
+
+      const state = homeReducer(loadedState, fetchHomeAddons({
+        errorHandlerId: 'some-error-handler-id',
+        featuredCollectionSlug: 'some-collection-slug',
+        featuredCollectionUser: 'mozilla',
+      }));
+
+      expect(state.resultsLoaded).toEqual(false);
     });
   });
 
   describe('fetchHomeAddons()', () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
+      featuredCollectionSlug: 'some-collection-slug',
+      featuredCollectionUser: 'mozilla',
     };
 
     it('throws an error when errorHandlerId is missing', () => {
@@ -51,11 +76,30 @@ describe(__filename, () => {
         fetchHomeAddons(partialParams);
       }).toThrow('errorHandlerId is required');
     });
+
+    it('throws an error when featuredCollectionSlug is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.featuredCollectionSlug;
+
+      expect(() => {
+        fetchHomeAddons(partialParams);
+      }).toThrow('featuredCollectionSlug is required');
+    });
+
+    it('throws an error when featuredCollectionUser is missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.featuredCollectionUser;
+
+      expect(() => {
+        fetchHomeAddons(partialParams);
+      }).toThrow('featuredCollectionUser is required');
+    });
   });
 
   describe('loadHomeAddons()', () => {
     const defaultParams = {
       popularExtensions: {},
+      featuredCollection: {},
     };
 
     it('throws an error when popular extensions are missing', () => {
@@ -65,6 +109,15 @@ describe(__filename, () => {
       expect(() => {
         loadHomeAddons(partialParams);
       }).toThrow('popularExtensions is required');
+    });
+
+    it('throws an error when featured collection add-ons are missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.featuredCollection;
+
+      expect(() => {
+        loadHomeAddons(partialParams);
+      }).toThrow('featuredCollection is required');
     });
   });
 });


### PR DESCRIPTION
Fix #3309

---

This PR adds the featured collection shelf. It adds a test for the missing error rendering mentioned in https://github.com/mozilla/addons-frontend/pull/3365#discussion_r143070227.

⚠️ this collection does not exist in stage/dev 😢  I manually changed to `happy-2015` to test it, but I dont know what else to do. It could maybe part of the `config` (since it has different configs depending on the envs) but I did not see any similar config data...

## (Fake) Screenshot

<img width="1392" alt="screen shot 2017-10-06 at 15 06 34" src="https://user-images.githubusercontent.com/217628/31279088-fac364c4-aaa7-11e7-950e-5ce208eec35a.png">
