### PR TITLE
Fix up long strings in search results so they wrap

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -112,6 +112,7 @@
     margin: 0;
     max-width: 465px;
     width: 100%;
+    word-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
Fixes #3499
Before:

<img width="1404" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31560216-5c4e9f6c-b04b-11e7-878c-5ef1adde3c7f.png">

After:

<img width="1400" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31560241-6eb54f0c-b04b-11e7-985b-a09440cb4106.png">
