### PR TITLE
Fix moment locale

### DIFF
--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -276,8 +276,10 @@ export function makeI18n(
   // localised dates, times, etc.
   if (i18n.options && typeof i18n.options._momentDefineLocale === 'function') {
     i18n.options._momentDefineLocale();
-    moment.locale(makeMomentLocale(i18n.lang));
   }
+
+  // This makes sure moment always uses the current locale.
+  moment.locale(makeMomentLocale(i18n.lang));
 
   // Wrap the core Jed functionality so that we can always strip leading whitespace
   // from translation keys to match the same process used in extraction.

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -427,6 +427,7 @@ describe('i18n utils', () => {
       };
       const i18n = utils.makeI18n(i18nData, 'fr', FakeJed);
       expect(i18n.moment.locale()).toEqual('fr');
+      sinon.assert.called(i18nData.options._momentDefineLocale);
     });
 
     it('does not localise if _momentDefineLocale is not a function', () => {
@@ -439,6 +440,17 @@ describe('i18n utils', () => {
 
       const i18n = utils.makeI18n(i18nData, 'en', FakeJed);
       expect(i18n.moment.locale()).toEqual('en');
+    });
+
+    it('always passes the locale to moment', () => {
+      const i18nData = {
+        options: {
+          _momentDefineLocale: null,
+          locale_data: { messages: { '': { lang: 'fr' } } },
+        },
+      };
+      const i18n = utils.makeI18n(i18nData, 'fr', FakeJed);
+      expect(i18n.moment.locale()).toEqual('fr');
     });
 
     it('formats a number', () => {


### PR DESCRIPTION
Fix #3443

---

This PR makes sure `moment` gets the correct locale all the time, otherwise it might reuse the wrong locale on the server, and the client will have to patch it on load, causing a visual glitch mentioned in #3443.

Steps to reproduce:

- load a page with a date, e.g., https://addons-dev.allizom.org/en-US/firefox/collections/mozilla/change-up-your-tabs/
- change the language to something other than English, like German (Deutsch) or suomi
- refresh the page
- change the language to English (US)
- 💥

You should see the wrong formatted date loaded first and then updated when the client side is fully loaded. The aim of this PR is to solve this by always setting the current locale to `moment`.