### PR TITLE
Update homepage content for Feb 15

### DIFF
--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -13,7 +13,6 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
   SEARCH_SORT_POPULAR,
-  SEARCH_SORT_TOP_RATED,
   VIEW_CONTEXT_HOME,
 } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
@@ -24,20 +23,21 @@ import Icon from 'ui/components/Icon';
 import './styles.scss';
 
 
-export const FIRST_COLLECTION_SLUG = 'dynamic-media-downloaders';
-export const FIRST_COLLECTION_USER = 'mozilla';
+export const COLLECTIONS_TO_FETCH = [
+  { slug: 'privacy-matters', user: 'mozilla' },
+  { slug: 're-imagine-search', user: 'mozilla' },
+  { slug: 'addonsofthemonth', user: 'mozilla' },
+];
 
 export class HomeBase extends React.Component {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
-    firstCollection: PropTypes.array.isRequired,
+    collections: PropTypes.array.isRequired,
     featuredExtensions: PropTypes.array.isRequired,
-    featuredThemes: PropTypes.array.isRequired,
+    popularThemes: PropTypes.array.isRequired,
     i18n: PropTypes.object.isRequired,
-    popularExtensions: PropTypes.array.isRequired,
     resultsLoaded: PropTypes.bool.isRequired,
-    topRatedExtensions: PropTypes.array.isRequired,
   }
 
   componentWillMount() {
@@ -48,8 +48,7 @@ export class HomeBase extends React.Component {
     if (!resultsLoaded) {
       dispatch(fetchHomeAddons({
         errorHandlerId: errorHandler.id,
-        firstCollectionSlug: FIRST_COLLECTION_SLUG,
-        firstCollectionUser: FIRST_COLLECTION_USER,
+        collectionsToFetch: COLLECTIONS_TO_FETCH,
       }));
     }
   }
@@ -155,13 +154,11 @@ export class HomeBase extends React.Component {
   render() {
     const {
       errorHandler,
-      firstCollection,
+      collections,
       featuredExtensions,
-      featuredThemes,
+      popularThemes,
       i18n,
-      popularExtensions,
       resultsLoaded,
-      topRatedExtensions,
     } = this.props;
 
     // translators: The ending ellipsis alludes to a row of icons for each type
@@ -197,62 +194,6 @@ export class HomeBase extends React.Component {
         </Card>
 
         <LandingAddonsCard
-          addons={popularExtensions}
-          className="Home-PopularExtensions"
-          header={i18n.gettext('Popular extensions')}
-          footerText={i18n.gettext('See more popular extensions')}
-          footerLink={{
-            pathname: '/search/',
-            query: {
-              addonType: ADDON_TYPE_EXTENSION,
-              sort: SEARCH_SORT_POPULAR,
-            },
-          }}
-          loading={resultsLoaded === false}
-        />
-
-        <LandingAddonsCard
-          addons={firstCollection}
-          className="Home-FeaturedCollection"
-          header={i18n.gettext('Media downloaders')}
-          footerText={i18n.gettext('See more media downloaders')}
-          footerLink={{ pathname:
-            `/collections/${FIRST_COLLECTION_USER}/${FIRST_COLLECTION_SLUG}/`,
-          }}
-          loading={resultsLoaded === false}
-        />
-
-        <LandingAddonsCard
-          addons={featuredThemes}
-          className="Home-FeaturedThemes"
-          header={i18n.gettext('Featured themes')}
-          footerText={i18n.gettext('See more featured themes')}
-          footerLink={{
-            pathname: '/search/',
-            query: {
-              addonType: ADDON_TYPE_THEME,
-              featured: true,
-            },
-          }}
-          loading={resultsLoaded === false}
-        />
-
-        <LandingAddonsCard
-          addons={topRatedExtensions}
-          className="Home-TopRatedExtensions"
-          header={i18n.gettext('Top-rated Extensions')}
-          footerText={i18n.gettext('See more highly rated Extensions')}
-          footerLink={{
-            pathname: '/search/',
-            query: {
-              addonType: ADDON_TYPE_EXTENSION,
-              sort: SEARCH_SORT_TOP_RATED,
-            },
-          }}
-          loading={resultsLoaded === false}
-        />
-
-        <LandingAddonsCard
           addons={featuredExtensions}
           className="Home-FeaturedExtensions"
           header={i18n.gettext('Featured extensions')}
@@ -263,6 +204,54 @@ export class HomeBase extends React.Component {
               addonType: ADDON_TYPE_EXTENSION,
               featured: true,
             },
+          }}
+          loading={resultsLoaded === false}
+        />
+
+        <LandingAddonsCard
+          addons={collections[0]}
+          className="Home-FeaturedCollection"
+          header={i18n.gettext('Privacy tools')}
+          footerText={i18n.gettext('See more privacy tools')}
+          footerLink={{ pathname:
+            `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`,
+          }}
+          loading={resultsLoaded === false}
+        />
+
+        <LandingAddonsCard
+          addons={popularThemes}
+          className="Home-PopularThemes"
+          header={i18n.gettext('Popular themes')}
+          footerText={i18n.gettext('See more popular themes')}
+          footerLink={{
+            pathname: '/search/',
+            query: {
+              addonType: ADDON_TYPE_THEME,
+              sort: SEARCH_SORT_POPULAR,
+            },
+          }}
+          loading={resultsLoaded === false}
+        />
+
+        <LandingAddonsCard
+          addons={collections[1]}
+          className="Home-FeaturedCollection"
+          header={i18n.gettext('Re-imagine search')}
+          footerText={i18n.gettext('See more search extensions')}
+          footerLink={{ pathname:
+            `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`,
+          }}
+          loading={resultsLoaded === false}
+        />
+
+        <LandingAddonsCard
+          addons={collections[2]}
+          className="Home-FeaturedCollection"
+          header={i18n.gettext(`February's new featured extensions`)}
+          footerText={i18n.gettext('See all the new featured extensions')}
+          footerLink={{ pathname:
+            `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`,
           }}
           loading={resultsLoaded === false}
         />
@@ -286,12 +275,10 @@ export class HomeBase extends React.Component {
 
 export function mapStateToProps(state) {
   return {
-    firstCollection: state.home.firstCollection,
+    collections: state.home.collections,
     featuredExtensions: state.home.featuredExtensions,
-    featuredThemes: state.home.featuredThemes,
-    popularExtensions: state.home.popularExtensions,
+    popularThemes: state.home.popularThemes,
     resultsLoaded: state.home.resultsLoaded,
-    topRatedExtensions: state.home.topRatedExtensions,
   };
 }
 

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -213,9 +213,9 @@ export class HomeBase extends React.Component {
           className="Home-FeaturedCollection"
           header={i18n.gettext('Privacy tools')}
           footerText={i18n.gettext('See more privacy tools')}
-          footerLink={{ pathname:
-            `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`,
-          }}
+          footerLink={
+            `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`
+          }
           loading={resultsLoaded === false}
         />
 
@@ -239,20 +239,20 @@ export class HomeBase extends React.Component {
           className="Home-FeaturedCollection"
           header={i18n.gettext('Re-imagine search')}
           footerText={i18n.gettext('See more search extensions')}
-          footerLink={{ pathname:
-            `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`,
-          }}
+          footerLink={
+            `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`
+          }
           loading={resultsLoaded === false}
         />
 
         <LandingAddonsCard
           addons={collections[2]}
           className="Home-FeaturedCollection"
-          header={i18n.gettext(`February's new featured extensions`)}
+          header={i18n.gettext(`February’s new featured extensions`)}
           footerText={i18n.gettext('See all the new featured extensions')}
-          footerLink={{ pathname:
-            `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`,
-          }}
+          footerLink={
+            `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`
+          }
           loading={resultsLoaded === false}
         />
 

--- a/src/amo/components/HomeHeroBanner/index.js
+++ b/src/amo/components/HomeHeroBanner/index.js
@@ -21,19 +21,19 @@ export class HomeHeroBannerBase extends React.Component<Props> {
     return [
       (
         <HeroSection
-          key="wikipedia-context-menu-search"
-          linkTo="/addon/wikipedia-context-menu-search/"
+          key="hero-1"
+          linkTo="/addon/temporary-containers/"
         >
-          <h3>{i18n.gettext('Wikipedia Context Menu Search')}</h3>
+          <h3>{i18n.gettext('Temporary Containers')}</h3>
 
           <p>
-            {i18n.gettext('Highlight any text and search Wikipedia.')}
+            {i18n.gettext('Open pages with disposable data containers.')}
           </p>
         </HeroSection>
       ),
       (
         <HeroSection
-          key="momentumdash"
+          key="hero-2"
           linkTo="/addon/momentumdash/"
         >
           <h3>{i18n.gettext('Momentum')}</h3>
@@ -46,64 +46,62 @@ export class HomeHeroBannerBase extends React.Component<Props> {
       ),
       (
         <HeroSection
-          key="undo-close-tab-button"
-          linkTo="/addon/undo-close-tab-button/"
+          key="hero-3"
+          linkTo="/addon/kimetrak/"
         >
-          <h3>{i18n.gettext('Undo Close Tab Button')}</h3>
+          <h3>{i18n.gettext('Kimetrak')}</h3>
 
-          <p>{i18n.gettext('Never lose a page again.')}</p>
+          <p>{i18n.gettext('Track who’s tracking you.')}</p>
         </HeroSection>
       ),
       (
         <HeroSection
-          key="grammarly"
-          linkTo="/addon/grammarly-1/"
+          key="hero-4"
+          linkTo="/addon/mailvelope/"
         >
-          <h3>{i18n.gettext('Grammarly')}</h3>
+          <h3>{i18n.gettext('Mailvelope')}</h3>
           <p>
-            {i18n.gettext(`Get grammar help anywhere you write on the
-              web—social media, email, docs and more.`)}
+            {i18n.gettext('Secure encryption for webmail.')}
           </p>
         </HeroSection>
       ),
       (
         <HeroSection
-          key="facebook-filter"
-          linkTo="/addon/facebook-filter/"
+          key="hero-5"
+          linkTo="/addon/%E7%BF%BB%E8%AF%91%E4%BE%A0-translate-man/"
         >
-          <h3>{i18n.gettext('Facebook Filter')}</h3>
+          <h3>{i18n.gettext('Translate Man')}</h3>
           <p>
-            {i18n.gettext(`Remove ads, promoted content, and other clutter
-              from your feed.`)}
+            {i18n.gettext('Point-and-click instant translations.')}
           </p>
         </HeroSection>
       ),
       (
         <HeroSection
-          key="gesturefy"
-          linkTo="/addon/gesturefy/"
+          key="hero-6"
+          linkTo="/addon/ublock-origin/"
         >
-          <h3>{i18n.gettext('Gesturefy')}</h3>
+          <h3>{i18n.gettext('uBlock Origin')}</h3>
 
-          <p>{i18n.gettext('40+ customizable mouse gestures.')}</p>
+          <p>{i18n.gettext('Efficient, powerful ad blocker.')}</p>
         </HeroSection>
       ),
       (
         <HeroSection
-          key="lastpass"
-          linkTo="/addon/lastpass-password-manager/"
+          key="hero-7"
+          linkTo="/addon/ghostery/"
         >
-          <h3>{i18n.gettext('LastPass Password Manager')}</h3>
+          <h3>{i18n.gettext('Ghostery')}</h3>
 
           <p>
-            {i18n.gettext(`Easily manage all your passwords for all devices
-              from one spot`)}
+            {i18n.gettext(`Popular anti-tracking extension now has
+              ad blocking ability.`)}
           </p>
         </HeroSection>
       ),
       (
         <HeroSection
-          key="multi-account-containers"
+          key="hero-8"
           linkTo="/addon/multi-account-containers/"
         >
           <h3>{i18n.gettext('Multi-Account Containers')}</h3>
@@ -116,12 +114,41 @@ export class HomeHeroBannerBase extends React.Component<Props> {
       ),
       (
         <HeroSection
-          key="tree-style-tab"
-          linkTo="/addon/tree-style-tab/"
+          key="hero-9"
+          linkTo="/addon/searchpreview/"
         >
-          <h3>{i18n.gettext('Tree Style Tab')}</h3>
+          <h3>{i18n.gettext('SearchPreview')}</h3>
 
-          <p>{i18n.gettext('Display tabs in a space-saving “tree” layout.')}</p>
+          <p>
+            {i18n.gettext(`Enhance search results with thumbnail previews,
+              popularity ranks & more.`)}
+          </p>
+        </HeroSection>
+      ),
+      (
+        <HeroSection
+          key="hero-10"
+          linkTo="/addon/forget_me_not/"
+        >
+          <h3>{i18n.gettext('Forget Me Not')}</h3>
+
+          <p>
+            {i18n.gettext(`Automatically delete data (cookies, local storage,
+              etc.) on all sites you visit except those on your whitelist.`)}
+          </p>
+        </HeroSection>
+      ),
+      (
+        <HeroSection
+          key="hero-11"
+          linkTo="/addon/zoom/"
+        >
+          <h3>{i18n.gettext('Zoom for Firefox')}</h3>
+
+          <p>
+            {i18n.gettext(`Simple zoom in/out tool for a close-up view of any
+              web content.`)}
+          </p>
         </HeroSection>
       ),
     ];

--- a/src/amo/components/HomeHeroBanner/index.js
+++ b/src/amo/components/HomeHeroBanner/index.js
@@ -68,7 +68,7 @@ export class HomeHeroBannerBase extends React.Component<Props> {
       (
         <HeroSection
           key="hero-5"
-          linkTo="/addon/%E7%BF%BB%E8%AF%91%E4%BE%A0-translate-man/"
+          linkTo="/addon/翻译侠-translate-man/"
         >
           <h3>{i18n.gettext('Translate Man')}</h3>
           <p>
@@ -108,7 +108,7 @@ export class HomeHeroBannerBase extends React.Component<Props> {
 
           <p>
             {i18n.gettext(`Keep different parts of your online
-              life—work, personal, etc.—separated by color-coded tabs`)}
+              life—work, personal, etc.—separated by color-coded tabs.`)}
           </p>
         </HeroSection>
       ),

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -1,34 +1,28 @@
 /* @flow */
 import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import { createInternalAddon } from 'core/reducers/addons';
-import type { CollectionAddonsListResponse } from 'amo/reducers/collections';
 import type { AddonType, ExternalAddonType } from 'core/types/addons';
 
 export const FETCH_HOME_ADDONS: 'FETCH_HOME_ADDONS' = 'FETCH_HOME_ADDONS';
 export const LOAD_HOME_ADDONS: 'LOAD_HOME_ADDONS' = 'LOAD_HOME_ADDONS';
 
 export type HomeState = {
-  firstCollection: Array<AddonType>,
+  collections: Array<Object>,
   featuredExtensions: Array<AddonType>,
-  featuredThemes: Array<AddonType>,
-  popularExtensions: Array<AddonType>,
+  popularThemes: Array<AddonType>,
   resultsLoaded: boolean,
-  topRatedExtensions: Array<AddonType>,
 };
 
 export const initialState: HomeState = {
-  firstCollection: [],
+  collections: [],
   featuredExtensions: [],
-  featuredThemes: [],
-  popularExtensions: [],
+  popularThemes: [],
   resultsLoaded: false,
-  topRatedExtensions: [],
 };
 
 type FetchHomeAddonsParams = {|
   errorHandlerId: string,
-  firstCollectionSlug: string,
-  firstCollectionUser: string,
+  collectionsToFetch: Array<Object>,
 |};
 
 type FetchHomeAddonsAction = {|
@@ -38,25 +32,20 @@ type FetchHomeAddonsAction = {|
 
 export const fetchHomeAddons = ({
   errorHandlerId,
-  firstCollectionSlug,
-  firstCollectionUser,
+  collectionsToFetch,
 }: FetchHomeAddonsParams): FetchHomeAddonsAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
-  if (!firstCollectionSlug) {
-    throw new Error('firstCollectionSlug is required');
-  }
-  if (!firstCollectionUser) {
-    throw new Error('firstCollectionUser is required');
+  if (!collectionsToFetch) {
+    throw new Error('collectionsToFetch is required');
   }
 
   return {
     type: FETCH_HOME_ADDONS,
     payload: {
       errorHandlerId,
-      firstCollectionSlug,
-      firstCollectionUser,
+      collectionsToFetch,
     },
   };
 };
@@ -76,11 +65,9 @@ type ApiAddonsResponse = {|
 |};
 
 type LoadHomeAddonsParams = {|
-  firstCollection: CollectionAddonsListResponse,
+  collections: Array<Object>,
   featuredExtensions: ApiAddonsResponse,
-  featuredThemes: ApiAddonsResponse,
-  popularExtensions: ApiAddonsResponse,
-  topRatedExtensions: ApiAddonsResponse,
+  popularThemes: ApiAddonsResponse,
 |};
 
 type LoadHomeAddonsAction = {|
@@ -89,36 +76,26 @@ type LoadHomeAddonsAction = {|
 |};
 
 export const loadHomeAddons = ({
-  firstCollection,
+  collections,
   featuredExtensions,
-  featuredThemes,
-  popularExtensions,
-  topRatedExtensions,
+  popularThemes,
 }: LoadHomeAddonsParams): LoadHomeAddonsAction => {
-  if (!firstCollection) {
-    throw new Error('firstCollection is required');
+  if (!collections) {
+    throw new Error('collections is required');
   }
   if (!featuredExtensions) {
     throw new Error('featuredExtensions are required');
   }
-  if (!featuredThemes) {
-    throw new Error('featuredThemes are required');
-  }
-  if (!popularExtensions) {
-    throw new Error('popularExtensions are required');
-  }
-  if (!topRatedExtensions) {
-    throw new Error('topRatedExtensions are required');
+  if (!popularThemes) {
+    throw new Error('popularThemes are required');
   }
 
   return {
     type: LOAD_HOME_ADDONS,
     payload: {
-      firstCollection,
+      collections,
       featuredExtensions,
-      featuredThemes,
-      popularExtensions,
-      topRatedExtensions,
+      popularThemes,
     },
   };
 };
@@ -148,25 +125,23 @@ const reducer = (
 
     case LOAD_HOME_ADDONS: {
       const {
-        firstCollection,
+        collections,
         featuredExtensions,
-        featuredThemes,
-        popularExtensions,
-        topRatedExtensions,
+        popularThemes,
       } = action.payload;
 
       return {
         ...state,
-        firstCollection: firstCollection.results
-          .slice(0, LANDING_PAGE_ADDON_COUNT)
-          .map((item) => {
-            return createInternalAddon(item.addon);
-          }),
+        collections: collections.map((collection) => {
+          return collection.results
+            .slice(0, LANDING_PAGE_ADDON_COUNT)
+            .map((item) => {
+              return createInternalAddon(item.addon);
+            });
+        }),
         featuredExtensions: createInternalAddons(featuredExtensions),
-        featuredThemes: createInternalAddons(featuredThemes),
-        popularExtensions: createInternalAddons(popularExtensions),
+        popularThemes: createInternalAddons(popularThemes),
         resultsLoaded: true,
-        topRatedExtensions: createInternalAddons(topRatedExtensions),
       };
     }
 

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -31,12 +31,12 @@ export function* fetchHomeAddons({
 
     const collections = [];
     // eslint-disable-next-line no-restricted-syntax
-    for (const coll of collectionsToFetch) {
+    for (const collection of collectionsToFetch) {
       const result = yield call(getCollectionAddons, {
         api: state.api,
         page: 1,
-        slug: coll.slug,
-        user: coll.user,
+        slug: collection.slug,
+        user: collection.user,
       });
       collections.push(result);
     }

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -10,8 +10,6 @@ import {
   ADDON_TYPE_THEME,
   SEARCH_SORT_RANDOM,
   SEARCH_SORT_POPULAR,
-  SEARCH_SORT_TOP_RATED,
-  SEARCH_SORT_TRENDING,
 } from 'core/constants';
 import { search as searchApi } from 'core/api/search';
 import log from 'core/logger';
@@ -21,8 +19,7 @@ import { createErrorHandler, getState } from 'core/sagas/utils';
 export function* fetchHomeAddons({
   payload: {
     errorHandlerId,
-    firstCollectionSlug,
-    firstCollectionUser,
+    collectionsToFetch,
   },
 }) {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -32,20 +29,22 @@ export function* fetchHomeAddons({
   try {
     const state = yield select(getState);
 
-    const {
-      firstCollection,
-      featuredExtensions,
-      featuredThemes,
-      popularExtensions,
-      topRatedExtensions,
-      upAndComingExtensions,
-    } = yield all({
-      firstCollection: call(getCollectionAddons, {
+    const collections = [];
+    // eslint-disable-next-line no-restricted-syntax
+    for (const coll of collectionsToFetch) {
+      const result = yield call(getCollectionAddons, {
         api: state.api,
         page: 1,
-        slug: firstCollectionSlug,
-        user: firstCollectionUser,
-      }),
+        slug: coll.slug,
+        user: coll.user,
+      });
+      collections.push(result);
+    }
+
+    const {
+      featuredExtensions,
+      popularThemes,
+    } = yield all({
       featuredExtensions: call(searchApi, {
         api: state.api,
         filters: {
@@ -56,52 +55,21 @@ export function* fetchHomeAddons({
         },
         page: 1,
       }),
-      featuredThemes: call(searchApi, {
+      popularThemes: call(searchApi, {
         api: state.api,
         filters: {
           addonType: ADDON_TYPE_THEME,
-          featured: true,
-          page_size: LANDING_PAGE_ADDON_COUNT,
-          sort: SEARCH_SORT_RANDOM,
-        },
-        page: 1,
-      }),
-      popularExtensions: call(searchApi, {
-        api: state.api,
-        filters: {
-          addonType: ADDON_TYPE_EXTENSION,
           page_size: LANDING_PAGE_ADDON_COUNT,
           sort: SEARCH_SORT_POPULAR,
-        },
-        page: 1,
-      }),
-      topRatedExtensions: call(searchApi, {
-        api: state.api,
-        filters: {
-          addonType: ADDON_TYPE_EXTENSION,
-          page_size: LANDING_PAGE_ADDON_COUNT,
-          sort: SEARCH_SORT_TOP_RATED,
-        },
-        page: 1,
-      }),
-      upAndComingExtensions: call(searchApi, {
-        api: state.api,
-        filters: {
-          addonType: ADDON_TYPE_EXTENSION,
-          page_size: LANDING_PAGE_ADDON_COUNT,
-          sort: SEARCH_SORT_TRENDING,
         },
         page: 1,
       }),
     });
 
     yield put(loadHomeAddons({
-      firstCollection,
+      collections,
       featuredExtensions,
-      featuredThemes,
-      popularExtensions,
-      topRatedExtensions,
-      upAndComingExtensions,
+      popularThemes,
     }));
   } catch (error) {
     log.warn(`Home add-ons failed to load: ${error}`);

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -67,9 +67,9 @@ describe(__filename, () => {
 
     expect(shelf).toHaveProp('header', 'Privacy tools');
     expect(shelf).toHaveProp('footerText', 'See more privacy tools');
-    expect(shelf).toHaveProp('footerLink', { pathname:
-      `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`,
-    });
+    expect(shelf).toHaveProp('footerLink',
+      `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`
+    );
     expect(shelf).toHaveProp('loading', true);
   });
 
@@ -81,9 +81,9 @@ describe(__filename, () => {
 
     expect(shelf).toHaveProp('header', 'Re-imagine search');
     expect(shelf).toHaveProp('footerText', 'See more search extensions');
-    expect(shelf).toHaveProp('footerLink', { pathname:
-      `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`,
-    });
+    expect(shelf).toHaveProp('footerLink',
+      `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`
+    );
     expect(shelf).toHaveProp('loading', true);
   });
 
@@ -93,11 +93,11 @@ describe(__filename, () => {
     const shelves = root.find(LandingAddonsCard);
     const shelf = shelves.find('.Home-FeaturedCollection').at(2);
 
-    expect(shelf).toHaveProp('header', `February's new featured extensions`);
+    expect(shelf).toHaveProp('header', `February’s new featured extensions`);
     expect(shelf).toHaveProp('footerText', 'See all the new featured extensions');
-    expect(shelf).toHaveProp('footerLink', { pathname:
-      `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`,
-    });
+    expect(shelf).toHaveProp('footerLink',
+      `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`
+    );
     expect(shelf).toHaveProp('loading', true);
   });
 

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -2,8 +2,7 @@ import * as React from 'react';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import Home, {
-  FIRST_COLLECTION_SLUG,
-  FIRST_COLLECTION_USER,
+  COLLECTIONS_TO_FETCH,
   HomeBase,
 } from 'amo/components/Home';
 import HomeHeroBanner from 'amo/components/HomeHeroBanner';
@@ -12,6 +11,7 @@ import { fetchHomeAddons, loadHomeAddons } from 'amo/reducers/home';
 import { createApiError } from 'core/api/index';
 import {
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
   SEARCH_SORT_POPULAR,
   VIEW_CONTEXT_HOME,
 } from 'core/constants';
@@ -65,10 +65,38 @@ describe(__filename, () => {
     const shelves = root.find(LandingAddonsCard);
     const shelf = shelves.find('.Home-FeaturedCollection').at(0);
 
-    expect(shelf).toHaveProp('header', 'Media downloaders');
-    expect(shelf).toHaveProp('footerText', 'See more media downloaders');
+    expect(shelf).toHaveProp('header', 'Privacy tools');
+    expect(shelf).toHaveProp('footerText', 'See more privacy tools');
     expect(shelf).toHaveProp('footerLink', { pathname:
-      `/collections/${FIRST_COLLECTION_USER}/${FIRST_COLLECTION_SLUG}/`,
+      `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`,
+    });
+    expect(shelf).toHaveProp('loading', true);
+  });
+
+  it('renders a second featured collection shelf', () => {
+    const root = render();
+
+    const shelves = root.find(LandingAddonsCard);
+    const shelf = shelves.find('.Home-FeaturedCollection').at(1);
+
+    expect(shelf).toHaveProp('header', 'Re-imagine search');
+    expect(shelf).toHaveProp('footerText', 'See more search extensions');
+    expect(shelf).toHaveProp('footerLink', { pathname:
+      `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`,
+    });
+    expect(shelf).toHaveProp('loading', true);
+  });
+
+  it('renders a third featured collection shelf', () => {
+    const root = render();
+
+    const shelves = root.find(LandingAddonsCard);
+    const shelf = shelves.find('.Home-FeaturedCollection').at(2);
+
+    expect(shelf).toHaveProp('header', `February's new featured extensions`);
+    expect(shelf).toHaveProp('footerText', 'See all the new featured extensions');
+    expect(shelf).toHaveProp('footerLink', { pathname:
+      `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`,
     });
     expect(shelf).toHaveProp('loading', true);
   });
@@ -112,17 +140,17 @@ describe(__filename, () => {
     });
   });
 
-  it('renders a popular extensions shelf', () => {
+  it('renders a popular themes shelf', () => {
     const root = render();
 
     const shelves = root.find(LandingAddonsCard);
-    const shelf = shelves.find('.Home-PopularExtensions');
-    expect(shelf).toHaveProp('header', 'Popular extensions');
-    expect(shelf).toHaveProp('footerText', 'See more popular extensions');
+    const shelf = shelves.find('.Home-PopularThemes');
+    expect(shelf).toHaveProp('header', 'Popular themes');
+    expect(shelf).toHaveProp('footerText', 'See more popular themes');
     expect(shelf).toHaveProp('footerLink', {
       pathname: '/search/',
       query: {
-        addonType: ADDON_TYPE_EXTENSION,
+        addonType: ADDON_TYPE_THEME,
         sort: SEARCH_SORT_POPULAR,
       },
     });
@@ -167,8 +195,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeDispatch, setViewContext(VIEW_CONTEXT_HOME));
     sinon.assert.calledWith(fakeDispatch, fetchHomeAddons({
       errorHandlerId: errorHandler.id,
-      firstCollectionSlug: FIRST_COLLECTION_SLUG,
-      firstCollectionUser: FIRST_COLLECTION_USER,
+      collectionsToFetch: COLLECTIONS_TO_FETCH,
     }));
   });
 
@@ -178,18 +205,18 @@ describe(__filename, () => {
     const addons = [{ ...fakeAddon, slug: 'addon' }];
     const themes = [{ ...fakeTheme }];
 
-    const firstCollection = createFakeCollectionAddons({ addons });
+    const collections = [
+      createFakeCollectionAddons({ addons }),
+      createFakeCollectionAddons({ addons }),
+      createFakeCollectionAddons({ addons }),
+    ];
     const featuredExtensions = createAddonsApiResult(addons);
-    const featuredThemes = createAddonsApiResult(themes);
-    const popularExtensions = createAddonsApiResult(addons);
-    const topRatedExtensions = createAddonsApiResult(themes);
+    const popularThemes = createAddonsApiResult(themes);
 
     store.dispatch(loadHomeAddons({
-      firstCollection,
+      collections,
       featuredExtensions,
-      featuredThemes,
-      popularExtensions,
-      topRatedExtensions,
+      popularThemes,
     }));
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
@@ -207,25 +234,26 @@ describe(__filename, () => {
     expect(firstCollectionShelf)
       .toHaveProp('addons', addons.map((addon) => createInternalAddon(addon)));
 
+    const secondCollectionShelf = shelves.find('.Home-FeaturedCollection')
+      .at(1);
+    expect(secondCollectionShelf).toHaveProp('loading', false);
+    expect(secondCollectionShelf)
+      .toHaveProp('addons', addons.map((addon) => createInternalAddon(addon)));
+
+    const thirdCollectionShelf = shelves.find('.Home-FeaturedCollection')
+      .at(2);
+    expect(thirdCollectionShelf).toHaveProp('loading', false);
+    expect(thirdCollectionShelf)
+      .toHaveProp('addons', addons.map((addon) => createInternalAddon(addon)));
+
     const featuredExtensionsShelf = shelves.find('.Home-FeaturedExtensions');
     expect(featuredExtensionsShelf).toHaveProp('loading', false);
     expect(featuredExtensionsShelf)
       .toHaveProp('addons', addons.map((addon) => createInternalAddon(addon)));
 
-    const featuredThemesShelf = shelves.find('.Home-FeaturedThemes');
-    expect(featuredThemesShelf).toHaveProp('loading', false);
-    expect(featuredThemesShelf)
-      .toHaveProp('addons', themes.map((theme) => createInternalAddon(theme)));
-
-    const popularExtensionsShelf = shelves.find('.Home-PopularExtensions');
-    expect(popularExtensionsShelf).toHaveProp('loading', false);
-    expect(popularExtensionsShelf)
-      .toHaveProp('addons', addons.map((addon) => createInternalAddon(addon)));
-
-    const topRatedExtensionsShelf = shelves
-      .find('.Home-TopRatedExtensions');
-    expect(topRatedExtensionsShelf).toHaveProp('loading', false);
-    expect(topRatedExtensionsShelf)
+    const popularThemesShelf = shelves.find('.Home-PopularThemes');
+    expect(popularThemesShelf).toHaveProp('loading', false);
+    expect(popularThemesShelf)
       .toHaveProp('addons', themes.map((theme) => createInternalAddon(theme)));
   });
 

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -30,33 +30,27 @@ describe(__filename, () => {
       const { store } = dispatchClientMetadata();
 
       store.dispatch(loadHomeAddons({
-        firstCollection: createFakeCollectionAddons({
+        collections: [createFakeCollectionAddons({
           addons: Array(10).fill(fakeAddon),
-        }),
+        })],
         featuredExtensions: createAddonsApiResult([fakeAddon]),
-        featuredThemes: createAddonsApiResult([fakeTheme]),
-        popularExtensions: createAddonsApiResult([fakeAddon]),
-        topRatedExtensions: createAddonsApiResult([fakeTheme]),
+        popularThemes: createAddonsApiResult([fakeTheme]),
       }));
 
       const homeState = store.getState().home;
 
       expect(homeState.resultsLoaded).toEqual(true);
-      expect(homeState.firstCollection)
+      expect(homeState.collections)
+        .toHaveLength(1);
+      expect(homeState.collections[0])
         .toHaveLength(LANDING_PAGE_ADDON_COUNT);
-      expect(homeState.firstCollection).toEqual(
+      expect(homeState.collections[0]).toEqual(
         Array(LANDING_PAGE_ADDON_COUNT).fill(createInternalAddon(fakeAddon))
       );
       expect(homeState.featuredExtensions).toEqual([
         createInternalAddon(fakeAddon),
       ]);
-      expect(homeState.featuredThemes).toEqual([
-        createInternalAddon(fakeTheme),
-      ]);
-      expect(homeState.popularExtensions).toEqual([
-        createInternalAddon(fakeAddon),
-      ]);
-      expect(homeState.topRatedExtensions).toEqual([
+      expect(homeState.popularThemes).toEqual([
         createInternalAddon(fakeTheme),
       ]);
     });
@@ -66,8 +60,7 @@ describe(__filename, () => {
 
       const state = homeReducer(loadedState, fetchHomeAddons({
         errorHandlerId: 'some-error-handler-id',
-        firstCollectionSlug: 'some-collection-slug',
-        firstCollectionUser: 'mozilla',
+        collectionsToFetch: [],
       }));
 
       expect(state.resultsLoaded).toEqual(false);
@@ -77,8 +70,7 @@ describe(__filename, () => {
   describe('fetchHomeAddons()', () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
-      firstCollectionSlug: 'some-collection-slug',
-      firstCollectionUser: 'mozilla',
+      collectionsToFetch: [],
     };
 
     it('throws an error when errorHandlerId is missing', () => {
@@ -90,42 +82,30 @@ describe(__filename, () => {
       }).toThrow('errorHandlerId is required');
     });
 
-    it('throws an error when firstCollectionSlug is missing', () => {
+    it('throws an error when collectionsToFetch is missing', () => {
       const partialParams = { ...defaultParams };
-      delete partialParams.firstCollectionSlug;
+      delete partialParams.collectionsToFetch;
 
       expect(() => {
         fetchHomeAddons(partialParams);
-      }).toThrow('firstCollectionSlug is required');
-    });
-
-    it('throws an error when firstCollectionUser is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.firstCollectionUser;
-
-      expect(() => {
-        fetchHomeAddons(partialParams);
-      }).toThrow('firstCollectionUser is required');
+      }).toThrow('collectionsToFetch is required');
     });
   });
 
   describe('loadHomeAddons()', () => {
     const defaultParams = {
-      firstCollection: {},
+      collections: [],
       featuredExtensions: {},
-      featuredThemes: {},
-      popularExtensions: {},
-      topRatedExtensions: {},
-      upAndComingExtensions: {},
+      popularThemes: {},
     };
 
-    it('throws an error when the first collection add-ons are missing', () => {
+    it('throws an error when the collections array is missing', () => {
       const partialParams = { ...defaultParams };
-      delete partialParams.firstCollection;
+      delete partialParams.collections;
 
       expect(() => {
         loadHomeAddons(partialParams);
-      }).toThrow('firstCollection is required');
+      }).toThrow('collections is required');
     });
 
     it('throws an error when featured extensions are missing', () => {
@@ -137,31 +117,13 @@ describe(__filename, () => {
       }).toThrow('featuredExtensions are required');
     });
 
-    it('throws an error when featured themes are missing', () => {
+    it('throws an error when popular themes are missing', () => {
       const partialParams = { ...defaultParams };
-      delete partialParams.featuredThemes;
+      delete partialParams.popularThemes;
 
       expect(() => {
         loadHomeAddons(partialParams);
-      }).toThrow('featuredThemes are required');
-    });
-
-    it('throws an error when popular extensions are missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.popularExtensions;
-
-      expect(() => {
-        loadHomeAddons(partialParams);
-      }).toThrow('popularExtensions are required');
-    });
-
-    it('throws an error when top-rated themes are missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.topRatedExtensions;
-
-      expect(() => {
-        loadHomeAddons(partialParams);
-      }).toThrow('topRatedExtensions are required');
+      }).toThrow('popularThemes are required');
     });
   });
 });


### PR DESCRIPTION
Fixes #4330 

This changes all the necessary files for the content update, and also includes a change to the way that collections are requested by and fetched for the home page. A variable number of collections can now be requested without requiring changes to the reducer or the saga.

I feel like a further refactor could be beneficial. It would be nice if the home page could specify which datasets it needs, and the reducer and the saga could  maintain the logic for all of the possible datasets (as opposed to adding and  removing code each time a change is required). Then the saga could retrieve only the requested data, and pass only the requested data back. As this procedure is only in place temporarily, I wasn't sure if it was worth making that change as well, but I'm happy to do so if you think it would be worthwhile.
