### PR TITLE
Always link to add-on stats when they are declared public

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -57,7 +57,7 @@ export class AddonMoreInfoBase extends React.Component<Props> {
     return this.renderDefinitions({
       homepage,
       supportUrl,
-      statsLink: addon && isAddonAuthor({ addon, userId }) ? (
+      statsLink: addon && (isAddonAuthor({ addon, userId }) || addon.public_stats) ? (
         <Link
           className="AddonMoreInfo-stats-link"
           href={`/addon/${addon.slug}/statistics/`}

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -235,13 +235,14 @@ describe(__filename, () => {
     expect(statsLink).toHaveLength(0);
   });
 
-  it('link to stats if add-on public_stats is true', () => {
+  it('links to stats if add-on public_stats is true', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
-      slug: 'coolio',
+      public_stats: true,
     });
     const root = render({
       addon,
+      // Make sure no user is signed in.
       store: dispatchClientMetadata().store,
     });
 

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -214,6 +214,7 @@ describe(__filename, () => {
     const addon = createInternalAddon({
       ...fakeAddon,
       slug: 'coolio',
+      public_stats: false,
       authors: [
         {
           ...fakeAddon.authors[0],
@@ -232,6 +233,20 @@ describe(__filename, () => {
 
     const statsLink = root.find('.AddonMoreInfo-stats-link');
     expect(statsLink).toHaveLength(0);
+  });
+
+  it('link to stats if add-on public_stats is true', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      slug: 'coolio',
+    });
+    const root = render({
+      addon,
+      store: dispatchClientMetadata().store,
+    });
+
+    const statsLink = root.find('.AddonMoreInfo-stats-link');
+    expect(statsLink).toHaveLength(1);
   });
 
   it('links to stats if add-on author is viewing the page', () => {


### PR DESCRIPTION
Fixes: #3603 

This patch was started by @tsl143 - thanks!

**Before:**

While logged out, viewing an add-on that has public stats looked like:

<img width="336" alt="screenshot 2017-10-30 16 41 18" src="https://user-images.githubusercontent.com/55398/32197198-4861bd74-bd91-11e7-9e35-5b4b29ba2784.png">

**After:**

<img width="338" alt="screenshot 2017-10-30 16 41 36" src="https://user-images.githubusercontent.com/55398/32197213-57cd4df0-bd91-11e7-8232-d836a78a65ce.png">
