### PR TITLE
Upgrade to redux-saga-tester with fixed dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "react-test-renderer": "^15.5.4",
     "react-transform-hmr": "^1.0.4",
     "redux-devtools": "^3.3.2",
-    "redux-saga-tester": "1.0.370",
+    "redux-saga-tester": "^1.0.372",
     "require-uncached": "^1.0.3",
     "rimraf": "^2.6.1",
     "sass-loader": "^6.0.3",

--- a/tests/unit/TestPackageJson.js
+++ b/tests/unit/TestPackageJson.js
@@ -4,9 +4,10 @@ import path from 'path';
 import config from 'config';
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(config.get('basePath'), 'package.json')));
-const skipDevDeps = [
-  'redux-saga-tester',
-];
+
+// When a dev-dep needs to be pinned the package name should be added to this list.
+// Please add a comment with a link to a bug so we know why it was added.
+const skipDevDeps = [];
 
 describe('Package JSON', () => {
   Object.keys(packageJson.devDependencies).forEach((key) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,10 @@ ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+
 anymatch@^1.1.0, anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -7058,9 +7062,11 @@ redux-logger@3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-saga-tester@1.0.370:
-  version "1.0.370"
-  resolved "https://registry.yarnpkg.com/redux-saga-tester/-/redux-saga-tester-1.0.370.tgz#d3f5dbdac89f4c33bd28d7ab7ead6d573f1a7e38"
+redux-saga-tester@1.0.372:
+  version "1.0.372"
+  resolved "https://registry.yarnpkg.com/redux-saga-tester/-/redux-saga-tester-1.0.372.tgz#303ca137664d0675400f14b2a1ba936ab0721e57"
+  dependencies:
+    wnpm-ci "^6.2.52"
 
 redux-saga@0.15.6:
   version "0.15.6"
@@ -7559,6 +7565,10 @@ shell-quote@^1.4.3:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shelljs@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.5.3.tgz#c54982b996c76ef0c1e6b59fbdc5825f5b713113"
 
 shelljs@^0.7.7:
   version "0.7.8"
@@ -8273,6 +8283,12 @@ then-request@^2.0.1:
     promise "^7.1.1"
     qs "^6.1.0"
 
+thenify@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -8792,6 +8808,13 @@ window-size@0.1.0:
 window-size@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
+
+wnpm-ci@^6.2.52:
+  version "6.2.52"
+  resolved "https://registry.yarnpkg.com/wnpm-ci/-/wnpm-ci-6.2.52.tgz#be8b221dc061eaca0b0426123105d3fa4470baa7"
+  dependencies:
+    shelljs "^0.5.3"
+    thenify "^3.2.0"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Now the redux-saga-tester package has been updated we don't need to skip it any more.

I've left the skip list in play since it may be useful again in the future.