### PR TITLE
Fix count of written add-on reviews in listing

### DIFF
--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -174,7 +174,7 @@ export class AddonReviewListBase extends React.Component<Props> {
     }
 
     const addonRatingCount = addon && addon.ratings ?
-      addon.ratings.count : null;
+      addon.ratings.text_count : null;
     let addonName;
     let reviewCountHTML;
     if (addon) {

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -472,6 +472,26 @@ describe(__filename, () => {
       expect(h3.render().find('a')).toHaveLength(2);
     });
 
+    it('configures CardList with a count of text reviews', () => {
+      dispatchAddon({
+        ...fakeAddon,
+        ratings: {
+          ...fakeAddon.ratings,
+          // It has 2 star ratings.
+          count: 2,
+          // ...but only 1 text review.
+          text_count: 1,
+        },
+      });
+      dispatchAddonReviews();
+      const root = render();
+
+      const cardList = root.find('.AddonReviewList-reviews');
+      expect(cardList).toHaveProp('header');
+      expect(cardList.prop('header'))
+        .toContain('1 review for this add-on');
+    });
+
     it('configures a paginator with the right URL', () => {
       dispatchAddon();
       dispatchAddonReviews();


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2327 (as a follow-up). The count on the listing screen also needed fixing: https://github.com/mozilla/addons-frontend/issues/2327#issuecomment-343863193