### PR TITLE
Add a query string to the favicon link to force clients to retrieve the newest one

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -70,6 +70,11 @@ module.exports = {
   apiHost: apiProdHost,
   apiPath: '/api/v3',
 
+  // The version for the favicon.
+  // This should be changed when a new favicon is pushed to the CDN to prevent
+  // client caching.
+  faviconVersion: 2,
+
   // The keys listed here will be exposed on the client.
   // Since by definition client-side code is public these config keys
   // must not contain sensitive data.

--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -84,7 +84,7 @@ export default class ServerHtml extends Component {
 
   getFaviconLink() {
     const { _config } = this.props;
-    return `${_config.get('amoCDN')}/favicon.ico`;
+    return `${_config.get('amoCDN')}/favicon.ico?v=2`;
   }
 
   render() {

--- a/src/core/containers/ServerHtml.js
+++ b/src/core/containers/ServerHtml.js
@@ -84,7 +84,7 @@ export default class ServerHtml extends Component {
 
   getFaviconLink() {
     const { _config } = this.props;
-    return `${_config.get('amoCDN')}/favicon.ico?v=2`;
+    return `${_config.get('amoCDN')}/favicon.ico?v=${_config.get('faviconVersion')}`;
   }
 
   render() {

--- a/tests/unit/core/containers/TestServerHtml.js
+++ b/tests/unit/core/containers/TestServerHtml.js
@@ -116,7 +116,7 @@ describe('<ServerHtml />', () => {
     const _config = getFakeConfig({ amoCDN });
     const html = findRenderedDOMComponentWithTag(render({ _config }), 'html');
     const favicon = html.querySelector('link[rel="shortcut icon"]');
-    expect(favicon.getAttribute('href')).toEqual(`${amoCDN}/favicon.ico`);
+    expect(favicon.getAttribute('href')).toEqual(`${amoCDN}/favicon.ico?v=2`);
   });
 
   it('renders title', () => {

--- a/tests/unit/core/containers/TestServerHtml.js
+++ b/tests/unit/core/containers/TestServerHtml.js
@@ -116,7 +116,8 @@ describe('<ServerHtml />', () => {
     const _config = getFakeConfig({ amoCDN });
     const html = findRenderedDOMComponentWithTag(render({ _config }), 'html');
     const favicon = html.querySelector('link[rel="shortcut icon"]');
-    expect(favicon.getAttribute('href')).toEqual(`${amoCDN}/favicon.ico?v=2`);
+    expect(favicon.getAttribute('href')).toEqual(
+      `${amoCDN}/favicon.ico?v=${_config.get('faviconVersion')}`);
   });
 
   it('renders title', () => {


### PR DESCRIPTION
Fixes #4365 

I was unable to reproduce issue #4365, but @diox was, so we believe it is a caching issue. The favicon is configured to be cached with `Cache-Control: max-age=315360000` so we need to force a refresh on clients who still have the old favicon. 
