### PR TITLE
Cause incorrect page numbers to return a 404 in "All reviews" pages

### DIFF
--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -99,7 +99,7 @@ export class AddonReviewListBase extends React.Component<Props> {
       dispatch(fetchReviews({
         addonSlug: params.addonSlug,
         errorHandlerId: errorHandler.id,
-        page: parsePage(location.query.page),
+        page: location.query.page,
       }));
     }
   }

--- a/src/core/sagas/search.js
+++ b/src/core/sagas/search.js
@@ -10,7 +10,6 @@ import { SEARCH_STARTED } from 'core/constants';
 import log from 'core/logger';
 import { abortSearch } from 'core/reducers/search';
 import { createErrorHandler, getState } from 'core/sagas/utils';
-import { parsePage } from 'core/utils';
 
 
 export function* fetchSearchResults({ payload }) {
@@ -21,7 +20,6 @@ export function* fetchSearchResults({ payload }) {
 
   try {
     const { filters } = payload;
-    const page = parsePage(filters.page);
 
     const state = yield select(getState);
 
@@ -29,7 +27,6 @@ export function* fetchSearchResults({ payload }) {
       api: state.api,
       auth: true,
       filters,
-      page,
     });
     const { entities, result } = response;
 

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -215,6 +215,7 @@ describe(__filename, () => {
     });
 
     it('dispatches fetchReviews with an invalid page variable', () => {
+      // We intentionally pass invalid pages to the API to get a 404 response.
       const dispatch = sinon.stub(store, 'dispatch');
       const errorHandler = createStubErrorHandler();
       const addonSlug = fakeAddon.slug;

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -214,6 +214,25 @@ describe(__filename, () => {
       }));
     });
 
+    it('dispatches fetchReviews with an invalid page variable', () => {
+      const dispatch = sinon.stub(store, 'dispatch');
+      const errorHandler = createStubErrorHandler();
+      const addonSlug = fakeAddon.slug;
+      const page = 'x';
+
+      render({
+        errorHandler,
+        location: { query: { page } },
+        params: { addonSlug },
+      });
+
+      sinon.assert.calledWith(dispatch, fetchReviews({
+        addonSlug,
+        errorHandlerId: errorHandler.id,
+        page,
+      }));
+    });
+
     it('fetches reviews when the page changes', () => {
       const dispatch = sinon.stub(store, 'dispatch');
       const errorHandler = createStubErrorHandler();

--- a/tests/unit/core/sagas/testSearch.js
+++ b/tests/unit/core/sagas/testSearch.js
@@ -51,33 +51,6 @@ describe(__filename, () => {
     mockApi.verify();
   });
 
-  it('handles missing page filter for search', async () => {
-    const entities = sinon.stub();
-    const result = sinon.stub();
-    const state = sagaTester.getState();
-
-    const filters = { query: 'test' };
-
-    mockApi
-      .expects('search')
-      .once()
-      .withArgs({
-        api: state.api,
-        auth: true,
-        filters,
-        // The search saga will set `page` to `parsePage(filters.page)`, so
-        // in the case of a missing `page` param it should be `1`.
-        page: 1,
-      })
-      .returns(Promise.resolve({ entities, result }));
-
-    _searchStart({ filters });
-
-    // The saga should respond by dispatching the search loaded action.
-    await sagaTester.waitFor(SEARCH_LOADED);
-    mockApi.verify();
-  });
-
   it('clears the error handler', async () => {
     _searchStart({ filters: { query: 'foo' } });
 


### PR DESCRIPTION
Fixes #4081 

The problem here is that we are sanitizing the page number via `parsePage` before sending it to the API, which causes any non-numbers and the number 0 to be converted to a 1. When that is passed into `fetchReviews` it of course retrieves the first page of reviews.

Simply removing that sanitization fixes this issue and allows the API to return a 404 as expected, which is similar to how `SearchBase` behaves.

I'm not sure if there are any other repercussions to this change, but everything seems to behave as expected. I do wonder, however, if it might not be a better approach to check the page value before even dispatching `fetchReviews` to avoid making that call if the number is invalid? That's not what `SearchBase` does, but it might be worth considering.