### PR TITLE
Update the favicon urls to directly point to the CDN

### DIFF
--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom/server';
 import serialize from 'serialize-javascript';
 import Helmet from 'react-helmet';
+import config from 'config';
 
 
 export default class ServerHtml extends Component {
@@ -79,6 +80,10 @@ export default class ServerHtml extends Component {
       this.getStatic({ filePath: assets.javascript[js], type: 'js', index }));
   }
 
+  getFaviconLink() {
+    return `${config.get('amoCDN')}/favicon.ico`;
+  }
+
   render() {
     const { component, htmlLang, htmlDir, noScriptStyles, store } = this.props;
     // This must happen before Helmet.rewind() see
@@ -91,7 +96,7 @@ export default class ServerHtml extends Component {
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <link rel="shortcut icon" href="/favicon.ico?v=1" />
+          <link rel="shortcut icon" href={this.getFaviconLink()} />
           {head.title.toComponent()}
           {head.meta.toComponent()}
           {this.getStyle()}

--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -19,13 +19,15 @@ export default class ServerHtml extends Component {
     sriData: PropTypes.object.isRequired,
     store: PropTypes.object.isRequired,
     trackingEnabled: PropTypes.bool,
+    _config: PropTypes.object,
   };
 
   static defaultProps = {
     htmlDir: 'ltr',
     htmlLang: 'en-US',
     trackingEnabled: false,
-  }
+    _config: config,
+  };
 
   getStatic({ filePath, type, index }) {
     const { includeSri, sriData, appName } = this.props;
@@ -81,7 +83,8 @@ export default class ServerHtml extends Component {
   }
 
   getFaviconLink() {
-    return `${config.get('amoCDN')}/favicon.ico`;
+    const { _config } = this.props;
+    return `${_config.get('amoCDN')}/favicon.ico`;
   }
 
   render() {

--- a/tests/unit/core/containers/TestServerHtml.js
+++ b/tests/unit/core/containers/TestServerHtml.js
@@ -5,6 +5,7 @@ import {
   findRenderedDOMComponentWithTag,
   renderIntoDocument,
 } from 'react-dom/test-utils';
+import config from 'config';
 
 import ServerHtml from 'core/containers/ServerHtml';
 import FakeApp, {
@@ -113,7 +114,7 @@ describe('<ServerHtml />', () => {
   it('renders favicon', () => {
     const html = findRenderedDOMComponentWithTag(render(), 'html');
     const favicon = html.querySelector('link[rel="shortcut icon"]');
-    expect(favicon.getAttribute('href')).toEqual('/favicon.ico?v=1');
+    expect(favicon.getAttribute('href')).toEqual(`${config.get('amoCDN')}/favicon.ico`);
   });
 
   it('renders title', () => {

--- a/tests/unit/core/containers/TestServerHtml.js
+++ b/tests/unit/core/containers/TestServerHtml.js
@@ -5,12 +5,12 @@ import {
   findRenderedDOMComponentWithTag,
   renderIntoDocument,
 } from 'react-dom/test-utils';
-import config from 'config';
 
 import ServerHtml from 'core/containers/ServerHtml';
 import FakeApp, {
   fakeAssets, fakeSRIData,
 } from 'tests/unit/core/server/fakeApp';
+import { getFakeConfig } from 'tests/unit/helpers';
 
 describe('<ServerHtml />', () => {
   const _helmetCanUseDOM = Helmet.canUseDOM;
@@ -26,6 +26,9 @@ describe('<ServerHtml />', () => {
   const fakeStore = {
     getState: () => ({ foo: 'bar' }),
   };
+
+  const amoCDN = 'https://test.cdn.net';
+  const _config = getFakeConfig({ amoCDN });
 
   function render(opts = {}) {
     const pageProps = {
@@ -112,9 +115,9 @@ describe('<ServerHtml />', () => {
   });
 
   it('renders favicon', () => {
-    const html = findRenderedDOMComponentWithTag(render(), 'html');
+    const html = findRenderedDOMComponentWithTag(render({ _config }), 'html');
     const favicon = html.querySelector('link[rel="shortcut icon"]');
-    expect(favicon.getAttribute('href')).toEqual(`${config.get('amoCDN')}/favicon.ico`);
+    expect(favicon.getAttribute('href')).toEqual(`${amoCDN}/favicon.ico`);
   });
 
   it('renders title', () => {

--- a/tests/unit/core/containers/TestServerHtml.js
+++ b/tests/unit/core/containers/TestServerHtml.js
@@ -27,9 +27,6 @@ describe('<ServerHtml />', () => {
     getState: () => ({ foo: 'bar' }),
   };
 
-  const amoCDN = 'https://test.cdn.net';
-  const _config = getFakeConfig({ amoCDN });
-
   function render(opts = {}) {
     const pageProps = {
       appName: 'disco',
@@ -115,6 +112,8 @@ describe('<ServerHtml />', () => {
   });
 
   it('renders favicon', () => {
+    const amoCDN = 'https://test.cdn.net';
+    const _config = getFakeConfig({ amoCDN });
     const html = findRenderedDOMComponentWithTag(render({ _config }), 'html');
     const favicon = html.querySelector('link[rel="shortcut icon"]');
     expect(favicon.getAttribute('href')).toEqual(`${amoCDN}/favicon.ico`);


### PR DESCRIPTION
Fixes #3275 

This uses the `amoCDN` key from the config object to create the favicon link in
ServerHtml.js.
