### PR TITLE
fix(package): update react-super-responsive-table to version 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "react-redux": "5.0.6",
     "react-router": "2.8.1",
     "react-router-scroll": "0.4.3",
-    "react-super-responsive-table": "0.3.0",
+    "react-super-responsive-table": "4.0.2",
     "react-textarea-autosize": "5.1.0",
     "redux": "3.7.2",
     "redux-connect": "4.0.2",


### PR DESCRIPTION
Closes #3656

Huge bump but it seems nothing has really changed.. only build/release stuff.