### PR TITLE
I4009: image alt overflow issue

### DIFF
--- a/src/amo/components/SearchSuggestion/styles.scss
+++ b/src/amo/components/SearchSuggestion/styles.scss
@@ -19,6 +19,8 @@
   @include margin-end(12px);
 
   height: 16px;
+  // To handle 404 images, image width is very small so alt text distorts UI
+  // https://github.com/mozilla/addons-frontend/issues/4009
   overflow: hidden;
   width: 16px;
 }

--- a/src/amo/components/SearchSuggestion/styles.scss
+++ b/src/amo/components/SearchSuggestion/styles.scss
@@ -19,6 +19,7 @@
   @include margin-end(12px);
 
   height: 16px;
+  overflow: hidden;
   width: 16px;
 }
 


### PR DESCRIPTION
Fixes #4009 

Before:
<img width="200" alt="screen shot 2018-01-28 at 8 39 09 pm" src="https://user-images.githubusercontent.com/5318732/35483719-600df61a-046b-11e8-8caf-25235dc6a4b9.png">

After:
<img width="200" alt="screen shot 2018-01-28 at 8 38 07 pm" src="https://user-images.githubusercontent.com/5318732/35483724-67268ba6-046b-11e8-9a67-b5d69ad1afcb.png">
