### PR TITLE
Fix error handling in review-reply form

### DIFF
--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -246,7 +246,7 @@ export class AddonReviewListItemBase extends React.Component {
         {replyingToReview ?
           <DismissibleTextForm
             className="AddonReviewListItem-reply-form"
-            isSubmitting={submittingReply}
+            isSubmitting={submittingReply && !errorHandler.hasError()}
             onDismiss={this.onDismissReviewReply}
             onSubmit={this.onSubmitReviewReply}
             placeholder={i18n.gettext(

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -175,7 +175,6 @@ export class AddonReviewListItemBase extends React.Component {
           'AddonReviewListItem-reply': isReply,
         })}
       >
-        {errorHandler.renderErrorIfPresent()}
         {isReply ? (
           <h4 className="AddonReviewListItem-reply-header">
             <Icon name="reply-arrow" />
@@ -236,6 +235,7 @@ export class AddonReviewListItemBase extends React.Component {
               ) : null
           }
         </div>
+        {errorHandler.renderErrorIfPresent()}
         {review && review.reply ? (
           <AddonReviewListItem
             addon={addon}

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -10,6 +10,10 @@
 
     @include margin-end(6px);
   }
+
+  .ErrorList {
+    margin-top: 6px;
+  }
 }
 
 .AddonReviewListItem-review-header {

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -90,7 +90,7 @@ export class DismissibleTextFormBase extends React.Component {
       submitButtonInProgressText,
     } = this.props;
 
-    const sendButtonIsDisabled = isSubmitting || !this.state.text;
+    const sendButtonIsDisabled = isSubmitting || !this.state.text.trim();
 
     const text = {
       placeholder: placeholder || i18n.gettext('Enter text.'),

--- a/src/ui/components/ErrorList/styles.scss
+++ b/src/ui/components/ErrorList/styles.scss
@@ -1,14 +1,23 @@
 @import "~core/css/inc/vars";
 @import "~ui/css/vars";
 
-.ErrorList {
+.ErrorList,
+.CardList .ErrorList {
   background-color: $report-base-color;
+}
+
+.ErrorList {
   border-radius: $border-radius-default;
   color: $white;
   margin: 0;
   margin-bottom: 10px;
   padding: 10px;
   text-align: center;
+}
+
+.ErrorList-item,
+.CardList .ErrorList-item {
+  background: none;
 }
 
 .ErrorList-item {

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -330,6 +330,27 @@ describe(__filename, () => {
     expect(textForm).toHaveProp('isSubmitting', false);
   });
 
+  it('resets the reply form state when there is an error', () => {
+    // Simulate submitting a reply that will result in an error.
+    const review = _setReview(fakeReview);
+    store.dispatch(showReplyToReviewForm({ reviewId: review.id }));
+    store.dispatch(sendReplyToReview({
+      body: 'A developer reply',
+      errorHandlerId: 'some-id',
+      originalReviewId: review.id,
+    }));
+
+    const errorHandler = new ErrorHandler({
+      id: 'some-id', dispatch: store.dispatch,
+    });
+    errorHandler.handle(new Error('some unexpected error'));
+
+    const root = render({ errorHandler, review });
+
+    const textForm = root.find('.AddonReviewListItem-reply-form');
+    expect(textForm).toHaveProp('isSubmitting', false);
+  });
+
   it('cannot submit a reply without a review', () => {
     const root = render({ review: null });
 

--- a/tests/unit/ui/components/TestDismissibleTextForm.js
+++ b/tests/unit/ui/components/TestDismissibleTextForm.js
@@ -169,6 +169,14 @@ describe(__filename, () => {
       .toHaveProp('disabled', true);
   });
 
+  it('disables submit button before non-empty text has been entered', () => {
+    // Enter only white space:
+    const root = shallowRender({ text: '    ' });
+
+    expect(root.find('.DismissibleTextForm-submit'))
+      .toHaveProp('disabled', true);
+  });
+
   it('disables the dismiss button while submitting the form', () => {
     const root = shallowRender({ isSubmitting: true });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3415

This does a few things:
* Fixes specificity issues in the `ErrorList` styles so that the error message is visible
* Allows the user to edit their reply and try again in case there's an error
* Prevents the user from submitting a blank reply, i.e. one with just white space

The error banner looks like this but keep in mind this specific error is no longer possible to trigger:

<img width="850" alt="screenshot 2017-10-09 16 53 58" src="https://user-images.githubusercontent.com/55398/31360354-9a94cdf4-ad13-11e7-99ed-ab1a67707dcc.png">
