### PR TITLE
Fix search box visual length

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -18,7 +18,7 @@
   }
 
   @include respond-to(extraLarge) {
-    grid-template-columns: max-content 1fr auto;
+    grid-template-columns: max-content 1fr 1fr;
     grid-template-rows: 46px auto;
     margin: 0 auto;
     max-width: $max-content-width;
@@ -170,6 +170,7 @@
 .Header-search-form {
   grid-column: 1 / 2;
   grid-row: 1 / 3;
+  justify-self: end;
   margin: 10px 0 0;
   min-width: 144px;
 
@@ -184,7 +185,6 @@
     align-self: center;
     margin-top: 6px;
     max-width: 284px;
-    min-width: 144px;
     width: 100%;
   }
 }


### PR DESCRIPTION
Fixes: #3501
Before:

<img width="1400" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31560377-fb34ea3c-b04b-11e7-944a-8ff51eeef6c2.png">

After:

<img width="1360" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31560352-d94d1c8c-b04b-11e7-897d-c5210f4deeb1.png">

Still works in safari too.


<img width="779" alt="localhost_3000_ar_firefox_" src="https://user-images.githubusercontent.com/1514/31560884-f591b518-b04d-11e7-8e69-b68ce81ec692.png">
