### PR TITLE
Toggle button of the extension is displayed correctly on resize

### DIFF
--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -171,16 +171,9 @@ $addon-padding: 20px;
   }
 
   &:not(.theme) .content {
-    align-items: left;
-    flex-direction: column;
+    align-items: center;
+    flex-direction: row;
     width: calc(100% - 94px);
-  }
-
-  @include respond-to(large) {
-    &:not(.theme) .content {
-      align-items: center;
-      flex-direction: row;
-    }
   }
 
   .notification {


### PR DESCRIPTION
Issue #4190.
![ff2](https://user-images.githubusercontent.com/17615573/35463647-b1064f90-0317-11e8-87f3-a1bade94827b.png)
![ff3](https://user-images.githubusercontent.com/17615573/35463648-b13eba9c-0317-11e8-8bad-79f4b33eaec9.png)

Its working here. But when we decrease width below 350 px its shows something like this : 

![ff4](https://user-images.githubusercontent.com/17615573/35463691-ee1c0a78-0317-11e8-8821-7b51ddb448e1.png)

After removing the side padding : 

![ff5](https://user-images.githubusercontent.com/17615573/35463714-0bd17846-0318-11e8-9f1a-12a1b245d56e.png)

Is there any need to change ?
