### PR TITLE
fix: Do not overwrite button styles in tooltip lists

### DIFF
--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -36,9 +36,11 @@
   a:visited,
   a:hover,
   a:active {
-    color: $blue-50;
-    font-weight: normal;
-    text-decoration: none;
+    &:not(.Button) {
+      color: $blue-50;
+      font-weight: normal;
+      text-decoration: none;
+    }
   }
 }
 

--- a/src/ui/components/TooltipMenu/styles.scss
+++ b/src/ui/components/TooltipMenu/styles.scss
@@ -70,32 +70,39 @@
     a,
     a:link,
     button {
-      @include text-align-start();
-
-      color: $grey-90;
-      font-size: $font-size-m-smaller;
-      line-height: 1.6;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       width: 100%;
+
+      &:not(.Button) {
+        @include text-align-start();
+
+        color: $grey-90;
+        font-size: $font-size-m-smaller;
+        line-height: 1.6;
+      }
     }
 
     a,
     a:link,
     button {
-      @include font-medium();
+      &:not(.Button) {
+        @include font-medium();
 
-      cursor: pointer;
-      margin: 0;
-      padding: 0;
-      text-decoration: none;
+        cursor: pointer;
+        margin: 0;
+        padding: 0;
+        text-decoration: none;
+      }
     }
 
     a:hover,
     a:focus,
     a:active {
-      color: $blue-50;
+      &:not(.Button) {
+        color: $blue-50;
+      }
     }
 
     @include respond-to(medium) {


### PR DESCRIPTION
Fixes #4303, by not overriding button styles inside these elements. The nesting on a lot of this CSS is pretty rough/complex by necessity and this was the most future-proof way to solve it for now. It could use future cleanup.

### Before
<img width="331" alt="screenshot 2018-02-05 12 42 43" src="https://user-images.githubusercontent.com/90871/35805025-13e6e3ac-0a72-11e8-8829-feccda87a998.png">
<img width="351" alt="screenshot 2018-02-05 12 42 39" src="https://user-images.githubusercontent.com/90871/35805026-142a80da-0a72-11e8-9db8-84563edca764.png">


### After
<img width="340" alt="screenshot 2018-02-05 12 39 02" src="https://user-images.githubusercontent.com/90871/35804969-df0d8244-0a71-11e8-9ccd-3acba49a198c.png">
<img width="365" alt="screenshot 2018-02-05 12 38 58" src="https://user-images.githubusercontent.com/90871/35804970-df62c1fa-0a71-11e8-9617-572f47ae4b24.png">