### PR TITLE
Increase the possible height of the add-on description on desktop

### DIFF
--- a/src/ui/components/ShowMoreCard/ShowMoreCard.scss
+++ b/src/ui/components/ShowMoreCard/ShowMoreCard.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  footer.Card-footer-link {
+  .Card-footer-link {
     @include respond-to(large) {
       display: none;
     }

--- a/src/ui/components/ShowMoreCard/ShowMoreCard.scss
+++ b/src/ui/components/ShowMoreCard/ShowMoreCard.scss
@@ -1,4 +1,5 @@
 @import "~core/css/inc/vars";
+@import "~core/css/inc/mixins";
 
 .ShowMoreCard-contents {
   &::after {
@@ -25,5 +26,23 @@
     }
 
     max-height: none;
+  }
+}
+
+.AddonDescription {
+  .ShowMoreCard-contents {
+    @include respond-to(large) {
+      &::after {
+        height: 0;
+      }
+
+      max-height: none;
+    }
+  }
+
+  footer.Card-footer-link {
+    @include respond-to(large) {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
Fixes #3787 

I know that this patch is highly flawed, but I figured providing some sample code would help illustrate the problems I'm struggling with and make the questions I'm going to ask below more clear...

We want to increase the amount of space that the `ShowMoreCard` allows on desktop, for the add-on description. I increased the allowable space by adding a rule for `respond-to(large)`, which seems to work, but I'm not sure if that's the correct approach. Are we equating desktop with `large`? What about `medium`?

Assuming the above is okay, the other part of the problem is deciding when to show the "Read more" footer. The current code has 150px hardcoded as a limit in the `ShowMoreCard` component, but now the limit is different between desktop and mobile. I tried to solve this with a css-only solution, but couldn't figure out how to do so. I think a css-only solution would be preferable, if it's possible. Not being able to figure that out, I decided to make `maxHeight` a property of the `ShowMoreCard` component, so that we could have a different `maxHeight` value for different instances (which we need). I then tried to figure out if we were on desktop or not in the `Addon` component so I could pass the correct `maxHeight` into the `ShowMoreCard` component. I did this by looking at `userAgentInfo`, but I think that's flawed. I'm also not happy about having to keep the correct maxHeight value in sync between the css file and the js file, but I guess we're already doing that with the current 150pm value.

So, do you have any suggestions for a better approach to this, or if my approach is not terribly off base, how can I improve it as I still think it's quite flawed?
