### PR TITLE
Try pinning redux-saga-tester deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "react-test-renderer": "^15.5.4",
     "react-transform-hmr": "^1.0.4",
     "redux-devtools": "^3.3.2",
-    "redux-saga-tester": "^1.0.252",
+    "redux-saga-tester": "1.0.370",
     "require-uncached": "^1.0.3",
     "rimraf": "^2.6.1",
     "sass-loader": "^6.0.3",

--- a/tests/unit/TestPackageJson.js
+++ b/tests/unit/TestPackageJson.js
@@ -4,11 +4,16 @@ import path from 'path';
 import config from 'config';
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(config.get('basePath'), 'package.json')));
+const skipDevDeps = [
+  'redux-saga-tester',
+];
 
 describe('Package JSON', () => {
   Object.keys(packageJson.devDependencies).forEach((key) => {
     it(`should have devDependencies[${key}] version prefixed with "^"`, () => {
-      expect(packageJson.devDependencies[key]).toEqual(expect.stringMatching(/^(\^|git)/));
+      if (!skipDevDeps.includes(key)) {
+        expect(packageJson.devDependencies[key]).toEqual(expect.stringMatching(/^(\^|git)/));
+      }
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7058,9 +7058,9 @@ redux-logger@3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-saga-tester@^1.0.252:
-  version "1.0.291"
-  resolved "https://registry.yarnpkg.com/redux-saga-tester/-/redux-saga-tester-1.0.291.tgz#6b6fd9855bebfaa29ad381eaaab56cfe62f1d5b0"
+redux-saga-tester@1.0.370:
+  version "1.0.370"
+  resolved "https://registry.yarnpkg.com/redux-saga-tester/-/redux-saga-tester-1.0.370.tgz#d3f5dbdac89f4c33bd28d7ab7ead6d573f1a7e38"
 
 redux-saga@0.15.6:
   version "0.15.6"


### PR DESCRIPTION
Try a fork of redux-saga-tester to see if we can work around the deps failures. 

Oddly this seems to be pulling in a different lower version number since the fork is based on master.