### PR TITLE
Style report button and more info card in add-on detail page

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -572,9 +572,9 @@ export class AddonBase extends React.Component {
             {this.renderShowMoreCard()}
           </div>
 
-          <AddonMoreInfo addon={addon} />
-
           {this.renderRatingsCard()}
+
+          <AddonMoreInfo addon={addon} />
 
           {this.renderVersionReleaseNotes()}
 

--- a/src/amo/components/AddonMoreInfo/styles.scss
+++ b/src/amo/components/AddonMoreInfo/styles.scss
@@ -1,26 +1,24 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
+@import "~photon-colors/colors";
 
 .AddonMoreInfo-contents {
   margin: 0;
   padding: 0;
 
   dt {
-    font-weight: bold;
-    line-height: 1.2;
+    @include font-regular();
+
+    color: $grey-50;
     margin: 0;
     padding: 0;
   }
 
   dd {
-    line-height: 1.2;
-    margin: 0 0 3px;
-    padding: 0;
+    @include font-medium();
 
-    a:link {
-      font-size: $font-size-s;
-      font-weight: bold;
-    }
+    margin: 0 0 12px;
+    padding: 0;
   }
 }
 

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -146,7 +146,7 @@ export class ReportAbuseButtonBase extends React.Component<Props> {
       >
         <div className="ReportAbuseButton--preview">
           <Button
-            className="ReportAbuseButton-show-more Button--report Button--small"
+            className="ReportAbuseButton-show-more Button--report Button--wide"
             onClick={this.showReportUI}
           >
             {i18n.gettext('Report this add-on for abuse')}

--- a/src/amo/components/ReportAbuseButton/styles.scss
+++ b/src/amo/components/ReportAbuseButton/styles.scss
@@ -1,7 +1,7 @@
 @import "~ui/css/vars";
 
 .ReportAbuseButton {
-  margin: 12px auto;
+  margin: 24px auto 12px;
 }
 
 .ReportAbuseButton-header {
@@ -14,6 +14,7 @@
 
 .ReportAbuseButton--preview {
   display: inline-block;
+  width: 100%;
 
   .ReportAbuseButton--is-expanded & {
     display: none;

--- a/src/ui/components/Button/Button.scss
+++ b/src/ui/components/Button/Button.scss
@@ -57,9 +57,10 @@
 
 .Button--report {
   @include button(
-    $background: $report-base-color,
-    $background-active: $report-active-color,
-    $background-hover: $report-hover-color
+    $background: transparentize($grey-90, 0.9),
+    $background-active: transparentize($grey-90, 0.7),
+    $background-hover: transparentize($grey-90, 0.8),
+    $color: $grey-90
   );
 }
 


### PR DESCRIPTION
Fix #3599

---

This PR updates the style of the report button and adds some space on the "More Info" card. It also moves the "rating" card before the "more info" one, as requested here: https://github.com/mozilla/addons-frontend/issues/3553#issuecomment-338252865.

## Screenshots

<img width="447" alt="screen shot 2017-10-31 at 13 19 38" src="https://user-images.githubusercontent.com/217628/32223629-6afe28ce-be3e-11e7-8556-29686ec7cd7a.png">
<img width="1392" alt="screen shot 2017-10-31 at 13 19 52" src="https://user-images.githubusercontent.com/217628/32223630-6b18e18c-be3e-11e7-8b46-625444ca085c.png">
