### PR TITLE
Render LANDING_PAGE_ADDON_COUNT placeholders in LandingAddonsCard

### DIFF
--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
+import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 
 export default class LandingAddonsCard extends React.Component {
@@ -14,12 +15,24 @@ export default class LandingAddonsCard extends React.Component {
     footerText: PropTypes.string.isRequired,
     header: PropTypes.node.isRequired,
     loading: PropTypes.bool.isRequired,
+    placeholderCount: PropTypes.number.isRequired,
+  }
+
+  static defaultProps = {
+    placeholderCount: LANDING_PAGE_ADDON_COUNT,
   }
 
   render() {
     const {
-      addons, className, footerLink, footerText, header, loading,
+      addons,
+      className,
+      footerLink,
+      footerText,
+      header,
+      loading,
+      placeholderCount,
     } = this.props;
+
     const linkSearchURL = {
       ...footerLink,
       query: convertFiltersToQueryParams(footerLink.query),
@@ -34,6 +47,7 @@ export default class LandingAddonsCard extends React.Component {
         header={header}
         type="horizontal"
         loading={loading}
+        placeholderCount={placeholderCount}
       />
     );
   }

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -3,10 +3,11 @@ import { shallow } from 'enzyme';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
+import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
 
-describe('amo/components/LandingAddonsCard', () => {
+describe(__filename, () => {
   function render(customProps = {}) {
     const props = {
       addons: [fakeAddon],
@@ -33,5 +34,10 @@ describe('amo/components/LandingAddonsCard', () => {
     const addons = [{ ...fakeAddon, slug: 'custom-addon' }];
     const root = render({ addons });
     expect(root.find(AddonsCard)).toHaveProp('addons', addons);
+  });
+
+  it('sets the number of placeholders to render while loading', () => {
+    const root = render({ loading: true });
+    expect(root).toHaveProp('placeholderCount', LANDING_PAGE_ADDON_COUNT);
   });
 });


### PR DESCRIPTION
Fix #3135

---

This PR reduces the number of placeholders rendered while loading in a `LandingAddonsCard`.

## Screenshots

Before:

![](https://user-images.githubusercontent.com/1514/30425488-4a40bf06-9941-11e7-9fc5-daca7a89a89a.png)

After:

<img width="1392" alt="screen shot 2017-10-16 at 19 19 45" src="https://user-images.githubusercontent.com/217628/31625649-1111c7a0-b2a7-11e7-9c9e-d40622dfba4b.png">
