### PR TITLE
fix: Use href instead of to for Links in header

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -101,12 +101,12 @@ export class HeaderBase extends React.Component {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem>
-                <Link to={`/user/${siteUser.username}/`}>
+                <Link href={`/user/${siteUser.username}/`}>
                   {i18n.gettext('View Profile')}
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem>
-                <Link to="/users/edit">
+                <Link href="/users/edit">
                   {i18n.gettext('Edit Profile')}
                 </Link>
               </DropdownMenuItem>


### PR DESCRIPTION
(fix #4397)

Looks like this slipped in unintentionally, sorry about that.