### PR TITLE
Fix langpack display

### DIFF
--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -34,7 +34,7 @@ type LanguageToolListProps = {|
 
 
 // Get languages into a list of objects sorted by the english name.
-const languageList = Object.keys(languages).map((langKey) => {
+const sortedLanguages = Object.keys(languages).map((langKey) => {
   return {
     english: languages[langKey].English,
     locale: langKey,
@@ -178,10 +178,10 @@ export class LanguageToolsBase extends React.Component<Props> {
             </Tr>
           </Thead>
           <Tbody>
-            {addons && addons.length ? languageList.map((lang) => {
+            {addons && addons.length ? sortedLanguages.map((language) => {
               const toolsInLocale = addons ?
                 addons.filter((addon) => {
-                  return addon.target_locale === lang.locale;
+                  return addon.target_locale === language.locale;
                 }) : null;
 
               // This means there are no language tools available in this
@@ -202,18 +202,22 @@ export class LanguageToolsBase extends React.Component<Props> {
                 <Tr
                   className={classNames(
                     'LanguageTools-table-row',
-                    `LanguageTools-lang-${lang.locale}`,
+                    `LanguageTools-lang-${language.locale}`,
                   )}
-                  key={lang.locale}
+                  key={language.locale}
                 >
                   <Td>
-                    <strong>{lang.english}</strong> <span lang={lang.locale}>{lang.native}</span>
+                    <strong>
+                      {language.english}
+                    </strong> <span lang={language.locale}>
+                      {language.native}
+                    </span>
                   </Td>
-                  <Td className={`LanguageTools-lang-${lang.locale}-languagePacks`}>
+                  <Td className={`LanguageTools-lang-${language.locale}-languagePacks`}>
                     {languagePacks.length ?
                       <LanguageToolList addons={languagePacks} /> : null}
                   </Td>
-                  <Td className={`LanguageTools-lang-${lang.locale}-dictionaries`}>
+                  <Td className={`LanguageTools-lang-${language.locale}-dictionaries`}>
                     {dictionaries.length ?
                       <LanguageToolList addons={dictionaries} /> : null}
                   </Td>

--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -15,7 +15,7 @@ import {
   ADDON_TYPE_LANG,
   VIEW_CONTEXT_LANGUAGE_TOOLS,
 } from 'core/constants';
-import languages from 'core/languages';
+import { languagesUnfiltered as languages } from 'core/languages';
 import translate from 'core/i18n/translate';
 import { fetchLanguageTools } from 'core/reducers/addons';
 import Card from 'ui/components/Card';
@@ -31,6 +31,19 @@ import './styles.scss';
 type LanguageToolListProps = {|
   addons?: Array<AddonType>,
 |};
+
+
+// Get languages into a list of objects sorted by the english name.
+const languageList = Object.keys(languages).map((langKey) => {
+  return {
+    english: languages[langKey].English,
+    locale: langKey,
+    native: languages[langKey].native,
+  };
+}).sort((a, b) => {
+  return a.english > b.english;
+});
+
 
 export const LanguageToolList = ({ addons }: LanguageToolListProps) => {
   if (!addons) {
@@ -167,10 +180,10 @@ export class LanguageToolsBase extends React.Component<Props> {
             </Tr>
           </Thead>
           <Tbody>
-            {addons && addons.length ? Object.keys(languages).map((langKey) => {
-              const toolsInLocale = addons ? addons
-                .filter((addon) => {
-                  return addon.target_locale === langKey;
+            {addons && addons.length ? languageList.map((lang) => {
+              const toolsInLocale = addons ?
+                addons.filter((addon) => {
+                  return addon.target_locale === lang.locale;
                 }) : null;
 
               // This means there are no language tools available in this
@@ -182,6 +195,7 @@ export class LanguageToolsBase extends React.Component<Props> {
               const dictionaries = toolsInLocale.filter((addon) => {
                 return addon.type === ADDON_TYPE_DICT;
               });
+
               const languagePacks = toolsInLocale.filter((addon) => {
                 return addon.type === ADDON_TYPE_LANG;
               });
@@ -190,18 +204,18 @@ export class LanguageToolsBase extends React.Component<Props> {
                 <Tr
                   className={classNames(
                     'LanguageTools-table-row',
-                    `LanguageTools-lang-${langKey}`,
+                    `LanguageTools-lang-${lang.locale}`,
                   )}
-                  key={langKey}
+                  key={lang.locale}
                 >
-                  <Td lang={langKey}>
-                    {languages[langKey].native}
+                  <Td>
+                    <strong>{lang.english}</strong> <span lang={lang.locale}>{lang.native}</span>
                   </Td>
-                  <Td className={`LanguageTools-lang-${langKey}-languagePacks`}>
+                  <Td className={`LanguageTools-lang-${lang.locale}-languagePacks`}>
                     {languagePacks.length ?
                       <LanguageToolList addons={languagePacks} /> : null}
                   </Td>
-                  <Td className={`LanguageTools-lang-${langKey}-dictionaries`}>
+                  <Td className={`LanguageTools-lang-${lang.locale}-dictionaries`}>
                     {dictionaries.length ?
                       <LanguageToolList addons={dictionaries} /> : null}
                   </Td>

--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -41,7 +41,12 @@ const languageList = Object.keys(languages).map((langKey) => {
     native: languages[langKey].native,
   };
 }).sort((a, b) => {
-  return a.english > b.english;
+  if (a.english < b.english) {
+    return -1;
+  } else if (a.english === b.english) {
+    return 0;
+  }
+  return 1;
 });
 
 

--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -40,14 +40,7 @@ const languageList = Object.keys(languages).map((langKey) => {
     locale: langKey,
     native: languages[langKey].native,
   };
-}).sort((a, b) => {
-  if (a.english < b.english) {
-    return -1;
-  } else if (a.english === b.english) {
-    return 0;
-  }
-  return 1;
-});
+}).sort((a, b) => a.english.localeCompare(b.english));
 
 
 export const LanguageToolList = ({ addons }: LanguageToolListProps) => {

--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -621,3 +621,5 @@ export default config.get('langs').reduce((object, locale) => {
 
   return object;
 }, {});
+
+export const languagesUnfiltered = languages;

--- a/tests/unit/amo/components/TestLanguageTools.js
+++ b/tests/unit/amo/components/TestLanguageTools.js
@@ -143,6 +143,11 @@ describe(__filename, () => {
     expect(root.find('.LanguageTools-lang-fr')).toHaveLength(1);
     expect(root.find('.LanguageTools-lang-ur')).toHaveLength(1);
     expect(root.find('.LanguageTools-lang-zh-TW')).toHaveLength(1);
+
+    // Zulu is not a supported locale on the site but since Firefox UI locales
+    // are not necessarily going to match the site locales we should
+    // still render the zulu language pack and dictionary.
+    expect(root.find('.LanguageTools-lang-zu')).toHaveLength(1);
   });
 
   it('renders multiple addons in a list using LanguageToolList', () => {

--- a/tests/unit/amo/components/TestLanguageTools.js
+++ b/tests/unit/amo/components/TestLanguageTools.js
@@ -64,6 +64,11 @@ describe(__filename, () => {
       target_locale: 'zh-TW',
       type: ADDON_TYPE_LANG,
     }),
+    createFakeLanguageAddon({
+      name: 'isiZulu',
+      target_locale: 'zu',
+      type: ADDON_TYPE_LANG,
+    }),
   ];
 
   function renderShallow({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/528

The main change here was to use a unfiltered set of language data so all relevant locales are represented rather than using the default subset that's relevant to our site.

I also added sorting by English locale since this makes the ordering make more sense rather than the sorting on locale code when the display is the native locale string. We could look to improve on this in due course but it matches what's on the old site.

Before: 

<img width="1374" alt="dictionaries_and_language_packs_ _add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/32791413-e25db658-c958-11e7-96f1-94120bec3a10.png">

After:

<img width="1618" alt="dictionaries_and_language_packs_ _add-ons_for_firefox" src="https://user-images.githubusercontent.com/1514/32791495-17d9de10-c959-11e7-97a2-3af97006a456.png">

