### PR TITLE
Revert "Disable the add-to-collection prompt option in the menu (#4227)"

### DIFF
--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 /* global window */
-/* eslint-disable react/sort-comp, react/no-unused-prop-types */
+/* eslint-disable react/sort-comp */
 import makeClassName from 'classnames';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -50,13 +50,6 @@ type SelectData = {|
   actionOptions: Array<Object>,
   collectionOptions: Array<Object>,
   disabled: boolean,
-|};
-
-type CreateOptionParams = {|
-  disabled?: boolean,
-  key: string,
-  onSelect?: OnSelectOptionType,
-  text: string,
 |};
 
 export class AddAddonToCollectionBase extends React.Component<Props> {
@@ -135,15 +128,19 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
     }));
   }
 
-  createOption({
-    text, key, onSelect, disabled = false,
-  }: CreateOptionParams) {
+  createOption(
+    {
+      text, key, onSelect,
+    }: {
+      // eslint-disable-next-line react/no-unused-prop-types
+      text: string, key: string, onSelect?: OnSelectOptionType,
+    }
+  ) {
     if (onSelect) {
       this.optionSelectHandlers[key] = onSelect;
     }
     return (
       <option
-        disabled={disabled}
         className="AddAddonToCollection-option"
         key={key}
         value={key}
@@ -185,9 +182,7 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
 
     actionOptions.push(
       this.createOption({
-        text: i18n.gettext('Select a collection…'),
-        key: 'default',
-        disabled: true,
+        text: i18n.gettext('Select a collection…'), key: 'default',
       })
     );
 

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -284,7 +284,7 @@ describe(__filename, () => {
         .toContain(`Added to ${secondCollection.name}`);
     });
 
-    it('disables the select the prompt', () => {
+    it('does nothing when you select the prompt', () => {
       signInAndDispatchCollections();
 
       const dispatchStub = sinon.stub(store, 'dispatch');
@@ -294,11 +294,8 @@ describe(__filename, () => {
       const promptOption = findOption({
         root, text: 'Select a collection…',
       });
-      expect(promptOption).toHaveProp('disabled', true);
 
-      // Try selecting the prompt (the first option) which shouldn't
-      // do anything. This is to make sure the event handler correctly
-      // ignores the event.
+      // Select the prompt (first option) which doesn't do anything.
       select.simulate('change', createFakeEvent({
         target: { value: promptOption.prop('value') },
       }));


### PR DESCRIPTION
This reverts commit 0da83fe6274c1c1cc9ad6ed87c7fa2ef2d44bbfa.

We decided not to disable the first option of the select. See https://github.com/mozilla/addons/issues/11361