### PR TITLE
Add API/actions/sagas for flagging reviews

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -1,15 +1,18 @@
 /* @flow */
 import {
-  SHOW_EDIT_REVIEW_FORM,
-  SHOW_REPLY_TO_REVIEW_FORM,
   FETCH_REVIEWS,
   HIDE_EDIT_REVIEW_FORM,
   HIDE_REPLY_TO_REVIEW_FORM,
   SEND_REPLY_TO_REVIEW,
+  SEND_REVIEW_FLAG,
   SET_ADDON_REVIEWS,
   SET_REVIEW,
   SET_REVIEW_REPLY,
+  SET_REVIEW_WAS_FLAGGED,
+  SHOW_EDIT_REVIEW_FORM,
+  SHOW_REPLY_TO_REVIEW_FORM,
 } from 'amo/constants';
+import type { FlagReviewReasonType } from 'amo/constants';
 import type {
   ExternalReviewReplyType, ExternalReviewType,
 } from 'amo/api/reviews';
@@ -51,7 +54,7 @@ export function denormalizeReview(
 }
 
 export type SetReviewAction = {|
-  type: string,
+  type: typeof SET_REVIEW,
   payload: UserReviewType,
 |};
 
@@ -70,7 +73,7 @@ type SetReviewReplyParams = {|
 |};
 
 export type SetReviewReplyAction = {|
-  type: string,
+  type: typeof SET_REVIEW_REPLY,
   payload: SetReviewReplyParams,
 |};
 
