### PR TITLE
Add config for functional tests.

### DIFF
--- a/config/functional-development-amo.js
+++ b/config/functional-development-amo.js
@@ -1,0 +1,17 @@
+module.exports = {
+  // Statics will be served by node.
+  staticHost: '',
+  // FIXME: sign-in isn't working.
+  // fxaConfig: 'local',
+
+  enableClientConsole: true,
+  apiStageHost: "http://olympia.test",
+
+  CSP: false,
+
+  // This is needed to serve assets locally.
+  enableNodeStatics: true,
+  trackingEnabled: false,
+  // Do not send client side errors to Sentry.
+  publicSentryDsn: null,
+};

--- a/config/functional-development-amo.js
+++ b/config/functional-development-amo.js
@@ -1,3 +1,4 @@
+// HOSTNAME=functional.test must be set to use this config.
 module.exports = {
   // Statics will be served by node.
   staticHost: '',

--- a/config/functional-development-amo.js
+++ b/config/functional-development-amo.js
@@ -5,7 +5,7 @@ module.exports = {
   // fxaConfig: 'local',
 
   enableClientConsole: true,
-  apiStageHost: "http://olympia.test",
+  apiStageHost: 'http://olympia.test',
 
   CSP: false,
 


### PR DESCRIPTION
Fixes #4294

* A config named functional-development-amo for setting up the
addons-frontend server for running the uitests at the addons-server repo.

I followed the ```short-hostname``` option found here: https://github.com/lorenwest/node-config/wiki/Configuration-Files#file-load-order

My env variables to run this on docker-compose with the addons-frontend image as the base image are:
``` 
- NODE_APP_INSTANCE=amo
- NODE_ENV=development
- API_HOST=http://olympia.test
- HOSTNAME=functional.test
```
