### PR TITLE
Fix wrapping of unbroken strings in detail page

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -120,12 +120,17 @@
   flex-basis: 100%;
   flex-grow: 1;
   order: 2;
+  word-wrap: break-word;
 
   @include respond-to(medium) {
     flex-grow: 0;
     margin-bottom: 0;
     max-width: 550px;
   }
+}
+
+.AddonDescription-contents {
+  word-wrap: break-word;
 }
 
 .Addon .InstallButton {


### PR DESCRIPTION
Fixes #3517

Before:

<img width="1391" alt="banners_and_alerts_and_add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31637304-1b5e568e-b29c-11e7-816d-e20f1103f001.png">

After:

<img width="1382" alt="add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/31637313-27e9b7f4-b29c-11e7-84dd-4142d0e4e5d6.png">
