### PR TITLE
Ensure history is defined in the store while testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -33,6 +33,10 @@ module.exports = {
     '**/[Tt]est(*).js?(x)',
     '**/__tests__/**/*.js?(x)',
   ],
+  // This will initialize the jsdom document with a URL which is necessary
+  // for History push state to work.
+  // See https://github.com/ReactTraining/react-router/issues/5030
+  testURL: 'http://localhost/',
   transform: {
     '^.+\\.js$': 'babel-jest',
     // This transforms images to be a module that exports the filename.

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -1,5 +1,6 @@
 import { createStore as _createStore, combineReducers } from 'redux';
 import createSagaMiddleware from 'redux-saga';
+import { browserHistory } from 'react-router';
 import { routerMiddleware, routerReducer as routing } from 'react-router-redux';
 
 import addonsByAuthors from 'amo/reducers/addonsByAuthors';
@@ -25,7 +26,9 @@ import user from 'core/reducers/user';
 import { middleware } from 'core/store';
 
 
-export default function createStore(history, initialState = {}) {
+export default function createStore({
+  history = browserHistory, initialState = {},
+} = {}) {
   const sagaMiddleware = createSagaMiddleware();
   const store = _createStore(
     combineReducers({

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -51,7 +51,9 @@ export default function makeClient(
       }
     }
 
-    const { sagaMiddleware, store } = createStore(browserHistory, initialState);
+    const { sagaMiddleware, store } = createStore({
+      history: browserHistory, initialState,
+    });
     const history = syncHistoryWithStore(browserHistory, store);
 
     if (sagas && sagaMiddleware) {

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -90,7 +90,7 @@ function renderHTML({ props = {}, pageProps }) {
 
 function showErrorPage({ createStore, error = {}, req, res, status, config }) {
   const memoryHistory = createMemoryHistory(req.url);
-  const { store } = createStore(memoryHistory);
+  const { store } = createStore({ history: memoryHistory });
   const pageProps = getPageProps({ store, req, res, config });
 
   const componentDeclaredStatus = NestedStatus.rewind();
@@ -237,7 +237,9 @@ function baseServer(routes, createStore, {
     res.vary('DNT');
 
     const memoryHistory = createMemoryHistory(req.url);
-    const { sagaMiddleware, store } = createStore(memoryHistory);
+    const { sagaMiddleware, store } = createStore({
+      history: memoryHistory,
+    });
     const history = syncHistoryWithStore(memoryHistory, store);
 
     match({ history, location: req.url, routes }, async (

--- a/src/disco/store.js
+++ b/src/disco/store.js
@@ -1,5 +1,6 @@
 import { createStore as _createStore, combineReducers } from 'redux';
 import createSagaMiddleware from 'redux-saga';
+import { browserHistory } from 'react-router';
 import { routerMiddleware, routerReducer as routing } from 'react-router-redux';
 
 import { middleware } from 'core/store';
@@ -13,7 +14,9 @@ import discoResults from 'disco/reducers/discoResults';
 import redirectTo from 'core/reducers/redirectTo';
 
 
-export default function createStore(history, initialState = {}) {
+export default function createStore({
+  history = browserHistory, initialState = {},
+} = {}) {
   const sagaMiddleware = createSagaMiddleware();
   const store = _createStore(
     combineReducers({

--- a/tests/unit/amo/components/TestLanguagePicker.js
+++ b/tests/unit/amo/components/TestLanguagePicker.js
@@ -18,7 +18,7 @@ import { fakeI18n } from 'tests/unit/helpers';
 describe('LanguagePicker', () => {
   function renderLanguagePicker({ ...props }) {
     const initialState = { api: { clientApp: 'android', lang: 'fr' } };
-    const { store } = createStore(initialState);
+    const { store } = createStore({ initialState });
 
     return findRenderedComponentWithType(renderIntoDocument(
       <Provider store={store}>

--- a/tests/unit/amo/components/TestSearchResults.js
+++ b/tests/unit/amo/components/TestSearchResults.js
@@ -16,7 +16,7 @@ import { fakeI18n } from 'tests/unit/helpers';
 describe('<SearchResults />', () => {
   function renderResults(props) {
     const initialState = { api: { clientApp: 'android', lang: 'en-GB' } };
-    const { store } = createStore(initialState);
+    const { store } = createStore({ initialState });
 
     return findRenderedComponentWithType(render(
       <Provider store={store}>


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4013

I ran into this while trying to hook up the redux-router to some tests using the new react patch (https://github.com/mozilla/addons-frontend/pull/3975). This PR doesn't solve any immediate problems but adds a few things:

- prepares us for testing with `redux-router` in the future
- switches to object params in `createStore()` which will make `undefined` variables less confusing. Before this patch I was getting `TypeError: Cannot read property 'push' of undefined` which was hard to track down.