### PR TITLE
fix: Don't set input to 100% (Fix #4268)

### DIFF
--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -28,7 +28,6 @@ textarea {
   font-size: $font-size-m-smaller;
   line-height: 1.4;
   padding: 4px;
-  width: 100%;
 }
 
 *,

--- a/src/ui/components/DismissibleTextForm/styles.scss
+++ b/src/ui/components/DismissibleTextForm/styles.scss
@@ -41,6 +41,7 @@
   min-height: 51px;
   padding: 6px;
   resize: none;
+  width: 100%;
 
   @include respond-to(medium) {
     padding: 12px;


### PR DESCRIPTION
### Before
<img width="729" alt="screenshot 2018-01-31 13 48 47" src="https://user-images.githubusercontent.com/90871/35626518-dd2cb32e-068d-11e8-87c7-591749720bd1.png">

### After
<img width="714" alt="screenshot 2018-01-31 13 46 38" src="https://user-images.githubusercontent.com/90871/35626523-e0e81fb2-068d-11e8-9fcd-0ed7676121ea.png">
