### PR TITLE
fix: Remove API keys from header menu (fix #3686)

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -120,14 +120,6 @@ export class HeaderBase extends React.Component {
                   {i18n.gettext('Submit a New Theme')}
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuItem>
-                <Link
-                  href="/developers/addon/api/key/"
-                  prependClientApp={false}
-                >
-                  {i18n.gettext('Manage API Keys')}
-                </Link>
-              </DropdownMenuItem>
 
               <DropdownMenuItem
                 className={'Header-logout-button'}


### PR DESCRIPTION
Fixes #3686

Easy fix here, just removing this item.