### PR TITLE
fix: Don't rely on empty arrays as being unloaded

### DIFF
--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -62,7 +62,7 @@ export class HomeBase extends React.Component {
 
     dispatch(setViewContext(VIEW_CONTEXT_HOME));
 
-    if (popularExtensions.length === 0) {
+    if (popularExtensions === null) {
       dispatch(fetchHomeAddons({ errorHandlerId: errorHandler.id }));
     }
   }
@@ -159,7 +159,7 @@ export class HomeBase extends React.Component {
               sort: SEARCH_SORT_POPULAR,
             },
           }}
-          loading={popularExtensions.length === 0}
+          loading={popularExtensions === null}
         />
 
         <Card

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -6,7 +6,7 @@ export const FETCH_HOME_ADDONS: 'FETCH_HOME_ADDONS' = 'FETCH_HOME_ADDONS';
 export const LOAD_HOME_ADDONS: 'LOAD_HOME_ADDONS' = 'LOAD_HOME_ADDONS';
 
 export type HomeState = {
-  popularExtensions: ?Array<AddonType>,
+  popularExtensions: Array<AddonType>| null,
 };
 
 export const initialState: HomeState = {

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -6,7 +6,7 @@ export const FETCH_HOME_ADDONS: 'FETCH_HOME_ADDONS' = 'FETCH_HOME_ADDONS';
 export const LOAD_HOME_ADDONS: 'LOAD_HOME_ADDONS' = 'LOAD_HOME_ADDONS';
 
 export type HomeState = {
-  popularExtensions: Array<AddonType>,
+  popularExtensions: ?Array<AddonType>,
 };
 
 export const initialState: HomeState = {

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -10,7 +10,7 @@ export type HomeState = {
 };
 
 export const initialState: HomeState = {
-  popularExtensions: [],
+  popularExtensions: null,
 };
 
 type FetchHomeAddonsParams = {|


### PR DESCRIPTION
Fixes #3372 
There were few other array length checks such as in `amo/api/review.js` but those were being returned from API as an array so `=== null` check wouldn't work.