### PR TITLE
Adjust subject shelf texts

### DIFF
--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -161,23 +161,27 @@ export class HomeBase extends React.Component {
       upAndComingExtensions,
     } = this.props;
 
+    // translators: The ending ellipsis alludes to a row of icons for each type
+    // of extension.
+    const extensionsHeader = i18n.gettext(`Customize the way Firefox works with
+      extensions. Are you interested in…`);
+    const themesHeader = i18n.gettext(`Change the way Firefox looks with
+      themes.`);
+
     return (
       <div className="Home">
         {errorHandler.renderErrorIfPresent()}
 
         <HomeHeroBanner />
 
-        <Card className="Home-SubjectShelf Home-CuratedCollections">
+        <Card
+          className="Home-SubjectShelf Home-CuratedCollections"
+          header={extensionsHeader}
+        >
           <div className="Home-SubjectShelf-text-wrapper">
             <h2 className="Home-SubjectShelf-subheading">
-              {i18n.gettext('Extensions change how Firefox works')}
+              {extensionsHeader}
             </h2>
-            <p className="Home-SubjectShelf-description">
-              {/* translators: The ending ellipsis alludes to a row of icons
-              for each type of extension */}
-              {i18n.gettext(`Customize the way Firefox works with extensions.
-                Are you interested in…`)}
-            </p>
           </div>
 
           {this.renderCuratedCollections()}
@@ -224,14 +228,14 @@ export class HomeBase extends React.Component {
           loading={resultsLoaded === false}
         />
 
-        <Card className="Home-SubjectShelf Home-CuratedThemes">
+        <Card
+          className="Home-SubjectShelf Home-CuratedThemes"
+          header={themesHeader}
+        >
           <div className="Home-SubjectShelf-text-wrapper">
             <h2 className="Home-SubjectShelf-subheading">
-              {i18n.gettext('Themes change how Firefox looks')}
+              {themesHeader}
             </h2>
-            <p className="Home-SubjectShelf-description">
-              {i18n.gettext(`Change the way Firefox looks with themes.`)}
-            </p>
           </div>
 
           {this.renderCuratedThemes()}

--- a/src/amo/components/Home/styles.scss
+++ b/src/amo/components/Home/styles.scss
@@ -13,6 +13,14 @@
 }
 
 .Home-SubjectShelf {
+  .Card-header {
+    display: block;
+
+    @include respond-to(large) {
+      display: none;
+    }
+  }
+
   .Card-contents {
     display: flex;
     flex-flow: row wrap;
@@ -21,41 +29,33 @@
     overflow: auto;
     width: 100%;
 
-    @include respond-to(medium) {
-      padding: 24px 36px;
-    }
-
     @include respond-to(large) {
+      border-top-left-radius: $border-radius-default;
+      border-top-right-radius: $border-radius-default;
       flex-wrap: nowrap;
+      padding: 24px 36px;
     }
   }
 }
 
 .Home-SubjectShelf-text-wrapper {
-  align-self: auto;
+  align-self: center;
+  display: none;
   height: auto;
 
-  @include respond-to(medium) {
-    align-self: center;
-  }
-
   @include respond-to(large) {
-    max-width: 150px;
+    align-self: center;
+    display: block;
+    max-width: 130px;
   }
 
   @include respond-to(extraLarge) {
-    height: 86px;
     max-width: 250px;
   }
 }
 
 .Home-SubjectShelf-subheading {
-  font-size: $font-size-default;
-  margin: 0 0 3px;
-}
-
-.Home-SubjectShelf-description {
-  font-size: $font-size-default;
+  font-size: $font-size-m-smaller;
   margin: 0;
 }
 


### PR DESCRIPTION
Fix #3621 

---

This PR removes headlines on the subject shelves and makes things a little nicer.

## Screenshots

<img width="447" alt="screen shot 2017-10-27 at 15 26 02" src="https://user-images.githubusercontent.com/217628/32106414-da6b5116-bb2b-11e7-9e8e-c490c2424109.png">
<img width="447" alt="screen shot 2017-10-27 at 15 26 06" src="https://user-images.githubusercontent.com/217628/32106415-da8e2cae-bb2b-11e7-95e2-a43b6259ead4.png">
<img width="931" alt="screen shot 2017-10-27 at 15 28 52" src="https://user-images.githubusercontent.com/217628/32106416-dab9472c-bb2b-11e7-8e2d-8bd76eedef15.png">
<img width="931" alt="screen shot 2017-10-27 at 15 28 56" src="https://user-images.githubusercontent.com/217628/32106417-dad6b488-bb2b-11e7-817d-15ed841d2bd9.png">
<img width="1392" alt="screen shot 2017-10-27 at 15 28 59" src="https://user-images.githubusercontent.com/217628/32106418-db0f98d4-bb2b-11e7-9929-42af6907a825.png">
<img width="1392" alt="screen shot 2017-10-27 at 15 29 01" src="https://user-images.githubusercontent.com/217628/32106419-db365334-bb2b-11e7-9aac-261af344c187.png">
