### PR TITLE
Use different datadog keys per count/timing (for stats)

### DIFF
--- a/src/core/middleware/datadogTiming.js
+++ b/src/core/middleware/datadogTiming.js
@@ -27,11 +27,11 @@ export const datadogTiming = ({
     // TODO: generate a key based on the rendered component, which
     // I think is in server/base.js -> match() -> renderProps.components
 
-    client.increment(`response_code.${res.statusCode}`);
+    client.increment(`response_code.${res.statusCode}.count`);
 
     const responseTypeKey = `response.${req.method}`;
-    client.increment(responseTypeKey);
+    client.increment(`${responseTypeKey}.count`);
     // The time variable is response time in milleseconds.
-    client.timing(responseTypeKey, time);
+    client.timing(`${responseTypeKey}.time`, time);
   });
 };

--- a/tests/unit/core/middleware/test_datadogTiming.js
+++ b/tests/unit/core/middleware/test_datadogTiming.js
@@ -75,7 +75,7 @@ describe(__filename, () => {
       await testClient().get('/').end();
 
       sinon.assert.calledWith(
-        hotShotsClient.timing, 'response.GET', sinon.match.number,
+        hotShotsClient.timing, 'response.GET.time', sinon.match.number,
       );
     });
 
@@ -83,7 +83,7 @@ describe(__filename, () => {
       await testClient().post('/en-US/firefox/something/', {}).end();
 
       sinon.assert.calledWith(
-        hotShotsClient.timing, 'response.POST', sinon.match.number,
+        hotShotsClient.timing, 'response.POST.time', sinon.match.number,
       );
     });
 
@@ -91,7 +91,7 @@ describe(__filename, () => {
       await testClient().get('/').end();
 
       sinon.assert.calledWith(
-        hotShotsClient.increment, 'response.GET',
+        hotShotsClient.increment, 'response.GET.count',
       );
     });
 
@@ -99,7 +99,7 @@ describe(__filename, () => {
       await testClient().post('/en-US/firefox/something/', {}).end();
 
       sinon.assert.calledWith(
-        hotShotsClient.increment, 'response.POST',
+        hotShotsClient.increment, 'response.POST.count',
       );
     });
 
@@ -107,7 +107,7 @@ describe(__filename, () => {
       await testClient().get('/').end();
 
       sinon.assert.calledWith(
-        hotShotsClient.increment, 'response_code.302',
+        hotShotsClient.increment, 'response_code.302.count',
       );
     });
   });


### PR DESCRIPTION
Follow up to https://github.com/mozilla/addons-frontend/issues/3755

The timing and count stats need to have different keys.