### PR TITLE
fix: Combine all and beta versions

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -132,22 +132,26 @@ export class AddonMoreInfoBase extends React.Component<Props> {
         </Link>
       ) : null,
       versionHistoryLink: addonHasVersionHistory(addon) ? (
-        <Link
-          className="AddonMoreInfo-version-history-link"
-          href={`/addon/${addon.slug}/versions/`}
-        >
-          {i18n.gettext('See all versions')}
-        </Link>
+        <li>
+          <Link
+            className="AddonMoreInfo-version-history-link"
+            href={`/addon/${addon.slug}/versions/`}
+          >
+            {i18n.gettext('See all versions')}
+          </Link>
+        </li>
       ) : null,
       // Since current_beta_version is just an alias to the latest beta,
       // we can assume that no betas exist at all if it is null.
       betaVersionsLink: addon.current_beta_version ? (
-        <Link
-          className="AddonMoreInfo-beta-versions-link"
-          href={`/addon/${addon.slug}/versions/beta`}
-        >
-          {i18n.gettext('See all beta versions')}
-        </Link>
+        <li>
+          <Link
+            className="AddonMoreInfo-beta-versions-link"
+            href={`/addon/${addon.slug}/versions/beta`}
+          >
+            {i18n.gettext('See all beta versions')}
+          </Link>
+        </li>
       ) : null,
     });
   }
@@ -216,18 +220,16 @@ export class AddonMoreInfoBase extends React.Component<Props> {
           <dd key="eula-contents">{eulaLink}</dd>,
         ])}
 
-        {renderNodesIf(versionHistoryLink, [
+        {renderNodesIf((versionHistoryLink || betaVersionsLink), [
           <dt className="AddonMoreInfo-version-history-title" key="history-title">
             {i18n.gettext('Version History')}
           </dt>,
-          <dd key="history-contents">{versionHistoryLink}</dd>,
-        ])}
-
-        {renderNodesIf(betaVersionsLink, [
-          <dt className="AddonMoreInfo-beta-versions-title" key="beta-title">
-            {i18n.gettext('Beta Versions')}
-          </dt>,
-          <dd key="beta-contents">{betaVersionsLink}</dd>,
+          <dd key="history-contents">
+            <ul className="AddonMoreInfo-links-contents-list">
+              {versionHistoryLink}
+              {betaVersionsLink}
+            </ul>
+          </dd>,
         ])}
 
         {renderNodesIf(statsLink, [

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -404,8 +404,6 @@ describe(__filename, () => {
     const addon = createInternalAddon({ ...fakeTheme });
     const root = render({ addon });
 
-    expect(root.find('.AddonMoreInfo-version-history-title'))
-      .toHaveLength(0);
     expect(root.find('.AddonMoreInfo-version-history-link'))
       .toHaveLength(0);
   });
@@ -421,8 +419,6 @@ describe(__filename, () => {
     });
     const root = render({ addon });
 
-    expect(root.find('.AddonMoreInfo-beta-versions-title'))
-      .toHaveLength(1);
     const link = root.find('.AddonMoreInfo-beta-versions-link');
     expect(link).toHaveProp('href', `/addon/${addon.slug}/versions/beta`);
   });
@@ -433,8 +429,6 @@ describe(__filename, () => {
     });
     const root = render({ addon });
 
-    expect(root.find('.AddonMoreInfo-beta-versions-title'))
-      .toHaveLength(0);
     expect(root.find('.AddonMoreInfo-beta-versions-link'))
       .toHaveLength(0);
   });


### PR DESCRIPTION
(fix #3768)

Simple tweak–just combines the version links into one section, similar to the links section at the top of the card.

### Before
<img width="1250" alt="screenshot 2017-11-03 23 37 14" src="https://user-images.githubusercontent.com/90871/32399761-c27f25da-c0f0-11e7-8920-089119c9446b.png">

### After
<img width="1250" alt="screenshot 2017-11-03 23 36 14" src="https://user-images.githubusercontent.com/90871/32399762-c2a3d0ce-c0f0-11e7-9973-b91ffcca5c6d.png">
