### PR TITLE
chore: Add config option to disable version checks in search

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -43,6 +43,13 @@ module.exports = {
   isDeployed: true,
   isDevelopment: false,
 
+  // For all Firefox 57+ (Quantum) UAs, send the `appversion` in all API
+  // search requests. This will return only compatible add-ons, which is
+  // good for UX (it prevents a lot of incompatible old add-ons).
+  // Disable this in development when working with stage data, which is
+  // very out-of-date and mostly not 57+ compatible.
+  restrictSearchResultsToAppVersion: true,
+
   // The canonical list of enabled apps.
   validAppNames,
 
@@ -77,6 +84,7 @@ module.exports = {
     'apiHost',
     'apiPath',
     'appName',
+    'restrictSearchResultsToAppVersion',
     'cookieMaxAge',
     'cookieName',
     'cookieSecure',

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -3,6 +3,11 @@ module.exports = {
   proxyApiHost: 'http://olympia.dev',
   proxyPort: 3000,
   proxyEnabled: true,
+  // Setting this to false returns add-ons that are not compatible but means
+  // developers can pull from a much larger dataset on the local/-dev/-stage
+  // servers. Set this to true to only get compatible add-ons (this is what
+  // happens in production) but get a lot fewer add-ons in search results.
+  restrictSearchResultsToAppVersion: false,
   fxaConfig: 'local',
   trackingEnabled: false,
 };

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -1,4 +1,5 @@
 import { oneLine } from 'common-tags';
+import defaultConfig from 'config';
 
 import {
   ADDON_TYPE_THEME,
@@ -32,6 +33,7 @@ export const paramsToFilter = {
 };
 
 export function addVersionCompatibilityToFilters({
+  config = defaultConfig,
   filters,
   userAgentInfo,
 } = {}) {
@@ -57,10 +59,16 @@ export function addVersionCompatibilityToFilters({
     // with a version of at least 57, at least for now. Find the explanation
     // here: https://github.com/mozilla/addons-frontend/pull/2969#issuecomment-323551742
     if (browserVersion >= 57) {
-      log.debug(oneLine`Setting "compatibleWithVersion" to current application
+      if (config.get('restrictSearchResultsToAppVersion')) {
+        log.debug(oneLine`Setting "compatibleWithVersion" to current application
         version (Firefox ${browserVersion}) so only relevant extensions are
         displayed.`);
-      newFilters.compatibleWithVersion = userAgentInfo.browser.version;
+        newFilters.compatibleWithVersion = userAgentInfo.browser.version;
+      } else {
+        log.warn(oneLine`restrictSearchResultsToAppVersion config set;
+          not setting "compatibleWithVersion" to current application version,
+          even though it's above 57.`);
+      }
     }
   }
 

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -14,10 +14,18 @@ import {
   fixFiltersForAndroidThemes,
 } from 'core/searchUtils';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
-import { userAgents, userAgentsByPlatform } from 'tests/unit/helpers';
+import {
+  getFakeConfig,
+  userAgents,
+  userAgentsByPlatform,
+} from 'tests/unit/helpers';
 
 
 describe(__filename, () => {
+  const fakeConfig = getFakeConfig({
+    restrictSearchResultsToAppVersion: true,
+  });
+
   describe('addVersionCompatibilityToFilters', () => {
     it('returns unmodified filters if not Firefox', () => {
       const { state } = dispatchClientMetadata({
@@ -25,6 +33,7 @@ describe(__filename, () => {
       });
 
       const newFilters = addVersionCompatibilityToFilters({
+        config: fakeConfig,
         filters: { query: 'foo' },
         userAgentInfo: state.api.userAgentInfo,
       });
@@ -69,6 +78,7 @@ describe(__filename, () => {
       });
 
       const newFilters = addVersionCompatibilityToFilters({
+        config: fakeConfig,
         filters: { query: 'foo' },
         userAgentInfo: state.api.userAgentInfo,
       });
@@ -77,6 +87,23 @@ describe(__filename, () => {
         compatibleWithVersion: '57.1',
         query: 'foo',
       });
+    });
+
+    it('does not add compatibleWithVersion when config is disabled', () => {
+      const fakeConfigWithVersionFalse = getFakeConfig({
+        restrictSearchResultsToAppVersion: false,
+      });
+      const { state } = dispatchClientMetadata({
+        userAgent: userAgentsByPlatform.mac.firefox57,
+      });
+
+      const newFilters = addVersionCompatibilityToFilters({
+        config: fakeConfigWithVersionFalse,
+        filters: { query: 'foo' },
+        userAgentInfo: state.api.userAgentInfo,
+      });
+
+      expect(newFilters).toEqual({ query: 'foo' });
     });
 
     it('requires filters', () => {


### PR DESCRIPTION
Fixes #4152

Adds a config option (set to `true` for normal environments and `false` for development environments) that ignores version compatibility checks. This means we get add-ons returned in searches when using -stage data.

### Before

<img width="1260" alt="screenshot 2018-01-13 00 33 30" src="https://user-images.githubusercontent.com/90871/34900786-bc1471aa-f7fa-11e7-891c-5032041410dc.png">

### After

<img width="1260" alt="screenshot 2018-01-13 00 08 44" src="https://user-images.githubusercontent.com/90871/34900787-c0d9dc84-f7fa-11e7-876f-0d0e787f910d.png">
