### PR TITLE
chore: Use 6 not 7 as max hero section index

### DIFF
--- a/src/amo/components/HomeHeroBanner/styles.scss
+++ b/src/amo/components/HomeHeroBanner/styles.scss
@@ -69,7 +69,7 @@ $colors: ("blue", #228ae6, #1b6ec2)
 
 // Generate CSS classes depending on the order (indexes) of the Hero sections.
 @for $x from 0 through 6 {
-  @for $y from 0 through 7 {
+  @for $y from 0 through 6 {
     @for $z from 0 through 6 {
       // It is not possible to have the same values for two (or more) different
       // indexes.


### PR DESCRIPTION
This was just an error on my part.

See: https://github.com/mozilla/addons-frontend/pull/4024#discussion_r154734047