### PR TITLE
Mark client as incompatible if add-on does not have a compatible version

### DIFF
--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -39,7 +39,16 @@ export const fakeAddon = Object.freeze({
   categories: { firefox: ['other'] },
   current_beta_version: null,
   current_version: {
-    compatibility: {},
+    compatibility: {
+      [CLIENT_APP_ANDROID]: {
+        min: '48.0',
+        max: '*',
+      },
+      [CLIENT_APP_FIREFOX]: {
+        min: '48.0',
+        max: '*',
+      },
+    },
     id: 123,
     license: { name: 'tofulicense', url: 'http://license.com/' },
     version: '2.0.0',

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -21,6 +21,7 @@ import { createInternalAddon } from 'core/reducers/addons';
 import * as themePreview from 'core/themePreview';
 import {
   createFakeEvent,
+  createFakeMozWindow,
   fakeI18n,
   sampleUserAgentParsed,
   shallowUntilTarget,
@@ -41,10 +42,6 @@ describe(__filename, () => {
     compatible: false,
     reason: INCOMPATIBLE_NO_OPENSEARCH,
   });
-
-  const createFakeMozWindow = () => {
-    return { external: { AddSearchProvider: sinon.stub() } };
-  };
 
   const renderProps = (customProps = {}) => ({
     addon: createInternalAddon(fakeAddon),

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -2,6 +2,7 @@ import { oneLine } from 'common-tags';
 import UAParser from 'ua-parser-js';
 
 import {
+  ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
@@ -22,6 +23,7 @@ import {
 } from 'core/utils/compatibility';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 import {
+  createFakeMozWindow,
   userAgents,
   userAgentsByPlatform,
 } from 'tests/unit/helpers';
@@ -148,7 +150,7 @@ describe(__filename, () => {
       const fakeOpenSearchAddon = createInternalAddon({
         ...fakeAddon, type: ADDON_TYPE_OPENSEARCH,
       });
-      const fakeWindow = { external: { AddSearchProvider: sinon.stub() } };
+      const fakeWindow = createFakeMozWindow();
 
       expect(isCompatibleWithUserAgent({
         _window: fakeWindow, addon: fakeOpenSearchAddon, userAgentInfo }))
@@ -395,21 +397,97 @@ describe(__filename, () => {
       expect(fakeLog.info.firstCall.args[0])
         .toContain(`addon is type ${ADDON_TYPE_OPENSEARCH}`);
     });
+
+    it('marks clientApp as unsupported without compatibility', () => {
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          compatibility: {
+            // Add Android compatibility but not Firefox compatibility.
+            [CLIENT_APP_ANDROID]: {
+              min: '48.0',
+              max: '*',
+            },
+          },
+        },
+        type: ADDON_TYPE_EXTENSION,
+      });
+      const { supportsClientApp } = getCompatibleVersions({
+        addon, clientApp: CLIENT_APP_FIREFOX,
+      });
+
+      expect(supportsClientApp).toEqual(false);
+    });
+
+    it('marks clientApp as supported with compatibility', () => {
+      const clientApp = CLIENT_APP_ANDROID;
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          compatibility: {
+            [clientApp]: {
+              min: '48.0',
+              max: '*',
+            },
+          },
+        },
+        type: ADDON_TYPE_EXTENSION,
+      });
+      const { supportsClientApp } = getCompatibleVersions({
+        addon, clientApp,
+      });
+
+      expect(supportsClientApp).toEqual(true);
+    });
+
+    it('always marks clientApp as supported for opensearch add-ons', () => {
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          // No clientApp is supported.
+          compatibility: {},
+        },
+        type: ADDON_TYPE_OPENSEARCH,
+      });
+      const { supportsClientApp } = getCompatibleVersions({
+        addon, clientApp: CLIENT_APP_ANDROID,
+      });
+
+      expect(supportsClientApp).toEqual(true);
+    });
   });
 
   describe('getClientCompatibility', () => {
     it('returns true for Firefox (reason undefined when compatibile)', () => {
-      const { browser, os } = UAParser(userAgents.firefox[0]);
+      const {
+        browser, os,
+      } = UAParser(userAgentsByPlatform.mac.firefox57);
       const userAgentInfo = { browser, os };
+      const clientApp = CLIENT_APP_FIREFOX;
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          compatibility: {
+            [clientApp]: {
+              min: '48.0',
+              max: '*',
+            },
+          },
+        },
+      });
 
       expect(getClientCompatibility({
-        addon: createInternalAddon(fakeAddon),
-        clientApp: CLIENT_APP_FIREFOX,
+        addon,
+        clientApp,
         userAgentInfo,
       })).toEqual({
         compatible: true,
-        maxVersion: null,
-        minVersion: null,
+        maxVersion: addon.current_version.compatibility[clientApp].max,
+        minVersion: addon.current_version.compatibility[clientApp].min,
         reason: null,
       });
     });
