### PR TITLE
Allow to find addons by ID

### DIFF
--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -57,7 +57,9 @@ export type FetchAddonAction = {|
   |},
 |};
 
-export function fetchAddon({ errorHandler, slug }: FetchAddonParams): FetchAddonAction {
+export function fetchAddon(
+  { errorHandler, slug }: FetchAddonParams
+): FetchAddonAction {
   if (!errorHandler) {
     throw new Error('errorHandler cannot be empty');
   }
@@ -287,7 +289,10 @@ export default function addonsReducer(
       const { addons } = action.payload;
       const newState = { ...state };
       Object.keys(addons).forEach((key) => {
-        newState[key] = createInternalAddon(addons[key]);
+        const addon = createInternalAddon(addons[key]);
+
+        newState[addon.id] = addon;
+        newState[key] = addon;
       });
       return newState;
     }

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -42,18 +42,22 @@ describe(__filename, () => {
         ...createInternalAddon(anotherFakeAddon),
         isRestartRequired: false,
       },
+      [anotherFakeAddon.id]: {
+        ...createInternalAddon(anotherFakeAddon),
+        isRestartRequired: false,
+      },
     });
   });
 
-  it('stores all add-ons', () => {
+  it('stores all add-ons, indexed by id and slug', () => {
     const addonResults = [
-      { ...fakeAddon, slug: 'first-slug' },
-      { ...fakeAddon, slug: 'second-slug' },
+      { ...fakeAddon, slug: 'first-slug', id: 123 },
+      { ...fakeAddon, slug: 'second-slug', id: 456 },
     ];
     const state = addons(undefined,
       loadAddons(createFetchAllAddonsResult(addonResults).entities));
     expect(Object.keys(state).sort())
-      .toEqual(['first-slug', 'second-slug']);
+      .toEqual(['123', '456', 'first-slug', 'second-slug']);
   });
 
   it('ignores empty results', () => {


### PR DESCRIPTION
Fix #3610

---

This PR allows to load add-ons by ID so that we can load a detail page by ID or slug.

The problem is that we rely on `normalizr` after having fetched the add-ons, which uses the add-on `slug` as key. When user wants to load a page by ID, all the API calls are correctly executed but then `normalizr` changes the response payload for the add-ons. The `addons` reducer then loads the add-ons by `slug`, not by `ID`. Because of this, the UI does not find the requested add-on and is in error state.

Pros: it is BC, safe and it works
Cons: it adds more data to the `addon` reducer

What do you think?