### PR TITLE
fix: Allow HTML entities in collection description

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -18,7 +18,7 @@ import { withFixedErrorHandler } from 'core/errorHandler';
 import log from 'core/logger';
 import { hasPermission } from 'amo/reducers/users';
 import translate from 'core/i18n/translate';
-import { parsePage } from 'core/utils';
+import { parsePage, sanitizeHTML } from 'core/utils';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
@@ -142,7 +142,11 @@ export class CollectionBase extends React.Component<Props> {
             {collection ? collection.name : <LoadingText />}
           </h1>
           <p className="Collection-description">
-            {collection ? collection.description : <LoadingText />}
+            {collection ? (
+              <span
+                dangerouslySetInnerHTML={sanitizeHTML(collection.description)}
+              />
+            ) : <LoadingText />}
           </p>
           <MetadataCard
             metadata={[

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -66,6 +66,22 @@ describe(__filename, () => {
     expect(wrapper.find('.Collection-wrapper')).toHaveLength(1);
   });
 
+  it('allows HTML entities in the Collection description', () => {
+    const { store } = dispatchClientMetadata();
+
+    store.dispatch(loadCurrentCollection({
+      addons: createFakeCollectionAddons(),
+      detail: {
+        ...defaultCollectionDetail,
+        description: 'Apples &amp; carrots',
+      },
+    }));
+    const wrapper = renderComponent({ store });
+
+    expect(wrapper.find('.Collection-description').html())
+      .toContain('Apples &amp; carrots');
+  });
+
   it('renders loading indicators when there is no collection', () => {
     const wrapper = renderComponent({ collection: null });
 
@@ -134,7 +150,6 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -153,7 +168,6 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -229,7 +243,6 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -278,7 +291,6 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -313,7 +325,6 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -365,7 +376,6 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -500,7 +510,6 @@ describe(__filename, () => {
   it('renders an HTML title', () => {
     const { store } = dispatchClientMetadata();
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -518,7 +527,6 @@ describe(__filename, () => {
   it('renders an edit link when user has `Collections:Edit` permission', () => {
     const { store } = dispatchSignInActions({ permissions: [COLLECTIONS_EDIT] });
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: defaultCollectionDetail,
@@ -532,7 +540,6 @@ describe(__filename, () => {
     const authorUserId = 11;
     const { store } = dispatchSignInActions({ userId: authorUserId });
 
-    // We need a collection for this test case.
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
       detail: createFakeCollectionDetail({


### PR DESCRIPTION
Fix #4213 

### Before
<img width="1349" alt="screenshot 2018-01-26 17 31 09" src="https://user-images.githubusercontent.com/90871/35453105-da07b6d8-02c0-11e8-9c66-b8a3cd147c22.png">

### After
<img width="1349" alt="screenshot 2018-01-26 17 26 07" src="https://user-images.githubusercontent.com/90871/35453095-d2043038-02c0-11e8-9462-5fdde75014e4.png">
