### PR TITLE
Fixes see more string at themes category page

### DIFF
--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -165,7 +165,7 @@ export class CategoryBase extends React.Component {
             featured: true,
           },
         },
-        featuredFooterText: i18n.gettext('See more'),
+        featuredFooterText: i18n.gettext('See more featured themes'),
         trendingHeader: i18n.gettext('Trending themes'),
         trendingFooterLink: {
           pathname: '/search/',
@@ -175,7 +175,7 @@ export class CategoryBase extends React.Component {
             sort: SEARCH_SORT_TRENDING,
           },
         },
-        trendingFooterText: i18n.gettext('See more'),
+        trendingFooterText: i18n.gettext('See more trending themes'),
         highlyRatedHeader: i18n.gettext('Top rated themes'),
         highlyRatedFooterLink: {
           pathname: '/search/',
@@ -185,7 +185,7 @@ export class CategoryBase extends React.Component {
             sort: SEARCH_SORT_TOP_RATED,
           },
         },
-        highlyRatedFooterText: i18n.gettext('See more'),
+        highlyRatedFooterText: i18n.gettext('See more top rated themes'),
       },
     };
 

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -399,7 +399,7 @@ describe(__filename, () => {
 
     expect(landingShelves.at(0)).toHaveClassName('FeaturedAddons');
     expect(landingShelves.at(0)).toHaveProp('header', 'Featured themes');
-    expect(landingShelves.at(0)).toHaveProp('footerText', 'See more');
+    expect(landingShelves.at(0)).toHaveProp('footerText', 'See more featured themes');
     expect(landingShelves.at(0)).toHaveProp('footerLink', {
       pathname: `/search/`,
       query: {
@@ -411,7 +411,7 @@ describe(__filename, () => {
 
     expect(landingShelves.at(1)).toHaveClassName('HighlyRatedAddons');
     expect(landingShelves.at(1)).toHaveProp('header', 'Top rated themes');
-    expect(landingShelves.at(1)).toHaveProp('footerText', 'See more');
+    expect(landingShelves.at(1)).toHaveProp('footerText', 'See more top rated themes');
     expect(landingShelves.at(1)).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {
@@ -423,7 +423,7 @@ describe(__filename, () => {
 
     expect(landingShelves.at(2)).toHaveClassName('TrendingAddons');
     expect(landingShelves.at(2)).toHaveProp('header', 'Trending themes');
-    expect(landingShelves.at(2)).toHaveProp('footerText', 'See more');
+    expect(landingShelves.at(2)).toHaveProp('footerText', 'See more trending themes');
     expect(landingShelves.at(2)).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {


### PR DESCRIPTION
Fixes: #3858 

Before:
<img width="1242" alt="screen shot 2017-11-09 at 6 18 38 pm" src="https://user-images.githubusercontent.com/5318732/32606216-7d6b9f6c-c57a-11e7-9f5a-11227aae1fa5.png">

After:
<img width="1249" alt="screen shot 2017-11-09 at 6 19 21 pm" src="https://user-images.githubusercontent.com/5318732/32606231-8c15c34e-c57a-11e7-8237-59376a279e69.png">

