### PR TITLE
make sure collections get loaded when params change

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -79,6 +79,13 @@ export class CollectionBase extends React.Component {
       }
     }
 
+    if (collection && (
+      collection.slug !== params.slug ||
+      collection.authorUsername !== params.user
+    )) {
+      collectionChanged = true;
+    }
+
     if (!collection || collectionChanged) {
       this.props.dispatch(fetchCollection({
         errorHandlerId: errorHandler.id,

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -12,11 +12,13 @@ export const LOAD_COLLECTION_PAGE: 'LOAD_COLLECTION_PAGE'
 export type CollectionType = {
   addons: Array<AddonType>,
   authorName: string,
+  authorUsername: string,
   description: string | null,
   id: number,
   lastUpdatedDate: string,
   name: string,
   numberOfAddons: number,
+  slug: string,
 };
 
 export type CollectionsState = {|
@@ -199,11 +201,13 @@ export const createInternalCollection = ({
 }: CreateInternalCollectionParams): CollectionType => ({
   addons: createInternalAddons(items),
   authorName: detail.author.name,
+  authorUsername: detail.author.username,
   description: detail.description,
   id: detail.id,
   lastUpdatedDate: detail.modified,
   name: detail.name,
   numberOfAddons: detail.addon_count,
+  slug: detail.slug,
 });
 
 type Action =

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -29,14 +29,18 @@ import {
 
 
 describe(__filename, () => {
+  // These values match the `createFakeCollectionDetail()` helper data.
+  const defaultUser = 'johndoe';
+  const defaultSlug = 'my-addons';
+
   const getProps = () => ({
     dispatch: sinon.stub(),
     errorHandler: createStubErrorHandler(),
     i18n: fakeI18n(),
     location: { query: {} },
     params: {
-      user: 'user-id-or-name',
-      slug: 'collection-slug',
+      user: defaultUser,
+      slug: defaultSlug,
     },
     store: dispatchClientMetadata().store,
   });
@@ -268,15 +272,11 @@ describe(__filename, () => {
     const page = 123;
     const location = { query: {} };
     const newLocation = { query: { page } };
-
     const errorHandler = createStubErrorHandler();
-    const slug = 'collection-slug';
-    const user = 'some-user';
 
     const wrapper = renderComponent({
       errorHandler,
       location,
-      params: { slug, user },
       store,
     });
     fakeDispatch.reset();
@@ -288,8 +288,70 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeDispatch, fetchCollectionPage({
       errorHandlerId: errorHandler.id,
       page,
-      slug,
-      user,
+      user: defaultUser,
+      slug: defaultSlug,
+    }));
+  });
+
+  it('dispatches fetchCollection when user param has changed', () => {
+    const errorHandler = createStubErrorHandler();
+    const store = dispatchClientMetadata().store;
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+
+    // We need a collection for this test case.
+    store.dispatch(loadCollection({
+      addons: createFakeCollectionAddons(),
+      detail: createFakeCollectionDetail(),
+    }));
+
+    const wrapper = renderComponent({
+      errorHandler,
+      store,
+    });
+    fakeDispatch.reset();
+
+    const newParams = {
+      slug: defaultSlug,
+      user: 'another-user',
+    };
+    wrapper.setProps({ params: newParams });
+
+    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.calledWith(fakeDispatch, fetchCollection({
+      errorHandlerId: errorHandler.id,
+      page: 1,
+      ...newParams,
+    }));
+  });
+
+  it('dispatches fetchCollection when slug param has changed', () => {
+    const errorHandler = createStubErrorHandler();
+    const store = dispatchClientMetadata().store;
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+
+    // We need a collection for this test case.
+    store.dispatch(loadCollection({
+      addons: createFakeCollectionAddons(),
+      detail: createFakeCollectionDetail(),
+    }));
+
+    const wrapper = renderComponent({
+      errorHandler,
+      store,
+    });
+    fakeDispatch.reset();
+
+    const newParams = {
+      slug: 'some-other-collection-slug',
+      user: defaultUser,
+    };
+    wrapper.setProps({ params: newParams });
+
+    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.calledWith(fakeDispatch, fetchCollection({
+      errorHandlerId: errorHandler.id,
+      page: 1,
+      ...newParams,
     }));
   });
 

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -29,9 +29,9 @@ import {
 
 
 describe(__filename, () => {
-  // These values match the `createFakeCollectionDetail()` helper data.
-  const defaultUser = 'johndoe';
-  const defaultSlug = 'my-addons';
+  const defaultCollectionDetail = createFakeCollectionDetail();
+  const defaultUser = defaultCollectionDetail.author.username;
+  const defaultSlug = defaultCollectionDetail.slug;
 
   const getProps = () => ({
     dispatch: sinon.stub(),
@@ -122,7 +122,7 @@ describe(__filename, () => {
     // We need a collection for this test case.
     store.dispatch(loadCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
+      detail: defaultCollectionDetail,
     }));
 
     const wrapper = renderComponent({ store });
@@ -141,7 +141,7 @@ describe(__filename, () => {
     // We need a collection for this test case.
     store.dispatch(loadCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
+      detail: defaultCollectionDetail,
     }));
 
     const location = { query: {} };
@@ -217,7 +217,7 @@ describe(__filename, () => {
     // We need a collection for this test case.
     store.dispatch(loadCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
+      detail: defaultCollectionDetail,
     }));
 
     const errorHandler = createStubErrorHandler();
@@ -266,7 +266,7 @@ describe(__filename, () => {
     // We need a collection for this test case.
     store.dispatch(loadCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
+      detail: defaultCollectionDetail,
     }));
 
     const page = 123;
@@ -301,7 +301,7 @@ describe(__filename, () => {
     // We need a collection for this test case.
     store.dispatch(loadCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
+      detail: defaultCollectionDetail,
     }));
 
     const wrapper = renderComponent({
@@ -332,7 +332,7 @@ describe(__filename, () => {
     // We need a collection for this test case.
     store.dispatch(loadCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
+      detail: defaultCollectionDetail,
     }));
 
     const wrapper = renderComponent({
@@ -382,7 +382,7 @@ describe(__filename, () => {
     // User loads the collection page.
     store.dispatch(loadCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
+      detail: defaultCollectionDetail,
     }));
 
     const wrapper = renderComponent({


### PR DESCRIPTION
Fix #3482

---

This PR makes sure collections get loaded correctly on the client.

## Gifs

Before:

![2017-10-12 22 00 37](https://user-images.githubusercontent.com/217628/31516504-1100ed4c-af99-11e7-8f23-d4e987a60404.gif)

After:

![2017-10-12 21 54 15](https://user-images.githubusercontent.com/217628/31516203-08756b7c-af98-11e7-8fad-223af3343061.gif)
