### PR TITLE
Reset search state when filters become empty

### DIFF
--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -12,6 +12,7 @@ import SearchContextCard from 'amo/components/SearchContextCard';
 import SearchFilters from 'amo/components/SearchFilters';
 import SearchResults from 'amo/components/SearchResults';
 import { searchStart } from 'core/actions/search';
+import { resetSearch } from 'core/reducers/search';
 import Paginate from 'core/components/Paginate';
 import {
   ADDON_TYPE_EXTENSION,
@@ -79,14 +80,18 @@ export class SearchBase extends React.Component {
     const { context, dispatch, errorHandler } = this.props;
     const { addonType } = newFilters;
 
-    if (hasSearchFilters(newFilters) && !deepEqual(oldFilters, newFilters)) {
-      dispatch(searchStart({
-        errorHandlerId: errorHandler.id,
-        filters: newFilters,
-      }));
+    if (!deepEqual(oldFilters, newFilters)) {
+      if (hasSearchFilters(newFilters)) {
+        dispatch(searchStart({
+          errorHandlerId: errorHandler.id,
+          filters: newFilters,
+        }));
 
-      if (addonType) {
-        dispatch(setViewContext(addonType));
+        if (addonType) {
+          dispatch(setViewContext(addonType));
+        }
+      } else {
+        dispatch(resetSearch());
       }
     }
 

--- a/src/core/reducers/search.js
+++ b/src/core/reducers/search.js
@@ -6,6 +6,7 @@ import { createInternalAddon } from 'core/reducers/addons';
 
 
 const SEARCH_ABORTED = 'SEARCH_ABORTED';
+const SEARCH_RESET = 'SEARCH_RESET';
 
 export const initialState = {
   count: 0,
@@ -16,6 +17,10 @@ export const initialState = {
 
 export const abortSearch = () => {
   return { type: SEARCH_ABORTED };
+};
+
+export const resetSearch = () => {
+  return { type: SEARCH_RESET };
 };
 
 export default function search(state = initialState, action) {
@@ -45,6 +50,8 @@ export default function search(state = initialState, action) {
         results: [],
         loading: false,
       };
+    case SEARCH_RESET:
+      return initialState;
     default:
       return state;
   }

--- a/tests/unit/amo/components/TestSearch.js
+++ b/tests/unit/amo/components/TestSearch.js
@@ -23,6 +23,7 @@ import {
 } from 'core/constants';
 import { createApiError } from 'core/api/index';
 import { ErrorHandler } from 'core/errorHandler';
+import { resetSearch } from 'core/reducers/search';
 import ErrorList from 'ui/components/ErrorList';
 import {
   dispatchClientMetadata,
@@ -142,6 +143,14 @@ describe(__filename, () => {
       errorHandlerId: props.errorHandler.id,
       filters: newFilters,
     }));
+  });
+
+  it('dispatches a SEARCH_RESET when filters become empty', () => {
+    const root = render({ filters: { query: 'foo' } });
+
+    root.setProps({ filters: {} });
+
+    sinon.assert.calledWith(props.dispatch, resetSearch());
   });
 
   it('sets the viewContext to the addonType if addonType exists', () => {

--- a/tests/unit/core/reducers/test_search.js
+++ b/tests/unit/core/reducers/test_search.js
@@ -3,6 +3,7 @@ import { createInternalAddon } from 'core/reducers/addons';
 import search, {
   abortSearch,
   initialState,
+  resetSearch,
 } from 'core/reducers/search';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
@@ -103,6 +104,19 @@ describe(__filename, () => {
         createInternalAddon({ ...fakeAddon, slug: 'food' }),
         createInternalAddon({ ...fakeAddon, slug: 'foo' }),
       ]);
+    });
+  });
+
+  describe('SEARCH_RESET', () => {
+    it('resets the state to its initial state', () => {
+      const state = search(initialState, searchStart({
+        errorHandlerId: 'foo',
+        filters: { query: 'foo' },
+      }));
+      expect(state).not.toEqual(initialState);
+
+      const newState = search(state, resetSearch());
+      expect(newState).toEqual(initialState);
     });
   });
 });


### PR DESCRIPTION
Fix #3746

---

This PR resets the search state when search filters become empty.

## Gif

![2017-11-10 22 25 02](https://user-images.githubusercontent.com/217628/32679297-3b34aff2-c666-11e7-8970-ee47982e3174.gif)
