### PR TITLE
Improve TooltipMenu keyboard accessibility

### DIFF
--- a/src/ui/components/TooltipMenu/index.js
+++ b/src/ui/components/TooltipMenu/index.js
@@ -17,6 +17,8 @@ type Props = {|
 |};
 
 export default class TooltipMenu extends React.Component<Props> {
+  container: React.ElementRef<'div'> | null;
+
   render() {
     const {
       idPrefix, items, openerClass, openerText, openerTitle,
@@ -27,27 +29,30 @@ export default class TooltipMenu extends React.Component<Props> {
     const describedBy = `${idPrefix || ''}TooltipMenu`;
 
     return (
-      <RCTooltip
-        align={{ offset: [0, 6] }}
-        destroyTooltipOnHide
-        id={describedBy}
-        overlay={
-          <ul className="TooltipMenu-list">
-            {items}
-          </ul>
-        }
-        placement="bottom"
-        prefixCls="TooltipMenu"
-        trigger={['click']}
-      >
-        <button
-          className={makeClassName('TooltipMenu-opener', openerClass)}
-          aria-describedby={describedBy}
-          title={openerTitle}
+      <div ref={(ref) => { this.container = ref; }}>
+        <RCTooltip
+          align={{ offset: [0, 6] }}
+          getTooltipContainer={() => this.container}
+          destroyTooltipOnHide
+          id={describedBy}
+          overlay={
+            <ul className="TooltipMenu-list">
+              {items}
+            </ul>
+          }
+          placement="bottom"
+          prefixCls="TooltipMenu"
+          trigger={['click']}
         >
-          {openerText}
-        </button>
-      </RCTooltip>
+          <button
+            className={makeClassName('TooltipMenu-opener', openerClass)}
+            aria-describedby={describedBy}
+            title={openerTitle}
+          >
+            {openerText}
+          </button>
+        </RCTooltip>
+      </div>
     );
   }
 }

--- a/src/ui/components/TooltipMenu/styles.scss
+++ b/src/ui/components/TooltipMenu/styles.scss
@@ -44,7 +44,8 @@
   box-shadow: 0 0 2px transparentize($black, 0.5);
 }
 
-.TooltipMenu-list {
+.TooltipMenu-list,
+.CardList .TooltipMenu-list {
   background: $white;
   border-radius: $border-radius-default;
   list-style-type: none;
@@ -54,7 +55,10 @@
   // Make sure this masks the box shadow of TooltipMenu-arrow.
   z-index: 2;
 
-  .ListItem {
+  .ListItem,
+  .CardList .ListItem {
+    background: none;
+    margin: 0;
     padding: 6px;
     padding-top: 0;
 

--- a/tests/unit/ui/components/TestTooltipMenu.js
+++ b/tests/unit/ui/components/TestTooltipMenu.js
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 import RCTooltip from 'rc-tooltip';
 
@@ -7,13 +7,20 @@ import TooltipMenu from 'ui/components/TooltipMenu';
 
 
 describe(__filename, () => {
-  const render = (customProps = {}) => {
-    const props = {
+  const renderProps = (customProps = {}) => {
+    return {
       openerText: 'Open menu',
       items: [<ListItem key="first" />],
       ...customProps,
     };
-    return shallow(<TooltipMenu {...props} />);
+  };
+
+  const render = (customProps = {}) => {
+    return shallow(<TooltipMenu {...renderProps(customProps)} />);
+  };
+
+  const renderAndMount = (customProps = {}) => {
+    return mount(<TooltipMenu {...renderProps(customProps)} />);
   };
 
   it('renders an opener with a custom class', () => {
@@ -57,5 +64,20 @@ describe(__filename, () => {
     const overlay = shallow(rcTooltip.prop('overlay'));
     expect(overlay.find('.FirstItem')).toHaveLength(1);
     expect(overlay.find('.SecondItem')).toHaveLength(1);
+  });
+
+  it('attaches the tooltip to a container element', () => {
+    const root = renderAndMount();
+
+    const tooltip = root.find(RCTooltip);
+    expect(tooltip).toHaveProp('getTooltipContainer');
+
+    const getContainer = tooltip.prop('getTooltipContainer');
+    const div = getContainer();
+
+    // This checks that a DOM node ref was returned.
+    // Attaching the tooltip to a nearby container (as opposed to the
+    // body) is necessary for keyboard accessibility.
+    expect(div).toBeDefined();
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3556

You can now use the tab key to step through the menu. It's a little rough around the edges but this is an improvement from where it was before.