### PR TITLE
Only require extensions to declare clientApp compatibility

### DIFF
--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -19,7 +19,17 @@ import log from 'core/logger';
 export function getCompatibleVersions({ _log = log, addon, clientApp } = {}) {
   let maxVersion = null;
   let minVersion = null;
-  let supportsClientApp = false;
+  let supportsClientApp;
+  if (addon && addon.type === ADDON_TYPE_EXTENSION) {
+    // Extensions must opt into compatibility for each client app by
+    // defining min/max versions. Until we see that definition, assume
+    // they are incompatible.
+    supportsClientApp = false;
+  } else {
+    // Non-extension add-ons do not need to define min/max client app
+    // versions so assume they are compatible.
+    supportsClientApp = true;
+  }
   if (
     addon && addon.current_version && addon.current_version.compatibility
   ) {
@@ -31,7 +41,6 @@ export function getCompatibleVersions({ _log = log, addon, clientApp } = {}) {
       _log.info(oneLine`addon is type ${ADDON_TYPE_OPENSEARCH}; no
         compatibility info found but this is expected.`,
         { addon, clientApp });
-      supportsClientApp = true;
     } else {
       _log.error(
         'addon found with no compatibility info for valid clientApp',

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -37,23 +37,21 @@ export function getCompatibleVersions({ _log = log, addon, clientApp } = {}) {
     // in current_version.compatibility
     supportsClientApp = false;
   }
+
   if (
-    addon && addon.current_version && addon.current_version.compatibility
+    addon && addon.current_version && addon.current_version.compatibility &&
+    addon.current_version.compatibility[clientApp]
   ) {
-    if (addon.current_version.compatibility[clientApp]) {
-      supportsClientApp = true;
-      maxVersion = addon.current_version.compatibility[clientApp].max;
-      minVersion = addon.current_version.compatibility[clientApp].min;
-    } else if (addon.type === ADDON_TYPE_OPENSEARCH) {
-      _log.info(oneLine`addon is type ${ADDON_TYPE_OPENSEARCH}; no
-        compatibility info found but this is expected.`,
-        { addon, clientApp });
-    } else {
-      _log.error(
-        'addon found with no compatibility info for valid clientApp',
-        { addon, clientApp }
-      );
-    }
+    supportsClientApp = true;
+    maxVersion = addon.current_version.compatibility[clientApp].max;
+    minVersion = addon.current_version.compatibility[clientApp].min;
+  }
+
+  if (addon && !supportsClientApp) {
+    _log.error(
+      'addon found with no compatibility info for valid clientApp',
+      { addon, clientApp }
+    );
   }
 
   return { supportsClientApp, maxVersion, minVersion };

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -3,8 +3,10 @@ import { oneLine } from 'common-tags';
 import mozCompare from 'mozilla-version-comparator';
 
 import {
+  ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
+  ADDON_TYPE_THEME,
   INCOMPATIBLE_FIREFOX_FOR_IOS,
   INCOMPATIBLE_NO_OPENSEARCH,
   INCOMPATIBLE_NOT_FIREFOX,
@@ -20,15 +22,20 @@ export function getCompatibleVersions({ _log = log, addon, clientApp } = {}) {
   let maxVersion = null;
   let minVersion = null;
   let supportsClientApp;
-  if (addon && addon.type === ADDON_TYPE_EXTENSION) {
-    // Extensions must opt into compatibility for each client app by
-    // defining min/max versions. Until we see that definition, assume
-    // they are incompatible.
-    supportsClientApp = false;
-  } else {
-    // Non-extension add-ons do not need to define min/max client app
-    // versions so assume they are compatible.
+  if (
+    addon &&
+    [ADDON_TYPE_OPENSEARCH, ADDON_TYPE_DICT, ADDON_TYPE_THEME]
+      .includes(addon.type)
+  ) {
+    // For now we need to assume that the compatibility object for these
+    // add-ons cannot be trusted.
+    // TODO: default this to false when
+    // https://github.com/mozilla/addons-server/issues/6781 is fixed.
     supportsClientApp = true;
+  } else {
+    // Assume the add-on is incompatible until we see explicit support
+    // in current_version.compatibility
+    supportsClientApp = false;
   }
   if (
     addon && addon.current_version && addon.current_version.compatibility

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -113,6 +113,7 @@ export const fakeTheme = Object.freeze({
   }],
   current_version: {
     ...fakeAddon.current_version,
+    compatibility: {},
     version: '0',
   },
   description: 'This is the add-on description',

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -378,8 +378,8 @@ describe(__filename, () => {
       expect(minVersion).toEqual(null);
     });
 
-    it('should log info when OpenSearch type is found', () => {
-      const fakeLog = { info: sinon.stub() };
+    it('should not log an error when OpenSearch type is found', () => {
+      const fakeLog = { error: sinon.stub() };
       const openSearchAddon = createInternalAddon({
         ...fakeAddon,
         current_version: {
@@ -388,16 +388,14 @@ describe(__filename, () => {
         },
         type: ADDON_TYPE_OPENSEARCH,
       });
-      const { maxVersion, minVersion } = getCompatibleVersions({
+
+      getCompatibleVersions({
         _log: fakeLog,
         addon: openSearchAddon,
         clientApp: CLIENT_APP_FIREFOX,
       });
 
-      expect(maxVersion).toEqual(null);
-      expect(minVersion).toEqual(null);
-      expect(fakeLog.info.firstCall.args[0])
-        .toContain(`addon is type ${ADDON_TYPE_OPENSEARCH}`);
+      sinon.assert.notCalled(fakeLog.error);
     });
 
     it('marks clientApp as unsupported without extension compatibility', () => {

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -2,7 +2,9 @@ import { oneLine } from 'common-tags';
 import UAParser from 'ua-parser-js';
 
 import {
+  ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
@@ -21,7 +23,7 @@ import {
   getClientCompatibility,
   isCompatibleWithUserAgent,
 } from 'core/utils/compatibility';
-import { fakeAddon } from 'tests/unit/amo/helpers';
+import { fakeAddon, fakeTheme } from 'tests/unit/amo/helpers';
 import {
   createFakeMozWindow,
   userAgents,
@@ -447,10 +449,60 @@ describe(__filename, () => {
         ...fakeAddon,
         current_version: {
           ...fakeAddon.current_version,
-          // No clientApp is supported.
+          // Search providers do not declare clientApp compatibility.
           compatibility: {},
         },
         type: ADDON_TYPE_OPENSEARCH,
+      });
+      const { supportsClientApp } = getCompatibleVersions({
+        addon, clientApp: CLIENT_APP_ANDROID,
+      });
+
+      expect(supportsClientApp).toEqual(true);
+    });
+
+    it('always marks clientApp as supported for themes', () => {
+      const addon = createInternalAddon({
+        ...fakeTheme,
+        current_version: {
+          ...fakeTheme.current_version,
+          // Themes do not declare clientApp compatibility.
+          compatibility: {},
+        },
+      });
+      const { supportsClientApp } = getCompatibleVersions({
+        addon, clientApp: CLIENT_APP_ANDROID,
+      });
+
+      expect(supportsClientApp).toEqual(true);
+    });
+
+    it('always marks clientApp as supported for dictionaries', () => {
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          // Dictionaries do not declare clientApp compatibility.
+          compatibility: {},
+        },
+        type: ADDON_TYPE_DICT,
+      });
+      const { supportsClientApp } = getCompatibleVersions({
+        addon, clientApp: CLIENT_APP_ANDROID,
+      });
+
+      expect(supportsClientApp).toEqual(true);
+    });
+
+    it('always marks clientApp as supported for lang packs', () => {
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          // Lang packs do not declare clientApp compatibility.
+          compatibility: {},
+        },
+        type: ADDON_TYPE_LANG,
       });
       const { supportsClientApp } = getCompatibleVersions({
         addon, clientApp: CLIENT_APP_ANDROID,

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -400,20 +400,32 @@ describe(__filename, () => {
         .toContain(`addon is type ${ADDON_TYPE_OPENSEARCH}`);
     });
 
-    it('marks clientApp as unsupported without compatibility', () => {
+    it('marks clientApp as unsupported without extension compatibility', () => {
       const addon = createInternalAddon({
         ...fakeAddon,
         current_version: {
           ...fakeAddon.current_version,
-          compatibility: {
-            // Add Android compatibility but not Firefox compatibility.
-            [CLIENT_APP_ANDROID]: {
-              min: '48.0',
-              max: '*',
-            },
-          },
+          // This add-on is not compatible with any client apps.
+          compatibility: {},
         },
         type: ADDON_TYPE_EXTENSION,
+      });
+      const { supportsClientApp } = getCompatibleVersions({
+        addon, clientApp: CLIENT_APP_FIREFOX,
+      });
+
+      expect(supportsClientApp).toEqual(false);
+    });
+
+    it('marks clientApp as unsupported without lang pack compatibility', () => {
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          // This add-on is not compatible with any client apps.
+          compatibility: {},
+        },
+        type: ADDON_TYPE_LANG,
       });
       const { supportsClientApp } = getCompatibleVersions({
         addon, clientApp: CLIENT_APP_FIREFOX,
@@ -486,23 +498,6 @@ describe(__filename, () => {
           compatibility: {},
         },
         type: ADDON_TYPE_DICT,
-      });
-      const { supportsClientApp } = getCompatibleVersions({
-        addon, clientApp: CLIENT_APP_ANDROID,
-      });
-
-      expect(supportsClientApp).toEqual(true);
-    });
-
-    it('always marks clientApp as supported for lang packs', () => {
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        current_version: {
-          ...fakeAddon.current_version,
-          // Lang packs do not declare clientApp compatibility.
-          compatibility: {},
-        },
-        type: ADDON_TYPE_LANG,
       });
       const { supportsClientApp } = getCompatibleVersions({
         addon, clientApp: CLIENT_APP_ANDROID,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3669

This fixes not only themes but also dictionaries and search providers.