### PR TITLE
Update shelves style

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -168,6 +168,7 @@
     background-color: $white;
     display: grid;
     grid-auto-flow: initial;
+    grid-gap: 6px;
     grid-template-columns: repeat(2, 1fr);
     margin: 0;
     padding: 0;
@@ -187,12 +188,6 @@
 
     .SearchResult-icon {
       border-radius: $border-radius-default;
-    }
-
-    @include respond-to(large) {
-      .SearchResult.SearchResult--theme {
-        margin: 0 5px;
-      }
     }
 
     @include respond-to(extraLarge) {

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -10,22 +10,18 @@
       background: $white;
       border-bottom-left-radius: $border-radius-default;
       border-bottom-right-radius: $border-radius-default;
-      padding: 0 36px;
+      padding: 12px 6px;
     }
 
     .Card-footer,
     .Card-footer-link {
-      @include end(20px);
+      @include end(0);
       @include text-align-end();
 
       background: none;
       border: 0;
       position: absolute;
       top: 0;
-
-      @include respond-to(large) {
-        @include end(0);
-      }
     }
 
     ul.AddonsCard-list {
@@ -34,12 +30,17 @@
       grid-template-columns: repeat(4, 25%);
 
       .SearchResult {
-        @include padding-start(0);
-
         grid-column: auto;
-        margin-bottom: 0;
+        margin: 0 6px 1px;
         // Prevents content overflow.
         min-width: 0;
+        padding: 12px 24px;
+        transition: background-color $transition-short ease-in-out;
+      }
+
+      .SearchResult:hover {
+        background-color: $grey-10;
+        border-radius: $border-radius-default;
       }
 
       .SearchResult-result {
@@ -75,10 +76,6 @@
       }
 
       .SearchResult--theme {
-        @include margin-end(24px);
-
-        padding: 24px 0;
-
         // stylelint-disable max-nesting-depth
         .SearchResult-result {
           display: block;

--- a/src/amo/components/Search/styles.scss
+++ b/src/amo/components/Search/styles.scss
@@ -48,6 +48,10 @@
       grid-row: 2 / 4;
       // Allows the grid item to contain the content preventing overflow.
       min-width: 0;
+
+      .SearchResult {
+        padding: 24px 36px;
+      }
     }
   }
 

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -25,7 +25,7 @@
 
   .SearchResult--theme & {
     flex-grow: 1;
-    margin: -10px -10px 10px;
+    margin-bottom: 10px;
     min-height: 64px;
     overflow: hidden;
     width: calc(100% + 20px);
@@ -82,10 +82,11 @@
 }
 
 .SearchResult-name {
+  @include font-medium();
+
   color: $type-black;
   flex-grow: 1;
   font-size: $font-size-m-smaller;
-  font-weight: 400;
   line-height: 1.2;
   margin: 0;
   padding: 0;
@@ -96,7 +97,6 @@
   .SearchResult-link:focus &,
   .SearchResult-link:hover & {
     color: $link-color;
-    text-decoration: underline;
   }
 
   .LoadingText {


### PR DESCRIPTION
refs #3593

---

This PR slightly improves the different shelves by adding a `hover` state with background fading. It is getting closer and closer to the mockups. It also aligns the different addon lists vertically and horizontally with the header title positions.

## Gifs

![2017-10-24 12 55 56](https://user-images.githubusercontent.com/217628/31939534-18b9676e-b8bb-11e7-9cff-4247a83d53c6.gif)
![2017-10-24 12 56 05](https://user-images.githubusercontent.com/217628/31939535-1916f438-b8bb-11e7-83f3-09cab38c2525.gif)

## Screenshots

<img width="1392" alt="screen shot 2017-10-24 at 12 58 34" src="https://user-images.githubusercontent.com/217628/31939538-1d2cc0b6-b8bb-11e7-8651-939caca4a240.png">
<img width="1392" alt="screen shot 2017-10-24 at 12 58 39" src="https://user-images.githubusercontent.com/217628/31939540-1d48397c-b8bb-11e7-857a-3201a0ef3871.png">
<img width="1392" alt="screen shot 2017-10-24 at 12 58 43" src="https://user-images.githubusercontent.com/217628/31939541-1d6638be-b8bb-11e7-9e96-5f9f0eed5d9e.png">
<img width="1392" alt="screen shot 2017-10-24 at 12 59 56" src="https://user-images.githubusercontent.com/217628/31939592-461b3bd8-b8bb-11e7-8fa7-47ddafbf6609.png">
<img width="1392" alt="screen shot 2017-10-24 at 13 00 03" src="https://user-images.githubusercontent.com/217628/31939593-463bcb78-b8bb-11e7-9a7a-6bc97fd22228.png">
