### PR TITLE
Fix input text color on dark GTK themes (fix mozilla/addons#657)

### DIFF
--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -25,6 +25,7 @@ textarea {
   border: 1px solid $grey-50;
   border-radius: $border-radius-xs;
   box-shadow: none;
+  color: $black;
   font-size: $font-size-m-smaller;
   line-height: 1.4;
   padding: 4px;


### PR DESCRIPTION
Fixes mozilla/addons#657.

This sets explicit `color` for `input, textarea`.

Before:
![screenshot_20180310_001049](https://user-images.githubusercontent.com/4330357/37230182-85171c06-23f7-11e8-9d01-3dbe9285f7ed.png)

After:
![screenshot_20180310_000638](https://user-images.githubusercontent.com/4330357/37230086-4a32d0bc-23f7-11e8-8f73-da49fdf2d2d7.png)
