### PR TITLE
Update header to work better with long translations

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -17,7 +17,7 @@
     padding: 0 $header-footer-gutter 10px;
   }
 
-  @include respond-to(extraLarge) {
+  @include respond-to(extraExtraLarge) {
     grid-template-columns: max-content 1fr 1fr;
     grid-template-rows: 46px auto;
     margin: 0 auto;
@@ -41,12 +41,11 @@
     @include text-align-start();
 
     align-self: end;
-    grid-column: 1 / 3;
     grid-row: 1 / 2;
-    margin: 24px 0 0;
+    margin: 48px 0 0;
   }
 
-  @include respond-to(extraLarge) {
+  @include respond-to(extraExtraLarge) {
     @include margin-end(24px);
 
     align-self: center;
@@ -67,7 +66,7 @@
     vertical-align: middle;
   }
 
-  @include respond-to(extraLarge) {
+  @include respond-to(extraExtraLarge) {
     vertical-align: bottom;
   }
 }
@@ -86,7 +85,7 @@
     margin: 0;
     text-decoration: none;
 
-    @include respond-to(extraLarge) {
+    @include respond-to(extraExtraLarge) {
       font-size: $font-size-header-title;
     }
   }
@@ -104,7 +103,7 @@
     grid-row: 1 / 2;
   }
 
-  @include respond-to(extraLarge) {
+  @include respond-to(extraExtraLarge) {
     grid-column: 2 / -1;
     grid-row: 1 / 2;
   }
@@ -167,12 +166,11 @@
     margin: 0;
   }
 
-  @include respond-to(extraLarge) {
+  @include respond-to(extraExtraLarge) {
     @include margin-end(12px);
 
     align-self: center;
     grid-column: 2;
-    grid-row: 2 / 2;
     margin: 22px 0 0;
     padding: 0;
   }
@@ -188,13 +186,12 @@
   @include respond-to(medium) {
     grid-column: 3 / 3;
     grid-row: 2 / 2;
-    margin-top: 0;
+    margin-top: 6px;
     max-width: 250px;
   }
 
   @include respond-to(extraLarge) {
     align-self: center;
-    margin-top: 6px;
     max-width: 284px;
     width: 100%;
   }

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -19,6 +19,7 @@ $breakpoints: (
   medium: only screen and (min-width: 500px),
   large: only screen and (min-width: 720px),
   extraLarge: only screen and (min-width: 900px),
+  extraExtraLarge: only screen and (min-width: 1150px),
 );
 $page-margin: 20px 10px;
 


### PR DESCRIPTION
Fixes  #3519

Moves the full-screen header to a later breakpoint.

## Before:

### Firefox
![it](https://user-images.githubusercontent.com/15685960/31618126-c1d020cc-b299-11e7-9fb2-362e900720a2.png)

### Chrome
![2017-10-16_1738](https://user-images.githubusercontent.com/15685960/31618147-cddf3aba-b299-11e7-9292-709c639e0c3f.png)

## After:

### Firefox:

![screen shot 2017-10-17 at 13 07 23](https://user-images.githubusercontent.com/1514/31678444-36df8c8e-b33c-11e7-8281-f107df661af9.png)

![screen shot 2017-10-17 at 13 06 56](https://user-images.githubusercontent.com/1514/31678448-372ad658-b33c-11e7-955f-8ecc541194c3.png)

![screen shot 2017-10-17 at 13 07 03](https://user-images.githubusercontent.com/1514/31678446-370af414-b33c-11e7-9951-f9161fcbcd86.png)

![screen shot 2017-10-17 at 13 07 14](https://user-images.githubusercontent.com/1514/31678445-36f0b0ea-b33c-11e7-9073-129aa82eb383.png)


### Chrome

<img width="625" alt="componenti_aggiuntivi_per_firefox" src="https://user-images.githubusercontent.com/1514/31678600-a5666222-b33c-11e7-9bbf-6f699003a2c5.png">
