### PR TITLE
Add moment to the NSP exclusions list

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,7 +2,7 @@
   "exceptions": [
     // https://github.com/mozilla/addons-frontend/issues/3195
     "https://nodesecurity.io/advisories/525",
-    // https://github.com/moment/moment/issues/4163
+    // https://github.com/mozilla/addons-frontend/issues/3989
     "https://nodesecurity.io/advisories/532"
   ]
 }

--- a/.nsprc
+++ b/.nsprc
@@ -1,6 +1,8 @@
 {
   "exceptions": [
     // https://github.com/mozilla/addons-frontend/issues/3195
-    "https://nodesecurity.io/advisories/525"
+    "https://nodesecurity.io/advisories/525",
+    // https://github.com/moment/moment/issues/4163
+    "https://nodesecurity.io/advisories/532"
   ]
 }


### PR DESCRIPTION
Refs #3989

Since there is no fix yet, we add an exclusion entry so that next builds can pass.