### PR TITLE
Fix update-collection saga, clean up collection reducer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,9 +13,11 @@
     // See: https://github.com/facebook/flow/issues/1609
     "SyntheticEvent": true,
     // Standard DOM globals:
+    "Generator": true,
     "HTMLElement": true,
     "HTMLInputElement": true,
     "HTMLSelectElement": true,
+    "HTMLTextAreaElement": true,
     "Node": true,
   },
   "parser": "babel-eslint",

--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -10,7 +10,7 @@ import type {
 } from 'core/types/api';
 
 
-type GetCollectionParams = {|
+export type GetCollectionParams = {|
   api: ApiStateType,
   slug: string,
   user: string | number,
@@ -33,7 +33,7 @@ export const getCollectionDetail = (
   });
 };
 
-type GetCollectionAddonsParams = {|
+export type GetCollectionAddonsParams = {|
   ...GetCollectionParams,
   nextURL?: string,
   page?: number,
@@ -104,7 +104,7 @@ export const listCollections = (
   return callApi({ auth: true, endpoint, state: api });
 };
 
-type GetAllUserCollectionsParams = {|
+export type GetAllUserCollectionsParams = {|
   ...ListCollectionsParams,
   _allPages?: typeof allPages,
   _listCollections?: typeof listCollections,
@@ -124,7 +124,7 @@ export const getAllUserCollections = async (
   return results;
 };
 
-type AddAddonToCollectionParams = {|
+export type AddAddonToCollectionParams = {|
   addon: string | number,
   api: ApiStateType,
   collection: string | number,
@@ -154,7 +154,7 @@ export const addAddonToCollection = (
   });
 };
 
-type UpdateCollectionParams = {|
+export type UpdateCollectionParams = {|
   api: ApiStateType,
   collectionSlug: string,
   defaultLocale?: string,

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -29,9 +29,9 @@ export const ADDON_ADDED_TO_COLLECTION: 'ADDON_ADDED_TO_COLLECTION'
   = 'ADDON_ADDED_TO_COLLECTION';
 export const LOAD_COLLECTION_ADDONS: 'LOAD_COLLECTION_ADDONS'
   = 'LOAD_COLLECTION_ADDONS';
-export const FINISH_UPDATE_COLLECTION: 'FINISH_UPDATE_COLLECTION'
-  = 'FINISH_UPDATE_COLLECTION';
 export const UPDATE_COLLECTION: 'UPDATE_COLLECTION' = 'UPDATE_COLLECTION';
+export const DELETE_COLLECTION_BY_SLUG: 'DELETE_COLLECTION_BY_SLUG'
+  = 'DELETE_COLLECTION_BY_SLUG';
 
 export type CollectionType = {
   addons: Array<AddonType> | null,
@@ -98,7 +98,7 @@ type FetchCurrentCollectionParams = {|
   user: number | string,
 |};
 
-type FetchCurrentCollectionAction = {|
+export type FetchCurrentCollectionAction = {|
   type: typeof FETCH_CURRENT_COLLECTION,
   payload: FetchCurrentCollectionParams,
 |};
@@ -130,7 +130,7 @@ type FetchUserCollectionsParams = {|
   userId: number,
 |};
 
-type FetchUserCollectionsAction = {|
+export type FetchUserCollectionsAction = {|
   type: typeof FETCH_USER_COLLECTIONS,
   payload: FetchUserCollectionsParams,
 |};
@@ -204,7 +204,7 @@ type FetchCurrentCollectionPageParams = {|
   page: number,
 |};
 
-type FetchCurrentCollectionPageAction = {|
+export type FetchCurrentCollectionPageAction = {|
   type: typeof FETCH_CURRENT_COLLECTION_PAGE,
   payload: FetchCurrentCollectionPageParams,
 |};
@@ -416,7 +416,7 @@ type AddAddonToCollectionParams = {|
   userId: number,
 |};
 
-type AddAddonToCollectionAction = {|
+export type AddAddonToCollectionAction = {|
   type: typeof ADD_ADDON_TO_COLLECTION,
   payload: AddAddonToCollectionParams,
 |};
@@ -459,7 +459,7 @@ type UpdateCollectionParams = {|
   user: number | string,
 |};
 
-type UpdateCollectionAction = {|
+export type UpdateCollectionAction = {|
   type: typeof UPDATE_COLLECTION,
   payload: UpdateCollectionParams,
 |};
@@ -502,29 +502,21 @@ export const updateCollection = ({
   };
 };
 
-type FinishUpdateCollectionParams = {|
-  collectionSlug: string,
-  successful: boolean,
+type DeleteCollectionBySlugAction = {|
+  type: typeof DELETE_COLLECTION_BY_SLUG,
+  payload: {| slug: string |},
 |};
 
-type FinishUpdateCollectionAction = {|
-  type: typeof FINISH_UPDATE_COLLECTION,
-  payload: FinishUpdateCollectionParams,
-|};
-
-export const finishUpdateCollection = (
-  { collectionSlug, successful }: FinishUpdateCollectionParams = {}
-): FinishUpdateCollectionAction => {
-  if (!collectionSlug) {
-    throw new Error('The collectionSlug parameter is required');
-  }
-  if (typeof successful === 'undefined') {
-    throw new Error('The successful parameter is required');
+export const deleteCollectionBySlug = (
+  slug: string
+): DeleteCollectionBySlugAction => {
+  if (!slug) {
+    throw new Error('A slug is required');
   }
 
   return {
-    type: FINISH_UPDATE_COLLECTION,
-    payload: { collectionSlug, successful },
+    type: DELETE_COLLECTION_BY_SLUG,
+    payload: { slug },
   };
 };
 
@@ -655,10 +647,10 @@ type Action =
   | AbortFetchUserCollectionsAction
   | AddAddonToCollectionAction
   | AddonAddedToCollectionAction
+  | DeleteCollectionBySlugAction
   | FetchCurrentCollectionAction
   | FetchCurrentCollectionPageAction
   | FetchUserCollectionsAction
-  | FinishUpdateCollectionAction
   | LoadCollectionAddonsAction
   | LoadCurrentCollectionAction
   | LoadCurrentCollectionPageAction
@@ -894,19 +886,16 @@ const reducer = (
       };
     }
 
-    case FINISH_UPDATE_COLLECTION: {
-      const { collectionSlug, successful } = action.payload;
+    case DELETE_COLLECTION_BY_SLUG: {
+      const { slug } = action.payload;
+      const collectionId = state.bySlug[slug];
 
-      return {
-        ...state,
-        collectionUpdates: {
-          [collectionSlug]: {
-            ...state.collectionUpdates[collectionSlug],
-            updating: false,
-            successful,
-          },
-        },
-      };
+      if (collectionId) {
+        const newIdMap = { ...state.byId };
+        delete newIdMap[collectionId];
+        return { ...state, byId: newIdMap };
+      }
+      return state;
     }
 
     default:

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -1,3 +1,4 @@
+/* @flow */
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 import {
   ADD_ADDON_TO_COLLECTION,
@@ -9,15 +10,31 @@ import {
   abortFetchCurrentCollection,
   abortFetchUserCollections,
   addonAddedToCollection,
-  finishUpdateCollection,
+  deleteCollectionBySlug,
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
 } from 'amo/reducers/collections';
 import * as api from 'amo/api/collections';
-import { closeFormOverlay } from 'core/reducers/formOverlay';
+import {
+  beginFormOverlaySubmit, closeFormOverlay, finishFormOverlaySubmit,
+} from 'core/reducers/formOverlay';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
+import type {
+  AddAddonToCollectionParams,
+  GetAllUserCollectionsParams,
+  GetCollectionAddonsParams,
+  GetCollectionParams,
+  UpdateCollectionParams,
+} from 'amo/api/collections';
+import type {
+  AddAddonToCollectionAction,
+  FetchCurrentCollectionAction,
+  FetchCurrentCollectionPageAction,
+  FetchUserCollectionsAction,
+  UpdateCollectionAction,
+} from 'amo/reducers/collections';
 
 export function* fetchCurrentCollection({
   payload: {
@@ -26,7 +43,7 @@ export function* fetchCurrentCollection({
     slug,
     user,
   },
-}) {
+}: FetchCurrentCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -34,18 +51,22 @@ export function* fetchCurrentCollection({
   try {
     const state = yield select(getState);
 
+    const baseParams = {
+      api: state.api,
+      slug,
+      user,
+    };
+
+    const detailParams: $Shape<GetCollectionParams> = {
+      ...baseParams,
+    };
+    const addonsParams: $Shape<GetCollectionAddonsParams> = {
+      ...baseParams,
+      page,
+    };
     const { detail, addons } = yield all({
-      detail: call(api.getCollectionDetail, {
-        api: state.api,
-        slug,
-        user,
-      }),
-      addons: call(api.getCollectionAddons, {
-        api: state.api,
-        page,
-        slug,
-        user,
-      }),
+      detail: call(api.getCollectionDetail, detailParams),
+      addons: call(api.getCollectionAddons, addonsParams),
     });
 
     yield put(loadCurrentCollection({ addons, detail }));
@@ -63,7 +84,7 @@ export function* fetchCurrentCollectionPage({
     slug,
     user,
   },
-}) {
+}: FetchCurrentCollectionPageAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -71,12 +92,13 @@ export function* fetchCurrentCollectionPage({
   try {
     const state = yield select(getState);
 
-    const addons = yield call(api.getCollectionAddons, {
+    const params: GetCollectionAddonsParams = {
       api: state.api,
       page,
       slug,
       user,
-    });
+    };
+    const addons = yield call(api.getCollectionAddons, params);
 
     yield put(loadCurrentCollectionPage({ addons }));
   } catch (error) {
@@ -88,16 +110,17 @@ export function* fetchCurrentCollectionPage({
 
 export function* fetchUserCollections({
   payload: { errorHandlerId, userId },
-}) {
+}: FetchUserCollectionsAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
 
   try {
     const state = yield select(getState);
 
-    const collections = yield call(api.getAllUserCollections, {
+    const params: GetAllUserCollectionsParams = {
       api: state.api, user: userId,
-    });
+    };
+    const collections = yield call(api.getAllUserCollections, params);
 
     yield put(loadUserCollections({ userId, collections }));
   } catch (error) {
@@ -111,19 +134,21 @@ export function* addAddonToCollection({
   payload: {
     addonId, collectionId, collectionSlug, errorHandlerId, notes, userId,
   },
-}) {
+}: AddAddonToCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
 
   try {
     const state = yield select(getState);
-    yield call(api.addAddonToCollection, {
+
+    const params: AddAddonToCollectionParams = {
       addon: addonId,
       api: state.api,
       collection: collectionSlug,
       notes,
       user: userId,
-    });
+    };
+    yield call(api.addAddonToCollection, params);
 
     yield put(addonAddedToCollection({
       addonId, userId, collectionId,
@@ -144,36 +169,40 @@ export function* updateCollection({
     formOverlayId,
     isPublic,
     name,
-    slug,
     user,
   },
-}) {
+}: UpdateCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
 
   try {
+    yield put(beginFormOverlaySubmit(formOverlayId));
+
     const state = yield select(getState);
-    yield call(api.updateCollection, {
+    const params: UpdateCollectionParams = {
       api: state.api,
       collectionSlug,
       defaultLocale,
       description,
       isPublic,
       name,
-      slug,
       user,
-    });
+    };
+    yield call(api.updateCollection, params);
 
+    // Invalidate the stored collection object. This will force each
+    // component to re-fetch the collection.
+    yield put(deleteCollectionBySlug(collectionSlug));
     yield put(closeFormOverlay(formOverlayId));
-    yield put(finishUpdateCollection({ collectionSlug, successful: true }));
+    yield put(finishFormOverlaySubmit(formOverlayId));
   } catch (error) {
     log.warn(`Failed to update collection: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(finishUpdateCollection({ collectionSlug, successful: false }));
+    yield put(finishFormOverlaySubmit(formOverlayId));
   }
 }
 
-export default function* collectionsSaga() {
+export default function* collectionsSaga(): Generator<any, any, any> {
   yield takeLatest(FETCH_CURRENT_COLLECTION, fetchCurrentCollection);
   yield takeLatest(
     FETCH_CURRENT_COLLECTION_PAGE, fetchCurrentCollectionPage

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -1,5 +1,4 @@
 /* @flow */
-/* global Generator */
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -6,10 +6,10 @@ import reducer, {
   addonAddedToCollection,
   createInternalAddons,
   createInternalCollection,
+  deleteCollectionBySlug,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   fetchUserCollections,
-  finishUpdateCollection,
   getCollectionById,
   getCurrentCollection,
   initialState,
@@ -883,58 +883,56 @@ describe(__filename, () => {
     });
   });
 
-  describe('finishUpdateCollection', () => {
-    const getParams = (params = {}) => {
-      return {
-        collectionSlug: 'some-collection', successful: true, ...params,
-      };
-    };
-
-    it('requires collectionSlug parameter', () => {
-      const params = getParams();
-      delete params.collectionSlug;
-
-      expect(() => finishUpdateCollection(params))
-        .toThrow(/collectionSlug parameter is required/);
+  describe('deleteCollectionBySlug', () => {
+    it('requires a slug', () => {
+      expect(() => deleteCollectionBySlug()).toThrow(/slug is required/);
     });
 
-    it('requires successful parameter', () => {
-      const params = getParams();
-      delete params.successful;
+    it('does nothing when no collection exists', () => {
+      const state = reducer(undefined, deleteCollectionBySlug('a-slug'));
 
-      expect(() => finishUpdateCollection(params))
-        .toThrow(/successful parameter is required/);
+      expect(state.byId).toEqual(initialState.byId);
     });
 
-    it('handles a falsy successful parameter', () => {
-      const params = getParams({ successful: false });
+    it('deletes a collection', () => {
+      const collectionAddons = createFakeCollectionAddons();
+      const collectionDetail = createFakeCollectionDetail();
 
-      // Make sure this doesn't throw.
-      finishUpdateCollection(params);
+      let state = reducer(undefined, loadCurrentCollection({
+        addons: collectionAddons,
+        detail: collectionDetail,
+      }));
+
+      state = reducer(state, deleteCollectionBySlug(collectionDetail.slug));
+
+      expect(state.byId[collectionDetail.id]).toBeUndefined();
     });
 
-    it('finishes a successful update', () => {
-      const collectionSlug = 'some-collection';
+    it('preserves other collections', () => {
+      let state;
 
-      const params = getParams({ collectionSlug, successful: true });
-      const state = reducer(initialState, finishUpdateCollection(params));
+      const collection1Addons = createFakeCollectionAddons();
+      const collection1Detail = createFakeCollectionDetail();
+      state = reducer(state, loadCurrentCollection({
+        addons: collection1Addons,
+        detail: collection1Detail,
+      }));
 
-      expect(state.collectionUpdates[collectionSlug].updating)
-        .toEqual(false);
-      expect(state.collectionUpdates[collectionSlug].successful)
-        .toEqual(true);
-    });
+      const collection2Addons = createFakeCollectionAddons();
+      const collection2Detail = createFakeCollectionDetail();
+      state = reducer(state, loadCurrentCollection({
+        addons: collection2Addons,
+        detail: collection2Detail,
+      }));
 
-    it('finishes an unsuccessful update', () => {
-      const collectionSlug = 'some-collection';
+      const action = deleteCollectionBySlug(collection2Detail.slug);
+      state = reducer(state, action);
 
-      const params = getParams({ collectionSlug, successful: false });
-      const state = reducer(initialState, finishUpdateCollection(params));
-
-      expect(state.collectionUpdates[collectionSlug].updating)
-        .toEqual(false);
-      expect(state.collectionUpdates[collectionSlug].successful)
-        .toEqual(false);
+      expect(state.byId[collection1Detail.id])
+        .toEqual(createInternalCollection({
+          detail: collection1Detail,
+          items: collection1Addons.results,
+        }));
     });
   });
 });


### PR DESCRIPTION
* Fixes https://github.com/mozilla/addons-frontend/issues/4350 by invalidating the collection object after an update
* Fixes https://github.com/mozilla/addons-frontend/issues/4351 by removing the `finishUpdateCollection()` action which is no longer needed