### PR TITLE
Fix safari header moving around

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -12,13 +12,13 @@
   padding: 0 12px;
 
   @include respond-to(medium) {
-    grid-template-columns: auto auto;
+    grid-template-columns: 1fr;
     min-height: 98px;
     padding: 0 $header-footer-gutter 10px;
   }
 
   @include respond-to(extraLarge) {
-    grid-template-columns: max-content auto auto;
+    grid-template-columns: max-content 1fr auto;
     grid-template-rows: 46px auto;
     margin: 0 auto;
     max-width: $max-content-width;
@@ -93,7 +93,6 @@
 }
 
 .Header-user-and-external-links {
-  @include margin-start(auto);
   @include text-align-end();
 
   grid-column: 3 / span 2;
@@ -175,8 +174,6 @@
   min-width: 144px;
 
   @include respond-to(medium) {
-    @include margin-start(auto);
-
     grid-column: 3 / 3;
     grid-row: 2 / 2;
     margin-top: 0;


### PR DESCRIPTION
Fixes #3497 

Before:


![safari-weirdness](https://user-images.githubusercontent.com/1514/31558730-079a860c-b046-11e7-86ca-9a5784e90027.gif)


After:

![safari-weirdness-fixed](https://user-images.githubusercontent.com/1514/31558789-38d2194c-b046-11e7-8850-cafcd2b3ab4c.gif)

