### PR TITLE
Add link to edit a collection

### DIFF
--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -12,6 +12,7 @@ export const ABORT_FETCH_COLLECTION: 'ABORT_FETCH_COLLECTION' = 'ABORT_FETCH_COL
 
 export type CollectionType = {
   addons: Array<AddonType>,
+  authorId: number,
   authorName: string,
   authorUsername: string,
   description: string | null,
@@ -209,6 +210,7 @@ export const createInternalCollection = ({
   items,
 }: CreateInternalCollectionParams): CollectionType => ({
   addons: createInternalAddons(items),
+  authorId: detail.author.id,
   authorName: detail.author.name,
   authorUsername: detail.author.username,
   description: detail.description,

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -235,3 +235,5 @@ export const THEMES_REVIEW = 'Personas:Review';
 export const STATS_VIEW = 'Stats:View';
 // Admin super powers. Very few users will have this permission.
 export const ADMIN_SUPER_POWERS = 'Admin:%';
+// Can edit all collections.
+export const COLLECTIONS_EDIT = 'Collections:Edit';

--- a/src/ui/components/MetadataCard/index.js
+++ b/src/ui/components/MetadataCard/index.js
@@ -25,10 +25,13 @@ const MetadataCard = (props: Props) => {
           throw new Error('title is required');
         }
 
+        const hasContent = content || content === '' ||
+          parseInt(content, 10) === 0;
+
         return (
           <dl className="MetadataCard-list" key={title}>
             <dd className="MetadataCard-content">
-              {content || content === '' ? content : <LoadingText />}
+              {hasContent ? content : <LoadingText />}
             </dd>
             <dt className="MetadataCard-title">{title}</dt>
           </dl>

--- a/src/ui/components/MetadataCard/index.js
+++ b/src/ui/components/MetadataCard/index.js
@@ -25,8 +25,8 @@ const MetadataCard = (props: Props) => {
           throw new Error('title is required');
         }
 
-        const hasContent = content || content === '' ||
-          parseInt(content, 10) === 0;
+        // Empty string and zero values are allowed.
+        const hasContent = content || content === '' || content === 0;
 
         return (
           <dl className="MetadataCard-list" key={title}>

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -305,11 +305,15 @@ export function dispatchAutocompleteResults({
   return { store };
 }
 
-export const createFakeCollectionDetail = ({ name = 'My Addons' } = {}) => {
+export const createFakeCollectionDetail = ({
+  name = 'My Addons',
+  count = 123,
+  authorId = 99999,
+} = {}) => {
   return {
-    addon_count: 123,
+    addon_count: count,
     author: {
-      id: Date.now(),
+      id: authorId,
       name: 'John Doe',
       url: 'http://olympia.dev/en-US/firefox/user/johndoe/',
       username: 'johndoe',

--- a/tests/unit/ui/components/TestMetadataCard.js
+++ b/tests/unit/ui/components/TestMetadataCard.js
@@ -82,6 +82,20 @@ describe(__filename, () => {
     expect(item.find('dt')).toHaveText('I am title');
   });
 
+  it('allows a zero value to render empty content', () => {
+    const item = renderShallow({
+      metadata: [
+        {
+          content: 0,
+          title: 'I am title',
+        },
+      ],
+    });
+
+    expect(item.find('dd')).toHaveText('0');
+    expect(item.find('dt')).toHaveText('I am title');
+  });
+
   it('throws an error if metadata is missing', () => {
     expect(() => {
       renderShallow({ metadata: null });


### PR DESCRIPTION
Fix #3766

---

This PR adds a link to edit a collection when user is the owner or has the `Collections:Edit` permission.

It also fixes the special case when a user has a collection without any add-ons in it (it was not rendering the number of addons on the left and it the pagination was displayed on the right). Please see the first screenshots.

## Screenshots

Before:

![screen shot 2017-11-10 at 16 59 17](https://user-images.githubusercontent.com/217628/32666672-875b0fda-c638-11e7-90d9-a0ad4ec3afe7.png)

After:

![screen shot 2017-11-10 at 16 49 57](https://user-images.githubusercontent.com/217628/32666540-07ee2c0a-c638-11e7-833e-a15c68bd3a59.png)
![screen shot 2017-11-10 at 16 54 45](https://user-images.githubusercontent.com/217628/32666542-083155de-c638-11e7-8d65-a471298d20d2.png)