### PR TITLE
feat: Add newlines to add-on summary

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -31,6 +31,7 @@ import {
 } from 'core/constants';
 import { withInstallHelpers } from 'core/installAddon';
 import {
+  nl2br,
   sanitizeHTML,
   sanitizeUserHTML,
 } from 'core/utils';
@@ -423,7 +424,8 @@ export class AddonBase extends React.Component {
       const summary = addon.summary ? addon.summary : addon.description;
 
       if (summary && summary.length) {
-        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(summary, ['a']);
+        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(
+          nl2br(summary), ['a', 'br']);
         showSummary = true;
       }
     } else {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -462,6 +462,18 @@ describe(__filename, () => {
     expect(root.find('.Addon-summary').html()).not.toContain('<script>');
   });
 
+  it('adds <br> tags for newlines in a summary', () => {
+    const summaryWithNewlines = 'Hello\nI am an add-on.';
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        summary: summaryWithNewlines,
+      }),
+    });
+
+    expect(root.find('.Addon-summary').render().find('br')).toHaveLength(1);
+  });
+
   it('sanitizes bad description HTML', () => {
     const scriptHTML = '<script>alert(document.cookie);</script>';
     const root = renderAsDOMNode({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/522.

### Before
<img width="1250" alt="screenshot 2017-11-06 15 32 03" src="https://user-images.githubusercontent.com/90871/32449038-75711414-c308-11e7-87b9-142025333f30.png">

### After
<img width="1250" alt="screenshot 2017-11-06 15 32 06" src="https://user-images.githubusercontent.com/90871/32449045-78aac760-c308-11e7-9b63-8e4bb4b99ae8.png">