### PR TITLE
Fix missing add-on install sources

### DIFF
--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -15,6 +15,9 @@ import { categoriesFetch } from 'core/actions/categories';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
+  INSTALL_SOURCE_FEATURED,
+  INSTALL_SOURCE_TOP_RATED,
+  INSTALL_SOURCE_TRENDING,
   SEARCH_SORT_TRENDING,
   SEARCH_SORT_TOP_RATED,
 } from 'core/constants';
@@ -251,6 +254,7 @@ export class CategoryBase extends React.Component {
         {this.renderIfNotEmpty(
           featuredAddons,
           <LandingAddonsCard
+            addonInstallSource={INSTALL_SOURCE_FEATURED}
             addons={featuredAddons}
             className="FeaturedAddons"
             footerText={html.featuredFooterText}
@@ -262,6 +266,7 @@ export class CategoryBase extends React.Component {
         {this.renderIfNotEmpty(
           highlyRatedAddons,
           <LandingAddonsCard
+            addonInstallSource={INSTALL_SOURCE_TOP_RATED}
             addons={highlyRatedAddons}
             className="HighlyRatedAddons"
             footerLink={html.highlyRatedFooterLink}
@@ -273,6 +278,7 @@ export class CategoryBase extends React.Component {
         {this.renderIfNotEmpty(
           trendingAddons,
           <LandingAddonsCard
+            addonInstallSource={INSTALL_SOURCE_TRENDING}
             addons={trendingAddons}
             className="TrendingAddons"
             footerLink={html.trendingFooterLink}

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -14,6 +14,9 @@ import Categories from 'amo/components/Categories';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
+  INSTALL_SOURCE_FEATURED,
+  INSTALL_SOURCE_TOP_RATED,
+  INSTALL_SOURCE_TRENDING,
   SEARCH_SORT_TRENDING,
   SEARCH_SORT_TOP_RATED,
 } from 'core/constants';
@@ -238,6 +241,7 @@ export class LandingPageBase extends React.Component {
         {this.renderIfNotEmpty(
           featuredAddons,
           <LandingAddonsCard
+            addonInstallSource={INSTALL_SOURCE_FEATURED}
             addons={featuredAddons}
             className="FeaturedAddons"
             footerText={html.featuredFooterText}
@@ -249,6 +253,7 @@ export class LandingPageBase extends React.Component {
         {this.renderIfNotEmpty(
           highlyRatedAddons,
           <LandingAddonsCard
+            addonInstallSource={INSTALL_SOURCE_TOP_RATED}
             addons={highlyRatedAddons}
             className="HighlyRatedAddons"
             footerLink={html.highlyRatedFooterLink}
@@ -260,6 +265,7 @@ export class LandingPageBase extends React.Component {
         {this.renderIfNotEmpty(
           trendingAddons,
           <LandingAddonsCard
+            addonInstallSource={INSTALL_SOURCE_TRENDING}
             addons={trendingAddons}
             className="TrendingAddons"
             footerLink={html.trendingFooterLink}

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -95,6 +95,8 @@ export const INSTALL_SOURCE_FEATURED = 'featured';
 export const INSTALL_SOURCE_HERO_PROMO = 'hp-dl-promo';
 export const INSTALL_SOURCE_MOST_POPULAR = 'mostpopular';
 export const INSTALL_SOURCE_SEARCH = 'search';
+export const INSTALL_SOURCE_TOP_RATED = 'rating';
+export const INSTALL_SOURCE_TRENDING = 'hotness';
 
 // View Contexts that aren't an addonType
 export const VIEW_CONTEXT_EXPLORE = 'VIEW_CONTEXT_EXPLORE';


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4475

This only fixes the missing install sources on extension landing pages and category pages. When I get clarification on the `src=filter` part of the original issue, I'll address them with a separate patch.