### PR TITLE
Make all visual representations of the user's personal ratings yellow

### DIFF
--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -67,7 +67,7 @@ export class AddonMetaBase extends React.Component<Props> {
                   className="AddonMeta-item-header"
                   rating={averageRating}
                   readOnly
-                  styleName="small"
+                  styleSize="small"
                 />
               ),
               title: i18n.gettext('Overall Rating'),

--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -202,7 +202,7 @@ export class AddonReviewBase extends React.Component<Props, State> {
         />
         {/* eslint-enable react/no-danger */}
         <Rating
-          styleName="large"
+          styleSize="large"
           rating={review.rating}
           onSelectRating={this.onSelectRating}
         />

--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -14,7 +14,7 @@ import translate from 'core/i18n/translate';
 import defaultLocalStateCreator, { LocalState } from 'core/localState';
 import log from 'core/logger';
 import OverlayCard from 'ui/components/OverlayCard';
-import Rating from 'ui/components/Rating';
+import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { SubmitReviewParams } from 'amo/api/reviews';
 import type { ApiStateType } from 'core/reducers/api';
@@ -201,9 +201,9 @@ export class AddonReviewBase extends React.Component<Props, State> {
           dangerouslySetInnerHTML={sanitizeHTML(prompt, ['a'])}
         />
         {/* eslint-enable react/no-danger */}
-        <Rating
+        <UserRating
           styleSize="large"
-          rating={review.rating}
+          review={review}
           onSelectRating={this.onSelectRating}
         />
         <form className="AddonReview-form" onSubmit={this.onSubmit}>

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -233,7 +233,7 @@ export class AddonReviewListItemBase extends React.Component<Props> {
           {review && !isReply ?
             <Rating
               styleSize="small"
-              isOwner={siteUser && review && review.userId === siteUser.id}
+              review={review}
               rating={review.rating}
               readOnly
             />

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -21,7 +21,7 @@ import {
 } from 'amo/actions/reviews';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
-import Rating from 'ui/components/Rating';
+import UserRating from 'ui/components/UserRating';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { ReviewState } from 'amo/reducers/reviews';
@@ -231,10 +231,9 @@ export class AddonReviewListItemBase extends React.Component<Props> {
         {reviewBody}
         <div className="AddonReviewListItem-byline">
           {review && !isReply ?
-            <Rating
+            <UserRating
               styleSize="small"
               review={review}
-              rating={review.rating}
               readOnly
             />
             : null

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -231,7 +231,14 @@ export class AddonReviewListItemBase extends React.Component<Props> {
         {reviewBody}
         <div className="AddonReviewListItem-byline">
           {review && !isReply ?
-            <Rating styleName="small" rating={review.rating} readOnly />
+            <Rating
+              styleName={
+                siteUser && review && review.userId === siteUser.id ?
+                  'small-by-user' : 'small'
+              }
+              rating={review.rating}
+              readOnly
+            />
             : null
           }
           {byline}

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -232,10 +232,8 @@ export class AddonReviewListItemBase extends React.Component<Props> {
         <div className="AddonReviewListItem-byline">
           {review && !isReply ?
             <Rating
-              styleName={
-                siteUser && review && review.userId === siteUser.id ?
-                  'small-by-user' : 'small'
-              }
+              styleSize="small"
+              isOwner={siteUser && review && review.userId === siteUser.id}
               rating={review.rating}
               readOnly
             />

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -22,7 +22,7 @@ import {
 } from 'core/constants';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
-import DefaultRating from 'ui/components/Rating';
+import DefaultUserRating from 'ui/components/UserRating';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type {
@@ -50,7 +50,7 @@ type SubmitReviewFunc = (SubmitReviewParams) => Promise<void>;
 type Props = {|
   AddonReview: typeof DefaultAddonReview,
   AuthenticateButton: typeof DefaultAuthenticateButton,
-  Rating: typeof DefaultRating,
+  UserRating: typeof DefaultUserRating,
   ReportAbuseButton: typeof DefaultReportAbuseButton,
   addon: AddonType,
   apiState: ApiStateType,
@@ -75,7 +75,7 @@ export class RatingManagerBase extends React.Component<Props, State> {
   static defaultProps = {
     AddonReview: DefaultAddonReview,
     AuthenticateButton: DefaultAuthenticateButton,
-    Rating: DefaultRating,
+    UserRating: DefaultUserRating,
     ReportAbuseButton: DefaultReportAbuseButton,
   }
 
@@ -178,7 +178,7 @@ export class RatingManagerBase extends React.Component<Props, State> {
   render() {
     const {
       AddonReview,
-      Rating,
+      UserRating,
       ReportAbuseButton,
       i18n,
       addon,
@@ -206,10 +206,10 @@ export class RatingManagerBase extends React.Component<Props, State> {
               {prompt}
             </legend>
             {!isLoggedIn ? this.renderLogInToRate() : null}
-            <Rating
+            <UserRating
               readOnly={!isLoggedIn}
               onSelectRating={this.onSelectRating}
-              rating={userReview ? userReview.rating : undefined}
+              review={userReview}
             />
           </fieldset>
         </form>

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -100,7 +100,7 @@ export class SearchResultBase extends React.Component {
                 <Rating
                   rating={addon ? addon.ratings.average : 0}
                   readOnly
-                  styleName="small"
+                  styleSize="small"
                 />
               </div>
               {addonAuthors}

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -1,34 +1,33 @@
 import makeClassName from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { getCurrentUser } from 'amo/reducers/users';
 import log from 'core/logger';
 import translate from 'core/i18n/translate';
 
 import './styles.scss';
 
 
-const RATING_STYLE_SIZES = ['small', 'large'];
+export const RATING_STYLE_SIZE_TYPES = { small: '', large: '' };
+const RATING_STYLE_SIZES = Object.keys(RATING_STYLE_SIZE_TYPES);
 
 export class RatingBase extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     i18n: PropTypes.object.isRequired,
+    isOwner: PropTypes.bool,
     onSelectRating: PropTypes.func,
     rating: PropTypes.number,
     readOnly: PropTypes.bool,
     styleSize: PropTypes.oneOf(RATING_STYLE_SIZES),
-    review: PropTypes.object,
-    isOwner: PropTypes.bool,
   }
 
   static defaultProps = {
     className: '',
     readOnly: false,
     styleSize: 'large',
+    isOwner: false,
   }
 
   constructor(props) {
@@ -122,16 +121,6 @@ export class RatingBase extends React.Component {
   }
 }
 
-export function mapStateToProps(state, ownProps) {
-  const { review } = ownProps;
-  const siteUser = getCurrentUser(state.users);
-  const isOwner = siteUser && review && review.userId === siteUser.id;
-  return { isOwner };
-}
-
-const Rating = compose(
-  connect(mapStateToProps),
+export default compose(
   translate({ withRef: true }),
 )(RatingBase);
-
-export default Rating;

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -9,7 +9,7 @@ import translate from 'core/i18n/translate';
 import './styles.scss';
 
 
-const RATING_STYLES = ['small', 'large', 'small-monochrome'];
+const RATING_STYLES = ['small', 'large', 'small-monochrome', 'small-by-user'];
 
 export class RatingBase extends React.Component {
   static propTypes = {

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -9,7 +9,7 @@ import translate from 'core/i18n/translate';
 import './styles.scss';
 
 
-const RATING_STYLES = ['small', 'large', 'small-monochrome', 'small-by-user'];
+const RATING_STYLE_SIZES = ['small', 'large'];
 
 export class RatingBase extends React.Component {
   static propTypes = {
@@ -18,13 +18,15 @@ export class RatingBase extends React.Component {
     onSelectRating: PropTypes.func,
     rating: PropTypes.number,
     readOnly: PropTypes.bool,
-    styleName: PropTypes.oneOf(RATING_STYLES),
+    styleSize: PropTypes.oneOf(RATING_STYLE_SIZES),
+    isOwner: PropTypes.bool,
   }
 
   static defaultProps = {
     className: '',
     readOnly: false,
-    styleName: 'large',
+    styleSize: 'large',
+    isOwner: false,
   }
 
   constructor(props) {
@@ -83,11 +85,11 @@ export class RatingBase extends React.Component {
   }
 
   render() {
-    const { className, i18n, rating, readOnly, styleName } = this.props;
-    if (!RATING_STYLES.includes(styleName)) {
+    const { className, i18n, rating, readOnly, styleSize, isOwner } = this.props;
+    if (!RATING_STYLE_SIZES.includes(styleSize)) {
       throw new Error(
-        `styleName=${styleName} is not a valid value; ` +
-        `possible values: ${RATING_STYLES.join(', ')}`);
+        `styleSize=${styleSize} is not a valid value; ` +
+        `possible values: ${RATING_STYLE_SIZES.join(', ')}`);
     }
     let description;
     if (rating) {
@@ -97,8 +99,10 @@ export class RatingBase extends React.Component {
       description = i18n.gettext('No ratings');
     }
 
-    const allClassNames = makeClassName('Rating', `Rating--${styleName}`,
-      className, { 'Rating--editable': !readOnly });
+    const allClassNames = makeClassName(
+      'Rating', `Rating--${styleSize}`, className,
+      { 'Rating--editable': !readOnly }, { 'Rating--by-owner': isOwner }
+    );
 
     return (
       <div

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -1,8 +1,10 @@
 import makeClassName from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import { getCurrentUser } from 'amo/reducers/users';
 import log from 'core/logger';
 import translate from 'core/i18n/translate';
 
@@ -19,6 +21,7 @@ export class RatingBase extends React.Component {
     rating: PropTypes.number,
     readOnly: PropTypes.bool,
     styleSize: PropTypes.oneOf(RATING_STYLE_SIZES),
+    review: PropTypes.object,
     isOwner: PropTypes.bool,
   }
 
@@ -26,7 +29,6 @@ export class RatingBase extends React.Component {
     className: '',
     readOnly: false,
     styleSize: 'large',
-    isOwner: false,
   }
 
   constructor(props) {
@@ -100,8 +102,9 @@ export class RatingBase extends React.Component {
     }
 
     const allClassNames = makeClassName(
-      'Rating', `Rating--${styleSize}`, className,
-      { 'Rating--editable': !readOnly }, { 'Rating--by-owner': isOwner }
+      'Rating', `Rating--${styleSize}`, className, {
+        'Rating--editable': !readOnly, 'Rating--by-owner': isOwner,
+      }
     );
 
     return (
@@ -119,6 +122,16 @@ export class RatingBase extends React.Component {
   }
 }
 
-export default compose(
+export function mapStateToProps(state, ownProps) {
+  const { review } = ownProps;
+  const siteUser = getCurrentUser(state.users);
+  const isOwner = siteUser && review && review.userId === siteUser.id;
+  return { isOwner };
+}
+
+const Rating = compose(
+  connect(mapStateToProps),
   translate({ withRef: true }),
 )(RatingBase);
+
+export default Rating;

--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -55,7 +55,8 @@
 }
 
 .Rating--small .Rating-choice,
-.Rating--small-monochrome .Rating-choice {
+.Rating--small-monochrome .Rating-choice,
+.Rating--small-by-user .Rating-choice {
   background-size: $rating-s-star-size;
   height: $rating-s-star-size + $rating-s-star-gutter;
   margin: 0;
@@ -73,5 +74,15 @@
 
   .Rating-half-star {
     background-image: url("~ui/components/Icon/img/star-half.svg");
+  }
+}
+
+.Rating--small-by-user {
+  .Rating-choice {
+    background-image: url("./img/dim-star-gold.svg");
+  }
+
+  .Rating-selected-star {
+    background-image: url("./img/full-star-gold.svg");
   }
 }

--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -55,7 +55,6 @@
 }
 
 .Rating--small .Rating-choice,
-.Rating--small-monochrome .Rating-choice,
 .Rating--small-by-user .Rating-choice {
   background-size: $rating-s-star-size;
   height: $rating-s-star-size + $rating-s-star-gutter;
@@ -63,21 +62,7 @@
   width: $rating-s-star-size + $rating-s-star-gutter;
 }
 
-.Rating--small-monochrome {
-  .Rating-choice {
-    background-image: url("~ui/components/Icon/img/star-empty.svg");
-  }
-
-  .Rating-selected-star {
-    background-image: url("~ui/components/Icon/img/star-full.svg");
-  }
-
-  .Rating-half-star {
-    background-image: url("~ui/components/Icon/img/star-half.svg");
-  }
-}
-
-.Rating--small-by-user {
+.Rating--by-owner {
   .Rating-choice {
     background-image: url("./img/dim-star-gold.svg");
   }

--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -54,8 +54,7 @@
   }
 }
 
-.Rating--small .Rating-choice,
-.Rating--small-by-user .Rating-choice {
+.Rating--small .Rating-choice {
   background-size: $rating-s-star-size;
   height: $rating-s-star-size + $rating-s-star-gutter;
   margin: 0;

--- a/src/ui/components/UserRating/index.js
+++ b/src/ui/components/UserRating/index.js
@@ -7,49 +7,44 @@ import { getCurrentUser } from 'amo/reducers/users';
 import Rating, { RATING_STYLE_SIZE_TYPES } from 'ui/components/Rating';
 import translate from 'core/i18n/translate';
 import type { UserReviewType } from 'amo/actions/reviews';
-
+import type { UsersStateType } from 'amo/reducers/users';
 
 type Props = {|
   className?: string,
-  isOwner: boolean,
-  onSelectRating?: Function,
-  readOnly: boolean,
-  review: UserReviewType,
+  isOwner?: boolean,
+  onSelectRating?: (SyntheticEvent<any>) => void,
+  readOnly?: boolean,
+  review?: UserReviewType,
   // eslint-disable-next-line no-undef
-  styleSize: $Keys<typeof RATING_STYLE_SIZE_TYPES>,
+  styleSize?: $Keys<typeof RATING_STYLE_SIZE_TYPES>,
 |};
 
 
-export class UserRatingBase extends React.Component<Props> {
-  static defaultProps = {
-    styleSize: 'large',
-  };
+export const UserRatingBase = (props: Props) => {
+  const { className, isOwner, readOnly, onSelectRating, review, styleSize } = props;
 
-  render() {
-    const { className, isOwner, readOnly, onSelectRating, review, styleSize } = this.props;
-
-    return (
-      <Rating
-        className={className}
-        isOwner={isOwner}
-        onSelectRating={onSelectRating}
-        rating={(review && review.rating) || 0}
-        readOnly={readOnly}
-        styleSize={styleSize}
-      />
-    );
-  }
-}
+  return (
+    <Rating
+      className={className}
+      isOwner={isOwner}
+      onSelectRating={onSelectRating}
+      rating={(review && review.rating) || 0}
+      readOnly={readOnly}
+      styleSize={styleSize}
+    />
+  );
+};
 
 const mapStateToProps = (
-  state: Object, ownProps: Props
-): $Shape<Props> => {
+  state: {| users: UsersStateType |},
+  ownProps: Props
+) => {
   const { review } = ownProps;
   const siteUser = getCurrentUser(state.users);
   return { isOwner: !!(siteUser && review && review.userId === siteUser.id) };
 };
 
 export default compose(
-  translate({ withRef: true }),
+  translate(),
   connect(mapStateToProps)
 )(UserRatingBase);

--- a/src/ui/components/UserRating/index.js
+++ b/src/ui/components/UserRating/index.js
@@ -1,0 +1,55 @@
+/* @flow */
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import { getCurrentUser } from 'amo/reducers/users';
+import Rating, { RATING_STYLE_SIZE_TYPES } from 'ui/components/Rating';
+import translate from 'core/i18n/translate';
+import type { UserReviewType } from 'amo/actions/reviews';
+
+
+type Props = {|
+  className?: string,
+  isOwner: boolean,
+  onSelectRating?: Function,
+  readOnly: boolean,
+  review: UserReviewType,
+  // eslint-disable-next-line no-undef
+  styleSize: $Keys<typeof RATING_STYLE_SIZE_TYPES>,
+|};
+
+
+export class UserRatingBase extends React.Component<Props> {
+  static defaultProps = {
+    styleSize: 'large',
+  };
+
+  render() {
+    const { className, isOwner, readOnly, onSelectRating, review, styleSize } = this.props;
+
+    return (
+      <Rating
+        className={className}
+        isOwner={isOwner}
+        onSelectRating={onSelectRating}
+        rating={(review && review.rating) || 0}
+        readOnly={readOnly}
+        styleSize={styleSize}
+      />
+    );
+  }
+}
+
+const mapStateToProps = (
+  state: Object, ownProps: Props
+): $Shape<Props> => {
+  const { review } = ownProps;
+  const siteUser = getCurrentUser(state.users);
+  return { isOwner: !!(siteUser && review && review.userId === siteUser.id) };
+};
+
+export default compose(
+  translate({ withRef: true }),
+  connect(mapStateToProps)
+)(UserRatingBase);

--- a/tests/unit/amo/components/TestAddonReview.js
+++ b/tests/unit/amo/components/TestAddonReview.js
@@ -17,7 +17,7 @@ import {
   createFakeEvent, createStubErrorHandler, fakeI18n, shallowUntilTarget,
 } from 'tests/unit/helpers';
 import OverlayCard from 'ui/components/OverlayCard';
-import Rating from 'ui/components/Rating';
+import UserRating from 'ui/components/UserRating';
 
 const defaultReview = {
   addonId: fakeAddon.id,
@@ -305,7 +305,7 @@ describe(__filename, () => {
     const review = { ...defaultReview };
     const root = render({ review });
 
-    const rating = root.find(Rating);
+    const rating = root.find(UserRating);
     const onSelectRating = rating.prop('onSelectRating');
     const newRating = 1;
     onSelectRating(newRating);
@@ -326,7 +326,7 @@ describe(__filename, () => {
       target: { value: enteredReviewText },
     }));
 
-    const rating = root.find(Rating);
+    const rating = root.find(UserRating);
     const onSelectRating = rating.prop('onSelectRating');
     const newRating = 1;
     onSelectRating(newRating);

--- a/tests/unit/amo/components/TestAddonReview.js
+++ b/tests/unit/amo/components/TestAddonReview.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 
 import I18nProvider from 'core/i18n/Provider';
@@ -67,8 +68,11 @@ describe(__filename, () => {
     const props = renderProps(customProps);
     return mount(
       <I18nProvider i18n={props.i18n}>
-        <AddonReview {...props} />
-      </I18nProvider>
+        <Provider store={props.store}>
+          <AddonReview {...props} />
+        </Provider>
+      </I18nProvider>,
+      { context: props }
     );
   };
 

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -146,6 +146,7 @@ describe(__filename, () => {
     const rating = root.find(Rating);
     expect(rating).toHaveProp('rating', 2);
     expect(rating).toHaveProp('readOnly', true);
+    expect(rating).toHaveProp('styleName', 'small');
   });
 
   it('renders newlines in review bodies', () => {
@@ -195,6 +196,14 @@ describe(__filename, () => {
     const root = render({ review });
 
     expect(root.find('.AddonReviewListItem-edit')).toHaveLength(0);
+  });
+
+  it('uses proper rating class if you wrote the review', () => {
+    const review = signInAndDispatchSavedReview();
+    const root = render({ review });
+    const rating = root.find(Rating);
+
+    expect(rating).toHaveProp('styleName', 'small-by-user');
   });
 
   it('lets you begin editing your review', () => {

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -146,7 +146,7 @@ describe(__filename, () => {
     const rating = root.find(Rating);
     expect(rating).toHaveProp('rating', 2);
     expect(rating).toHaveProp('readOnly', true);
-    expect(rating).toHaveProp('styleName', 'small');
+    expect(rating).toHaveProp('styleSize', 'small');
   });
 
   it('renders newlines in review bodies', () => {
@@ -198,12 +198,12 @@ describe(__filename, () => {
     expect(root.find('.AddonReviewListItem-edit')).toHaveLength(0);
   });
 
-  it('uses proper rating class if you wrote the review', () => {
+  it('assigns isOwner property if you wrote the review', () => {
     const review = signInAndDispatchSavedReview();
     const root = render({ review });
     const rating = root.find(Rating);
 
-    expect(rating).toHaveProp('styleName', 'small-by-user');
+    expect(rating).toHaveProp('isOwner', true);
   });
 
   it('lets you begin editing your review', () => {

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -128,11 +128,10 @@ describe(__filename, () => {
   };
 
   it('renders a review', () => {
-    const root = render({
-      review: _setReview({
-        ...fakeReview, id: 1, rating: 2,
-      }),
+    const review = _setReview({
+      ...fakeReview, id: 1, rating: 2,
     });
+    const root = render({ review });
 
     expect(root.find('h3'))
       .toHaveText(fakeReview.title);
@@ -147,6 +146,7 @@ describe(__filename, () => {
     expect(rating).toHaveProp('rating', 2);
     expect(rating).toHaveProp('readOnly', true);
     expect(rating).toHaveProp('styleSize', 'small');
+    expect(rating).toHaveProp('review', review);
   });
 
   it('renders newlines in review bodies', () => {
@@ -196,14 +196,6 @@ describe(__filename, () => {
     const root = render({ review });
 
     expect(root.find('.AddonReviewListItem-edit')).toHaveLength(0);
-  });
-
-  it('assigns isOwner property if you wrote the review', () => {
-    const review = signInAndDispatchSavedReview();
-    const root = render({ review });
-    const rating = root.find(Rating);
-
-    expect(rating).toHaveProp('isOwner', true);
   });
 
   it('lets you begin editing your review', () => {

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -29,7 +29,7 @@ import {
 import ErrorList from 'ui/components/ErrorList';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
-import Rating from 'ui/components/Rating';
+import UserRating from 'ui/components/UserRating';
 
 
 describe(__filename, () => {
@@ -142,8 +142,7 @@ describe(__filename, () => {
     expect(root.find('.AddonReviewListItem-byline'))
       .toIncludeText(fakeReview.user.name);
 
-    const rating = root.find(Rating);
-    expect(rating).toHaveProp('rating', 2);
+    const rating = root.find(UserRating);
     expect(rating).toHaveProp('readOnly', true);
     expect(rating).toHaveProp('styleSize', 'small');
     expect(rating).toHaveProp('review', review);
@@ -635,7 +634,7 @@ describe(__filename, () => {
     it('hides ratings for replies', () => {
       const root = renderReply();
 
-      expect(root.find(Rating)).toHaveLength(0);
+      expect(root.find(UserRating)).toHaveLength(0);
     });
 
     it('does not include a user name in the byline', () => {

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -247,23 +247,23 @@ describe('RatingManager', () => {
 
   it('configures a rating component', () => {
     const userReview = setReview(fakeReview).payload;
-    const RatingStub = sinon.spy(() => (<div />));
+    const UserRatingStub = sinon.spy(() => (<div />));
 
-    const root = render({ Rating: RatingStub, userReview });
+    const root = render({ UserRating: UserRatingStub, userReview });
 
-    expect(RatingStub.called).toEqual(true);
-    const props = RatingStub.firstCall.args[0];
+    expect(UserRatingStub.called).toEqual(true);
+    const props = UserRatingStub.firstCall.args[0];
     expect(props.onSelectRating).toEqual(root.onSelectRating);
-    expect(props.rating).toEqual(userReview.rating);
+    expect(props.review).toEqual(userReview);
   });
 
   it('sets a blank rating when there is no saved review', () => {
-    const RatingStub = sinon.spy(() => (<div />));
+    const UserRatingStub = sinon.spy(() => (<div />));
 
-    render({ Rating: RatingStub, userReview: null });
+    render({ UserRating: UserRatingStub, userReview: null });
 
-    expect(RatingStub.called).toEqual(true);
-    const props = RatingStub.firstCall.args[0];
+    expect(UserRatingStub.called).toEqual(true);
+    const props = UserRatingStub.firstCall.args[0];
     expect(props.rating).toBe(undefined);
   });
 

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Provider } from 'react-redux';
 import {
   findRenderedComponentWithType,
   renderIntoDocument,
@@ -34,32 +35,41 @@ import {
 } from 'tests/unit/helpers';
 
 
-function render(customProps = {}) {
-  const props = {
-    AddonReview: () => <div />,
-    AuthenticateButton: () => <div />,
-    ReportAbuseButton: () => <div />,
-    addon: createInternalAddon(fakeAddon),
-    apiState: signedInApiState,
-    errorHandler: sinon.stub(),
-    location: fakeRouterLocation({ pathname: '/some/location/' }),
-    version: fakeAddon.current_version,
-    userId: 91234,
-    submitReview: () => Promise.resolve(),
-    loadSavedReview: () => Promise.resolve(),
-    ...customProps,
-  };
-  const RatingManager = translate({ withRef: true })(RatingManagerBase);
-  const root = findRenderedComponentWithType(renderIntoDocument(
-    <I18nProvider i18n={fakeI18n()}>
-      <RatingManager {...props} />
-    </I18nProvider>
-  ), RatingManager);
-
-  return root.getWrappedInstance();
-}
-
 describe('RatingManager', () => {
+  let store;
+
+  beforeEach(() => {
+    store = createStore().store;
+  });
+
+  function render(customProps = {}) {
+    const props = {
+      AddonReview: () => <div />,
+      AuthenticateButton: () => <div />,
+      ReportAbuseButton: () => <div />,
+      addon: createInternalAddon(fakeAddon),
+      apiState: signedInApiState,
+      errorHandler: sinon.stub(),
+      location: fakeRouterLocation({ pathname: '/some/location/' }),
+      version: fakeAddon.current_version,
+      userId: 91234,
+      submitReview: () => Promise.resolve(),
+      loadSavedReview: () => Promise.resolve(),
+      store,
+      ...customProps,
+    };
+    const RatingManager = translate({ withRef: true })(RatingManagerBase);
+    const root = findRenderedComponentWithType(renderIntoDocument(
+      <I18nProvider i18n={fakeI18n()}>
+        <Provider store={props.store}>
+          <RatingManager {...props} />
+        </Provider>
+      </I18nProvider>
+    ), RatingManager);
+
+    return root.getWrappedInstance();
+  }
+
   it('prompts you to rate the add-on by name', () => {
     const root = render({
       addon: createInternalAddon({ ...fakeAddon, name: 'Some Add-on' }),
@@ -415,12 +425,6 @@ describe('RatingManager', () => {
   });
 
   describe('mapStateToProps', () => {
-    let store;
-
-    beforeEach(() => {
-      store = createStore().store;
-    });
-
     function getMappedProps({
       state = store.getState(),
       componentProps = {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -44,6 +44,11 @@ describe('ui/components/Rating', () => {
     expect(root.element.className).toContain('Rating--small');
   });
 
+  it('can be classified as small-by-user', () => {
+    const root = render({ styleName: 'small-by-user' });
+    expect(root.element.className).toContain('Rating--small-by-user');
+  });
+
   it('throws an error for invalid styleNames', () => {
     expect(() => render({ styleName: 'x-large' }))
       .toThrowError(/styleName=x-large is not a valid value; possible values: small,/);

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -27,7 +27,7 @@ function makeFakeEvent() {
   };
 }
 
-describe('ui/components/Rating', () => {
+describe(__filename, () => {
   function selectRating(root, ratingNumber) {
     const button = root.ratingElements[ratingNumber];
     expect(button).toBeTruthy();
@@ -42,6 +42,11 @@ describe('ui/components/Rating', () => {
   it('can be classified as small', () => {
     const root = render({ styleSize: 'small' });
     expect(root.element.className).toContain('Rating--small');
+  });
+
+  it('can be classified as owned', () => {
+    const root = render({ isOwner: true });
+    expect(root.element.className).toContain('Rating--by-owner');
   });
 
   it('classifies as unowned by default', () => {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -40,18 +40,18 @@ describe('ui/components/Rating', () => {
   });
 
   it('can be classified as small', () => {
-    const root = render({ styleName: 'small' });
+    const root = render({ styleSize: 'small' });
     expect(root.element.className).toContain('Rating--small');
   });
 
-  it('can be classified as small-by-user', () => {
-    const root = render({ styleName: 'small-by-user' });
-    expect(root.element.className).toContain('Rating--small-by-user');
+  it('can be classified as owned', () => {
+    const root = render({ isOwner: true });
+    expect(root.element.className).toContain('Rating--by-owner');
   });
 
-  it('throws an error for invalid styleNames', () => {
-    expect(() => render({ styleName: 'x-large' }))
-      .toThrowError(/styleName=x-large is not a valid value; possible values: small,/);
+  it('throws an error for invalid styleSize', () => {
+    expect(() => render({ styleSize: 'x-large' }))
+      .toThrowError(/styleSize=x-large is not a valid value; possible values: small,/);
   });
 
   it('lets you select a one star rating', () => {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -6,25 +6,12 @@ import {
 } from 'react-dom/test-utils';
 import { findDOMNode } from 'react-dom';
 
-import { setReview } from 'amo/actions/reviews';
 import { fakeI18n } from 'tests/unit/helpers';
 import Rating, { RatingBase } from 'ui/components/Rating';
-import {
-  dispatchClientMetadata,
-  dispatchSignInActions,
-  fakeReview,
-} from 'tests/unit/amo/helpers';
-
-let store;
-
-beforeEach(() => {
-  store = dispatchClientMetadata().store;
-});
 
 function render(customProps = {}) {
   const props = {
     i18n: fakeI18n(),
-    store,
     ...customProps,
   };
   return findRenderedComponentWithType(renderIntoDocument(
@@ -38,19 +25,6 @@ function makeFakeEvent() {
     stopPropagation: sinon.stub(),
     currentTarget: {},
   };
-}
-
-function signInAndDispatchSavedReview({ siteUserId, reviewUserId }) {
-  dispatchSignInActions({ store, userId: siteUserId });
-  const review = {
-    ...fakeReview,
-    user: {
-      ...fakeReview.user,
-      id: reviewUserId,
-    },
-  };
-  store.dispatch(setReview(review));
-  return store.getState().reviews.byId[review.id];
 }
 
 describe('ui/components/Rating', () => {
@@ -70,19 +44,8 @@ describe('ui/components/Rating', () => {
     expect(root.element.className).toContain('Rating--small');
   });
 
-  it('is classified as owned if you wrote the review', () => {
-    const review = signInAndDispatchSavedReview({
-      siteUserId: 123, reviewUserId: 123,
-    });
-    const root = render({ review });
-    expect(root.element.className).toContain('Rating--by-owner');
-  });
-
-  it('is not classified as owned if you did not write the review', () => {
-    const review = signInAndDispatchSavedReview({
-      siteUserId: 123, reviewUserId: 456,
-    });
-    const root = render({ review });
+  it('classifies as unowned by default', () => {
+    const root = render();
     expect(root.element.className).not.toContain('Rating--by-owner');
   });
 

--- a/tests/unit/ui/components/TestUserRating.js
+++ b/tests/unit/ui/components/TestUserRating.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
 import { denormalizeReview } from 'amo/actions/reviews';
-import UserRating, { UserRatingBase } from 'ui/components/UserRating';
 import { logOutUser } from 'amo/reducers/users';
+import Rating from 'ui/components/Rating';
+import UserRating, { UserRatingBase } from 'ui/components/UserRating';
 import {
   dispatchClientMetadata,
   dispatchSignInActions,
@@ -39,7 +40,7 @@ function signInAndReturnReview({ siteUserId, reviewUserId }) {
   });
 }
 
-describe('ui/components/UserRating', () => {
+describe(__filename, () => {
   it('renders a Rating', () => {
     const props = {
       review: fakeReview,
@@ -47,14 +48,14 @@ describe('ui/components/UserRating', () => {
       readOnly: true,
       styleSize: 'small',
     };
-    const root = render(props);
+    const root = render(props).find(Rating);
     expect(root).toHaveProp('className', props.className);
     expect(root).toHaveProp('readOnly', props.readOnly);
     expect(root).toHaveProp('styleSize', props.styleSize);
   });
 
   it('passes the rating from the review to Rating', () => {
-    const root = render({ review: fakeReview });
+    const root = render({ review: denormalizeReview(fakeReview) });
     expect(root).toHaveProp('rating', fakeReview.rating);
   });
 
@@ -75,8 +76,11 @@ describe('ui/components/UserRating', () => {
   });
 
   it('passes isOwned: false to Rating if no user is logged in', () => {
+    const review = signInAndReturnReview({
+      siteUserId: 123, reviewUserId: 123,
+    });
     store.dispatch(logOutUser());
-    const root = render({ review: fakeReview });
+    const root = render({ review });
     expect(root).toHaveProp('isOwner', false);
   });
 });

--- a/tests/unit/ui/components/TestUserRating.js
+++ b/tests/unit/ui/components/TestUserRating.js
@@ -1,0 +1,82 @@
+import * as React from 'react';
+
+import { denormalizeReview } from 'amo/actions/reviews';
+import UserRating, { UserRatingBase } from 'ui/components/UserRating';
+import { logOutUser } from 'amo/reducers/users';
+import {
+  dispatchClientMetadata,
+  dispatchSignInActions,
+  fakeReview,
+} from 'tests/unit/amo/helpers';
+import {
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+
+let store;
+
+beforeEach(() => {
+  store = dispatchClientMetadata().store;
+});
+
+function render(customProps = {}) {
+  const props = {
+    i18n: fakeI18n(),
+    store,
+    ...customProps,
+  };
+  return shallowUntilTarget(<UserRating {...props} />, UserRatingBase);
+}
+
+function signInAndReturnReview({ siteUserId, reviewUserId }) {
+  dispatchSignInActions({ store, userId: siteUserId });
+  return denormalizeReview({
+    ...fakeReview,
+    user: {
+      ...fakeReview.user,
+      id: reviewUserId,
+    },
+  });
+}
+
+describe('ui/components/UserRating', () => {
+  it('renders a Rating', () => {
+    const props = {
+      review: fakeReview,
+      className: 'my-class',
+      readOnly: true,
+      styleSize: 'small',
+    };
+    const root = render(props);
+    expect(root).toHaveProp('className', props.className);
+    expect(root).toHaveProp('readOnly', props.readOnly);
+    expect(root).toHaveProp('styleSize', props.styleSize);
+  });
+
+  it('passes the rating from the review to Rating', () => {
+    const root = render({ review: fakeReview });
+    expect(root).toHaveProp('rating', fakeReview.rating);
+  });
+
+  it('passes isOwned: true to Rating if you wrote the review', () => {
+    const review = signInAndReturnReview({
+      siteUserId: 123, reviewUserId: 123,
+    });
+    const root = render({ review });
+    expect(root).toHaveProp('isOwner', true);
+  });
+
+  it('passes isOwned: false to Rating if you did not write the review', () => {
+    const review = signInAndReturnReview({
+      siteUserId: 123, reviewUserId: 456,
+    });
+    const root = render({ review });
+    expect(root).toHaveProp('isOwner', false);
+  });
+
+  it('passes isOwned: false to Rating if no user is logged in', () => {
+    store.dispatch(logOutUser());
+    const root = render({ review: fakeReview });
+    expect(root).toHaveProp('isOwner', false);
+  });
+});


### PR DESCRIPTION
Fixes #4355 

This adds a new styleName to the Rating component to support a different style of stars for a rating submitted by the current user.

Note that as per #4355, the only place this change needed to be made was on the list of reviews where a user's own review should appear with yellow starts, and all other reviews should appear with grey stars.

Before:

<img width="964" alt="screenshot 2018-02-26 13 04 57" src="https://user-images.githubusercontent.com/142755/36686958-1fe5f000-1af6-11e8-8039-5b0ca0585515.png">

After:

<img width="960" alt="screenshot 2018-02-26 12 58 52" src="https://user-images.githubusercontent.com/142755/36686967-2a132854-1af6-11e8-99a6-6afd06014102.png">

