### PR TITLE
Be sure to sort all sections before slicing them

### DIFF
--- a/src/core/reducers/heroBanners.js
+++ b/src/core/reducers/heroBanners.js
@@ -25,12 +25,13 @@ export default function heroBannerOrderReducer(state = initialState, action) {
   switch (action.type) {
     case SET_HERO_BANNER_ORDER: {
       const { name, random, sections } = action.payload;
-      const orderArray = [...sections.keys()].slice(0, MAX_ITEMS);
+      const orderArray = [...sections.keys()];
+      const order = random ? knuthShuffle(orderArray) : orderArray;
 
       return {
         ...state,
         [name]: {
-          order: random ? knuthShuffle(orderArray) : orderArray,
+          order: order.slice(0, MAX_ITEMS),
         },
       };
     }

--- a/tests/unit/amo/reducers/testHeroBanners.js
+++ b/tests/unit/amo/reducers/testHeroBanners.js
@@ -77,6 +77,27 @@ describe(__filename, () => {
     });
   });
 
+  it('randomizes first and then picks three sections', () => {
+    const sections = [0, 1, 2, 3, 4, 5];
+    // Our sort algorithm is reverse ordering.
+    const knuthShuffleSpy = sinon
+      .stub(knuthShuffle, 'knuthShuffle')
+      .callsFake((sectionsToSort) => {
+        return sectionsToSort.reverse();
+      });
+
+    const state = heroBannerOrderReducer(initialState, setHeroBannerOrder({
+      name: 'CoolPage',
+      random: true,
+      sections,
+    }));
+
+    sinon.assert.called(knuthShuffleSpy);
+    expect(state).toMatchObject({
+      CoolPage: { order: [5, 4, 3] },
+    });
+  });
+
   describe('carousel actions', () => {
     it('requires name', () => {
       const partialParams = { ...defaultParams };


### PR DESCRIPTION
Fix #3608

---

While addressing changes in another PR related to the Hero Banner, I could not display the "Ad blocks" card, like never. I looked at the code of the reducer and it seems we never take all the sections into account, only the `MAX_ITEMS` first.

This PR fixes this by sorting all the sections first and then reducing the set of sections to display.