### PR TITLE
I4135 - submit rating popup font consistency

### DIFF
--- a/src/amo/components/AddonReview/styles.scss
+++ b/src/amo/components/AddonReview/styles.scss
@@ -35,8 +35,6 @@
 
 .AddonReview-textarea,
 .AddonReview-submit {
-  @include font-regular();
-
   border: 2px solid $form-border-color;
   border-radius: 8px;
   box-shadow: none;

--- a/src/amo/components/AddonReview/styles.scss
+++ b/src/amo/components/AddonReview/styles.scss
@@ -35,6 +35,8 @@
 
 .AddonReview-textarea,
 .AddonReview-submit {
+  @include font-regular();
+
   border: 2px solid $form-border-color;
   border-radius: 8px;
   box-shadow: none;

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -18,6 +18,8 @@ html {
 // to fix #3640
 input,
 textarea {
+  @include font-regular();
+
   background: $white;
 }
 


### PR DESCRIPTION
Fixes #4135 
Inconsistent fonts in submit review popup.

Before:
<img width="770" alt="before" src="https://user-images.githubusercontent.com/5318732/35436942-60aa0f0c-02b6-11e8-85c5-e8af561151ed.png">

After
<img width="769" alt="after" src="https://user-images.githubusercontent.com/5318732/35436947-69dea15a-02b6-11e8-96a8-f365bcbdbda9.png">
