### PR TITLE
fix: Use InstallButton all the time on AMO (fix #3557)

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -499,6 +499,7 @@ export class AddonBase extends React.Component {
                 disabled={!isCompatible}
                 ref={(ref) => { this.installButton = ref; }}
                 status={installStatus}
+                useButton
               /> : null
             }
 

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -46,6 +46,7 @@ export class InstallButtonBase extends React.Component {
     textcolor: PropTypes.string,
     type: PropTypes.oneOf(validAddonTypes),
     uninstall: PropTypes.func.isRequired,
+    useButton: PropTypes.bool,
     userAgentInfo: PropTypes.string.isRequired,
     _log: PropTypes.object,
     _window: PropTypes.object,
@@ -53,6 +54,7 @@ export class InstallButtonBase extends React.Component {
 
   static defaultProps = {
     getClientCompatibility: _getClientCompatibility,
+    useButton: false,
     _log: log,
     _window: typeof window !== 'undefined' ? window : {},
   }
@@ -79,7 +81,7 @@ export class InstallButtonBase extends React.Component {
     // OpenSearch plugins display their own prompt so using the "Add to
     // Firefox" button regardless on mozAddonManager support is a better UX.
     const useButton = (hasAddonManager !== undefined && !hasAddonManager) ||
-      addon.type === ADDON_TYPE_OPENSEARCH;
+      addon.type === ADDON_TYPE_OPENSEARCH || this.props.useButton;
     let button;
 
     const { compatible } = getClientCompatibility({

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -454,6 +454,11 @@ describe(__filename, () => {
     expect(root.prop('slug')).toEqual(fakeAddon.slug);
   });
 
+  it('always uses a button and not a switch for the InstallButton', () => {
+    const root = shallowRender().find(InstallButton);
+    expect(root.prop('useButton')).toEqual(true);
+  });
+
   it('sets the type in the header', () => {
     const root = shallowRender();
     expect(root.find('.AddonDescription').prop('header'))

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -205,6 +205,25 @@ describe(__filename, () => {
     expect(button).toHaveProp('disabled', true);
   });
 
+  it('renders a switch button if useButton is false', () => {
+    const root = render({ useButton: false });
+
+    expect(root).toHaveClassName('InstallButton--use-switch');
+  });
+
+  it('renders a button if useButton is true', () => {
+    const root = render({ useButton: true });
+
+    expect(root).toHaveClassName('InstallButton--use-button');
+
+    const button = root.childAt(1);
+
+    expect(button.type()).toEqual(Button);
+    expect(button).toHaveClassName('Button--action');
+    expect(button).toHaveClassName('InstallButton-button');
+    expect(button.children()).toIncludeText('Add to Firefox');
+  });
+
   it('renders a button for OpenSearch regardless of mozAddonManager', () => {
     const root = render({
       addon: createInternalAddon({


### PR DESCRIPTION
Force the InstallButton to always be a button on AMO.

Note that the Disco Pane should still stay a switch because it's nice to have a toggle there and it's less an issue.

### After

<img width="1250" alt="screenshot 2017-10-18 21 35 53" src="https://user-images.githubusercontent.com/90871/31741513-66bac502-b44c-11e7-9758-9dc23105f817.png">
