### PR TITLE
Fetch featured themes on Android

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -13,6 +13,7 @@ import log from 'core/logger';
 import {
   addVersionCompatibilityToFilters,
   convertFiltersToQueryParams,
+  fixFiltersForAndroidThemes,
 } from 'core/searchUtils';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { ApiStateType } from 'core/reducers/api';
@@ -207,11 +208,12 @@ type FeaturedParams = {|
 |};
 
 export function featured({ api, filters, page }: FeaturedParams) {
+  const newFilters = fixFiltersForAndroidThemes({ api, filters });
+
   return callApi({
     endpoint: 'addons/featured',
     params: {
-      app: api.clientApp,
-      ...convertFiltersToQueryParams(filters),
+      ...convertFiltersToQueryParams(newFilters),
       page,
     },
     schema: { results: [addon] },

--- a/src/core/api/search.js
+++ b/src/core/api/search.js
@@ -1,17 +1,11 @@
 /* @flow */
-import { oneLine } from 'common-tags';
-
 import { addon, callApi } from 'core/api';
-import {
-  ADDON_TYPE_THEME,
-  CLIENT_APP_ANDROID,
-} from 'core/constants';
-import log from 'core/logger';
-import type { ApiStateType } from 'core/reducers/api';
 import {
   addVersionCompatibilityToFilters,
   convertFiltersToQueryParams,
+  fixFiltersForAndroidThemes,
 } from 'core/searchUtils';
+import type { ApiStateType } from 'core/reducers/api';
 
 
 export type SearchParams = {|
@@ -37,34 +31,8 @@ export type SearchParams = {|
 export function search(
   { api, auth = false, filters = {} }: SearchParams
 ) {
-  let newFilters = { ...filters };
-  if (!newFilters.clientApp && api.clientApp) {
-    log.debug(
-      `No clientApp found in filters; using api.clientApp (${api.clientApp})`);
-    newFilters.clientApp = api.clientApp;
-  }
-
-  // TODO: This loads Firefox personas (lightweight themes) for Android
-  // until
-  // https:// github.com/mozilla/addons-frontend/issues/1723#issuecomment-278793546
-  // and https://github.com/mozilla/addons-server/issues/4766 are addressed.
-  // Essentially: right now there are no categories for the combo
-  // of "Android" + "Themes" but Firefox lightweight themes will work fine
-  // on mobile so we request "Firefox" + "Themes" for Android instead.
-  // Obviously we need to fix this on the API end so our requests aren't
-  // overridden, but for now this will work.
-  if (
-    newFilters.clientApp === CLIENT_APP_ANDROID &&
-    newFilters.addonType === ADDON_TYPE_THEME
-  ) {
-    log.info(oneLine`addonType: ${newFilters.addonType}/clientApp:
-      ${newFilters.clientApp} is not supported. Changing clientApp to
-      "firefox"`);
-    newFilters.clientApp = 'firefox';
-  }
-
-  newFilters = addVersionCompatibilityToFilters({
-    filters: newFilters,
+  const newFilters = addVersionCompatibilityToFilters({
+    filters: fixFiltersForAndroidThemes({ api, filters }),
     userAgentInfo: api.userAgentInfo,
   });
 

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -3,6 +3,7 @@ import { oneLine } from 'common-tags';
 import {
   ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
 } from 'core/constants';
 import log from 'core/logger';
 
@@ -132,8 +133,8 @@ export const fixFiltersForAndroidThemes = ({ api, filters }) => {
   ) {
     log.info(oneLine`addonType: ${newFilters.addonType}/clientApp:
       ${newFilters.clientApp} is not supported. Changing clientApp to
-      "firefox"`);
-    newFilters.clientApp = 'firefox';
+      "${CLIENT_APP_FIREFOX}"`);
+    newFilters.clientApp = CLIENT_APP_FIREFOX;
   }
 
   return newFilters;

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -1,5 +1,9 @@
 import { oneLine } from 'common-tags';
 
+import {
+  ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
+} from 'core/constants';
 import log from 'core/logger';
 
 
@@ -103,3 +107,34 @@ export function hasSearchFilters(filters) {
   delete filtersSubset.page_size;
   return filtersSubset && !!Object.keys(filtersSubset).length;
 }
+
+export const fixFiltersForAndroidThemes = ({ api, filters }) => {
+  const newFilters = { ...filters };
+
+  if (!newFilters.clientApp && api.clientApp) {
+    log.debug(
+      `No clientApp found in filters; using api.clientApp (${api.clientApp})`);
+    newFilters.clientApp = api.clientApp;
+  }
+
+  // TODO: This loads Firefox personas (lightweight themes) for Android
+  // until
+  // https:// github.com/mozilla/addons-frontend/issues/1723#issuecomment-278793546
+  // and https://github.com/mozilla/addons-server/issues/4766 are addressed.
+  // Essentially: right now there are no categories for the combo
+  // of "Android" + "Themes" but Firefox lightweight themes will work fine
+  // on mobile so we request "Firefox" + "Themes" for Android instead.
+  // Obviously we need to fix this on the API end so our requests aren't
+  // overridden, but for now this will work.
+  if (
+    newFilters.clientApp === CLIENT_APP_ANDROID &&
+    newFilters.addonType === ADDON_TYPE_THEME
+  ) {
+    log.info(oneLine`addonType: ${newFilters.addonType}/clientApp:
+      ${newFilters.clientApp} is not supported. Changing clientApp to
+      "firefox"`);
+    newFilters.clientApp = 'firefox';
+  }
+
+  return newFilters;
+};

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -269,7 +269,7 @@ describe(__filename, () => {
         });
     });
 
-    it('sets app to `firefox` when addon type is theme for Android', () => {
+    it('changes theme requests for android to firefox results', async () => {
       // See: https://github.com/mozilla/addons-frontend/issues/3408
       mockWindow.expects('fetch')
         .withArgs(`${apiHost}/api/v3/addons/featured/?app=firefox&type=persona&lang=en-US`)
@@ -281,25 +281,11 @@ describe(__filename, () => {
         lang: 'en-US',
       });
 
-      return api.featured({
+      await api.featured({
         api: state.api,
         filters: { addonType: ADDON_TYPE_THEME },
-      })
-        .then((response) => {
-          expect(response).toEqual({
-            entities: {
-              addons: {
-                foo: { slug: 'foo' },
-                food: { slug: 'food' },
-                football: { slug: 'football' },
-              },
-            },
-            result: {
-              results: ['foo', 'food', 'football'],
-            },
-          });
-          return mockWindow.verify();
-        });
+      });
+      mockWindow.verify();
     });
   });
 

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -5,7 +5,11 @@ import config, { util as configUtil } from 'config';
 import utf8 from 'utf8';
 
 import * as api from 'core/api';
-import { ADDON_TYPE_THEME, CLIENT_APP_ANDROID } from 'core/constants';
+import {
+  ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
+} from 'core/constants';
 import {
   createFakeAutocompleteResult,
   dispatchClientMetadata,
@@ -235,7 +239,40 @@ describe(__filename, () => {
 
     it('sets the app, lang, and type query', () => {
       mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/featured/?app=android&type=persona&lang=en-US`)
+        .withArgs(`${apiHost}/api/v3/addons/featured/?app=firefox&type=persona&lang=en-US`)
+        .once()
+        .returns(mockResponse());
+
+      const { state } = dispatchClientMetadata({
+        clientApp: CLIENT_APP_FIREFOX,
+        lang: 'en-US',
+      });
+
+      return api.featured({
+        api: state.api,
+        filters: { addonType: ADDON_TYPE_THEME },
+      })
+        .then((response) => {
+          expect(response).toEqual({
+            entities: {
+              addons: {
+                foo: { slug: 'foo' },
+                food: { slug: 'food' },
+                football: { slug: 'football' },
+              },
+            },
+            result: {
+              results: ['foo', 'food', 'football'],
+            },
+          });
+          return mockWindow.verify();
+        });
+    });
+
+    it('sets app to `firefox` when addon type is theme for Android', () => {
+      // See: https://github.com/mozilla/addons-frontend/issues/3408
+      mockWindow.expects('fetch')
+        .withArgs(`${apiHost}/api/v3/addons/featured/?app=firefox&type=persona&lang=en-US`)
         .once()
         .returns(mockResponse());
 

--- a/tests/unit/core/api/test_search.js
+++ b/tests/unit/core/api/test_search.js
@@ -198,36 +198,20 @@ describe(__filename, () => {
       });
   });
 
-  it('changes theme requests for android to firefox results', () => {
+  it('changes theme requests for android to firefox results', async () => {
     // FIXME: This shouldn't fail if the args are in a different order.
     mockWindow.expects('fetch')
       .withArgs(`${apiHost}/api/v3/addons/search/?app=firefox&page=3&type=persona&lang=en-US`)
       .once()
       .returns(mockResponse());
 
-    return _search({
+    await _search({
       filters: {
         addonType: ADDON_TYPE_THEME,
         clientApp: CLIENT_APP_ANDROID,
         page: parsePage(3),
       },
-    })
-      .then(() => mockWindow.verify());
-  });
-
-  it('allows overrides to clientApp', () => {
-    // FIXME: This shouldn't fail if the args are in a different order.
-    mockWindow.expects('fetch')
-      .withArgs(`${apiHost}/api/v3/addons/search/?app=android&page=3&q=foo&lang=en-US`)
-      .once()
-      .returns(mockResponse());
-    return _search({
-      filters: {
-        clientApp: CLIENT_APP_ANDROID,
-        page: parsePage(3),
-        query: 'foo',
-      },
-    })
-      .then(() => mockWindow.verify());
+    });
+    mockWindow.verify();
   });
 });

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -202,10 +202,10 @@ describe(__filename, () => {
       expect(newFilters).toEqual(filters);
     });
 
-    it('does not do anything when clientApp is `firefox`', () => {
+    it('does not change filters unless clientApp is `android`', () => {
       const filters = {
         addonType: ADDON_TYPE_THEME,
-        clientApp: CLIENT_APP_FIREFOX,
+        clientApp: 'some-bogus-client',
       };
 
       const newFilters = fixFiltersForAndroidThemes({ filters });


### PR DESCRIPTION
Fix #3408

---

This PR fixes an issue with the themes for Android by porting the same workaround used in the search API to the featured API, since both are different.