### PR TITLE
Not compatible with Firefox Quantum

### DIFF
--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -30,6 +30,9 @@ export const AddonBadgesBase = (props: Props) => {
     }
   };
 
+  const isIncompatible = addon && addon.type === ADDON_TYPE_EXTENSION &&
+    !addon.isWebExtension;
+
   return (
     <div className="AddonBadges">
       {addon && addon.is_featured ? (
@@ -48,6 +51,12 @@ export const AddonBadgesBase = (props: Props) => {
         <Badge
           type="experimental"
           label={i18n.gettext('Experimental')}
+        />
+      ) : null}
+      {isIncompatible ? (
+        <Badge
+          type="not-compatible"
+          label={i18n.gettext('Not compatible with Firefox Quantum')}
         />
       ) : null}
     </div>

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -3,15 +3,18 @@
 @import "~ui/css/vars";
 
 .AddonBadges {
-  @include respond-to(medium) {
+  width: 100%;
+
+  @include respond-to(large) {
     display: flex;
+    flex-flow: row wrap;
   }
 }
 
 .AddonBadges .Badge {
   @include text-align-end();
 
-  @include respond-to(medium) {
+  @include respond-to(large) {
     @include margin-end(6px);
     @include text-align-start();
   }

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -231,6 +231,7 @@ export function createInternalAddon(
       windows: undefined,
     },
     isRestartRequired: false,
+    isWebExtension: false,
   };
 
   if (addon.type === ADDON_TYPE_THEME && apiAddon.theme_data) {
@@ -262,6 +263,9 @@ export function createInternalAddon(
     });
     addon.isRestartRequired = apiAddon.current_version.files.some(
       (file) => !!file.is_restart_required
+    );
+    addon.isWebExtension = apiAddon.current_version.files.some(
+      (file) => !!file.is_webextension
     );
   }
 

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -152,5 +152,6 @@ export type AddonType = {
     windows: ?string,
   },
   isRestartRequired: boolean,
+  isWebExtension: boolean,
   themeData?: ThemeData,
 };

--- a/src/ui/components/Badge/index.js
+++ b/src/ui/components/Badge/index.js
@@ -8,7 +8,7 @@ import './styles.scss';
 
 type Props = {|
   label: string,
-  type?: 'experimental' | 'featured' | 'restart-required',
+  type?: 'experimental' | 'featured' | 'restart-required' | 'not-compatible',
 |};
 
 const getIconNameForType = (type) => {
@@ -25,6 +25,7 @@ const getIconNameForType = (type) => {
 
 const Badge = ({ label, type }: Props) => {
   if (type && ![
+    'not-compatible',
     'experimental',
     'featured',
     'restart-required',

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -5,7 +5,7 @@
 .Badge {
   color: $grey-90;
   font-size: $font-size-m-smaller;
-  line-height: 1.4;
+  line-height: 1.2;
   margin: 0 0 6px;
 
   @include respond-to(medium) {

--- a/src/ui/components/Icon/not-compatible.svg
+++ b/src/ui/components/Icon/not-compatible.svg
@@ -1,0 +1,13 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>
+    Not-compatible
+  </title>
+  <defs>
+    <path id="a" d="M4 7h8v2H4z"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <path d="M8 0C3.59 0 0 3.59 0 8s3.59 8 8 8 8-3.59 8-8-3.59-8-8-8zm0 14c-3.31 0-6-2.69-6-6s2.69-6 6-6 6 2.69 6 6-2.69 6-6 6z" fill="#D70022" fill-rule="nonzero"/>
+    <use fill="#D8D8D8" xlink:href="#a"/>
+    <path stroke="#D70022" d="M4.5 7.5h7v1h-7z"/>
+  </g>
+</svg>

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -166,3 +166,7 @@
 .Icon-heart {
   @include icon($name: "heart");
 }
+
+.Icon-not-compatible {
+  @include icon($name: "not-compatible");
+}

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -126,4 +126,14 @@ describe(__filename, () => {
 
     expect(root.find(Badge)).toHaveLength(0);
   });
+
+  it('does not display a badge when the addon is not an extension', () => {
+    const addon = createInternalAddon(createFakeAddon({
+      type: ADDON_TYPE_THEME,
+      files: [{ is_webextension: false }],
+    }));
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
 });

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -106,4 +106,24 @@ describe(__filename, () => {
 
     expect(root.find(Badge)).toHaveLength(0);
   });
+
+  it('displays a badge when the addon is not a web extension', () => {
+    const addon = createInternalAddon(createFakeAddon({
+      files: [{ is_webextension: false }],
+    }));
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'not-compatible');
+    expect(root.find(Badge))
+      .toHaveProp('label', 'Not compatible with Firefox Quantum');
+  });
+
+  it('does not display a badge when the addon is a web extension', () => {
+    const addon = createInternalAddon(createFakeAddon({
+      files: [{ is_webextension: true }],
+    }));
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveLength(0);
+  });
 });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -78,6 +78,7 @@ describe(__filename, () => {
         [OS_WINDOWS]: undefined,
       },
       isRestartRequired: false,
+      isWebExtension: true,
     });
   });
 
@@ -107,6 +108,7 @@ describe(__filename, () => {
         [OS_WINDOWS]: undefined,
       },
       isRestartRequired: false,
+      isWebExtension: true,
     };
     delete expectedTheme.theme_data;
 
@@ -272,6 +274,51 @@ describe(__filename, () => {
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
     expect(state[addon.slug].isRestartRequired).toBe(true);
+  });
+
+  it('exposes `isWebExtension` attribute from current version files', () => {
+    const addon = createFakeAddon({
+      files: [
+        { ...fakeAddon.current_version.files[0], is_webextension: true },
+      ],
+    });
+
+    const state = addons(undefined,
+      loadAddons(createFetchAddonResult(addon).entities));
+    expect(state[addon.slug].isWebExtension).toBe(true);
+  });
+
+  it('sets `isWebExtension` to `false` when add-on is not a web extension', () => {
+    const addon = createFakeAddon({
+      files: [
+        { ...fakeAddon.current_version.files[0], is_webextension: false },
+      ],
+    });
+
+    const state = addons(undefined,
+      loadAddons(createFetchAddonResult(addon).entities));
+    expect(state[addon.slug].isWebExtension).toBe(false);
+  });
+
+  it('sets `isWebExtension` to `false` when addon has no files', () => {
+    const addon = createFakeAddon({ files: [] });
+
+    const state = addons(undefined,
+      loadAddons(createFetchAddonResult(addon).entities));
+    expect(state[addon.slug].isWebExtension).toBe(false);
+  });
+
+  it('sets `isWebExtension` to `true` when any file declares it', () => {
+    const addon = createFakeAddon({
+      files: [
+        { ...fakeAddon.current_version.files[0], is_webextension: false },
+        { ...fakeAddon.current_version.files[0], is_webextension: true },
+      ],
+    });
+
+    const state = addons(undefined,
+      loadAddons(createFetchAddonResult(addon).entities));
+    expect(state[addon.slug].isWebExtension).toBe(true);
   });
 
   describe('fetchAddon', () => {

--- a/tests/unit/disco/containers/TestDiscoPane.js
+++ b/tests/unit/disco/containers/TestDiscoPane.js
@@ -149,6 +149,7 @@ describe(__filename, () => {
           windows: undefined,
         },
         isRestartRequired: false,
+        isWebExtension: true,
       }]);
     });
 


### PR DESCRIPTION
Fix #3780

---

This PR adds a new badge to mark the non-webext add-ons as "not compatible with FF Quantum".

## Screenshots

<img width="1392" alt="screen shot 2017-11-06 at 21 06 44" src="https://user-images.githubusercontent.com/217628/32461520-680e14f6-c336-11e7-8378-6151f6be1417.png">
<img width="1003" alt="screen shot 2017-11-06 at 20 47 57" src="https://user-images.githubusercontent.com/217628/32461193-59608f16-c335-11e7-993f-987d0bc9d6f1.png">
<img width="709" alt="screen shot 2017-11-06 at 20 48 05" src="https://user-images.githubusercontent.com/217628/32461194-59800dfa-c335-11e7-970c-49e52478aed5.png">
<img width="447" alt="screen shot 2017-11-06 at 20 48 08" src="https://user-images.githubusercontent.com/217628/32461195-599d2c8c-c335-11e7-8a76-b5dad6fe9f5c.png">
