### PR TITLE
Link to the root of the status site

### DIFF
--- a/src/amo/components/Footer/index.js
+++ b/src/amo/components/Footer/index.js
@@ -75,7 +75,7 @@ export class FooterBase extends React.Component {
                   {i18n.gettext('Review Guide')}
                 </Link>
               </li>
-              <li><a href="https://status.mozilla.org/#addons.mozilla.org_service_history">{i18n.gettext('Site Status')}</a></li>
+              <li><a href="https://status.mozilla.org/">{i18n.gettext('Site Status')}</a></li>
               <li>
                 <a
                   href="#desktop"


### PR DESCRIPTION
Fixes #3972

Linking with the fragment id messes up the status site's history because it seems to eat the fragment. Also the fragment isn't doing anything to show the status for add-ons so we may as well just link to the root of the status site.