### PR TITLE
Use exclusion filter to retrieve other add-ons by authors

### DIFF
--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -116,9 +116,6 @@ const reducer = (
         byAddonSlug: {
           ...state.byAddonSlug,
           [action.payload.slug]: action.payload.addons
-            // This ensures we do not display the main add-on in the list of
-            // "add-ons by these authors".
-            .filter((addon) => addon.slug !== action.payload.slug)
             .slice(0, OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE)
             .map((addon) => createInternalAddon(addon)),
         },

--- a/src/amo/sagas/addonsByAuthors.js
+++ b/src/amo/sagas/addonsByAuthors.js
@@ -24,9 +24,8 @@ export function* fetchOtherAddonsByAuthors({ payload }) {
       filters: {
         addonType,
         author: authors.join(','),
-        // We need one more add-on than the number to display because the API
-        // may return the main add-on and we cannot tell the API to exclude it.
-        page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 1,
+        exclude_addons: slug,
+        page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
         sort: SEARCH_SORT_TRENDING,
       },
     });

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -19,6 +19,7 @@ export const paramsToFilter = {
   appversion: 'compatibleWithVersion',
   author: 'author',
   category: 'category',
+  exclude_addons: 'exclude_addons',
   featured: 'featured',
   page: 'page',
   // TODO: Change our filter to `pageSize`, for consistency.

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -47,16 +47,6 @@ describe(__filename, () => {
       });
     });
 
-    it('excludes the main add-on from the list of add-ons', () => {
-      const state = reducer(undefined, loadOtherAddonsByAuthors({
-        slug: fakeAddon.slug,
-        addons: [fakeAddon],
-      }));
-      expect(state.byAddonSlug).toEqual({
-        [fakeAddon.slug]: [],
-      });
-    });
-
     it('always ensures the page size is consistent', () => {
       const slug = 'addon-slug';
       const state = reducer(undefined, loadOtherAddonsByAuthors({

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -59,7 +59,8 @@ describe(__filename, () => {
         filters: {
           addonType: ADDON_TYPE_THEME,
           author: authors.join(','),
-          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 1,
+          exclude_addons: slug,
+          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,
         },
       })
@@ -114,7 +115,8 @@ describe(__filename, () => {
         filters: {
           addonType: ADDON_TYPE_THEME,
           author: authors.join(','),
-          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 1,
+          exclude_addons: slug,
+          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,
         },
       })


### PR DESCRIPTION
Fix #3119

---

This PR cleans up the way we fetch the other add-ons by authors.