### PR TITLE
Add edition to allowed params to be passed through to the disco pane API

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -55,6 +55,7 @@ module.exports = {
   taarParamsToUse: [
     'branch',
     'clientId',
+    'edition',
     'platform',
     'study',
   ],


### PR DESCRIPTION
Fixes #4320 

Running this locally with `yarn run disco` and hitting http://127.0.0.1:3000/en-US/firefox/discovery/pane/48.0/Darwin/normal?edition=china shows up the different content.