### PR TITLE
Add an add-on to a collection

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
     // Standard DOM globals:
     "HTMLElement": true,
     "HTMLInputElement": true,
+    "HTMLSelectElement": true,
     "Node": true,
   },
   "parser": "babel-eslint",

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -242,6 +242,9 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
       });
     }
 
+    // translators: This is a header for a list meaning Add to [some collection name]
+    const collectionOptLabel = i18n.gettext('Add to…');
+
     return (
       <div className={makeClassName('AddAddonToCollection', className)}>
         {errorHandler.renderErrorIfPresent()}
@@ -253,7 +256,7 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
         >
           {actionOptions}
           {collectionOptions.length ? (
-            <optgroup label={i18n.gettext('Add to…')}>
+            <optgroup label={collectionOptLabel}>
               {collectionOptions}
             </optgroup>
           ) : null}

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -61,7 +61,8 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
 
   componentDidMount() {
     // This runs as componentDidMount() to only load data client side,
-    // not server side.
+    // not server side. By skipping server side rendering, no extra API
+    // requests will be made on the server.
     this.loadDataIfNeeded();
   }
 
@@ -70,17 +71,17 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
   }
 
   loadDataIfNeeded(nextProps?: Props) {
-    const allProps = { ...this.props, ...nextProps };
+    const combinedProps = { ...this.props, ...nextProps };
     const {
       dispatch,
       errorHandler,
       loadingUserCollections,
       userCollections,
       siteUserId,
-    } = allProps;
+    } = combinedProps;
 
     if (errorHandler.hasError()) {
-      // Abort loadng data so that the error can be rendered.
+      // Abort loading data so that the error can be rendered.
       return;
     }
 
@@ -155,9 +156,9 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
 
     let progressMessage;
     if (loadingUserCollections) {
-      progressMessage = i18n.gettext('Loading...');
+      progressMessage = i18n.gettext('Loading…');
     } else if (loadingAddonsInCollections) {
-      progressMessage = i18n.gettext('Adding...');
+      progressMessage = i18n.gettext('Adding…');
     }
     if (progressMessage) {
       // Create a disabled select box with a single option.

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -45,7 +45,11 @@ type Props = {|
 
 type OnSelectOptionType = () => void;
 
-type SelectData = {| options: Array<Object>, disabled: boolean |};
+type SelectData = {|
+  actionOptions: Array<Object>,
+  collectionOptions: Array<Object>,
+  disabled: boolean,
+|};
 
 export class AddAddonToCollectionBase extends React.Component<Props> {
   optionSelectHandlers: { [key: string]: OnSelectOptionType };
@@ -154,7 +158,10 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
       userCollections,
     } = this.props;
 
+    const actionOptions = [];
+    const collectionOptions = [];
     let progressMessage;
+
     if (loadingUserCollections) {
       progressMessage = i18n.gettext('Loading…');
     } else if (loadingAddonsInCollections) {
@@ -162,23 +169,23 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
     }
     if (progressMessage) {
       // Create a disabled select box with a single option.
+      actionOptions.push(
+        this.createOption({ text: progressMessage, key: 'default' })
+      );
       return {
         disabled: true,
-        options: [
-          this.createOption({
-            text: progressMessage, key: 'default',
-          }),
-        ],
+        actionOptions,
+        collectionOptions,
       };
     }
 
-    const options = [
+    actionOptions.push(
       this.createOption({
         text: i18n.gettext('Add to collection'), key: 'default',
-      }),
-    ];
+      })
+    );
 
