### PR TITLE
Pressing enter should not cancel the form

### DIFF
--- a/src/ui/components/FormOverlay/index.js
+++ b/src/ui/components/FormOverlay/index.js
@@ -122,12 +122,17 @@ export class FormOverlayBase extends React.Component<Props> {
             <form>
               {children}
               <div className="FormOverlay-form-buttons">
+                {/*
+                  type=button is necessary to override the default
+                  of type=submit
+                */}
                 <Button
                   buttonType="neutral"
                   disabled={formIsDisabled}
                   onClick={this.onCancel}
                   className="FormOverlay-cancel"
                   puffy
+                  type="button"
                 >
                   {i18n.gettext('Cancel')}
                 </Button>


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4433 by setting the cancel button to `type=button`. Previously, the default of `type=submit` was taking effect which triggered the `onCancel` handler. After this new patch, pressing enter will trigger the `onSubmit` handler.