### PR TITLE
Make sure i18n.moment uses the correct locale

### DIFF
--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -300,7 +300,5 @@ export function makeI18n(
     return scopedMoment;
   };
 
-  i18n.moment.locale = () => momentLocale;
-
   return i18n;
 }

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -278,19 +278,29 @@ export function makeI18n(
     i18n.options._momentDefineLocale();
   }
 
-  // This makes sure moment always uses the current locale.
-  moment.locale(makeMomentLocale(i18n.lang));
-
-  // Wrap the core Jed functionality so that we can always strip leading whitespace
-  // from translation keys to match the same process used in extraction.
+  // Wrap the core Jed functionality so that we can always strip leading
+  // whitespace from translation keys to match the same process used in
+  // extraction.
   i18n._dcnpgettext = i18n.dcnpgettext;
   i18n.dcnpgettext = function dcnpgettext(domain, context, singularKey, pluralKey, val) {
     return i18n._dcnpgettext(domain, context, oneLineTranslationString(singularKey),
       oneLineTranslationString(pluralKey), val);
   };
 
-  // We add a translated "moment" property to our `i18n` object
-  // to make translated date/time/etc. easy.
-  i18n.moment = moment;
+  const momentLocale = makeMomentLocale(i18n.lang);
+
+  // We add a translated "moment" property to our `i18n` object to make
+  // translated date/time/etc. easy.
+  i18n.moment = (...params) => {
+    const scopedMoment = moment(...params);
+
+    // This also makes sure moment always uses the current locale.
+    scopedMoment.locale(momentLocale);
+
+    return scopedMoment;
+  };
+
+  i18n.moment.locale = () => momentLocale;
+
   return i18n;
 }

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -418,7 +418,7 @@ describe('i18n utils', () => {
         },
       };
       const i18n = utils.makeI18n(i18nData, 'fr', FakeJed);
-      expect(i18n.moment.locale()).toEqual('fr');
+      expect(i18n.moment().locale()).toEqual('fr');
       sinon.assert.called(i18nData.options._momentDefineLocale);
     });
 
@@ -431,7 +431,7 @@ describe('i18n utils', () => {
       };
 
       const i18n = utils.makeI18n(i18nData, 'en', FakeJed);
-      expect(i18n.moment.locale()).toEqual('en');
+      expect(i18n.moment().locale()).toEqual('en');
     });
 
     it('always passes the locale to moment', () => {
@@ -442,7 +442,7 @@ describe('i18n utils', () => {
         },
       };
       const i18n = utils.makeI18n(i18nData, 'fr', FakeJed);
-      expect(i18n.moment.locale()).toEqual('fr');
+      expect(i18n.moment().locale()).toEqual('fr');
     });
 
     it('formats a number', () => {
@@ -484,7 +484,7 @@ describe('i18n utils', () => {
       const i18n = utils.makeI18n({}, 'fr', FakeJed);
       // We modify the moment locale, globally.
       moment.locale('de');
-      expect(i18n.moment.locale()).toEqual('fr');
+      expect(i18n.moment().locale()).toEqual('fr');
     });
   });
 });

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -482,7 +482,8 @@ describe('i18n utils', () => {
 
     it('always returns a scoped moment instance', () => {
       const i18n = utils.makeI18n({}, 'fr', FakeJed);
-      // We modify the moment locale, globally.
+      // Modifying the locale globally below does not affect the instance
+      // created previously.
       moment.locale('de');
       expect(i18n.moment().locale()).toEqual('fr');
     });

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -487,5 +487,10 @@ describe('i18n utils', () => {
       moment.locale('de');
       expect(i18n.moment().locale()).toEqual('fr');
     });
+
+    it('formats a date', () => {
+      const i18n = utils.makeI18n({}, 'fr', FakeJed);
+      expect(i18n.moment('1988-09-22').format('ll')).toEqual('22 sept. 1988');
+    });
   });
 });

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -398,15 +398,7 @@ describe('i18n utils', () => {
       }
     }
 
-    beforeEach(() => {
-      // FIXME: Our moment is not immutable so we reset it before each test.
-      // This is annoying to work around because of the locale `require()`s
-      // and it only affects tests so it'd be nice to fix but doesn't break
-      // anything.
-      moment.locale('en');
-    });
-
-    it('adds a localised moment to the i18n object', () => {
+    it('adds a localised moment function to the i18n object', () => {
       const i18nData = {};
       const i18n = utils.makeI18n(i18nData, 'en-US', FakeJed);
       expect(i18n.moment).toBeTruthy();
@@ -486,6 +478,13 @@ describe('i18n utils', () => {
       expect(i18n.formatNumber(number)).toEqual('12 345');
       sinon.assert.calledWith(toLocaleStringSpy, 'fr');
       sinon.assert.notCalled(numberFormatSpy);
+    });
+
+    it('always returns a scoped moment instance', () => {
+      const i18n = utils.makeI18n({}, 'fr', FakeJed);
+      // We modify the moment locale, globally.
+      moment.locale('de');
+      expect(i18n.moment.locale()).toEqual('fr');
     });
   });
 });


### PR DESCRIPTION
Fix #3819
Fix #3538

---

This PR changes the `i18n.moment` property and now only exposes a function to return localized moment instances. It is needed to avoid random locales to be used by moment (because it is used globally). The added test case simulates what is describe in both issues fixed above. The `locale` function has been added for the test suite and works as we expect.

Note that we cannot use global/static `moment` methods anymore like:

- https://momentjs.com/docs/#/durations/
- https://momentjs.com/docs/#/utilities/

Absolutely all other methods are called on an instance of `moment` and therefore will continue to work as intended. I don't think we should rely on any of the other global/static `moment` methods anyway because we would issue similar issues again.