### PR TITLE
Fix min height of language tool entries

### DIFF
--- a/src/amo/components/LanguageTools/styles.scss
+++ b/src/amo/components/LanguageTools/styles.scss
@@ -2,6 +2,8 @@
 @import "~core/css/inc/mixins";
 @import "~ui/css/vars";
 
+$cell-padding: 6px;
+
 .LanguageTools {
   margin: 12px;
 }
@@ -41,6 +43,10 @@
 
   th,
   td {
-    padding: 6px;
+    padding: $cell-padding;
+  }
+
+  td {
+    min-height: $font-size-m + (2 * $cell-padding);
   }
 }


### PR DESCRIPTION
Fix #3454

---

This PR fixes a visual glitch when some entries are not present in a given language on the "Dictionaries and Language Packs" page and on small screens. I used `31px` because that was the height for other regular rows.

Before:

<img width="442" alt="screen shot 2017-10-23 at 19 55 23" src="https://user-images.githubusercontent.com/217628/31904682-38655986-b82c-11e7-942a-240b2b142c06.png">


After:

<img width="399" alt="screen shot 2017-10-23 at 19 36 10" src="https://user-images.githubusercontent.com/217628/31904611-13f3d834-b82c-11e7-8847-b019a9a32dc5.png">
