### PR TITLE
Fix long title in review page

### DIFF
--- a/src/amo/components/AddonReviewList/styles.scss
+++ b/src/amo/components/AddonReviewList/styles.scss
@@ -63,6 +63,7 @@
   font-size: $font-size-m;
   margin: 0;
   padding: 0;
+  word-break: break-all;
 
   a,
   a:link {


### PR DESCRIPTION
Fix #3715

---

Before:

<img width="447" alt="screen shot 2017-10-31 at 15 40 33" src="https://user-images.githubusercontent.com/217628/32230556-bf091cb6-be53-11e7-8fc0-6908a5d6a9b7.png">

After:

<img width="447" alt="screen shot 2017-10-31 at 15 49 37" src="https://user-images.githubusercontent.com/217628/32230557-bf2ea878-be53-11e7-9a09-474ecd9868f9.png">
