### PR TITLE
Remove "Site Identifier" from listing pages

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -464,6 +464,7 @@ export class AddonBase extends React.Component {
           'Addon--has-more-than-0-addons': numberOfAddonsByAuthors > 0,
           'Addon--has-more-than-3-addons': numberOfAddonsByAuthors > 3,
         })}
+        data-site-identifier={addon ? addon.id : null}
       >
         {errorBanner}
         <Card className="" photonStyle>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -33,7 +33,6 @@ export class AddonMoreInfoBase extends React.Component<Props> {
       return this.renderDefinitions({
         versionLastUpdated: <LoadingText minWidth={20} />,
         versionLicense: <LoadingText minWidth={20} />,
-        addonId: <LoadingText minWidth={20} />,
       });
     }
 
@@ -102,7 +101,6 @@ export class AddonMoreInfoBase extends React.Component<Props> {
           {i18n.gettext('Read the license agreement for this add-on')}
         </Link>
       ) : null,
-      addonId: addon.id,
       versionHistoryLink: addonHasVersionHistory(addon) ? (
         <Link
           className="AddonMoreInfo-version-history-link"
@@ -135,7 +133,6 @@ export class AddonMoreInfoBase extends React.Component<Props> {
     versionLicenseLink = null,
     versionHistoryLink = null,
     betaVersionsLink = null,
-    addonId,
   }: Object) {
     const { i18n } = this.props;
     return (
@@ -199,16 +196,6 @@ export class AddonMoreInfoBase extends React.Component<Props> {
           </dt>
         ) : null}
         {statsLink ? <dd>{statsLink}</dd> : null}
-        <dt
-          className="AddonMoreInfo-database-id-title"
-          title={i18n.gettext(`This ID is useful for debugging and
-            identifying your add-on to site administrators.`)}
-        >
-          {i18n.gettext('Site Identifier')}
-        </dt>
-        <dd className="AddonMoreInfo-database-id-content">
-          {addonId}
-        </dd>
       </dl>
     );
   }

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1239,6 +1239,13 @@ describe(__filename, () => {
 
     expect(root.find(Badge)).toHaveLength(0);
   });
+
+  it('renders the site identifier as a data attribute', () => {
+    const addon = createInternalAddon({ ...fakeAddon, id: 9001 });
+    const root = shallowRender({ addon });
+
+    expect(root.find('.Addon')).toHaveProp('data-site-identifier', 9001);
+  });
 });
 
 describe('mapStateToProps', () => {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -1,4 +1,3 @@
-import { oneLine } from 'common-tags';
 import React from 'react';
 
 import AddonMoreInfo, {
@@ -42,9 +41,8 @@ describe(__filename, () => {
     // These fields will be visible during loading since
     // they will always exist for the loaded add-on.
     expect(root.find('.AddonMoreInfo-last-updated-title')).toHaveLength(1);
-    expect(root.find('.AddonMoreInfo-database-id-title')).toHaveLength(1);
 
-    expect(root.find(LoadingText)).toHaveLength(2);
+    expect(root.find(LoadingText)).toHaveLength(1);
 
     // These fields will not be visible during loading
     // since they may not exist.
@@ -209,19 +207,6 @@ describe(__filename, () => {
       .toHaveText('Read the license agreement for this add-on');
     expect(root.find('.AddonMoreInfo-eula-link'))
       .toHaveProp('href', '/addon/chill-out/eula/');
-  });
-
-  it('renders the ID and title attribute', () => {
-    const addon = createInternalAddon({ ...fakeAddon, id: 9001 });
-    const root = render({ addon });
-
-    expect(root.find('.AddonMoreInfo-database-id-title'))
-      .toHaveText('Site Identifier');
-    expect(root.find('.AddonMoreInfo-database-id-title'))
-      .toHaveProp('title', oneLine`This ID is useful for debugging and
-        identifying your add-on to site administrators.`);
-    expect(root.find('.AddonMoreInfo-database-id-content'))
-      .toHaveText('9001');
   });
 
   it('does not link to stats if user is not author of the add-on', () => {


### PR DESCRIPTION
Fix #3567

---

This PR removes the site identifier in the meta info of an add-on. It adds this identifier as a data attribute (`data-site-identifier`) set on the `.Addon` element.