### PR TITLE
Fix column height calculation in ESR

### DIFF
--- a/src/amo/components/Search/styles.scss
+++ b/src/amo/components/Search/styles.scss
@@ -48,6 +48,8 @@
       grid-row: 2 / 5;
       // Allows the grid item to contain the content preventing overflow.
       min-width: 0;
+      // Hack to force column height calculations in ESR 52.
+      width: 100%;
 
       .SearchResult {
         padding: 24px 36px;

--- a/src/amo/components/Search/styles.scss
+++ b/src/amo/components/Search/styles.scss
@@ -49,6 +49,7 @@
       // Allows the grid item to contain the content preventing overflow.
       min-width: 0;
       // Hack to force column height calculations in ESR 52.
+      // See: https://github.com/mozilla/addons/issues/566
       width: 100%;
 
       .SearchResult {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/566

Before the fix the search results height is > 50000px high before you get to the pagination.

![search_results_for__toggle_javascript__ _add-ons_for_firefox](https://user-images.githubusercontent.com/1514/33606740-7a747c34-d9b6-11e7-9966-5e4dbaaa8cfa.jpg)

After the fix - there's no massive gap:

![search_results_for__toggle_javascript__ _add-ons_for_firefox](https://user-images.githubusercontent.com/1514/33606759-8e862aa6-d9b6-11e7-8523-402fe36c3389.jpg)
