### PR TITLE
Add missing border-bottom on active section link

### DIFF
--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -57,6 +57,7 @@
   &:hover {
     &::after {
       background-color: $white;
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
Fix #3713

---

Before:

<img width="380" alt="screen shot 2017-10-31 at 15 11 23" src="https://user-images.githubusercontent.com/217628/32228597-f822f58a-be4e-11e7-9a34-76a4c7dcba37.png">

After:

<img width="352" alt="screen shot 2017-10-31 at 15 20 10" src="https://user-images.githubusercontent.com/217628/32228612-01dbfa0e-be4f-11e7-8d2c-1bb66b66dde8.png">
