### PR TITLE
Track analytics of the standalone install button

### DIFF
--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -9,7 +9,7 @@ import InstallSwitch from 'core/components/InstallSwitch';
 import {
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
-  INSTALL_CATEGORY,
+  INSTALL_STARTED_CATEGORY,
   TRACKING_TYPE_EXTENSION,
   validAddonTypes,
 } from 'core/constants';
@@ -73,12 +73,12 @@ export class InstallButtonBase extends React.Component {
     installTheme(event.currentTarget, { ...addon, status });
   }
 
-  trackInstall({ addonName }) {
+  trackInstallStarted({ addonName }) {
     const { _tracking } = this.props;
 
     _tracking.sendEvent({
       action: TRACKING_TYPE_EXTENSION,
-      category: INSTALL_CATEGORY,
+      category: INSTALL_STARTED_CATEGORY,
       label: addonName,
     });
   }
@@ -134,7 +134,7 @@ export class InstallButtonBase extends React.Component {
 
         _log.info('Adding OpenSearch Provider', { addon });
         _window.external.AddSearchProvider(installURL);
-        this.trackInstall({ addonName: addon.name });
+        this.trackInstallStarted({ addonName: addon.name });
 
         return false;
       };
@@ -156,7 +156,7 @@ export class InstallButtonBase extends React.Component {
         event.stopPropagation();
         return false;
       } : () => {
-        this.trackInstall({ addonName: addon.name });
+        this.trackInstallStarted({ addonName: addon.name });
       };
       button = (
         <Button

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -166,6 +166,7 @@ export const INSTALL_ERROR = 'INSTALL_ERROR';
 
 // Tracking categories.
 export const INSTALL_CATEGORY = 'AMO Addon / Theme Installs';
+export const INSTALL_STARTED_CATEGORY = 'AMO Addon / Theme Installs Started';
 export const UNINSTALL_CATEGORY = 'AMO Addon / Theme Uninstalls';
 export const CLICK_CATEGORY = 'AMO Addon / Theme Clicks';
 

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -25,6 +25,7 @@ import {
   INSTALL_ERROR,
   INSTALL_CANCELLED,
   INSTALL_FAILED,
+  INSTALL_STARTED_CATEGORY,
   INSTALLING,
   OS_ALL,
   OS_ANDROID,
@@ -83,6 +84,12 @@ export function installTheme(
     [DISABLED, UNINSTALLED, UNKNOWN].includes(status)
   ) {
     _themeAction(node, THEME_INSTALL);
+    // For consistency, track both a start-install and an install event.
+    _tracking.sendEvent({
+      action: TRACKING_TYPE_THEME,
+      category: INSTALL_STARTED_CATEGORY,
+      label: name,
+    });
     _tracking.sendEvent({
       action: TRACKING_TYPE_THEME,
       category: INSTALL_CATEGORY,
@@ -388,6 +395,11 @@ export class WithInstallHelpers extends React.Component {
     } = this.props;
 
     dispatch({ type: START_DOWNLOAD, payload: { guid } });
+    _tracking.sendEvent({
+      action: TRACKING_TYPE_EXTENSION,
+      category: INSTALL_STARTED_CATEGORY,
+      label: name,
+    });
 
     const installURL = findInstallURL({ installURLs, userAgentInfo });
     return _addonManager.install(

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -12,7 +12,7 @@ import {
   ADDON_TYPE_THEME,
   INCOMPATIBLE_NO_OPENSEARCH,
   INCOMPATIBLE_NOT_FIREFOX,
-  INSTALL_CATEGORY,
+  INSTALL_STARTED_CATEGORY,
   OS_ALL,
   TRACKING_TYPE_EXTENSION,
   UNKNOWN,
@@ -337,7 +337,7 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(_tracking.sendEvent, {
       action: TRACKING_TYPE_EXTENSION,
-      category: INSTALL_CATEGORY,
+      category: INSTALL_STARTED_CATEGORY,
       label: addon.name,
     });
   });
@@ -360,7 +360,7 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(_tracking.sendEvent, {
       action: TRACKING_TYPE_EXTENSION,
-      category: INSTALL_CATEGORY,
+      category: INSTALL_STARTED_CATEGORY,
       label: addon.name,
     });
   });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -51,7 +51,10 @@ const enabledExtension = Promise.resolve({
 });
 
 export function getFakeAddonManagerWrapper({
-  getAddon = enabledExtension, permissionPromptsEnabled = true } = {}) {
+  getAddon = enabledExtension,
+  permissionPromptsEnabled = true,
+  ...overrides
+} = {}) {
   return {
     addChangeListeners: sinon.stub(),
     enable: sinon.stub().returns(Promise.resolve()),
@@ -59,6 +62,7 @@ export function getFakeAddonManagerWrapper({
     install: sinon.stub().returns(Promise.resolve()),
     uninstall: sinon.stub().returns(Promise.resolve()),
     hasPermissionPromptsEnabled: sinon.stub().returns(permissionPromptsEnabled),
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3600

- is this the right way to do it?
- the `mozAddonManager` does it like this but only *after* a successful installation. I'm not sure if we need to set this event apart.
- the old site seems to be using a different analytics framework so I'm not sure if this matches what's going on there.