### PR TITLE
Display a tooltip for screenshots

### DIFF
--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -44,7 +44,7 @@ const formatPreviews = (previews) => (
 );
 
 export const thumbnailContent = (item) => (
-  <img src={item.src} className="ScreenShots-image" height={HEIGHT} width={WIDTH} alt="" />
+  <img src={item.src} className="ScreenShots-image" height={HEIGHT} width={WIDTH} alt="" title={item.title} />
 );
 
 export default class ScreenShots extends React.Component {

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -49,7 +49,7 @@ describe('<ScreenShots />', () => {
   });
 
   it('renders custom thumbnail', () => {
-    const item = { src: 'https://foo.com/img.png' };
+    const item = { src: 'https://foo.com/img.png', title: 'test title' };
     const thumbnail = shallow(thumbnailContent(item));
 
     expect(thumbnail.type()).toEqual('img');
@@ -57,6 +57,7 @@ describe('<ScreenShots />', () => {
     expect(thumbnail.prop('height')).toEqual(HEIGHT);
     expect(thumbnail.prop('width')).toEqual(WIDTH);
     expect(thumbnail.prop('alt')).toEqual('');
+    expect(thumbnail.prop('title')).toEqual('test title');
   });
 
   it('scrolls to the active item on close', () => {


### PR DESCRIPTION
Fixes #3917

This adds a title attribute to the img tag that is generated for screenshot thumbnails
which will result in a tooltip when hovering.

It uses the value of item.title for the title, which comes from the caption property of
the preview object returned via the API.