### PR TITLE
Fix screenshot overflow in FirefoxESR

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -202,6 +202,8 @@
       // This span makes sure the left widget does not move vertically when
       // there is a long description.
       grid-row: 1 / span 100000;
+      // Fixes screenshot overflow in FF 52 ESR.
+      max-width: 100%;
       overflow-x: hidden;
     }
 


### PR DESCRIPTION
Fixes #3509

Before (using firefox ESR 52.x)

<img width="1692" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31575619-e10c109e-b0e2-11e7-8467-df7a7084a4ee.png">

After:

<img width="1404" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31575624-fc596b58-b0e2-11e7-8f33-fc91ae8b0b2d.png">
