### PR TITLE
Preserve existing filters when typing a new search

### DIFF
--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -155,7 +155,7 @@ export class SearchFiltersBase extends React.Component {
           </Select>
 
           {/* Categories are linked to addonType so we don't allow changing the
-            addonType if a filter is set. */}
+            addonType if a category is set. */}
           {!filters.category && (
             <div>
               <label

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -21,6 +21,7 @@ import {
 import {
   convertOSToFilterValue,
   convertFiltersToQueryParams,
+  convertQueryParamsToFilters,
 } from 'core/searchUtils';
 import Icon from 'ui/components/Icon';
 
@@ -37,6 +38,8 @@ export class SearchFormBase extends React.Component {
     errorHandler: PropTypes.object.isRequired,
     i18n: PropTypes.object.isRequired,
     loadingSuggestions: PropTypes.bool.isRequired,
+    // See ReactRouterLocation in 'core/types/router'
+    location: PropTypes.object.isRequired,
     pathname: PropTypes.string.isRequired,
     query: PropTypes.string.isRequired,
     router: PropTypes.object.isRequired,
@@ -87,12 +90,17 @@ export class SearchFormBase extends React.Component {
   }
 
   createFiltersFromQuery(newFilters) {
-    const { userAgentInfo } = this.props;
-    const filters = { ...newFilters };
+    const { location, userAgentInfo } = this.props;
+    // Preserve any existing search filters.
+    const filtersFromLocation = convertQueryParamsToFilters(location.query);
+    // Do not preserve page. New searches should always start on page 1.
+    delete filtersFromLocation.page;
 
-    filters.operatingSystem = convertOSToFilterValue(userAgentInfo.os.name);
-
-    return filters;
+    return {
+      operatingSystem: convertOSToFilterValue(userAgentInfo.os.name),
+      ...filtersFromLocation,
+      ...newFilters,
+    };
   }
 
   goToSearch(query) {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4120

This patch preserves any existing filters for these user actions:
* Typing keywords in the search bar and viewing auto-completion results
* Typing a keyword and pressing enter in the search bar to go to the search results page