### PR TITLE
API helpers for creating a collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "hot-shots": "5.2.0",
     "html-entities": "1.2.1",
     "humps": "2.0.1",
+    "invariant": "2.2.3",
     "isomorphic-fetch": "2.2.1",
     "jed": "1.1.1",
     "join-url": "2.0.0",

--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -156,13 +156,48 @@ export const addAddonToCollection = (
   });
 };
 
+type ModifyCollectionParams = {|
+  api: ApiStateType,
+  defaultLocale: ?string,
+  description: ?LocalizedString,
+  // Even though the API accepts string|number, we need to always use
+  // string usernames. This helps keep public-facing URLs consistent.
+  user: string,
+  // eslint-disable-next-line no-use-before-define
+  _modifyCollection?: typeof modifyCollection,
+  _validateLocalizedString?: typeof validateLocalizedString,
+|};
+
+export type UpdateCollectionParams = {|
+  ...ModifyCollectionParams,
+  // We identify the collection by its slug. This is confusing because the
+  // slug can also be edited.
+  // TODO: use the actual ID instead.
+  // See https://github.com/mozilla/addons-server/issues/7529
+  collectionSlug: string,
+  name: ?LocalizedString,
+  // This is a value for a new slug, if defined.
+  slug: ?string,
+|};
+
+export type CreateCollectionParams = {|
+  ...ModifyCollectionParams,
+  name: LocalizedString,
+  slug: string,
+|};
+
 export const modifyCollection = (
   action: 'create' | 'update',
-  params: Object
+  params: {
+    ...ModifyCollectionParams,
+    collectionSlug?: string,
+    name?: ?LocalizedString,
+    slug?: ?string,
+  }
 ): Promise<void> => {
   const {
     api,
-    collectionSlug,
+    collectionSlug = '',
     defaultLocale,
     description,
     name,
@@ -206,35 +241,6 @@ export const modifyCollection = (
     state: api,
   });
 };
-
-type ModifyCollectionParams = {|
-  api: ApiStateType,
-  defaultLocale: ?string,
-  description: ?LocalizedString,
-  // Even though the API accepts string|number, we need to always use
-  // string usernames. This helps keep public-facing URLs consistent.
-  user: string,
-  _modifyCollection?: typeof modifyCollection,
-  _validateLocalizedString?: typeof validateLocalizedString,
-|};
-
-export type UpdateCollectionParams = {|
-  ...ModifyCollectionParams,
-  // We identify the collection by its slug. This is confusing because the
-  // slug can also be edited.
-  // TODO: use the actual ID instead.
-  // See https://github.com/mozilla/addons-server/issues/7529
-  collectionSlug: string,
-  name: ?LocalizedString,
-  // This is a value for a new slug, if defined.
-  slug: ?string,
-|};
-
-export type CreateCollectionParams = {|
-  ...ModifyCollectionParams,
-  name: LocalizedString,
-  slug: string,
-|};
 
 export const updateCollection = ({
   api,

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -391,7 +391,7 @@ describe(__filename, () => {
   describe('updateCollection', () => {
     it('calls modifyCollection with the expected params', async () => {
       const validator = sinon.stub();
-      const modifier = sinon.stub();
+      const modifier = sinon.spy(() => Promise.resolve());
       const modifyParams = {
         api: apiState,
         collectionSlug: 'collection-slug',
@@ -416,7 +416,7 @@ describe(__filename, () => {
   describe('createCollection', () => {
     it('calls modifyCollection with the expected params', async () => {
       const validator = sinon.stub();
-      const modifier = sinon.stub();
+      const modifier = sinon.spy(() => Promise.resolve());
       const modifyParams = {
         api: apiState,
         defaultLocale: undefined,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4471,6 +4471,12 @@ intl@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
 
+invariant@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
+  dependencies:
+    loose-envify "^1.0.0"
+
 invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"


### PR DESCRIPTION
Fixes #4504 

This adds helpers for creating a collection, and refactors the code for updating a collection to be shared with that for creating a collection.