### PR TITLE
fix: Explore mobile categories buttons

### DIFF
--- a/src/amo/components/LandingPage/styles.scss
+++ b/src/amo/components/LandingPage/styles.scss
@@ -26,7 +26,7 @@
 }
 
 .LandingPage-button {
-  display: block;
+  width: 100%;
 
   @include respond-to(medium) {
     display: none;


### PR DESCRIPTION
Fix #4298

### Before
![screen shot 2018-02-02 at 13 38 43](https://user-images.githubusercontent.com/90871/35736067-ac99c94e-081e-11e8-9a9a-1954e5b880d0.png)

### After
![screen shot 2018-02-02 at 13 33 55](https://user-images.githubusercontent.com/90871/35736072-afdf3d3c-081e-11e8-9346-6548fe58cc3f.png)