-    options.push(this.createOption({
+    actionOptions.push(this.createOption({
       text: i18n.gettext('Create new collection'),
       key: 'create-new-collection',
       onSelect: () => {
@@ -195,7 +202,7 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
         // Make an option for adding the add-on to this collection.
         // If the user selects a collection that the add-on already
         // belongs to, they will see an error.
-        options.push(this.createOption({
+        collectionOptions.push(this.createOption({
           text: collection.name,
           key: `collection-${collection.id}`,
           onSelect: () => {
@@ -205,14 +212,16 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
       });
     }
 
-    return { options, disabled: false };
+    return { actionOptions, collectionOptions, disabled: false };
   }
 
   render() {
     const {
       className, errorHandler, i18n, addonInCollections,
     } = this.props;
-    const { options, disabled } = this.getSelectData();
+    const {
+      actionOptions, collectionOptions, disabled,
+    } = this.getSelectData();
 
     let addedNotices = [];
     if (addonInCollections) {
@@ -242,7 +251,12 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
           onChange={this.onSelectOption}
           className="AddAddonToCollection-select"
         >
-          {options}
+          {actionOptions}
+          {collectionOptions.length ? (
+            <optgroup label={i18n.gettext('Add to…')}>
+              {collectionOptions}
+            </optgroup>
+          ) : null}
         </Select>
       </div>
     );

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -1,0 +1,301 @@
+/* @flow */
+/* global window */
+/* eslint-disable react/sort-comp */
+import makeClassName from 'classnames';
+import React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import {
+  addAddonToCollection, fetchUserCollections,
+} from 'amo/reducers/collections';
+import { withFixedErrorHandler } from 'core/errorHandler';
+import translate from 'core/i18n/translate';
+import log from 'core/logger';
+import Select from 'ui/components/Select';
+import Notice from 'ui/components/Notice';
+import type { AddonType } from 'core/types/addons';
+import type { ErrorHandlerType } from 'core/errorHandler';
+import type { I18nType } from 'core/types/i18n';
+import type { DispatchFunc } from 'core/types/redux';
+import type {
+  CollectionId, CollectionsState, CollectionType,
+} from 'amo/reducers/collections';
+import type { UsersStateType } from 'amo/reducers/users';
+import type { ElementEvent } from 'core/types/dom';
+
+import './styles.scss';
+
+
+type Props = {|
+  addon: AddonType | null,
+  className?: string,
+  dispatch: DispatchFunc,
+  errorHandler: ErrorHandlerType,
+  i18n: I18nType,
+  loadingAddonsInCollections: boolean,
+  loadingUserCollections: boolean,
+  siteUserId: number | null,
+  // These are all user collections that the current add-on is a part of.
+  addonInCollections: Array<CollectionType> | null,
+  // These are all collections belonging to the user.
+  userCollections: Array<CollectionType> | null,
+  _window: typeof window | Object,
+|};
+
+type OnSelectOptionType = () => void;
+
+type SelectData = {| options: Array<Object>, disabled: boolean |};
+
+export class AddAddonToCollectionBase extends React.Component<Props> {
+  optionSelectHandlers: { [key: string]: OnSelectOptionType };
+
+  static defaultProps = {
+    _window: typeof window !== 'undefined' ? window : {},
+  };
+
+  constructor(props: Props) {
+    super(props);
+    this.optionSelectHandlers = {};
+  }
+
+  componentDidMount() {
+    // This runs as componentDidMount() to only load data client side,
+    // not server side.
+    this.loadDataIfNeeded();
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    this.loadDataIfNeeded(nextProps);
+  }
+
+  loadDataIfNeeded(nextProps?: Props) {
+    const allProps = { ...this.props, ...nextProps };
+    const {
+      dispatch,
+      errorHandler,
+      loadingUserCollections,
+      userCollections,
+      siteUserId,
+    } = allProps;
+
+    if (errorHandler.hasError()) {
+      // Abort loadng data so that the error can be rendered.
+      return;
+    }
+
+    if (siteUserId && !loadingUserCollections && !userCollections) {
+      dispatch(fetchUserCollections({
+        errorHandlerId: errorHandler.id, userId: siteUserId,
+      }));
+    }
+  }
+
+  onSelectOption = (event: ElementEvent<HTMLSelectElement>) => {
+    event.preventDefault();
+    const key = event.target.value;
+    const handleOption = this.optionSelectHandlers[key];
+    if (handleOption) {
+      handleOption();
+    } else {
+      log.warn(`No handler for option: "${key}"`);
+    }
+  }
+
+  addToCollection(collection: CollectionType) {
+    const { addon, errorHandler, dispatch, siteUserId } = this.props;
+    if (!addon) {
+      throw new Error(
+        'Cannot add to collection because no add-on has been loaded');
+    }
+    if (!siteUserId) {
+      throw new Error(
+        'Cannot add to collection because you are not signed in');
+    }
+
+    dispatch(addAddonToCollection({
+      addonId: addon.id,
+      collectionId: collection.id,
+      collectionSlug: collection.slug,
+      errorHandlerId: errorHandler.id,
+      userId: siteUserId,
+    }));
+  }
+
+  createOption(
+    {
+      text, key, onSelect,
+    }: {
+      // eslint-disable-next-line react/no-unused-prop-types
+      text: string, key: string, onSelect?: OnSelectOptionType,
+    }
+  ) {
+    if (onSelect) {
+      this.optionSelectHandlers[key] = onSelect;
+    }
+    return (
+      <option
+        className="AddAddonToCollection-option"
+        key={key}
+        value={key}
+      >
+        {text}
+      </option>
+    );
+  }
+
+  getSelectData(): SelectData {
+    const {
+      _window,
+      i18n,
+      loadingAddonsInCollections,
+      loadingUserCollections,
+      userCollections,
+    } = this.props;
+
+    let progressMessage;
+    if (loadingUserCollections) {
+      progressMessage = i18n.gettext('Loading...');
+    } else if (loadingAddonsInCollections) {
+      progressMessage = i18n.gettext('Adding...');
+    }
+    if (progressMessage) {
+      // Create a disabled select box with a single option.
+      return {
+        disabled: true,
+        options: [
+          this.createOption({
+            text: progressMessage, key: 'default',
+          }),
+        ],
+      };
+    }
+
+    const options = [
+      this.createOption({
+        text: i18n.gettext('Add to collection'), key: 'default',
+      }),
+    ];
+
+    options.push(this.createOption({
+      text: i18n.gettext('Create new collection'),
+      key: 'create-new-collection',
+      onSelect: () => {
+        // TODO: show create collection overlay when it's implemented.
+        // See
+        // https://github.com/mozilla/addons-frontend/issues/4003
+        // https://github.com/mozilla/addons-frontend/issues/3993
+        _window.location = '/collections/add';
+      },
+    }));
+
+    if (userCollections && userCollections.length) {
+      userCollections.forEach((collection) => {
+        // Make an option for adding the add-on to this collection.
+        // If the user selects a collection that the add-on already
+        // belongs to, they will see an error.
+        options.push(this.createOption({
+          text: collection.name,
+          key: `collection-${collection.id}`,
+          onSelect: () => {
+            this.addToCollection(collection);
+          },
+        }));
+      });
+    }
+
+    return { options, disabled: false };
+  }
+
+  render() {
+    const {
+      className, errorHandler, i18n, addonInCollections,
+    } = this.props;
+    const { options, disabled } = this.getSelectData();
+
+    let addedNotices = [];
+    if (addonInCollections) {
+      addedNotices = addonInCollections.map((collection) => {
+        const notice = i18n.sprintf(
+          i18n.gettext('Added to %(collectionName)s'),
+          { collectionName: collection.name }
+        );
+        return (
+          <Notice
+            type="success"
+            key={collection.id}
+            className="AddAddonToCollection-added"
+          >
+            {notice}
+          </Notice>
+        );
+      });
+    }
+
+    return (
+      <div className={makeClassName('AddAddonToCollection', className)}>
+        {errorHandler.renderErrorIfPresent()}
+        {addedNotices}
+        <Select
+          disabled={disabled}
+          onChange={this.onSelectOption}
+          className="AddAddonToCollection-select"
+        >
+          {options}
+        </Select>
+      </div>
+    );
+  }
+}
+
+const expandCollections = (
+  collections: CollectionsState,
+  meta?: { collections: Array<CollectionId> | null }
+): Array<CollectionType> | null => {
+  return meta && meta.collections ?
+    meta.collections.map((id) => collections.byId[id]) :
+    null;
+};
+
+export const mapStateToProps = (
+  state: {| collections: CollectionsState, users: UsersStateType |},
+  ownProps: Props
+) => {
+  const collections = state.collections;
+  const siteUserId = state.users.currentUserID;
+
+  let userCollections;
+  let addonInCollections;
+
+  if (siteUserId) {
+    userCollections = collections.userCollections[siteUserId];
+    const { addon } = ownProps;
+    if (addon) {
+      addonInCollections =
+        collections.addonInCollections[siteUserId] &&
+        collections.addonInCollections[siteUserId][addon.id];
+    }
+  }
+  return {
+    loadingAddonsInCollections:
+      addonInCollections ? addonInCollections.loading : false,
+    loadingUserCollections:
+      userCollections ? userCollections.loading : false,
+    siteUserId,
+    addonInCollections:
+      expandCollections(collections, addonInCollections),
+    userCollections:
+      expandCollections(collections, userCollections),
+  };
+};
+
+export const extractId = (ownProps: Props) => {
+  const { addon, siteUserId } = ownProps;
+  return `${addon ? addon.id : ''}-${siteUserId || ''}`;
+};
+
+export default compose(
+  connect(mapStateToProps),
+  translate(),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
+)(AddAddonToCollectionBase);

--- a/src/amo/components/AddAddonToCollection/styles.scss
+++ b/src/amo/components/AddAddonToCollection/styles.scss
@@ -1,0 +1,7 @@
+.AddAddonToCollection-select {
+  width: 100%;
+}
+
+.AddAddonToCollection-added {
+  margin-bottom: 10px;
+}

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import AddAddonToCollection from 'amo/components/AddAddonToCollection';
 import Link from 'amo/components/Link';
 import { STATS_VIEW } from 'core/constants';
 import translate from 'core/i18n/translate';
@@ -244,13 +245,18 @@ export class AddonMoreInfoBase extends React.Component<Props> {
   }
 
   render() {
-    const { i18n } = this.props;
+    const { addon, i18n } = this.props;
 
     return (
       <Card
         className="AddonMoreInfo"
         header={i18n.gettext('More information')}
       >
+        <AddAddonToCollection
+          className="AddonMoreInfo-add-to-collection"
+          addon={addon}
+        />
+
         {this.listContent()}
       </Card>
     );

--- a/src/amo/components/AddonMoreInfo/styles.scss
+++ b/src/amo/components/AddonMoreInfo/styles.scss
@@ -2,6 +2,10 @@
 @import "~amo/css/inc/vars";
 @import "~photon-colors/colors";
 
+.AddonMoreInfo-add-to-collection {
+  margin-bottom: 12px;
+}
+
 .AddonMoreInfo-contents {
   margin: 0;
   padding: 0;

--- a/src/ui/components/Button/index.js
+++ b/src/ui/components/Button/index.js
@@ -42,6 +42,8 @@ export default class Button extends React.Component {
         props.to = to;
       }
 
+      // Only a Link needs a disabled css class. This is because button
+      // is styled based on its disabled property.
       props.className = setClassName({ disabled: props.disabled });
 
       if (props.disabled) {

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -1,0 +1,388 @@
+import React from 'react';
+
+import AddAddonToCollection, {
+  extractId, AddAddonToCollectionBase, mapStateToProps,
+} from 'amo/components/AddAddonToCollection';
+import {
+  addAddonToCollection,
+  addonAddedToCollection,
+  createInternalCollection,
+  fetchUserCollections,
+  loadUserCollections,
+} from 'amo/reducers/collections';
+import { ErrorHandler } from 'core/errorHandler';
+import { createInternalAddon } from 'core/reducers/addons';
+import {
+  createFakeCollectionDetail,
+  dispatchClientMetadata,
+  dispatchSignInActions,
+  fakeAddon,
+} from 'tests/unit/amo/helpers';
+import {
+  createFakeEvent,
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+import ErrorList from 'ui/components/ErrorList';
+
+
+describe(__filename, () => {
+  let store;
+
+  beforeEach(() => {
+    store = dispatchClientMetadata().store;
+  });
+
+  const getProps = (customProps = {}) => {
+    return {
+      addon: createInternalAddon(fakeAddon),
+      i18n: fakeI18n(),
+      store,
+      _window: {},
+      ...customProps,
+    };
+  };
+
+  const render = (customProps = {}) => {
+    const props = getProps(customProps);
+    return shallowUntilTarget(
+      <AddAddonToCollection {...props} />, AddAddonToCollectionBase
+    );
+  };
+
+  const signInAndDispatchCollections = ({
+    userId = 1,
+    collections = [
+      createFakeCollectionDetail({ authorId: userId }),
+    ],
+  } = {}) => {
+    dispatchSignInActions({ store, userId });
+    store.dispatch(loadUserCollections({ userId, collections }));
+  };
+
+  const createSomeCollections = ({ authorId = 1 } = {}) => {
+    const firstCollection = createFakeCollectionDetail({
+      authorId, name: 'first',
+    });
+    const secondCollection = createFakeCollectionDetail({
+      authorId, name: 'second',
+    });
+
+    return { firstCollection, secondCollection };
+  };
+
+  it('lets you specify the css class', () => {
+    const root = render({ className: 'MyClass' });
+
+    expect(root).toHaveClassName('MyClass');
+    expect(root).toHaveClassName('AddAddonToCollection');
+  });
+
+  describe('fetching user collections', () => {
+    it('fetches user collections on first render', () => {
+      const userId = 5543;
+      dispatchSignInActions({ store, userId });
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      const root = render();
+
+      sinon.assert.calledWith(dispatchSpy, fetchUserCollections({
+        errorHandlerId: root.instance().props.errorHandler.id, userId,
+      }));
+    });
+
+    it('fetches user collections on update', () => {
+      dispatchSignInActions({ store, userId: 1 });
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      const root = render();
+      dispatchSpy.reset();
+
+      const userId = 2;
+      dispatchSignInActions({ store, userId });
+      root.setProps(mapStateToProps(store.getState(), {}));
+
+      sinon.assert.calledWith(dispatchSpy, fetchUserCollections({
+        errorHandlerId: root.instance().props.errorHandler.id, userId,
+      }));
+    });
+
+    it('does not fetch user collections when signed out', () => {
+      dispatchClientMetadata({ store });
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      render();
+
+      sinon.assert.notCalled(dispatchSpy);
+    });
+
+    it('does not fetch collections on first render if they exist', () => {
+      signInAndDispatchCollections();
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      render();
+
+      sinon.assert.notCalled(dispatchSpy);
+    });
+
+    it('does not fetch collections on update if they exist', () => {
+      signInAndDispatchCollections();
+
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      const root = render();
+      dispatchSpy.reset();
+
+      // Pretend this is updating some unrelated props.
+      root.setProps({});
+
+      sinon.assert.notCalled(dispatchSpy);
+    });
+
+    it('does not fetch user collections while loading', () => {
+      const addon = createInternalAddon(fakeAddon);
+      const userId = 5543;
+      dispatchSignInActions({ store, userId });
+      store.dispatch(fetchUserCollections({
+        errorHandlerId: 'some-id', userId,
+      }));
+
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      render({ addon });
+
+      sinon.assert.notCalled(dispatchSpy);
+    });
+  });
+
+  describe('selecting a user collection', () => {
+    const findOption = ({ root, text }) => {
+      const option = root.find('.AddAddonToCollection-option')
+        .filterWhere((opt) => opt.text() === text);
+      expect(option).toHaveLength(1);
+      return option;
+    };
+
+    it('renders a disabled select when loading user collections', () => {
+      const userId = 5543;
+      dispatchSignInActions({ store, userId });
+      store.dispatch(fetchUserCollections({
+        errorHandlerId: 'some-id', userId,
+      }));
+
+      const root = render();
+
+      const select = root.find('.AddAddonToCollection-select');
+      expect(select.props().disabled).toEqual(true);
+      expect(select.html()).toContain('Loading...');
+    });
+
+    it('renders a disabled select when adding add-on to collection', () => {
+      const addon = createInternalAddon(fakeAddon);
+      const userId = 5543;
+      dispatchSignInActions({ store, userId });
+      store.dispatch(addAddonToCollection({
+        addonId: addon.id,
+        userId,
+        collectionId: 321,
+        collectionSlug: 'some-collection',
+        errorHandlerId: 'error-handler',
+      }));
+
+      const root = render({ addon });
+
+      const select = root.find('.AddAddonToCollection-select');
+      expect(select.props().disabled).toEqual(true);
+      expect(select.html()).toContain('Adding...');
+    });
+
+    it('lets you select a collection', () => {
+      const addon = createInternalAddon({ ...fakeAddon, id: 234 });
+      const authorId = 1;
+
+      const { firstCollection, secondCollection } =
+        createSomeCollections({ authorId });
+
+      signInAndDispatchCollections({
+        userId: authorId,
+        collections: [firstCollection, secondCollection],
+      });
+      const dispatchStub = sinon.stub(store, 'dispatch');
+      const root = render({ addon });
+
+      const select = root.find('.AddAddonToCollection-select');
+      const secondOption = findOption({
+        root, text: secondCollection.name,
+      });
+
+      // Add the add-on to the second collection.
+      select.simulate('change', createFakeEvent({
+        target: { value: secondOption.prop('value') },
+      }));
+
+      sinon.assert.calledWith(dispatchStub, addAddonToCollection({
+        errorHandlerId: root.instance().props.errorHandler.id,
+        addonId: addon.id,
+        collectionId: secondCollection.id,
+        collectionSlug: secondCollection.slug,
+        userId: authorId,
+      }));
+    });
+
+    it('shows a notice that you added to a collection', () => {
+      const addon = createInternalAddon(fakeAddon);
+      const authorId = 1;
+
+      const { firstCollection } = createSomeCollections({ authorId });
+
+      signInAndDispatchCollections({
+        userId: authorId, collections: [firstCollection],
+      });
+      store.dispatch(addonAddedToCollection({
+        addonId: addon.id,
+        userId: authorId,
+        collectionId: firstCollection.id,
+      }));
+
+      const root = render({ addon });
+
+      const notice = root.find('Notice');
+      expect(notice.prop('type')).toEqual('success');
+      expect(notice.html()).toContain(`Added to ${firstCollection.name}`);
+    });
+
+    it('shows notices for each target collection', () => {
+      const addon = createInternalAddon(fakeAddon);
+      const authorId = 1;
+
+      const { firstCollection, secondCollection } =
+        createSomeCollections({ authorId });
+
+      signInAndDispatchCollections({
+        userId: authorId,
+        collections: [firstCollection, secondCollection],
+      });
+
+      const addParams = { addonId: addon.id, userId: authorId };
+
+      // Add the add-on to both collections.
+      store.dispatch(addonAddedToCollection({
+        ...addParams, collectionId: firstCollection.id,
+      }));
+
+      store.dispatch(addonAddedToCollection({
+        ...addParams, collectionId: secondCollection.id,
+      }));
+
+      const root = render({ addon });
+
+      const notice = root.find('Notice');
+      expect(notice.at(0).html())
+        .toContain(`Added to ${firstCollection.name}`);
+      expect(notice.at(1).html())
+        .toContain(`Added to ${secondCollection.name}`);
+    });
+
+    it('does nothing when you select the prompt', () => {
+      signInAndDispatchCollections();
+
+      const dispatchStub = sinon.stub(store, 'dispatch');
+      const root = render();
+
+      const select = root.find('.AddAddonToCollection-select');
+      const promptOption = findOption({
+        root, text: 'Add to collection',
+      });
+
+      // Select the prompt (first option) which doesn't do anything.
+      select.simulate('change', createFakeEvent({
+        target: { value: promptOption.prop('value') },
+      }));
+
+      sinon.assert.notCalled(dispatchStub);
+    });
+
+    it('lets you create a new collection', () => {
+      const addon = createInternalAddon({ ...fakeAddon, id: 234 });
+      signInAndDispatchCollections();
+
+      const _window = { location: null };
+      const root = render({ addon, _window });
+
+      const select = root.find('.AddAddonToCollection-select');
+      const createOption = findOption({
+        root, text: 'Create new collection',
+      });
+
+      select.simulate('change', createFakeEvent({
+        target: { value: createOption.prop('value') },
+      }));
+
+      expect(_window.location).toEqual('/collections/add');
+    });
+
+    it('requires an add-on before you can add to a collection', () => {
+      signInAndDispatchCollections();
+      const root = render({ addon: null });
+
+      const collection = createInternalCollection({
+        detail: createFakeCollectionDetail(),
+      });
+      // This should not be possible through the UI.
+      expect(() => root.instance().addToCollection(collection))
+        .toThrow(/no add-on has been loaded/);
+    });
+
+    it('requires you to sign in before adding to a collection', () => {
+      const root = render();
+
+      const collection = createInternalCollection({
+        detail: createFakeCollectionDetail(),
+      });
+      // This should not be possible through the UI.
+      expect(() => root.instance().addToCollection(collection))
+        .toThrow(/you are not signed in/);
+    });
+  });
+
+  describe('error handling', () => {
+    const createFailedErrorHandler = () => {
+      const error = new Error('unexpected error');
+      const errorHandler = new ErrorHandler({
+        dispatch: store.dispatch, id: 'some-error-handler',
+      });
+      errorHandler.handle(error);
+      return errorHandler;
+    };
+
+    it('renders an error', () => {
+      const root = render({ errorHandler: createFailedErrorHandler() });
+
+      expect(root.find(ErrorList)).toHaveLength(1);
+    });
+
+    it('does not load data when there is an error', () => {
+      dispatchSignInActions({ store });
+      const errorHandler = createFailedErrorHandler();
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      render({ errorHandler });
+
+      sinon.assert.notCalled(dispatchSpy);
+    });
+  });
+
+  describe('extractId', () => {
+    const _props = (customProps = {}) => {
+      return {
+        ...getProps(customProps),
+        ...mapStateToProps(store.getState(), {}),
+      };
+    };
+
+    it('renders an ID without an add-on or user ID', () => {
+      expect(extractId(_props({ addon: null }))).toEqual('-');
+    });
+
+    it('renders an ID with an add-on ID and user ID', () => {
+      const addon = createInternalAddon({ ...fakeAddon, id: 5432 });
+      const userId = 1234;
+      dispatchSignInActions({ store, userId });
+      expect(extractId(_props({ addon })))
+        .toEqual(`${addon.id}-${userId}`);
+    });
+  });
+});

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -190,6 +190,13 @@ describe(__filename, () => {
       expect(select.html()).toContain('Adding…');
     });
 
+    it('does not render collection optgroup without collections', () => {
+      dispatchSignInActions({ store });
+      const root = render();
+
+      expect(root.find('optgroup')).toHaveLength(0);
+    });
+
     it('lets you select a collection', () => {
       const addon = createInternalAddon({ ...fakeAddon, id: 234 });
       const authorId = 1;

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -167,8 +167,8 @@ describe(__filename, () => {
       const root = render();
 
       const select = root.find('.AddAddonToCollection-select');
-      expect(select.props().disabled).toEqual(true);
-      expect(select.html()).toContain('Loading...');
+      expect(select).toHaveProp('disabled', true);
+      expect(select.html()).toContain('Loading…');
     });
 
     it('renders a disabled select when adding add-on to collection', () => {
@@ -186,8 +186,8 @@ describe(__filename, () => {
       const root = render({ addon });
 
       const select = root.find('.AddAddonToCollection-select');
-      expect(select.props().disabled).toEqual(true);
-      expect(select.html()).toContain('Adding...');
+      expect(select).toHaveProp('disabled', true);
+      expect(select.html()).toContain('Adding…');
     });
 
     it('lets you select a collection', () => {

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -26,9 +26,10 @@ import { loadCurrentUserAccount } from 'amo/reducers/users';
 import {
   createStubErrorHandler,
   createUserAccountResponse,
-  userAuthToken,
+  randomId,
   sampleUserAgent,
   signedInApiState as coreSignedInApiState,
+  userAuthToken,
 } from 'tests/unit/helpers';
 
 
@@ -274,7 +275,7 @@ export function createAddonsApiResult(results) {
 
 export function createFakeAutocompleteResult({ name = 'suggestion-result' } = {}) {
   return {
-    id: Date.now(),
+    id: randomId(),
     icon_url: `${config.get('amoCDN')}/${name}.png`,
     name,
     url: `https://example.org/en-US/firefox/addons/${name}/`,
@@ -335,7 +336,7 @@ export const createFakeCollectionDetail = ({
     },
     default_locale: 'en-US',
     description: 'some description',
-    id: Date.now(),
+    id: randomId(),
     modified: Date.now(),
     name,
     public: true,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -19,6 +19,11 @@ import { fakeAddon } from 'tests/unit/amo/helpers';
 export const sampleUserAgent = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1';
 export const sampleUserAgentParsed = UAParser(sampleUserAgent);
 
+export const randomId = () => {
+  // Add 1 to make sure it's never zero.
+  return Math.floor(Math.random() * 10000) + 1;
+};
+
 /*
  * Return a fake authentication token that can be
  * at least decoded in a realistic way.


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/2768

This implements a simple UI for adding an extension to an existing collection from the detail page. If you add an extension to a collection and then reload the page (or visit it again later) you will not see an indication that it is a part of a collection. This was a deliberate choice to reduce complexity. Instead, you will see a clear and concise error if you try to add it.

UX mock: https://github.com/mozilla/addons-frontend/issues/3993#issuecomment-349064460



![addons-frontend-collection mov](https://user-images.githubusercontent.com/55398/35017414-5c198246-fae2-11e7-8bc6-1adec6eb4bf0.gif)
