### PR TITLE
Fix the way we detect IDs (integer) in slugs

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -102,7 +102,7 @@ export class AddonBase extends React.Component {
     // of an error.
     if (!errorHandler.hasError()) {
       if (addon) {
-        if (Number.isInteger(params.slug)) {
+        if (!isNaN(params.slug)) {
           // We only load add-ons by slug, but ID must be supported too because
           // it is a legacy behavior.
           dispatch(sendServerRedirect({
@@ -597,7 +597,7 @@ export function mapStateToProps(state, ownProps) {
 
   // It is possible to load an add-on by its ID but in the routing parameters,
   // the parameter is always named `slug`.
-  if (slug && Number.isInteger(slug)) {
+  if (slug && !isNaN(slug)) {
     addon = getAddonByID(state, slug);
   }
 

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -440,6 +440,25 @@ describe(__filename, () => {
     sinon.assert.callCount(fakeDispatch, 1);
   });
 
+  it('dispatches a server redirect when slug is a stringified integer', () => {
+    const clientApp = CLIENT_APP_FIREFOX;
+    const { store } = dispatchClientMetadata({ clientApp });
+    const addon = createInternalAddon(fakeAddon);
+    store.dispatch(_loadAddons({ addon }));
+
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+    renderComponent({
+      // We set the numeric `id` as slug, casted as a string.
+      params: { slug: `${addon.id}` }, store,
+    });
+
+    sinon.assert.calledWith(fakeDispatch, sendServerRedirect({
+      status: 301,
+      url: `/en-US/${clientApp}/addon/${addon.slug}/`,
+    }));
+    sinon.assert.callCount(fakeDispatch, 1);
+  });
+
   it('sanitizes a title', () => {
     const root = shallowRender({
       addon: createInternalAddon({


### PR DESCRIPTION
Fix #3610

---

In a previous PR, I thought `Number.isInteger` was more readable and explicit but it turns out it does not parse stringified numbers. I reverted the changes to use `!isNaN` and provided a test case.