### PR TITLE
Fix inconsistent border-radius

### DIFF
--- a/src/amo/components/AddonReviewList/styles.scss
+++ b/src/amo/components/AddonReviewList/styles.scss
@@ -54,7 +54,6 @@
 }
 
 .AddonReviewList-header-icon-image {
-  border-radius: $border-radius-default;
   display: block;
   height: 36px;
 }


### PR DESCRIPTION
Fixes #3786, there's a new issue filed to discuss this for future re-implementation here: https://github.com/mozilla/addons-frontend/issues/3793

Before: 

<img width="503" alt="reviews_for_tile_tabs_-_add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/32438584-edff4052-c2e2-11e7-9eea-b57df21f5952.png">

After:

<img width="479" alt="reviews_for_tile_tabs_-_add-ons_for_firefox 2" src="https://user-images.githubusercontent.com/1514/32438589-f399f2fa-c2e2-11e7-9580-805d8981b62c.png">

