### PR TITLE
'see more' consistency fix

### DIFF
--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -132,7 +132,7 @@ export class CategoryBase extends React.Component {
             featured: true,
           },
         },
-        featuredFooterText: i18n.gettext('See more'),
+        featuredFooterText: i18n.gettext('See more featured extensions'),
         trendingHeader: i18n.gettext('Trending extensions'),
         trendingFooterLink: {
           pathname: '/search/',
@@ -142,7 +142,7 @@ export class CategoryBase extends React.Component {
             sort: SEARCH_SORT_TRENDING,
           },
         },
-        trendingFooterText: i18n.gettext('See more'),
+        trendingFooterText: i18n.gettext('See more trending extensions'),
         highlyRatedHeader: i18n.gettext('Top rated extensions'),
         highlyRatedFooterLink: {
           pathname: '/search/',
@@ -152,7 +152,7 @@ export class CategoryBase extends React.Component {
             sort: SEARCH_SORT_TOP_RATED,
           },
         },
-        highlyRatedFooterText: i18n.gettext('See more'),
+        highlyRatedFooterText: i18n.gettext('See more top rated extensions'),
       },
       [ADDON_TYPE_THEME]: {
         title: i18n.gettext('Themes'),

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -350,7 +350,7 @@ describe(__filename, () => {
 
     expect(landingShelves.at(0)).toHaveClassName('FeaturedAddons');
     expect(landingShelves.at(0)).toHaveProp('header', 'Featured extensions');
-    expect(landingShelves.at(0)).toHaveProp('footerText', 'See more');
+    expect(landingShelves.at(0)).toHaveProp('footerText', 'See more featured extensions');
     expect(landingShelves.at(0)).toHaveProp('footerLink', {
       pathname: `/search/`,
       query: {
@@ -362,7 +362,7 @@ describe(__filename, () => {
 
     expect(landingShelves.at(1)).toHaveClassName('HighlyRatedAddons');
     expect(landingShelves.at(1)).toHaveProp('header', 'Top rated extensions');
-    expect(landingShelves.at(1)).toHaveProp('footerText', 'See more');
+    expect(landingShelves.at(1)).toHaveProp('footerText', 'See more top rated extensions');
     expect(landingShelves.at(1)).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {
@@ -375,7 +375,7 @@ describe(__filename, () => {
     expect(landingShelves.at(2)).toHaveClassName('TrendingAddons');
     expect(landingShelves.at(2))
       .toHaveProp('header', 'Trending extensions');
-    expect(landingShelves.at(2)).toHaveProp('footerText', 'See more');
+    expect(landingShelves.at(2)).toHaveProp('footerText', 'See more trending extensions');
     expect(landingShelves.at(2)).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {


### PR DESCRIPTION
Fixes #3854 

Before
<img width="1248" alt="screen shot 2017-11-09 at 3 33 31 pm" src="https://user-images.githubusercontent.com/5318732/32599858-cc57236a-c563-11e7-91ae-75d5a8cca848.png">

After
<img width="1215" alt="screen shot 2017-11-09 at 3 33 58 pm" src="https://user-images.githubusercontent.com/5318732/32599874-d5a681e0-c563-11e7-82ca-b24368d78127.png">
