### PR TITLE
Fix `yarn amo` for developing with a local addons-server API

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,36 +202,41 @@ If you would like to use `https://addons-dev.allizom.org` for data you should us
 `yarn amo:dev` command. See the table of commands up above for similar
 hosted options.
 
-### Configuring for local development
+### Local configuration
 
-The `dev` scripts above will connect to a hosted development API by default.
-If you want to run your own
-[addons-server](https://github.com/mozilla/addons-server)
-API or make any other local changes, just add a local configuration
-file for each app. For example, to run your own discovery pane API, first create
-a local config file:
+If you need to override any settings while running `yarn amo`, `yarn amo:dev`, or `yarn amo:stage`, first create a local config file named exactly like this:
 
-    touch config/local-development-disco.js
+    touch config/local-development-amo.js
 
-Be sure to prefix the file with **local-development-** so that it doesn't pollute the
-test suite.
-Here's what `local-development-disco.js` would look like when
-overriding the `apiHost` parameter so that it points to your docker container:
+Make any config changes. For example:
 
 ```javascript
 module.exports = {
-  apiHost: 'http://olympia.dev',
+  trackingEnabled: true,
 };
 ```
 
-When you start up your front-end Discovery Pane server, it will now apply
-overrides from your local configuration file:
-
-    yarn disco
+Restart the server to see it take affect.
 
 Consult the
 [config file loading order docs](https://github.com/lorenwest/node-config/wiki/Configuration-Files#file-load-order)
 to learn more about how configuration is applied.
+
+### Running the Discopane for local development
+
+When running `yarn disco`, your local server will be configured for a hosted development API. If you want to run your own [addons-server](https://github.com/mozilla/addons-server) API or make any other local changes, you'll need to create a custom config file named exactly like this:
+
+    touch config/local-development-disco.js
+
+Here's what `local-development-disco.js` would look like when overriding the `apiHost` parameter so that it points to your docker container:
+
+```javascript
+module.exports = {
+  apiHost: 'http://olympia.test',
+};
+```
+
+Restart the server to see it take affect.
 
 ### Configuring an Android device for local development
 

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -1,6 +1,6 @@
 module.exports = {
   apiHost: 'http://localhost:3000',
-  proxyApiHost: 'http://olympia.dev',
+  proxyApiHost: 'http://olympia.test',
   proxyPort: 3000,
   proxyEnabled: true,
   // Setting this to false returns add-ons that are not compatible but means

--- a/docs/using-the-staging-sites-api.md
+++ b/docs/using-the-staging-sites-api.md
@@ -1,5 +1,5 @@
 # Development Using the Stage (or Dev) API
 
-By default the local dev server (ran using `yarn amo`) will load data from the local docker instance (usually found at http://olympia.dev/). Admittedly this dataset is incomplete and small. While we discourage usage of the production API for development, you can safely develop against the "Dev" or "Stage" servers using `yarn amo:dev` or `yarn amo:stage`. This will give you a large amount of data to work with when testing out new features.
+By default the local dev server (ran using `yarn amo`) will load data from the local docker instance (usually found at http://olympia.test/). Admittedly this dataset is incomplete and small. While we discourage usage of the production API for development, you can safely develop against the "Dev" or "Stage" servers using `yarn amo:dev` or `yarn amo:stage`. This will give you a large amount of data to work with when testing out new features.
 
 It's best to use these commands rather than setting the `API_HOST` and other environment variables directly: these commands automatically set the API and CDN variables appropriately so screenshots, icons, etc. will load correctly.

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -376,7 +376,7 @@ describe(__filename, () => {
   });
 
   it('renders a single author', () => {
-    const authorUrl = 'http://olympia.dev/en-US/firefox/user/krupa/';
+    const authorUrl = 'http://olympia.test/en-US/firefox/user/krupa/';
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeAddon,
@@ -396,10 +396,10 @@ describe(__filename, () => {
         ...fakeAddon,
         authors: [{
           name: 'Krupa',
-          url: 'http://olympia.dev/en-US/firefox/user/krupa/',
+          url: 'http://olympia.test/en-US/firefox/user/krupa/',
         }, {
           name: 'Fligtar',
-          url: 'http://olympia.dev/en-US/firefox/user/fligtar/',
+          url: 'http://olympia.test/en-US/firefox/user/fligtar/',
         }],
       }),
     });
@@ -519,7 +519,7 @@ describe(__filename, () => {
         ...fakeAddon,
         authors: [{
           name: 'Krupa',
-          url: 'http://olympia.dev/en-US/firefox/user/krupa/',
+          url: 'http://olympia.test/en-US/firefox/user/krupa/',
         }],
       }),
     });

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -38,7 +38,7 @@ export const fakeAddon = Object.freeze({
     id: 98811255,
     name: 'Krupa',
     picture_url: 'https://addons.cdn.mozilla.net/static/img/anon_user.png',
-    url: 'http://olympia.dev/en-US/firefox/user/krupa/',
+    url: 'http://olympia.test/en-US/firefox/user/krupa/',
     username: 'krupa',
   }],
   average_daily_users: 100,
@@ -116,7 +116,7 @@ export const fakeTheme = Object.freeze({
   ...fakeAddon,
   authors: [{
     name: 'MaDonna',
-    url: 'http://olympia.dev/en-US/firefox/user/madonna/',
+    url: 'http://olympia.test/en-US/firefox/user/madonna/',
     username: 'MaDonna',
   }],
   current_version: {
@@ -333,7 +333,7 @@ export const createFakeCollectionDetail = ({
     author: {
       id: authorId,
       name: authorName,
-      url: 'http://olympia.dev/en-US/firefox/user/johndoe/',
+      url: 'http://olympia.test/en-US/firefox/user/johndoe/',
       username: authorUsername,
     },
     default_locale: 'en-US',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4347 with one config change. The rest of the changes here are for the documentation.

I am testing with Docker against https://github.com/mozilla/addons-server/pull/7402 (we should wait to merge until that has landed).

**For developers**: We need to update our `/etc/hosts` file according to https://github.com/mozilla/addons-server/pull/7402/files#diff-01e2128b6420f1c2f6f27eb5340138dfL70