### PR TITLE
WIP: feat: Add an option to randomize carousels

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "jed": "1.1.1",
     "join-url": "2.0.0",
     "jsdom": "11.3.0",
+    "knuth-shuffle": "1.0.1",
     "localforage": "1.5.1",
     "lodash.debounce": "4.0.8",
     "moment": "2.18.1",

--- a/src/amo/components/HomeCarousel/index.js
+++ b/src/amo/components/HomeCarousel/index.js
@@ -78,7 +78,7 @@ export class HomeCarouselBase extends React.Component {
   render() {
     return (
       <div className="HomeCarousel">
-        <Carousel sections={this.carouselSections()} />
+        <Carousel random sections={this.carouselSections()} />
       </div>
     );
   }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -4,6 +4,7 @@ import url from 'url';
 
 import { oneLine } from 'common-tags';
 import config from 'config';
+import { knuthShuffle } from 'knuth-shuffle';
 import mozCompare from 'mozilla-version-comparator';
 import React from 'react';
 import { asyncConnect as defaultAsyncConnect } from 'redux-connect';
@@ -476,4 +477,8 @@ export function addonHasVersionHistory(addon) {
     ADDON_TYPE_OPENSEARCH,
     ADDON_TYPE_THEME,
   ].includes(addon.type);
+}
+
+export function randomizeArray(array, { shuffleMethod = knuthShuffle } = {}) {
+  return shuffleMethod(Array.prototype.slice.call(array));
 }

--- a/src/ui/components/Carousel/styles.scss
+++ b/src/ui/components/Carousel/styles.scss
@@ -53,7 +53,7 @@ $extraHeightForCard: 28px;
   // fix properly. This means te content in RTL doesn't change order after
   // the client re-render.
   direction: ltr;
-  overflow-x: auto;
+  overflow: hidden;
 }
 
 .Carousel--first-render {

--- a/tests/unit/amo/components/TestHomeCarousel.js
+++ b/tests/unit/amo/components/TestHomeCarousel.js
@@ -20,5 +20,6 @@ describe(__filename, () => {
 
     expect(root).toHaveClassName('HomeCarousel');
     expect(root.find(Carousel)).toHaveLength(1);
+    expect(root.find(Carousel)).toHaveProp('random', true);
   });
 });

--- a/tests/unit/core/test_utils.js
+++ b/tests/unit/core/test_utils.js
@@ -1,13 +1,11 @@
 import url from 'url';
 
 import { oneLine } from 'common-tags';
-import React from 'react';
 import config from 'config';
+import { mount } from 'enzyme';
 import { sprintf } from 'jed';
-import {
-  renderIntoDocument,
-  findRenderedComponentWithType,
-} from 'react-addons-test-utils';
+import * as knuthShuffle from 'knuth-shuffle';
+import React from 'react';
 import { compose } from 'redux';
 import UAParser from 'ua-parser-js';
 
