### PR TITLE
Fix safari more link position and header dropdown movement

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -142,10 +142,21 @@
 }
 
 .Header-SectionLinks {
+  align-items: baseline;
   grid-column: 1 / span 4;
   grid-row: 3 / 4;
   margin: 16px auto 1px;
+  min-height: 28px;
   z-index: 4;
+
+  .DropdownMenu-button-text {
+    overflow: visible;
+    padding-bottom: 3px;
+  }
+
+  .Icon-inverted-caret {
+    height: 9px;
+  }
 
   @include respond-to(medium) {
     @include margin-start(-12px);
@@ -162,7 +173,7 @@
     align-self: center;
     grid-column: 2;
     grid-row: 2 / 2;
-    margin: 20px 0 6px;
+    margin: 22px 0 0;
     padding: 0;
   }
 }


### PR DESCRIPTION
Fixes #3503 
Fixes #3505 

For #3503

Before: 
<img width="656" alt="localhost_3000_ar_firefox_" src="https://user-images.githubusercontent.com/1514/31561428-b9bb9962-b04f-11e7-8ca0-2bd765743475.png">

After:
<img width="824" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31564050-6536260a-b059-11e7-8c99-83b72dd9d185.png">

For #3505

Before:
![small-header-movement](https://user-images.githubusercontent.com/1514/31564180-d030f7d2-b059-11e7-9739-a34e5e71cbdb.gif)

After:

The header no longer moves when hovering over "Explore"

![small-header-movement-fixed](https://user-images.githubusercontent.com/1514/31564185-d219724a-b059-11e7-96f8-b9e4f2231e7c.gif)
