### PR TITLE
Get rid of the old featured API in favor of the search one

### DIFF
--- a/src/amo/sagas/featured.js
+++ b/src/amo/sagas/featured.js
@@ -6,8 +6,8 @@ import { call, put, select, takeEvery } from 'redux-saga/effects';
 
 import { loadFeatured } from 'amo/actions/featured';
 import { FEATURED_ADDONS_TO_LOAD } from 'amo/constants';
-import { featured as featuredApi } from 'core/api';
-import { FEATURED_GET } from 'core/constants';
+import { search as searchApi } from 'core/api/search';
+import { FEATURED_GET, SEARCH_SORT_RANDOM } from 'core/constants';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 
@@ -18,8 +18,17 @@ export function* fetchFeaturedAddons(
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
     const state = yield select(getState);
-    const filters = { addonType, page_size: FEATURED_ADDONS_TO_LOAD };
-    const response = yield call(featuredApi, { api: state.api, filters });
+
+    const response = yield call(searchApi, {
+      api: state.api,
+      filters: {
+        addonType,
+        featured: true,
+        page_size: FEATURED_ADDONS_TO_LOAD,
+        sort: SEARCH_SORT_RANDOM,
+      },
+      page: 1,
+    });
 
     yield put(loadFeatured({
       addonType,

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -9,9 +9,9 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
   SEARCH_SORT_POPULAR,
+  SEARCH_SORT_RANDOM,
   SEARCH_SORT_TRENDING,
 } from 'core/constants';
-import { featured as featuredApi } from 'core/api';
 import { search as searchApi } from 'core/api/search';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
@@ -52,12 +52,15 @@ export function* fetchHomeAddons({
         slug: featuredCollectionSlug,
         user: featuredCollectionUser,
       }),
-      featuredThemes: call(featuredApi, {
+      featuredThemes: call(searchApi, {
         api: state.api,
         filters: {
           addonType: ADDON_TYPE_THEME,
+          featured: true,
           page_size: LANDING_PAGE_ADDON_COUNT,
+          sort: SEARCH_SORT_RANDOM,
         },
+        page: 1,
       }),
       upAndComingExtensions: call(searchApi, {
         api: state.api,

--- a/src/amo/sagas/landing.js
+++ b/src/amo/sagas/landing.js
@@ -7,10 +7,10 @@ import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 
 import { loadLanding } from 'amo/actions/landing';
 import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
-import { featured as featuredApi } from 'core/api';
 import { search as searchApi } from 'core/api/search';
 import {
   LANDING_GET,
+  SEARCH_SORT_RANDOM,
   SEARCH_SORT_TRENDING,
   SEARCH_SORT_TOP_RATED,
 } from 'core/constants';
@@ -35,7 +35,15 @@ export function* fetchLandingAddons(
     }
 
     const [featured, highlyRated, trending] = yield all([
-      call(featuredApi, { api, filters }),
+      call(searchApi, {
+        api,
+        filters: {
+          ...filters,
+          featured: true,
+          sort: SEARCH_SORT_RANDOM,
+        },
+        page: 1,
+      }),
       call(searchApi, {
         api,
         filters: { ...filters, sort: SEARCH_SORT_TOP_RATED },

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -13,7 +13,6 @@ import log from 'core/logger';
 import {
   addVersionCompatibilityToFilters,
   convertFiltersToQueryParams,
-  fixFiltersForAndroidThemes,
 } from 'core/searchUtils';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { ApiStateType } from 'core/reducers/api';
@@ -199,26 +198,6 @@ export function startLoginUrl(
   }
   const query = makeQueryString(params);
   return `${API_BASE}/accounts/login/start/${query}`;
-}
-
-type FeaturedParams = {|
-  api: ApiStateType,
-  filters: Object,
-  page: number,
-|};
-
-export function featured({ api, filters, page }: FeaturedParams) {
-  const newFilters = fixFiltersForAndroidThemes({ api, filters });
-
-  return callApi({
-    endpoint: 'addons/featured',
-    params: {
-      ...convertFiltersToQueryParams(newFilters),
-      page,
-    },
-    schema: { results: [addon] },
-    state: api,
-  });
 }
 
 export function categories({ api }: {| api: ApiStateType |}) {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -102,6 +102,7 @@ export const VIEW_CONTEXT_LANGUAGE_TOOLS = 'VIEW_CONTEXT_LANGUAGE_TOOLS';
 export const SEARCH_SORT_TRENDING = 'hotness';
 export const SEARCH_SORT_TOP_RATED = 'rating';
 export const SEARCH_SORT_POPULAR = 'users';
+export const SEARCH_SORT_RANDOM = 'random';
 
 // Operating system for add-ons and files
 export const OS_ALL = 'all';

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -1,6 +1,5 @@
 import SagaTester from 'redux-saga-tester';
 
-import * as api from 'core/api';
 import * as searchApi from 'core/api/search';
 import {
   getLanding,
@@ -14,6 +13,7 @@ import {
   LANDING_LOADED,
   SEARCH_SORT_TRENDING,
   SEARCH_SORT_TOP_RATED,
+  SEARCH_SORT_RANDOM,
 } from 'core/constants';
 import apiReducer from 'core/reducers/api';
 import {
@@ -27,13 +27,11 @@ describe(__filename, () => {
   describe('fetchLandingAddons', () => {
     let apiState;
     let errorHandler;
-    let mockApi;
     let mockSearchApi;
     let sagaTester;
 
     beforeEach(() => {
       errorHandler = createStubErrorHandler();
-      mockApi = sinon.mock(api);
       mockSearchApi = sinon.mock(searchApi);
 
       const { state } = dispatchClientMetadata();
@@ -67,9 +65,17 @@ describe(__filename, () => {
       const featured = createAddonsApiResult([{
         ...fakeAddon, slug: 'featured-addon',
       }]);
-      mockApi
-        .expects('featured')
-        .withArgs({ ...baseArgs, filters: { ...baseFilters } })
+      mockSearchApi
+        .expects('search')
+        .withArgs({
+          ...baseArgs,
+          filters: {
+            ...baseFilters,
+            featured: true,
+            sort: SEARCH_SORT_RANDOM,
+          },
+          page: 1,
+        })
         .returns(Promise.resolve(featured));
 
       const highlyRated = createAddonsApiResult([{
@@ -103,7 +109,7 @@ describe(__filename, () => {
       _getLanding({ addonType });
 
       await sagaTester.waitFor(LANDING_LOADED);
-      mockApi.verify();
+      mockSearchApi.verify();
 
       const calledActions = sagaTester.getCalledActions();
       expect(calledActions[1]).toEqual(loadLanding({
@@ -113,7 +119,10 @@ describe(__filename, () => {
 
     it('dispatches an error', async () => {
       const error = new Error('some API error maybe');
-      mockApi.expects('featured').returns(Promise.reject(error));
+      mockSearchApi
+        .expects('search')
+        .exactly(3)
+        .returns(Promise.reject(error));
 
       _getLanding();
 
@@ -137,11 +146,16 @@ describe(__filename, () => {
       const featured = createAddonsApiResult([
         { ...fakeAddon, slug: 'featured-addon' },
       ]);
-      mockApi
-        .expects('featured')
+      mockSearchApi
+        .expects('search')
         .withArgs({
           ...baseArgs,
-          filters: baseFilters,
+          filters: {
+            ...baseFilters,
+            featured: true,
+            sort: SEARCH_SORT_RANDOM,
+          },
+          page: 1,
         })
         .returns(Promise.resolve(featured));
 
@@ -178,7 +192,7 @@ describe(__filename, () => {
       _getLanding({ addonType, category });
 
       await sagaTester.waitFor(LANDING_LOADED);
-      mockApi.verify();
+      mockSearchApi.verify();
 
       const calledActions = sagaTester.getCalledActions();
       expect(calledActions[1]).toEqual(loadLanding({
@@ -197,11 +211,16 @@ describe(__filename, () => {
       const featured = createAddonsApiResult([
         { ...fakeAddon, slug: 'featured-addon' },
       ]);
-      mockApi
-        .expects('featured')
+      mockSearchApi
+        .expects('search')
         .withArgs({
           ...baseArgs,
-          filters: baseFilters,
+          filters: {
+            ...baseFilters,
+            featured: true,
+            sort: SEARCH_SORT_RANDOM,
+          },
+          page: 1,
         })
         .returns(Promise.resolve(featured));
 
@@ -238,7 +257,7 @@ describe(__filename, () => {
       _getLanding({ addonType, category: undefined });
 
       await sagaTester.waitFor(LANDING_LOADED);
-      mockApi.verify();
+      mockSearchApi.verify();
 
       const calledActions = sagaTester.getCalledActions();
       expect(calledActions[1]).toEqual(loadLanding({

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -7,13 +7,13 @@ import homeReducer, {
   loadHomeAddons,
 } from 'amo/reducers/home';
 import homeSaga from 'amo/sagas/home';
-import * as api from 'core/api';
 import * as searchApi from 'core/api/search';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
   SEARCH_SORT_POPULAR,
   SEARCH_SORT_TRENDING,
+  SEARCH_SORT_RANDOM,
 } from 'core/constants';
 import apiReducer from 'core/reducers/api';
 import { createStubErrorHandler } from 'tests/unit/helpers';
@@ -28,14 +28,12 @@ import {
 
 describe(__filename, () => {
   let errorHandler;
-  let mockApi;
   let mockCollectionsApi;
   let mockSearchApi;
   let sagaTester;
 
   beforeEach(() => {
     errorHandler = createStubErrorHandler();
-    mockApi = sinon.mock(api);
     mockCollectionsApi = sinon.mock(collectionsApi);
     mockSearchApi = sinon.mock(searchApi);
     sagaTester = new SagaTester({
@@ -97,14 +95,17 @@ describe(__filename, () => {
         .returns(Promise.resolve(featuredCollection));
 
       const featuredThemes = createAddonsApiResult([fakeTheme]);
-      mockApi
-        .expects('featured')
+      mockSearchApi
+        .expects('search')
         .withArgs({
           ...baseArgs,
           filters: {
             ...baseFilters,
             addonType: ADDON_TYPE_THEME,
+            featured: true,
+            sort: SEARCH_SORT_RANDOM,
           },
+          page: 1,
         })
         .returns(Promise.resolve(featuredThemes));
 
@@ -137,7 +138,6 @@ describe(__filename, () => {
       });
 
       await sagaTester.waitFor(expectedLoadAction.type);
-      mockApi.verify();
       mockCollectionsApi.verify();
       mockSearchApi.verify();
 

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -8,7 +8,6 @@ import * as api from 'core/api';
 import {
   ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
-  CLIENT_APP_FIREFOX,
 } from 'core/constants';
 import {
   createFakeAutocompleteResult,
@@ -223,69 +222,6 @@ describe(__filename, () => {
     it('handles true values', () => {
       const query = api.makeQueryString({ some_flag: true });
       expect(query).toEqual('?some_flag=true');
-    });
-  });
-
-  describe('featured add-ons api', () => {
-    const mockResponse = () => createApiResponse({
-      jsonData: {
-        results: [
-          { slug: 'foo' },
-          { slug: 'food' },
-          { slug: 'football' },
-        ],
-      },
-    });
-
-    it('sets the app, lang, and type query', () => {
-      mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/featured/?app=firefox&type=persona&lang=en-US`)
-        .once()
-        .returns(mockResponse());
-
-      const { state } = dispatchClientMetadata({
-        clientApp: CLIENT_APP_FIREFOX,
-        lang: 'en-US',
-      });
-
-      return api.featured({
-        api: state.api,
-        filters: { addonType: ADDON_TYPE_THEME },
-      })
-        .then((response) => {
-          expect(response).toEqual({
-            entities: {
-              addons: {
-                foo: { slug: 'foo' },
-                food: { slug: 'food' },
-                football: { slug: 'football' },
-              },
-            },
-            result: {
-              results: ['foo', 'food', 'football'],
-            },
-          });
-          return mockWindow.verify();
-        });
-    });
-
-    it('changes theme requests for android to firefox results', async () => {
-      // See: https://github.com/mozilla/addons-frontend/issues/3408
-      mockWindow.expects('fetch')
-        .withArgs(`${apiHost}/api/v3/addons/featured/?app=firefox&type=persona&lang=en-US`)
-        .once()
-        .returns(mockResponse());
-
-      const { state } = dispatchClientMetadata({
-        clientApp: CLIENT_APP_ANDROID,
-        lang: 'en-US',
-      });
-
-      await api.featured({
-        api: state.api,
-        filters: { addonType: ADDON_TYPE_THEME },
-      });
-      mockWindow.verify();
     });
   });
 


### PR DESCRIPTION
Fix #3307

---

This PR removes calls to the Featured API in favor of the Search API so that we can leverage all its parameters (including `appversion`) and return compatible add-ons only. The UI update will follow in #3137.