### PR TITLE
Expand state for user collections

### DIFF
--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -48,3 +48,22 @@ export const getCollectionAddons = (
     state: api,
   });
 };
+
+type ListCollectionsParams = {|
+  api: ApiStateType,
+  user: string | number,
+|};
+
+export const listCollections = (
+  { api, user }: ListCollectionsParams
+) => {
+  if (!user) {
+    throw new Error('The user parameter is required');
+  }
+
+  return callApi({
+    auth: true,
+    endpoint: `accounts/account/${user}/collections`,
+    state: api,
+  });
+};

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -7,7 +7,7 @@ import { compose } from 'redux';
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
 import {
-  fetchCollection,
+  fetchCurrentCollection,
   fetchCurrentCollectionPage,
 } from 'amo/reducers/collections';
 import NotFound from 'amo/components/ErrorPage/NotFound';
@@ -97,7 +97,7 @@ export class CollectionBase extends React.Component<Props> {
     }
 
     if (!collection || collectionChanged) {
-      this.props.dispatch(fetchCollection({
+      this.props.dispatch(fetchCurrentCollection({
         errorHandlerId: errorHandler.id,
         page: parsePage(location.query.page),
         slug: params.slug,

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -217,9 +217,13 @@ export class CollectionBase extends React.Component<Props> {
 export const mapStateToProps = (
   state: {| collections: CollectionsState, user: UserStateType |}
 ) => {
-  const { current: collection, loading } = state.collections;
+  const { id: collectionId, loading } = state.collections.current;
 
   let hasEditPermission = false;
+  let collection;
+  if (collectionId) {
+    collection = state.collections.byId[collectionId];
+  }
 
   if (collection) {
     hasEditPermission = collection.authorId === state.user.id ||

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -8,7 +8,7 @@ import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
 import {
   fetchCollection,
-  fetchCollectionPage,
+  fetchCurrentCollectionPage,
 } from 'amo/reducers/collections';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import { COLLECTIONS_EDIT } from 'core/constants';
@@ -108,7 +108,7 @@ export class CollectionBase extends React.Component<Props> {
     }
 
     if (collection && addonsPageChanged) {
-      this.props.dispatch(fetchCollectionPage({
+      this.props.dispatch(fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         page: parsePage(location.query.page),
         slug: params.slug,

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -9,6 +9,7 @@ import Link from 'amo/components/Link';
 import {
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
+  getCurrentCollection,
 } from 'amo/reducers/collections';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import { COLLECTIONS_EDIT } from 'core/constants';
@@ -217,14 +218,11 @@ export class CollectionBase extends React.Component<Props> {
 export const mapStateToProps = (
   state: {| collections: CollectionsState, user: UserStateType |}
 ) => {
-  const { id: collectionId, loading } = state.collections.current;
+  const { loading } = state.collections.current;
 
   let hasEditPermission = false;
-  let collection;
-  if (collectionId) {
-    collection = state.collections.byId[collectionId];
-  }
 
+  const collection = getCurrentCollection(state.collections);
   if (collection) {
     hasEditPermission = collection.authorId === state.user.id ||
       hasPermission(state, COLLECTIONS_EDIT);

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -2,14 +2,15 @@
 import { createInternalAddon } from 'core/reducers/addons';
 import type { AddonType, ExternalAddonType } from 'core/types/addons';
 
-export const FETCH_COLLECTION: 'FETCH_COLLECTION' = 'FETCH_COLLECTION';
+export const FETCH_CURRENT_COLLECTION: 'FETCH_CURRENT_COLLECTION'
+  = 'FETCH_CURRENT_COLLECTION';
 export const LOAD_COLLECTION: 'LOAD_COLLECTION' = 'LOAD_COLLECTION';
 export const FETCH_CURRENT_COLLECTION_PAGE: 'FETCH_CURRENT_COLLECTION_PAGE'
   = 'FETCH_CURRENT_COLLECTION_PAGE';
 export const LOAD_COLLECTION_PAGE: 'LOAD_COLLECTION_PAGE'
   = 'LOAD_COLLECTION_PAGE';
-export const ABORT_FETCH_COLLECTION: 'ABORT_FETCH_COLLECTION'
-  = 'ABORT_FETCH_COLLECTION';
+export const ABORT_FETCH_CURRENT_COLLECTION: 'ABORT_FETCH_CURRENT_COLLECTION'
+  = 'ABORT_FETCH_CURRENT_COLLECTION';
 
 export type CollectionType = {
   addons: Array<AddonType>,
@@ -45,24 +46,24 @@ export const initialState: CollectionsState = {
   current: { id: null, loading: false },
 };
 
-type FetchCollectionParams = {|
+type FetchCurrentCollectionParams = {|
   errorHandlerId: string,
   page?: number,
   slug: string,
   user: number | string,
 |};
 
-type FetchCollectionAction = {|
-  type: typeof FETCH_COLLECTION,
-  payload: FetchCollectionParams,
+type FetchCurrentCollectionAction = {|
+  type: typeof FETCH_CURRENT_COLLECTION,
+  payload: FetchCurrentCollectionParams,
 |};
 
-export const fetchCollection = ({
+export const fetchCurrentCollection = ({
   errorHandlerId,
   page,
   slug,
   user,
-}: FetchCollectionParams = {}): FetchCollectionAction => {
+}: FetchCurrentCollectionParams = {}): FetchCurrentCollectionAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
@@ -74,13 +75,13 @@ export const fetchCollection = ({
   }
 
   return {
-    type: FETCH_COLLECTION,
+    type: FETCH_CURRENT_COLLECTION,
     payload: { errorHandlerId, page, slug, user },
   };
 };
 
 type FetchCurrentCollectionPageParams = {|
-  ...FetchCollectionParams,
+  ...FetchCurrentCollectionParams,
   page: number,
 |};
 
@@ -195,12 +196,12 @@ export const loadCollectionPage = ({
   };
 };
 
-type AbortFetchCollection = {|
-  type: typeof ABORT_FETCH_COLLECTION,
+type AbortFetchCurrentCollection = {|
+  type: typeof ABORT_FETCH_CURRENT_COLLECTION,
 |};
 
-export const abortFetchCollection = (): AbortFetchCollection => {
-  return { type: ABORT_FETCH_COLLECTION };
+export const abortFetchCurrentCollection = (): AbortFetchCurrentCollection => {
+  return { type: ABORT_FETCH_CURRENT_COLLECTION };
 };
 
 type CreateInternalCollectionParams = {|
@@ -234,11 +235,11 @@ export const createInternalCollection = ({
 });
 
 type Action =
-  | FetchCollectionAction
+  | FetchCurrentCollectionAction
   | LoadCollectionAction
   | FetchCurrentCollectionPageAction
   | LoadCollectionPageAction
-  | AbortFetchCollection
+  | AbortFetchCurrentCollection
 ;
 
 const reducer = (
@@ -246,7 +247,7 @@ const reducer = (
   action: Action
 ): CollectionsState => {
   switch (action.type) {
-    case FETCH_COLLECTION:
+    case FETCH_CURRENT_COLLECTION:
       return {
         ...state,
         current: {
@@ -333,7 +334,7 @@ const reducer = (
       };
     }
 
-    case ABORT_FETCH_COLLECTION:
+    case ABORT_FETCH_CURRENT_COLLECTION:
       return {
         ...state,
         current: {

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -308,6 +308,37 @@ export const createInternalAddons = (
   });
 };
 
+type GetCollectionByIdParams = {|
+  state: CollectionsState,
+  id: CollectionId,
+|};
+
+export const getCollectionById = (
+  { id, state }: GetCollectionByIdParams
+): CollectionType | null => {
+  if (!id) {
+    throw new Error('The id parameter is required');
+  }
+  if (!state) {
+    throw new Error('The state parameter is required');
+  }
+
+  return state.byId[id] || null;
+};
+
+export const getCurrentCollection = (
+  state: CollectionsState
+): CollectionType | null => {
+  if (!state) {
+    throw new Error('The state parameter is required');
+  }
+  if (!state.current.id) {
+    return null;
+  }
+
+  return getCollectionById({ id: state.current.id, state });
+};
+
 export const createInternalCollection = ({
   detail,
   items,
@@ -355,10 +386,7 @@ const reducer = (
         loading: true,
       };
 
-      let currentCollection;
-      if (state.current.id) {
-        currentCollection = state.byId[state.current.id];
-      }
+      const currentCollection = getCurrentCollection(state);
       if (!currentCollection) {
         return { ...state, current };
       }
@@ -402,10 +430,7 @@ const reducer = (
     case LOAD_CURRENT_COLLECTION_PAGE: {
       const { addons } = action.payload;
 
-      let currentCollection;
-      if (state.current.id) {
-        currentCollection = state.byId[state.current.id];
-      }
+      const currentCollection = getCurrentCollection(state);
       if (!currentCollection) {
         throw new Error(
           `${action.type}: a current collection does not exist`);

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -4,11 +4,12 @@ import type { AddonType, ExternalAddonType } from 'core/types/addons';
 
 export const FETCH_CURRENT_COLLECTION: 'FETCH_CURRENT_COLLECTION'
   = 'FETCH_CURRENT_COLLECTION';
-export const LOAD_COLLECTION: 'LOAD_COLLECTION' = 'LOAD_COLLECTION';
+export const LOAD_CURRENT_COLLECTION: 'LOAD_CURRENT_COLLECTION'
+  = 'LOAD_CURRENT_COLLECTION';
 export const FETCH_CURRENT_COLLECTION_PAGE: 'FETCH_CURRENT_COLLECTION_PAGE'
   = 'FETCH_CURRENT_COLLECTION_PAGE';
-export const LOAD_COLLECTION_PAGE: 'LOAD_COLLECTION_PAGE'
-  = 'LOAD_COLLECTION_PAGE';
+export const LOAD_CURRENT_COLLECTION_PAGE: 'LOAD_CURRENT_COLLECTION_PAGE'
+  = 'LOAD_CURRENT_COLLECTION_PAGE';
 export const ABORT_FETCH_CURRENT_COLLECTION: 'ABORT_FETCH_CURRENT_COLLECTION'
   = 'ABORT_FETCH_CURRENT_COLLECTION';
 
@@ -147,20 +148,20 @@ export type CollectionAddonsListResponse = {|
   results: ExternalCollectionAddons,
 |};
 
-type LoadCollectionParams = {|
+type LoadCurrentCollectionParams = {|
   addons: CollectionAddonsListResponse,
   detail: ExternalCollectionDetail,
 |};
 
-type LoadCollectionAction = {|
-  type: typeof LOAD_COLLECTION,
-  payload: LoadCollectionParams,
+type LoadCurrentCollectionAction = {|
+  type: typeof LOAD_CURRENT_COLLECTION,
+  payload: LoadCurrentCollectionParams,
 |};
 
-export const loadCollection = ({
+export const loadCurrentCollection = ({
   addons,
   detail,
-}: LoadCollectionParams = {}): LoadCollectionAction => {
+}: LoadCurrentCollectionParams = {}): LoadCurrentCollectionAction => {
   if (!addons) {
     throw new Error('addons are required');
   }
@@ -169,29 +170,29 @@ export const loadCollection = ({
   }
 
   return {
-    type: LOAD_COLLECTION,
+    type: LOAD_CURRENT_COLLECTION,
     payload: { addons, detail },
   };
 };
 
-type LoadCollectionPageParams = {|
+type LoadCurrentCollectionPageParams = {|
   addons: CollectionAddonsListResponse,
 |};
 
-type LoadCollectionPageAction = {|
-  type: typeof LOAD_COLLECTION_PAGE,
-  payload: LoadCollectionPageParams,
+type LoadCurrentCollectionPageAction = {|
+  type: typeof LOAD_CURRENT_COLLECTION_PAGE,
+  payload: LoadCurrentCollectionPageParams,
 |};
 
-export const loadCollectionPage = ({
+export const loadCurrentCollectionPage = ({
   addons,
-}: LoadCollectionPageParams = {}): LoadCollectionPageAction => {
+}: LoadCurrentCollectionPageParams = {}): LoadCurrentCollectionPageAction => {
   if (!addons) {
     throw new Error('addons are required');
   }
 
   return {
-    type: LOAD_COLLECTION_PAGE,
+    type: LOAD_CURRENT_COLLECTION_PAGE,
     payload: { addons },
   };
 };
@@ -236,9 +237,9 @@ export const createInternalCollection = ({
 
 type Action =
   | FetchCurrentCollectionAction
-  | LoadCollectionAction
+  | LoadCurrentCollectionAction
   | FetchCurrentCollectionPageAction
-  | LoadCollectionPageAction
+  | LoadCurrentCollectionPageAction
   | AbortFetchCurrentCollection
 ;
 
@@ -283,7 +284,7 @@ const reducer = (
       };
     }
 
-    case LOAD_COLLECTION: {
+    case LOAD_CURRENT_COLLECTION: {
       const { addons, detail } = action.payload;
 
       return {
@@ -306,7 +307,7 @@ const reducer = (
       };
     }
 
-    case LOAD_COLLECTION_PAGE: {
+    case LOAD_CURRENT_COLLECTION_PAGE: {
       const { addons } = action.payload;
 
       let currentCollection;

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -4,11 +4,12 @@ import type { AddonType, ExternalAddonType } from 'core/types/addons';
 
 export const FETCH_COLLECTION: 'FETCH_COLLECTION' = 'FETCH_COLLECTION';
 export const LOAD_COLLECTION: 'LOAD_COLLECTION' = 'LOAD_COLLECTION';
-export const FETCH_COLLECTION_PAGE: 'FETCH_COLLECTION_PAGE'
-  = 'FETCH_COLLECTION_PAGE';
+export const FETCH_CURRENT_COLLECTION_PAGE: 'FETCH_CURRENT_COLLECTION_PAGE'
+  = 'FETCH_CURRENT_COLLECTION_PAGE';
 export const LOAD_COLLECTION_PAGE: 'LOAD_COLLECTION_PAGE'
   = 'LOAD_COLLECTION_PAGE';
-export const ABORT_FETCH_COLLECTION: 'ABORT_FETCH_COLLECTION' = 'ABORT_FETCH_COLLECTION';
+export const ABORT_FETCH_COLLECTION: 'ABORT_FETCH_COLLECTION'
+  = 'ABORT_FETCH_COLLECTION';
 
 export type CollectionType = {
   addons: Array<AddonType>,
@@ -78,22 +79,22 @@ export const fetchCollection = ({
   };
 };
 
-type FetchCollectionPageParams = {|
+type FetchCurrentCollectionPageParams = {|
   ...FetchCollectionParams,
   page: number,
 |};
 
-type FetchCollectionPageAction = {|
-  type: typeof FETCH_COLLECTION_PAGE,
-  payload: FetchCollectionPageParams,
+type FetchCurrentCollectionPageAction = {|
+  type: typeof FETCH_CURRENT_COLLECTION_PAGE,
+  payload: FetchCurrentCollectionPageParams,
 |};
 
-export const fetchCollectionPage = ({
+export const fetchCurrentCollectionPage = ({
   errorHandlerId,
   page,
   slug,
   user,
-}: FetchCollectionPageParams = {}): FetchCollectionPageAction => {
+}: FetchCurrentCollectionPageParams = {}): FetchCurrentCollectionPageAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
@@ -108,7 +109,7 @@ export const fetchCollectionPage = ({
   }
 
   return {
-    type: FETCH_COLLECTION_PAGE,
+    type: FETCH_CURRENT_COLLECTION_PAGE,
     payload: { errorHandlerId, page, slug, user },
   };
 };
@@ -235,7 +236,7 @@ export const createInternalCollection = ({
 type Action =
   | FetchCollectionAction
   | LoadCollectionAction
-  | FetchCollectionPageAction
+  | FetchCurrentCollectionPageAction
   | LoadCollectionPageAction
   | AbortFetchCollection
 ;
@@ -254,7 +255,7 @@ const reducer = (
         },
       };
 
-    case FETCH_COLLECTION_PAGE: {
+    case FETCH_CURRENT_COLLECTION_PAGE: {
       const current = {
         id: state.current.id,
         loading: true,

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -333,8 +333,13 @@ const reducer = (
     }
 
     case ABORT_FETCH_COLLECTION:
-      // TODO: change this so that only the fetched collection is erased.
-      return initialState;
+      return {
+        ...state,
+        current: {
+          id: null,
+          loading: false,
+        },
+      };
 
     default:
       return state;

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -20,8 +20,6 @@ export const LOAD_USER_COLLECTIONS: 'LOAD_USER_COLLECTIONS'
   = 'LOAD_USER_COLLECTIONS';
 
 export type CollectionType = {
-  // TODO: make sure components/Collection will
-  // fetch add-ons if needed
   addons: Array<AddonType> | null,
   authorId: number,
   authorName: string,

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -1,7 +1,7 @@
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 import {
   FETCH_COLLECTION,
-  FETCH_COLLECTION_PAGE,
+  FETCH_CURRENT_COLLECTION_PAGE,
   abortFetchCollection,
   loadCollection,
   loadCollectionPage,
@@ -47,7 +47,7 @@ export function* fetchCollection({
   }
 }
 
-export function* fetchCollectionPage({
+export function* fetchCurrentCollectionPage({
   payload: {
     errorHandlerId,
     page,
@@ -79,5 +79,7 @@ export function* fetchCollectionPage({
 
 export default function* collectionsSaga() {
   yield takeLatest(FETCH_COLLECTION, fetchCollection);
-  yield takeLatest(FETCH_COLLECTION_PAGE, fetchCollectionPage);
+  yield takeLatest(
+    FETCH_CURRENT_COLLECTION_PAGE, fetchCurrentCollectionPage
+  );
 }

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -2,7 +2,7 @@ import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 import {
   FETCH_CURRENT_COLLECTION,
   FETCH_CURRENT_COLLECTION_PAGE,
-  abortFetchCollection,
+  abortFetchCurrentCollection,
   loadCollection,
   loadCollectionPage,
 } from 'amo/reducers/collections';
@@ -43,7 +43,7 @@ export function* fetchCurrentCollection({
   } catch (error) {
     log.warn(`Collection failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortFetchCollection());
+    yield put(abortFetchCurrentCollection());
   }
 }
 
@@ -73,7 +73,7 @@ export function* fetchCurrentCollectionPage({
   } catch (error) {
     log.warn(`Collection page failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortFetchCollection());
+    yield put(abortFetchCurrentCollection());
   }
 }
 

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -3,8 +3,8 @@ import {
   FETCH_CURRENT_COLLECTION,
   FETCH_CURRENT_COLLECTION_PAGE,
   abortFetchCurrentCollection,
-  loadCollection,
-  loadCollectionPage,
+  loadCurrentCollection,
+  loadCurrentCollectionPage,
 } from 'amo/reducers/collections';
 import * as api from 'amo/api/collections';
 import log from 'core/logger';
@@ -39,7 +39,7 @@ export function* fetchCurrentCollection({
       }),
     });
 
-    yield put(loadCollection({ addons, detail }));
+    yield put(loadCurrentCollection({ addons, detail }));
   } catch (error) {
     log.warn(`Collection failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));
@@ -69,7 +69,7 @@ export function* fetchCurrentCollectionPage({
       user,
     });
 
-    yield put(loadCollectionPage({ addons }));
+    yield put(loadCurrentCollectionPage({ addons }));
   } catch (error) {
     log.warn(`Collection page failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -1,6 +1,6 @@
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 import {
-  FETCH_COLLECTION,
+  FETCH_CURRENT_COLLECTION,
   FETCH_CURRENT_COLLECTION_PAGE,
   abortFetchCollection,
   loadCollection,
@@ -10,7 +10,7 @@ import * as api from 'amo/api/collections';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 
-export function* fetchCollection({
+export function* fetchCurrentCollection({
   payload: {
     errorHandlerId,
     page,
@@ -78,7 +78,7 @@ export function* fetchCurrentCollectionPage({
 }
 
 export default function* collectionsSaga() {
-  yield takeLatest(FETCH_COLLECTION, fetchCollection);
+  yield takeLatest(FETCH_CURRENT_COLLECTION, fetchCurrentCollection);
   yield takeLatest(
     FETCH_CURRENT_COLLECTION_PAGE, fetchCurrentCollectionPage
   );

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -2,6 +2,7 @@ import * as api from 'core/api';
 import {
   getCollectionAddons,
   getCollectionDetail,
+  listCollections,
 } from 'amo/api/collections';
 import { parsePage } from 'core/utils';
 import { createApiResponse } from 'tests/unit/helpers';
@@ -101,6 +102,42 @@ describe(__filename, () => {
         .returns(createApiResponse());
 
       await getCollectionAddons(params);
+      mockApi.verify();
+    });
+  });
+
+  describe('listCollections', () => {
+    const getListParams = (params = {}) => {
+      return {
+        api: apiState,
+        user: 'user-id-or-string',
+        ...params,
+      };
+    };
+
+    it('throws an error when the user parameter is missing', () => {
+      const params = getListParams();
+      delete params.user;
+
+      expect(() => listCollections(params))
+        .toThrow(/user parameter is required/);
+    });
+
+    it('calls the list collections API', async () => {
+      const user = 'some-user-id';
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          auth: true,
+          endpoint: `accounts/account/${user}/collections`,
+          state: apiState,
+        })
+        .once()
+        .returns(createApiResponse());
+
+      const params = getListParams({ user });
+      await listCollections(params);
       mockApi.verify();
     });
   });

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -12,7 +12,7 @@ import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
 import {
-  fetchCollection,
+  fetchCurrentCollection,
   fetchCurrentCollectionPage,
   loadCollection,
 } from 'amo/reducers/collections';
@@ -86,7 +86,7 @@ describe(__filename, () => {
     expect(wrapper.find(AddonsCard)).toHaveProp('loading', true);
   });
 
-  it('dispatches fetchCollection on mount', () => {
+  it('dispatches fetchCurrentCollection on mount', () => {
     const store = dispatchClientMetadata().store;
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
@@ -97,7 +97,7 @@ describe(__filename, () => {
     renderComponent({ errorHandler, params: { slug, user }, store });
 
     sinon.assert.callCount(fakeDispatch, 1);
-    sinon.assert.calledWith(fakeDispatch, fetchCollection({
+    sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       page: 1,
       slug,
@@ -105,7 +105,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('passes the page from query string to fetchCollection', () => {
+  it('passes the page from query string to fetchCurrentCollection', () => {
     const store = dispatchClientMetadata().store;
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
@@ -122,7 +122,7 @@ describe(__filename, () => {
     });
 
     sinon.assert.callCount(fakeDispatch, 1);
-    sinon.assert.calledWith(fakeDispatch, fetchCollection({
+    sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       page,
       slug,
@@ -178,7 +178,7 @@ describe(__filename, () => {
     const slug = 'collection-slug';
     const user = 'some-user';
 
-    store.dispatch(fetchCollection({
+    store.dispatch(fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       slug,
       user,
@@ -225,7 +225,7 @@ describe(__filename, () => {
     sinon.assert.notCalled(fakeDispatch);
   });
 
-  it('dispatches fetchCollection when location pathname has changed', () => {
+  it('dispatches fetchCurrentCollection when location pathname has changed', () => {
     const store = dispatchClientMetadata().store;
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
@@ -266,7 +266,7 @@ describe(__filename, () => {
     });
 
     sinon.assert.callCount(fakeDispatch, 1);
-    sinon.assert.calledWith(fakeDispatch, fetchCollection({
+    sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       page,
       slug: newSlug,
@@ -308,7 +308,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('dispatches fetchCollection when user param has changed', () => {
+  it('dispatches fetchCurrentCollection when user param has changed', () => {
     const errorHandler = createStubErrorHandler();
     const store = dispatchClientMetadata().store;
     const fakeDispatch = sinon.spy(store, 'dispatch');
@@ -332,14 +332,14 @@ describe(__filename, () => {
     wrapper.setProps({ params: newParams });
 
     sinon.assert.callCount(fakeDispatch, 1);
-    sinon.assert.calledWith(fakeDispatch, fetchCollection({
+    sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       page: 1,
       ...newParams,
     }));
   });
 
-  it('dispatches fetchCollection when slug param has changed', () => {
+  it('dispatches fetchCurrentCollection when slug param has changed', () => {
     const errorHandler = createStubErrorHandler();
     const store = dispatchClientMetadata().store;
     const fakeDispatch = sinon.spy(store, 'dispatch');
@@ -363,7 +363,7 @@ describe(__filename, () => {
     wrapper.setProps({ params: newParams });
 
     sinon.assert.callCount(fakeDispatch, 1);
-    sinon.assert.calledWith(fakeDispatch, fetchCollection({
+    sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       page: 1,
       ...newParams,

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -14,7 +14,7 @@ import MetadataCard from 'ui/components/MetadataCard';
 import {
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
-  loadCollection,
+  loadCurrentCollection,
 } from 'amo/reducers/collections';
 import { createApiError } from 'core/api/index';
 import { COLLECTIONS_EDIT } from 'core/constants';
@@ -135,7 +135,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -154,7 +154,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -230,7 +230,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -279,7 +279,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -314,7 +314,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -345,7 +345,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -376,7 +376,7 @@ describe(__filename, () => {
     const collectionAddons = createFakeCollectionAddons();
     const collectionDetail = createFakeCollectionDetail();
 
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: collectionAddons,
       detail: collectionDetail,
     }));
@@ -394,7 +394,7 @@ describe(__filename, () => {
     const collectionAddons = createFakeCollectionAddons({ addons: [] });
     const collectionDetail = createFakeCollectionDetail({ count: 0 });
 
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: collectionAddons,
       detail: collectionDetail,
     }));
@@ -411,7 +411,7 @@ describe(__filename, () => {
     const user = defaultUser;
 
     // User loads the collection page.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -480,7 +480,7 @@ describe(__filename, () => {
     const store = dispatchClientMetadata().store;
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -498,7 +498,7 @@ describe(__filename, () => {
     const { store } = dispatchSignInActions({ permissions: [COLLECTIONS_EDIT] });
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
     }));
@@ -512,7 +512,7 @@ describe(__filename, () => {
     const { store } = dispatchSignInActions({ userId: authorUserId });
 
     // We need a collection for this test case.
-    store.dispatch(loadCollection({
+    store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: createFakeCollectionDetail({
         authorId: authorUserId,

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -407,8 +407,8 @@ describe(__filename, () => {
     const store = dispatchClientMetadata().store;
 
     const errorHandler = createStubErrorHandler();
-    const slug = 'collection-slug';
-    const user = 'user-id-or-name';
+    const slug = defaultCollectionDetail.slug;
+    const user = defaultUser;
 
     // User loads the collection page.
     store.dispatch(loadCollection({

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -13,7 +13,7 @@ import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
 import {
   fetchCollection,
-  fetchCollectionPage,
+  fetchCurrentCollectionPage,
   loadCollection,
 } from 'amo/reducers/collections';
 import { createApiError } from 'core/api/index';
@@ -198,7 +198,7 @@ describe(__filename, () => {
     const slug = 'collection-slug';
     const user = 'some-user';
 
-    store.dispatch(fetchCollectionPage({
+    store.dispatch(fetchCurrentCollectionPage({
       errorHandlerId: errorHandler.id,
       page: 123,
       slug,
@@ -274,7 +274,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('dispatches fetchCollectionPage when page has changed', () => {
+  it('dispatches fetchCurrentCollectionPage when page has changed', () => {
     const store = dispatchClientMetadata().store;
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
@@ -300,7 +300,7 @@ describe(__filename, () => {
     wrapper.setProps({ location: newLocation });
 
     sinon.assert.callCount(fakeDispatch, 1);
-    sinon.assert.calledWith(fakeDispatch, fetchCollectionPage({
+    sinon.assert.calledWith(fakeDispatch, fetchCurrentCollectionPage({
       errorHandlerId: errorHandler.id,
       page,
       user: defaultUser,
@@ -425,7 +425,7 @@ describe(__filename, () => {
     expect(wrapper.find(AddonsCard)).toHaveProp('loading', false);
 
     // User clicks on 'next' pagination link.
-    store.dispatch(fetchCollectionPage({
+    store.dispatch(fetchCurrentCollectionPage({
       errorHandlerId: errorHandler.id,
       page: 2,
       slug,

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -316,6 +316,7 @@ export const createFakeCollectionDetail = ({
   name = 'My Addons',
   count = 123,
   authorId = 99999,
+  ...params
 } = {}) => {
   return {
     addon_count: count,
@@ -334,6 +335,7 @@ export const createFakeCollectionDetail = ({
     slug: 'my-addons',
     url: `https://example.org/en-US/firefox/collections/johndoe/my-addons/`,
     uuid: 'ef7e1344-1c3d-4bbb-bbd8-df9d8c9020ec',
+    ...params,
   };
 };
 

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -212,6 +212,30 @@ describe(__filename, () => {
       expect(newState.current.loading).toEqual(false);
       expect(newState.current.id).toEqual(null);
     });
+
+    it('preserves collection data when fetching is aborted', () => {
+      const firstCollection = createFakeCollectionDetail({ id: 1 });
+      const secondCollection = createFakeCollectionDetail({ id: 2 });
+
+      let state;
+      state = reducer(undefined, loadCollection({
+        addons: createFakeCollectionAddons(),
+        detail: firstCollection,
+      }));
+
+      state = reducer(state, loadCollection({
+        addons: createFakeCollectionAddons(),
+        detail: secondCollection,
+      }));
+
+      state = reducer(state, abortFetchCollection());
+
+      // Make sure collection data still exists.
+      expect(state.byId[firstCollection.id]).toBeDefined();
+      expect(state.byId[secondCollection.id]).toBeDefined();
+      expect(state.current.loading).toEqual(false);
+      expect(state.current.id).toEqual(null);
+    });
   });
 
   describe('fetchCollection()', () => {

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -2,7 +2,7 @@ import reducer, {
   abortFetchCollection,
   createInternalAddons,
   createInternalCollection,
-  fetchCollection,
+  fetchCurrentCollection,
   fetchCurrentCollectionPage,
   initialState,
   loadCollection,
@@ -30,7 +30,7 @@ describe(__filename, () => {
     });
 
     it('indicates when fetching a collection', () => {
-      const state = reducer(undefined, fetchCollection({
+      const state = reducer(undefined, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
         user: 'some-user-id-or-name',
@@ -101,7 +101,7 @@ describe(__filename, () => {
       }));
 
       // 2. User navigates to another collection.
-      state = reducer(state, fetchCollection({
+      state = reducer(state, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
         user: 'some-user-id-or-name',
@@ -172,7 +172,7 @@ describe(__filename, () => {
     });
 
     it('resets the current collection when fetching is aborted', () => {
-      const state = reducer(undefined, fetchCollection({
+      const state = reducer(undefined, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
         user: 'some-user-id-or-name',
@@ -209,7 +209,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('fetchCollection()', () => {
+  describe('fetchCurrentCollection()', () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
       slug: 'some-collection-slug',
@@ -221,7 +221,7 @@ describe(__filename, () => {
       delete partialParams.errorHandlerId;
 
       expect(() => {
-        fetchCollection(partialParams);
+        fetchCurrentCollection(partialParams);
       }).toThrow('errorHandlerId is required');
     });
 
@@ -230,7 +230,7 @@ describe(__filename, () => {
       delete partialParams.slug;
 
       expect(() => {
-        fetchCollection(partialParams);
+        fetchCurrentCollection(partialParams);
       }).toThrow('slug is required');
     });
 
@@ -239,7 +239,7 @@ describe(__filename, () => {
       delete partialParams.user;
 
       expect(() => {
-        fetchCollection(partialParams);
+        fetchCurrentCollection(partialParams);
       }).toThrow('user is required');
     });
   });

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -1,5 +1,5 @@
 import reducer, {
-  abortFetchCollection,
+  abortFetchCurrentCollection,
   createInternalAddons,
   createInternalCollection,
   fetchCurrentCollection,
@@ -180,7 +180,7 @@ describe(__filename, () => {
 
       expect(state.current.loading).toEqual(true);
 
-      const newState = reducer(state, abortFetchCollection());
+      const newState = reducer(state, abortFetchCurrentCollection());
       expect(newState.current.loading).toEqual(false);
       expect(newState.current.id).toEqual(null);
     });
@@ -199,7 +199,7 @@ describe(__filename, () => {
         detail: secondCollection,
       }));
 
-      state = reducer(state, abortFetchCollection());
+      state = reducer(state, abortFetchCurrentCollection());
 
       // Make sure collection data still exists.
       expect(state.byId[firstCollection.id]).toBeDefined();

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -5,8 +5,8 @@ import reducer, {
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   initialState,
-  loadCollection,
-  loadCollectionPage,
+  loadCurrentCollection,
+  loadCurrentCollectionPage,
 } from 'amo/reducers/collections';
 import { parsePage } from 'core/utils';
 import { createStubErrorHandler } from 'tests/unit/helpers';
@@ -55,7 +55,7 @@ describe(__filename, () => {
       const collectionAddons = createFakeCollectionAddons();
       const collectionDetail = createFakeCollectionDetail();
 
-      let state = reducer(undefined, loadCollection({
+      let state = reducer(undefined, loadCurrentCollection({
         addons: collectionAddons,
         detail: collectionDetail,
       }));
@@ -75,7 +75,7 @@ describe(__filename, () => {
       const collectionAddons = createFakeCollectionAddons();
       const collectionDetail = createFakeCollectionDetail();
 
-      const state = reducer(undefined, loadCollection({
+      const state = reducer(undefined, loadCurrentCollection({
         addons: collectionAddons,
         detail: collectionDetail,
       }));
@@ -95,7 +95,7 @@ describe(__filename, () => {
       const collectionDetail = createFakeCollectionDetail();
 
       // 1. User loads a collection.
-      let state = reducer(undefined, loadCollection({
+      let state = reducer(undefined, loadCurrentCollection({
         addons: collectionAddons,
         detail: collectionDetail,
       }));
@@ -116,7 +116,7 @@ describe(__filename, () => {
       const collectionDetail = createFakeCollectionDetail();
 
       // 1. User loads a collection.
-      let state = reducer(undefined, loadCollection({
+      let state = reducer(undefined, loadCurrentCollection({
         addons: collectionAddons,
         detail: collectionDetail,
       }));
@@ -143,7 +143,7 @@ describe(__filename, () => {
     it('cannot load collection page without a current collection', () => {
       const addons = createFakeCollectionAddons();
 
-      expect(() => reducer(undefined, loadCollectionPage({ addons })))
+      expect(() => reducer(undefined, loadCurrentCollectionPage({ addons })))
         .toThrow(/current collection does not exist/);
     });
 
@@ -153,7 +153,7 @@ describe(__filename, () => {
 
       // Load a current collection.
       // TODO: rename to loadCurrentCollection()
-      let state = reducer(undefined, loadCollection({
+      let state = reducer(undefined, loadCurrentCollection({
         addons: collectionAddons,
         detail: collectionDetail,
       }));
@@ -161,7 +161,7 @@ describe(__filename, () => {
       const newAddons = createFakeCollectionAddons({
         addons: [{ ...fakeAddon, id: 333 }],
       });
-      state = reducer(state, loadCollectionPage({ addons: newAddons }));
+      state = reducer(state, loadCurrentCollectionPage({ addons: newAddons }));
 
       const loadedCollection = state.byId[state.current.id];
 
@@ -189,12 +189,12 @@ describe(__filename, () => {
       const firstCollection = createFakeCollectionDetail({ id: 1 });
       const secondCollection = createFakeCollectionDetail({ id: 2 });
 
-      let state = reducer(undefined, loadCollection({
+      let state = reducer(undefined, loadCurrentCollection({
         addons: createFakeCollectionAddons(),
         detail: firstCollection,
       }));
 
-      state = reducer(state, loadCollection({
+      state = reducer(state, loadCurrentCollection({
         addons: createFakeCollectionAddons(),
         detail: secondCollection,
       }));
@@ -244,7 +244,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('loadCollection()', () => {
+  describe('loadCurrentCollection()', () => {
     const defaultParams = {
       addons: createFakeCollectionAddons(),
       detail: createFakeCollectionDetail(),
@@ -255,7 +255,7 @@ describe(__filename, () => {
       delete partialParams.addons;
 
       expect(() => {
-        loadCollection(partialParams);
+        loadCurrentCollection(partialParams);
       }).toThrow('addons are required');
     });
 
@@ -264,7 +264,7 @@ describe(__filename, () => {
       delete partialParams.detail;
 
       expect(() => {
-        loadCollection(partialParams);
+        loadCurrentCollection(partialParams);
       }).toThrow('detail is required');
     });
   });
@@ -314,10 +314,10 @@ describe(__filename, () => {
     });
   });
 
-  describe('loadCollectionPage()', () => {
+  describe('loadCurrentCollectionPage()', () => {
     it('throws an error when addons are missing', () => {
       expect(() => {
-        loadCollectionPage();
+        loadCurrentCollectionPage();
       }).toThrow('addons are required');
     });
   });

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -3,7 +3,7 @@ import reducer, {
   createInternalAddons,
   createInternalCollection,
   fetchCollection,
-  fetchCollectionPage,
+  fetchCurrentCollectionPage,
   initialState,
   loadCollection,
   loadCollectionPage,
@@ -41,7 +41,7 @@ describe(__filename, () => {
     });
 
     it('sets a loading flag when fetching a collection page', () => {
-      const state = reducer(undefined, fetchCollectionPage({
+      const state = reducer(undefined, fetchCurrentCollectionPage({
         errorHandlerId: createStubErrorHandler().id,
         page: parsePage(2),
         slug: 'some-collection-slug',
@@ -60,7 +60,7 @@ describe(__filename, () => {
         detail: collectionDetail,
       }));
 
-      state = reducer(state, fetchCollectionPage({
+      state = reducer(state, fetchCurrentCollectionPage({
         errorHandlerId: createStubErrorHandler().id,
         page: parsePage(2),
         slug: collectionDetail.slug,
@@ -122,7 +122,7 @@ describe(__filename, () => {
       }));
 
       // 2. User clicks the "next" pagination link.
-      state = reducer(state, fetchCollectionPage({
+      state = reducer(state, fetchCurrentCollectionPage({
         errorHandlerId: createStubErrorHandler().id,
         page: parsePage(2),
         slug: 'some-collection-slug',
@@ -269,7 +269,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('fetchCollectionPage()', () => {
+  describe('fetchCurrentCollectionPage()', () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
       page: 123,
@@ -282,7 +282,7 @@ describe(__filename, () => {
       delete partialParams.errorHandlerId;
 
       expect(() => {
-        fetchCollectionPage(partialParams);
+        fetchCurrentCollectionPage(partialParams);
       }).toThrow('errorHandlerId is required');
     });
 
@@ -291,7 +291,7 @@ describe(__filename, () => {
       delete partialParams.slug;
 
       expect(() => {
-        fetchCollectionPage(partialParams);
+        fetchCurrentCollectionPage(partialParams);
       }).toThrow('slug is required');
     });
 
@@ -300,7 +300,7 @@ describe(__filename, () => {
       delete partialParams.user;
 
       expect(() => {
-        fetchCollectionPage(partialParams);
+        fetchCurrentCollectionPage(partialParams);
       }).toThrow('user is required');
     });
 
@@ -309,7 +309,7 @@ describe(__filename, () => {
       delete partialParams.page;
 
       expect(() => {
-        fetchCollectionPage(partialParams);
+        fetchCurrentCollectionPage(partialParams);
       }).toThrow('page is required');
     });
   });

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -154,8 +154,6 @@ describe(__filename, () => {
       const collectionAddons = createFakeCollectionAddons();
       const collectionDetail = createFakeCollectionDetail();
 
-      // Load a current collection.
-      // TODO: rename to loadCurrentCollection()
       let state = reducer(undefined, loadCurrentCollection({
         addons: collectionAddons,
         detail: collectionDetail,

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -5,8 +5,8 @@ import collectionsReducer, {
   abortFetchCurrentCollection,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
-  loadCollection,
-  loadCollectionPage,
+  loadCurrentCollection,
+  loadCurrentCollectionPage,
 } from 'amo/reducers/collections';
 import collectionsSaga from 'amo/sagas/collections';
 import apiReducer from 'core/reducers/api';
@@ -77,7 +77,7 @@ describe(__filename, () => {
 
       _fetchCurrentCollection({ page: parsePage(1), slug, user });
 
-      const expectedLoadAction = loadCollection({
+      const expectedLoadAction = loadCurrentCollection({
         addons: collectionAddons,
         detail: collectionDetail,
       });
@@ -142,7 +142,7 @@ describe(__filename, () => {
 
       _fetchCurrentCollectionPage({ page: parsePage(1), slug, user });
 
-      const expectedLoadAction = loadCollectionPage({
+      const expectedLoadAction = loadCurrentCollectionPage({
         addons: collectionAddons,
       });
 

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -4,7 +4,7 @@ import * as collectionsApi from 'amo/api/collections';
 import collectionsReducer, {
   abortFetchCollection,
   fetchCollection,
-  fetchCollectionPage,
+  fetchCurrentCollectionPage,
   loadCollection,
   loadCollectionPage,
 } from 'amo/reducers/collections';
@@ -117,9 +117,9 @@ describe(__filename, () => {
     });
   });
 
-  describe('fetchCollectionPage', () => {
-    function _fetchCollectionPage(params) {
-      sagaTester.dispatch(fetchCollectionPage({
+  describe('fetchCurrentCollectionPage', () => {
+    function _fetchCurrentCollectionPage(params) {
+      sagaTester.dispatch(fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         ...params,
       }));
@@ -140,7 +140,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.resolve(collectionAddons));
 
-      _fetchCollectionPage({ page: parsePage(1), slug, user });
+      _fetchCurrentCollectionPage({ page: parsePage(1), slug, user });
 
       const expectedLoadAction = loadCollectionPage({
         addons: collectionAddons,
@@ -155,7 +155,7 @@ describe(__filename, () => {
     });
 
     it('clears the error handler', async () => {
-      _fetchCollectionPage({ page: parsePage(1), slug, user });
+      _fetchCurrentCollectionPage({ page: parsePage(1), slug, user });
 
       const expectedAction = errorHandler.createClearingAction();
 
@@ -172,7 +172,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchCollectionPage({ page: parsePage(1), slug, user });
+      _fetchCurrentCollectionPage({ page: parsePage(1), slug, user });
 
       const errorAction = errorHandler.createErrorAction(error);
       await sagaTester.waitFor(errorAction.type);

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -3,7 +3,7 @@ import SagaTester from 'redux-saga-tester';
 import * as collectionsApi from 'amo/api/collections';
 import collectionsReducer, {
   abortFetchCollection,
-  fetchCollection,
+  fetchCurrentCollection,
   fetchCurrentCollectionPage,
   loadCollection,
   loadCollectionPage,
@@ -40,9 +40,9 @@ describe(__filename, () => {
     sagaTester.start(collectionsSaga);
   });
 
-  describe('fetchCollection', () => {
-    function _fetchCollection(params) {
-      sagaTester.dispatch(fetchCollection({
+  describe('fetchCurrentCollection', () => {
+    function _fetchCurrentCollection(params) {
+      sagaTester.dispatch(fetchCurrentCollection({
         errorHandlerId: errorHandler.id,
         ...params,
       }));
@@ -75,7 +75,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.resolve(collectionAddons));
 
-      _fetchCollection({ page: parsePage(1), slug, user });
+      _fetchCurrentCollection({ page: parsePage(1), slug, user });
 
       const expectedLoadAction = loadCollection({
         addons: collectionAddons,
@@ -91,7 +91,7 @@ describe(__filename, () => {
     });
 
     it('clears the error handler', async () => {
-      _fetchCollection({ slug, user });
+      _fetchCurrentCollection({ slug, user });
 
       const expectedAction = errorHandler.createClearingAction();
 
@@ -108,7 +108,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchCollection({ slug, user });
+      _fetchCurrentCollection({ slug, user });
 
       const errorAction = errorHandler.createErrorAction(error);
       await sagaTester.waitFor(errorAction.type);

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -2,7 +2,7 @@ import SagaTester from 'redux-saga-tester';
 
 import * as collectionsApi from 'amo/api/collections';
 import collectionsReducer, {
-  abortFetchCollection,
+  abortFetchCurrentCollection,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   loadCollection,
@@ -113,7 +113,7 @@ describe(__filename, () => {
       const errorAction = errorHandler.createErrorAction(error);
       await sagaTester.waitFor(errorAction.type);
       expect(sagaTester.getCalledActions()[2]).toEqual(errorAction);
-      expect(sagaTester.getCalledActions()[3]).toEqual(abortFetchCollection());
+      expect(sagaTester.getCalledActions()[3]).toEqual(abortFetchCurrentCollection());
     });
   });
 
@@ -177,7 +177,7 @@ describe(__filename, () => {
       const errorAction = errorHandler.createErrorAction(error);
       await sagaTester.waitFor(errorAction.type);
       expect(sagaTester.getCalledActions()[2]).toEqual(errorAction);
-      expect(sagaTester.getCalledActions()[3]).toEqual(abortFetchCollection());
+      expect(sagaTester.getCalledActions()[3]).toEqual(abortFetchCurrentCollection());
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4016

I will need to fetch/store user collections to make a dropdown on the add-on detail page that lets you add an extension to a collection.

Sorry for all the noise; the re-organization of the state will make this a bit cumbersome to review.