### PR TITLE
Explicitly ask API to wrap outgoing URLs

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -119,7 +119,12 @@ export function callApi({
   // Preserve the original query string if there is one.
   // This might happen when we parse `next` URLs returned by the API.
   const queryString = makeQueryString({
-    ...parsedUrl.query, ...params, lang: state.lang,
+    ...parsedUrl.query,
+    ...params,
+    lang: state.lang,
+    // Always return URLs wrapped by the outgoing proxy.
+    // Example: http://outgoing.prod.mozaws.net/
+    wrap_outgoing_links: true,
   });
 
   const options = {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -446,7 +446,7 @@ export const urlWithTheseParams = (params) => {
     const { query } = url.parse(urlString, true);
 
     // eslint-disable-next-line no-restricted-syntax
-    for (const param of Object.keys(params)) {
+    for (const param in params) {
       if (!query[param] || query[param] !== params[param].toString()) {
         return false;
       }

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,4 +1,6 @@
 /* global Response */
+import url from 'url';
+
 import base64url from 'base64url';
 import config, { util as configUtil } from 'config';
 import { shallow } from 'enzyme';
@@ -430,4 +432,26 @@ export const getFakeConfig = (params = {}) => {
     }
   }
   return Object.assign(configUtil.cloneDeep(config), params);
+};
+
+/*
+ * A sinon matcher to check if the URL contains the declared params.
+ *
+ * Example:
+ *
+ * mockWindow.expects('fetch').withArgs(urlWithTheseParams({ page: 1 }))
+ */
+export const urlWithTheseParams = (params) => {
+  return sinon.match((urlString) => {
+    const { query } = url.parse(urlString, true);
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const param of Object.keys(params)) {
+      if (!query[param] || query[param] !== params[param].toString()) {
+        return false;
+      }
+    }
+
+    return true;
+  }, `urlWithTheseParams(${JSON.stringify(params)})`);
 };


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4393 by configuring all API requests with the new parameter.

Because all API requests have a new query param, this broke a lot of tests that were too tightly coupled to the entire URL. I fixed all of those by making the tests ignore parts of the URL that were not relevant. This is something we've been meaning to do for a while now. I thought there was an issue on file but I couldn't find it.

Sorry for the noise but this cleanup should make the tests more robust.