### PR TITLE
Sagas/reducers for adding an add-on to a collection

### DIFF
--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -540,11 +540,9 @@ type ChangeAddonCollectionsLoadingFlagParams = {|
   loading: boolean,
 |};
 
-export const changeAddonCollectionsLoadingFlag = (
-  {
-    addonId, userId, state, loading,
-  }: ChangeAddonCollectionsLoadingFlagParams = {}
-): CollectionsState => {
+export const changeAddonCollectionsLoadingFlag = ({
+  addonId, userId, state, loading,
+}: ChangeAddonCollectionsLoadingFlagParams = {}): CollectionsState => {
   const userState = state.addonInCollections[userId];
   const addonState = userState && userState[addonId];
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4150

This adds two sagas along with reducers to support them:

* I implemented the `addAddonToCollection` saga. When the user goes to an add-on detail page, they can add the add-on to a collection by choosing it from a select box. That action will run this saga.
* The `fetchUserCollections` saga now fetches all collections, not just the first 25. This is so the select box can present all of them.