### PR TITLE
Fix pagination when over 25k add-ons

### DIFF
--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -7,6 +7,8 @@ import translate from 'core/i18n/translate';
 
 import './Paginate.scss';
 
+// This is the maximal number of add-ons the API can return for a query.
+const MAX_ADDONS = 25000;
 
 function makePageNumbers({ start, end }) {
   const pages = [];
@@ -25,7 +27,10 @@ export class PaginateBase extends React.Component {
     pathname: PropTypes.string.isRequired,
     perPage: PropTypes.number,
     queryParams: PropTypes.object,
-    showPages: PropTypes.number,
+    showPages: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.boolean,
+    ]),
   }
 
   static defaultProps = {
@@ -38,7 +43,11 @@ export class PaginateBase extends React.Component {
     if (perPage <= 0) {
       throw new TypeError(`A perPage value of ${perPage} is not allowed`);
     }
-    return Math.ceil(count / perPage);
+
+    const pageCount = Math.ceil(count / perPage);
+    const maxPage = Math.ceil(MAX_ADDONS / perPage);
+
+    return pageCount > maxPage ? maxPage : pageCount;
   }
 
   visiblePages({ pageCount }) {
@@ -128,5 +137,5 @@ export class PaginateBase extends React.Component {
 }
 
 export default compose(
-  translate({ withRef: true }),
+  translate(),
 )(PaginateBase);

--- a/tests/unit/core/components/TestPaginate.js
+++ b/tests/unit/core/components/TestPaginate.js
@@ -1,20 +1,14 @@
 /* global document */
-
 import React from 'react';
-import { render, findDOMNode } from 'react-dom';
-import {
-  renderIntoDocument,
-  findRenderedComponentWithType,
-  scryRenderedComponentsWithType,
-} from 'react-addons-test-utils';
+import { render } from 'react-dom';
 import { Route, Router, createMemoryHistory } from 'react-router';
 
-import Paginate from 'core/components/Paginate';
+import Paginate, { PaginateBase } from 'core/components/Paginate';
 import PaginatorLink from 'core/components/PaginatorLink';
-import { fakeI18n } from 'tests/unit/helpers';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 
-describe('<Paginate />', () => {
+describe(__filename, () => {
   const getRenderProps = () => ({
     i18n: fakeI18n(),
     count: 20,
@@ -27,65 +21,79 @@ describe('<Paginate />', () => {
       ...getRenderProps(),
       ...extra,
     };
-    return findRenderedComponentWithType(renderIntoDocument(
-      <Paginate {...props} />
-    ), Paginate).getWrappedInstance();
+
+    return shallowUntilTarget(<Paginate {...props} />, PaginateBase);
   }
 
   describe('methods', () => {
     describe('validation', () => {
       it('does not allow an undefined count', () => {
-        const props = getRenderProps();
-        delete props.count;
-        expect(() => renderIntoDocument(<Paginate {...props} />))
-          .toThrowError(/count property cannot be undefined/);
+        expect(() => {
+          renderPaginate({ count: undefined });
+        }).toThrowError(/count property cannot be undefined/);
       });
 
       it('does not allow an undefined currentPage', () => {
-        const props = getRenderProps();
-        delete props.currentPage;
-        expect(() => renderIntoDocument(<Paginate {...props} />))
-          .toThrowError(/currentPage property cannot be undefined/);
+        expect(() => {
+          renderPaginate({ currentPage: undefined });
+        }).toThrowError(/currentPage property cannot be undefined/);
       });
 
       it('does not allow an undefined pathname', () => {
-        const props = getRenderProps();
-        delete props.pathname;
-        expect(() => renderIntoDocument(<Paginate {...props} />))
-          .toThrowError(/pathname property cannot be undefined/);
+        expect(() => {
+          renderPaginate({ pathname: undefined });
+        }).toThrowError(/pathname property cannot be undefined/);
       });
     });
 
     describe('pageCount()', () => {
       it('is count / perPage', () => {
-        const root = renderPaginate({ count: 100, perPage: 5 });
+        const root = renderPaginate({ count: 100, perPage: 5 }).instance();
         expect(root.pageCount()).toEqual(20);
       });
 
       it('uses the ceiling of the result', () => {
-        const root = renderPaginate({ count: 101, perPage: 5 });
+        const root = renderPaginate({ count: 101, perPage: 5 }).instance();
         expect(root.pageCount()).toEqual(21);
       });
 
       it('can handle a count of zero', () => {
-        const root = renderPaginate({ count: 0 });
+        const root = renderPaginate({ count: 0 }).instance();
         expect(root.pageCount()).toEqual(0);
       });
 
       it('does not allow a per page value of zero', () => {
-        expect(() => renderPaginate({ count: 5, perPage: 0 }))
-          .toThrowError(/0 is not allowed/);
+        expect(() => {
+          renderPaginate({ count: 5, perPage: 0 });
+        }).toThrowError(/0 is not allowed/);
       });
 
       it('does not allow a negative per page value', () => {
-        expect(() => renderPaginate({ count: 5, perPage: -1 }))
-          .toThrowError(/-1 is not allowed/);
+        expect(() => {
+          renderPaginate({ count: 5, perPage: -1 });
+        }).toThrowError(/-1 is not allowed/);
+      });
+
+      it('limits the page count', () => {
+        const root = renderPaginate({
+          count: 30000,
+          perPage: 25,
+        }).instance();
+        expect(root.pageCount()).toEqual(1000);
+      });
+
+      it('uses MAX_ADDONS to compute the max page count', () => {
+        const root = renderPaginate({
+          count: 30000,
+          perPage: 100,
+        }).instance();
+        expect(root.pageCount()).toEqual(250);
       });
     });
 
     describe('visiblePages()', () => {
       function getVisiblePages(customProps = {}) {
-        const root = renderPaginate(customProps);
+        const root = renderPaginate(customProps).instance();
         return root.visiblePages({ pageCount: root.pageCount() });
       }
 
@@ -163,13 +171,13 @@ describe('<Paginate />', () => {
       const commonParams = { count: 3, perPage: 10, showPages: 5 };
 
       it('will not render if there is only one page', () => {
-        const root = findDOMNode(renderPaginate({ ...commonParams }));
-        expect(root).toEqual(null);
+        const root = renderPaginate({ ...commonParams });
+        expect(root.html()).toEqual(null);
       });
 
       it('will render with more than one page', () => {
-        const root = findDOMNode(renderPaginate({ ...commonParams, count: 30 }));
-        expect(root.classList.contains('Paginate')).toBeTruthy();
+        const root = renderPaginate({ ...commonParams, count: 30 });
+        expect(root.find('.Paginate')).toHaveLength(1);
       });
     });
   });
@@ -191,13 +199,14 @@ describe('<Paginate />', () => {
       queryParams,
     });
 
-    const links = scryRenderedComponentsWithType(root, PaginatorLink);
+    const links = root.find(PaginatorLink);
     // Just do a quick sanity check on the first link.
-    expect(links[0].props.LinkComponent).toEqual(LinkComponent);
-    expect(links[0].props.queryParams).toEqual(queryParams);
-    expect(links[0].props.currentPage).toEqual(currentPage);
-    expect(links[0].props.pathname).toEqual(pathname);
-    expect(links[0].props.pageCount).toEqual(pageCount);
+    const firstLink = links.at(0);
+    expect(firstLink).toHaveProp('LinkComponent', LinkComponent);
+    expect(firstLink).toHaveProp('queryParams', queryParams);
+    expect(firstLink).toHaveProp('currentPage', currentPage);
+    expect(firstLink).toHaveProp('pathname', pathname);
+    expect(firstLink).toHaveProp('pageCount', pageCount);
   });
 
   it('renders the right links', () => {
@@ -219,6 +228,7 @@ describe('<Paginate />', () => {
     function renderPaginateRoute() {
       return new Promise((resolve) => {
         const node = document.createElement('div');
+
         render((
           <Router history={createMemoryHistory('/')}>
             <Route path="/" component={PaginateWrapper} />
@@ -231,7 +241,10 @@ describe('<Paginate />', () => {
 
     return renderPaginateRoute().then((root) => {
       const links = Array.from(root.querySelectorAll('a'));
-      expect(links.map((link) => [link.textContent, link.getAttribute('href')])).toEqual([
+      expect(links.map((link) => [
+        link.textContent,
+        link.getAttribute('href'),
+      ])).toEqual([
         ['Previous', '/some-path/?page=4'],
         ['3', '/some-path/?page=3'],
         ['4', '/some-path/?page=4'],


### PR DESCRIPTION
Fix #3887

---

This PR fixes the `Paginate` component to not display more pages than allowed by the API. Currently, the API can return up to 25k add-ons. If we go over this limit, we get a 404 (for example, with 25 add-ons per page, we can navigate up to page `1000` and page `1001` will 404).

The diff is larger than expected because I updated the test file.

## Screenshot

![screen shot 2017-11-13 at 15 52 42](https://user-images.githubusercontent.com/217628/32731798-13d4e568-c88b-11e7-9ba7-c8fd5c7f684f.png)
