### PR TITLE
fix: Don't disable Search Plugins on the server (fix #4047)

### DIFF
--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -46,6 +46,7 @@ export function isCompatibleWithUserAgent({
   minVersion,
   userAgentInfo,
   _log = log,
+  _hasWindow = typeof window !== 'undefined',
   _window = typeof window !== 'undefined' ? window : {},
 } = {}) {
   // If the userAgent is false there was likely a programming error.
@@ -101,6 +102,11 @@ export function isCompatibleWithUserAgent({
 
     if (
       addon.type === ADDON_TYPE_OPENSEARCH &&
+      // If window isn't defined but the browser is Firefox, this is likely a
+      // server-side render, so we shouldn't condemn this search plugin to
+      // incompatibility yet, or it will stay disabled.
+      // See: https://github.com/mozilla/addons-frontend/issues/4047
+      _hasWindow &&
       !(_window.external && 'AddSearchProvider' in _window.external)
     ) {
       return { compatible: false, reason: INCOMPATIBLE_NO_OPENSEARCH };

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -1,4 +1,3 @@
-import { oneLine } from 'common-tags';
 import UAParser from 'ua-parser-js';
 
 import {
@@ -106,19 +105,56 @@ describe(__filename, () => {
       });
     });
 
-    it(oneLine`should use a Firefox for iOS reason code even if minVersion is
-      also not met`, () => {
-        const userAgentInfo = {
-          browser: { name: 'Firefox', version: '8.0' },
-          os: { name: 'iOS' },
-        };
-        expect(isCompatibleWithUserAgent({
-          addon: createInternalAddon(fakeAddon),
-          minVersion: '9.0',
-          userAgentInfo,
-        }))
-          .toEqual({ compatible: false, reason: INCOMPATIBLE_FIREFOX_FOR_IOS });
+    it('should use a Firefox for iOS reason code even if minVersion is also not met', () => {
+      const userAgentInfo = {
+        browser: { name: 'Firefox', version: '8.0' },
+        os: { name: 'iOS' },
+      };
+      expect(isCompatibleWithUserAgent({
+        addon: createInternalAddon(fakeAddon),
+        minVersion: '9.0',
+        userAgentInfo,
+      }))
+        .toEqual({ compatible: false, reason: INCOMPATIBLE_FIREFOX_FOR_IOS });
+    });
+
+    it('should not mark a Firefox client without window as incompatible', () => {
+      // See: https://github.com/mozilla/addons-frontend/issues/4047
+      const userAgentInfo = {
+        browser: { name: 'Firefox' },
+        os: { name: 'Windows' },
+      };
+      const fakeOpenSearchAddon = createInternalAddon({
+        ...fakeAddon, type: ADDON_TYPE_OPENSEARCH,
       });
+      const fakeWindow = undefined;
+
+      expect(isCompatibleWithUserAgent({
+        _hasWindow: false,
+        _window: fakeWindow,
+        addon: fakeOpenSearchAddon,
+        userAgentInfo,
+      })).toEqual({ compatible: true, reason: null });
+    });
+
+    it('should mark a non-Firefox client without window as incompatible', () => {
+      // See: https://github.com/mozilla/addons-frontend/issues/4047
+      const userAgentInfo = {
+        browser: { name: 'Chrome' },
+        os: { name: 'Windows' },
+      };
+      const fakeOpenSearchAddon = createInternalAddon({
+        ...fakeAddon, type: ADDON_TYPE_OPENSEARCH,
+      });
+      const fakeWindow = undefined;
+
+      expect(isCompatibleWithUserAgent({
+        _hasWindow: false,
+        _window: fakeWindow,
+        addon: fakeOpenSearchAddon,
+        userAgentInfo,
+      })).toEqual({ compatible: false, reason: INCOMPATIBLE_NOT_FIREFOX });
+    });
 
     it('should mark Firefox without window.external as incompatible', () => {
       const userAgentInfo = {


### PR DESCRIPTION
### Before

<img width="1349" alt="screenshot 2018-02-01 00 29 31" src="https://user-images.githubusercontent.com/90871/35654877-0e0de5ae-06e7-11e8-9df9-0fd356a489ac.png">

(Note the install button is disabled, and originally the page will load with an incompatibility notice)

### After

<img width="1349" alt="screenshot 2018-02-01 00 27 56" src="https://user-images.githubusercontent.com/90871/35654888-1f0c25b4-06e7-11e8-9e8b-36aa3f7c07c7.png">
