### PR TITLE
Add target=_blank attribute to disco links only

### DIFF
--- a/src/core/purify.js
+++ b/src/core/purify.js
@@ -2,14 +2,5 @@ import createDOMPurify from 'dompurify';
 
 import universalWindow from 'core/window';
 
-const purify = createDOMPurify(universalWindow);
-export default purify;
 
-purify.addHook('afterSanitizeAttributes', (node) => {
-  // Set all elements owning target to target=_blank
-  // and add rel="noopener noreferrer".
-  if ('target' in node) {
-    node.setAttribute('target', '_blank');
-    node.setAttribute('rel', 'noopener noreferrer');
-  }
-});
+export default createDOMPurify(universalWindow);

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -77,10 +77,10 @@ export function isValidClientApp(value, { _config = config } = {}) {
   return _config.get('validClientApplications').includes(value);
 }
 
-export function sanitizeHTML(text, allowTags = []) {
+export function sanitizeHTML(text, allowTags = [], _purify = purify) {
   // TODO: Accept tags to allow and run through dom-purify.
   return {
-    __html: purify.sanitize(text, { ALLOWED_TAGS: allowTags }),
+    __html: _purify.sanitize(text, { ALLOWED_TAGS: allowTags }),
   };
 }
 

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -29,7 +29,7 @@ import translate from 'core/i18n/translate';
 import { withInstallHelpers } from 'core/installAddon';
 import themeAction from 'core/themePreview';
 import tracking, { getAction } from 'core/tracking';
-import { sanitizeHTMLWithNewTabLinks } from 'disco/utils';
+import { sanitizeHTMLWithExternalLinks } from 'disco/utils';
 import {
   getClientCompatibility as _getClientCompatibility,
 } from 'core/utils/compatibility';
@@ -145,7 +145,7 @@ export class AddonBase extends React.Component {
       <div
         className="editorial-description"
         dangerouslySetInnerHTML={
-          sanitizeHTMLWithNewTabLinks(description, ['a', 'blockquote', 'cite'])
+          sanitizeHTMLWithExternalLinks(description, ['a', 'blockquote', 'cite'])
         }
       />
     );
@@ -264,7 +264,7 @@ export class AddonBase extends React.Component {
               onClick={this.clickHeadingLink}
               className="heading"
               dangerouslySetInnerHTML={
-                sanitizeHTMLWithNewTabLinks(heading, ['a', 'span'])
+                sanitizeHTMLWithExternalLinks(heading, ['a', 'span'])
               }
             />
             {this.getDescription()}

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -29,9 +29,7 @@ import translate from 'core/i18n/translate';
 import { withInstallHelpers } from 'core/installAddon';
 import themeAction from 'core/themePreview';
 import tracking, { getAction } from 'core/tracking';
-import {
-  sanitizeHTML,
-} from 'core/utils';
+import { sanitizeHTMLWithNewTabLinks } from 'disco/utils';
 import {
   getClientCompatibility as _getClientCompatibility,
 } from 'core/utils/compatibility';
@@ -147,7 +145,7 @@ export class AddonBase extends React.Component {
       <div
         className="editorial-description"
         dangerouslySetInnerHTML={
-          sanitizeHTML(description, ['a', 'blockquote', 'cite'])
+          sanitizeHTMLWithNewTabLinks(description, ['a', 'blockquote', 'cite'])
         }
       />
     );
@@ -265,7 +263,9 @@ export class AddonBase extends React.Component {
             <h2
               onClick={this.clickHeadingLink}
               className="heading"
-              dangerouslySetInnerHTML={sanitizeHTML(heading, ['a', 'span'])}
+              dangerouslySetInnerHTML={
+                sanitizeHTMLWithNewTabLinks(heading, ['a', 'span'])
+              }
             />
             {this.getDescription()}
           </div>

--- a/src/disco/components/AddonCompatibilityError/index.js
+++ b/src/disco/components/AddonCompatibilityError/index.js
@@ -8,7 +8,7 @@ import {
   INCOMPATIBLE_UNDER_MIN_VERSION,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
-import { sanitizeHTML } from 'core/utils';
+import { sanitizeHTMLWithNewTabLinks } from 'disco/utils';
 
 import './style.scss';
 
@@ -52,7 +52,7 @@ export class AddonCompatibilityErrorBase extends React.Component {
     return (
       <div
         className="AddonCompatibilityError"
-        dangerouslySetInnerHTML={sanitizeHTML(message, ['a'])}
+        dangerouslySetInnerHTML={sanitizeHTMLWithNewTabLinks(message, ['a'])}
       />
     );
   }

--- a/src/disco/components/AddonCompatibilityError/index.js
+++ b/src/disco/components/AddonCompatibilityError/index.js
@@ -8,7 +8,7 @@ import {
   INCOMPATIBLE_UNDER_MIN_VERSION,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
-import { sanitizeHTMLWithNewTabLinks } from 'disco/utils';
+import { sanitizeHTMLWithExternalLinks } from 'disco/utils';
 
 import './style.scss';
 
@@ -52,7 +52,7 @@ export class AddonCompatibilityErrorBase extends React.Component {
     return (
       <div
         className="AddonCompatibilityError"
-        dangerouslySetInnerHTML={sanitizeHTMLWithNewTabLinks(message, ['a'])}
+        dangerouslySetInnerHTML={sanitizeHTMLWithExternalLinks(message, ['a'])}
       />
     );
   }

--- a/src/disco/purify.js
+++ b/src/disco/purify.js
@@ -1,0 +1,17 @@
+import createDOMPurify from 'dompurify';
+
+import universalWindow from 'core/window';
+
+
+const discoPurify = createDOMPurify(universalWindow);
+
+discoPurify.addHook('afterSanitizeAttributes', (node) => {
+  // Set all elements owning target to target=_blank
+  // and add rel="noopener noreferrer".
+  if ('target' in node) {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
+export default discoPurify;

--- a/src/disco/utils.js
+++ b/src/disco/utils.js
@@ -1,0 +1,7 @@
+import { sanitizeHTML } from 'core/utils';
+import purify from 'disco/purify';
+
+
+export const sanitizeHTMLWithNewTabLinks = (text, allowTags = []) => {
+  return sanitizeHTML(text, allowTags, purify);
+};

--- a/src/disco/utils.js
+++ b/src/disco/utils.js
@@ -2,6 +2,7 @@ import { sanitizeHTML } from 'core/utils';
 import purify from 'disco/purify';
 
 
-export const sanitizeHTMLWithNewTabLinks = (text, allowTags = []) => {
+export const sanitizeHTMLWithExternalLinks = (text, allowTags = []) => {
+  // This purify instance is configured with a hook to fix link targets.
   return sanitizeHTML(text, allowTags, purify);
 };

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -43,6 +43,7 @@ import {
   render404IfConfigKeyIsFalse,
   safeAsyncConnect,
   safePromise,
+  sanitizeHTML,
   sanitizeUserHTML,
   visibleAddonType,
   trimAndAddProtocolToUrl,
@@ -825,9 +826,7 @@ describe('sanitizeUserHTML', () => {
   it('allows some tags', () => {
     const customHtml =
       '<b>check</b> <i>out</i> <a href="http://mysite">my site</a>';
-    expect(sanitize(customHtml)).toMatch(new RegExp(
-      '<b>check</b> <i>out</i> <a href="http://mysite" .*>my site</a>'
-    ));
+    expect(sanitize(customHtml)).toEqual(customHtml);
   });
 
   it('does not allow certain tags', () => {
@@ -837,5 +836,22 @@ describe('sanitizeUserHTML', () => {
 
   it('does nothing to null values', () => {
     expect(sanitize(null)).toEqual('');
+  });
+});
+
+describe('sanitizeHTML', () => {
+  it('does not change links', () => {
+    const html = '<a href="http://example.org">link</a>';
+    expect(sanitizeHTML(html, ['a'])).toEqual({
+      __html: html,
+    });
+  });
+
+  // This is a built-in feature of dompurify.
+  it('removes `target` attribute on links', () => {
+    const html = '<a href="http://example.org" target="_blank">link</a>';
+    expect(sanitizeHTML(html, ['a'])).toEqual({
+      __html: '<a href="http://example.org">link</a>',
+    });
   });
 });

--- a/tests/unit/disco/test_utils.js
+++ b/tests/unit/disco/test_utils.js
@@ -1,0 +1,14 @@
+import { sanitizeHTMLWithNewTabLinks } from 'disco/utils';
+
+describe('sanitizeHTMLWithNewTabLinks', () => {
+  it('adds `target` and `rel` attributes to HTML "targetable" elements', () => {
+    const html = '<a href="http://example.org">link</a>';
+    expect(sanitizeHTMLWithNewTabLinks(html, ['a'])).toEqual({
+      __html: [
+        '<a href="http://example.org" target="_blank" rel="noopener noreferrer">',
+        'link',
+        '</a>',
+      ].join(''),
+    });
+  });
+});

--- a/tests/unit/disco/test_utils.js
+++ b/tests/unit/disco/test_utils.js
@@ -1,9 +1,9 @@
-import { sanitizeHTMLWithNewTabLinks } from 'disco/utils';
+import { sanitizeHTMLWithExternalLinks } from 'disco/utils';
 
-describe('sanitizeHTMLWithNewTabLinks', () => {
+describe('sanitizeHTMLWithExternalLinks', () => {
   it('adds `target` and `rel` attributes to HTML "targetable" elements', () => {
     const html = '<a href="http://example.org">link</a>';
-    expect(sanitizeHTMLWithNewTabLinks(html, ['a'])).toEqual({
+    expect(sanitizeHTMLWithExternalLinks(html, ['a'])).toEqual({
       __html: [
         '<a href="http://example.org" target="_blank" rel="noopener noreferrer">',
         'link',


### PR DESCRIPTION
Fix #3554

---

This PR restricts the DOM Purify hook that adds `target="_blank"` to links (actually, "targetable" elements) to the `disco` project. Before it was used everywhere.