### PR TITLE
Change name of auth cookie to fix broken logout

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -32,7 +32,7 @@ module.exports = {
 
   // 2592000 is 30 days in seconds.
   cookieMaxAge: 2592000,
-  cookieName: 'api_auth_token',
+  cookieName: 'frontend_auth_token',
   cookieSecure: true,
 
   enableClientConsole: false,


### PR DESCRIPTION
This is complimentary to the server changes happening in https://github.com/mozilla/addons-server/issues/7396

The server cookie was changed in https://github.com/mozilla/addons-server/pull/7397