### PR TITLE
I4086: word wrap for show more card contents

### DIFF
--- a/src/ui/components/ShowMoreCard/ShowMoreCard.scss
+++ b/src/ui/components/ShowMoreCard/ShowMoreCard.scss
@@ -17,6 +17,7 @@
   max-height: 150px;
   overflow: hidden;
   position: relative;
+  word-wrap: break-word;
 
   .ShowMoreCard--expanded & {
     &::after {


### PR DESCRIPTION
Fixes: #4086 

PS: word wrapping on `showmore-card-contents` so that this may not replicate at other places too

Before:
<img width="774" alt="screen shot 2018-01-28 at 8 23 48 pm" src="https://user-images.githubusercontent.com/5318732/35483533-5454c9fe-0469-11e8-9f5c-72a5e0ae3d60.png">

After:
<img width="851" alt="screen shot 2018-01-28 at 8 22 23 pm" src="https://user-images.githubusercontent.com/5318732/35483537-5b0b98cc-0469-11e8-8798-572d62f9ee46.png">
