### PR TITLE
fix: Close dropdown on click

### DIFF
--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -67,7 +67,7 @@
   .DropdownMenu-button {
     display: block;
     margin-top: 2px;
-    padding: 0;
+    padding: 0 0 2px;
   }
 
   .DropdownMenu-button-text {

--- a/src/ui/components/DropdownMenu/index.js
+++ b/src/ui/components/DropdownMenu/index.js
@@ -1,8 +1,10 @@
 /* @flow */
+import { oneLine } from 'common-tags';
 import * as React from 'react';
 import classNames from 'classnames';
 import onClickOutside from 'react-onclickoutside';
 
+import log from 'core/logger';
 import Icon from 'ui/components/Icon';
 import DropdownMenuItem from 'ui/components/DropdownMenuItem';
 
@@ -17,35 +19,67 @@ type Props = {|
 
 type State = {|
   buttonIsActive: boolean,
+  setByHover: boolean,
 |};
 
 export class DropdownMenuBase extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    this.state = { buttonIsActive: false };
+    this.state = { buttonIsActive: false, setByHover: false };
   }
 
   handleOnClick = (event: SyntheticEvent<any>) => {
     event.preventDefault();
+
+    if (this.state.setByHover) {
+      this.setState({ setByHover: false });
+      return;
+    }
 
     this.setState((previousState) => ({
       buttonIsActive: !previousState.buttonIsActive,
     }));
   }
 
+  handleOnClickForLinks = (event: SyntheticEvent<any>) => {
+    // If a link inside the menu is clicked, we should close the dropdown.
+    // See: https://github.com/mozilla/addons-frontend/issues/3452
+    if (event.target && event.target.tagName === 'A') {
+      log.debug(oneLine`Setting state of DropdownMenu to buttonIsActive to
+        false, because a link inside the menu was clicked.`);
+      this.setState({ buttonIsActive: false, setByHover: false });
+    }
+  }
+
   handleClickOutside = () => {
-    this.setState({ buttonIsActive: false });
+    this.setState({ buttonIsActive: false, setByHover: false });
+  }
+
+  handleOnMouseEnter = () => {
+    this.setState({ buttonIsActive: true, setByHover: true });
+  }
+
+  handleOnMouseLeave = () => {
+    this.setState({ buttonIsActive: false, setByHover: false });
   }
 
   render() {
     const { children, className, text } = this.props;
 
+    // ESLint doesn't like the event handlers we attach to the
+    // div below, but they're just re-creating hover in JS and dismissing
+    // the menu when links inside it are clicked, so it's not really
+    // an interactive element.
+    /* eslint-disable jsx-a11y/no-static-element-interactions */
     return (
       <div
         className={classNames('DropdownMenu', className, {
           'DropdownMenu--active': this.state.buttonIsActive,
         })}
+        onClick={this.handleOnClickForLinks}
+        onMouseEnter={this.handleOnMouseEnter}
+        onMouseLeave={this.handleOnMouseLeave}
       >
         <button
           className="DropdownMenu-button"
@@ -65,6 +99,7 @@ export class DropdownMenuBase extends React.Component<Props, State> {
         )}
       </div>
     );
+    /* eslint-enable jsx-a11y/no-static-element-interactions */
   }
 }
 

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -11,22 +11,6 @@
   padding-top: 4px;
   position: relative;
 
-  // This media query is needed because `:hover` on mobile prevents the
-  // main button to close the dropdown menu. On mobile,
-  // `.DropdownMenu--active` controls the visibility of the menu.
-  // On "large" devices (and above), `:hover` also opens the menu.
-  @include respond-to(large) {
-    &:hover {
-      .DropdownMenu-items {
-        display: block;
-      }
-
-      .Icon-inverted-caret {
-        opacity: 1;
-      }
-    }
-  }
-
   @include respond-to(medium) {
     height: auto;
     padding-bottom: 6px;

--- a/tests/unit/ui/components/TestDropdownMenu.js
+++ b/tests/unit/ui/components/TestDropdownMenu.js
@@ -61,6 +61,68 @@ describe(__filename, () => {
     expect(menu).not.toHaveClassName('DropdownMenu--active');
   });
 
+  it('resets the menu state on click', () => {
+    // See: https://github.com/mozilla/addons-frontend/issues/3452
+    const root = mount(
+      <DropdownMenu text="Menu">
+        <DropdownMenuItem>
+          <a className="TestLink" href="/test-link/">Test!</a>
+        </DropdownMenuItem>
+      </DropdownMenu>
+    );
+    const menu = root.find('.DropdownMenu');
+
+    // User clicks the menu main button to open it.
+    menu.find('.DropdownMenu-button').simulate('click', createFakeEvent());
+    expect(menu).toHaveClassName('DropdownMenu--active');
+
+    // User clicks a link.
+    menu.find('.TestLink').simulate('click', createFakeEvent());
+    expect(menu).not.toHaveClassName('DropdownMenu--active');
+  });
+
+  it('sets active on mouseEnter/clears on mouseLeave', () => {
+    // We do this instead of a :hover with CSS to allow clearing the active
+    // state after a click.
+    const root = mount(<DropdownMenu text="Menu" />);
+    const menu = root.find('.DropdownMenu');
+
+    // User hovers on the menu.
+    menu.simulate('mouseEnter', createFakeEvent());
+    expect(menu).toHaveClassName('DropdownMenu--active');
+
+    // User's mouse leaves the menu.
+    menu.simulate('mouseLeave', createFakeEvent());
+    expect(menu).not.toHaveClassName('DropdownMenu--active');
+  });
+
+  it('allows the user to hover then click without dismissing the menu', () => {
+    const root = mount(<DropdownMenu text="Menu" />);
+    const menu = root.find('.DropdownMenu');
+
+    // User hovers on the menu.
+    menu.simulate('mouseEnter', createFakeEvent());
+    expect(menu).toHaveClassName('DropdownMenu--active');
+
+    // User clicks the menu's main button once, which should not hide it.
+    menu.find('.DropdownMenu-button').simulate('click', createFakeEvent());
+    expect(menu).toHaveClassName('DropdownMenu--active');
+  });
+
+  it('allows the user to hover, then dismiss the menu with a click', () => {
+    const root = mount(<DropdownMenu text="Menu" />);
+    const menu = root.find('.DropdownMenu');
+
+    // User hovers on the menu.
+    menu.simulate('mouseEnter', createFakeEvent());
+    expect(menu).toHaveClassName('DropdownMenu--active');
+
+    // User clicks the menu's main button twice, which will dismiss it.
+    menu.find('.DropdownMenu-button').simulate('click', createFakeEvent());
+    menu.find('.DropdownMenu-button').simulate('click', createFakeEvent());
+    expect(menu).not.toHaveClassName('DropdownMenu--active');
+  });
+
   it('optionally takes a class name', () => {
     const menu = renderComponent(
       <DropdownMenu text="Menu" className="my-class" />


### PR DESCRIPTION
Fix #3452.

Changes to use a JS hover to allow us to dismiss the menu on a click.

### Screencast
![2017-10-25 15 23 31](https://user-images.githubusercontent.com/90871/32005246-b6d5d884-b99b-11e7-9a17-11f1abd3f474.gif)