### PR TITLE
Use masking fallback for ESR

### DIFF
--- a/src/amo/components/CategoryIcon/styles.scss
+++ b/src/amo/components/CategoryIcon/styles.scss
@@ -11,9 +11,9 @@ $default-icon-size: 64px;
   transform: scale(0.8);
   width: $default-icon-size;
 
-  // This prevents Edge from rendering a square block of color because it can't
-  // mask over the SVG.
-  @supports (-ms-ime-align:auto) {
+  // This prevents Edge/ESR 52 from rendering a square block of color because
+  // it can't mask over the SVG.
+  @supports not (mask: url("./#{$name}.svg") no-repeat 50% 50%) {
     background: transparent url("./#{$name}.svg") center no-repeat;
     background-size: contain;
     content: "";


### PR DESCRIPTION
Fixes #4033 

**Note:** _this doesn't show the full set of colours since the masking isn't supported in 52 but it should show the correct colours from 53 onwards and all other browsers that support masking._

Edge should continue to show the fall-back too.

Before: 

![add-ons_for_firefox](https://user-images.githubusercontent.com/1514/33605841-37b02e82-d9b3-11e7-88bd-0d9b57ec6056.jpg)

After:
 
![add-ons_for_firefox](https://user-images.githubusercontent.com/1514/33712097-254c1bca-db3e-11e7-868c-2439b151268a.jpg)
