### PR TITLE
Display stats links to admins or users with 'Stats:View' permission

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -7,7 +7,7 @@ import Link from 'amo/components/Link';
 import ReportAbuseButton from 'amo/components/ReportAbuseButton';
 import { STATS_VIEW } from 'core/constants';
 import translate from 'core/i18n/translate';
-import { hasPermission, isAdmin } from 'core/reducers/user';
+import { hasPermission } from 'core/reducers/user';
 import type { AddonType } from 'core/types/addons';
 import {
   addonHasVersionHistory,
@@ -26,7 +26,7 @@ type Props = {|
   addon: AddonType | null,
   i18n: I18nType,
   userId: number | null,
-  canViewStats: boolean,
+  hasStatsPermission: boolean,
 |};
 
 const renderNodesIf = (includeContent: boolean, nodes: Array<any>) => {
@@ -35,7 +35,7 @@ const renderNodesIf = (includeContent: boolean, nodes: Array<any>) => {
 
 export class AddonMoreInfoBase extends React.Component<Props> {
   listContent() {
-    const { addon, i18n, userId, canViewStats } = this.props;
+    const { addon, i18n, userId, hasStatsPermission } = this.props;
 
     if (!addon) {
       return this.renderDefinitions({
@@ -79,7 +79,7 @@ export class AddonMoreInfoBase extends React.Component<Props> {
     }
 
     let statsLink = null;
-    if (isAddonAuthor({ addon, userId }) || addon.public_stats || canViewStats) {
+    if (isAddonAuthor({ addon, userId }) || addon.public_stats || hasStatsPermission) {
       statsLink = (
         <Link
           className="AddonMoreInfo-stats-link"
@@ -259,7 +259,7 @@ export class AddonMoreInfoBase extends React.Component<Props> {
 export const mapStateToProps = (state: {| user: UserStateType |}) => {
   return {
     userId: state.user.id,
-    canViewStats: isAdmin(state) || hasPermission(state, STATS_VIEW),
+    hasStatsPermission: hasPermission(state, STATS_VIEW),
   };
 };
 

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -5,7 +5,9 @@ import { compose } from 'redux';
 
 import Link from 'amo/components/Link';
 import ReportAbuseButton from 'amo/components/ReportAbuseButton';
+import { STATS_VIEW } from 'core/constants';
 import translate from 'core/i18n/translate';
+import { hasPermission, isAdmin } from 'core/reducers/user';
 import type { AddonType } from 'core/types/addons';
 import {
   addonHasVersionHistory,
@@ -15,6 +17,7 @@ import {
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
 import type { I18nType } from 'core/types/i18n';
+import type { UserStateType } from 'core/reducers/user';
 
 import './styles.scss';
 
@@ -23,6 +26,7 @@ type Props = {|
   addon: AddonType | null,
   i18n: I18nType,
   userId: number | null,
+  canViewStats: boolean,
 |};
 
 const renderNodesIf = (includeContent: boolean, nodes: Array<any>) => {
@@ -31,7 +35,7 @@ const renderNodesIf = (includeContent: boolean, nodes: Array<any>) => {
 
 export class AddonMoreInfoBase extends React.Component<Props> {
   listContent() {
-    const { addon, i18n, userId } = this.props;
+    const { addon, i18n, userId, canViewStats } = this.props;
 
     if (!addon) {
       return this.renderDefinitions({
@@ -74,18 +78,23 @@ export class AddonMoreInfoBase extends React.Component<Props> {
       supportEmail = null;
     }
 
-    return this.renderDefinitions({
-      homepage,
-      supportUrl,
-      supportEmail,
-      statsLink: addon && (isAddonAuthor({ addon, userId }) || addon.public_stats) ? (
+    let statsLink = null;
+    if (isAddonAuthor({ addon, userId }) || addon.public_stats || canViewStats) {
+      statsLink = (
         <Link
           className="AddonMoreInfo-stats-link"
           href={`/addon/${addon.slug}/statistics/`}
         >
           {i18n.gettext('Visit stats dashboard')}
         </Link>
-      ) : null,
+      );
+    }
+
+    return this.renderDefinitions({
+      homepage,
+      supportUrl,
+      supportEmail,
+      statsLink,
       version: addonHasVersionHistory(addon) ?
         addon.current_version.version : null,
       versionLastUpdated: i18n.sprintf(
@@ -247,9 +256,10 @@ export class AddonMoreInfoBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (state: Object) => {
+export const mapStateToProps = (state: {| user: UserStateType |}) => {
   return {
     userId: state.user.id,
+    canViewStats: isAdmin(state) || hasPermission(state, STATS_VIEW),
   };
 };
 

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -231,3 +231,7 @@ export const ADDONS_EDIT = 'Addons:Edit';
 export const ADDONS_REVIEW = 'Addons:Review';
 // Can access the theme reviewer tools to approve/reject theme submissions.
 export const THEMES_REVIEW = 'Personas:Review';
+// Can view statistics for all addons, regardless of privacy settings.
+export const STATS_VIEW = 'Stats:View';
+// Admin super powers. Very few users will have this permission.
+export const ADMIN_SUPER_POWERS = 'Admin:%';

--- a/src/core/reducers/user.js
+++ b/src/core/reducers/user.js
@@ -53,11 +53,12 @@ export const hasPermission = (
     return false;
   }
 
-  return permissions.includes(permission);
-};
+  // Admins have absolutely all permissions.
+  if (permissions.includes(ADMIN_SUPER_POWERS)) {
+    return true;
+  }
 
-export const isAdmin = (state: { user: UserStateType }): boolean => {
-  return hasPermission(state, ADMIN_SUPER_POWERS);
+  return permissions.includes(permission);
 };
 
 export default function reducer(

--- a/src/core/reducers/user.js
+++ b/src/core/reducers/user.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { LOG_OUT_USER } from 'core/constants';
+import { ADMIN_SUPER_POWERS, LOG_OUT_USER } from 'core/constants';
 
 
 const LOAD_USER_PROFILE = 'LOAD_USER_PROFILE';
@@ -43,6 +43,21 @@ export const selectDisplayName = (state: { user: UserStateType }) => {
   // We fallback to the username if no display name has been defined by the
   // user.
   return state.user.username;
+};
+
+export const hasPermission = (
+  state: { user: UserStateType }, permission: string,
+): boolean => {
+  const permissions = state.user.permissions;
+  if (!permissions) {
+    return false;
+  }
+
+  return permissions.includes(permission);
+};
+
+export const isAdmin = (state: { user: UserStateType }): boolean => {
+  return hasPermission(state, ADMIN_SUPER_POWERS);
 };
 
 export default function reducer(

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -8,6 +8,8 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
+  ADMIN_SUPER_POWERS,
+  STATS_VIEW,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -313,6 +315,34 @@ describe(__filename, () => {
     expect(statsLink).toHaveLength(1);
     expect(statsLink).toHaveProp('children', 'Visit stats dashboard');
     expect(statsLink).toHaveProp('href', '/addon/coolio/statistics/');
+  });
+
+  it('links to stats if user has STATS_VIEW permission', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      public_stats: false,
+    });
+    const root = render({
+      addon,
+      store: dispatchSignInActions({ permissions: [STATS_VIEW] }).store,
+    });
+
+    const statsLink = root.find('.AddonMoreInfo-stats-link');
+    expect(statsLink).toHaveLength(1);
+  });
+
+  it('links to stats if user is ADMIN', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      public_stats: false,
+    });
+    const root = render({
+      addon,
+      store: dispatchSignInActions({ permissions: [ADMIN_SUPER_POWERS] }).store,
+    });
+
+    const statsLink = root.find('.AddonMoreInfo-stats-link');
+    expect(statsLink).toHaveLength(1);
   });
 
   it('links to version history if add-on is extension', () => {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -8,7 +8,6 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
-  ADMIN_SUPER_POWERS,
   STATS_VIEW,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
@@ -325,20 +324,6 @@ describe(__filename, () => {
     const root = render({
       addon,
       store: dispatchSignInActions({ permissions: [STATS_VIEW] }).store,
-    });
-
-    const statsLink = root.find('.AddonMoreInfo-stats-link');
-    expect(statsLink).toHaveLength(1);
-  });
-
-  it('links to stats if user is ADMIN', () => {
-    const addon = createInternalAddon({
-      ...fakeAddon,
-      public_stats: false,
-    });
-    const root = render({
-      addon,
-      store: dispatchSignInActions({ permissions: [ADMIN_SUPER_POWERS] }).store,
     });
 
     const statsLink = root.find('.AddonMoreInfo-stats-link');

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -213,13 +213,19 @@ export function dispatchSignInActions({
   userId = 12345,
   username = 'user-1234',
   displayName = null,
+  permissions = [],
   ...otherArgs
 } = {}) {
   const { store } = dispatchClientMetadata(otherArgs);
 
   store.dispatch(setAuthToken(authToken));
   store.dispatch(loadUserProfile({
-    profile: createUserProfileResponse({ id: userId, username, displayName }),
+    profile: createUserProfileResponse({
+      id: userId,
+      username,
+      displayName,
+      permissions,
+    }),
   }));
 
   return {

--- a/tests/unit/core/reducers/test_user.js
+++ b/tests/unit/core/reducers/test_user.js
@@ -6,7 +6,6 @@ import {
   THEMES_REVIEW,
 } from 'core/constants';
 import reducer, {
-  isAdmin,
   isAuthenticated,
   loadUserProfile,
   selectDisplayName,
@@ -154,27 +153,13 @@ describe(__filename, () => {
 
       expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
     });
-  });
-
-  describe('isAdmin selector', () => {
-    it('returns `false` when user is not logged in', () => {
-      const { state } = dispatchClientMetadata();
-
-      expect(isAdmin(state)).toEqual(false);
-    });
-
-    it('returns `false` when user is not admin', () => {
-      const permissions = [ADMIN_TOOLS_VIEW];
-      const { state } = dispatchSignInActions({ permissions });
-
-      expect(isAdmin(state)).toEqual(false);
-    });
 
     it('returns `true` when user is admin', () => {
       const permissions = [ADMIN_SUPER_POWERS];
       const { state } = dispatchSignInActions({ permissions });
 
-      expect(isAdmin(state)).toEqual(true);
+
+      expect(hasPermission(state, THEMES_REVIEW)).toEqual(true);
     });
   });
 });

--- a/tests/unit/core/reducers/test_user.js
+++ b/tests/unit/core/reducers/test_user.js
@@ -1,9 +1,16 @@
 import { logOutUser } from 'core/actions';
-import { ADMIN_TOOLS_VIEW } from 'core/constants';
+import {
+  ADMIN_SUPER_POWERS,
+  ADMIN_TOOLS_VIEW,
+  STATS_VIEW,
+  THEMES_REVIEW,
+} from 'core/constants';
 import reducer, {
+  isAdmin,
   isAuthenticated,
   loadUserProfile,
   selectDisplayName,
+  hasPermission,
 } from 'core/reducers/user';
 import { createUserProfileResponse } from 'tests/unit/helpers';
 import {
@@ -118,6 +125,56 @@ describe(__filename, () => {
       const { state } = dispatchSignInActions({ username });
 
       expect(selectDisplayName(state)).toEqual(username);
+    });
+  });
+
+  describe('hasPermission selector', () => {
+    it('returns `true` when user has the given permission', () => {
+      const permissions = [ADMIN_TOOLS_VIEW, STATS_VIEW];
+      const { state } = dispatchSignInActions({ permissions });
+
+      expect(hasPermission(state, STATS_VIEW)).toEqual(true);
+    });
+
+    it('returns `false` when user does not have the given permission', () => {
+      const permissions = [ADMIN_TOOLS_VIEW, STATS_VIEW];
+      const { state } = dispatchSignInActions({ permissions });
+
+      expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
+    });
+
+    it('returns `false` when user state has no permissions', () => {
+      const { state } = dispatchSignInActions({ permissions: null });
+
+      expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
+    });
+
+    it('returns `false` when user is not logged in', () => {
+      const { state } = dispatchClientMetadata();
+
+      expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
+    });
+  });
+
+  describe('isAdmin selector', () => {
+    it('returns `false` when user is not logged in', () => {
+      const { state } = dispatchClientMetadata();
+
+      expect(isAdmin(state)).toEqual(false);
+    });
+
+    it('returns `false` when user is not admin', () => {
+      const permissions = [ADMIN_TOOLS_VIEW];
+      const { state } = dispatchSignInActions({ permissions });
+
+      expect(isAdmin(state)).toEqual(false);
+    });
+
+    it('returns `true` when user is admin', () => {
+      const permissions = [ADMIN_SUPER_POWERS];
+      const { state } = dispatchSignInActions({ permissions });
+
+      expect(isAdmin(state)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
Fix #3604

---

This PR relies on the newly added `permissions` state (in `user` reducer) to display the stats link to any users with the `Stats:View` permission or admins.