### PR TITLE
Fix search filters

### DIFF
--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -126,74 +126,76 @@ export class SearchFiltersBase extends React.Component {
         className="SearchFilters"
         header={i18n.gettext('Filter results')}
       >
-        <label
-          className="SearchFilters-label"
-          htmlFor="SearchFilters-Sort"
-        >
-          {i18n.gettext('Sort by')}
-        </label>
-        <select
-          className="SearchFilters-select"
-          id="SearchFilters-Sort"
-          name="sort"
-          onChange={this.onSelectElementChange}
-          value={filters.sort || 'relevance'}
-        >
-          {this.sortOptions().map((option) => {
-            return <option key={option.name} {...option} />;
-          })}
-        </select>
+        <form autoComplete="off">
+          <label
+            className="SearchFilters-label"
+            htmlFor="SearchFilters-Sort"
+          >
+            {i18n.gettext('Sort by')}
+          </label>
+          <select
+            className="SearchFilters-select"
+            id="SearchFilters-Sort"
+            name="sort"
+            onChange={this.onSelectElementChange}
+            value={filters.sort || 'relevance'}
+          >
+            {this.sortOptions().map((option) => {
+              return <option key={option.value} {...option} />;
+            })}
+          </select>
 
-        <label
-          className="SearchFilters-AddonType-label SearchFilters-label"
-          htmlFor="SearchFilters-AddonType"
-        >
-          {i18n.gettext('Add-on Type')}
-        </label>
-        <select
-          className="SearchFilters-AddonType SearchFilters-select"
-          id="SearchFilters-AddonType"
-          name="addonType"
-          onChange={this.onSelectElementChange}
-          value={filters.addonType || NO_FILTER}
-        >
-          {this.addonTypeOptions().map((option) => {
-            return <option key={option.name} {...option} />;
-          })}
-        </select>
+          <label
+            className="SearchFilters-AddonType-label SearchFilters-label"
+            htmlFor="SearchFilters-AddonType"
+          >
+            {i18n.gettext('Add-on Type')}
+          </label>
+          <select
+            className="SearchFilters-AddonType SearchFilters-select"
+            id="SearchFilters-AddonType"
+            name="addonType"
+            onChange={this.onSelectElementChange}
+            value={filters.addonType || NO_FILTER}
+          >
+            {this.addonTypeOptions().map((option) => {
+              return <option key={option.value} {...option} />;
+            })}
+          </select>
 
-        <label
-          className="SearchFilters-OperatingSystem-label SearchFilters-label"
-          htmlFor="SearchFilters-OperatingSystem"
-        >
-          {i18n.gettext('Operating System')}
-        </label>
-        <select
-          className="SearchFilters-OperatingSystem SearchFilters-select"
-          id="SearchFilters-OperatingSystem"
-          name="operatingSystem"
-          onChange={this.onSelectElementChange}
-          value={filters.operatingSystem || NO_FILTER}
-        >
-          {this.operatingSystemOptions().map((option) => {
-            return <option key={option.name} {...option} />;
-          })}
-        </select>
+          <label
+            className="SearchFilters-OperatingSystem-label SearchFilters-label"
+            htmlFor="SearchFilters-OperatingSystem"
+          >
+            {i18n.gettext('Operating System')}
+          </label>
+          <select
+            className="SearchFilters-OperatingSystem SearchFilters-select"
+            id="SearchFilters-OperatingSystem"
+            name="operatingSystem"
+            onChange={this.onSelectElementChange}
+            value={filters.operatingSystem || NO_FILTER}
+          >
+            {this.operatingSystemOptions().map((option) => {
+              return <option key={option.value} {...option} />;
+            })}
+          </select>
 
-        <input
-          className="SearchFilters-Featured"
-          checked={!!filters.featured}
-          id="SearchFilters-Featured"
-          name="featured"
-          onChange={this.onChangeCheckbox}
-          type="checkbox"
-        />
-        <label
-          className="SearchFilters-label SearchFilters-Featured-label"
-          htmlFor="SearchFilters-Featured"
-        >
-          {i18n.gettext('Featured add-ons only')}
-        </label>
+          <input
+            className="SearchFilters-Featured"
+            checked={!!filters.featured}
+            id="SearchFilters-Featured"
+            name="featured"
+            onChange={this.onChangeCheckbox}
+            type="checkbox"
+          />
+          <label
+            className="SearchFilters-label SearchFilters-Featured-label"
+            htmlFor="SearchFilters-Featured"
+          >
+            {i18n.gettext('Featured add-ons only')}
+          </label>
+        </form>
       </ExpandableCard>
     );
   }


### PR DESCRIPTION
Fix #3121

---

So, this PR fixes a weird bug related to the search filters being updated with the wrong values on page refresh. First, I thought that was an issue related to the `key` prop not correctly set on each `option`, so I changed that but it did not work actually... Yet, this still fixes something. I started to investigate more, but it was not easy to trigger the problem. Here are a few steps to make it work (or fail depending on your point of view):

- go to https://addons-dev.allizom.org/en-US/firefox/themes/
- click on "more trending themes"
- refresh (might not be necessary)
- go to "extensions" (header link)
- go to "more trending extensions" (well, looks good to me)
- refresh and 💥 

I thought that was a bug in the `render()` of the `SearchFilters` component, not being updated with the right `props`, but no. It gets the correct `props`, all the time. Ha! I checked on https://github.com/facebook/react but found related issues that have all been fixed... So I tried the previous scenario in Chrome and I could not reproduce it. Doh! I tried many other things to reproduce in Chrome but I was unsuccessful.

I then googled for known issues with Firefox and I found this: [Why doesn't Firefox show the correct default select option?](https://stackoverflow.com/questions/1479233/why-doesnt-firefox-show-the-correct-default-select-option), related to this [bugzilla ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=46845). 💡 Firefox sometimes thinks it is a good idea to keep the old values of a `form`, but here it is not really a good idea, so we have to tell it not to do that.

That's how the `<form autoComplete="off">` landed in this patch 😅 