### PR TITLE
Fix a visual glitch in the More menu item

### DIFF
--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -42,7 +42,7 @@
     font-size: $font-size-s;
     font-weight: normal;
     max-width: 100px;
-    overflow-x: hidden;
+    overflow: hidden;
     text-decoration: none;
     text-overflow: ellipsis;
     white-space: nowrap;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3389

I don't really understand what's going on here but this seems to fix it. Maybe it's a Firefox bug.

Before:

![screenshot-2017-10-6 add-ons for firefox](https://user-images.githubusercontent.com/55398/31295448-40b52124-aaa4-11e7-8ba9-128931be4d8e.png)

After:

![screenshot-2017-10-6 add-ons for firefox 1](https://user-images.githubusercontent.com/55398/31295457-45e504de-aaa4-11e7-8e4b-76f4c00511ea.png)
