### PR TITLE
Fix text overflow on add-on summary

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -120,6 +120,7 @@
   flex-basis: 100%;
   flex-grow: 1;
   order: 2;
+  overflow-x: auto;
   word-wrap: break-word;
 
   @include respond-to(medium) {


### PR DESCRIPTION
Fix #3517

---
Before:

<img width="447" alt="screen shot 2017-10-17 at 16 06 27" src="https://user-images.githubusercontent.com/217628/31669357-2c356b82-b355-11e7-9be3-22970f37fe49.png">


After:

![screen shot 2017-10-17 at 16 01 25](https://user-images.githubusercontent.com/217628/31669322-18a85fca-b355-11e7-87a1-c570aced100c.png)
