### PR TITLE
Fix download links (add utm query params)

### DIFF
--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
+import { makeQueryStringWithUTM } from 'amo/utils';
 import {
   INCOMPATIBLE_FIREFOX_FOR_IOS,
   INCOMPATIBLE_NO_OPENSEARCH,
@@ -22,7 +23,6 @@ import './style.scss';
 export class AddonCompatibilityErrorBase extends React.Component {
   static propTypes = {
     i18n: PropTypes.object.isRequired,
-    lang: PropTypes.string.isRequired,
     log: PropTypes.object,
     minVersion: PropTypes.string.isRequired,
     reason: PropTypes.string.isRequired,
@@ -37,14 +37,16 @@ export class AddonCompatibilityErrorBase extends React.Component {
   render() {
     const {
       i18n,
-      lang,
       log,
       minVersion,
       reason,
       userAgentInfo,
     } = this.props;
-    const downloadUrl = `https://www.mozilla.org/${lang}/firefox/`;
-    let message;
+
+    const queryString = makeQueryStringWithUTM({
+      utm_content: 'install-addon-button',
+    });
+    const downloadUrl = `https://www.mozilla.org/firefox/new/${queryString}`;
 
     if (typeof reason === 'undefined') {
       throw new Error('AddonCompatibilityError requires a "reason" prop');
@@ -53,6 +55,7 @@ export class AddonCompatibilityErrorBase extends React.Component {
       throw new Error('minVersion is required; it cannot be undefined');
     }
 
+    let message;
     if (reason === INCOMPATIBLE_NOT_FIREFOX) {
       message = i18n.sprintf(i18n.gettext(`You need to
         <a href="%(downloadUrl)s">download Firefox</a> to install this
@@ -101,7 +104,7 @@ export class AddonCompatibilityErrorBase extends React.Component {
 }
 
 export function mapStateToProps(state) {
-  return { lang: state.api.lang, userAgentInfo: state.api.userAgentInfo };
+  return { userAgentInfo: state.api.userAgentInfo };
 }
 
 export default compose(

--- a/src/amo/components/DownloadFirefoxButton/index.js
+++ b/src/amo/components/DownloadFirefoxButton/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import { makeQueryStringWithUTM } from 'amo/utils';
 import translate from 'core/i18n/translate';
 import type { ApiStateType, UserAgentInfoType } from 'core/reducers/api';
 import Button from 'ui/components/Button';
@@ -24,6 +25,10 @@ export const DownloadFirefoxButtonBase = ({
     return null;
   }
 
+  const queryString = makeQueryStringWithUTM({
+    utm_content: 'header-download-button',
+  });
+
   return (
     <Button
       className={classNames(
@@ -33,7 +38,7 @@ export const DownloadFirefoxButtonBase = ({
         'Button--small',
         className,
       )}
-      href="https://mozilla.org/firefox/"
+      href={`https://www.mozilla.org/firefox/new/${queryString}`}
     >
       {i18n.gettext('Download Firefox')}
     </Button>

--- a/src/amo/utils.js
+++ b/src/amo/utils.js
@@ -1,8 +1,10 @@
+/* eslint camelcase: 0 */
 import base62 from 'base62';
 
 import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
+import { makeQueryString } from 'core/api';
 
 
 export function getErrorComponent(status) {
@@ -30,3 +32,17 @@ export function getDjangoBase62() {
     '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz');
   return base62;
 }
+
+export const makeQueryStringWithUTM = ({
+  utm_source = 'addons.mozilla.org',
+  utm_medium = 'referral',
+  utm_campaign = 'non-fx-button',
+  utm_content,
+}) => {
+  return makeQueryString({
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_content,
+  });
+};

--- a/tests/unit/amo/components/TestAddonCompatibilityError.js
+++ b/tests/unit/amo/components/TestAddonCompatibilityError.js
@@ -50,13 +50,19 @@ describe(__filename, () => {
 
   it('renders a notice for non-Firefox browsers', () => {
     _dispatchClientMetadata({
-      lang: 'en-GB', userAgent: userAgentsByPlatform.mac.chrome41,
+      userAgent: userAgentsByPlatform.mac.chrome41,
     });
     const root = render({ reason: INCOMPATIBLE_NOT_FIREFOX });
 
     expect(
       root.find('.AddonCompatibilityError').render().find('a').attr('href')
-    ).toEqual('https://www.mozilla.org/en-GB/firefox/');
+    ).toEqual([
+      'https://www.mozilla.org/firefox/new/',
+      '?utm_source=addons.mozilla.org',
+      '&utm_medium=referral',
+      '&utm_campaign=non-fx-button',
+      '&utm_content=install-addon-button',
+    ].join(''));
     expect(
       root.find('.AddonCompatibilityError').render().text()
     ).toContain('You need to download Firefox to install this add-on.');
@@ -75,7 +81,6 @@ describe(__filename, () => {
 
   it('renders a notice for old versions of Firefox', () => {
     _dispatchClientMetadata({
-      lang: 'en-GB',
       userAgent: userAgentsByPlatform.mac.firefox33,
     });
     const root = render({
@@ -87,7 +92,7 @@ describe(__filename, () => {
 
     expect(
       root.find('.AddonCompatibilityError').render().find('a').attr('href')
-    ).toEqual('https://www.mozilla.org/en-GB/firefox/');
+    ).toMatch(new RegExp('https://www.mozilla.org/firefox/new/'));
     expect(text).toContain(
       'This add-on requires a newer version of Firefox');
     expect(text).toContain('(at least version 34.0)');

--- a/tests/unit/amo/components/TestDownloadFirefoxButton.js
+++ b/tests/unit/amo/components/TestDownloadFirefoxButton.js
@@ -59,5 +59,12 @@ describe(__filename, () => {
     const root = render({ store });
 
     expect(root).toHaveClassName('DownloadFirefoxButton');
+    expect(root).toHaveProp('href', [
+      'https://www.mozilla.org/firefox/new/',
+      '?utm_source=addons.mozilla.org',
+      '&utm_medium=referral',
+      '&utm_campaign=non-fx-button',
+      '&utm_content=header-download-button',
+    ].join(''));
   });
 });


### PR DESCRIPTION
Fix #3803

---

This PR adds `utm` query parameters to the "download firefox" links.