### PR TITLE
Display rating stars on more extensions by authors

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -392,7 +392,6 @@ export class AddonBase extends React.Component {
         addons={addonsByAuthors}
         className={classnames}
         header={header}
-        showMetadata={false}
         showSummary={false}
         type="horizontal"
       />

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -193,6 +193,22 @@
     grid-template-columns: repeat(2, 1fr);
     margin: 0;
     padding: 0;
+
+    .SearchResult-metadata {
+      display: none;
+    }
+  }
+}
+
+.AddonDescription-more-addons:not(.AddonDescription-more-addons--theme) {
+  .Card-contents .AddonsCard-list {
+    @include respond-to(large) {
+      grid-template-columns: repeat(1, 1fr);
+    }
+
+    @include respond-to(extraExtraLarge) {
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
 }
 


### PR DESCRIPTION
Fix #3684

---

I had to slightly change how the add-ons are listed by adding the rating stars, but it looks better now :)

<img width="1392" alt="screen shot 2017-10-30 at 16 55 17" src="https://user-images.githubusercontent.com/217628/32181242-30ee974a-bd94-11e7-8ce6-72bf258a5156.png">
<img width="981" alt="screen shot 2017-10-30 at 16 55 24" src="https://user-images.githubusercontent.com/217628/32181243-310d3470-bd94-11e7-9c7a-4dc2ecdb49fd.png">
