### PR TITLE
Fixes 4253: added hyphen when word breaks

### DIFF
--- a/src/ui/components/MetadataCard/styles.scss
+++ b/src/ui/components/MetadataCard/styles.scss
@@ -19,6 +19,7 @@
   @include text-align-start();
 
   flex: 1;
+  hyphens: auto;
   margin: 12px;
   max-width: 25%;
 


### PR DESCRIPTION
Fixes #4253 

This puts hyphen at every word break, to make more sense with i18N.

Before:
<img width="351" alt="screen shot 2018-03-03 at 9 51 42 pm" src="https://user-images.githubusercontent.com/5318732/36936577-36e14bc0-1f2d-11e8-843c-f42c10c801b1.png">

After:
<img width="349" alt="screen shot 2018-03-03 at 9 49 50 pm" src="https://user-images.githubusercontent.com/5318732/36936579-4173d800-1f2d-11e8-86d2-4854c423bef6.png">
