### PR TITLE
Disably addonType search filter when category type is set

### DIFF
--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -153,23 +153,27 @@ export class SearchFiltersBase extends React.Component {
             })}
           </select>
 
-          <label
-            className="SearchFilters-AddonType-label SearchFilters-label"
-            htmlFor="SearchFilters-AddonType"
-          >
-            {i18n.gettext('Add-on Type')}
-          </label>
-          <select
-            className="SearchFilters-AddonType SearchFilters-select"
-            id="SearchFilters-AddonType"
-            name="addonType"
-            onChange={this.onSelectElementChange}
-            value={filters.addonType || NO_FILTER}
-          >
-            {this.addonTypeOptions().map((option) => {
-              return <option key={option.value} {...option} />;
-            })}
-          </select>
+          {!filters.category && (
+            <div>
+              <label
+                className="SearchFilters-AddonType-label SearchFilters-label"
+                htmlFor="SearchFilters-AddonType"
+              >
+                {i18n.gettext('Add-on Type')}
+              </label>
+              <select
+                className="SearchFilters-AddonType SearchFilters-select"
+                id="SearchFilters-AddonType"
+                name="addonType"
+                onChange={this.onSelectElementChange}
+                value={filters.addonType || NO_FILTER}
+              >
+                {this.addonTypeOptions().map((option) => {
+                  return <option key={option.value} {...option} />;
+                })}
+              </select>
+            </div>
+          )}
 
           <label
             className="SearchFilters-OperatingSystem-label SearchFilters-label"

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -153,6 +153,8 @@ export class SearchFiltersBase extends React.Component {
             })}
           </select>
 
+          {/* Categories are linked to addonType so we don't allow changing the
+            addonType if a filter is set. */}
           {!filters.category && (
             <div>
               <label

--- a/tests/unit/amo/components/TestSearchFilters.js
+++ b/tests/unit/amo/components/TestSearchFilters.js
@@ -246,6 +246,7 @@ describe(__filename, () => {
   });
 
   it('does not display the addonType filter when a category is defined', () => {
+    // See: https://github.com/mozilla/addons-frontend/issues/3747
     const root = render({ filters: { category: 'abstract' } });
 
     expect(root.find('.SearchFilters-AddonType')).toHaveLength(0);

--- a/tests/unit/amo/components/TestSearchFilters.js
+++ b/tests/unit/amo/components/TestSearchFilters.js
@@ -244,4 +244,10 @@ describe(__filename, () => {
       }),
     });
   });
+
+  it('does not display the addonType filter when a category is defined', () => {
+    const root = render({ filters: { category: 'abstract' } });
+
+    expect(root.find('.SearchFilters-AddonType')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Fix #3747

---

This PR does not display the add-on type select filter when a category filter is set.

## Screenshot

<img width="1392" alt="screen shot 2017-11-02 at 14 32 45" src="https://user-images.githubusercontent.com/217628/32328622-cc77a90c-bfda-11e7-875f-4d399bcfe7ea.png">