@@ -463,18 +541,31 @@ describe(__filename, () => {
     });
 
     it('returns incompatible for non-Firefox UA', () => {
-      const { browser, os } = UAParser(userAgents.firefox[0]);
+      const { browser, os } = UAParser(userAgentsByPlatform.mac.chrome41);
       const userAgentInfo = { browser, os };
+      const clientApp = CLIENT_APP_FIREFOX;
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          compatibility: {
+            [clientApp]: {
+              min: '*',
+              max: '57.0',
+            },
+          },
+        },
+      });
 
       expect(getClientCompatibility({
-        addon: createInternalAddon(fakeAddon),
-        clientApp: CLIENT_APP_FIREFOX,
+        addon,
+        clientApp,
         userAgentInfo,
       })).toEqual({
-        compatible: true,
-        maxVersion: null,
-        minVersion: null,
-        reason: null,
+        compatible: false,
+        maxVersion: addon.current_version.compatibility[clientApp].max,
+        minVersion: addon.current_version.compatibility[clientApp].min,
+        reason: INCOMPATIBLE_NOT_FIREFOX,
       });
     });
 
@@ -534,6 +625,60 @@ describe(__filename, () => {
       })).toMatchObject({
         compatible: false,
         reason: INCOMPATIBLE_OVER_MAX_VERSION,
+      });
+    });
+
+    it('returns incompatible when add-on does not support client app', () => {
+      const {
+        browser, os,
+      } = UAParser(userAgentsByPlatform.mac.firefox57);
+      const userAgentInfo = { browser, os };
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          // The clientApp is not supported:
+          compatibility: {},
+        },
+      });
+
+      expect(getClientCompatibility({
+        addon,
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgentInfo,
+      })).toEqual({
+        compatible: false,
+        maxVersion: null,
+        minVersion: null,
+        reason: INCOMPATIBLE_UNSUPPORTED_PLATFORM,
+      });
+    });
+
+    it('returns compatible for opensearch add-ons', () => {
+      const {
+        browser, os,
+      } = UAParser(userAgentsByPlatform.mac.firefox57);
+      const userAgentInfo = { browser, os };
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_OPENSEARCH,
+        current_version: {
+          ...fakeAddon.current_version,
+          // These add-ons do not define clientApp support:
+          compatibility: {},
+        },
+      });
+
+      expect(getClientCompatibility({
+        addon,
+        clientApp: CLIENT_APP_FIREFOX,
+        userAgentInfo,
+        _window: createFakeMozWindow(),
+      })).toEqual({
+        compatible: true,
+        maxVersion: null,
+        minVersion: null,
+        reason: null,
       });
     });
   });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -310,6 +310,12 @@ export function createFakeEvent(extraProps = {}) {
   };
 }
 
+export const createFakeMozWindow = () => {
+  // This is a special Mozilla window that allows you to
+  // install open search add-ons.
+  return { external: { AddSearchProvider: sinon.stub() } };
+};
+
 export function createStubErrorHandler(capturedError = null) {
   return new ErrorHandler({
     id: 'create-stub-error-handler-id',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3649

I think this has been broken since the dawn of `addons-frontend`. This explains the bug: https://github.com/mozilla/addons-frontend/issues/3649#issuecomment-339726425

The solution here is to mark a client incompatible if the add-on's current version has no compatibility data for it at all. Mat verified on IRC that this behavior is correct.

The implications is that many Android pages will have disabled buttons when they didn't have disabled buttons before.