### PR TITLE
Fixes #3070 - Only initiate autocomplete when 𝑛 characters are present

### DIFF
--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -165,7 +165,7 @@ export class AutoSearchInputBase extends React.Component<Props, State> {
 
     if (value.length < SEARCH_TERM_MIN_LENGTH) {
       log.debug(oneLine`Ignoring suggestions fetch because query
-      subceeds min length (${SEARCH_TERM_MIN_LENGTH})`);
+      does not meet the required length (${SEARCH_TERM_MIN_LENGTH})`);
 
       this.props.dispatch(autocompleteCancel());
       return;

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -155,7 +155,7 @@ export class AutoSearchInputBase extends React.Component<Props, State> {
   }
 
   handleSuggestionsFetchRequested = (
-    { value, reason }: OnSuggestionsFetchRequestedParams
+    { value }: OnSuggestionsFetchRequestedParams
   ) => {
     if (!value) {
       log.debug(oneLine`Ignoring suggestions fetch requested because
@@ -183,11 +183,6 @@ export class AutoSearchInputBase extends React.Component<Props, State> {
     const filters = this.createFiltersFromQuery(value);
 
     this.setState({ autocompleteIsOpen: true });
-
-    if (reason === 'input-focused') {
-      log.debug('Ignoring suggestions fetch on search input focus');
-      return;
-    }
 
     this.dispatchAutocompleteStart({ filters });
   }

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -31,6 +31,7 @@ import type { ErrorHandlerType } from 'core/errorHandler';
 
 import './styles.scss';
 
+export const SEARCH_TERM_MIN_LENGTH = 3;
 export const SEARCH_TERM_MAX_LENGTH = 100;
 
 // TODO: port reducers/autocomplete.js to Flow and move this there.
@@ -162,10 +163,20 @@ export class AutoSearchInputBase extends React.Component<Props, State> {
       return;
     }
 
+    if (value.length < SEARCH_TERM_MIN_LENGTH) {
+      log.debug(oneLine`Ignoring suggestions fetch because query
+      subceeds min length (${SEARCH_TERM_MIN_LENGTH})`);
+
+      this.props.dispatch(autocompleteCancel());
+      return;
+    }
+
     if (value.length > SEARCH_TERM_MAX_LENGTH) {
       log.debug(oneLine`Ignoring suggestions fetch because query
         exceeds max length (${SEARCH_TERM_MAX_LENGTH})`
       );
+
+      this.props.dispatch(autocompleteCancel());
       return;
     }
 
@@ -271,6 +282,7 @@ export class AutoSearchInputBase extends React.Component<Props, State> {
 
     const inputProps = {
       className: 'AutoSearchInput-query',
+      minLength: SEARCH_TERM_MIN_LENGTH,
       maxLength: SEARCH_TERM_MAX_LENGTH,
       name: inputName,
       onChange: this.handleSearchChange,

--- a/src/core/reducers/autocomplete.js
+++ b/src/core/reducers/autocomplete.js
@@ -56,6 +56,7 @@ export default function reducer(state = initialState, action = {}) {
       return {
         ...state,
         loading: false,
+        suggestions: [],
       };
     case AUTOCOMPLETE_STARTED:
       return {

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -316,7 +316,7 @@ describe(__filename, () => {
         root, query: 't'.repeat(SEARCH_TERM_MAX_LENGTH + 1),
       });
 
-      sinon.assert.notCalled(dispatchSpy);
+      sinon.assert.called(dispatchSpy);
     });
 
     it('does not fetch suggestions on focus', () => {

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Autosuggest from 'react-autosuggest';
 
 import AutoSearchInput, {
-  extractId, AutoSearchInputBase, SEARCH_TERM_MAX_LENGTH,
+  extractId, AutoSearchInputBase, SEARCH_TERM_MIN_LENGTH, SEARCH_TERM_MAX_LENGTH,
 } from 'amo/components/AutoSearchInput';
 import SearchSuggestion from 'amo/components/SearchSuggestion';
 import {
@@ -305,6 +305,18 @@ describe(__filename, () => {
       fetchSuggestions({ root, query: '' });
 
       sinon.assert.notCalled(dispatchSpy);
+    });
+
+    it('does not fetch suggestions for a really short value', () => {
+      const { store } = dispatchClientMetadata();
+      const dispatchSpy = sinon.stub(store, 'dispatch');
+      const root = render({ store });
+
+      fetchSuggestions({
+        root, query: 't'.repeat(SEARCH_TERM_MIN_LENGTH - 1),
+      });
+
+      sinon.assert.called(dispatchSpy);
     });
 
     it('does not fetch suggestions for a really long value', () => {

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -316,7 +316,8 @@ describe(__filename, () => {
         root, query: 't'.repeat(SEARCH_TERM_MIN_LENGTH - 1),
       });
 
-      sinon.assert.called(dispatchSpy);
+      sinon.assert.calledWith(dispatchSpy, autocompleteCancel());
+      sinon.assert.callCount(dispatchSpy, 1);
     });
 
     it('does not fetch suggestions for a really long value', () => {
@@ -328,7 +329,8 @@ describe(__filename, () => {
         root, query: 't'.repeat(SEARCH_TERM_MAX_LENGTH + 1),
       });
 
-      sinon.assert.called(dispatchSpy);
+      sinon.assert.calledWith(dispatchSpy, autocompleteCancel());
+      sinon.assert.callCount(dispatchSpy, 1);
     });
 
     it('does not fetch suggestions on focus', () => {

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -333,18 +333,6 @@ describe(__filename, () => {
       sinon.assert.callCount(dispatchSpy, 1);
     });
 
-    it('does not fetch suggestions on focus', () => {
-      const { store } = dispatchClientMetadata();
-      const dispatchSpy = sinon.stub(store, 'dispatch');
-      const root = render({ store });
-
-      fetchSuggestions({
-        root, query: 'panda themes', reason: 'input-focused',
-      });
-
-      sinon.assert.notCalled(dispatchSpy);
-    });
-
     it('keeps the search results menu open while searching', () => {
       const { store } = dispatchAutocompleteResults({
         results: [createFakeAutocompleteResult()],

--- a/tests/unit/core/reducers/test_autocomplete.js
+++ b/tests/unit/core/reducers/test_autocomplete.js
@@ -28,7 +28,7 @@ describe(__filename, () => {
       } = reducer(previousState, autocompleteCancel());
 
       expect(loading).toEqual(false);
-      expect(suggestions).toEqual(previousState.suggestions);
+      expect(suggestions).toEqual([]);
     });
 
     it('handles AUTOCOMPLETE_STARTED', () => {


### PR DESCRIPTION
Fixes #3070 - Only initiate autocomplete for the search bar after `𝑛` characters have been entered. In this case, `𝑛` should be a configurable integer value.

### WIP - March 11, 2018

#### Game Plan:
- [x] Hard-code functionality to filter only with 2 or more characters present
- [x] Remove hard-coded value and allow configurability on what `𝑛` may be (~_possibly pass in another value to the respective function?_~ create a constant variable to be used globally => **check with devs**)
- [x] Clear the results if under minimum threshold
- [x] Review respective unit tests and update/create new ones as necessary