### PR TITLE
Allow unbroken strings in screenshot captions to be wrapped

### DIFF
--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -43,3 +43,7 @@ $screenshot-width: 320px;
 .pswp__img {
   object-fit: contain;
 }
+
+.ScreenShots-list .pswp__caption {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
Fixes #4334
This is done by applying the overflow-wrap: break-word rule to the div that contains the caption.
