### PR TITLE
Show LastUpdated date when search results are sorted by "Recently Updated"

### DIFF
--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -20,6 +20,7 @@ export default class AddonsCard extends React.Component {
     type: PropTypes.string,
     showMetadata: PropTypes.bool,
     showSummary: PropTypes.bool,
+    sortedByDate: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -39,6 +40,7 @@ export default class AddonsCard extends React.Component {
       showMetadata,
       showSummary,
       type,
+      sortedByDate,
       ...otherProps
     } = this.props;
 
@@ -52,6 +54,7 @@ export default class AddonsCard extends React.Component {
             key={addon.slug}
             showMetadata={showMetadata}
             showSummary={showSummary}
+            sortedByDate={sortedByDate}
           />
         );
       });

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -21,6 +21,7 @@ export class SearchResultBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     showMetadata: PropTypes.bool,
     showSummary: PropTypes.bool,
+    sortedByDate: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -33,8 +34,21 @@ export class SearchResultBase extends React.Component {
     return addon && addon.type === ADDON_TYPE_THEME;
   }
 
+  lastUpdatedText() {
+    const { addon, i18n, sortedByDate } = this.props;
+    const lastUpdated = addon && sortedByDate && i18n.sprintf(
+      // translators: This will output, in English:
+      // "2 months ago (Dec 12 2016)"
+      i18n.gettext('%(timeFromNow)s (%(date)s)'), {
+        timeFromNow: i18n.moment(addon.last_updated).fromNow(),
+        date: i18n.moment(addon.last_updated).format('ll'),
+      }
+    );
+    return lastUpdated && `${i18n.gettext('Last updated')}: ${lastUpdated}`;
+  }
+
   renderResult() {
-    const { addon, i18n, showMetadata, showSummary } = this.props;
+    const { addon, i18n, showMetadata, showSummary, sortedByDate } = this.props;
 
     const isTheme = this.addonIsTheme();
     const averageDailyUsers = addon && addon.average_daily_users;
@@ -63,6 +77,14 @@ export class SearchResultBase extends React.Component {
         </h3>
       );
     }
+
+    const lastUpdated = sortedByDate ?
+      (
+        <h3 className="SearchResult-lastUpdated SearchResult--meta-section">
+          {this.lastUpdatedText() || <LoadingText />}
+        </h3>
+      ) :
+      null;
 
     let summary = null;
     if (showSummary) {
@@ -104,6 +126,7 @@ export class SearchResultBase extends React.Component {
                 />
               </div>
               {addonAuthors}
+              {lastUpdated}
             </div>
           ) : null}
         </div>

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -145,6 +145,8 @@
 }
 
 .SearchResult-author {
+  @include margin-end(10px);
+
   display: none;
   word-wrap: break-word;
 

--- a/src/amo/components/SearchResults.js
+++ b/src/amo/components/SearchResults.js
@@ -5,6 +5,7 @@ import { compose } from 'redux';
 import AddonsCard from 'amo/components/AddonsCard';
 import translate from 'core/i18n/translate';
 import { hasSearchFilters } from 'core/searchUtils';
+import { SEARCH_SORT_UPDATED } from 'core/constants';
 
 
 class SearchResults extends React.Component {
@@ -59,6 +60,7 @@ class SearchResults extends React.Component {
           addons={hasSearchFilters(filters) ? results : null}
           header={i18n.gettext('Search results')}
           loading={loading}
+          sortedByDate={filters.sort && filters.sort === SEARCH_SORT_UPDATED}
         >
           {messageText ? (
             <p

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -98,6 +98,7 @@ export const SEARCH_SORT_TRENDING = 'hotness';
 export const SEARCH_SORT_TOP_RATED = 'rating';
 export const SEARCH_SORT_POPULAR = 'users';
 export const SEARCH_SORT_RANDOM = 'random';
+export const SEARCH_SORT_UPDATED = 'updated';
 
 // Operating system for add-ons and files
 export const OS_ALL = 'all';

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -11,6 +11,8 @@ import Rating from 'ui/components/Rating';
 
 
 describe(__filename, () => {
+  const lastUpdated = Date.now();
+
   const baseAddon = createInternalAddon({
     ...fakeAddon,
     authors: [
@@ -20,6 +22,7 @@ describe(__filename, () => {
     average_daily_users: 5253,
     name: 'A search result',
     slug: 'a-search-result',
+    last_updated: lastUpdated,
   });
 
   function render({ addon = baseAddon, lang = 'en-GB', ...props } = {}) {
@@ -175,5 +178,18 @@ describe(__filename, () => {
     const root = render({ showMetadata: false });
 
     expect(root.find('.SearchResult-metadata')).toHaveLength(0);
+  });
+
+  it('renders the lastUpdate date when requested', () => {
+    const root = render({ sortedByDate: true });
+
+    expect(root.find('.SearchResult-lastUpdated'))
+      .toIncludeText('Last updated: a few seconds ago');
+  });
+
+  it('excludes the lastUpdate date when not requested', () => {
+    const root = render();
+
+    expect(root).not.toHaveClassName('SearchResult-lastUpdated');
   });
 });

--- a/tests/unit/amo/components/TestSearchResults.js
+++ b/tests/unit/amo/components/TestSearchResults.js
@@ -11,6 +11,7 @@ import SearchResults from 'amo/components/SearchResults';
 import I18nProvider from 'core/i18n/Provider';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 import { fakeI18n } from 'tests/unit/helpers';
+import { SEARCH_SORT_UPDATED } from 'core/constants';
 
 
 describe('<SearchResults />', () => {
@@ -98,5 +99,14 @@ describe('<SearchResults />', () => {
 
     expect(addonsCard.props.addons).toEqual(results);
     expect(addonsCard.props.loading).toEqual(false);
+  });
+
+  it('passes the correct value for sortedByDate to AddonsCard', () => {
+    const root = renderResults({
+      filters: { query: 'test', sort: SEARCH_SORT_UPDATED },
+    });
+    const addonsCard = findRenderedComponentWithType(root, AddonsCard);
+
+    expect(addonsCard.props.sortedByDate).toEqual(true);
   });
 });


### PR DESCRIPTION
Fixes #3783 

This displays a LastUpdated date for each search result if the search included a sort order of "Recently Updated".

Note that the layout and appearance likely needs to change, and I've requested UX feedback in issue #3783. I think the logic can be reviewed at this point as it may need significant changes as well.