@@ -96,7 +99,7 @@ type FetchReviewsParams = {|
 |};
 
 export type FetchReviewsAction = {|
-  type: string,
+  type: typeof FETCH_REVIEWS,
   payload: {|
     addonSlug: string,
     errorHandlerId: string,
@@ -129,7 +132,7 @@ export const setDenormalizedReview = (
 };
 
 export type SetAddonReviewsAction = {|
-  type: string,
+  type: typeof SET_ADDON_REVIEWS,
   payload: {|
     addonSlug: string,
     reviewCount: number,
@@ -173,7 +176,7 @@ type SendReplyToReviewParams = {|
 |};
 
 export type SendReplyToReviewAction = {|
-  type: string,
+  type: typeof SEND_REPLY_TO_REVIEW,
   payload: SendReplyToReviewParams,
 |};
 
@@ -202,7 +205,7 @@ type ReviewIdActionParams = {|
 
 export const reviewIdAction = (
   { reviewId, type }: ReviewIdActionParams = {}
-) => {
+): any => {
   if (!reviewId) {
     throw new Error('The reviewId parameter is required');
   }
@@ -214,7 +217,7 @@ type ShowEditReviewFormParams = {|
 |};
 
 export type ShowEditReviewFormAction = {|
-  type: string,
+  type: typeof SHOW_EDIT_REVIEW_FORM,
   payload: ShowEditReviewFormParams,
 |};
 
@@ -229,7 +232,7 @@ type ShowReplyToReviewParams = {|
 |};
 
 export type ShowReplyToReviewFormAction = {|
-  type: string,
+  type: typeof SHOW_REPLY_TO_REVIEW_FORM,
   payload: ShowReplyToReviewParams,
 |};
 
@@ -244,7 +247,7 @@ type HideEditReviewFormParams = {|
 |};
 
 export type HideEditReviewFormAction = {|
-  type: string,
+  type: typeof HIDE_EDIT_REVIEW_FORM,
   payload: HideEditReviewFormParams,
 |};
 
@@ -259,7 +262,7 @@ type HideReplyToReviewFormParams = {|
 |};
 
 export type HideReplyToReviewFormAction = {|
-  type: string,
+  type: typeof HIDE_REPLY_TO_REVIEW_FORM,
   payload: HideReplyToReviewFormParams,
 |};
 
@@ -267,4 +270,59 @@ export const hideReplyToReviewForm = (
   { reviewId }: HideReplyToReviewFormParams = {}
 ): HideReplyToReviewFormAction => {
   return reviewIdAction({ type: HIDE_REPLY_TO_REVIEW_FORM, reviewId });
+};
+
+type FlagReviewParams = {|
+  errorHandlerId: string,
+  note?: string,
+  reason: FlagReviewReasonType,
+  reviewId: number,
+|};
+
+export type FlagReviewAction = {|
+  type: typeof SEND_REVIEW_FLAG,
+  payload: FlagReviewParams,
+|};
+
+export const flagReview = (
+  { errorHandlerId, note, reason, reviewId }: FlagReviewParams = {}
+): FlagReviewAction => {
+  if (!errorHandlerId) {
+    throw new Error('The errorHandlerId parameter is required');
+  }
+  if (!reason) {
+    throw new Error('The reason parameter is required');
+  }
+  if (!reviewId) {
+    throw new Error('The reviewId parameter is required');
+  }
+  return {
+    type: SEND_REVIEW_FLAG,
+    payload: { errorHandlerId, note, reason, reviewId },
+  };
+};
+
+type ReviewWasFlaggedParams = {|
+  reason: FlagReviewReasonType,
+  reviewId: number,
+|};
+
+export type ReviewWasFlaggedAction = {|
+  type: typeof SET_REVIEW_WAS_FLAGGED,
+  payload: ReviewWasFlaggedParams,
+|};
+
+export const setReviewWasFlagged = (
+  { reason, reviewId }: ReviewWasFlaggedParams = {}
+): ReviewWasFlaggedAction => {
+  if (!reason) {
+    throw new Error('The reason parameter is required');
+  }
+  if (!reviewId) {
+    throw new Error('The reviewId parameter is required');
+  }
+  return {
+    type: SET_REVIEW_WAS_FLAGGED,
+    payload: { reason, reviewId },
+  };
 };

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -1,7 +1,9 @@
 /* @flow */
 import { oneLine } from 'common-tags';
 
+import { REVIEW_FLAG_REASON_OTHER } from 'amo/constants';
 import { callApi } from 'core/api';
+import type { FlagReviewReasonType } from 'amo/constants';
 import type { ApiStateType } from 'core/reducers/api';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { PaginatedApiResponse } from 'core/types/api';
@@ -188,3 +190,40 @@ export function getLatestUserReview(
         ${JSON.stringify(reviews)}`);
     });
 }
+
+type FlagReviewParams = {|
+  apiState?: ApiStateType,
+  errorHandler?: ErrorHandlerType,
+  note?: string,
+  reason: FlagReviewReasonType,
+  reviewId: number,
+|};
+
+export const flagReview = (
+  { apiState, errorHandler, note, reason, reviewId }: FlagReviewParams = {}
+): Promise<void> => {
+  return new Promise((resolve) => {
+    if (!reviewId) {
+      throw new Error('The reviewId parameter is required');
+    }
+    if (!reason) {
+      throw new Error('The reason parameter is required');
+    }
+    if (reason === REVIEW_FLAG_REASON_OTHER && !note) {
+      throw new Error(
+        `When reason is ${reason}, the note parameter is required`
+      );
+    }
+    resolve(callApi({
+      auth: true,
+      body: {
+        flag: reason,
+        note,
+      },
+      endpoint: `reviews/review/${reviewId}/flag/`,
+      errorHandler,
+      method: 'POST',
+      state: apiState,
+    }));
+  });
+};

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -1,13 +1,37 @@
+/* @flow */
 // Action types.
-export const SHOW_EDIT_REVIEW_FORM = 'SHOW_EDIT_REVIEW_FORM';
-export const SHOW_REPLY_TO_REVIEW_FORM = 'SHOW_REPLY_TO_REVIEW_FORM';
-export const FETCH_REVIEWS = 'FETCH_REVIEWS';
-export const HIDE_EDIT_REVIEW_FORM = 'HIDE_EDIT_REVIEW_FORM';
-export const HIDE_REPLY_TO_REVIEW_FORM = 'HIDE_REPLY_TO_REVIEW_FORM';
-export const SET_ADDON_REVIEWS = 'SET_ADDON_REVIEWS';
-export const SET_REVIEW = 'SET_REVIEW';
-export const SET_REVIEW_REPLY = 'SET_REVIEW_REPLY';
-export const SEND_REPLY_TO_REVIEW = 'SEND_REPLY_TO_REVIEW';
+export const SHOW_EDIT_REVIEW_FORM: 'SHOW_EDIT_REVIEW_FORM' =
+  'SHOW_EDIT_REVIEW_FORM';
+export const SHOW_REPLY_TO_REVIEW_FORM: 'SHOW_REPLY_TO_REVIEW_FORM' =
+  'SHOW_REPLY_TO_REVIEW_FORM';
+export const FETCH_REVIEWS: 'FETCH_REVIEWS' = 'FETCH_REVIEWS';
+export const HIDE_EDIT_REVIEW_FORM: 'HIDE_EDIT_REVIEW_FORM' =
+  'HIDE_EDIT_REVIEW_FORM';
+export const HIDE_REPLY_TO_REVIEW_FORM: 'HIDE_REPLY_TO_REVIEW_FORM' =
+  'HIDE_REPLY_TO_REVIEW_FORM';
+export const SET_ADDON_REVIEWS: 'SET_ADDON_REVIEWS' = 'SET_ADDON_REVIEWS';
+export const SET_REVIEW: 'SET_REVIEW' = 'SET_REVIEW';
+export const SET_REVIEW_REPLY: 'SET_REVIEW_REPLY' = 'SET_REVIEW_REPLY';
+export const SET_REVIEW_WAS_FLAGGED: 'SET_REVIEW_WAS_FLAGGED' =
+  'SET_REVIEW_WAS_FLAGGED';
+export const SEND_REPLY_TO_REVIEW: 'SEND_REPLY_TO_REVIEW' =
+  'SEND_REPLY_TO_REVIEW';
+export const SEND_REVIEW_FLAG: 'SEND_REVIEW_FLAG' = 'SEND_REVIEW_FLAG';
+
+export const REVIEW_FLAG_REASON_SPAM: 'review_flag_reason_spam' =
+  'review_flag_reason_spam';
+export const REVIEW_FLAG_REASON_LANGUAGE: 'review_flag_reason_language' =
+  'review_flag_reason_language';
+export const REVIEW_FLAG_REASON_BUG_SUPPORT: 'review_flag_reason_bug_support' =
+  'review_flag_reason_bug_support';
+export const REVIEW_FLAG_REASON_OTHER: 'review_flag_reason_other' =
+  'review_flag_reason_other';
+
+export type FlagReviewReasonType =
+  | typeof REVIEW_FLAG_REASON_SPAM
+  | typeof REVIEW_FLAG_REASON_LANGUAGE
+  | typeof REVIEW_FLAG_REASON_BUG_SUPPORT
+  | typeof REVIEW_FLAG_REASON_OTHER;
 
 // Number of total featured add-ons to load.
 export const FEATURED_ADDONS_TO_LOAD = 25;

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -12,7 +12,17 @@ import {
   SET_REVIEW_REPLY,
 } from 'amo/constants';
 import { denormalizeReview } from 'amo/actions/reviews';
-import type { UserReviewType } from 'amo/actions/reviews';
+import type {
+  HideEditReviewFormAction,
+  HideReplyToReviewFormAction,
+  SendReplyToReviewAction,
+  SetAddonReviewsAction,
+  SetReviewAction,
+  SetReviewReplyAction,
+  ShowEditReviewFormAction,
+  ShowReplyToReviewFormAction,
+  UserReviewType,
+} from 'amo/actions/reviews';
 
 type ReviewsById = {
   [id: number]: UserReviewType,
@@ -140,45 +150,56 @@ export const changeViewState = (
   };
 };
 
+type ReviewActionType =
+  | HideEditReviewFormAction
+  | HideReplyToReviewFormAction
+  | SendReplyToReviewAction
+  | SetAddonReviewsAction
+  | SetReviewAction
+  | SetReviewReplyAction
+  | ShowEditReviewFormAction
+  | ShowReplyToReviewFormAction;
+
 export default function reviewsReducer(
   state: ReviewState = initialState,
-  { payload, type }: {| payload: any, type: string |},
+  action: ReviewActionType,
 ) {
-  switch (type) {
+  switch (action.type) {
     case SEND_REPLY_TO_REVIEW:
       return changeViewState({
         state,
-        reviewId: payload.originalReviewId,
+        reviewId: action.payload.originalReviewId,
         stateChange: { submittingReply: true },
       });
     case SHOW_EDIT_REVIEW_FORM:
       return changeViewState({
         state,
-        reviewId: payload.reviewId,
+        reviewId: action.payload.reviewId,
         stateChange: { editingReview: true },
       });
     case SHOW_REPLY_TO_REVIEW_FORM:
       return changeViewState({
         state,
-        reviewId: payload.reviewId,
+        reviewId: action.payload.reviewId,
         stateChange: { replyingToReview: true },
       });
     case HIDE_EDIT_REVIEW_FORM:
       return changeViewState({
         state,
-        reviewId: payload.reviewId,
+        reviewId: action.payload.reviewId,
         stateChange: { editingReview: false },
       });
     case HIDE_REPLY_TO_REVIEW_FORM:
       return changeViewState({
         state,
-        reviewId: payload.reviewId,
+        reviewId: action.payload.reviewId,
         stateChange: {
           replyingToReview: false,
           submittingReply: false,
         },
       });
     case SET_REVIEW: {
+      const { payload } = action;
       const existingReviews =
         state[payload.userId] ? state[payload.userId][payload.addonId] : {};
       const latestReview = payload;
@@ -196,7 +217,7 @@ export default function reviewsReducer(
       };
     }
     case SET_REVIEW_REPLY: {
-      const reviewId = payload.originalReviewId;
+      const reviewId = action.payload.originalReviewId;
       const review = state.byId[reviewId];
       if (!review) {
         throw new Error(oneLine`Cannot store reply to review ID
@@ -208,12 +229,13 @@ export default function reviewsReducer(
           ...state.byId,
           [review.id]: {
             ...review,
-            reply: denormalizeReview(payload.reply),
+            reply: denormalizeReview(action.payload.reply),
           },
         },
       };
     }
     case SET_ADDON_REVIEWS: {
+      const { payload } = action;
       return {
         ...state,
         byId: storeReviewObjects({ state, reviews: payload.reviews }),

--- a/tests/unit/amo/actions/testReviews.js
+++ b/tests/unit/amo/actions/testReviews.js
@@ -1,14 +1,16 @@
 import {
   denormalizeReview,
   fetchReviews,
+  flagReview,
   reviewIdAction,
   sendReplyToReview,
   setDenormalizedReview,
   setReview,
+  setReviewWasFlagged,
   setReviewReply,
   setAddonReviews,
 } from 'amo/actions/reviews';
-import { SET_REVIEW } from 'amo/constants';
+import { REVIEW_FLAG_REASON_SPAM, SET_REVIEW } from 'amo/constants';
 import { fakeAddon, fakeReview } from 'tests/unit/amo/helpers';
 
 // See reducer tests for more coverage of review actions.
@@ -170,6 +172,65 @@ describe(__filename, () => {
 
     it('requires a reviewId', () => {
       expect(() => reviewIdAction({ type: 'SOME_TYPE' }))
+        .toThrow(/reviewId parameter is required/);
+    });
+  });
+
+  describe('flagReview', () => {
+    const defaultParams = () => {
+      return {
+        errorHandlerId: 'some-id',
+        reason: REVIEW_FLAG_REASON_SPAM,
+        reviewId: fakeReview.id,
+      };
+    };
+
+    it('requires an errorHandlerId', () => {
+      const params = defaultParams();
+      delete params.errorHandlerId;
+
+      expect(() => flagReview(params))
+        .toThrow(/errorHandlerId parameter is required/);
+    });
+
+    it('requires a reason', () => {
+      const params = defaultParams();
+      delete params.reason;
+
+      expect(() => flagReview(params))
+        .toThrow(/reason parameter is required/);
+    });
+
+    it('requires a reviewId', () => {
+      const params = defaultParams();
+      delete params.reviewId;
+
+      expect(() => flagReview(params))
+        .toThrow(/reviewId parameter is required/);
+    });
+  });
+
+  describe('setReviewWasFlagged', () => {
+    const defaultParams = () => {
+      return {
+        reason: REVIEW_FLAG_REASON_SPAM,
+        reviewId: fakeReview.id,
+      };
+    };
+
+    it('requires a reason', () => {
+      const params = defaultParams();
+      delete params.reason;
+
+      expect(() => setReviewWasFlagged(params))
+        .toThrow(/reason parameter is required/);
+    });
+
+    it('requires a reviewId', () => {
+      const params = defaultParams();
+      delete params.reviewId;
+
+      expect(() => setReviewWasFlagged(params))
         .toThrow(/reviewId parameter is required/);
     });
   });

--- a/tests/unit/amo/sagas/testReviews.js
+++ b/tests/unit/amo/sagas/testReviews.js
@@ -3,13 +3,19 @@ import SagaTester from 'redux-saga-tester';
 import * as reviewsApi from 'amo/api/reviews';
 import {
   fetchReviews,
+  flagReview,
   hideReplyToReviewForm,
   setAddonReviews,
   sendReplyToReview,
   setReview,
   setReviewReply,
+  setReviewWasFlagged,
 } from 'amo/actions/reviews';
-import { SET_ADDON_REVIEWS } from 'amo/constants';
+import {
+  REVIEW_FLAG_REASON_OTHER,
+  REVIEW_FLAG_REASON_SPAM,
+  SET_ADDON_REVIEWS,
+} from 'amo/constants';
 import reviewsReducer from 'amo/reducers/reviews';
 import reviewsSaga from 'amo/sagas/reviews';
 import apiReducer from 'core/reducers/api';
@@ -80,7 +86,7 @@ describe(__filename, () => {
       const errorAction = errorHandler.createErrorAction(error);
       await sagaTester.waitFor(errorAction.type);
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[1]).toEqual(errorAction);
+      expect(calledActions.slice(-1).pop()).toEqual(errorAction);
     });
   });
 
@@ -107,6 +113,7 @@ describe(__filename, () => {
         ...review,
         reply: {
           ...review,
+          id: 3421,
           body: 'Some developer reply to the review',
           ...reply,
         },
@@ -126,11 +133,12 @@ describe(__filename, () => {
         .withArgs({
           apiState,
           body,
-          errorHandler: undefined,
           originalReviewId,
           title,
         })
-        .returns(Promise.resolve(createReplyToReviewResponse()));
+        .returns(Promise.resolve(createReplyToReviewResponse({
+          review,
+        })));
 
       _sendReplyToReview({ originalReviewId, body, title });
       const lastExpectedAction = hideReplyToReviewForm({
@@ -141,7 +149,7 @@ describe(__filename, () => {
       mockApi.verify();
 
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[4]).toEqual(lastExpectedAction);
+      expect(calledActions.slice(-1).pop()).toEqual(lastExpectedAction);
     });
 
     it('loads a review from the reply response', async () => {
@@ -152,7 +160,7 @@ describe(__filename, () => {
       const title = 'Title of the Reply';
 
       const reviewFromResponse = createReplyToReviewResponse({
-        reply: { body, title },
+        review, reply: { body, title },
       });
 
       mockApi
@@ -183,17 +191,84 @@ describe(__filename, () => {
       await sagaTester.waitFor(errorAction.type);
 
       const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[2]).toEqual(errorAction);
+      expect(calledActions.slice(-1).pop()).toEqual(errorAction);
+      mockApi.verify();
     });
 
     it('clears the error handler', async () => {
-      _sendReplyToReview();
+      const review = _setFakeReview();
+
+      mockApi
+        .expects('replyToReview')
+        .returns(Promise.resolve(createReplyToReviewResponse()));
+
+      _sendReplyToReview({ originalReviewId: review.id });
 
       const expectedAction = errorHandler.createClearingAction();
 
       await sagaTester.waitFor(expectedAction.type);
-      expect(sagaTester.getCalledActions()[1])
+      expect(sagaTester.getCalledActions()[2])
         .toEqual(errorHandler.createClearingAction());
+      mockApi.verify();
+    });
+  });
+
+  describe('handleFlagReview', () => {
+    const _flagReview = (params = {}) => {
+      sagaTester.dispatch(flagReview({
+        errorHandlerId: errorHandler.id,
+        reason: REVIEW_FLAG_REASON_SPAM,
+        reviewId: fakeReview.id,
+        ...params,
+      }));
+    };
+
+    it('clears the error handler', async () => {
+      _flagReview();
+
+      const expectedAction = errorHandler.createClearingAction();
+
+      await sagaTester.waitFor(expectedAction.type);
+      expect(sagaTester.getCalledActions()[1]).toEqual(expectedAction);
+    });
+
+    it('posts a review flag to the API', async () => {
+      const reviewId = fakeReview.id;
+      const note = 'I do not like the color of this review';
+      const reason = REVIEW_FLAG_REASON_OTHER;
+
+      mockApi
+        .expects('flagReview')
+        .once()
+        .withArgs({
+          apiState,
+          note,
+          reason,
+          reviewId,
+        })
+        .returns(Promise.resolve());
+
+      _flagReview({ note, reason, reviewId });
+
+      const expectedAction = setReviewWasFlagged({ reason, reviewId });
+      await sagaTester.waitFor(expectedAction.type);
+      mockApi.verify();
+    });
+
+    it('handles API errors', async () => {
+      const error = new Error('some API error');
+      mockApi
+        .expects('flagReview')
+        .returns(Promise.reject(error));
+
+      _flagReview();
+
+      const errorAction = errorHandler.createErrorAction(error);
+      await sagaTester.waitFor(errorAction.type);
+
+      const calledActions = sagaTester.getCalledActions();
+      expect(calledActions.slice(-1).pop()).toEqual(errorAction);
+      mockApi.verify();
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3495

* Adds low-level API stuff needed for the UI (https://github.com/mozilla/addons-frontend/issues/2774)
* Adds type safety to the reviews reducer
* Fixes issues with the review saga test that I hadn't noticed before

For context, this is how I envision the UI will work:
* The user goes to the list of all add-on reviews
* They see one that needs flagging
* The click on 'Flag this review' and get a dropdown similar to the More menu item. 
* The can select things like: Flag for spam, inappropriate language, misplaced bug report, or other (this will allow them to enter a text explanation)