### PR TITLE
Make sure to set the right context in search

### DIFF
--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -34,6 +34,7 @@ import './styles.scss';
 export class SearchBase extends React.Component {
   static propTypes = {
     LinkComponent: PropTypes.node.isRequired,
+    context: PropTypes.string.isRequired,
     count: PropTypes.number,
     dispatch: PropTypes.func.isRequired,
     enableSearchFilters: PropTypes.bool,
@@ -73,7 +74,8 @@ export class SearchBase extends React.Component {
   }
 
   dispatchSearch({ newFilters = {}, oldFilters = {} } = {}) {
-    const { dispatch, errorHandler } = this.props;
+    const { context, dispatch, errorHandler } = this.props;
+    const { addonType } = newFilters;
 
     if (hasSearchFilters(newFilters) && !deepEqual(oldFilters, newFilters)) {
       dispatch(searchStart({
@@ -81,12 +83,13 @@ export class SearchBase extends React.Component {
         filters: newFilters,
       }));
 
-      const { addonType } = newFilters;
       if (addonType) {
         dispatch(setViewContext(addonType));
-      } else {
-        dispatch(setViewContext(VIEW_CONTEXT_EXPLORE));
       }
+    }
+
+    if (!addonType && context !== VIEW_CONTEXT_EXPLORE) {
+      dispatch(setViewContext(VIEW_CONTEXT_EXPLORE));
     }
   }
 
@@ -225,6 +228,7 @@ export class SearchBase extends React.Component {
 
 export function mapStateToProps(state) {
   return {
+    context: state.viewContext.context,
     count: state.search.count,
     filtersUsedForResults: state.search.filters,
     loading: state.search.loading,

--- a/tests/unit/amo/components/TestSearch.js
+++ b/tests/unit/amo/components/TestSearch.js
@@ -32,6 +32,7 @@ describe(__filename, () => {
 
   beforeEach(() => {
     props = {
+      context: VIEW_CONTEXT_EXPLORE,
       count: 80,
       dispatch: sinon.stub(),
       errorHandler: createStubErrorHandler(),
@@ -140,16 +141,6 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(
       fakeDispatch, setViewContext(ADDON_TYPE_EXTENSION));
-  });
-
-  it('sets the viewContext to exploring if no addonType found', () => {
-    const fakeDispatch = sinon.stub();
-    const filters = { query: 'test' };
-
-    render({ count: 0, dispatch: fakeDispatch, filters });
-
-    sinon.assert.calledWith(
-      fakeDispatch, setViewContext(VIEW_CONTEXT_EXPLORE));
   });
 
   it('should render an error', () => {
@@ -272,11 +263,32 @@ describe(__filename, () => {
     expect(wrapper.find('title')).toHaveText('Search results for "some terms"');
   });
 
+  it('sets the viewContext to exploring if viewContext has changed', () => {
+    const fakeDispatch = sinon.stub();
+    const filters = {};
+
+    render({ context: ADDON_TYPE_EXTENSION, dispatch: fakeDispatch, filters });
+
+    sinon.assert.calledWith(
+      fakeDispatch, setViewContext(VIEW_CONTEXT_EXPLORE));
+  });
+
+  it('does not set the viewContext if already set to exploring', () => {
+    const fakeDispatch = sinon.stub();
+    const filters = {};
+
+    render({ context: ADDON_TYPE_EXTENSION, dispatch: fakeDispatch, filters });
+
+    sinon.assert.calledWith(
+      fakeDispatch, setViewContext(VIEW_CONTEXT_EXPLORE));
+  });
+
   describe('mapStateToProps()', () => {
     const { state } = dispatchClientMetadata();
 
     it('returns count, loading, and results', () => {
       expect(mapStateToProps(state)).toEqual({
+        context: state.viewContext.context,
         count: state.search.count,
         filtersUsedForResults: state.search.filters,
         loading: state.search.loading,


### PR DESCRIPTION
Fix #3689 (comment)

---

This PR makes sure we set the right `viewContext` during a search.