### PR TITLE
I4089 - distorted stats section fix

### DIFF
--- a/src/ui/components/MetadataCard/styles.scss
+++ b/src/ui/components/MetadataCard/styles.scss
@@ -20,7 +20,7 @@
 
   flex: 1;
   margin: 12px;
-  max-width: 30%;
+  max-width: 25%;
 
   dd {
     line-height: 1.4;
@@ -31,5 +31,6 @@
   dt {
     color: $grey-50;
     line-height: 1.4;
+    word-wrap: break-word;
   }
 }


### PR DESCRIPTION
Fixes: #4089 

Before: 
![screen shot 2018-01-27 at 00 18 17](https://user-images.githubusercontent.com/5318732/35455725-0baf0c44-02f9-11e8-9643-b54debb214f7.png)

After:
<img width="1414" alt="screen shot 2018-01-27 at 12 22 57 am" src="https://user-images.githubusercontent.com/5318732/35455752-1bc2c01c-02f9-11e8-99fd-7a546066e956.png">

**NOTE**
Need to change max-width from 30% to 25%, to adjust case when user number is large.
<img width="1433" alt="screen shot 2018-01-27 at 12 23 23 am" src="https://user-images.githubusercontent.com/5318732/35455785-3d498cd4-02f9-11e8-9017-d91f4d597085.png">
