### PR TITLE
feat: Add User Avatar component

### DIFF
--- a/src/ui/components/Icon/img/anonymous-user.svg
+++ b/src/ui/components/Icon/img/anonymous-user.svg
@@ -1,0 +1,23 @@
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="64" height="64" rx="4"></rect>
+    </defs>
+    <g id="Screens" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="User-Profile---View---1366px" transform="translate(-60.000000, -171.000000)">
+            <g id="Group" transform="translate(24.000000, 135.000000)">
+                <g id="Group-69-Copy" transform="translate(36.000000, 36.000000)">
+                    <g id="Rectangle-Copy-5">
+                        <use fill="#F9F9FA" fill-rule="evenodd" xlink:href="#path-1"></use>
+                        <rect stroke="#EBEBEB" stroke-width="1" x="0.5" y="0.5" width="63" height="63" rx="4"></rect>
+                    </g>
+                    <g id="Icon/User" transform="translate(8.960000, 8.960000)" fill="#D7D7DB" fill-rule="nonzero">
+                        <path d="M29.6335833,26.8774167 C27.646,28.0446667 25.4111667,28.75 23,28.75 C20.5888333,28.75 18.354,28.0446667 16.3664167,26.8774167 C9.38016667,27.3355 3.83333333,33.1506667 3.83333333,40.25 L3.83333333,43.5658333 L5.16541667,43.99325 C5.42225,44.07375 11.5728333,46 23,46 C34.4271667,46 40.57775,44.07375 40.8345833,43.99325 L42.1666667,43.5658333 L42.1666667,40.25 C42.1666667,33.1506667 36.6198333,27.3355 29.6335833,26.8774167 Z" id="Shape"></path>
+                        <path d="M23,24.9166667 C29.4764167,24.9166667 34.5,17.70425 34.5,11.5 C34.5,5.15775 29.34225,0 23,0 C16.65775,0 11.5,5.15775 11.5,11.5 C11.5,17.70425 16.5235833,24.9166667 23,24.9166667 Z" id="Shape"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/ui/components/UserAvatar/index.js
+++ b/src/ui/components/UserAvatar/index.js
@@ -1,0 +1,23 @@
+/* @flow */
+import * as React from 'react';
+import makeClassName from 'classnames';
+
+import Icon from 'ui/components/Icon';
+import type { UserType } from 'amo/reducers/users';
+
+
+type Props = {|
+  className?: string,
+  user?: UserType,
+|};
+
+const UserAvatar = ({ className, user }: Props) => {
+  const _className = makeClassName('UserAvatar', className);
+
+  return (user && user.picture_type && user.picture_type.length ?
+    <img alt="" className={_className} src={user.picture_url} /> :
+    <Icon className={_className} name="anonymous-user" />
+  );
+};
+
+export default UserAvatar;

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -323,7 +323,9 @@ describe(__filename, () => {
     });
     const root = render({
       addon,
-      store: dispatchSignInActions({ permissions: [STATS_VIEW] }).store,
+      store: dispatchSignInActions({
+        userProps: { permissions: [STATS_VIEW] },
+      }).store,
     });
 
     const statsLink = root.find('.AddonMoreInfo-stats-link');

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -273,7 +273,10 @@ describe(__filename, () => {
   });
 
   it('lets an admin reply to a review', () => {
-    dispatchSignInActions({ store, permissions: [ALL_SUPER_POWERS] });
+    dispatchSignInActions({
+      store,
+      userProps: { permissions: [ALL_SUPER_POWERS] },
+    });
 
     const addon = createInternalAddon(fakeAddon);
     const review = _setReview({

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -531,7 +531,11 @@ describe(__filename, () => {
   });
 
   it('renders an edit link when user has `Collections:Edit` permission', () => {
-    const { store } = dispatchSignInActions({ permissions: [COLLECTIONS_EDIT] });
+    const { store } = dispatchSignInActions({
+      userProps: {
+        permissions: [COLLECTIONS_EDIT],
+      },
+    });
 
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
@@ -546,7 +550,9 @@ describe(__filename, () => {
   it('links to a Collection edit page', () => {
     // Turn off edit-overlay feature so that the component renders a link.
     const fakeConfig = getFakeConfig({ enableCollectionEdit: false });
-    const { store } = dispatchSignInActions({ permissions: [COLLECTIONS_EDIT] });
+    const { store } = dispatchSignInActions({
+      userProps: { permissions: [COLLECTIONS_EDIT] },
+    });
 
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
@@ -565,7 +571,7 @@ describe(__filename, () => {
     // Turn on the edit-overlay feature.
     const fakeConfig = getFakeConfig({ enableCollectionEdit: true });
     const { store } = dispatchSignInActions({
-      permissions: [COLLECTIONS_EDIT],
+      userProps: { permissions: [COLLECTIONS_EDIT] },
     });
 
     store.dispatch(loadCurrentCollection({

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -68,8 +68,10 @@ describe(__filename, () => {
   it('displays a menu and the display name when user is signed in', () => {
     const displayName = 'King of the Elephants';
     const { store } = dispatchSignInActions({
-      display_name: displayName,
-      username: 'babar',
+      userProps: {
+        display_name: displayName,
+        username: 'babar',
+      },
     });
     const wrapper = renderHeader({ store });
 
@@ -78,7 +80,9 @@ describe(__filename, () => {
   });
 
   it('displays the username when user is signed in but has no display name', () => {
-    const { store } = dispatchSignInActions({ username: 'babar' });
+    const { store } = dispatchSignInActions({
+      userProps: { username: 'babar' },
+    });
     const wrapper = renderHeader({ store });
 
     expect(wrapper.find(DropdownMenu)).toHaveLength(1);
@@ -86,7 +90,9 @@ describe(__filename, () => {
   });
 
   it("displays user's collection when user is signed in", () => {
-    const { store } = dispatchSignInActions({ username: 'babar' });
+    const { store } = dispatchSignInActions({
+      userProps: { username: 'babar' },
+    });
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-collections-link');
 
@@ -95,7 +101,9 @@ describe(__filename, () => {
   });
 
   it('allows a signed-in user to log out', () => {
-    const { store } = dispatchSignInActions({ username: 'babar' });
+    const { store } = dispatchSignInActions({
+      userProps: { username: 'babar' },
+    });
     const handleLogOut = sinon.stub();
 
     const wrapper = renderHeader({ store, handleLogOut });
@@ -110,8 +118,10 @@ describe(__filename, () => {
 
   it('displays the reviewer tools link when user has a reviewer permission', () => {
     const { store } = dispatchSignInActions({
-      username: 'babar',
-      permissions: ['Addons:PostReview'],
+      userProps: {
+        permissions: ['Addons:PostReview'],
+        username: 'babar',
+      },
     });
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-reviewer-tools-link');
@@ -122,7 +132,9 @@ describe(__filename, () => {
   });
 
   it('does not display the reviewer tools link when user does not have permission', () => {
-    const { store } = dispatchSignInActions({ username: 'babar' });
+    const { store } = dispatchSignInActions({
+      userProps: { username: 'babar' },
+    });
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-reviewer-tools-link');
 

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -218,38 +218,15 @@ export function dispatchClientMetadata({
 
 export function dispatchSignInActions({
   authToken = userAuthToken(),
-  biography = 'I love making add-ons!',
-  created = '2017-08-15T12:01:13Z',
   userId = 12345,
-  username = 'user-1234',
-  /* eslint-disable camelcase */
-  average_addon_rating = 4.3,
-  display_name = null,
-  num_addons_listed = 1,
-  picture_url = `${config.get('amoCDN')}/static/img/zamboni/anon_user.png`,
-  picture_type = '',
-  /* eslint-enable camelcase */
-  permissions = [],
-  homepage = null,
+  userProps = {},
   ...otherArgs
 } = {}) {
   const { store } = dispatchClientMetadata(otherArgs);
 
   store.dispatch(setAuthToken(authToken));
   store.dispatch(loadCurrentUserAccount({
-    user: createUserAccountResponse({
-      id: userId,
-      biography,
-      created,
-      homepage,
-      username,
-      average_addon_rating,
-      display_name,
-      num_addons_listed,
-      permissions,
-      picture_url,
-      picture_type,
-    }),
+    user: createUserAccountResponse({ id: userId, ...userProps }),
   }));
 
   return {

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -218,11 +218,19 @@ export function dispatchClientMetadata({
 
 export function dispatchSignInActions({
   authToken = userAuthToken(),
+  biography = 'I love making add-ons!',
+  created = '2017-08-15T12:01:13Z',
   userId = 12345,
   username = 'user-1234',
-  // eslint-disable-next-line camelcase
+  /* eslint-disable camelcase */
+  average_addon_rating = 4.3,
   display_name = null,
+  num_addons_listed = 1,
+  picture_url = `${config.get('amoCDN')}/static/img/zamboni/anon_user.png`,
+  picture_type = '',
+  /* eslint-enable camelcase */
   permissions = [],
+  homepage = null,
   ...otherArgs
 } = {}) {
   const { store } = dispatchClientMetadata(otherArgs);
@@ -231,10 +239,16 @@ export function dispatchSignInActions({
   store.dispatch(loadCurrentUserAccount({
     user: createUserAccountResponse({
       id: userId,
+      biography,
+      created,
+      homepage,
       username,
-      // eslint-disable-next-line camelcase
+      average_addon_rating,
       display_name,
+      num_addons_listed,
       permissions,
+      picture_url,
+      picture_type,
     }),
   }));
 

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -121,20 +121,22 @@ describe(__filename, () => {
   describe('hasPermission selector', () => {
     it('returns `true` when user has the given permission', () => {
       const permissions = [ADMIN_TOOLS_VIEW, STATS_VIEW];
-      const { state } = dispatchSignInActions({ permissions });
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasPermission(state, STATS_VIEW)).toEqual(true);
     });
 
     it('returns `false` when user does not have the given permission', () => {
       const permissions = [ADMIN_TOOLS_VIEW, STATS_VIEW];
-      const { state } = dispatchSignInActions({ permissions });
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
     });
 
     it('returns `false` when user state has no permissions', () => {
-      const { state } = dispatchSignInActions({ permissions: null });
+      const { state } = dispatchSignInActions({
+        userProps: { permissions: null },
+      });
 
       expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
     });
@@ -147,7 +149,7 @@ describe(__filename, () => {
 
     it('returns `true` when user is admin', () => {
       const permissions = [ALL_SUPER_POWERS];
-      const { state } = dispatchSignInActions({ permissions });
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
 
       expect(hasPermission(state, THEMES_REVIEW)).toEqual(true);
@@ -157,34 +159,36 @@ describe(__filename, () => {
   describe('hasAnyReviewerRelatedPermission selector', () => {
     it('returns `true` when user has ADDONS_POSTREVIEW', () => {
       const permissions = [ADDONS_POSTREVIEW, STATS_VIEW];
-      const { state } = dispatchSignInActions({ permissions });
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
     });
 
     it('returns `true` when user has ADDONS_CONTENTREVIEW', () => {
       const permissions = [STATS_VIEW, ADDONS_CONTENTREVIEW];
-      const { state } = dispatchSignInActions({ permissions });
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
     });
 
     it('returns `true` when user has ADDONS_REVIEW', () => {
       const permissions = [ADDONS_REVIEW];
-      const { state } = dispatchSignInActions({ permissions });
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
     });
 
     it('returns `false` when user does not have any reviewer permissions', () => {
       const permissions = [COLLECTIONS_EDIT, STATS_VIEW];
-      const { state } = dispatchSignInActions({ permissions });
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(false);
     });
 
     it('returns `false` when user state has no permissions', () => {
-      const { state } = dispatchSignInActions({ permissions: null });
+      const { state } = dispatchSignInActions({
+        userProps: { permissions: null },
+      });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(false);
     });
@@ -197,8 +201,7 @@ describe(__filename, () => {
 
     it('returns `true` when user is admin', () => {
       const permissions = [ALL_SUPER_POWERS];
-      const { state } = dispatchSignInActions({ permissions });
-
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
     });
@@ -207,7 +210,9 @@ describe(__filename, () => {
   describe('getDisplayName selector', () => {
     it('sets the display name when user has a display name', () => {
       const displayName = 'King of the Elephants';
-      const { state } = dispatchSignInActions({ display_name: displayName });
+      const { state } = dispatchSignInActions({
+        userProps: { display_name: displayName },
+      });
 
       expect(getDisplayName(getCurrentUser(state.users))).toEqual(displayName);
     });
@@ -216,8 +221,7 @@ describe(__filename, () => {
       const username = 'babar';
       const displayName = null;
       const { state } = dispatchSignInActions({
-        display_name: displayName,
-        username,
+        userProps: { display_name: displayName, username },
       });
 
       expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
@@ -227,8 +231,7 @@ describe(__filename, () => {
       const username = 'babar';
       const displayName = undefined;
       const { state } = dispatchSignInActions({
-        display_name: displayName,
-        username,
+        userProps: { display_name: displayName, username },
       });
 
       expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
@@ -238,8 +241,7 @@ describe(__filename, () => {
       const username = 'babar';
       const displayName = '';
       const { state } = dispatchSignInActions({
-        display_name: displayName,
-        username,
+        userProps: { display_name: displayName, username },
       });
 
       expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
@@ -247,7 +249,9 @@ describe(__filename, () => {
 
     it('returns the username when user did not define a display name', () => {
       const username = 'babar';
-      const { state } = dispatchSignInActions({ username });
+      const { state } = dispatchSignInActions({
+        userProps: { display_name: undefined, username },
+      });
 
       expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
     });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -386,27 +386,34 @@ export function createFakeLanguageTool(otherProps = {}) {
 
 export function createUserAccountResponse({
   id = 123456,
+  biography = 'I love making add-ons!',
   username = 'user-1234',
-  // eslint-disable-next-line camelcase
+  created = '2017-08-15T12:01:13Z',
+  /* eslint-disable camelcase */
+  average_addon_rating = 4.3,
   display_name = null,
+  num_addons_listed = 1,
+  picture_url = `${config.get('amoCDN')}/static/img/zamboni/anon_user.png`,
+  picture_type = '',
+  /* eslint-enable camelcase */
+  homepage = null,
   permissions = [],
 } = {}) {
   return {
-    average_addon_rating: null,
-    biography: '',
-    created: '2017-08-15T12:01:13Z',
-    // eslint-disable-next-line camelcase
+    average_addon_rating,
+    biography,
+    created,
     display_name,
-    homepage: '',
+    homepage,
     id,
     is_addon_developer: false,
     is_artist: false,
     location: '',
     name: '',
-    num_addons_listed: 0,
+    num_addons_listed,
     occupation: '',
-    picture_type: '',
-    picture_url: `${config.get('amoCDN')}/static/img/zamboni/anon_user.png`,
+    picture_type,
+    picture_url,
     url: null,
     username,
     permissions,

--- a/tests/unit/ui/components/TestUserAvatar.js
+++ b/tests/unit/ui/components/TestUserAvatar.js
@@ -14,9 +14,10 @@ describe(__filename, () => {
 
   it('renders user avatar', () => {
     const { state } = dispatchSignInActions({
-      id: 599,
-      picture_url: 'http://tofumatt.com/photo.jpg',
-      picture_type: 'jpg',
+      userProps: {
+        picture_url: 'http://tofumatt.com/photo.jpg',
+        picture_type: 'jpg',
+      },
     });
     const user = getCurrentUser(state.users);
     const root = renderUserAvatar({ user });
@@ -28,9 +29,10 @@ describe(__filename, () => {
 
   it('renders extra classNames when rendering an <img> tag', () => {
     const { state } = dispatchSignInActions({
-      id: 599,
-      picture_url: 'http://tofumatt.com/photo.jpg',
-      picture_type: 'jpg',
+      userProps: {
+        picture_url: 'http://tofumatt.com/photo.jpg',
+        picture_type: 'jpg',
+      },
     });
     const user = getCurrentUser(state.users);
     const root = renderUserAvatar({ className: 'test', user });
@@ -46,10 +48,12 @@ describe(__filename, () => {
 
   it('renders an anonymous icon if the user has no photo', () => {
     const { state } = dispatchSignInActions({
-      id: 599,
-      picture_url: 'anonymous.jpg',
-      // An empty picture type means no avatar.
-      picture_type: '',
+      userProps: {
+        picture_url: 'anonymous.jpg',
+        // An empty picture type means no avatar.
+        // See: https://github.com/mozilla/addons-server/issues/7679
+        picture_type: '',
+      },
     });
     const user = getCurrentUser(state.users);
     const root = renderUserAvatar({ user });

--- a/tests/unit/ui/components/TestUserAvatar.js
+++ b/tests/unit/ui/components/TestUserAvatar.js
@@ -1,0 +1,67 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { getCurrentUser } from 'amo/reducers/users';
+import Icon from 'ui/components/Icon';
+import UserAvatar from 'ui/components/UserAvatar';
+import { dispatchSignInActions } from 'tests/unit/amo/helpers';
+
+
+describe(__filename, () => {
+  function renderUserAvatar({ ...props } = {}) {
+    return shallow(<UserAvatar {...props} />);
+  }
+
+  it('renders user avatar', () => {
+    const { state } = dispatchSignInActions({
+      id: 599,
+      picture_url: 'http://tofumatt.com/photo.jpg',
+      picture_type: 'jpg',
+    });
+    const user = getCurrentUser(state.users);
+    const root = renderUserAvatar({ user });
+
+    expect(root.find('img.UserAvatar')).toHaveLength(1);
+    expect(root.find('.UserAvatar')).toHaveProp(
+      'src', 'http://tofumatt.com/photo.jpg');
+  });
+
+  it('renders extra classNames when rendering an <img> tag', () => {
+    const { state } = dispatchSignInActions({
+      id: 599,
+      picture_url: 'http://tofumatt.com/photo.jpg',
+      picture_type: 'jpg',
+    });
+    const user = getCurrentUser(state.users);
+    const root = renderUserAvatar({ className: 'test', user });
+
+    expect(root.find('img.test')).toHaveLength(1);
+  });
+
+  it('renders extra classNames when rendering an Icon component', () => {
+    const root = renderUserAvatar({ className: 'test', user: null });
+
+    expect(root.find(Icon).find('.test')).toHaveLength(1);
+  });
+
+  it('renders an anonymous icon if the user has no photo', () => {
+    const { state } = dispatchSignInActions({
+      id: 599,
+      picture_url: 'anonymous.jpg',
+      // An empty picture type means no avatar.
+      picture_type: '',
+    });
+    const user = getCurrentUser(state.users);
+    const root = renderUserAvatar({ user });
+
+    expect(root.find(Icon).find('.UserAvatar'))
+      .toHaveProp('name', 'anonymous-user');
+  });
+
+  it('renders an anonymous icon if there is no user', () => {
+    const root = renderUserAvatar({ user: null });
+
+    expect(root.find(Icon).find('.UserAvatar'))
+      .toHaveProp('name', 'anonymous-user');
+  });
+});


### PR DESCRIPTION
Adds a user avatar component that renders an anonymous user icon when the user is `null` (loading) or has no picture set.

fix #4471