### PR TITLE
Prevent a flicker when focusing search box on mobile

### DIFF
--- a/src/amo/components/SearchForm/styles.scss
+++ b/src/amo/components/SearchForm/styles.scss
@@ -17,6 +17,8 @@
   @include padding-end(6px);
   @include padding-start(28px);
 
+  // This prevents a flicker of black when focusing on mobile.
+  background-color: $white;
   border: 1px solid $white;
   border-radius: $border-radius-s;
   color: $black;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3615

This only happens on mobile so I didn't make a screencast. I was able to reproduce the issue [with these steps](https://github.com/mozilla/addons-frontend/#configuring-an-android-device-for-local-development) before fixing it.