### PR TITLE
I4056 - fixes word break in review list page

### DIFF
--- a/src/amo/components/AddonReviewList/styles.scss
+++ b/src/amo/components/AddonReviewList/styles.scss
@@ -53,6 +53,10 @@
   height: 36px;
 }
 
+.AddonReviewList-header-text {
+  min-width: 50%;
+}
+
 .AddonReviewList-header-icon-image {
   display: block;
   height: 36px;
@@ -62,7 +66,7 @@
   font-size: $font-size-m;
   margin: 0;
   padding: 0;
-  word-break: break-all;
+  word-wrap: break-word;
 
   a,
   a:link {

--- a/src/amo/components/AddonReviewList/styles.scss
+++ b/src/amo/components/AddonReviewList/styles.scss
@@ -54,6 +54,7 @@
 }
 
 .AddonReviewList-header-text {
+  // https://stackoverflow.com/questions/36150458
   min-width: 50%;
 }
 


### PR DESCRIPTION
Fixes #4056 

Before:
<img width="765" alt="screen shot 2017-12-08 at 2 26 03 pm" src="https://user-images.githubusercontent.com/5318732/33758360-f00c1942-dc23-11e7-8cb7-179cfb703cc2.png">

After:
<img width="774" alt="screen shot 2017-12-08 at 2 26 28 pm" src="https://user-images.githubusercontent.com/5318732/33758365-f79d4bea-dc23-11e7-919f-8fac1553bc20.png">
