### PR TITLE
Show disabled add-on error pages

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -420,7 +420,7 @@ export class AddonBase extends React.Component {
           errorHandler.capturedError.responseStatusCode === 403 ||
           errorHandler.capturedError.responseStatusCode === 404
       ) {
-        return <NotFound />;
+        return <NotFound errorCode={errorHandler.capturedError.code} />;
       }
       // Show a list of errors at the top of the add-on section.
       errorBanner = errorHandler.renderError();

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -1,23 +1,27 @@
+/* @flow */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import NestedStatus from 'react-nested-status';
 
 import SuggestedPages from 'amo/components/SuggestedPages';
+import {
+  ERROR_ADDON_DISABLED_BY_ADMIN, ERROR_ADDON_DISABLED_BY_DEV,
+} from 'core/constants';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
 import Card from 'ui/components/Card';
+import type { I18nType } from 'core/types/i18n';
 
 import 'amo/components/ErrorPage/ErrorPage.scss';
 
+type Props = {|
+  errorCode?: string,
+  i18n: I18nType,
+|};
 
-export class NotFoundBase extends React.Component {
-  static propTypes = {
-    i18n: PropTypes.object.isRequired,
-  }
-
+export class NotFoundBase extends React.Component<Props> {
   render() {
-    const { i18n } = this.props;
+    const { errorCode, i18n } = this.props;
 
     const fileAnIssueText = i18n.sprintf(i18n.gettext(`
       If you followed a link from somewhere, please
@@ -25,6 +29,19 @@ export class NotFoundBase extends React.Component {
       what you were looking for, and we'll do our best to fix it.`),
     { url: 'https://github.com/mozilla/addons-frontend/issues/new/' });
 
+    let explanation;
+    if (errorCode === ERROR_ADDON_DISABLED_BY_DEV) {
+      explanation =
+        i18n.gettext('This add-on has been removed by its author.');
+    } else if (errorCode === ERROR_ADDON_DISABLED_BY_ADMIN) {
+      explanation =
+        i18n.gettext('This add-on has been disabled by an administrator.');
+    } else {
+      explanation = i18n.gettext(`
+        Sorry, but we can't find anything at the address you entered.
+        If you followed a link to an add-on, it's possible that add-on
+        has been removed by its author.`);
+    }
 
     /* eslint-disable react/no-danger */
     return (
@@ -33,16 +50,16 @@ export class NotFoundBase extends React.Component {
           className="ErrorPage NotFound"
           header={i18n.gettext('Page not found')}
         >
-          <p>
-            {i18n.gettext(`
-              Sorry, but we can't find anything at the address you entered.
-              If you followed a link to an add-on, it's possible that add-on
-              has been removed by its author.`)}
-          </p>
+          <p className="NotFound-explanation">{explanation}</p>
 
           <SuggestedPages />
 
-          <p dangerouslySetInnerHTML={sanitizeHTML(fileAnIssueText, ['a'])} />
+          <p
+            className="NotFound-fileAnIssueText"
+            dangerouslySetInnerHTML={
+              sanitizeHTML(fileAnIssueText, ['a'])
+            }
+          />
         </Card>
       </NestedStatus>
     );

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -37,10 +37,8 @@ export class NotFoundBase extends React.Component<Props> {
       explanation =
         i18n.gettext('This add-on has been disabled by an administrator.');
     } else {
-      explanation = i18n.gettext(`
-        Sorry, but we can't find anything at the address you entered.
-        If you followed a link to an add-on, it's possible that add-on
-        has been removed by its author.`);
+      explanation = i18n.gettext(
+        `Sorry, but we can't find anything at the address you entered.`);
     }
 
     /* eslint-disable react/no-danger */

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -31,11 +31,11 @@ export class NotFoundBase extends React.Component<Props> {
 
     let explanation;
     if (errorCode === ERROR_ADDON_DISABLED_BY_DEV) {
-      explanation =
-        i18n.gettext('This add-on has been removed by its author.');
+      explanation = i18n.gettext(
+        'This add-on has been removed by its author.');
     } else if (errorCode === ERROR_ADDON_DISABLED_BY_ADMIN) {
-      explanation =
-        i18n.gettext('This add-on has been disabled by an administrator.');
+      explanation = i18n.gettext(
+        'This add-on has been disabled by an administrator.');
     } else {
       explanation = i18n.gettext(
         `Sorry, but we can't find anything at the address you entered.`);

--- a/src/core/components/ErrorPage/NotFound/index.js
+++ b/src/core/components/ErrorPage/NotFound/index.js
@@ -5,6 +5,8 @@ import NestedStatus from 'react-nested-status';
 
 import translate from 'core/i18n/translate';
 
+// For the AMO-specific component see
+// src/amo/components/ErrorPage/NotFound
 
 export class NotFoundBase extends React.Component {
   static propTypes = {

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -197,6 +197,10 @@ export const ERROR_UNKNOWN = 'ERROR_UNKNOWN';
 export const API_ERROR_DECODING_SIGNATURE = 'ERROR_DECODING_SIGNATURE';
 export const API_ERROR_INVALID_HEADER = 'ERROR_INVALID_HEADER';
 export const API_ERROR_SIGNATURE_EXPIRED = 'ERROR_SIGNATURE_EXPIRED';
+// Interpreted error codes.
+export const ERROR_ADDON_DISABLED_BY_DEV = 'ERROR_ADDON_DISABLED_BY_DEV';
+export const ERROR_ADDON_DISABLED_BY_ADMIN =
+  'ERROR_ADDON_DISABLED_BY_ADMIN';
 
 // This is the limit in milleseconds for how long a setTimeout delay can be.
 // No setTimeout should be scheduled for this time because it

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -41,25 +41,35 @@ function getMessagesFromError(error) {
             // Add a generic error not related to a specific field.
             errorData.messages.push(msg);
           } else {
-            // Add field specific error message.
-            // The field is not localized but we need to show it as a hint.
+            // Add a field specific error message.
+            // TODO: localize field keys.
+            // The field string is not localized but we still show
+            // it as a hint.
             errorData.messages.push(`${key}: ${msg}`);
           }
         });
       } else if (key === 'code') {
         errorData.code = value;
-      } else if (key === 'is_disabled_by_developer' && value === true) {
-        const newCode = ERROR_ADDON_DISABLED_BY_DEV;
-        logCodeChange({ oldCode: errorData.code, newCode });
-        errorData.code = newCode;
-      } else if (key === 'is_disabled_by_mozilla' && value === true) {
-        const newCode = ERROR_ADDON_DISABLED_BY_ADMIN;
-        logCodeChange({ oldCode: errorData.code, newCode });
-        errorData.code = newCode;
+      } else if (key === 'is_disabled_by_developer') {
+        if (value === true) {
+          const newCode = ERROR_ADDON_DISABLED_BY_DEV;
+          logCodeChange({ oldCode: errorData.code, newCode });
+          errorData.code = newCode;
+        }
+      } else if (key === 'is_disabled_by_mozilla') {
+        if (value === true) {
+          const newCode = ERROR_ADDON_DISABLED_BY_ADMIN;
+          logCodeChange({ oldCode: errorData.code, newCode });
+          errorData.code = newCode;
+        }
       } else if (typeof value === 'string' || typeof value === 'object') {
-        // This is most likely not a form field error so just show
-        // the message.
+        // This is a catch-all for errors that are not structured like
+        // Django/DRF form field errors. It won't be perfect but at least
+        // the user will see some kind of error.
         errorData.messages.push(value);
+      } else {
+        log.warn(
+          `Ignoring key "${key}": "${value}" in data of error response`);
       }
     });
   }

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -30,13 +30,13 @@ function getMessagesFromError(error) {
   if (error && error.response && error.response.data) {
     // Extract a code and messages from the JSON response.
     Object.keys(error.response.data).forEach((key) => {
-      const val = error.response.data[key];
-      if (Array.isArray(val)) {
+      const value = error.response.data[key];
+      if (Array.isArray(value)) {
         // Most API reponse errors will consist of a key (which could be
         // a form field) and an array of localized messages.
         // More info:
         // http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#bad-requests
-        val.forEach((msg) => {
+        value.forEach((msg) => {
           if (key === 'non_field_errors') {
             // Add a generic error not related to a specific field.
             errorData.messages.push(msg);
@@ -47,19 +47,19 @@ function getMessagesFromError(error) {
           }
         });
       } else if (key === 'code') {
-        errorData.code = val;
-      } else if (key === 'is_disabled_by_developer' && val === true) {
+        errorData.code = value;
+      } else if (key === 'is_disabled_by_developer' && value === true) {
         const newCode = ERROR_ADDON_DISABLED_BY_DEV;
         logCodeChange({ oldCode: errorData.code, newCode });
         errorData.code = newCode;
-      } else if (key === 'is_disabled_by_mozilla' && val === true) {
+      } else if (key === 'is_disabled_by_mozilla' && value === true) {
         const newCode = ERROR_ADDON_DISABLED_BY_ADMIN;
         logCodeChange({ oldCode: errorData.code, newCode });
         errorData.code = newCode;
-      } else if (typeof val === 'string' || typeof val === 'object') {
+      } else if (typeof value === 'string' || typeof value === 'object') {
         // This is most likely not a form field error so just show
         // the message.
-        errorData.messages.push(val);
+        errorData.messages.push(value);
       }
     });
   }

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -32,9 +32,10 @@ function getMessagesFromError(error) {
     Object.keys(error.response.data).forEach((key) => {
       const val = error.response.data[key];
       if (Array.isArray(val)) {
-        // Most API reponse errors will consist of a key (which could be a
-        // form field) and an array of localized messages.
-        // More info: http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#bad-requests
+        // Most API reponse errors will consist of a key (which could be
+        // a form field) and an array of localized messages.
+        // More info:
+        // http://addons-server.readthedocs.io/en/latest/topics/api/overview.html#bad-requests
         val.forEach((msg) => {
           if (key === 'non_field_errors') {
             // Add a generic error not related to a specific field.
@@ -55,7 +56,7 @@ function getMessagesFromError(error) {
         const newCode = ERROR_ADDON_DISABLED_BY_ADMIN;
         logCodeChange({ oldCode: errorData.code, newCode });
         errorData.code = newCode;
-      } else if (typeof val === 'string') {
+      } else if (typeof val === 'string' || typeof val === 'object') {
         // This is most likely not a form field error so just show
         // the message.
         errorData.messages.push(val);

--- a/tests/unit/amo/components/TestNotFound.js
+++ b/tests/unit/amo/components/TestNotFound.js
@@ -1,21 +1,20 @@
 import React from 'react';
-import {
-  renderIntoDocument,
-  findRenderedComponentWithType,
-} from 'react-addons-test-utils';
-import { findDOMNode } from 'react-dom';
-import { Provider } from 'react-redux';
 import { loadFail } from 'redux-connect/lib/store';
 
-import NotFound from 'amo/components/ErrorPage/NotFound';
+import NotFound, {
+  NotFoundBase,
+} from 'amo/components/ErrorPage/NotFound';
+import SuggestedPages from 'amo/components/SuggestedPages';
 import { createApiError } from 'core/api';
-import I18nProvider from 'core/i18n/Provider';
+import {
+  ERROR_ADDON_DISABLED_BY_ADMIN, ERROR_ADDON_DISABLED_BY_DEV,
+} from 'core/constants';
 import { dispatchSignInActions } from 'tests/unit/amo/helpers';
-import { fakeI18n } from 'tests/unit/helpers';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 
-describe('<NotFound />', () => {
-  function render({ ...props }) {
+describe(__filename, () => {
+  function render(customProps = {}) {
     const { store } = dispatchSignInActions();
     const error = createApiError({
       apiURL: 'http://test.com',
@@ -23,18 +22,36 @@ describe('<NotFound />', () => {
     });
     store.dispatch(loadFail('ReduxKey', error));
 
-    return findDOMNode(findRenderedComponentWithType(renderIntoDocument(
-      <Provider store={store}>
-        <I18nProvider i18n={fakeI18n()}>
-          <NotFound {...props} />
-        </I18nProvider>
-      </Provider>
-    ), NotFound));
+    const props = {
+      i18n: fakeI18n(),
+      store,
+      ...customProps,
+    };
+
+    return shallowUntilTarget(<NotFound {...props} />, NotFoundBase);
   }
 
   it('renders a not found error', () => {
-    const rootNode = render();
+    const root = render();
 
-    expect(rootNode.textContent).toContain('Page not found');
+    expect(root.find('.ErrorPage'))
+      .toHaveProp('header', 'Page not found');
+    expect(root.find(SuggestedPages)).toHaveLength(1);
+    expect(root.find('.NotFound-fileAnIssueText').html())
+      .toContain('file an issue');
+  });
+
+  it('renders a disabled by developer error', () => {
+    const root = render({ errorCode: ERROR_ADDON_DISABLED_BY_DEV });
+
+    expect(root.find('.NotFound-explanation').html())
+      .toContain('This add-on has been removed by its author.');
+  });
+
+  it('renders a disabled by admin error', () => {
+    const root = render({ errorCode: ERROR_ADDON_DISABLED_BY_ADMIN });
+
+    expect(root.find('.NotFound-explanation').html())
+      .toContain('This add-on has been disabled by an administrator.');
   });
 });

--- a/tests/unit/core/reducers/test_errors.js
+++ b/tests/unit/core/reducers/test_errors.js
@@ -204,4 +204,18 @@ describe('errors reducer', () => {
       responseStatusCode: 401,
     });
   });
+
+  it('adds nested error messages', () => {
+    const nested = { inner: 'This is a nested message.' };
+    const error = createApiError({
+      response: { status: 401 },
+      apiURL: 'https://some/api/endpoint',
+      // There is not a known API response but we should make sure to
+      // support it just in case.
+      jsonResponse: { nested },
+    });
+    const action = setError({ id: 'some-id', error });
+    const state = errors(undefined, action);
+    expect(state[action.payload.id].messages).toEqual([nested]);
+  });
 });

--- a/tests/unit/core/reducers/test_errors.js
+++ b/tests/unit/core/reducers/test_errors.js
@@ -218,4 +218,16 @@ describe('errors reducer', () => {
     const state = errors(undefined, action);
     expect(state[action.payload.id].messages).toEqual([nested]);
   });
+
+  it('ignores unknown error keys', () => {
+    const error = createApiError({
+      response: { status: 401 },
+      apiURL: 'https://some/api/endpoint',
+      // There is no way to guess what this is so we just ignore it.
+      jsonResponse: { unknown_key: true },
+    });
+    const action = setError({ id: 'some-id', error });
+    const state = errors(undefined, action);
+    expect(state[action.payload.id].messages).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2261

**Before:**

<img width="624" alt="screenshot 2017-10-30 20 10 56" src="https://user-images.githubusercontent.com/55398/32203041-da6fc20c-bdae-11e7-9eb3-b8689aa52fe2.png">

**After** 

Developer disabled add-ons:

<img width="625" alt="screenshot 2017-10-30 20 09 01" src="https://user-images.githubusercontent.com/55398/32203044-df876042-bdae-11e7-87eb-c58cf8ebebcd.png">

Admin disabled add-ons:

<img width="625" alt="screenshot 2017-10-30 20 10 06" src="https://user-images.githubusercontent.com/55398/32203046-e1f9034e-bdae-11e7-813d-3496ef977252.png">

All other 404s:

<img width="625" alt="screenshot 2017-10-31 09 57 57" src="https://user-images.githubusercontent.com/55398/32230909-32ea76a2-be22-11e7-8c50-10fbd693c801.png">
