### PR TITLE
Remove randomly generated style colors

### DIFF
--- a/src/amo/components/HomeHeroBanner/styles.scss
+++ b/src/amo/components/HomeHeroBanner/styles.scss
@@ -46,7 +46,7 @@ $colors-third-item:  ("cyan", #15aabf, #1098ad)
 
 .HeroSection {
   &:nth-child(1) {
-    $color: nth($colors-first-item, random(length($colors-first-item)));
+    $color: nth($colors-first-item, 1);
     $bg-color: nth($color, 2);
     $fg-color: nth($color, 3);
 
@@ -56,7 +56,7 @@ $colors-third-item:  ("cyan", #15aabf, #1098ad)
   }
 
   &:nth-child(2) {
-    $color: nth($colors-second-item, random(length($colors-second-item)));
+    $color: nth($colors-second-item, 1);
     $bg-color: nth($color, 2);
     $fg-color: nth($color, 3);
 
@@ -66,7 +66,7 @@ $colors-third-item:  ("cyan", #15aabf, #1098ad)
   }
 
   &:nth-child(3) {
-    $color: nth($colors-third-item, random(length($colors-third-item)));
+    $color: nth($colors-third-item, 1);
     $bg-color: nth($color, 2);
     $fg-color: nth($color, 3);
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4229

The hash in the filename of the final stylesheet asset is generated from its contents. When we deployed a build to multiple server instances, they were each generating different file names.