### PR TITLE
feat: Addon details styles/badges

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -7,6 +7,8 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 
 import { setViewContext } from 'amo/actions/viewContext';
+import AddonBadges from 'amo/components/AddonBadges';
+import AddonsCard from 'amo/components/AddonsCard';
 import AddonCompatibilityError from 'amo/components/AddonCompatibilityError';
 import AddonMeta from 'amo/components/AddonMeta';
 import AddonMoreInfo from 'amo/components/AddonMoreInfo';
@@ -43,8 +45,6 @@ import Card from 'ui/components/Card';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import ShowMoreCard from 'ui/components/ShowMoreCard';
-import Badge from 'ui/components/Badge';
-import AddonsCard from 'amo/components/AddonsCard';
 
 import './styles.scss';
 
@@ -144,19 +144,6 @@ export class AddonBase extends React.Component {
 
   onClick = (event) => {
     this.props.toggleThemePreview(event.currentTarget);
-  }
-
-  getFeaturedText(addonType) {
-    const { i18n } = this.props;
-
-    switch (addonType) {
-      case ADDON_TYPE_EXTENSION:
-        return i18n.gettext('Featured Extension');
-      case ADDON_TYPE_THEME:
-        return i18n.gettext('Featured Theme');
-      default:
-        return i18n.gettext('Featured Add-on');
-    }
   }
 
   dispatchFetchOtherAddonsByAuthors({ addon }) {
@@ -429,13 +416,19 @@ export class AddonBase extends React.Component {
     const addonType = addon ? addon.type : ADDON_TYPE_EXTENSION;
 
     const summaryProps = {};
+    let showSummary = false;
     if (addon) {
       // Themes lack a summary so we do the inverse :-/
       // TODO: We should file an API bug about this...
       const summary = addon.summary ? addon.summary : addon.description;
-      summaryProps.dangerouslySetInnerHTML = sanitizeHTML(summary, ['a']);
+
+      if (summary && summary.length) {
+        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(summary, ['a']);
+        showSummary = true;
+      }
     } else {
       summaryProps.children = <LoadingText width={100} />;
+      showSummary = true;
     }
 
     const titleProps = {};
@@ -464,18 +457,12 @@ export class AddonBase extends React.Component {
     const addonPreviews = addon ? addon.previews : [];
 
     let isCompatible = false;
-    let isExperimental = false;
-    let isFeatured = false;
-    let isRestartRequired = false;
     let compatibility;
     if (addon) {
       compatibility = getClientCompatibility({
         addon, clientApp, userAgentInfo,
       });
       isCompatible = compatibility.compatible;
-      isExperimental = addon.is_experimental;
-      isFeatured = addon.is_featured;
-      isRestartRequired = addon.isRestartRequired;
     }
 
     const numberOfAddonsByAuthors = addonsByAuthors ? addonsByAuthors.length : 0;
@@ -498,43 +485,27 @@ export class AddonBase extends React.Component {
         <div className="Addon-header-wrapper">
           <Card className="Addon-header-info-card" photonStyle>
             <header className="Addon-header">
-              <h1 className="Addon-title" {...titleProps} />
-              <p className="Addon-summary" {...summaryProps} />
-
-              <div className="Addon-badges">
-                {isFeatured ? (
-                  <Badge
-                    type="featured"
-                    label={this.getFeaturedText(addonType)}
-                  />
-                ) : null}
-                {isRestartRequired ? (
-                  <Badge
-                    type="restart-required"
-                    label={i18n.gettext('Restart Required')}
-                  />
-                ) : null}
-                {isExperimental ? (
-                  <Badge
-                    type="experimental"
-                    label={i18n.gettext('Experimental')}
-                  />
-                ) : null}
-              </div>
-
-              {addon ?
-                <InstallButton
-                  {...this.props}
-                  className="Button--wide"
-                  disabled={!isCompatible}
-                  ref={(ref) => { this.installButton = ref; }}
-                  src={src}
-                  status={installStatus}
-                  useButton
-                /> : null
-              }
-
               {this.headerImage({ compatible: isCompatible })}
+
+              <h1 className="Addon-title" {...titleProps} />
+
+              <AddonBadges addon={addon} />
+
+              <div className="Addon-summary-and-install-button-wrapper">
+                {showSummary ?
+                  <p className="Addon-summary" {...summaryProps} /> : null}
+
+                {addon ?
+                  <InstallButton
+                    {...this.props}
+                    disabled={!isCompatible}
+                    ref={(ref) => { this.installButton = ref; }}
+                    src={src}
+                    status={installStatus}
+                    useButton
+                  /> : null
+                }
+              </div>
 
               <h2 className="visually-hidden">
                 {i18n.gettext('Extension Metadata')}

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -18,6 +18,14 @@
   }
 }
 
+.Addon-icon {
+  min-height: 72px;
+
+  @include respond-to(medium) {
+    min-height: 96px;
+  }
+}
+
 .Addon-icon-image {
   height: 48px;
   width: 48px;
@@ -50,11 +58,17 @@
 }
 
 .Addon-title {
+  @include font-regular();
+
   color: $black;
   font-size: $font-size-l;
-  margin: $padding-page-l 0;
+  margin: 0 0 $padding-page-l;
   width: 100%;
   word-wrap: break-word;
+
+  .Addon-persona & {
+    margin: $padding-page-l 0;
+  }
 
   @include respond-to(medium) {
     font-size: $font-size-xl;
@@ -62,6 +76,8 @@
 }
 
 .Addon-author {
+  @include font-light();
+
   display: block;
   word-wrap: break-word;
 
@@ -83,6 +99,7 @@
   display: flex;
   flex-flow: row wrap;
   justify-content: space-between;
+  position: relative;
 }
 
 .Addon-theme-header {
@@ -109,46 +126,23 @@
   width: 100%;
 }
 
-.Addon-title {
-  order: 1;
+.Addon-summary-and-install-button-wrapper {
+  width: 100%;
 
   @include respond-to(medium) {
-    flex-grow: 1;
+    display: flex;
+    justify-content: space-between;
   }
-}
-
-.Addon .AddonMeta {
-  order: 2;
-
-  @include respond-to(medium) {
-    @include margin-start(auto);
-
-    margin: 10px 0;
-    order: 0;
-    text-align: right;
-  }
-}
-
-.Addon-persona .AddonMeta {
-  @include respond-to(medium) {
-    order: 1;
-  }
-}
-
-.Addon .AddonMeta-item {
-  @include margin-start(auto);
 }
 
 .Addon-summary {
-  flex-basis: 100%;
-  flex-grow: 1;
-  order: 2;
+  font-size: $font-size-m-smaller;
   overflow-x: auto;
   word-wrap: break-word;
 
   @include respond-to(medium) {
-    flex-grow: 0;
-    margin-bottom: 0;
+    @include margin-end(24px);
+
     max-width: 550px;
   }
 }
@@ -158,23 +152,20 @@
 }
 
 .Addon .InstallButton {
-  margin-top: auto;
-  order: 3;
-}
-
-.Addon .InstallButton {
   @include respond-to(medium) {
     @include margin-start(auto);
 
-    align-self: flex-end;
+    align-content: center;
+    align-self: center;
   }
 }
 
-.Addon-badges {
-  flex-basis: 100%;
-  flex-grow: 1;
-  margin-bottom: 10px;
-  order: 4;
+.Addon .InstallButton-button {
+  width: 100%;
+
+  @include respond-to(medium) {
+    width: auto;
+  }
 }
 
 .AddonDescription-more-addons {

--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -1,0 +1,59 @@
+/* @flow */
+import React from 'react';
+import { compose } from 'redux';
+
+import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
+import translate from 'core/i18n/translate';
+import Badge from 'ui/components/Badge';
+import type { AddonType } from 'core/types/addons';
+import type { I18nType } from 'core/types/i18n';
+
+import './styles.scss';
+
+
+type Props = {|
+  addon: AddonType,
+  i18n: I18nType,
+|};
+
+export const AddonBadgesBase = (props: Props) => {
+  const { addon, i18n } = props;
+
+  const getFeaturedText = (addonType: string) => {
+    switch (addonType) {
+      case ADDON_TYPE_EXTENSION:
+        return i18n.gettext('Featured Extension');
+      case ADDON_TYPE_THEME:
+        return i18n.gettext('Featured Theme');
+      default:
+        return i18n.gettext('Featured Add-on');
+    }
+  };
+
+  return (
+    <div className="AddonBadges">
+      {addon && addon.is_featured ? (
+        <Badge
+          type="featured"
+          label={getFeaturedText(addon.type)}
+        />
+      ) : null}
+      {addon && addon.isRestartRequired ? (
+        <Badge
+          type="restart-required"
+          label={i18n.gettext('Restart Required')}
+        />
+      ) : null}
+      {addon && addon.is_experimental ? (
+        <Badge
+          type="experimental"
+          label={i18n.gettext('Experimental')}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default compose(
+  translate(),
+)(AddonBadgesBase);

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -1,0 +1,22 @@
+@import "~core/css/inc/mixins";
+@import "~amo/css/inc/vars";
+@import "~ui/css/vars";
+
+.AddonBadges {
+  @include respond-to(medium) {
+    display: flex;
+  }
+}
+
+.AddonBadges .Badge {
+  @include text-align-end();
+
+  @include respond-to(medium) {
+    @include margin-end(6px);
+    @include text-align-start();
+  }
+
+  @include respond-to(extraLarge) {
+    @include margin-end($padding-page-l);
+  }
+}

--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -9,6 +9,12 @@
   @include respond-to(large) {
     padding: $padding-page-l;
   }
+
+  .MetadataCard {
+    @include respond-to(large) {
+      margin-top: 12px;
+    }
+  }
 }
 
 .Collection-title {
@@ -19,37 +25,6 @@
 
 .Collection-description {
   font-size: $font-size-s;
-}
-
-.Collection-metadata {
-  background-color: $grey-10;
-  border-radius: $border-radius-m;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  margin-bottom: 10px;
-
-  @include respond-to(large) {
-    margin: 10px -10px 0;
-  }
-}
-
-.Collection-number-of-addons,
-.Collection-author-name,
-.Collection-last-updated {
-  @include text-align-start();
-
-  flex: 1;
-  margin: 10px 15px;
-  max-width: 30%;
-
-  dd {
-    margin: 0;
-  }
-
-  dt {
-    color: $grey-50;
-  }
 }
 
 .Collection-author-name-value {

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -22,6 +22,7 @@ import {
   getClientCompatibility as _getClientCompatibility,
 } from 'core/utils/compatibility';
 import Button from 'ui/components/Button';
+import Icon from 'ui/components/Icon';
 
 import './styles.scss';
 
@@ -124,6 +125,7 @@ export class InstallButtonBase extends React.Component {
           data-browsertheme={JSON.stringify(getThemeData(addon))}
           onClick={this.installTheme}
         >
+          <Icon name="plus" />
           {i18n.gettext('Install Theme')}
         </Button>
       );
@@ -147,6 +149,7 @@ export class InstallButtonBase extends React.Component {
           prependClientApp={false}
           prependLang={false}
         >
+          <Icon name="plus" />
           {i18n.gettext('Add to Firefox')}
         </Button>
       );
@@ -167,6 +170,7 @@ export class InstallButtonBase extends React.Component {
           prependClientApp={false}
           prependLang={false}
         >
+          <Icon name="plus" />
           {i18n.gettext('Add to Firefox')}
         </Button>
       );

--- a/src/core/components/InstallButton/styles.scss
+++ b/src/core/components/InstallButton/styles.scss
@@ -22,3 +22,7 @@
     }
   }
 }
+
+.InstallButton-button .Icon-plus {
+  vertical-align: baseline;
+}

--- a/src/ui/components/Badge/index.js
+++ b/src/ui/components/Badge/index.js
@@ -33,10 +33,10 @@ const Badge = ({ label, type }: Props) => {
   }
 
   return (
-    <span className={type ? `Badge Badge-${type}` : 'Badge'}>
-      {type && <Icon alt={label} name={getIconNameForType(type)} />}
+    <div className={type ? `Badge Badge-${type}` : 'Badge'}>
       {label}
-    </span>
+      {type && <Icon alt={label} name={getIconNameForType(type)} />}
+    </div>
   );
 };
 

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -3,22 +3,18 @@
 @import "~ui/css/vars";
 
 .Badge {
-  @include margin-end(10px);
-
-  border: 1px solid $grey-30;
-  border-radius: 3px;
   color: $grey-90;
-  display: inline-block;
   font-size: $font-size-m-smaller;
   line-height: 1.4;
-  margin-top: 10px;
-  padding: 8px 12px 6px;
-  text-align: center;
+  margin: 0 0 6px;
+
+  @include respond-to(medium) {
+    margin: 0 0 12px;
+  }
 
   .Icon {
-    @include margin-end(10px);
+    @include margin-start(6px);
 
-    margin-top: -2px;
-    vertical-align: middle;
+    vertical-align: top;
   }
 }

--- a/src/ui/components/Icon/plus.svg
+++ b/src/ui/components/Icon/plus.svg
@@ -1,0 +1,27 @@
+<svg width="48px" height="48px" viewBox="12 6 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <filter x="-11.9%" y="-36.7%" width="123.7%" height="186.7%" filterUnits="objectBoundingBox" id="filter-1">
+            <feOffset dx="0" dy="4" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="8" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0.0470588235   0 0 0 0 0.0470588235   0 0 0 0 0.0509803922  0 0 0 0.1 0" type="matrix" in="shadowBlurOuter1" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+    </defs>
+    <g id="Screens" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Extension-Detail---1366px" transform="translate(-612.000000, -355.000000)" stroke="#FFFFFF" stroke-width="3">
+            <g id="Group-16" transform="translate(24.000000, 136.000000)">
+                <g id="Group-75-Copy-4" filter="url(#filter-1)" transform="translate(579.000000, 209.000000)">
+                    <g id="Group-70" transform="translate(25.000000, 22.000000)">
+                        <path d="M8,0 L8,16" id="Shape"></path>
+                        <path d="M0,8 L16,8" id="Shape"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -151,6 +151,10 @@
   @include icon($name: "experimental-badge");
 }
 
+.Icon-plus {
+  @include icon($name: "plus");
+}
+
 .Icon-reply-arrow {
   @include icon($name: "reply-arrow");
 

--- a/src/ui/components/MetadataCard/styles.scss
+++ b/src/ui/components/MetadataCard/styles.scss
@@ -11,7 +11,7 @@
   justify-content: space-between;
 
   @include respond-to(large) {
-    margin: 10px -10px 0;
+    margin: 0 -12px;
   }
 }
 
@@ -19,7 +19,7 @@
   @include text-align-start();
 
   flex: 1;
-  margin: 10px 15px;
+  margin: 12px;
   max-width: 30%;
 
   dd {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -50,7 +50,6 @@ import { ErrorHandler } from 'core/errorHandler';
 import I18nProvider from 'core/i18n/Provider';
 import { sendServerRedirect } from 'core/reducers/redirectTo';
 import {
-  createFakeAddon,
   dispatchClientMetadata,
   dispatchSignInActions,
   fakeAddon,
@@ -66,7 +65,6 @@ import {
 } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
-import Badge from 'ui/components/Badge';
 
 
 function renderProps({
@@ -1207,85 +1205,6 @@ describe(__filename, () => {
       expect(root).toHaveClassName('.Addon--has-more-than-0-addons');
       expect(root).toHaveClassName('.Addon--has-more-than-3-addons');
     });
-  });
-
-  it('displays a badge when the addon is featured', () => {
-    const addon = createInternalAddon({ ...fakeAddon, is_featured: true });
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveProp('type', 'featured');
-    expect(root.find(Badge)).toHaveProp('label', 'Featured Extension');
-  });
-
-  it('adds a different badge label when a "theme" addon is featured', () => {
-    const addon = createInternalAddon({
-      ...fakeAddon, is_featured: true, type: ADDON_TYPE_THEME,
-    });
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveProp('type', 'featured');
-    expect(root.find(Badge)).toHaveProp('label', 'Featured Theme');
-  });
-
-  it('adds a different badge label when an addon of a different type is featured', () => {
-    const addon = createInternalAddon({
-      ...fakeAddon, is_featured: true, type: ADDON_TYPE_OPENSEARCH,
-    });
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveProp('type', 'featured');
-    expect(root.find(Badge)).toHaveProp('label', 'Featured Add-on');
-  });
-
-  it('does not display the featured badge when addon is not featured', () => {
-    const addon = createInternalAddon({ ...fakeAddon, is_featured: false });
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveLength(0);
-  });
-
-  it('displays a badge when the addon needs restart', () => {
-    const addon = createInternalAddon(createFakeAddon({
-      files: [{ is_restart_required: true }],
-    }));
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveProp('type', 'restart-required');
-    expect(root.find(Badge)).toHaveProp('label', 'Restart Required');
-  });
-
-  it('does not display the "restart required" badge when addon does not need restart', () => {
-    const addon = createInternalAddon(createFakeAddon({
-      files: [{ is_restart_required: false }],
-    }));
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveLength(0);
-  });
-
-  it('does not display the "restart required" badge when isRestartRequired is not true', () => {
-    const root = shallowRender({ addon: createInternalAddon(fakeAddon) });
-
-    expect(root.find(Badge)).toHaveLength(0);
-  });
-
-  it('displays a badge when the addon is experimental', () => {
-    const addon = createInternalAddon(createFakeAddon({
-      is_experimental: true,
-    }));
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveProp('type', 'experimental');
-    expect(root.find(Badge)).toHaveProp('label', 'Experimental');
-  });
-
-  it('does not display a badge when the addon is not experimental', () => {
-    const addon = createInternalAddon(createFakeAddon({
-      is_experimental: false,
-    }));
-    const root = shallowRender({ addon });
-
-    expect(root.find(Badge)).toHaveLength(0);
   });
 
   it('renders the site identifier as a data attribute', () => {

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -1,0 +1,109 @@
+import React from 'react';
+
+import AddonBadges, { AddonBadgesBase } from 'amo/components/AddonBadges';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_OPENSEARCH,
+  ADDON_TYPE_THEME,
+} from 'core/constants';
+import { createInternalAddon } from 'core/reducers/addons';
+import { createFakeAddon, fakeAddon } from 'tests/unit/amo/helpers';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+import Badge from 'ui/components/Badge';
+
+
+describe(__filename, () => {
+  function shallowRender(props) {
+    return shallowUntilTarget(
+      <AddonBadges i18n={fakeI18n()} {...props} />,
+      AddonBadgesBase
+    );
+  }
+
+  it('displays a badge when the addon is featured', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_featured: true,
+      type: ADDON_TYPE_EXTENSION,
+    });
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'featured');
+    expect(root.find(Badge)).toHaveProp('label', 'Featured Extension');
+  });
+
+  it('adds a different badge label when a "theme" addon is featured', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_featured: true,
+      type: ADDON_TYPE_THEME,
+    });
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'featured');
+    expect(root.find(Badge)).toHaveProp('label', 'Featured Theme');
+  });
+
+  it('adds a different badge label when an addon of a different type is featured', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_featured: true,
+      type: ADDON_TYPE_OPENSEARCH,
+    });
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'featured');
+    expect(root.find(Badge)).toHaveProp('label', 'Featured Add-on');
+  });
+
+  it('does not display the featured badge when addon is not featured', () => {
+    const addon = createInternalAddon({ ...fakeAddon, is_featured: false });
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
+
+  it('displays a badge when the addon needs restart', () => {
+    const addon = createInternalAddon(createFakeAddon({
+      files: [{ is_restart_required: true }],
+    }));
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'restart-required');
+    expect(root.find(Badge)).toHaveProp('label', 'Restart Required');
+  });
+
+  it('does not display the "restart required" badge when addon does not need restart', () => {
+    const addon = createInternalAddon(createFakeAddon({
+      files: [{ is_restart_required: false }],
+    }));
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
+
+  it('does not display the "restart required" badge when isRestartRequired is not true', () => {
+    const root = shallowRender({ addon: createInternalAddon(fakeAddon) });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
+
+  it('displays a badge when the addon is experimental', () => {
+    const addon = createInternalAddon(createFakeAddon({
+      is_experimental: true,
+    }));
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'experimental');
+    expect(root.find(Badge)).toHaveProp('label', 'Experimental');
+  });
+
+  it('does not display a badge when the addon is not experimental', () => {
+    const addon = createInternalAddon(createFakeAddon({
+      is_experimental: false,
+    }));
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
+});

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -115,7 +115,7 @@ describe(__filename, () => {
     const button = root.childAt(1);
 
     expect(button.type()).toEqual(Button);
-    expect(button.children()).toIncludeText('Install Theme');
+    expect(button.children()).toContain('Install Theme');
     expect(button).toHaveProp(
       'data-browsertheme', JSON.stringify(themePreview.getThemeData(addon))
     );
@@ -155,7 +155,7 @@ describe(__filename, () => {
 
     expect(button.type()).toEqual(Button);
 
-    expect(button.children()).toIncludeText('Add to Firefox');
+    expect(button.children()).toContain('Add to Firefox');
     expect(button).toHaveClassName('InstallButton-button');
     expect(button).not.toHaveClassName('Button--small');
     expect(button).toHaveProp('href', installURL);
@@ -257,7 +257,7 @@ describe(__filename, () => {
     expect(button.type()).toEqual(Button);
     expect(button).toHaveClassName('Button--action');
     expect(button).toHaveClassName('InstallButton-button');
-    expect(button.children()).toIncludeText('Add to Firefox');
+    expect(button.children()).toContain('Add to Firefox');
   });
 
   it('renders a button for OpenSearch regardless of mozAddonManager', () => {
@@ -276,7 +276,7 @@ describe(__filename, () => {
     expect(button.type()).toEqual(Button);
     expect(button).toHaveClassName('Button--action');
     expect(button).toHaveClassName('InstallButton-button');
-    expect(button.children()).toIncludeText('Add to Firefox');
+    expect(button.children()).toContain('Add to Firefox');
   });
 
   it('disables the OpenSearch button if not compatible', () => {
@@ -293,7 +293,7 @@ describe(__filename, () => {
 
     expect(button.type()).toEqual(Button);
     expect(button).toHaveClassName('InstallButton-button--disabled');
-    expect(button.children()).toIncludeText('Add to Firefox');
+    expect(button.children()).toContain('Add to Firefox');
   });
 
   it('disables install switch and uses button for OpenSearch plugins', () => {
@@ -311,7 +311,7 @@ describe(__filename, () => {
     });
 
     const installButton = rootNode.find('.InstallButton-button');
-    expect(installButton.children().text()).toEqual('Add to Firefox');
+    expect(installButton.children()).toContain('Add to Firefox');
     installButton.simulate('click', createFakeEvent());
 
     sinon.assert.calledWith(fakeLog.info, 'Adding OpenSearch Provider');


### PR DESCRIPTION
Fix #3588
Fix #3651 
Fix #3716

Note: Changes from the mocks–the badges on extensions are moved from the top-right to underneath the title. This is consistent across themes and extensions. Plus: @willdurand and I think it's nicer 😄 

### Extensions
![screen shot 2017-10-31 at 14 39 39](https://user-images.githubusercontent.com/90871/32229853-b13dc28a-be49-11e7-8f7d-b788bf988a9c.png)
![screen shot 2017-10-31 at 14 39 47](https://user-images.githubusercontent.com/90871/32229852-b12207de-be49-11e7-8c7e-49e145b933aa.png)
<img width="1250" alt="screenshot 2017-10-31 14 39 56" src="https://user-images.githubusercontent.com/90871/32229835-aa017778-be49-11e7-9358-abfd168aca6f.png">

### Themes
![screen shot 2017-10-31 at 01 30 09](https://user-images.githubusercontent.com/90871/32203465-574705fc-bddb-11e7-9c12-b92390369783.png)
![screen shot 2017-10-31 at 01 30 14](https://user-images.githubusercontent.com/90871/32203467-59f2e096-bddb-11e7-8f3e-35984cf56aec.png)
<img width="1250" alt="screenshot 2017-10-31 01 30 03" src="https://user-images.githubusercontent.com/90871/32203491-6d31f778-bddb-11e7-9086-4bfffbdf34dd.png">

### Multiple Badges
![screen shot 2017-10-31 at 16 03 00](https://user-images.githubusercontent.com/90871/32234651-4e358f5e-be55-11e7-8d09-802ba7f4eb11.png)
![screen shot 2017-10-31 at 16 03 03](https://user-images.githubusercontent.com/90871/32234650-4e184160-be55-11e7-8272-853eb3a203ea.png)
![screen shot 2017-10-31 at 16 03 09](https://user-images.githubusercontent.com/90871/32234649-4dd86eaa-be55-11e7-923d-d035bed0c0d8.png)