### PR TITLE
Fix how we determine Quantum compatibility

### DIFF
--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -35,7 +35,8 @@ export const AddonBadgesBase = (props: Props) => {
     }
   };
 
-  const isIncompatible = isQuantumCompatible({ addon }) === false;
+  const isIncompatible = addon.type === ADDON_TYPE_EXTENSION &&
+    isQuantumCompatible({ addon }) === false;
 
   return (
     <div className="AddonBadges">

--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -4,6 +4,7 @@ import { compose } from 'redux';
 
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import translate from 'core/i18n/translate';
+import { isQuantumCompatible } from 'core/utils/compatibility';
 import Badge from 'ui/components/Badge';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
@@ -19,6 +20,10 @@ type Props = {|
 export const AddonBadgesBase = (props: Props) => {
   const { addon, i18n } = props;
 
+  if (!addon) {
+    return null;
+  }
+
   const getFeaturedText = (addonType: string) => {
     switch (addonType) {
       case ADDON_TYPE_EXTENSION:
@@ -30,24 +35,23 @@ export const AddonBadgesBase = (props: Props) => {
     }
   };
 
-  const isIncompatible = addon && addon.type === ADDON_TYPE_EXTENSION &&
-    !addon.isWebExtension;
+  const isIncompatible = isQuantumCompatible({ addon }) === false;
 
   return (
     <div className="AddonBadges">
-      {addon && addon.is_featured ? (
+      {addon.is_featured ? (
         <Badge
           type="featured"
           label={getFeaturedText(addon.type)}
         />
       ) : null}
-      {addon && addon.isRestartRequired ? (
+      {addon.isRestartRequired ? (
         <Badge
           type="restart-required"
           label={i18n.gettext('Restart Required')}
         />
       ) : null}
-      {addon && addon.is_experimental ? (
+      {addon.is_experimental ? (
         <Badge
           type="experimental"
           label={i18n.gettext('Experimental')}

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -1,10 +1,12 @@
 /* global window */
 import { oneLine } from 'common-tags';
 import mozCompare from 'mozilla-version-comparator';
+import UAParser from 'ua-parser-js';
 
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
+  CLIENT_APP_FIREFOX,
   INCOMPATIBLE_FIREFOX_FOR_IOS,
   INCOMPATIBLE_NO_OPENSEARCH,
   INCOMPATIBLE_NOT_FIREFOX,
@@ -160,3 +162,17 @@ export function getClientCompatibility({
     reason,
   };
 }
+
+export const isQuantumCompatible = ({ addon }) => {
+  // HACK: we use a hardcoded User Agent string corresponding to MacOS/Firefox
+  // 57.0 to determine whether the given `addon` is compatible with Quantum.
+  // The OS is not important as far as it is not `iOS`.
+  //
+  // See: https://github.com/mozilla/addons-frontend/issues/3868.
+  const userAgentInfo = UAParser(oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X
+    10.12; rv:57.0) Gecko/20100101 Firefox/57.0`);
+  // We set `clientApp` to `firefox` because we do not want to rely on it.
+  const clientApp = CLIENT_APP_FIREFOX;
+
+  return getClientCompatibility({ addon, clientApp, userAgentInfo }).compatible;
+};

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -6,6 +6,7 @@ import UAParser from 'ua-parser-js';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
+  CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
   INCOMPATIBLE_FIREFOX_FOR_IOS,
   INCOMPATIBLE_NO_OPENSEARCH,
@@ -171,8 +172,18 @@ export const isQuantumCompatible = ({ addon }) => {
   // See: https://github.com/mozilla/addons-frontend/issues/3868.
   const userAgentInfo = UAParser(oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X
     10.12; rv:57.0) Gecko/20100101 Firefox/57.0`);
-  // We set `clientApp` to `firefox` because we do not want to rely on it.
-  const clientApp = CLIENT_APP_FIREFOX;
 
-  return getClientCompatibility({ addon, clientApp, userAgentInfo }).compatible;
+  const supportsDesktop57 = getClientCompatibility({
+    addon,
+    clientApp: CLIENT_APP_FIREFOX,
+    userAgentInfo,
+  }).compatible;
+
+  const supportsAndroid57 = getClientCompatibility({
+    addon,
+    clientApp: CLIENT_APP_ANDROID,
+    userAgentInfo,
+  }).compatible;
+
+  return supportsDesktop57 || supportsAndroid57;
 };

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -274,18 +274,24 @@ export function createFakeAutocompleteResult({ name = 'suggestion-result' } = {}
 }
 
 export function createFakeAddon({
-  files = [...fakeAddon.current_version.files], ...overrides
+  files = [...fakeAddon.current_version.files],
+  compatibility = { ...fakeAddon.current_version.compatibility },
+  // eslint-disable-next-line camelcase
+  is_strict_compatibility_enabled = fakeAddon.current_version.is_strict_compatibility_enabled,
+  ...overrides
 } = {}) {
   return {
     ...fakeAddon,
     current_version: {
       ...fakeAddon.current_version,
+      compatibility,
       files: files.map((fileProps) => {
         return {
           ...fakeAddon.current_version.files[0],
           ...fileProps,
         };
       }),
+      is_strict_compatibility_enabled,
     },
     ...overrides,
   };

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -20,8 +20,12 @@ import {
   getCompatibleVersions,
   getClientCompatibility,
   isCompatibleWithUserAgent,
+  isQuantumCompatible,
 } from 'core/utils/compatibility';
-import { fakeAddon } from 'tests/unit/amo/helpers';
+import {
+  createFakeAddon,
+  fakeAddon,
+} from 'tests/unit/amo/helpers';
 import {
   createFakeMozWindow,
   userAgents,
@@ -608,6 +612,38 @@ describe(__filename, () => {
         minVersion: null,
         reason: INCOMPATIBLE_UNSUPPORTED_PLATFORM,
       });
+    });
+  });
+
+  describe('isQuantumCompatible', () => {
+    it('returns `true` when add-on is compatible', () => {
+      const addon = createInternalAddon(createFakeAddon({
+        name: 'Firefox Multi-Account Containers',
+        compatibility: {
+          [CLIENT_APP_FIREFOX]: {
+            max: '*',
+            min: '53.0',
+          },
+        },
+        is_strict_compatibility_enabled: false,
+      }));
+
+      expect(isQuantumCompatible({ addon })).toEqual(true);
+    });
+
+    it('returns `false` when add-on is not compatible', () => {
+      const addon = createInternalAddon(createFakeAddon({
+        name: 'Firebug',
+        compatibility: {
+          [CLIENT_APP_FIREFOX]: {
+            max: '56.*',
+            min: '30.0a1',
+          },
+        },
+        is_strict_compatibility_enabled: true,
+      }));
+
+      expect(isQuantumCompatible({ addon })).toEqual(false);
     });
   });
 });

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -645,5 +645,25 @@ describe(__filename, () => {
 
       expect(isQuantumCompatible({ addon })).toEqual(false);
     });
+
+    it('returns `true` when add-on is compatible with one of the platforms', () => {
+      const addon = createInternalAddon(createFakeAddon({
+        compatibility: {
+          // This platform is not compatible...
+          [CLIENT_APP_FIREFOX]: {
+            max: '56.*',
+            min: '30.0a1',
+          },
+          // ...but this platform is compatible.
+          [CLIENT_APP_ANDROID]: {
+            max: '57.0',
+            min: '53.0',
+          },
+        },
+        is_strict_compatibility_enabled: true,
+      }));
+
+      expect(isQuantumCompatible({ addon })).toEqual(true);
+    });
   });
 });


### PR DESCRIPTION
Fix #3868

---

We use a forged User Agent string to be able to use the existing compatibility logic. It is not ideal but it is good-enough short-term. Th "not compatible with Firefox Quantum" badge should only be displayed if an add-on is not compatible with the desktop version of Quantum (`clientApp = firefox`).

## Screenshots

Before:

<img width="1392" alt="screen shot 2017-11-09 at 22 59 43" src="https://user-images.githubusercontent.com/217628/32664014-315a4c2a-c630-11e7-9387-8b03ac82adfa.png">

After:

<img width="1392" alt="screen shot 2017-11-09 at 23 00 32" src="https://user-images.githubusercontent.com/217628/32664015-3182e18a-c630-11e7-9ff7-972e748e0202.png">

**Important:** On Android, we do not show the badge on purpose because this extension is compatible with Quantum Desktop:

![screen shot 2017-11-10 at 17 40 42](https://user-images.githubusercontent.com/217628/32668597-520cbaee-c63e-11e7-9e0f-6d2fd7a0a82a.png)
