### PR TITLE
Refactor the addons reducer state

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -18,7 +18,11 @@ import DefaultRatingManager from 'amo/components/RatingManager';
 import ScreenShots from 'amo/components/ScreenShots';
 import Link from 'amo/components/Link';
 import { fetchOtherAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
-import { fetchAddon } from 'core/reducers/addons';
+import {
+  fetchAddon,
+  getAddonByID,
+  getAddonBySlug,
+} from 'core/reducers/addons';
 import { sendServerRedirect } from 'core/reducers/redirectTo';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import InstallButton from 'core/components/InstallButton';
@@ -589,7 +593,13 @@ export class AddonBase extends React.Component {
 
 export function mapStateToProps(state, ownProps) {
   const { slug } = ownProps.params;
-  const addon = state.addons[slug];
+  let addon = getAddonBySlug(state, slug);
+
+  // It is possible to load an add-on by its ID but in the routing parameters,
+  // the parameter is always named `slug`.
+  if (slug && !isNaN(slug)) {
+    addon = getAddonByID(state, slug);
+  }
 
   let addonsByAuthors;
   let installedAddon = {};

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -102,7 +102,7 @@ export class AddonBase extends React.Component {
     // of an error.
     if (!errorHandler.hasError()) {
       if (addon) {
-        if (!isNaN(params.slug)) {
+        if (Number.isInteger(params.slug)) {
           // We only load add-ons by slug, but ID must be supported too because
           // it is a legacy behavior.
           dispatch(sendServerRedirect({
@@ -597,7 +597,7 @@ export function mapStateToProps(state, ownProps) {
 
   // It is possible to load an add-on by its ID but in the routing parameters,
   // the parameter is always named `slug`.
-  if (slug && !isNaN(slug)) {
+  if (slug && Number.isInteger(slug)) {
     addon = getAddonByID(state, slug);
   }
 

--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -12,11 +12,11 @@ import RatingManager from 'amo/components/RatingManager';
 import { clearAddonReviews, fetchReviews } from 'amo/actions/reviews';
 import { setViewContext } from 'amo/actions/viewContext';
 import { expandReviewObjects } from 'amo/reducers/reviews';
-import { fetchAddon } from 'core/reducers/addons';
+import { fetchAddon, getAddonBySlug } from 'core/reducers/addons';
 import Paginate from 'core/components/Paginate';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
-import { findAddon, parsePage, sanitizeHTML } from 'core/utils';
+import { parsePage, sanitizeHTML } from 'core/utils';
 import { getAddonIconUrl } from 'core/imageUtils';
 import log from 'core/logger';
 import Link from 'amo/components/Link';
@@ -27,6 +27,7 @@ import LoadingText from 'ui/components/LoadingText';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { ReviewState } from 'amo/reducers/reviews';
+import type { AddonState } from 'core/reducers/addons';
 import type { ApiStateType } from 'core/reducers/api';
 import type { UserStateType } from 'core/reducers/user';
 import type { AddonType } from 'core/types/addons';
@@ -38,7 +39,7 @@ import './styles.scss';
 
 type Props = {|
   i18n: I18nType,
-  addon?: AddonType,
+  addon: AddonType | null,
   clientApp: string,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
@@ -291,7 +292,10 @@ export class AddonReviewListBase extends React.Component<Props> {
 }
 
 type AppState = {|
-  api: ApiStateType, user: UserStateType, reviews: ReviewState,
+  addons: AddonState,
+  api: ApiStateType,
+  user: UserStateType,
+  reviews: ReviewState,
 |};
 
 export function mapStateToProps(state: AppState, ownProps: Props) {
@@ -302,7 +306,7 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
   const reviewData = state.reviews.byAddon[addonSlug];
 
   return {
-    addon: findAddon(state, addonSlug),
+    addon: getAddonBySlug(state, addonSlug),
     clientApp: state.api.clientApp,
     lang: state.api.lang,
     reviewCount: reviewData && reviewData.reviewCount,

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -304,10 +304,8 @@ export const getAllAddons = (
 ): Array<AddonType> => {
   const addons = state.addons.byID;
 
-  // TODO: one day, Flow will get `Object.values()` right but for now... we
-  // have to deal with it.
-  // See: https://github.com/facebook/flow/issues/2221.
-  return Object.keys(addons).map((key: string) => addons[key]);
+  // $FLOW_FIXME: see https://github.com/facebook/flow/issues/2221.
+  return Object.values(addons);
 };
 
 export default function addonsReducer(

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -6,7 +6,7 @@ import config from 'config';
 import React from 'react';
 import { asyncConnect as defaultAsyncConnect } from 'redux-connect';
 
-import { loadAddons } from 'core/reducers/addons';
+import { getAddonBySlug, loadAddons } from 'core/reducers/addons';
 import { fetchAddon } from 'core/api';
 import GenericError from 'core/components/ErrorPage/GenericError';
 import NotFound from 'core/components/ErrorPage/NotFound';
@@ -118,10 +118,6 @@ export function sanitizeUserHTML(text) {
   ]);
 }
 
-export function findAddon(state, slug) {
-  return state.addons[slug];
-}
-
 export function refreshAddon({ addonSlug, apiState, dispatch } = {}) {
   return fetchAddon({ slug: addonSlug, api: apiState })
     .then(({ entities }) => dispatch(loadAddons(entities)));
@@ -139,11 +135,13 @@ export function loadAddonIfNeeded(
   { _refreshAddon = refreshAddon } = {},
 ) {
   const state = getState();
-  const addon = findAddon(state, slug);
+  const addon = getAddonBySlug(state, slug);
+
   if (addon) {
     log.info(`Found add-on ${slug}, ${addon.id} in state`);
     return Promise.resolve();
   }
+
   log.info(`Add-on ${slug} not found in state; fetching from API`);
   // This loads the add-on into state.
   return _refreshAddon({ addonSlug: slug, apiState: state.api, dispatch });

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -27,6 +27,7 @@ import {
 } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { withInstallHelpers } from 'core/installAddon';
+import { getAddonByGUID } from 'core/reducers/addons';
 import themeAction from 'core/themePreview';
 import tracking, { getAction } from 'core/tracking';
 import { sanitizeHTMLWithExternalLinks } from 'disco/utils';
@@ -287,8 +288,11 @@ export class AddonBase extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
+  // `ownProps.guid` is already "normalized" with `getGuid()` in the
+  // `DiscoPane` container component.
   const installation = state.installations[ownProps.guid];
-  const addon = state.addons[ownProps.guid];
+  const addon = getAddonByGUID(state, ownProps.guid);
+
   return {
     addon,
     ...addon,

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -13,6 +13,7 @@ import tracking from 'core/tracking';
 import { INSTALL_STATE } from 'core/constants';
 import InfoDialog from 'core/containers/InfoDialog';
 import { addChangeListeners } from 'core/addonManager';
+import { getAddonByGUID } from 'core/reducers/addons';
 import {
   NAVIGATION_CATEGORY,
   VIDEO_CATEGORY,
@@ -172,7 +173,15 @@ export class DiscoPaneBase extends React.Component {
 
 export function loadedAddons(state) {
   return state.discoResults.map(
-    (result) => ({ ...result, ...state.addons[result.addon] })
+    (result) => {
+      return {
+        ...result,
+        // `result` comes from the API call in `src/disco/api.js` and
+        // normalizer makes everything complicated...
+        // `addon` is actually the add-on's GUID.
+        ...getAddonByGUID(state, result.addon),
+      };
+    }
   );
 }
 

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -178,7 +178,7 @@ export function loadedAddons(state) {
         ...result,
         // `result` comes from the API call in `src/disco/api.js` and
         // normalizer makes everything complicated...
-        // `addon` is actually the add-on's GUID.
+        // `result.addon` is actually the add-on's GUID.
         ...getAddonByGUID(state, result.addon),
       };
     }

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1416,6 +1416,6 @@ describe('mapStateToProps', () => {
     signIn();
     const { addon } = _mapStateToProps();
 
-    expect(addon).toEqual(undefined);
+    expect(addon).toEqual(null);
   });
 });

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -107,7 +107,7 @@ describe(__filename, () => {
       expect(root.find(AddonReviewListItem)).toHaveLength(4);
       // Do a sanity check on the first placeholder;
       expect(root.find(AddonReviewListItem).at(0))
-        .toHaveProp('addon', undefined);
+        .toHaveProp('addon', null);
       expect(root.find(AddonReviewListItem).at(0))
         .toHaveProp('location', location);
       expect(root.find(AddonReviewListItem).at(0))
@@ -140,7 +140,7 @@ describe(__filename, () => {
       const root = render({
         params: { addonSlug: 'other-slug' },
       });
-      expect(root.instance().props.addon).toBe(undefined);
+      expect(root.instance().props.addon).toEqual(null);
     });
 
     it('fetches reviews if needed', () => {

--- a/tests/unit/amo/test_store.js
+++ b/tests/unit/amo/test_store.js
@@ -1,6 +1,7 @@
 import createStore from 'amo/store';
+import { initialState } from 'core/reducers/addons';
 
-describe('amo createStore', () => {
+describe(__filename, () => {
   it('sets the reducers', () => {
     const { store } = createStore();
     expect(Object.keys(store.getState()).sort()).toEqual([
@@ -30,6 +31,6 @@ describe('amo createStore', () => {
 
   it('creates an empty store', () => {
     const { store } = createStore();
-    expect(store.getState().addons).toEqual({});
+    expect(store.getState().addons).toEqual(initialState);
   });
 });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -4,6 +4,10 @@ import {
 import addons, {
   createInternalAddon,
   fetchAddon,
+  getAddonByGUID,
+  getAddonByID,
+  getAddonBySlug,
+  getAllAddons,
   getGuid,
   loadAddons,
   loadAddonResults,
@@ -15,7 +19,10 @@ import {
   createStubErrorHandler,
 } from 'tests/unit/helpers';
 import {
-  createFakeAddon, fakeAddon, fakeTheme,
+  createFakeAddon,
+  dispatchClientMetadata,
+  fakeAddon,
+  fakeTheme,
 } from 'tests/unit/amo/helpers';
 
 
@@ -31,34 +38,57 @@ describe(__filename, () => {
     const firstState = addons(undefined,
       loadAddons(createFetchAddonResult(fakeAddon).entities));
 
-    const anotherFakeAddon = { ...fakeAddon, slug: 'testing1234', id: 6401 };
+    const anotherFakeAddon = {
+      ...fakeAddon,
+      slug: 'testing1234',
+      id: 6401,
+    };
     const newState = addons(firstState,
       loadAddons(createFetchAddonResult(anotherFakeAddon).entities));
 
     const internalAddon = createInternalAddon(anotherFakeAddon);
-    expect(newState).toEqual({
-      ...firstState,
-      [anotherFakeAddon.slug]: internalAddon,
+    expect(newState.byID).toEqual({
+      ...firstState.byID,
       [anotherFakeAddon.id]: internalAddon,
+    });
+    expect(newState.bySlug).toEqual({
+      ...firstState.bySlug,
+      [anotherFakeAddon.slug]: anotherFakeAddon.id,
+    });
+    expect(newState.byGUID).toEqual({
+      ...firstState.byGUID,
+      [anotherFakeAddon.guid]: anotherFakeAddon.id,
     });
   });
 
-  it('stores all add-ons, indexed by id and slug', () => {
+  it('stores all add-ons, indexed by id', () => {
     const addonResults = [
       { ...fakeAddon, slug: 'first-slug', id: 123 },
       { ...fakeAddon, slug: 'second-slug', id: 456 },
     ];
     const state = addons(undefined,
       loadAddons(createFetchAllAddonsResult(addonResults).entities));
-    expect(Object.keys(state).sort())
-      .toEqual(['123', '456', 'first-slug', 'second-slug']);
+    expect(Object.keys(state.byID).sort()).toEqual(['123', '456']);
+  });
+
+  it('store all add-on slugs with their IDs', () => {
+    const addonResults = [
+      { ...fakeAddon, slug: 'first-slug', id: 123 },
+      { ...fakeAddon, slug: 'second-slug', id: 456 },
+    ];
+    const state = addons(undefined,
+      loadAddons(createFetchAllAddonsResult(addonResults).entities));
+    expect(state.bySlug).toEqual({
+      'first-slug': 123,
+      'second-slug': 456,
+    });
   });
 
   it('ignores empty results', () => {
     const addonResults = [];
     const state = addons(undefined,
       loadAddons(createFetchAllAddonsResult(addonResults).entities));
-    expect(Object.keys(state)).toEqual([]);
+    expect(Object.keys(state.byID)).toEqual([]);
   });
 
   it('stores a modified extension object', () => {
@@ -66,7 +96,7 @@ describe(__filename, () => {
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(extension).entities));
 
-    expect(state[extension.slug]).toEqual({
+    expect(state.byID[extension.id]).toEqual({
       ...extension,
       iconUrl: extension.icon_url,
       installURLs: {
@@ -113,7 +143,7 @@ describe(__filename, () => {
     };
     delete expectedTheme.theme_data;
 
-    expect(state[theme.slug]).toEqual(expectedTheme);
+    expect(state.byID[theme.id]).toEqual(expectedTheme);
   });
 
   it('does not let theme_data set properties to undefined', () => {
@@ -127,7 +157,7 @@ describe(__filename, () => {
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(theme).entities));
 
-    expect(state[theme.slug].id).toEqual(theme.id);
+    expect(state.byID[theme.id].id).toEqual(theme.id);
   });
 
   it('does not store undefined properties', () => {
@@ -136,7 +166,7 @@ describe(__filename, () => {
       loadAddons(createFetchAddonResult(extension).entities));
 
     // eslint-disable-next-line no-prototype-builtins
-    expect(state[extension.slug].hasOwnProperty('description'))
+    expect(state.byID[extension.id].hasOwnProperty('description'))
       .toEqual(false);
   });
 
@@ -144,7 +174,7 @@ describe(__filename, () => {
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(fakeTheme).entities));
 
-    expect(state[fakeTheme.slug].guid)
+    expect(state.byID[fakeTheme.id].guid)
       .toEqual('54321@personas.mozilla.org');
   });
 
@@ -170,7 +200,7 @@ describe(__filename, () => {
     });
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].installURLs).toMatchObject({
+    expect(state.byID[addon.id].installURLs).toMatchObject({
       [OS_MAC]: 'https://a.m.o/mac.xpi',
       [OS_WINDOWS]: 'https://a.m.o/windows.xpi',
       [OS_ALL]: 'https://a.m.o/all.xpi',
@@ -181,7 +211,7 @@ describe(__filename, () => {
     const addon = createFakeAddon({ files: [] });
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].installURLs).toMatchObject({
+    expect(state.byID[addon.id].installURLs).toMatchObject({
       [OS_MAC]: undefined,
       [OS_WINDOWS]: undefined,
       [OS_ALL]: undefined,
@@ -197,7 +227,7 @@ describe(__filename, () => {
     });
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].installURLs).toMatchObject({
+    expect(state.byID[addon.id].installURLs).toMatchObject({
       unexpectedPlatform: 'https://a.m.o/files/somewhere.xpi',
     });
   });
@@ -209,7 +239,7 @@ describe(__filename, () => {
     };
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].iconUrl).toEqual(addon.icon_url);
+    expect(state.byID[addon.id].iconUrl).toEqual(addon.icon_url);
   });
 
   it('does not use description from theme_data', () => {
@@ -224,12 +254,13 @@ describe(__filename, () => {
       theme_data: {
         ...fakeTheme.theme_data,
         description: 'None',
+        id: 42,
       },
     };
     const state = addons(
       {}, loadAddons(createFetchAddonResult(theme).entities));
 
-    expect(state[theme.slug].description).toBe(null);
+    expect(state.byID[theme.id].description).toEqual(null);
   });
 
   it('exposes `isRestartRequired` attribute from current version files', () => {
@@ -241,7 +272,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isRestartRequired).toBe(true);
+    expect(state.byID[addon.id].isRestartRequired).toBe(true);
   });
 
   it('sets `isRestartRequired` to `false` when restart is not required', () => {
@@ -253,7 +284,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isRestartRequired).toBe(false);
+    expect(state.byID[addon.id].isRestartRequired).toBe(false);
   });
 
   it('sets `isRestartRequired` to `false` when addon has no files', () => {
@@ -261,7 +292,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isRestartRequired).toBe(false);
+    expect(state.byID[addon.id].isRestartRequired).toBe(false);
   });
 
   it('sets `isRestartRequired` to `true` when any file declares it', () => {
@@ -274,7 +305,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isRestartRequired).toBe(true);
+    expect(state.byID[addon.id].isRestartRequired).toBe(true);
   });
 
   it('exposes `isWebExtension` attribute from current version files', () => {
@@ -284,7 +315,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isWebExtension).toBe(true);
+    expect(state.byID[addon.id].isWebExtension).toBe(true);
   });
 
   it('sets `isWebExtension` to `false` when add-on is not a web extension', () => {
@@ -294,7 +325,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isWebExtension).toBe(false);
+    expect(state.byID[addon.id].isWebExtension).toBe(false);
   });
 
   it('sets `isWebExtension` to `false` when addon has no files', () => {
@@ -302,7 +333,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isWebExtension).toBe(false);
+    expect(state.byID[addon.id].isWebExtension).toBe(false);
   });
 
   it('sets `isWebExtension` to `true` when any file declares it', () => {
@@ -315,7 +346,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isWebExtension).toBe(true);
+    expect(state.byID[addon.id].isWebExtension).toBe(true);
   });
 
   it('exposes `isMozillaSignedExtension` from current version files', () => {
@@ -325,7 +356,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isMozillaSignedExtension).toBe(true);
+    expect(state.byID[addon.id].isMozillaSignedExtension).toBe(true);
   });
 
   it('sets `isMozillaSignedExtension` to `false` when not declared', () => {
@@ -335,7 +366,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isMozillaSignedExtension).toBe(false);
+    expect(state.byID[addon.id].isMozillaSignedExtension).toBe(false);
   });
 
   it('sets `isMozillaSignedExtension` to `false` without files', () => {
@@ -343,7 +374,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isMozillaSignedExtension).toBe(false);
+    expect(state.byID[addon.id].isMozillaSignedExtension).toBe(false);
   });
 
   it('sets `isMozillaSignedExtension` to `true` when any file declares it', () => {
@@ -356,7 +387,7 @@ describe(__filename, () => {
 
     const state = addons(undefined,
       loadAddons(createFetchAddonResult(addon).entities));
-    expect(state[addon.slug].isMozillaSignedExtension).toBe(true);
+    expect(state.byID[addon.id].isMozillaSignedExtension).toBe(true);
   });
 
   describe('fetchAddon', () => {
@@ -420,6 +451,70 @@ describe(__filename, () => {
       expect(() => {
         loadAddonResults();
       }).toThrow('addons are required');
+    });
+  });
+
+  describe('getAddonByID', () => {
+    it('returns null if no add-on found with the given slug', () => {
+      const { state } = dispatchClientMetadata();
+
+      expect(getAddonByID(state, 'id')).toEqual(null);
+    });
+
+    it('returns an add-on by id', () => {
+      const { store } = dispatchClientMetadata();
+      store.dispatch(loadAddons(createFetchAddonResult(fakeAddon).entities));
+
+      expect(getAddonByID(store.getState(), fakeAddon.id))
+        .toEqual(createInternalAddon(fakeAddon));
+    });
+  });
+
+  describe('getAddonBySlug', () => {
+    it('returns null if no add-on found with the given slug', () => {
+      const { state } = dispatchClientMetadata();
+
+      expect(getAddonBySlug(state, 'slug')).toEqual(null);
+    });
+
+    it('returns an add-on by slug', () => {
+      const { store } = dispatchClientMetadata();
+      store.dispatch(loadAddons(createFetchAddonResult(fakeAddon).entities));
+
+      expect(getAddonBySlug(store.getState(), fakeAddon.slug))
+        .toEqual(createInternalAddon(fakeAddon));
+    });
+  });
+
+  describe('getAddonByGUID', () => {
+    it('returns null if no add-on found with the given guid', () => {
+      const { state } = dispatchClientMetadata();
+
+      expect(getAddonByGUID(state, 'guid')).toEqual(null);
+    });
+
+    it('returns an add-on by guid', () => {
+      const { store } = dispatchClientMetadata();
+      store.dispatch(loadAddons(createFetchAddonResult(fakeAddon).entities));
+
+      expect(getAddonByGUID(store.getState(), fakeAddon.guid))
+        .toEqual(createInternalAddon(fakeAddon));
+    });
+  });
+
+  describe('getAllAddons', () => {
+    it('returns an empty array when no add-ons are loaded', () => {
+      const { state } = dispatchClientMetadata();
+
+      expect(getAllAddons(state)).toEqual([]);
+    });
+
+    it('returns an array of add-ons', () => {
+      const { store } = dispatchClientMetadata();
+      store.dispatch(loadAddons(createFetchAddonResult(fakeAddon).entities));
+
+      expect(getAllAddons(store.getState()))
+        .toEqual([createInternalAddon(fakeAddon)]);
     });
   });
 });

--- a/tests/unit/disco/components/TestAddon.js
+++ b/tests/unit/disco/components/TestAddon.js
@@ -485,10 +485,8 @@ describe(__filename, () => {
         store.getState(), { guid: 'not-loaded-yet@addon' },
       );
 
-      expect(props).toMatchObject({
-        addon: undefined,
-        installURLs: {},
-      });
+      expect(props.addon).toEqual(null);
+      expect(props.installURLs).toEqual({});
     });
   });
 });


### PR DESCRIPTION
Fix #3421

---

This PR changes the shape of the `addons` reducer state. It introduces two hash maps to quickly lookup an add-on by GUID (disco) or slug (amo) and several selectors.

Add-ons are stored only once and by ID (slugs can change). The `bySlug` and `byGUID` state attributes are hash maps that store the `id` given a `slug` or `guid`.

If you want to retrieve an add-on by slug, you need to get its `id` first, and then get it in the set of `addons`. To ease that, there is a new `getAddonBySlug()` selector. It is the exact same thing for `guid` and `getAddonByGUID()`.

It is also possible to retrieve an add-on by ID using `getAddonByID()` and to get an array of all add-ons with `getAllAddons()`. These selectors should make things more readable.

---

Follow-up: #3957