### PR TITLE
Use add-on install source links like the old site

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -35,6 +35,7 @@ import {
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
   ENABLED,
+  INSTALL_SOURCE_DETAIL_PAGE,
   UNKNOWN,
 } from 'core/constants';
 import { withInstallHelpers } from 'core/installAddon';
@@ -661,6 +662,6 @@ export default compose(
   withRouter,
   translate({ withRef: true }),
   connect(mapStateToProps),
-  withInstallHelpers({ defaultInstallSource: 'dp-btn-primary' }),
+  withInstallHelpers({ defaultInstallSource: INSTALL_SOURCE_DETAIL_PAGE }),
   withFixedErrorHandler({ fileName: __filename, extractId }),
 )(AddonBase);

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -1,36 +1,46 @@
+/* @flow */
+/* eslint-disable react/sort-comp */
 import makeClassName from 'classnames';
-import PropTypes from 'prop-types';
 import * as React from 'react';
 
 import SearchResult from 'amo/components/SearchResult';
 import CardList from 'ui/components/CardList';
+import type { AddonType } from 'core/types/addons';
 
 import './styles.scss';
 
 
-export default class AddonsCard extends React.Component {
-  static propTypes = {
-    addons: PropTypes.array.isRequired,
-    children: PropTypes.node,
-    className: PropTypes.string,
-    loading: PropTypes.bool,
-    // When loading, this is the number of placeholders
-    // that will be rendered.
-    placeholderCount: PropTypes.number,
-    type: PropTypes.string,
-    showMetadata: PropTypes.bool,
-    showSummary: PropTypes.bool,
-  }
+type Props = {|
+  addonInstallSource?: string,
+  addons?: Array<AddonType> | null,
+  children?: React.Node,
+  className?: string,
+  loading?: boolean,
+  // When loading, this is the number of placeholders
+  // that will be rendered.
+  placeholderCount: number,
+  type?: 'horizontal',
+  showMetadata?: boolean,
+  showSummary?: boolean,
+
+  // These are all passed through to Card.
+  footerLink?: Object | string | null,
+  footerText?: string,
+  header?: React.Node,
+|};
+
+export default class AddonsCard extends React.Component<Props> {
+  cardContainer: React.ElementRef<any> | null;
 
   static defaultProps = {
     loading: false,
     // Set this to the default API page size.
     placeholderCount: 25,
-    type: 'list',
   }
 
   render() {
     const {
+      addonInstallSource,
       addons,
       children,
       className,
@@ -48,6 +58,7 @@ export default class AddonsCard extends React.Component {
       addons.forEach((addon) => {
         searchResults.push(
           <SearchResult
+            addonInstallSource={addonInstallSource}
             addon={addon}
             key={addon.slug}
             showMetadata={showMetadata}
@@ -63,10 +74,13 @@ export default class AddonsCard extends React.Component {
       }
     }
 
+    const allClassNames = makeClassName('AddonsCard', className, {
+      'AddonsCard--horizontal': type === 'horizontal',
+    });
     return (
       <CardList
         {...otherProps}
-        className={makeClassName('AddonsCard', `AddonsCard--${type}`, className)}
+        className={allClassNames}
         ref={(ref) => { this.cardContainer = ref; }}
       >
         {children}

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -16,7 +16,9 @@ import CollectionManager, {
   COLLECTION_OVERLAY,
 } from 'amo/components/CollectionManager';
 import NotFound from 'amo/components/ErrorPage/NotFound';
-import { COLLECTIONS_EDIT } from 'core/constants';
+import {
+  COLLECTIONS_EDIT, INSTALL_SOURCE_COLLECTION,
+} from 'core/constants';
 import Paginate from 'core/components/Paginate';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import { openFormOverlay } from 'core/reducers/formOverlay';
@@ -208,7 +210,7 @@ export class CollectionBase extends React.Component<Props> {
         </Card>
         <div className="Collection-items">
           <AddonsCard
-            addonInstallSource="collection"
+            addonInstallSource={INSTALL_SOURCE_COLLECTION}
             addons={addons}
             loading={!collection || loading}
           />

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -208,6 +208,7 @@ export class CollectionBase extends React.Component<Props> {
         </Card>
         <div className="Collection-items">
           <AddonsCard
+            addonInstallSource="collection"
             addons={addons}
             loading={!collection || loading}
           />

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -12,6 +12,8 @@ import { fetchHomeAddons } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
+  INSTALL_SOURCE_FEATURED,
+  INSTALL_SOURCE_MOST_POPULAR,
   SEARCH_SORT_POPULAR,
   VIEW_CONTEXT_HOME,
 } from 'core/constants';
@@ -194,7 +196,7 @@ export class HomeBase extends React.Component {
         </Card>
 
         <LandingAddonsCard
-          addonInstallSource="featured"
+          addonInstallSource={INSTALL_SOURCE_FEATURED}
           addons={featuredExtensions}
           className="Home-FeaturedExtensions"
           header={i18n.gettext('Featured extensions')}
@@ -221,7 +223,7 @@ export class HomeBase extends React.Component {
         />
 
         <LandingAddonsCard
-          addonInstallSource="mostpopular"
+          addonInstallSource={INSTALL_SOURCE_MOST_POPULAR}
           addons={popularThemes}
           className="Home-PopularThemes"
           header={i18n.gettext('Popular themes')}

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -194,6 +194,7 @@ export class HomeBase extends React.Component {
         </Card>
 
         <LandingAddonsCard
+          addonInstallSource="featured"
           addons={featuredExtensions}
           className="Home-FeaturedExtensions"
           header={i18n.gettext('Featured extensions')}
@@ -220,6 +221,7 @@ export class HomeBase extends React.Component {
         />
 
         <LandingAddonsCard
+          addonInstallSource="mostpopular"
           addons={popularThemes}
           className="Home-PopularThemes"
           header={i18n.gettext('Popular themes')}

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -1,29 +1,32 @@
+/* @flow */
 import makeClassName from 'classnames';
 import * as React from 'react';
-import PropTypes from 'prop-types';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
 import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
+import type { AddonType } from 'core/types/addons';
 
-export default class LandingAddonsCard extends React.Component {
-  static propTypes = {
-    addons: PropTypes.array.isRequired,
-    className: PropTypes.string,
-    footerLink: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-    footerText: PropTypes.string.isRequired,
-    header: PropTypes.node.isRequired,
-    loading: PropTypes.bool.isRequired,
-    placeholderCount: PropTypes.number,
-  }
+type Props = {|
+  addonInstallSource?: string,
+  addons?: Array<AddonType> | null,
+  className?: string,
+  footerLink?: Object | string | null,
+  footerText?: string,
+  header?: React.Node,
+  loading: boolean,
+  placeholderCount: number,
+|};
 
+export default class LandingAddonsCard extends React.Component<Props> {
   static defaultProps = {
     placeholderCount: LANDING_PAGE_ADDON_COUNT,
   }
 
   render() {
     const {
+      addonInstallSource,
       addons,
       className,
       footerLink,
@@ -36,7 +39,7 @@ export default class LandingAddonsCard extends React.Component {
     let footerLinkHtml = null;
     if (addons && addons.length >= placeholderCount) {
       let linkTo = footerLink;
-      if (typeof linkTo === 'object') {
+      if (linkTo && typeof linkTo === 'object') {
         // As a convenience, fix the query parameter.
         linkTo = {
           ...linkTo,
@@ -48,6 +51,7 @@ export default class LandingAddonsCard extends React.Component {
 
     return (
       <AddonsCard
+        addonInstallSource={addonInstallSource}
         addons={addons}
         className={makeClassName('LandingAddonsCard', className)}
         footerLink={footerLinkHtml}

--- a/src/amo/components/SearchResults.js
+++ b/src/amo/components/SearchResults.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import AddonsCard from 'amo/components/AddonsCard';
+import { INSTALL_SOURCE_SEARCH } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { hasSearchFilters } from 'core/searchUtils';
 
@@ -56,7 +57,7 @@ class SearchResults extends React.Component {
       <div ref={(ref) => { this.container = ref; }} className="SearchResults">
         {loadingMessage}
         <AddonsCard
-          addonInstallSource="search"
+          addonInstallSource={INSTALL_SOURCE_SEARCH}
           addons={hasSearchFilters(filters) ? results : null}
           header={i18n.gettext('Search results')}
           loading={loading}

--- a/src/amo/components/SearchResults.js
+++ b/src/amo/components/SearchResults.js
@@ -56,6 +56,7 @@ class SearchResults extends React.Component {
       <div ref={(ref) => { this.container = ref; }} className="SearchResults">
         {loadingMessage}
         <AddonsCard
+          addonInstallSource="search"
           addons={hasSearchFilters(filters) ? results : null}
           header={i18n.gettext('Search results')}
           loading={loading}

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -86,6 +86,16 @@ export const TRACKING_TYPE_EXTENSION = 'addon';
 export const TRACKING_TYPE_THEME = 'theme';
 export const TRACKING_TYPE_INVALID = 'invalid';
 
+// Add-on install tracking sources.
+// These key values may be linked to historic analytic data.
+export const INSTALL_SOURCE_COLLECTION = 'collection';
+export const INSTALL_SOURCE_DETAIL_PAGE = 'dp-btn-primary';
+export const INSTALL_SOURCE_DISCOVERY = 'discovery-promo';
+export const INSTALL_SOURCE_FEATURED = 'featured';
+export const INSTALL_SOURCE_HERO_PROMO = 'hp-dl-promo';
+export const INSTALL_SOURCE_MOST_POPULAR = 'mostpopular';
+export const INSTALL_SOURCE_SEARCH = 'search';
+
 // View Contexts that aren't an addonType
 export const VIEW_CONTEXT_EXPLORE = 'VIEW_CONTEXT_EXPLORE';
 export const VIEW_CONTEXT_HOME = 'VIEW_CONTEXT_HOME';

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -146,6 +146,11 @@ export function isAllowedOrigin(urlString, {
   return allowedOrigins.includes(`${parsedURL.protocol}//${parsedURL.host}`);
 }
 
+/*
+ * Returns a new URL with query params appended to `urlString`.
+ *
+ * `urlString` can be a relative or absolute URL.
+ */
 export function addQueryParams(urlString, queryParams = {}) {
   const urlObj = url.parse(urlString, true);
   // Clear search, since query object will only be used if search

--- a/src/disco/components/Addon.js
+++ b/src/disco/components/Addon.js
@@ -13,15 +13,16 @@ import AddonCompatibilityError from 'disco/components/AddonCompatibilityError';
 import HoverIntent from 'core/components/HoverIntent';
 import InstallButton from 'core/components/InstallButton';
 import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
   CLICK_CATEGORY,
   DOWNLOAD_FAILED,
   ERROR,
-  ADDON_TYPE_EXTENSION,
   FATAL_ERROR,
   FATAL_INSTALL_ERROR,
   FATAL_UNINSTALL_ERROR,
   INSTALL_FAILED,
-  ADDON_TYPE_THEME,
+  INSTALL_SOURCE_DISCOVERY,
   UNINSTALLING,
   validAddonTypes,
   validInstallStates,
@@ -323,5 +324,5 @@ export default compose(
   withRouter,
   translate({ withRef: true }),
   connect(mapStateToProps, undefined, undefined, { withRef: true }),
-  withInstallHelpers({ defaultInstallSource: 'discovery-promo' }),
+  withInstallHelpers({ defaultInstallSource: INSTALL_SOURCE_DISCOVERY }),
 )(AddonBase);

--- a/src/ui/components/HeroSection/index.js
+++ b/src/ui/components/HeroSection/index.js
@@ -3,6 +3,7 @@ import makeClassName from 'classnames';
 import * as React from 'react';
 
 import Link from 'amo/components/Link';
+import { addQueryParams } from 'core/utils';
 
 import './styles.scss';
 
@@ -33,7 +34,7 @@ export default class HeroSection extends React.Component<Props> {
         {linkTo ? (
           <Link
             className="HeroSection-link-wrapper"
-            to={linkTo}
+            to={addQueryParams(linkTo, { src: 'hp-dl-promo' })}
           >
             <div className="HeroSection-content">
               {children}

--- a/src/ui/components/HeroSection/index.js
+++ b/src/ui/components/HeroSection/index.js
@@ -3,6 +3,7 @@ import makeClassName from 'classnames';
 import * as React from 'react';
 
 import Link from 'amo/components/Link';
+import { INSTALL_SOURCE_HERO_PROMO } from 'core/constants';
 import { addQueryParams } from 'core/utils';
 
 import './styles.scss';
@@ -34,7 +35,7 @@ export default class HeroSection extends React.Component<Props> {
         {linkTo ? (
           <Link
             className="HeroSection-link-wrapper"
-            to={addQueryParams(linkTo, { src: 'hp-dl-promo' })}
+            to={addQueryParams(linkTo, { src: INSTALL_SOURCE_HERO_PROMO })}
           >
             <div className="HeroSection-content">
               {children}

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -45,6 +45,7 @@ import {
   CLIENT_APP_FIREFOX,
   ENABLED,
   INCOMPATIBLE_NOT_FIREFOX,
+  INSTALL_SOURCE_DETAIL_PAGE,
   INSTALLED,
   UNKNOWN,
 } from 'core/constants';
@@ -787,7 +788,8 @@ describe(__filename, () => {
 
     const button = root.find(InstallButton);
     // This value is passed to <Addon/> by the withInstallHelpers() HOC.
-    expect(button).toHaveProp('defaultInstallSource', 'dp-btn-primary');
+    expect(button)
+      .toHaveProp('defaultInstallSource', INSTALL_SOURCE_DETAIL_PAGE);
   });
 
   it('enables a theme preview for non-enabled add-ons', () => {

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -6,7 +6,7 @@ import SearchResult from 'amo/components/SearchResult';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
 
-describe('<AddonsCard />', () => {
+describe(__filename, () => {
   let addons;
 
   function render(props = {}) {
@@ -18,6 +18,18 @@ describe('<AddonsCard />', () => {
       { ...fakeAddon, name: 'I am add-on! ', slug: 'i-am-addon' },
       { ...fakeAddon, name: 'I am also add-on!', slug: 'i-am-also-addon' },
     ];
+  });
+
+  it('can render a horizontal class', () => {
+    const root = render({ type: 'horizontal' });
+
+    expect(root).toHaveClassName('AddonsCard--horizontal');
+  });
+
+  it('does not render a horizontal class by default', () => {
+    const root = render();
+
+    expect(root).not.toHaveClassName('AddonsCard--horizontal');
   });
 
   it('renders add-ons when supplied', () => {
@@ -61,5 +73,14 @@ describe('<AddonsCard />', () => {
     const results = root.find(SearchResult);
     expect(results).toHaveLength(1);
     expect(results.at(0)).toHaveProp('addon', fakeAddon);
+  });
+
+  it('renders search results with addonInstallSource', () => {
+    const addonInstallSource = 'featured-on-home-page';
+    const root = render({ addons: [fakeAddon], addonInstallSource });
+
+    const results = root.find(SearchResult);
+    expect(results.at(0))
+      .toHaveProp('addonInstallSource', addonInstallSource);
   });
 });

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -46,6 +46,15 @@ describe(__filename, () => {
     expect(root.find(AddonsCard)).toHaveProp('addons', addons);
   });
 
+  it('passes addonInstallSource to AddonsCard', () => {
+    const addonInstallSource = 'featured-on-home-page';
+    const addons = [createInternalAddon(fakeAddon)];
+    const root = render({ addons, addonInstallSource });
+
+    expect(root.find(AddonsCard))
+      .toHaveProp('addonInstallSource', addonInstallSource);
+  });
+
   it('sets the number of placeholders to render while loading', () => {
     const root = render({ loading: true });
     expect(root).toHaveProp('placeholderCount', LANDING_PAGE_ADDON_COUNT);

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -1,3 +1,5 @@
+import url from 'url';
+
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
@@ -93,6 +95,15 @@ describe(__filename, () => {
 
     expect(root.find('.SearchResult-link'))
       .toHaveProp('to', '/addon/a-search-result/');
+  });
+
+  it('links to the detail page with a source', () => {
+    const addonInstallSource = 'home-page-featured';
+    const root = render({ addonInstallSource });
+
+    const link = root.find('.SearchResult-link');
+    expect(url.parse(link.prop('to'), true).query)
+      .toMatchObject({ src: addonInstallSource });
   });
 
   it('renders the star ratings', () => {

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -503,7 +503,7 @@ describe(__filename, () => {
       }));
 
       expect(_getFileHash({
-        addon, installURL: `${url}?src=dp-btn-primary`,
+        addon, installURL: `${url}?src=some-install-source`,
       }))
         .toEqual('hash-of-file');
     });
@@ -512,12 +512,14 @@ describe(__filename, () => {
       const url = 'https://a.m.o/addons/file.xpi';
       const addon = createInternalAddon(createFakeAddon({
         files: [{
-          platform: OS_ALL, url: `${url}?src=`, hash: 'hash-of-file',
+          platform: OS_ALL,
+          url: `${url}?src=some-install-source`,
+          hash: 'hash-of-file',
         }],
       }));
 
       expect(_getFileHash({
-        addon, installURL: `${url}?src=dp-btn-primary`,
+        addon, installURL: `${url}?src=some-install-source`,
       }))
         .toEqual('hash-of-file');
     });

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -447,6 +447,13 @@ describe(__filename, () => {
       const output = addQueryParams('http://whatever.com/?foo=1&bar=2', { bar: 'updated' });
       expect(url.parse(output, true).query).toEqual({ foo: '1', bar: 'updated' });
     });
+
+    it('handles relative URLs', () => {
+      const output = addQueryParams('/relative/path/?one=1', { two: '2' });
+      expect(output).toMatch(/^\/relative\/path\//);
+      expect(url.parse(output, true).query)
+        .toEqual({ one: '1', two: '2' });
+    });
   });
 
   describe('ngettext', () => {

--- a/tests/unit/ui/components/TestHeroSection.js
+++ b/tests/unit/ui/components/TestHeroSection.js
@@ -36,7 +36,7 @@ describe(__filename, () => {
     const link = root.find(Link);
 
     expect(link).toHaveProp('className', 'HeroSection-link-wrapper');
-    expect(link).toHaveProp('to', '/whatever/');
+    expect(link).toHaveProp('to', '/whatever/?src=hp-dl-promo');
     expect(root.find('.HeroSection-wrapper')).toHaveLength(0);
   });
 

--- a/tests/unit/ui/components/TestHeroSection.js
+++ b/tests/unit/ui/components/TestHeroSection.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import Link from 'amo/components/Link';
+import { INSTALL_SOURCE_HERO_PROMO } from 'core/constants';
 import HeroSection from 'ui/components/HeroSection';
 
 
@@ -36,7 +37,8 @@ describe(__filename, () => {
     const link = root.find(Link);
 
     expect(link).toHaveProp('className', 'HeroSection-link-wrapper');
-    expect(link).toHaveProp('to', '/whatever/?src=hp-dl-promo');
+    expect(link)
+      .toHaveProp('to', `/whatever/?src=${INSTALL_SOURCE_HERO_PROMO}`);
     expect(root.find('.HeroSection-wrapper')).toHaveLength(0);
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4372 by adding the old add-on install source links. The issue specifies some old home page shelves that we aren't using anymore so I've asked about what to do there. I will file a follow-up issue for that if necessary.