### PR TITLE
fix: Developer Hub and Account Name options are not aligned

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -113,6 +113,7 @@
 
 .Header-button {
   margin-bottom: 12px;
+  vertical-align: top;
 }
 
 .Header-developer-hub-link {


### PR DESCRIPTION
Fixes #3303 
Before: 
<img width="346" alt="screen shot 2017-10-06 at 5 46 06 pm" src="https://user-images.githubusercontent.com/5318732/31277408-71918b88-aabe-11e7-87cd-3e4dc79ca0f2.png">

After:
<img width="330" alt="screen shot 2017-10-06 at 5 45 51 pm" src="https://user-images.githubusercontent.com/5318732/31277410-7869c844-aabe-11e7-8037-dad63a32edb5.png">
