### PR TITLE
fix: Make abuse button less intense

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -495,7 +495,7 @@ export class AddonBase extends React.Component {
             {addon ?
               <InstallButton
                 {...this.props}
-                className="Button--action Button--small"
+                className="Button--wide"
                 disabled={!isCompatible}
                 ref={(ref) => { this.installButton = ref; }}
                 status={installStatus}

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -146,7 +146,7 @@ export class ReportAbuseButtonBase extends React.Component<Props> {
       >
         <div className="ReportAbuseButton--preview">
           <Button
-            className="ReportAbuseButton-show-more Button--report"
+            className="ReportAbuseButton-show-more Button--report Button--small"
             onClick={this.showReportUI}
           >
             {i18n.gettext('Report this add-on for abuse')}

--- a/src/amo/components/ReportAbuseButton/styles.scss
+++ b/src/amo/components/ReportAbuseButton/styles.scss
@@ -1,7 +1,7 @@
 @import "~ui/css/vars";
 
 .ReportAbuseButton {
-  margin: 10px auto;
+  margin: 12px auto;
 }
 
 .ReportAbuseButton-header {
@@ -13,7 +13,7 @@
 }
 
 .ReportAbuseButton--preview {
-  display: block;
+  display: inline-block;
 
   .ReportAbuseButton--is-expanded & {
     display: none;


### PR DESCRIPTION
fix #3553

Makes the "Report this add-on for abuse" button less intense and make it not the most obvious CTA on the page by making the "Add to Firefox" button larger and it smaller.

Upon further reflection, yeah, I really made this too out there. The new design uses the action button style until the "Send report" button where a red style appears, making it clear the action is serious 😄 

### Before
<img width="1392" alt="screenshot 2017-10-20 01 41 07" src="https://user-images.githubusercontent.com/90871/31800396-7c533952-b538-11e7-946b-ae4e4be4430d.png">

![screen shot 2017-10-20 at 01 41 36](https://user-images.githubusercontent.com/90871/31800421-b4f5ad94-b538-11e7-8f1f-e4fe11af1a0d.png)

### After
<img width="1392" alt="screenshot 2017-10-20 01 41 09" src="https://user-images.githubusercontent.com/90871/31800405-943f15f4-b538-11e7-8186-60f059377d85.png">

![screen shot 2017-10-20 at 01 41 30](https://user-images.githubusercontent.com/90871/31800422-ba1e954c-b538-11e7-8338-3c596d32522b.png)
