### PR TITLE
Fix chrome height bug

### DIFF
--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -55,7 +55,7 @@
     display: grid;
     grid-auto-flow: column dense;
     grid-gap: 0 10px;
-    grid-template-columns: minmax(300px, 35%) auto;
+    grid-template-columns: minmax(300px, 35%) 1fr;
     margin: 10px 0 0;
 
     .Collection-detail {

--- a/src/amo/components/Search/styles.scss
+++ b/src/amo/components/Search/styles.scss
@@ -6,7 +6,7 @@
     display: grid;
     grid-auto-flow: column dense;
     grid-gap: 10px;
-    grid-template-columns: minmax(300px, 35%) auto;
+    grid-template-columns: minmax(300px, 35%) 1fr;
     padding: $padding-page;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7062,7 +7062,7 @@ redux-logger@3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-saga-tester@1.0.372:
+redux-saga-tester@^1.0.372:
   version "1.0.372"
   resolved "https://registry.yarnpkg.com/redux-saga-tester/-/redux-saga-tester-1.0.372.tgz#303ca137664d0675400f14b2a1ba936ab0721e57"
   dependencies:
@@ -8429,9 +8429,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-ua-parser-js@0.7.14:
-  version "0.7.14"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
+ua-parser-js@0.7.17:
+  version "0.7.17"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 ua-parser-js@^0.7.9:
   version "0.7.13"


### PR DESCRIPTION
Fixes #3015

Before: 

<img width="1474" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31556245-0e6ec6aa-b03c-11e7-92a9-73ed3c804a56.png">

After the fix there's no extra space rendered under the search results:

<img width="1532" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31556231-fa5dc33c-b03b-11e7-933b-90b0da33e1e0.png">