@@ -49,6 +47,7 @@ import {
   ngettext,
   nl2br,
   parsePage,
+  randomizeArray,
   refreshAddon,
   render404IfConfigKeyIsFalse,
   safeAsyncConnect,
@@ -901,15 +900,18 @@ describe('render404IfConfigKeyIsFalse', () => {
       render404IfConfigKeyIsFalse(configKey, { _config }),
     )(SomeComponent);
 
-    return renderIntoDocument(
+    return mount(
       <I18nProvider i18n={fakeI18n()}>
-        <WrappedComponent {...props} />
-      </I18nProvider>
+        <WrappedComponent i18n={fakeI18n()} {...props} />
+      </I18nProvider>,
+      SomeComponent
     );
   }
 
   it('requires a config key', () => {
-    expect(() => render404IfConfigKeyIsFalse()).toThrowError(/configKey cannot be empty/);
+    expect(() => {
+      render404IfConfigKeyIsFalse();
+    }).toThrowError(/configKey cannot be empty/);
   });
 
   it('returns a 404 when disabled by the config', () => {
@@ -918,11 +920,11 @@ describe('render404IfConfigKeyIsFalse', () => {
       get: sinon.spy(() => false),
     };
     const root = render({}, { _config, configKey });
-    const node = findRenderedComponentWithType(root, NotFound);
+    const node = root.find(NotFound);
 
-    expect(node).toBeTruthy();
-    expect(_config.get.called).toBeTruthy();
-    expect(_config.get.firstCall.args[0]).toEqual(configKey);
+    expect(node).toHaveLength(1);
+    sinon.assert.called(_config.get);
+    sinon.assert.calledWith(_config.get, configKey);
   });
 
   it('passes through component and props when enabled', () => {
@@ -930,7 +932,7 @@ describe('render404IfConfigKeyIsFalse', () => {
     const SomeComponent = sinon.spy(() => <div />);
     render({ color: 'orange', size: 'large' }, { SomeComponent, _config });
 
-    expect(SomeComponent.called).toBeTruthy();
+    sinon.assert.called(SomeComponent);
     const props = SomeComponent.firstCall.args[0];
     expect(props.color).toEqual('orange');
     expect(props.size).toEqual('large');
@@ -1270,5 +1272,19 @@ describe('sanitizeUserHTML', () => {
 
   it('does nothing to null values', () => {
     expect(sanitize(null)).toEqual('');
+  });
+});
+
+describe('randomizeArray', () => {
+  it('returns a copy of the array', () => {
+    const shuffleSpy = sinon.spy(knuthShuffle, 'knuthShuffle');
+    const sortedArray = [1, 2, 3];
+    const randomizedArray = randomizeArray(sortedArray,
+      { shuffleMethod: knuthShuffle.knuthShuffle });
+
+    expect(sortedArray).toEqual([1, 2, 3]);
+    expect(randomizedArray).toEqual(expect.arrayContaining(sortedArray));
+    expect(sortedArray).not.toBe(randomizedArray);
+    sinon.assert.called(shuffleSpy);
   });
 });

--- a/tests/unit/ui/components/TestCarousel.js
+++ b/tests/unit/ui/components/TestCarousel.js
@@ -2,6 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import NukaCarousel from 'nuka-carousel';
 
+import * as coreUtils from 'core/utils';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 import Carousel, { CarouselBase } from 'ui/components/Carousel';
 
@@ -94,5 +95,42 @@ describe(__filename, () => {
     expect(root.find('p')).toHaveLength(2);
     expect(root.find('.something')).toHaveLength(1);
     expect(root.find('.something-else')).toHaveLength(1);
+  });
+
+  it('does not randomize sections when random prop is false', () => {
+    const sections = [];
+    const sortSpy = sinon.spy(coreUtils, 'randomizeArray');
+
+    shallowRender({ random: false, sections });
+
+    sinon.assert.notCalled(sortSpy);
+  });
+
+  it('randomizes sections when random prop is set', () => {
+    const sections = [];
+    const sortSpy = sinon.spy(coreUtils, 'randomizeArray');
+
+    shallowRender({ random: true, sections });
+
+    sinon.assert.called(sortSpy);
+  });
+
+  it('does not re-sort sections if nextProps and props are equal', () => {
+    const sections = [
+      <p className="something" key="1">Howdy!</p>,
+      <p className="something-else" key="2">Bonjour !</p>,
+    ];
+    const root = shallowRender({ random: true, sections });
+    const sectionSortSpy = sinon.spy(root.instance(), 'storeSortedSections');
+
+    sinon.assert.notCalled(sectionSortSpy);
+
+    root.setProps({ random: true, sections });
+
+    sinon.assert.notCalled(sectionSortSpy);
+
+    root.setProps({ random: false, sections });
+
+    sinon.assert.called(sectionSortSpy);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4894,6 +4894,10 @@ known-css-properties@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.2.0.tgz#899c94be368e55b42d7db8d5be7d73a4a4a41454"
 
+knuth-shuffle@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/knuth-shuffle/-/knuth-shuffle-1.0.1.tgz#454940ae816c14e1af6e6f09d8828818f95b5191"
+
 kw-react-tween-state@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/kw-react-tween-state/-/kw-react-tween-state-0.1.5.tgz#744088988d35f14ccc2ca36af96bc09ece7ab78b"


### PR DESCRIPTION
Adds an option to randomly sort a carousel's sections and enables it on the Home page carousel.

Fix #3332.

Randomly sorting things led to even more issues with the difference between server/client load, and I thus far have settled on thinking we really shouldn't load the carousel on the client because of the weirdness of it until the client render happens.

I think this might be the best solution but I'll think about it a bit more and tidy this up tomorrow.