### PR TITLE
I4185: fix text overfow in collection

### DIFF
--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -21,10 +21,14 @@
   @include font-light();
 
   font-size: $font-size-l;
+  hyphens: auto;
+  word-wrap: break-word;
 }
 
 .Collection-description {
   font-size: $font-size-s;
+  hyphens: auto;
+  word-wrap: break-word;
 }
 
 .Collection-author-name-value {

--- a/src/ui/components/MetadataCard/styles.scss
+++ b/src/ui/components/MetadataCard/styles.scss
@@ -19,8 +19,10 @@
   @include text-align-start();
 
   flex: 1;
+  hyphens: auto;
   margin: 12px;
   max-width: 25%;
+  word-wrap: break-word;
 
   dd {
     line-height: 1.4;
@@ -31,6 +33,5 @@
   dt {
     color: $grey-50;
     line-height: 1.4;
-    word-wrap: break-word;
   }
 }


### PR DESCRIPTION
Fixes #4185 
Fixes #4493 
Closes #4493

Before:
<img width="489" alt="screen shot 2018-03-04 at 12 03 52 pm" src="https://user-images.githubusercontent.com/5318732/36942888-24d19d82-1fa4-11e8-90b6-3028109efdc3.png">
<img width="351" alt="screen shot 2018-03-03 at 9 51 42 pm" src="https://user-images.githubusercontent.com/5318732/36936577-36e14bc0-1f2d-11e8-843c-f42c10c801b1.png">



After:
<img width="480" alt="screen shot 2018-03-04 at 11 59 05 am" src="https://user-images.githubusercontent.com/5318732/36942881-08b5e162-1fa4-11e8-8e43-332b1a96b702.png">
<img width="349" alt="screen shot 2018-03-03 at 9 49 50 pm" src="https://user-images.githubusercontent.com/5318732/36936579-4173d800-1f2d-11e8-86d2-4854c423bef6.png">