### PR TITLE
fix: Language Tool page tables change size (fix #3645)

### DIFF
--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -155,7 +155,7 @@ export class LanguageToolsBase extends React.Component<Props> {
         <Table className="LanguageTools-table">
           <Thead>
             <Tr className="LanguageTools-header-row">
-              <Th className="LanguageTools-header-cell">
+              <Th className="LanguageTools-header-cell LanguageTool-localeName">
                 {i18n.gettext('Locale Name')}
               </Th>
               <Th className="LanguageTools-header-cell">
@@ -194,7 +194,9 @@ export class LanguageToolsBase extends React.Component<Props> {
                   )}
                   key={langKey}
                 >
-                  <Td lang={langKey}>{languages[langKey].native}</Td>
+                  <Td lang={langKey}>
+                    {languages[langKey].native}
+                  </Td>
                   <Td className={`LanguageTools-lang-${langKey}-languagePacks`}>
                     {languagePacks.length ?
                       <LanguageToolList addons={languagePacks} /> : null}

--- a/src/amo/components/LanguageTools/styles.scss
+++ b/src/amo/components/LanguageTools/styles.scss
@@ -54,3 +54,9 @@ $cell-padding: 6px;
     min-height: $font-size-m + (2 * $cell-padding);
   }
 }
+
+.LanguageTool-localeName {
+  @include respond-to(large) {
+    width: 25%;
+  }
+}


### PR DESCRIPTION
Doesn't affect mobile and medium screens where this isn't an issue.

### Before
![2017-10-26 13 03 35](https://user-images.githubusercontent.com/90871/32052167-44b28bb2-ba4f-11e7-80b2-c6045434162f.gif)

### After
![2017-10-26 12 59 06](https://user-images.githubusercontent.com/90871/32052500-4e1d3cbe-ba50-11e7-859b-9d529ed29456.gif)