### PR TITLE
Only flag a review for a single reason

### DIFF
--- a/src/amo/components/FlagReview/index.js
+++ b/src/amo/components/FlagReview/index.js
@@ -76,8 +76,8 @@ const mapStateToProps = (
   let flagState = {};
   if (ownProps.review) {
     const view = state.reviews.view[ownProps.review.id];
-    if (view && view.flags) {
-      flagState = view.flags[ownProps.reason];
+    if (view && view.flag && view.flag.reason === ownProps.reason) {
+      flagState = view.flag;
     }
   }
   return {

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -146,7 +146,7 @@ const mapStateToProps = (
   let wasFlagged = false;
   if (ownProps.review) {
     const view = state.reviews.view[ownProps.review.id];
-    if (view && view.flags) {
+    if (view && view.flag) {
       wasFlagged = true;
     }
   }

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -29,6 +29,7 @@ type Props = {|
   review: UserReviewType,
   siteUser: UserStateType,
   userIsAuthenticated: boolean,
+  wasFlagged: boolean,
 |};
 
 export class FlagReviewMenuBase extends React.Component<Props> {
@@ -45,6 +46,7 @@ export class FlagReviewMenuBase extends React.Component<Props> {
       review,
       siteUser,
       userIsAuthenticated,
+      wasFlagged,
     } = this.props;
 
     let items;
@@ -125,7 +127,9 @@ export class FlagReviewMenuBase extends React.Component<Props> {
         idPrefix="flag-review-"
         items={items}
         openerClass={openerClass}
-        openerText={i18n.gettext('Flag')}
+        openerText={wasFlagged ?
+          i18n.gettext('Flagged') : i18n.gettext('Flag')
+        }
         openerTitle={isDeveloperReply ?
           i18n.gettext('Flag this developer response') :
           i18n.gettext('Flag this review')
@@ -137,8 +141,17 @@ export class FlagReviewMenuBase extends React.Component<Props> {
 
 const mapStateToProps = (
   state: {| user: UserStateType, reviews: ReviewState |},
+  ownProps: Props,
 ) => {
+  let wasFlagged = false;
+  if (ownProps.review) {
+    const view = state.reviews.view[ownProps.review.id];
+    if (view && view.flags) {
+      wasFlagged = true;
+    }
+  }
   return {
+    wasFlagged,
     siteUser: state.user,
     userIsAuthenticated: isAuthenticated(state),
   };

--- a/tests/unit/amo/components/TestFlagReviewMenu.js
+++ b/tests/unit/amo/components/TestFlagReviewMenu.js
@@ -6,7 +6,9 @@ import {
   REVIEW_FLAG_REASON_LANGUAGE,
   REVIEW_FLAG_REASON_SPAM,
 } from 'amo/constants';
-import { denormalizeReview } from 'amo/actions/reviews';
+import {
+  denormalizeReview, setReviewWasFlagged,
+} from 'amo/actions/reviews';
 import FlagReview from 'amo/components/FlagReview';
 import FlagReviewMenu, {
   FlagReviewMenuBase,
@@ -178,6 +180,18 @@ describe(__filename, () => {
 
       expect(menu.find('.FlagReviewMenu-flag-bug-support-item'))
         .toHaveLength(0);
+    });
+
+    it('changes prompt after review has been flagged', () => {
+      const review = denormalizeReview(fakeReview);
+      store.dispatch(setReviewWasFlagged({
+        reason: REVIEW_FLAG_REASON_SPAM,
+        reviewId: review.id,
+      }));
+
+      const root = render({ review });
+
+      expect(root.find(TooltipMenu)).toHaveProp('openerText', 'Flagged');
     });
   });
 });

--- a/tests/unit/amo/reducers/testReviews.js
+++ b/tests/unit/amo/reducers/testReviews.js
@@ -11,9 +11,7 @@ import {
   setReview,
   setReviewReply,
 } from 'amo/actions/reviews';
-import {
-  REVIEW_FLAG_REASON_BUG_SUPPORT, REVIEW_FLAG_REASON_SPAM,
-} from 'amo/constants';
+import { REVIEW_FLAG_REASON_SPAM } from 'amo/constants';
 import reviewsReducer, {
   changeViewState, expandReviewObjects, initialState, storeReviewObjects,
 } from 'amo/reducers/reviews';
@@ -444,11 +442,10 @@ describe(__filename, () => {
         reviewId: review.id,
       }));
 
-      expect(state.view[review.id].flags).toMatchObject({
-        [REVIEW_FLAG_REASON_SPAM]: {
-          inProgress: true,
-          wasFlagged: false,
-        },
+      expect(state.view[review.id].flag).toMatchObject({
+        reason: REVIEW_FLAG_REASON_SPAM,
+        inProgress: true,
+        wasFlagged: false,
       });
     });
 
@@ -460,11 +457,10 @@ describe(__filename, () => {
         reviewId: review.id,
       }));
 
-      expect(state.view[review.id].flags).toMatchObject({
-        [REVIEW_FLAG_REASON_SPAM]: {
-          inProgress: false,
-          wasFlagged: true,
-        },
+      expect(state.view[review.id].flag).toMatchObject({
+        reason: REVIEW_FLAG_REASON_SPAM,
+        inProgress: false,
+        wasFlagged: true,
       });
     });
   });
@@ -517,17 +513,16 @@ describe(__filename, () => {
       expect(newState.view[review.id].secondFlag).toEqual(true);
     });
 
-    it('preserves existing flags per `reason` value', () => {
+    it('preserves existing flag review values', () => {
       const review = { ...fakeReview, id: 987 };
 
       const state = changeViewState({
         state: initialState,
         reviewId: review.id,
         stateChange: {
-          flags: {
-            [REVIEW_FLAG_REASON_SPAM]: {
-              inProgress: true,
-            },
+          flag: {
+            reason: REVIEW_FLAG_REASON_SPAM,
+            inProgress: true,
           },
         },
       });
@@ -536,53 +531,17 @@ describe(__filename, () => {
         state,
         reviewId: review.id,
         stateChange: {
-          flags: {
-            [REVIEW_FLAG_REASON_BUG_SUPPORT]: {
-              inProgress: false,
-            },
+          flag: {
+            reason: REVIEW_FLAG_REASON_SPAM,
+            wasFlagged: true,
           },
         },
       });
 
-      const newFlags = newState.view[review.id].flags;
-      expect(newFlags[REVIEW_FLAG_REASON_SPAM].inProgress)
-        .toEqual(true);
-      expect(newFlags[REVIEW_FLAG_REASON_BUG_SUPPORT].inProgress)
-        .toEqual(false);
-    });
-
-    it('preserves existing flag values for the same `reason`', () => {
-      const review = { ...fakeReview, id: 987 };
-
-      const state = changeViewState({
-        state: initialState,
-        reviewId: review.id,
-        stateChange: {
-          flags: {
-            [REVIEW_FLAG_REASON_SPAM]: {
-              inProgress: true,
-            },
-          },
-        },
-      });
-
-      const newState = changeViewState({
-        state,
-        reviewId: review.id,
-        stateChange: {
-          flags: {
-            [REVIEW_FLAG_REASON_SPAM]: {
-              wasFlagged: true,
-            },
-          },
-        },
-      });
-
-      const newFlags = newState.view[review.id].flags;
-      expect(newFlags[REVIEW_FLAG_REASON_SPAM].inProgress)
-        .toEqual(true);
-      expect(newFlags[REVIEW_FLAG_REASON_SPAM].wasFlagged)
-        .toEqual(true);
+      const newFlag = newState.view[review.id].flag;
+      expect(newFlag.inProgress).toEqual(true);
+      expect(newFlag.wasFlagged).toEqual(true);
+      expect(newFlag.reason).toEqual(REVIEW_FLAG_REASON_SPAM);
     });
 
     it('sets default view states', () => {
@@ -596,7 +555,7 @@ describe(__filename, () => {
 
       expect(state.view[review.id]).toEqual({
         editingReview: false,
-        flags: {},
+        flag: {},
         replyingToReview: false,
         submittingReply: false,
       });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3598

* After you flag a review, the prompt changes from *Flag* to *Flagged*
* The UI indicates that you can only flag a review for a single reason
* You can still change your mind and switch the reason

Screencast:

![addons-frontend-flag-review mov](https://user-images.githubusercontent.com/55398/32065025-306004ae-ba41-11e7-972e-9c5f35d05c54.gif)