### PR TITLE
Fix Photon notification issues

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -527,6 +527,14 @@ export class AddonBase extends React.Component {
         {errorBanner}
         <div className="Addon-header-wrapper">
           <Card className="Addon-header-info-card" photonStyle>
+            {compatibility && !isCompatible ? (
+              <AddonCompatibilityError
+                className="Addon-header-compatibility-error"
+                maxVersion={compatibility.maxVersion}
+                minVersion={compatibility.minVersion}
+                reason={compatibility.reason}
+              />
+            ) : null}
             <header className="Addon-header">
               {this.headerImage({ compatible: isCompatible })}
 
@@ -554,14 +562,6 @@ export class AddonBase extends React.Component {
                 {i18n.gettext('Extension Metadata')}
               </h2>
             </header>
-
-            {compatibility && !isCompatible ? (
-              <AddonCompatibilityError
-                maxVersion={compatibility.maxVersion}
-                minVersion={compatibility.minVersion}
-                reason={compatibility.reason}
-              />
-            ) : null}
           </Card>
 
           <Card className="Addon-header-meta-and-ratings" photonStyle>

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -48,6 +48,11 @@
 
     width: 65%;
   }
+
+  .AddonCompatibilityError {
+    margin: 0;
+    margin-bottom: 12px;
+  }
 }
 
 .Addon-header-meta-and-ratings {

--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -97,7 +97,7 @@ export class AddonCompatibilityErrorBase extends React.Component {
 
     return (
       <Notice type="error" className="AddonCompatibilityError">
-        <div dangerouslySetInnerHTML={sanitizeHTML(message, ['a'])} />
+        <span dangerouslySetInnerHTML={sanitizeHTML(message, ['a'])} />
       </Notice>
     );
   }

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -49,10 +49,12 @@ const Notice = ({
     <div className={finalClass}>
       <div className="Notice-icon" />
       <div className="Notice-column">
-        <p className="Notice-text">
-          {children}
-        </p>
-        {actionButton}
+        <div>
+          <p className="Notice-text">
+            {children}
+          </p>
+          {actionButton}
+        </div>
       </div>
     </div>
   );

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -61,7 +61,13 @@
   }
 
   background-color: $red-50;
-  color: $white;
+
+  &,
+  :link,
+  :hover,
+  :active {
+    color: $white;
+  }
 }
 
 .Notice-success {
@@ -87,5 +93,11 @@
   }
 
   background-color: $green-50;
-  color: $green-90;
+
+  &,
+  :link,
+  :hover,
+  :active {
+    color: $green-90;
+  }
 }

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -21,6 +21,11 @@
   width: 16px;
 }
 
+.Notice-column {
+  align-items: center;
+  display: flex;
+}
+
 .Notice-text {
   display: inline-block;
   margin: 0;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4169 (this issue contains a list of what was fixed).

Here is the updated link style as well as a fix for the vertical centering of the message:

<img width="739" alt="screenshot 2018-01-17 17 27 28" src="https://user-images.githubusercontent.com/55398/35072929-50b41a54-fbac-11e7-8a69-b10eeabd7aa7.png">

I could only reproduce the reload-and-it-jumps bug on dev, not locally. However, while inspecting the markup I think the culprit was putting a `<div>` inside of a `<p>` tag which seems to have created wonky HTML on the server only:

<img width="228" alt="screenshot 2018-01-17 17 16 51" src="https://user-images.githubusercontent.com/55398/35072976-76e7a02e-fbac-11e7-8c29-7db8cdea9e41.png">
