### PR TITLE
Expose permissions in user reducer

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -221,3 +221,13 @@ export const CATEGORY_COLORS = {
   [ADDON_TYPE_OPENSEARCH]: 12,
   [ADDON_TYPE_THEME]: 12,
 };
+
+// Can access the website admin interface index page. Inner pages may require
+// other/additional permissions.
+export const ADMIN_TOOLS_VIEW = 'AdminTools:View';
+// Allows viewing and editing of any add-ons details in developer tools.
+export const ADDONS_EDIT = 'Addons:Edit';
+// Can access the add-on reviewer tools to approve/reject add-on submissions.
+export const ADDONS_REVIEW = 'Addons:Review';
+// Can access the theme reviewer tools to approve/reject theme submissions.
+export const THEMES_REVIEW = 'Personas:Review';

--- a/src/core/reducers/user.js
+++ b/src/core/reducers/user.js
@@ -9,12 +9,14 @@ export type UserStateType = {
   id: ?number,
   username: ?string,
   displayName: ?string,
+  permissions: ?Array<string>,
 };
 
 export const initialState: UserStateType = {
   id: null,
   username: null,
   displayName: null,
+  permissions: null,
 };
 
 export const loadUserProfile = ({ profile }: Object) => {
@@ -56,6 +58,7 @@ export default function reducer(
         id: payload.profile.id,
         username: payload.profile.username,
         displayName: payload.profile.display_name,
+        permissions: payload.profile.permissions,
       };
     case LOG_OUT_USER:
       return initialState;

--- a/tests/unit/core/reducers/test_user.js
+++ b/tests/unit/core/reducers/test_user.js
@@ -1,4 +1,5 @@
 import { logOutUser } from 'core/actions';
+import { ADMIN_TOOLS_VIEW } from 'core/constants';
 import reducer, {
   isAuthenticated,
   loadUserProfile,
@@ -14,10 +15,11 @@ import {
 describe(__filename, () => {
   describe('reducer', () => {
     it('initializes properly', () => {
-      const { displayName, id, username } = reducer(undefined);
+      const { displayName, id, username, permissions } = reducer(undefined);
       expect(id).toEqual(null);
       expect(username).toEqual(null);
       expect(displayName).toEqual(null);
+      expect(permissions).toEqual(null);
     });
 
     it('ignores unrelated actions', () => {
@@ -29,11 +31,16 @@ describe(__filename, () => {
     });
 
     it('handles LOAD_USER_PROFILE', () => {
-      const { id, username } = reducer(undefined, loadUserProfile({
-        profile: createUserProfileResponse({ id: 1234, username: 'user-test' }),
+      const { id, username, permissions } = reducer(undefined, loadUserProfile({
+        profile: createUserProfileResponse({
+          id: 1234,
+          username: 'user-test',
+          permissions: [ADMIN_TOOLS_VIEW],
+        }),
       }));
       expect(id).toEqual(1234);
       expect(username).toEqual('user-test');
+      expect(permissions).toEqual([ADMIN_TOOLS_VIEW]);
     });
 
     it('throws an error when no profile is passed to LOAD_USER_PROFILE', () => {
@@ -46,10 +53,17 @@ describe(__filename, () => {
       const state = reducer(undefined, loadUserProfile({
         profile: createUserProfileResponse({ id: 12345, username: 'john' }),
       }));
-      const { displayName, id, username } = reducer(state, logOutUser());
+      const {
+        displayName,
+        id,
+        username,
+        permissions,
+      } = reducer(state, logOutUser());
+
       expect(id).toEqual(null);
       expect(username).toEqual(null);
       expect(displayName).toEqual(null);
+      expect(permissions).toEqual(null);
     });
   });
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -383,6 +383,7 @@ export function createUserProfileResponse({
   id = 123456,
   username = 'user-1234',
   displayName = null,
+  permissions = [],
 } = {}) {
   return {
     average_addon_rating: null,
@@ -401,6 +402,7 @@ export function createUserProfileResponse({
     picture_url: `${config.get('amoCDN')}/static/img/zamboni/anon_user.png`,
     url: null,
     username,
+    permissions,
   };
 }
 


### PR DESCRIPTION
Fix #3702

---

This PR exposes the permissions in the `user` reducer.