### PR TITLE
chore: Send params to TAAR (fix #3804)

### DIFF
--- a/src/disco/actions.js
+++ b/src/disco/actions.js
@@ -1,14 +1,18 @@
 import { GET_DISCO_RESULTS, LOAD_DISCO_RESULTS } from 'disco/constants';
 
 export function getDiscoResults({
-  errorHandlerId, telemetryClientId = undefined,
+  errorHandlerId, platform, telemetryClientId = undefined,
 } = {}) {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
+  if (!platform) {
+    throw new Error('platform is required');
+  }
+
   return {
     type: GET_DISCO_RESULTS,
-    payload: { errorHandlerId, telemetryClientId },
+    payload: { errorHandlerId, platform, telemetryClientId },
   };
 }
 

--- a/src/disco/api.js
+++ b/src/disco/api.js
@@ -11,10 +11,13 @@ export const discoResult = new schema.Entity(
   { idAttribute: (result) => getGuid(result.addon) }
 );
 
-export function getDiscoveryAddons({ api, telemetryClientId }) {
+export function getDiscoveryAddons({ api, platform, telemetryClientId }) {
   return callApi({
     endpoint: 'discovery',
-    params: { 'telemetry-client-id': telemetryClientId },
+    params: {
+      platform,
+      'telemetry-client-id': telemetryClientId,
+    },
     schema: { results: [discoResult] },
     state: api,
   });

--- a/src/disco/containers/DiscoPane.js
+++ b/src/disco/containers/DiscoPane.js
@@ -33,6 +33,9 @@ export class DiscoPaneBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     mozAddonManager: PropTypes.object,
+    params: {
+      platform: PropTypes.string.isRequired,
+    },
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     _addChangeListeners: PropTypes.func,
     _tracking: PropTypes.object,
@@ -51,7 +54,13 @@ export class DiscoPaneBase extends React.Component {
     super(props);
     this.state = { showVideo: false };
 
-    const { dispatch, errorHandler, location, results } = props;
+    const {
+      dispatch,
+      errorHandler,
+      location,
+      params,
+      results,
+    } = props;
     // TODO: fix this; it's not the right way to detect whether a
     // dispatch is needed. This should look for an undefined value
     // instead of an empty list because an empty list could be a valid
@@ -59,6 +68,7 @@ export class DiscoPaneBase extends React.Component {
     if (!errorHandler.hasError() && !results.length) {
       dispatch(getDiscoResults({
         errorHandlerId: errorHandler.id,
+        platform: params.platform,
         telemetryClientId: location.query.clientId,
       }));
     }

--- a/src/disco/sagas/disco.js
+++ b/src/disco/sagas/disco.js
@@ -13,13 +13,13 @@ import { getDiscoveryAddons } from 'disco/api';
 
 
 export function* fetchDiscoveryAddons({
-  payload: { errorHandlerId, telemetryClientId },
+  payload: { errorHandlerId, platform, telemetryClientId },
 }) {
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
     const state = yield select(getState);
     const { entities, result } = yield call(getDiscoveryAddons, {
-      api: state.api, telemetryClientId,
+      api: state.api, platform, telemetryClientId,
     });
 
     yield put(loadAddons(entities));

--- a/tests/unit/disco/containers/TestDiscoPane.js
+++ b/tests/unit/disco/containers/TestDiscoPane.js
@@ -67,6 +67,7 @@ describe(__filename, () => {
       dispatch: sinon.stub(),
       i18n,
       location: { query: {} },
+      params: { platform: 'Darwin' },
       results,
       _tracking: fakeTracking,
       _video: fakeVideo,
@@ -75,7 +76,9 @@ describe(__filename, () => {
   }
 
   function render(props = {}) {
-    return shallow(<DiscoPaneBase {...renderProps(props)} />);
+    return shallow(<DiscoPaneBase {...renderProps(props)} />, {
+      params: { platform: 'Darwin' },
+    });
   }
 
   function renderAndMount(customProps = {}) {
@@ -208,7 +211,9 @@ describe(__filename, () => {
       render({ errorHandler, dispatch, ...props });
 
       sinon.assert.calledWith(dispatch, getDiscoResults({
-        errorHandlerId: errorHandler.id, telemetryClientId: undefined,
+        errorHandlerId: errorHandler.id,
+        platform: 'Darwin',
+        telemetryClientId: undefined,
       }));
     });
 
@@ -227,6 +232,7 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(dispatch, getDiscoResults({
         errorHandlerId: errorHandler.id,
+        platform: 'Darwin',
         telemetryClientId: location.query.clientId,
       }));
     });

--- a/tests/unit/disco/sagas/testDisco.js
+++ b/tests/unit/disco/sagas/testDisco.js
@@ -40,6 +40,7 @@ describe(__filename, () => {
     function _getDiscoResults(overrides = {}) {
       sagaTester.dispatch(getDiscoResults({
         errorHandlerId: errorHandler.id,
+        platform: 'Darwin',
         ...overrides,
       }));
     }
@@ -66,7 +67,11 @@ describe(__filename, () => {
       const addonResponse = createFetchDiscoveryResult([addon1, addon2]);
       mockApi
         .expects('getDiscoveryAddons')
-        .withArgs({ api: apiState, telemetryClientId: undefined })
+        .withArgs({
+          api: apiState,
+          platform: 'Darwin',
+          telemetryClientId: undefined,
+        })
         .returns(Promise.resolve(addonResponse));
 
       const { entities, result } = addonResponse;
@@ -94,7 +99,11 @@ describe(__filename, () => {
 
       mockApi
         .expects('getDiscoveryAddons')
-        .withArgs({ api: apiState, telemetryClientId })
+        .withArgs({
+          api: apiState,
+          platform: 'Darwin',
+          telemetryClientId,
+        })
         .returns(Promise.resolve(addonResponse));
 
       const { entities, result } = addonResponse;

--- a/tests/unit/disco/test_actions.js
+++ b/tests/unit/disco/test_actions.js
@@ -31,14 +31,27 @@ describe('disco/actions/loadDiscoResults', () => {
 
 describe('disco/actions/getDiscoResults', () => {
   function defaultParams() {
-    return { errorHandlerId: 'some-id', telemetryClientId: 'client-id' };
+    return {
+      errorHandlerId: 'some-id',
+      platform: 'Darwin',
+      telemetryClientId: 'client-id',
+    };
   }
 
   it('requires errorHandlerId', () => {
     const params = defaultParams();
     delete params.errorHandlerId;
-    expect(() => getDiscoResults(params))
-      .toThrow(/errorHandlerId is required/);
+    expect(() => {
+      getDiscoResults(params);
+    }).toThrow(/errorHandlerId is required/);
+  });
+
+  it('requires platform', () => {
+    const params = defaultParams();
+    delete params.platform;
+    expect(() => {
+      getDiscoResults(params);
+    }).toThrow(/platform is required/);
   });
 
   it('adds errorHandlerId to the payload', () => {

--- a/tests/unit/disco/test_api.js
+++ b/tests/unit/disco/test_api.js
@@ -17,11 +17,11 @@ describe(__filename, () => {
 
   describe('getDiscoveryAddons', () => {
     it('calls the API', () => {
-      getDiscoveryAddons({ api: apiState });
+      getDiscoveryAddons({ api: apiState, platform: 'Windows' });
 
       sinon.assert.calledWith(callApiMock, {
         endpoint: 'discovery',
-        params: { 'telemetry-client-id': undefined },
+        params: { platform: 'Windows', 'telemetry-client-id': undefined },
         schema: { results: [discoResult] },
         state: apiState,
       });
@@ -29,11 +29,18 @@ describe(__filename, () => {
 
     it('calls the API with a telemetry client ID', () => {
       const telemetryClientId = 'client-id';
-      getDiscoveryAddons({ api: apiState, telemetryClientId });
+      getDiscoveryAddons({
+        api: apiState,
+        platform: 'Darwin',
+        telemetryClientId,
+      });
 
       sinon.assert.calledWith(callApiMock, {
         endpoint: 'discovery',
-        params: { 'telemetry-client-id': telemetryClientId },
+        params: {
+          platform: 'Darwin',
+          'telemetry-client-id': telemetryClientId,
+        },
         schema: { results: [discoResult] },
         state: apiState,
       });


### PR DESCRIPTION
Fix #3804.

These tests are quite old so this patch is pretty meh... I didn't want to spend a lot of time fixing up the tests because it'd be a PITA to review and I need to start on the user pages... there aren't actually many more weeks to this quarter 😓

The lang is already sent to the API so this just adds the platform sent to the Disco Pane to the API request, which addons-server will send to TAAR.