### PR TITLE
Reset page filter on change

### DIFF
--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -39,7 +39,7 @@ export class SearchFiltersBase extends React.Component {
   onSelectElementChange = (event) => {
     event.preventDefault();
 
-    const { clientApp, filters, lang, pathname, router } = this.props;
+    const { filters } = this.props;
     const newFilters = { ...filters };
 
     // Get the filter we're supposed to change and set it.
@@ -57,17 +57,13 @@ export class SearchFiltersBase extends React.Component {
       delete newFilters[filterName];
     }
 
-    // TODO: We do this in a few places; make a helper for it.
-    router.push({
-      pathname: `/${lang}/${clientApp}${pathname}`,
-      query: convertFiltersToQueryParams(newFilters),
-    });
+    this.doSearch({ newFilters });
 
     return false;
   }
 
   onChangeCheckbox = () => {
-    const { clientApp, filters, lang, pathname, router } = this.props;
+    const { filters } = this.props;
     const newFilters = { ...filters };
 
     // When a checkbox changes, we want to invert its previous value.
@@ -77,6 +73,18 @@ export class SearchFiltersBase extends React.Component {
       delete newFilters.featured;
     } else {
       newFilters.featured = true;
+    }
+
+    this.doSearch({ newFilters });
+  }
+
+  doSearch({ newFilters }) {
+    const { clientApp, lang, pathname, router } = this.props;
+
+    if (newFilters.page) {
+      // Since it's now a new search, reset the page.
+      // eslint-disable-next-line
+      newFilters.page = 1;
     }
 
     router.push({

--- a/tests/unit/amo/components/TestSearchFilters.js
+++ b/tests/unit/amo/components/TestSearchFilters.js
@@ -174,4 +174,74 @@ describe(__filename, () => {
       }),
     });
   });
+
+  it('resets the page filter when checkbox is checked', () => {
+    const root = render({
+      filters: {
+        page: 42,
+        query: 'Music player',
+      },
+    });
+
+    const checkbox = root.find('.SearchFilters-Featured');
+    checkbox.simulate('change', createFakeEvent());
+
+    sinon.assert.calledWithExactly(fakeRouter.push, {
+      pathname: `/en-US/android/search/`,
+      query: convertFiltersToQueryParams({
+        featured: true,
+        page: 1,
+        query: 'Music player',
+      }),
+    });
+  });
+
+  it('resets the page filter when checkbox is unchecked', () => {
+    const root = render({
+      filters: {
+        featured: true,
+        page: 42,
+        query: 'Music player',
+      },
+    });
+
+    const checkbox = root.find('.SearchFilters-Featured');
+    checkbox.simulate('change', createFakeEvent());
+
+    sinon.assert.calledWithExactly(fakeRouter.push, {
+      pathname: `/en-US/android/search/`,
+      query: convertFiltersToQueryParams({
+        page: 1,
+        query: 'Music player',
+      }),
+    });
+  });
+
+  it('resets the page filter when a select is updated', () => {
+    const root = render({
+      filters: {
+        page: 42,
+        query: 'Cool things',
+      },
+    });
+
+    const select = root.find('.SearchFilters-AddonType');
+    const currentTarget = {
+      getAttribute: () => {
+        return select.prop('name');
+      },
+      value: ADDON_TYPE_EXTENSION,
+    };
+
+    select.simulate('change', createFakeEvent({ currentTarget }));
+
+    sinon.assert.calledWithExactly(fakeRouter.push, {
+      pathname: `/en-US/android/search/`,
+      query: convertFiltersToQueryParams({
+        addonType: ADDON_TYPE_EXTENSION,
+        page: 1,
+        query: 'Cool things',
+      }),
+    });
+  });
 });


### PR DESCRIPTION
Fix #3579

---

This PR resets the `page` search filter when one of these filters is updated.