### PR TITLE
Create featured themes shelf on the homepage

### DIFF
--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -57,6 +57,7 @@ export class HomeBase extends React.Component {
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
     featuredCollection: PropTypes.array.isRequired,
+    featuredThemes: PropTypes.array.isRequired,
     i18n: PropTypes.object.isRequired,
     popularExtensions: PropTypes.array.isRequired,
     resultsLoaded: PropTypes.bool.isRequired,
@@ -153,6 +154,7 @@ export class HomeBase extends React.Component {
     const {
       errorHandler,
       featuredCollection,
+      featuredThemes,
       i18n,
       popularExtensions,
       resultsLoaded,
@@ -187,6 +189,15 @@ export class HomeBase extends React.Component {
           footerLink={{ pathname:
             `/collections/${FEATURED_COLLECTION_USER}/${FEATURED_COLLECTION_SLUG}/`,
           }}
+          loading={resultsLoaded === false}
+        />
+
+        <LandingAddonsCard
+          addons={featuredThemes}
+          className="Home-FeaturedThemes"
+          header={i18n.gettext('Featured themes')}
+          footerText={i18n.gettext('More featured themes')}
+          footerLink={{ pathname: '/themes/featured/' }}
           loading={resultsLoaded === false}
         />
 
@@ -236,6 +247,7 @@ export function mapStateToProps(state) {
   return {
     clientApp: state.api.clientApp,
     featuredCollection: state.home.featuredCollection,
+    featuredThemes: state.home.featuredThemes,
     popularExtensions: state.home.popularExtensions,
     resultsLoaded: state.home.resultsLoaded,
   };

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -7,8 +7,10 @@ import {
 } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
   SEARCH_SORT_POPULAR,
 } from 'core/constants';
+import { featured as featuredApi } from 'core/api';
 import { search as searchApi } from 'core/api/search';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
@@ -31,6 +33,7 @@ export function* fetchHomeAddons({
     const {
       popularExtensions,
       featuredCollection,
+      featuredThemes,
     } = yield all({
       popularExtensions: call(searchApi, {
         api: state.api,
@@ -47,11 +50,19 @@ export function* fetchHomeAddons({
         slug: featuredCollectionSlug,
         user: featuredCollectionUser,
       }),
+      featuredThemes: call(featuredApi, {
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_THEME,
+          page_size: LANDING_PAGE_ADDON_COUNT,
+        },
+      }),
     });
 
     yield put(loadHomeAddons({
       popularExtensions,
       featuredCollection,
+      featuredThemes,
     }));
   } catch (error) {
     log.warn(`Home add-ons failed to load: ${error}`);

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -36,6 +36,7 @@ import {
   createFakeCollectionAddons,
   dispatchClientMetadata,
   fakeAddon,
+  fakeTheme,
 } from 'tests/unit/amo/helpers';
 
 
@@ -150,10 +151,7 @@ describe(__filename, () => {
     const root = render();
 
     const shelves = root.find(LandingAddonsCard);
-    expect(shelves).toHaveLength(2);
-
-    // The popular extensions shelf is the first one.
-    const shelf = shelves.at(0);
+    const shelf = shelves.find('.Home-PopularExtensions');
     expect(shelf).toHaveProp('header', 'Most popular extensions');
     expect(shelf).toHaveProp('footerText', 'More popular extensions');
     expect(shelf).toHaveProp('footerLink', {
@@ -163,6 +161,17 @@ describe(__filename, () => {
         sort: SEARCH_SORT_POPULAR,
       },
     });
+    expect(shelf).toHaveProp('loading', true);
+  });
+
+  it('renders a featured themes shelf', () => {
+    const root = render();
+
+    const shelves = root.find(LandingAddonsCard);
+    const shelf = shelves.find('.Home-FeaturedThemes');
+    expect(shelf).toHaveProp('header', 'Featured themes');
+    expect(shelf).toHaveProp('footerText', 'More featured themes');
+    expect(shelf).toHaveProp('footerLink', { pathname: '/themes/featured/' });
     expect(shelf).toHaveProp('loading', true);
   });
 
@@ -186,11 +195,14 @@ describe(__filename, () => {
     const store = dispatchClientMetadata().store;
 
     const addons = [{ ...fakeAddon, slug: 'popular-addon' }];
+    const themes = [{ ...fakeTheme }];
     const featuredCollection = createFakeCollectionAddons({ addons });
+    const featuredThemes = createAddonsApiResult(themes);
     const popularExtensions = createAddonsApiResult(addons);
 
     store.dispatch(loadHomeAddons({
       featuredCollection,
+      featuredThemes,
       popularExtensions,
     }));
 
@@ -201,17 +213,22 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeDispatch, setViewContext(VIEW_CONTEXT_HOME));
 
     const shelves = root.find(LandingAddonsCard);
-    expect(shelves).toHaveLength(2);
+    expect(shelves).toHaveLength(3);
 
-    const popularExtensionsShelf = shelves.at(0);
+    const popularExtensionsShelf = shelves.find('.Home-PopularExtensions');
     expect(popularExtensionsShelf).toHaveProp('loading', false);
     expect(popularExtensionsShelf)
       .toHaveProp('addons', addons.map((addon) => createInternalAddon(addon)));
 
-    const featuredCollectionShelf = shelves.at(1);
+    const featuredCollectionShelf = shelves.find('.Home-FeaturedCollection');
     expect(featuredCollectionShelf).toHaveProp('loading', false);
     expect(featuredCollectionShelf)
       .toHaveProp('addons', addons.map((addon) => createInternalAddon(addon)));
+
+    const featuredThemesShelf = shelves.find('.Home-FeaturedThemes');
+    expect(featuredThemesShelf).toHaveProp('loading', false);
+    expect(featuredThemesShelf)
+      .toHaveProp('addons', themes.map((addon) => createInternalAddon(addon)));
   });
 
   it('displays an error if present', () => {

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -10,6 +10,7 @@ import {
   createFakeCollectionAddons,
   dispatchClientMetadata,
   fakeAddon,
+  fakeTheme,
 } from 'tests/unit/amo/helpers';
 
 
@@ -32,6 +33,7 @@ describe(__filename, () => {
         featuredCollection: createFakeCollectionAddons({
           addons: Array(10).fill(fakeAddon),
         }),
+        featuredThemes: createAddonsApiResult([fakeTheme]),
         popularExtensions: createAddonsApiResult([fakeAddon]),
       }));
 
@@ -46,6 +48,9 @@ describe(__filename, () => {
       expect(homeState.featuredCollection).toEqual(
         Array(LANDING_PAGE_ADDON_COUNT).fill(createInternalAddon(fakeAddon))
       );
+      expect(homeState.featuredThemes).toEqual([
+        createInternalAddon(fakeTheme),
+      ]);
     });
 
     it('sets `resultsLoaded` to `false` when fetching home add-ons', () => {
@@ -100,6 +105,7 @@ describe(__filename, () => {
     const defaultParams = {
       popularExtensions: {},
       featuredCollection: {},
+      featuredThemes: {},
     };
 
     it('throws an error when popular extensions are missing', () => {
@@ -118,6 +124,15 @@ describe(__filename, () => {
       expect(() => {
         loadHomeAddons(partialParams);
       }).toThrow('featuredCollection is required');
+    });
+
+    it('throws an error when featured themes are missing', () => {
+      const partialParams = { ...defaultParams };
+      delete partialParams.featuredThemes;
+
+      expect(() => {
+        loadHomeAddons(partialParams);
+      }).toThrow('featuredThemes is required');
     });
   });
 });

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -7,9 +7,11 @@ import homeReducer, {
   loadHomeAddons,
 } from 'amo/reducers/home';
 import homeSaga from 'amo/sagas/home';
+import * as api from 'core/api';
 import * as searchApi from 'core/api/search';
 import {
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
   SEARCH_SORT_POPULAR,
 } from 'core/constants';
 import apiReducer from 'core/reducers/api';
@@ -19,17 +21,20 @@ import {
   createFakeCollectionAddons,
   dispatchClientMetadata,
   fakeAddon,
+  fakeTheme,
 } from 'tests/unit/amo/helpers';
 
 
 describe(__filename, () => {
   let errorHandler;
+  let mockApi;
   let mockCollectionsApi;
   let mockSearchApi;
   let sagaTester;
 
   beforeEach(() => {
     errorHandler = createStubErrorHandler();
+    mockApi = sinon.mock(api);
     mockCollectionsApi = sinon.mock(collectionsApi);
     mockSearchApi = sinon.mock(searchApi);
     sagaTester = new SagaTester({
@@ -91,6 +96,18 @@ describe(__filename, () => {
         .once()
         .returns(Promise.resolve(featuredCollection));
 
+      const featuredThemes = createAddonsApiResult([fakeTheme]);
+      mockApi
+        .expects('featured')
+        .withArgs({
+          ...baseArgs,
+          filters: {
+            ...baseFilters,
+            addonType: ADDON_TYPE_THEME,
+          },
+        })
+        .returns(Promise.resolve(featuredThemes));
+
       _fetchHomeAddons({
         featuredCollectionSlug: slug,
         featuredCollectionUser: user,
@@ -98,6 +115,7 @@ describe(__filename, () => {
 
       const expectedLoadAction = loadHomeAddons({
         featuredCollection,
+        featuredThemes,
         popularExtensions,
       });
 


### PR DESCRIPTION
Fix #3311

---

This PR adds the featured themes shelf on the homepage.

## Screenshots

Firefox:

<img width="1392" alt="screen shot 2017-10-09 at 16 57 10" src="https://user-images.githubusercontent.com/217628/31345662-c02fdd94-ad16-11e7-8d20-4ff96af238f5.png">


Android:

<img width="1392" alt="screen shot 2017-10-09 at 17 23 13" src="https://user-images.githubusercontent.com/217628/31345648-bd12c91e-ad16-11e7-86c8-c7f7e1c1a74f.png">
