### PR TITLE
Use a fixed error handler for reviews list

### DIFF
--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -14,7 +14,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import { expandReviewObjects } from 'amo/reducers/reviews';
 import { fetchAddon } from 'core/reducers/addons';
 import Paginate from 'core/components/Paginate';
-import { withErrorHandler } from 'core/errorHandler';
+import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import { findAddon, parsePage, sanitizeHTML } from 'core/utils';
 import { getAddonIconUrl } from 'core/imageUtils';
@@ -313,9 +313,15 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
   };
 }
 
+export const extractId = (ownProps: Props) => {
+  const { location, params } = ownProps;
+
+  return `${params.addonSlug}-${parsePage(location.query.page)}`;
+};
+
 export default compose(
   connect(mapStateToProps),
   translate({ withRef: true }),
-  withErrorHandler({ name: 'AddonReviewList' }),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
   withRouter,
 )(AddonReviewListBase);

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -7,6 +7,7 @@ import {
 import { setViewContext } from 'amo/actions/viewContext';
 import AddonReviewList, {
   AddonReviewListBase,
+  extractId,
 } from 'amo/components/AddonReviewList';
 import AddonReviewListItem from 'amo/components/AddonReviewListItem';
 import NotFound from 'amo/components/ErrorPage/NotFound';
@@ -45,19 +46,21 @@ describe(__filename, () => {
     store = dispatchClientMetadata({ clientApp, lang }).store;
   });
 
-  const render = ({
-    params = {
-      addonSlug: fakeAddon.slug,
-    },
-    ...customProps
-  } = {}) => {
-    const props = {
+  const getProps = ({ ...customProps }) => {
+    return {
       i18n: fakeI18n(),
       location: { query: {} },
-      params,
+      params: {
+        addonSlug: fakeAddon.slug,
+      },
       store,
       ...customProps,
     };
+  };
+
+  const render = ({ ...customProps } = {}) => {
+    const props = getProps(customProps);
+
     return shallowUntilTarget(
       <AddonReviewList {...props} />, AddonReviewListBase
     );
@@ -577,6 +580,26 @@ describe(__filename, () => {
         pathname: `/${lang}/${clientApp}${root.instance().url()}`,
         query: { page: 1 },
       });
+    });
+  });
+
+  describe('extractId', () => {
+    it('returns a unique ID based on the addon slug and page', () => {
+      const ownProps = getProps({
+        params: { addonSlug: 'foobar' },
+        location: { query: { page: 22 } },
+      });
+
+      expect(extractId(ownProps)).toEqual(`foobar-22`);
+    });
+
+    it('returns a unique ID even when there is no page', () => {
+      const ownProps = getProps({
+        params: { addonSlug: 'foobar' },
+        location: { query: {} },
+      });
+
+      expect(extractId(ownProps)).toEqual(`foobar-1`);
     });
   });
 });


### PR DESCRIPTION
Fix #3273

---

This PR uses a "fixed" error handler to synchronize the server and client error handlers, avoiding to render a 200 and then a 404 when it is expected to get a 404. Now, the server returns a 404.

