### PR TITLE
Cope with null versions when dealing with incomplete add-ons

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -247,7 +247,7 @@ export class AddonBase extends React.Component {
         className="Addon-overall-rating"
         {...props}
       >
-        {addon ?
+        {addon && addon.current_version ?
           <RatingManager
             addon={addon}
             location={location}

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -215,6 +215,24 @@ export class AddonBase extends React.Component {
     let content;
     let footerPropName = 'footerText';
 
+    let ratingManager;
+    if (addon && addon.current_version) {
+      ratingManager = (
+        <RatingManager
+          addon={addon}
+          location={location}
+          version={addon.current_version}
+        />
+      );
+    } else {
+      ratingManager = (
+        <p className="Addon-no-rating-manager">
+          {i18n.gettext(`This add-on cannot be rated because no versions
+            have been published.`)}
+        </p>
+      );
+    }
+
     if (addon && addon.ratings.text_count) {
       const count = addon.ratings.text_count;
       const linkText = i18n.sprintf(
@@ -247,13 +265,7 @@ export class AddonBase extends React.Component {
         className="Addon-overall-rating"
         {...props}
       >
-        {addon && addon.current_version ?
-          <RatingManager
-            addon={addon}
-            location={location}
-            version={addon.current_version}
-          /> : null
-        }
+        {ratingManager}
       </Card>
     );
   }

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -89,13 +89,15 @@ export class AddonMoreInfoBase extends React.Component<Props> {
       );
     }
 
+    const currentVersion = addon.current_version;
+
     return this.renderDefinitions({
       homepage,
       supportUrl,
       supportEmail,
       statsLink,
-      version: addonHasVersionHistory(addon) ?
-        addon.current_version.version : null,
+      version: currentVersion && addonHasVersionHistory(addon) ?
+        currentVersion.version : null,
       versionLastUpdated: i18n.sprintf(
         // translators: This will output, in English:
         // "2 months ago (Dec 12 2016)"
@@ -104,14 +106,14 @@ export class AddonMoreInfoBase extends React.Component<Props> {
           date: i18n.moment(addon.last_updated).format('ll'),
         }
       ),
-      versionLicenseLink: addon.current_version.license ? (
+      versionLicenseLink: currentVersion && currentVersion.license ? (
         <Link
           className="AddonMoreInfo-license-link"
-          href={addon.current_version.license.url}
+          href={currentVersion.license.url}
           prependClientApp={false}
           prependLang={false}
         >
-          {addon.current_version.license.name}
+          {currentVersion.license.name}
         </Link>
       ) : null,
       privacyPolicyLink: addon.has_privacy_policy ? (

--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -248,7 +248,7 @@ export class AddonReviewListBase extends React.Component<Props> {
             </div>
           </div>
 
-          {addon ? (
+          {addon && addon.current_version ? (
             <RatingManager
               addon={addon}
               location={location}

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -104,17 +104,20 @@ export class RatingManagerBase extends React.Component<Props, State> {
     if (userReview) {
       log.info(`Editing reviewId ${userReview.id}`);
       if (userReview.versionId === params.versionId) {
-        log.info(
-          `Updating reviewId ${userReview.id} for versionId ${params.versionId}`);
+        log.info(oneLine`Updating reviewId ${userReview.id} for
+          versionId ${params.versionId || '[empty]'}`);
         params.reviewId = userReview.id;
       } else {
         // Since we have a version mismatch, submit the review against the
         // current most version, similar to how new reviews are created.
-        params.versionId = this.props.addon.current_version.id;
-        log.info(`Submitting a new review for versionId ${params.versionId}`);
+        params.versionId = this.props.addon.current_version &&
+          this.props.addon.current_version.id;
+        log.info(oneLine`Submitting a new review for
+          versionId ${params.versionId || '[empty]'}`);
       }
     } else {
-      log.info(`Submitting a new review for versionId ${params.versionId}`);
+      log.info(oneLine`Submitting a new review for
+        versionId ${params.versionId || '[empty]'}`);
     }
     return this.props.submitReview(params)
       .then(() => {

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -228,8 +228,10 @@ export function createInternalAddon(
     }
   }
 
-  if (apiAddon.current_version && apiAddon.current_version.files.length > 0) {
-    apiAddon.current_version.files.forEach((file) => {
+  const currentVersion = apiAddon.current_version;
+
+  if (currentVersion && currentVersion.files.length > 0) {
+    currentVersion.files.forEach((file) => {
       // eslint-disable-next-line no-prototype-builtins
       if (!addon.installURLs.hasOwnProperty(file.platform)) {
         log.warn(oneLine`Add-on ID ${apiAddon.id}, slug ${apiAddon.slug}
@@ -237,16 +239,16 @@ export function createInternalAddon(
       }
       addon.installURLs[file.platform] = file.url;
     });
-    addon.isRestartRequired = apiAddon.current_version.files.some(
+    addon.isRestartRequired = currentVersion.files.some(
       (file) => !!file.is_restart_required
     );
     // The following checks are a bit fragile since only one file needs
     // to contain the flag. However, it is highly unlikely to create an
     // add-on with mismatched file flags in the current DevHub.
-    addon.isWebExtension = apiAddon.current_version.files.some(
+    addon.isWebExtension = currentVersion.files.some(
       (file) => !!file.is_webextension
     );
-    addon.isMozillaSignedExtension = apiAddon.current_version.files.some(
+    addon.isMozillaSignedExtension = currentVersion.files.some(
       (file) => !!file.is_mozilla_signed_extension
     );
   }

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -100,7 +100,9 @@ export type ExternalAddonType = {|
   categories?: Object,
   contributions_url?: string,
   current_beta_version?: AddonVersionType,
-  current_version: AddonVersionType,
+  // If you make an API request as an admin for an incomplete
+  // add-on (status=0) then the current_version could be null.
+  current_version?: AddonVersionType,
   default_locale: string,
   description?: string,
   edit_url?: string,

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -680,6 +680,16 @@ describe(__filename, () => {
     expect(root.prop('location')).toEqual(location);
   });
 
+  it('does not show a ratings manager without a version', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      current_version: null,
+    });
+    const root = shallowRender({ addon });
+
+    expect(root.find(RatingManagerWithI18n)).toHaveLength(0);
+  });
+
   it('renders a summary', () => {
     const root = shallowRender();
     expect(root.find('.Addon-summary').html()).toContain(fakeAddon.summary);

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -688,6 +688,7 @@ describe(__filename, () => {
     const root = shallowRender({ addon });
 
     expect(root.find(RatingManagerWithI18n)).toHaveLength(0);
+    expect(root.find('.Addon-no-rating-manager')).toHaveLength(1);
   });
 
   it('renders a summary', () => {

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -574,6 +574,13 @@ describe(__filename, () => {
       expect(manager).toHaveProp('onReviewSubmitted');
     });
 
+    it('does not render a rating manager without a version', () => {
+      dispatchAddon({ ...fakeAddon, current_version: null });
+      const root = render();
+
+      expect(root.find(RatingManager)).toHaveLength(0);
+    });
+
     it('handles a submitted review', () => {
       const addonSlug = 'some-slug';
       dispatchAddon({ ...fakeAddon, slug: addonSlug });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4045

In addition to addressing that issue, this changes the Flow type of `addon.current_version` so that all typed code will be forced to guard against it.

Visiting a broken add-on now looks like this:

<img width="357" alt="screenshot 2017-12-06 17 31 07" src="https://user-images.githubusercontent.com/55398/33690942-725a0df2-daab-11e7-808c-19aab1a31886.png">
