### PR TITLE
Fix long theme title

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -114,11 +114,6 @@
 
   @include respond-to(medium) {
     flex-grow: 1;
-
-    .Addon-persona & {
-      flex-basis: 75%;
-      flex-grow: 0;
-    }
   }
 }
 


### PR DESCRIPTION
Fix #3690

---

Before:

![](https://user-images.githubusercontent.com/31961530/32178012-537e8810-bd94-11e7-8aa9-e0a5e54e12da.png)

After:

<img width="1392" alt="screen shot 2017-10-30 at 17 07 56" src="https://user-images.githubusercontent.com/217628/32181621-189397da-bd95-11e7-9e5c-47987d63aae3.png">
