### PR TITLE
Do not display footer link if not enough add-ons in LandingAddonsCard

### DIFF
--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -33,11 +33,14 @@ export default class LandingAddonsCard extends React.Component {
       placeholderCount,
     } = this.props;
 
-    const linkSearchURL = {
-      ...footerLink,
-      query: convertFiltersToQueryParams(footerLink.query),
-    };
-    const footerLinkHtml = <Link to={linkSearchURL}>{footerText}</Link>;
+    let footerLinkHtml = null;
+    if (addons && addons.length >= placeholderCount) {
+      const linkSearchURL = {
+        ...footerLink,
+        query: convertFiltersToQueryParams(footerLink.query),
+      };
+      footerLinkHtml = <Link to={linkSearchURL}>{footerText}</Link>;
+    }
 
     return (
       <AddonsCard

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -22,7 +22,6 @@ describe(__filename, () => {
       footerText: 'some text',
       header: 'Some Header',
       loading: false,
-      placeholderCount: LANDING_PAGE_ADDON_COUNT,
       ...customProps,
     };
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -4,13 +4,17 @@ import { shallow } from 'enzyme';
 import AddonsCard from 'amo/components/AddonsCard';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
 
 describe(__filename, () => {
   function render(customProps = {}) {
+    const addons = Array(LANDING_PAGE_ADDON_COUNT)
+      .fill(createInternalAddon(fakeAddon));
+
     const props = {
-      addons: [fakeAddon],
+      addons,
       footerLink: {
         pathname: '/some-path/',
         query: { param: 'something' },
@@ -18,20 +22,27 @@ describe(__filename, () => {
       footerText: 'some text',
       header: 'Some Header',
       loading: false,
+      placeholderCount: LANDING_PAGE_ADDON_COUNT,
       ...customProps,
     };
+
     return shallow(<LandingAddonsCard {...props} />);
   }
 
   it('passes loading parameter to AddonsCard', () => {
     const root = render({ loading: true });
     expect(root.find(AddonsCard)).toHaveProp('loading', true);
+
     root.setProps({ loading: false });
     expect(root.find(AddonsCard)).toHaveProp('loading', false);
+    expect(root.find(AddonsCard)).not.toHaveProp('footerLink', null);
   });
 
   it('passes addons to AddonsCard', () => {
-    const addons = [{ ...fakeAddon, slug: 'custom-addon' }];
+    const addons = [createInternalAddon({
+      ...fakeAddon,
+      slug: 'custom-addon',
+    })];
     const root = render({ addons });
     expect(root.find(AddonsCard)).toHaveProp('addons', addons);
   });
@@ -39,5 +50,14 @@ describe(__filename, () => {
   it('sets the number of placeholders to render while loading', () => {
     const root = render({ loading: true });
     expect(root).toHaveProp('placeholderCount', LANDING_PAGE_ADDON_COUNT);
+  });
+
+  it('hides the footer link when less add-ons than placeholderCount', () => {
+    const addons = [createInternalAddon({
+      ...fakeAddon,
+      slug: 'custom-addon',
+    })];
+    const root = render({ addons, placeholderCount: 2 });
+    expect(root.find(AddonsCard)).toHaveProp('footerLink', null);
   });
 });

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -214,7 +214,6 @@ describe(__filename, () => {
     });
 
     expect(root).toIncludeText('Featured extensions');
-    expect(root).toIncludeText('See more featured extensions');
   });
 
   it('renders a link to all categories', () => {
@@ -275,7 +274,6 @@ describe(__filename, () => {
     });
 
     expect(root).toIncludeText('Featured themes');
-    expect(root).toIncludeText('See more featured themes');
   });
 
   it('renders each add-on when set', () => {
@@ -284,6 +282,8 @@ describe(__filename, () => {
       featured: createAddonsApiResult([
         { ...fakeAddon, name: 'Howdy', slug: 'howdy' },
         { ...fakeAddon, name: 'Howdy again', slug: 'howdy-again' },
+        { ...fakeAddon, name: 'Howdy 2', slug: 'howdy-2' },
+        { ...fakeAddon, name: 'Howdy again 2', slug: 'howdy-again-2' },
       ]),
       highlyRated: createAddonsApiResult([
         { ...fakeAddon, name: 'High', slug: 'high' },
@@ -303,8 +303,14 @@ describe(__filename, () => {
       root.find('.SearchResult-name')
         .map((heading) => heading.text()))
       .toEqual([
-        'Howdy', 'Howdy again', 'High', 'High again', 'Pop', 'Pop again',
+        // featured
+        'Howdy', 'Howdy again', 'Howdy 2', 'Howdy again 2',
+        // highly rated
+        'High', 'High again',
+        // trending
+        'Pop', 'Pop again',
       ]);
+    expect(root).toIncludeText('See more featured themes');
   });
 
   it('renders not found if add-on type is not supported', () => {


### PR DESCRIPTION
Fix #3745

---

This PR hides the "see more" (footer) link when there are less than 4 add-ons displayed in a landing card.

Before:

![screen shot 2017-11-14 at 13 55 32](https://user-images.githubusercontent.com/217628/32785195-34372be2-c951-11e7-910c-66553b63931d.png)

After:

![screen shot 2017-11-14 at 13 55 11](https://user-images.githubusercontent.com/217628/32785194-34126334-c951-11e7-9b6e-a14c319e706c.png)