### PR TITLE
fix(package): update knuth-shuffle to version 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "jed": "1.1.1",
     "join-url": "2.0.0",
     "jsdom": "11.3.0",
-    "knuth-shuffle": "1.0.1",
+    "knuth-shuffle": "1.0.8",
     "localforage": "1.5.3",
     "lodash.debounce": "4.0.8",
     "moment": "2.19.1",


### PR DESCRIPTION
Closes #3675

Nothing fancy obviously, the author has moved his code to another Git platform.