### PR TITLE
Add a languageTools reducer

### DIFF
--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -16,6 +16,7 @@ import categories from 'core/reducers/categories';
 import errors from 'core/reducers/errors';
 import errorPage from 'core/reducers/errorPage';
 import heroBanners from 'core/reducers/heroBanners';
+import languageTools from 'core/reducers/languageTools';
 import infoDialog from 'core/reducers/infoDialog';
 import installations from 'core/reducers/installations';
 import redirectTo from 'core/reducers/redirectTo';
@@ -43,6 +44,7 @@ export default function createStore(initialState = {}) {
       infoDialog,
       installations,
       landing,
+      languageTools,
       reduxAsyncConnect,
       redirectTo,
       reviews,

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -14,7 +14,6 @@ import type {
 export const LOAD_ADDONS = 'LOAD_ADDONS';
 export const FETCH_ADDON = 'FETCH_ADDON';
 export const LOAD_ADDON_RESULTS = 'LOAD_ADDON_RESULTS';
-export const FETCH_LANGUAGE_TOOLS = 'FETCH_LANGUAGE_TOOLS';
 
 type ExternalAddonMap = {
   [addonSlug: string]: ExternalAddonType,
@@ -69,30 +68,6 @@ export function fetchAddon(
   return {
     type: FETCH_ADDON,
     payload: { errorHandlerId: errorHandler.id, slug },
-  };
-}
-
-type FetchLanguageToolsParams = {|
-  errorHandlerId: string,
-|};
-
-export type FetchLanguageToolsAction = {|
-  type: string,
-  payload: {|
-    errorHandlerId: string,
-  |},
-|};
-
-export function fetchLanguageTools(
-  { errorHandlerId }: FetchLanguageToolsParams = {}
-): FetchLanguageToolsAction {
-  if (!errorHandlerId) {
-    throw new Error('errorHandlerId is required');
-  }
-
-  return {
-    type: FETCH_LANGUAGE_TOOLS,
-    payload: { errorHandlerId },
   };
 }
 

--- a/src/core/reducers/languageTools.js
+++ b/src/core/reducers/languageTools.js
@@ -1,0 +1,95 @@
+/* @flow */
+import type { LanguageToolType } from 'core/types/addons';
+
+export const FETCH_LANGUAGE_TOOLS: 'FETCH_LANGUAGE_TOOLS'
+  = 'FETCH_LANGUAGE_TOOLS';
+export const LOAD_LANGUAGE_TOOLS: 'LOAD_LANGUAGE_TOOLS'
+  = 'LOAD_LANGUAGE_TOOLS';
+
+export type LanguageToolsState = {|
+  byID: { [id: string]: LanguageToolType },
+|};
+
+export const initialState: LanguageToolsState = {
+  byID: {},
+};
+
+type FetchLanguageToolsParams = {|
+  errorHandlerId: string,
+|};
+
+type FetchLanguageToolsAction = {|
+  type: typeof FETCH_LANGUAGE_TOOLS,
+  payload: FetchLanguageToolsParams,
+|};
+
+export const fetchLanguageTools = (
+  { errorHandlerId }: FetchLanguageToolsParams = {}
+): FetchLanguageToolsAction => {
+  if (!errorHandlerId) {
+    throw new Error('errorHandlerId is required');
+  }
+
+  return {
+    type: FETCH_LANGUAGE_TOOLS,
+    payload: { errorHandlerId },
+  };
+};
+
+type LoadLanguageToolsParams = {|
+  languageTools: Array<LanguageToolType>,
+|};
+
+type LoadLanguageToolsAction = {|
+  type: typeof LOAD_LANGUAGE_TOOLS,
+  payload: LoadLanguageToolsParams,
+|};
+
+export const loadLanguageTools = (
+  { languageTools }: LoadLanguageToolsParams = {}
+): LoadLanguageToolsAction => {
+  if (!languageTools) {
+    throw new Error('languageTools are required');
+  }
+
+  return {
+    type: LOAD_LANGUAGE_TOOLS,
+    payload: { languageTools },
+  };
+};
+
+export const getAllLanguageTools = (
+  state: { languageTools: LanguageToolsState }
+): Array<LanguageToolType> => {
+  const { byID } = state.languageTools;
+
+  // TODO: one day, Flow will get `Object.values()` right but for now... we
+  // have to deal with it.
+  // See: https://github.com/facebook/flow/issues/2221.
+  return Object.keys(byID).map((key) => byID[key]);
+};
+
+type Action =
+  | FetchLanguageToolsAction
+  | LoadLanguageToolsAction;
+
+export default function languageToolsReducer(
+  state: LanguageToolsState = initialState,
+  action: Action
+): LanguageToolsState {
+  switch (action.type) {
+    case LOAD_LANGUAGE_TOOLS: {
+      const byID = { ...state.byID };
+
+      action.payload.languageTools.forEach((item) => {
+        byID[`${item.id}`] = item;
+      });
+
+      return {
+        byID,
+      };
+    }
+    default:
+      return state;
+  }
+}

--- a/src/core/sagas/languageTools.js
+++ b/src/core/sagas/languageTools.js
@@ -8,8 +8,8 @@ import { languageTools as languageToolsApi } from 'core/api/languageTools';
 import log from 'core/logger';
 import {
   FETCH_LANGUAGE_TOOLS,
-  loadAddonResults,
-} from 'core/reducers/addons';
+  loadLanguageTools,
+} from 'core/reducers/languageTools';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 
 
@@ -25,7 +25,7 @@ export function* fetchLanguageTools({
 
     const response = yield call(languageToolsApi, { api: state.api });
 
-    yield put(loadAddonResults({ addons: response.results }));
+    yield put(loadLanguageTools({ languageTools: response.results }));
   } catch (error) {
     log.warn(`Loading Language tools failed: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -54,9 +54,17 @@ export type AddonAuthorType = {|
   username: string,
 |};
 
-export type LanguageToolData = {|
+export type LanguageToolType = {|
+  current_version: AddonVersionType,
+  default_locale: string,
+  guid: string,
+  id: number,
   locale_disambiguation?: string,
+  name: string,
+  slug: string,
   target_locale?: string,
+  type: string,
+  url: string,
 |};
 
 export type ThemeData = {|
@@ -142,7 +150,6 @@ export type ExternalAddonType = {|
  */
 export type AddonType = {
   ...ExternalAddonType,
-  ...LanguageToolData,
   ...ThemeData,
   // Here are some custom properties for our internal representation.
   iconUrl?: string,

--- a/tests/unit/amo/components/TestLanguageTools.js
+++ b/tests/unit/amo/components/TestLanguageTools.js
@@ -4,18 +4,16 @@ import React from 'react';
 import LanguageTools, {
   LanguageToolsBase,
   LanguageToolList,
-  mapStateToProps,
 } from 'amo/components/LanguageTools';
 import Link from 'amo/components/Link';
 import { ADDON_TYPE_DICT, ADDON_TYPE_LANG } from 'core/constants';
-import { loadAddonResults } from 'core/reducers/addons';
 import {
-  createFakeAddon,
-  dispatchClientMetadata,
-  fakeAddon,
-} from 'tests/unit/amo/helpers';
+  getAllLanguageTools,
+  loadLanguageTools,
+} from 'core/reducers/languageTools';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import {
-  createFakeLanguageAddon,
+  createFakeLanguageTool,
   fakeI18n,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
@@ -23,48 +21,57 @@ import LoadingText from 'ui/components/LoadingText';
 
 
 describe(__filename, () => {
-  const addons = [
-    createFakeLanguageAddon({
+  const languageTools = [
+    createFakeLanguageTool({
+      id: 1,
       name: 'Scottish Language Pack (with Irn-Bru)',
       target_locale: 'en-GB',
       type: ADDON_TYPE_LANG,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 2,
       name: 'Old stuffy English',
       target_locale: 'en-GB',
       type: ADDON_TYPE_DICT,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 3,
       name: 'English Language Pack with Extra Us',
       target_locale: 'en-GB',
       type: ADDON_TYPE_LANG,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 4,
       name: 'Cool new English',
       target_locale: 'en-US',
       type: ADDON_TYPE_DICT,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 5,
       name: 'le French Dictionary',
       target_locale: 'fr',
       type: ADDON_TYPE_DICT,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 6,
       name: 'French Language Pack',
       target_locale: 'fr',
       type: ADDON_TYPE_LANG,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 7,
       name: 'اُردو',
       target_locale: 'ur',
       type: ADDON_TYPE_DICT,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 8,
       name: '正體中文 (繁體)',
       target_locale: 'zh-TW',
       type: ADDON_TYPE_LANG,
     }),
-    createFakeLanguageAddon({
+    createFakeLanguageTool({
+      id: 9,
       name: 'isiZulu',
       target_locale: 'zu',
       type: ADDON_TYPE_LANG,
@@ -82,27 +89,16 @@ describe(__filename, () => {
     );
   }
 
-  it('renders LoadingText if addons are not set', () => {
+  it('renders LoadingText if language tools are not set', () => {
     const root = renderShallow();
 
     expect(root.find(LoadingText)).not.toHaveLength(0);
   });
 
-  it('renders LoadingText if addons are empty', () => {
+  it('renders LoadingText if language tools are empty', () => {
     const { store } = dispatchClientMetadata();
-    store.dispatch(loadAddonResults({ addons: {} }));
-    const root = renderShallow({ store });
+    store.dispatch(loadLanguageTools({ languageTools: [] }));
 
-    expect(root.find(LoadingText)).not.toHaveLength(0);
-  });
-
-  it('renders LoadingText if there are addons but no language addons', () => {
-    const { store } = dispatchClientMetadata();
-    store.dispatch(loadAddonResults({
-      addons: {
-        [fakeAddon.slug]: createFakeAddon(fakeAddon),
-      },
-    }));
     const root = renderShallow({ store });
 
     expect(root.find(LoadingText)).not.toHaveLength(0);
@@ -110,7 +106,8 @@ describe(__filename, () => {
 
   it('renders language tools in your locale', () => {
     const { store } = dispatchClientMetadata({ lang: 'fr' });
-    store.dispatch(loadAddonResults({ addons }));
+    store.dispatch(loadLanguageTools({ languageTools }));
+
     const root = renderShallow({ store });
 
     const dictionary = root.find(
@@ -132,7 +129,8 @@ describe(__filename, () => {
 
   it('omits "language tools in your locale" section if none available', () => {
     const { store } = dispatchClientMetadata({ lang: 'pt-BR' });
-    store.dispatch(loadAddonResults({ addons }));
+    store.dispatch(loadLanguageTools({ languageTools }));
+
     const root = renderShallow({ store });
 
     expect(root.find('.LanguageTools-in-your-locale')).toHaveLength(0);
@@ -140,7 +138,8 @@ describe(__filename, () => {
 
   it('renders language packs in the table view for the right language', () => {
     const { store } = dispatchClientMetadata();
-    store.dispatch(loadAddonResults({ addons }));
+    store.dispatch(loadLanguageTools({ languageTools }));
+
     const root = renderShallow({ store });
 
     expect(root.find('.LanguageTools-lang-en-GB')).toHaveLength(1);
@@ -155,9 +154,10 @@ describe(__filename, () => {
     expect(root.find('.LanguageTools-lang-zu')).toHaveLength(1);
   });
 
-  it('renders multiple addons in a list using LanguageToolList', () => {
+  it('renders multiple language tools in a list using LanguageToolList', () => {
     const { store } = dispatchClientMetadata();
-    store.dispatch(loadAddonResults({ addons }));
+    store.dispatch(loadLanguageTools({ languageTools }));
+
     const root = renderShallow({ store });
 
     const dictionaryList = root
@@ -170,9 +170,10 @@ describe(__filename, () => {
     expect(languagePackList).toHaveLength(1);
   });
 
-  it('does not render languages we know of but do not have addons for', () => {
+  it('does not render languages we know of but do not have languages for', () => {
     const { store } = dispatchClientMetadata();
-    store.dispatch(loadAddonResults({ addons }));
+    store.dispatch(loadLanguageTools({ languageTools }));
+
     const root = renderShallow({ store });
 
     expect(root.find('.LanguageTools-lang-es')).toHaveLength(0);
@@ -181,24 +182,25 @@ describe(__filename, () => {
   describe('LanguageToolList', () => {
     it('renders a LanguageToolList', () => {
       const { store } = dispatchClientMetadata({ lang: 'en-GB' });
-      store.dispatch(loadAddonResults({ addons }));
-      const languageTools = mapStateToProps(store.getState()).addons;
+      store.dispatch(loadLanguageTools({ languageTools }));
 
-      const languageToolsInYourLocale = languageTools.filter((addon) => {
-        return addon.target_locale === store.getState().api.lang;
+      const allLanguageTools = getAllLanguageTools(store.getState());
+
+      const languageToolsInYourLocale = allLanguageTools.filter((languageTool) => {
+        return languageTool.target_locale === store.getState().api.lang;
       });
-      const dictionaries = languageToolsInYourLocale.filter((addon) => {
-        return addon.type === ADDON_TYPE_DICT;
+      const dictionaries = languageToolsInYourLocale.filter((languageTool) => {
+        return languageTool.type === ADDON_TYPE_DICT;
       });
-      const languagePacks = languageToolsInYourLocale.filter((addon) => {
-        return addon.type === ADDON_TYPE_LANG;
+      const languagePacks = languageToolsInYourLocale.filter((languageTool) => {
+        return languageTool.type === ADDON_TYPE_LANG;
       });
 
       const dictionaryList = shallow(
-        <LanguageToolList addons={dictionaries} />
+        <LanguageToolList languageTools={dictionaries} />
       );
       const languagePackList = shallow(
-        <LanguageToolList addons={languagePacks} />
+        <LanguageToolList languageTools={languagePacks} />
       );
 
       expect(dictionaryList.find('.LanguageTools-addon-list'))
@@ -211,7 +213,7 @@ describe(__filename, () => {
   });
 
   it('renders nothing if addons are null', () => {
-    const root = shallow(<LanguageToolList addons={null} />);
+    const root = shallow(<LanguageToolList languageTools={null} />);
 
     expect(root.find('.LanguageTools-addon-list')).toHaveLength(0);
     expect(root.find('title')).toHaveLength(0);
@@ -219,7 +221,8 @@ describe(__filename, () => {
 
   it('renders an HTML title', () => {
     const { store } = dispatchClientMetadata({ lang: 'pt-BR' });
-    store.dispatch(loadAddonResults({ addons }));
+    store.dispatch(loadLanguageTools({ languageTools }));
+
     const root = renderShallow({ store });
 
     expect(root.find('title')).toHaveText('Dictionaries and Language Packs');

--- a/tests/unit/amo/test_store.js
+++ b/tests/unit/amo/test_store.js
@@ -18,6 +18,7 @@ describe('amo createStore', () => {
       'infoDialog',
       'installations',
       'landing',
+      'languageTools',
       'redirectTo',
       'reduxAsyncConnect',
       'reviews',

--- a/tests/unit/core/api/test_languageTools.js
+++ b/tests/unit/core/api/test_languageTools.js
@@ -6,7 +6,7 @@ import {
 } from 'tests/unit/amo/helpers';
 import {
   createApiResponse,
-  createFakeLanguageAddon,
+  createFakeLanguageTool,
 } from 'tests/unit/helpers';
 
 
@@ -20,7 +20,7 @@ describe(__filename, () => {
   describe('languageTools API', () => {
     function mockResponse() {
       return createApiResponse({
-        jsonData: { results: [createFakeLanguageAddon()] },
+        jsonData: { results: [createFakeLanguageTool()] },
       });
     }
 
@@ -44,7 +44,7 @@ describe(__filename, () => {
       const languageToolsResponse = await languageTools({ api: apiState });
       const jsonResponse = await languageToolsResponse.json();
 
-      expect(jsonResponse).toEqual({ results: [createFakeLanguageAddon()] });
+      expect(jsonResponse).toEqual({ results: [createFakeLanguageTool()] });
 
       mockApi.verify();
     });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -4,7 +4,6 @@ import {
 import addons, {
   createInternalAddon,
   fetchAddon,
-  fetchLanguageTools,
   getGuid,
   loadAddons,
   loadAddonResults,
@@ -413,14 +412,6 @@ describe(__filename, () => {
       const example = { thing: undefined };
       removeUndefinedProps(example);
       expect(example).toEqual({ thing: undefined });
-    });
-  });
-
-  describe('fetchLanguageTools', () => {
-    it('requires an errorHandlerId', () => {
-      expect(() => {
-        fetchLanguageTools();
-      }).toThrow('errorHandlerId is required');
     });
   });
 

--- a/tests/unit/core/reducers/test_languageTools.js
+++ b/tests/unit/core/reducers/test_languageTools.js
@@ -1,0 +1,72 @@
+import reducer, {
+  fetchLanguageTools,
+  getAllLanguageTools,
+  initialState,
+  loadLanguageTools,
+} from 'core/reducers/languageTools';
+import { createFakeLanguageTool } from 'tests/unit/helpers';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  it('initializes properly', () => {
+    const state = reducer(undefined, {});
+
+    expect(state).toEqual(initialState);
+  });
+
+  it('stores language tools', () => {
+    const language = createFakeLanguageTool();
+    const state = reducer(undefined, loadLanguageTools({
+      languageTools: [language],
+    }));
+
+    expect(state).toEqual({
+      byID: {
+        [language.id]: language,
+      },
+    });
+  });
+
+  it('ignores unrelated actions', () => {
+    const language = createFakeLanguageTool();
+    const firstState = reducer(undefined, loadLanguageTools({
+      languageTools: [language],
+    }));
+
+    expect(reducer(firstState, { type: 'UNRELATED_ACTION' }))
+      .toEqual(firstState);
+  });
+
+  describe('fetchLanguageTools', () => {
+    it('requires an errorHandlerId', () => {
+      expect(() => {
+        fetchLanguageTools();
+      }).toThrow('errorHandlerId is required');
+    });
+  });
+
+  describe('loadLanguageTools', () => {
+    it('requires language tools', () => {
+      expect(() => {
+        loadLanguageTools();
+      }).toThrow('languageTools are required');
+    });
+  });
+
+  describe('getAllLanguageTools', () => {
+    it('returns an empty array when no languages are stored', () => {
+      const { state } = dispatchClientMetadata();
+
+      expect(getAllLanguageTools(state)).toEqual([]);
+    });
+
+    it('returns an array of languages', () => {
+      const language = createFakeLanguageTool();
+      const { store } = dispatchClientMetadata();
+      store.dispatch(loadLanguageTools({ languageTools: [language] }));
+
+      expect(getAllLanguageTools(store.getState())).toEqual([language]);
+    });
+  });
+});

--- a/tests/unit/core/sagas/testLanguageTools.js
+++ b/tests/unit/core/sagas/testLanguageTools.js
@@ -7,7 +7,7 @@ import languageToolsReducer, {
 } from 'core/reducers/languageTools';
 import apiReducer from 'core/reducers/api';
 import languageToolsSaga from 'core/sagas/languageTools';
-import { dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import {
   createFakeLanguageTool,
   createStubErrorHandler,

--- a/tests/unit/core/sagas/testLanguageTools.js
+++ b/tests/unit/core/sagas/testLanguageTools.js
@@ -1,15 +1,15 @@
 import SagaTester from 'redux-saga-tester';
 
 import * as api from 'core/api/languageTools';
-import addonsReducer, {
+import languageToolsReducer, {
   fetchLanguageTools,
-  loadAddonResults,
-} from 'core/reducers/addons';
+  loadLanguageTools,
+} from 'core/reducers/languageTools';
 import apiReducer from 'core/reducers/api';
 import languageToolsSaga from 'core/sagas/languageTools';
 import { dispatchClientMetadata, fakeAddon } from 'tests/unit/amo/helpers';
 import {
-  createFakeLanguageAddon,
+  createFakeLanguageTool,
   createStubErrorHandler,
 } from 'tests/unit/helpers';
 
@@ -26,15 +26,14 @@ describe(__filename, () => {
       initialState: dispatchClientMetadata().state,
       reducers: {
         api: apiReducer,
-        addons: addonsReducer,
+        languageTools: languageToolsReducer,
       },
     });
     sagaTester.start(languageToolsSaga);
   });
 
   it('calls the API for language tools', async () => {
-    const addon = { ...fakeAddon, slug: 'fancy' };
-    const response = { results: createFakeLanguageAddon({ addon }) };
+    const response = { results: [createFakeLanguageTool()] };
 
     mockApi
       .expects('languageTools')
@@ -46,7 +45,9 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
     }));
 
-    const expectedLoadAction = loadAddonResults({ addons: response.results });
+    const expectedLoadAction = loadLanguageTools({
+      languageTools: response.results,
+    });
 
     await sagaTester.waitFor(expectedLoadAction.type);
     mockApi.verify();

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -362,16 +362,14 @@ export function createFakeAddonAbuseReport({
   };
 }
 
-export function createFakeLanguageAddon({
-  addon = fakeAddon,
-  ...otherProps
-} = {}) {
+export function createFakeLanguageTool(otherProps = {}) {
   return {
-    id: addon.id,
-    current_version: addon.current_version,
+    id: fakeAddon.id,
+    current_version: fakeAddon.current_version,
     default_locale: 'en-US',
+    guid: fakeAddon.guid,
     locale_disambiguation: '',
-    name: addon.name,
+    name: fakeAddon.name,
     target_locale: 'ach',
     type: ADDON_TYPE_LANG,
     url: 'https://addons.allizom.org/en-US/firefox/addon/acholi-ug-lp-test',


### PR DESCRIPTION
Fix #3939

---

This PR introduces a `languageTools` reducer because the language tools and search APIs return different results, hence the data sets should be separated.