### PR TITLE
Make sure the proper viewContext is set when loading a category page

### DIFF
--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -7,6 +7,7 @@ import Helmet from 'react-helmet';
 import { oneLine } from 'common-tags';
 
 import { getLanding } from 'amo/actions/landing';
+import { setViewContext } from 'amo/actions/viewContext';
 import CategoryHeader from 'amo/components/CategoryHeader';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
@@ -103,6 +104,8 @@ export class CategoryBase extends React.Component {
         return;
       }
     }
+
+    dispatch(setViewContext(addonType));
 
     if (
       !resultsLoaded ||

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { getLanding, loadLanding } from 'amo/actions/landing';
+import { setViewContext } from 'amo/actions/viewContext';
 import Category, { CategoryBase } from 'amo/components/Category';
 import CategoryHeader from 'amo/components/CategoryHeader';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
@@ -137,14 +138,15 @@ describe(__filename, () => {
     expect(root.find(ErrorList)).toHaveLength(1);
   });
 
-  it('fetches categories and landing data when not yet loaded', () => {
+  it('fetches categories and landing data and sets a viewContext when not yet loaded', () => {
     const fakeDispatch = sinon.stub(store, 'dispatch');
     render({}, { autoDispatchCategories: false });
 
-    sinon.assert.callCount(fakeDispatch, 2);
+    sinon.assert.callCount(fakeDispatch, 3);
     sinon.assert.calledWithMatch(fakeDispatch, categoriesFetch({
       errorHandlerId: errorHandler.id,
     }));
+    sinon.assert.calledWith(fakeDispatch, setViewContext(fakeCategory.type));
     sinon.assert.calledWith(fakeDispatch, getLanding({
       addonType: fakeCategory.type,
       category: fakeCategory.slug,
@@ -152,7 +154,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('does not fetch anything when already loaded', () => {
+  it('does not fetch anything, but sets a viewContext when already loaded', () => {
     _categoriesFetch();
     _categoriesLoad();
     _getLanding();
@@ -161,7 +163,8 @@ describe(__filename, () => {
     const fakeDispatch = sinon.stub(store, 'dispatch');
     render({}, { autoDispatchCategories: false });
 
-    sinon.assert.notCalled(fakeDispatch);
+    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.calledWith(fakeDispatch, setViewContext(fakeCategory.type));
   });
 
   it('does not fetch categories when an empty set was loaded', () => {
@@ -235,14 +238,15 @@ describe(__filename, () => {
     sinon.assert.notCalled(fakeDispatch);
   });
 
-  it('dispatches getLanding when results are not loaded', () => {
+  it('dispatches getLanding and sets a viewContext when results are not loaded', () => {
     _categoriesFetch();
     _categoriesLoad();
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
     render({}, { autoDispatchCategories: false });
 
-    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.callCount(fakeDispatch, 2);
+    sinon.assert.calledWith(fakeDispatch, setViewContext(fakeCategory.type));
     sinon.assert.calledWith(fakeDispatch, getLanding({
       addonType: fakeCategory.type,
       category: fakeCategory.slug,
@@ -250,7 +254,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('dispatches getLanding when category changes', () => {
+  it('dispatches getLanding and sets a viewContext when category changes', () => {
     const category = 'some-category-slug';
 
     _categoriesFetch();
@@ -272,6 +276,7 @@ describe(__filename, () => {
       },
     });
 
+    sinon.assert.calledWith(fakeDispatch, setViewContext(fakeCategory.type));
     sinon.assert.calledWith(fakeDispatch, getLanding({
       addonType: fakeCategory.type,
       category,
@@ -279,7 +284,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('dispatches getLanding when addonType changes', () => {
+  it('dispatches getLanding and sets a viewContext when addonType changes', () => {
     const addonType = ADDON_TYPE_EXTENSION;
     const category = fakeCategory.slug;
 
@@ -307,6 +312,7 @@ describe(__filename, () => {
       category,
       errorHandlerId: errorHandler.id,
     }));
+    sinon.assert.calledWith(fakeDispatch, setViewContext(addonType));
   });
 
   it('passes a category to the header', () => {

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -139,7 +139,8 @@ describe(__filename, () => {
     expect(root.find(ErrorList)).toHaveLength(1);
   });
 
-  it('fetches categories and landing data and sets a viewContext when not yet loaded', () => {
+  it('fetches categories and landing data ' +
+     'and sets a viewContext when not yet loaded', () => {
     const fakeDispatch = sinon.stub(store, 'dispatch');
     render({}, { autoDispatchCategories: false });
 
@@ -164,7 +165,6 @@ describe(__filename, () => {
     const fakeDispatch = sinon.stub(store, 'dispatch');
     render({}, { autoDispatchCategories: false });
 
-    sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.neverCalledWith(fakeDispatch, sinon.match({ type: CATEGORIES_FETCH }));
   });
 

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -10,6 +10,7 @@ import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
+  CATEGORIES_FETCH,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
   SEARCH_SORT_TRENDING,
@@ -154,7 +155,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('does not fetch anything, but sets a viewContext when already loaded', () => {
+  it('does not fetch categories when already loaded', () => {
     _categoriesFetch();
     _categoriesLoad();
     _getLanding();
@@ -164,7 +165,7 @@ describe(__filename, () => {
     render({}, { autoDispatchCategories: false });
 
     sinon.assert.callCount(fakeDispatch, 1);
-    sinon.assert.calledWith(fakeDispatch, setViewContext(fakeCategory.type));
+    sinon.assert.neverCalledWith(fakeDispatch, sinon.match({ type: CATEGORIES_FETCH }));
   });
 
   it('does not fetch categories when an empty set was loaded', () => {
@@ -238,15 +239,13 @@ describe(__filename, () => {
     sinon.assert.notCalled(fakeDispatch);
   });
 
-  it('dispatches getLanding and sets a viewContext when results are not loaded', () => {
+  it('dispatches getLanding when results are not loaded', () => {
     _categoriesFetch();
     _categoriesLoad();
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
     render({}, { autoDispatchCategories: false });
 
-    sinon.assert.callCount(fakeDispatch, 2);
-    sinon.assert.calledWith(fakeDispatch, setViewContext(fakeCategory.type));
     sinon.assert.calledWith(fakeDispatch, getLanding({
       addonType: fakeCategory.type,
       category: fakeCategory.slug,
@@ -254,7 +253,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('dispatches getLanding and sets a viewContext when category changes', () => {
+  it('dispatches getLanding when category changes', () => {
     const category = 'some-category-slug';
 
     _categoriesFetch();
@@ -276,7 +275,6 @@ describe(__filename, () => {
       },
     });
 
-    sinon.assert.calledWith(fakeDispatch, setViewContext(fakeCategory.type));
     sinon.assert.calledWith(fakeDispatch, getLanding({
       addonType: fakeCategory.type,
       category,
@@ -284,7 +282,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('dispatches getLanding and sets a viewContext when addonType changes', () => {
+  it('dispatches getLanding when addonType changes', () => {
     const addonType = ADDON_TYPE_EXTENSION;
     const category = fakeCategory.slug;
 
@@ -312,7 +310,6 @@ describe(__filename, () => {
       category,
       errorHandlerId: errorHandler.id,
     }));
-    sinon.assert.calledWith(fakeDispatch, setViewContext(addonType));
   });
 
   it('passes a category to the header', () => {


### PR DESCRIPTION
Fixes #4043 

When a category page is visited via direct link, the viewContext is not set to the proper value
which results in the wrong link in SectionLinks being highlighted. This patch adds a dispatch for
SET_VIEW_CONTEXT to the Category component to fix this issue.

I'm not entirely sure about the behaviour in the test for `does not fetch anything, but sets a viewContext when already loaded`. I think we still need to do this (i.e., set the viewContext), and that the test is therefore accurate, but I could be wrong about that.