### PR TITLE
Update see more links with more meaningful contents

### DIFF
--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -191,7 +191,7 @@ export class HomeBase extends React.Component {
           addons={popularExtensions}
           className="Home-PopularExtensions"
           header={i18n.gettext('Most Popular Extensions')}
-          footerText={i18n.gettext('See more')}
+          footerText={i18n.gettext('See more popular extensions')}
           footerLink={{
             pathname: '/search/',
             query: {
@@ -206,7 +206,7 @@ export class HomeBase extends React.Component {
           addons={featuredCollection}
           className="Home-FeaturedCollection"
           header={i18n.gettext('Change up your tabs')}
-          footerText={i18n.gettext('See more')}
+          footerText={i18n.gettext('See more tab extensions')}
           footerLink={{ pathname:
             `/collections/${FEATURED_COLLECTION_USER}/${FEATURED_COLLECTION_SLUG}/`,
           }}
@@ -217,7 +217,7 @@ export class HomeBase extends React.Component {
           addons={upAndComingExtensions}
           className="Home-UpAndComingExtensions"
           header={i18n.gettext('Up & Coming Extensions')}
-          footerText={i18n.gettext('See more')}
+          footerText={i18n.gettext('See more up & coming extensions')}
           footerLink={{
             pathname: '/search/',
             query: {
@@ -245,7 +245,7 @@ export class HomeBase extends React.Component {
           addons={featuredThemes}
           className="Home-FeaturedThemes"
           header={i18n.gettext('Featured themes')}
-          footerText={i18n.gettext('See more')}
+          footerText={i18n.gettext('See more featured themes')}
           footerLink={{
             pathname: '/search/',
             query: {

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -126,13 +126,13 @@ export class LandingPageBase extends React.Component {
             featured: true,
           },
         },
-        featuredFooterText: i18n.gettext('See more'),
+        featuredFooterText: i18n.gettext('See more featured extensions'),
         trendingHeader: i18n.gettext('Trending extensions'),
         trendingFooterLink: {
           pathname: '/search/',
           query: { addonType: ADDON_TYPE_EXTENSION, sort: SEARCH_SORT_TRENDING },
         },
-        trendingFooterText: i18n.gettext('See more'),
+        trendingFooterText: i18n.gettext('See more trending extensions'),
         highlyRatedHeader: i18n.gettext('Top rated extensions'),
         highlyRatedFooterLink: {
           pathname: '/search/',
@@ -141,7 +141,7 @@ export class LandingPageBase extends React.Component {
             sort: SEARCH_SORT_TOP_RATED,
           },
         },
-        highlyRatedFooterText: i18n.gettext('See more'),
+        highlyRatedFooterText: i18n.gettext('See more top rated extensions'),
       },
       [ADDON_TYPE_THEME]: {
         featuredHeader: i18n.gettext('Featured themes'),
@@ -152,19 +152,19 @@ export class LandingPageBase extends React.Component {
             featured: true,
           },
         },
-        featuredFooterText: i18n.gettext('See more'),
+        featuredFooterText: i18n.gettext('See more featured themes'),
         trendingHeader: i18n.gettext('Trending themes'),
         trendingFooterLink: {
           pathname: '/search/',
           query: { addonType: ADDON_TYPE_THEME, sort: SEARCH_SORT_TRENDING },
         },
-        trendingFooterText: i18n.gettext('See more'),
+        trendingFooterText: i18n.gettext('See more trending themes'),
         highlyRatedHeader: i18n.gettext('Top rated themes'),
         highlyRatedFooterLink: {
           pathname: '/search/',
           query: { addonType: ADDON_TYPE_THEME, sort: SEARCH_SORT_TOP_RATED },
         },
-        highlyRatedFooterText: i18n.gettext('See more'),
+        highlyRatedFooterText: i18n.gettext('See more top rated themes'),
       },
     };
 

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -214,7 +214,7 @@ describe(__filename, () => {
     });
 
     expect(root).toIncludeText('Featured extensions');
-    expect(root).toIncludeText('See more');
+    expect(root).toIncludeText('See more featured extensions');
   });
 
   it('renders a link to all categories', () => {
@@ -275,7 +275,7 @@ describe(__filename, () => {
     });
 
     expect(root).toIncludeText('Featured themes');
-    expect(root).toIncludeText('See more');
+    expect(root).toIncludeText('See more featured themes');
   });
 
   it('renders each add-on when set', () => {

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -67,7 +67,7 @@ describe(__filename, () => {
     const shelves = root.find(LandingAddonsCard);
     const shelf = shelves.find('.Home-PopularExtensions');
     expect(shelf).toHaveProp('header', 'Most Popular Extensions');
-    expect(shelf).toHaveProp('footerText', 'See more');
+    expect(shelf).toHaveProp('footerText', 'See more popular extensions');
     expect(shelf).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {
@@ -84,7 +84,7 @@ describe(__filename, () => {
     const shelves = root.find(LandingAddonsCard);
     const shelf = shelves.find('.Home-FeaturedCollection');
     expect(shelf).toHaveProp('header', 'Change up your tabs');
-    expect(shelf).toHaveProp('footerText', 'See more');
+    expect(shelf).toHaveProp('footerText', 'See more tab extensions');
     expect(shelf).toHaveProp('footerLink', { pathname:
       `/collections/${FEATURED_COLLECTION_USER}/${FEATURED_COLLECTION_SLUG}/`,
     });
@@ -97,7 +97,7 @@ describe(__filename, () => {
     const shelves = root.find(LandingAddonsCard);
     const shelf = shelves.find('.Home-FeaturedThemes');
     expect(shelf).toHaveProp('header', 'Featured themes');
-    expect(shelf).toHaveProp('footerText', 'See more');
+    expect(shelf).toHaveProp('footerText', 'See more featured themes');
     expect(shelf).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {
@@ -136,7 +136,7 @@ describe(__filename, () => {
     const shelves = root.find(LandingAddonsCard);
     const shelf = shelves.find('.Home-UpAndComingExtensions');
     expect(shelf).toHaveProp('header', 'Up & Coming Extensions');
-    expect(shelf).toHaveProp('footerText', 'See more');
+    expect(shelf).toHaveProp('footerText', 'See more up & coming extensions');
     expect(shelf).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {


### PR DESCRIPTION
Fix #3633

---

This PR adds more meaningful texts to the "see more" links.

## Screenshots

Landing page themes:

<img width="1392" alt="screen shot 2017-11-01 at 18 14 34" src="https://user-images.githubusercontent.com/217628/32287445-2d915fa8-bf31-11e7-9a6b-ba58b0bd338e.png">

Landing page extensions:

<img width="1392" alt="screen shot 2017-11-01 at 18 14 38" src="https://user-images.githubusercontent.com/217628/32287447-2dab0d40-bf31-11e7-9a47-a00541dc4fec.png">

Homepage:

<img width="1392" alt="screen shot 2017-11-01 at 18 14 50" src="https://user-images.githubusercontent.com/217628/32287448-2dc92e38-bf31-11e7-8aea-b5e4a33bc737.png">
<img width="1392" alt="screen shot 2017-11-01 at 18 14 56" src="https://user-images.githubusercontent.com/217628/32287449-2de74b48-bf31-11e7-884e-5828ce300a56.png">
