### PR TITLE
Remove all eslint-disable comments for for...of syntax

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -26,7 +26,6 @@ if (!app && !buildAll) {
 }
 
 const appsBuildList = buildAll ? config.get('validAppNames') : [app];
-// eslint-disable-next-line no-restricted-syntax
 for (const appName of appsBuildList) {
   const localeDir = path.join(__dirname, '../locale');
   const poFiles = glob.sync(`${localeDir}/**/${appName}.po`);

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -30,7 +30,6 @@ export function* fetchHomeAddons({
     const state = yield select(getState);
 
     const collections = [];
-    // eslint-disable-next-line no-restricted-syntax
     for (const collection of collectionsToFetch) {
       const result = yield call(getCollectionAddons, {
         api: state.api,

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -54,7 +54,6 @@ export function install(
   return _mozAddonManager.createInstall({ url })
     .then((installObj) => {
       const callback = (e) => eventCallback(installObj, e);
-      // eslint-disable-next-line no-restricted-syntax
       for (const event of INSTALL_EVENT_LIST) {
         log.info(`[install] Adding listener for ${event}`);
         installObj.addEventListener(event, callback);
@@ -95,7 +94,6 @@ export function addChangeListeners(callback, mozAddonManager) {
   }
 
   if (mozAddonManager && mozAddonManager.addEventListener) {
-    // eslint-disable-next-line no-restricted-syntax
     for (const event of GLOBAL_EVENTS) {
       log.info(`adding event listener for "${event}"`);
       mozAddonManager.addEventListener(event, handleChangeEvent);

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -46,7 +46,6 @@ export const getFileHash = ({ addon, installURL } = {}) => {
   // https://github.com/mozilla/addons-frontend/issues/3871
 
   if (addon.current_version) {
-    // eslint-disable-next-line no-restricted-syntax
     for (const file of addon.current_version.files) {
       // The API sometimes appends ?src= to URLs so we just check the
       // basename.

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -163,7 +163,6 @@ export function getLangFromHeader(
   let userLang;
   if (acceptLanguage) {
     const langList = parseAcceptLanguage(acceptLanguage);
-    // eslint-disable-next-line no-restricted-syntax
     for (const langPref of langList) {
       if (isSupportedLang(normalizeLang(langPref.lang), { _supportedLangs })) {
         userLang = langPref.lang;

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -35,7 +35,6 @@ export function ngettext(singular, plural, n) {
 
 export function getClientConfig(_config) {
   const clientConfig = {};
-  // eslint-disable-next-line no-restricted-syntax
   for (const key of _config.get('clientConfigKeys')) {
     clientConfig[key] = _config.get(key);
   }

--- a/tests/unit/TestCSPConfig.js
+++ b/tests/unit/TestCSPConfig.js
@@ -26,7 +26,6 @@ describe('CSP Config Defaults', () => {
     process.env.NODE_ENV = existingNodeEnv;
   });
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const env of deployedEnvs) {
     // eslint-disable-next-lint no-loop-func
     it(`should have a source-list config for ${env}`, () => {

--- a/tests/unit/TestFrameGuardConfig.js
+++ b/tests/unit/TestFrameGuardConfig.js
@@ -11,7 +11,6 @@ describe('App Specific Frameguard Config', () => {
     delete process.env.NODE_APP_INSTANCE;
   });
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const appName of appsList) {
     // eslint-disable-next-line no-loop-func
     it(`should default frameGuard to "deny" for ${appName} in production`, () => {

--- a/tests/unit/TestLocalesConfig.js
+++ b/tests/unit/TestLocalesConfig.js
@@ -12,7 +12,6 @@ const langs = config.get('langs');
 const basePath = config.get('basePath');
 
 describe(__filename, () => {
-  // eslint-disable-next-line no-restricted-syntax
   for (const lang of langs) {
     // eslint-disable no-loop-func
     it(`should have a corresponding ${lang} dir in locale`, () => {
@@ -20,7 +19,6 @@ describe(__filename, () => {
     });
   }
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const localeDir of glob.sync('locale/*')) {
     const locale = path.basename(localeDir);
     const lang = localeToLang(locale);
@@ -34,7 +32,6 @@ describe(__filename, () => {
 });
 
 describe('Check Locale JS for entities', () => {
-  // eslint-disable-next-line no-restricted-syntax
   for (const localeJSFile of glob.sync('src/locale/*/*.js')) {
     it(`${localeJSFile} should not have html entities`, (done) => {
       fs.readFile(localeJSFile, 'utf8', (err, data) => {

--- a/tests/unit/core/middleware/test_frameguardMiddleware.js
+++ b/tests/unit/core/middleware/test_frameguardMiddleware.js
@@ -15,7 +15,6 @@ describe('Frameguard Middleware', () => {
     delete process.env.NODE_APP_INSTANCE;
   });
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const appName of appsList) {
     // eslint-disable-next-line no-loop-func
     it(`provides the expected x-frame-options headers for ${appName}`, () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -429,7 +429,6 @@ export function createUserAccountResponse({
 //   ...
 // }
 export const getFakeConfig = (params = {}) => {
-  // eslint-disable-next-line no-restricted-syntax
   for (const key of Object.keys(params)) {
     if (!config.has(key)) {
       // This will help alert us when a test accidentally relies
@@ -452,7 +451,6 @@ export const urlWithTheseParams = (params) => {
   return sinon.match((urlString) => {
     const { query } = url.parse(urlString, true);
 
-    // eslint-disable-next-line no-restricted-syntax
     for (const param in params) {
       if (!query[param] || query[param] !== params[param].toString()) {
         return false;

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -45,7 +45,6 @@ const appName = config.get('appName');
 const appsBuildList = appName ? [appName] : config.get('validAppNames');
 
 const entryPoints = {};
-// eslint-disable-next-line no-restricted-syntax
 for (const app of appsBuildList) {
   entryPoints[app] = [
     hmr,

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -16,7 +16,6 @@ const appName = config.get('appName');
 const appsBuildList = appName ? [appName] : config.get('validAppNames');
 
 const entryPoints = {};
-// eslint-disable-next-line no-restricted-syntax
 for (const app of appsBuildList) {
   entryPoints[app] = `${app}/client`;
 }


### PR DESCRIPTION
Fixes #4477

Support for this syntax landed in https://github.com/mozilla/addons-frontend/commit/23f4d49813bba0eed1b0f19fb0729ee2cb1ea5d3, so we can now remove all the eslint comments that were added before this was supported.