### PR TITLE
Fix landing page

### DIFF
--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -41,6 +41,8 @@ export class LandingPageBase extends React.Component {
     // `componentWillReceiveProps()`.
     // eslint-disable-next-line react/no-unused-prop-types
     addonTypeOfResults: PropTypes.string.isRequired,
+    // This is a bug; context is used in `setViewContextType()`.
+    // eslint-disable-next-line react/no-unused-prop-types
     context: PropTypes.string.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
@@ -85,6 +87,7 @@ export class LandingPageBase extends React.Component {
   getLandingDataIfNeeded(nextProps = {}) {
     const {
       addonTypeOfResults,
+      dispatch,
       errorHandler,
       loading,
       params,
@@ -97,8 +100,8 @@ export class LandingPageBase extends React.Component {
     const requestedAddonType = apiAddonType(params.visibleAddonType);
 
     if (!loading && !errorHandler.hasError() &&
-      (!resultsLoaded || addonTypeOfResults !== requestedAddonType)) {
-      this.props.dispatch(getLanding({
+        (!resultsLoaded || addonTypeOfResults !== requestedAddonType)) {
+      dispatch(getLanding({
         addonType: requestedAddonType,
         errorHandlerId: errorHandler.id,
       }));
@@ -106,10 +109,10 @@ export class LandingPageBase extends React.Component {
   }
 
   setViewContextType(nextProps = {}) {
-    const { params } = { ...this.props, ...nextProps };
+    const { context, params } = { ...this.props, ...nextProps };
     const addonType = apiAddonType(params.visibleAddonType);
 
-    if (this.props.context !== addonType) {
+    if (context !== addonType) {
       this.props.dispatch(setViewContext(addonType));
     }
   }
@@ -276,7 +279,7 @@ export function mapStateToProps(state) {
 }
 
 export default compose(
-  withErrorHandler({ name: 'LandingPage' }),
   connect(mapStateToProps),
-  translate({ withRef: true }),
+  translate(),
+  withErrorHandler({ name: 'LandingPage' }),
 )(LandingPageBase);

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -41,6 +41,7 @@ export class LandingPageBase extends React.Component {
     // `componentWillReceiveProps()`.
     // eslint-disable-next-line react/no-unused-prop-types
     addonTypeOfResults: PropTypes.string.isRequired,
+    context: PropTypes.string.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
     featuredAddons: PropTypes.array.isRequired,
@@ -107,7 +108,10 @@ export class LandingPageBase extends React.Component {
   setViewContextType(nextProps = {}) {
     const { params } = { ...this.props, ...nextProps };
     const addonType = apiAddonType(params.visibleAddonType);
-    this.props.dispatch(setViewContext(addonType));
+
+    if (this.props.context !== addonType) {
+      this.props.dispatch(setViewContext(addonType));
+    }
   }
 
   contentForType = (visibleAddonType) => {
@@ -258,10 +262,11 @@ export class LandingPageBase extends React.Component {
 }
 
 export function mapStateToProps(state) {
-  const { landing } = state;
+  const { landing, viewContext } = state;
 
   return {
     addonTypeOfResults: landing.addonType,
+    context: viewContext.context,
     featuredAddons: landing.featured.results,
     highlyRatedAddons: landing.highlyRated.results,
     loading: landing.loading,

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -308,4 +308,26 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
     }));
   });
+
+  it('does not dispatch setViewContext when addonType does not change', () => {
+    const { store } = dispatchClientMetadata();
+
+    const addonType = ADDON_TYPE_EXTENSION;
+    const errorHandler = createStubErrorHandler();
+    const params = { visibleAddonType: visibleAddonType(addonType) };
+
+    store.dispatch(landingActions.getLanding({
+      addonType,
+      errorHandlerId: errorHandler.id,
+    }));
+    store.dispatch(setViewContext(addonType));
+
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    const root = render({ errorHandler, params, store });
+
+    fakeDispatch.reset();
+    root.setProps({ params });
+
+    sinon.assert.notCalled(fakeDispatch);
+  });
 });


### PR DESCRIPTION
Fix #3383

---

This PR makes sure a landing page fetches data again after having loaded a category page. It happens because we use the same (redux) action with an optional parameter (`category`) and the `LandingPage` component needed to check it to determine if it had to get data or not. I also made sure that we did not dispatch `setViewContext` too often.

This diff is rather large because I rewrote most of the test file with `shallowUntilTarget()`.

![2017-10-09 15 18 18](https://user-images.githubusercontent.com/217628/31340102-691623a8-ad05-11e7-8222-69c0bd81c585.gif)
