### PR TITLE
I4040 - Highlight author names on details page

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -84,7 +84,6 @@
   &,
   a,
   a:link {
-    color: $black;
     font-size: $font-size-m;
     font-weight: normal;
     text-decoration: none;


### PR DESCRIPTION
Fixes #4040 

**Before:**
<img width="528" alt="screen shot 2017-12-06 at 4 06 45 pm" src="https://user-images.githubusercontent.com/5318732/33657509-97d81710-da9f-11e7-8f3f-5211bc3a90ab.png">

**After**
<img width="494" alt="screen shot 2017-12-06 at 4 04 40 pm" src="https://user-images.githubusercontent.com/5318732/33657521-a1f9cf7c-da9f-11e7-8f4b-01e3d80dac0d.png">


