### PR TITLE
fix: Add tag support to search query params

### DIFF
--- a/src/amo/components/SearchPage/index.js
+++ b/src/amo/components/SearchPage/index.js
@@ -25,6 +25,7 @@ export const SearchPageBase = ({ filters, pathname, ...props }: Props) => {
     page: filters.page,
     query: filters.query,
     sort: filters.sort,
+    tag: filters.tag,
   });
 
   return (

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -26,6 +26,7 @@ export const paramsToFilter = {
   platform: 'operatingSystem',
   q: 'query',
   sort: 'sort',
+  tag: 'tag',
   type: 'addonType',
 };
 

--- a/tests/unit/amo/components/TestSearchPage.js
+++ b/tests/unit/amo/components/TestSearchPage.js
@@ -63,6 +63,7 @@ describe(__filename, () => {
           featured: true,
           page: 2,
           q: 'burger',
+          tag: 'firefox57',
         },
       },
     });
@@ -71,6 +72,7 @@ describe(__filename, () => {
       featured: true,
       page: 2,
       q: 'burger',
+      tag: 'firefox57',
     });
   });
 

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -106,6 +106,7 @@ describe(__filename, () => {
         page: 4,
         query: 'Cool things',
         author: 'johndoe',
+        tag: 'firefox57',
       });
 
       expect(queryParams).toEqual({
@@ -114,6 +115,7 @@ describe(__filename, () => {
         q: 'Cool things',
         type: ADDON_TYPE_THEME,
         author: 'johndoe',
+        tag: 'firefox57',
       });
     });
   });
@@ -125,6 +127,7 @@ describe(__filename, () => {
         page: 4,
         q: 'Cool things',
         type: ADDON_TYPE_THEME,
+        tag: 'firefox57',
       });
 
       expect(filters).toEqual({
@@ -132,6 +135,7 @@ describe(__filename, () => {
         compatibleWithVersion: '57.0',
         page: 4,
         query: 'Cool things',
+        tag: 'firefox57',
       });
     });
   });


### PR DESCRIPTION
(fix #3743)

Doesn't expose any tag UI, but this at least surfaces the query param to:

* the API
* the paginator (so clicking next/previous page works)

It should solve the issue of at least passing the link in #3743 around.

Just needs one review; whoever gets to it first.

### Before
<img width="1250" alt="screenshot 2017-11-02 10 27 45" src="https://user-images.githubusercontent.com/90871/32321267-7d8f0672-bfb8-11e7-8567-57681c240a32.png">

### After
<img width="1250" alt="screenshot 2017-11-02 10 27 09" src="https://user-images.githubusercontent.com/90871/32321274-820ef194-bfb8-11e7-820c-28670ce86e9b.png">
