### PR TITLE
Default to show beta-versions, gated by waffle switch on the backend

### DIFF
--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -25,7 +25,7 @@ module.exports = {
     },
   },
 
-  betaVersions: false,
+  betaVersions: true,
 
   enableCollectionEdit: true,
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -11,5 +11,5 @@ module.exports = {
   fxaConfig: 'local',
   trackingEnabled: false,
   enableCollectionEdit: true,
-  betaVersions: false,
+  betaVersions: true,
 };


### PR DESCRIPTION
`addons-server` defines whether the API exposes beta-versions or not and the frontend only displays the link if there are beta versions. So this patch will make showing/hiding beta-versions work by just flipping the waffle switch in the backend.