### PR TITLE
fix: Tweak version redirect and small size for disco pane

### DIFF
--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -198,8 +198,22 @@ function baseServer(routes, createStore, {
 
   const isDevelopment = config.get('isDevelopment');
   if (appName === 'disco' && isDevelopment) {
-    app.get('/', (req, res) =>
-      res.redirect(302, '/en-US/firefox/discovery/pane/48.0/Darwin/normal'));
+    // We use 57 (the first version of Firefox Quantum) here so that any
+    // version-dependent styles (eg.
+    // https://github.com/mozilla/addons-frontend/blob/master/src/disco/css/App.scss)
+    // are not loaded.
+    const defaultVersion = '57.0';
+
+    app.get('/', (req, res) => {
+      res.redirect(302,
+        `/en-US/firefox/discovery/pane/${defaultVersion}/Darwin/normal`);
+    });
+
+    app.get('/:version/', (req, res) => {
+      const version = req.params.version || defaultVersion;
+      res.redirect(302,
+        `/en-US/firefox/discovery/pane/${version}/Darwin/normal`);
+    });
   }
 
   // Handle application and lang redirections.

--- a/src/disco/css/Addon.scss
+++ b/src/disco/css/Addon.scss
@@ -82,19 +82,20 @@ $addon-padding: 20px;
     align-items: center;
     align-self: stretch;
     display: flex;
-    padding: 0 10px;
-    width: 94px;
+    padding: 0 5px;
+
+    @include respond-to(medium) {
+      padding: 0 10px;
+    }
+
+    @include respond-to(large) {
+      padding: 0 15px;
+    }
 
     img {
       display: block;
       height: 64px;
       width: 64px;
-    }
-  }
-
-  @include respond-to(large) {
-    .logo {
-      padding: 0 15px;
     }
   }
 
@@ -166,16 +167,9 @@ $addon-padding: 20px;
   }
 
   &:not(.theme) .content {
-    align-items: left;
-    flex-direction: column;
+    align-items: center;
+    flex-direction: row;
     width: calc(100% - 94px);
-  }
-
-  @include respond-to(large) {
-    &:not(.theme) .content {
-      align-items: center;
-      flex-direction: row;
-    }
   }
 
   .notification {

--- a/src/disco/css/App.scss
+++ b/src/disco/css/App.scss
@@ -33,7 +33,7 @@ img {
   box-sizing: content-box;
   margin: 0 auto;
   max-width: 680px;
-  min-width: 260px; // 300 - (20px + 20px)
+  min-width: 260px;
   padding: 10px 20px 20px;
 }
 


### PR DESCRIPTION
Close #4245.
Fix #4190.

This changes the redirect so we aren't pointing to a version of disco pane in development with padding compensation, but also fixes #4190.

### Before
![2018-02-13 16 33 14](https://user-images.githubusercontent.com/90871/36169414-1920fa8c-10f4-11e8-8147-25f46e76392f.gif)

![screen shot 2018-02-13 at 18 27 34](https://user-images.githubusercontent.com/90871/36169451-2ed2c036-10f4-11e8-9fd3-38bd7fe02ae2.png)
![screen shot 2018-02-13 at 18 27 28](https://user-images.githubusercontent.com/90871/36169453-2eee074c-10f4-11e8-894c-8980c7048eca.png)
![screen shot 2018-02-13 at 18 27 21](https://user-images.githubusercontent.com/90871/36169455-2f0c87c6-10f4-11e8-88ca-35ad6293527c.png)


### After
![2018-02-13 16 32 53](https://user-images.githubusercontent.com/90871/36169438-25472390-10f4-11e8-95bd-9996f0f80385.gif)

![screen shot 2018-02-13 at 18 24 48](https://user-images.githubusercontent.com/90871/36169489-43a68b28-10f4-11e8-917c-f72610f4931d.png)
![screen shot 2018-02-13 at 18 24 38](https://user-images.githubusercontent.com/90871/36169490-43c78436-10f4-11e8-9122-027a03e627a2.png)
![screen shot 2018-02-13 at 18 24 33](https://user-images.githubusercontent.com/90871/36169491-43e98b9e-10f4-11e8-9fe9-8faddce3a759.png)
