### PR TITLE
Allow LandingAddonsCard to accept a string for the footerLink property

### DIFF
--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -35,13 +35,15 @@ export default class LandingAddonsCard extends React.Component {
 
     let footerLinkHtml = null;
     if (addons && addons.length >= placeholderCount) {
-      const linkSearchURL = typeof footerLink === 'string' ?
-        footerLink :
-        {
-          ...footerLink,
-          query: convertFiltersToQueryParams(footerLink.query),
+      let linkTo = footerLink;
+      if (typeof linkTo === 'object') {
+        // As a convenience, fix the query parameter.
+        linkTo = {
+          ...linkTo,
+          query: convertFiltersToQueryParams(linkTo.query),
         };
-      footerLinkHtml = <Link to={linkSearchURL}>{footerText}</Link>;
+      }
+      footerLinkHtml = <Link to={linkTo}>{footerText}</Link>;
     }
 
     return (

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -11,7 +11,7 @@ export default class LandingAddonsCard extends React.Component {
   static propTypes = {
     addons: PropTypes.array.isRequired,
     className: PropTypes.string,
-    footerLink: PropTypes.object.isRequired,
+    footerLink: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     footerText: PropTypes.string.isRequired,
     header: PropTypes.node.isRequired,
     loading: PropTypes.bool.isRequired,
@@ -35,10 +35,12 @@ export default class LandingAddonsCard extends React.Component {
 
     let footerLinkHtml = null;
     if (addons && addons.length >= placeholderCount) {
-      const linkSearchURL = {
-        ...footerLink,
-        query: convertFiltersToQueryParams(footerLink.query),
-      };
+      const linkSearchURL = typeof footerLink === 'string' ?
+        footerLink :
+        {
+          ...footerLink,
+          query: convertFiltersToQueryParams(footerLink.query),
+        };
       footerLinkHtml = <Link to={linkSearchURL}>{footerText}</Link>;
     }
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -59,4 +59,10 @@ describe(__filename, () => {
     const root = render({ addons, placeholderCount: 2 });
     expect(root.find(AddonsCard)).toHaveProp('footerLink', null);
   });
+
+  it('accepts a string for the footer link', () => {
+    const linkString = '/some/link/';
+    const root = render({ footerLink: linkString });
+    expect(root.find(AddonsCard).prop('footerLink').props.to).toEqual(linkString);
+  });
 });


### PR DESCRIPTION
Fixes #4374 

It should really have been able to do this before, and this fixes the issue so we can now pass simple strings into LandingAddonsCard.footerLink.

Note that I'm fairly sure the way I am checking for the value in the test is wrong, but I wasn't sure how else to verify that the string passed made it into the AddonsCard properly. Feedback is appreciated.