### PR TITLE
Saga helpers for creating a collection

### DIFF
--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -80,6 +80,9 @@ export type CollectionsState = {
       |};
     },
   },
+  collectionUpdates: {
+    [collectionSlug: string]: {| updating: boolean, successful?: boolean |},
+  },
 };
 
 export const initialState: CollectionsState = {
@@ -88,6 +91,7 @@ export const initialState: CollectionsState = {
   current: { id: null, loading: false },
   userCollections: {},
   addonInCollections: {},
+  collectionUpdates: {},
 };
 
 type FetchCurrentCollectionParams = {|
@@ -449,7 +453,6 @@ export const addAddonToCollection = ({
 
 export type RequiredModifyCollectionParams = {|
   errorHandlerId: string,
-  formOverlayId: string,
   user: string,
 |};
 
@@ -485,11 +488,9 @@ export type UpdateCollectionAction = {|
 
 export const validateRequiredCollectionParams = ({
   errorHandlerId,
-  formOverlayId,
   user,
 }: RequiredModifyCollectionParams) => {
   invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(formOverlayId, 'formOverlayId is required');
   invariant(user, 'user is required');
 };
 
@@ -497,14 +498,12 @@ export const createCollection = ({
   errorHandlerId,
   defaultLocale,
   description,
-  formOverlayId,
   name,
   slug,
   user,
 }: CreateCollectionParams = {}): CreateCollectionAction => {
   validateRequiredCollectionParams({
     errorHandlerId,
-    formOverlayId,
     user,
   });
 
@@ -517,7 +516,6 @@ export const createCollection = ({
       errorHandlerId,
       defaultLocale,
       description,
-      formOverlayId,
       name,
       slug,
       user,
@@ -925,6 +923,20 @@ const reducer = (
         state,
         loading: false,
       });
+    }
+
+    case UPDATE_COLLECTION: {
+      const { collectionSlug } = action.payload;
+
+      return {
+        ...state,
+        collectionUpdates: {
+          [collectionSlug]: {
+            ...state.collectionUpdates[collectionSlug],
+            updating: true,
+          },
+        },
+      };
     }
 
     case DELETE_COLLECTION_BY_SLUG: {

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -447,13 +447,13 @@ export const addAddonToCollection = ({
   };
 };
 
-type RequiredModifyCollectionParams = {|
+export type RequiredModifyCollectionParams = {|
   errorHandlerId: string,
   formOverlayId: string,
   user: string,
 |};
 
-type OptionalModifyCollectionParams = {|
+export type OptionalModifyCollectionParams = {|
   defaultLocale: ?string,
   description: ?LocalizedString,
 |};

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -486,14 +486,6 @@ export type UpdateCollectionAction = {|
   payload: UpdateCollectionParams,
 |};
 
-export const validateRequiredCollectionParams = ({
-  errorHandlerId,
-  user,
-}: RequiredModifyCollectionParams) => {
-  invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(user, 'user is required');
-};
-
 export const createCollection = ({
   errorHandlerId,
   defaultLocale,
@@ -502,13 +494,10 @@ export const createCollection = ({
   slug,
   user,
 }: CreateCollectionParams = {}): CreateCollectionAction => {
-  validateRequiredCollectionParams({
-    errorHandlerId,
-    user,
-  });
-
-  invariant(name, 'name is required when creating');
-  invariant(slug, 'slug is required when creating');
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(user, 'user is required');
+  invariant(name, 'name is required when creating a collection');
+  invariant(slug, 'slug is required when creating a collection');
 
   return {
     type: CREATE_COLLECTION,
@@ -532,11 +521,8 @@ export const updateCollection = ({
   slug,
   user,
 }: UpdateCollectionParams = {}): UpdateCollectionAction => {
-  validateRequiredCollectionParams({
-    errorHandlerId,
-    user,
-  });
-
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(user, 'user is required');
   invariant(collectionSlug, 'collectionSlug is required when updating');
 
   return {

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -18,7 +18,6 @@ import reducer, {
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
-  updateCollection,
 } from 'amo/reducers/collections';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 import {

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -18,6 +18,7 @@ import reducer, {
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
+  updateCollection,
 } from 'amo/reducers/collections';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 import {
@@ -829,45 +830,14 @@ describe(__filename, () => {
   });
 
   describe('updateCollection', () => {
-    const getParams = (params = {}) => {
-      return {
-        errorHandlerId: 'error-handler-id',
-        collectionSlug: 'some-collection',
-        user: 'some-user-name',
-        ...params,
-      };
-    };
-
-    it('requires errorHandlerId parameter', () => {
-      const params = getParams();
-      delete params.errorHandlerId;
-
-      expect(() => updateCollection(params))
-        .toThrow(/errorHandlerId is required/);
-    });
-
-    it('requires collectionSlug parameter', () => {
-      const params = getParams();
-      delete params.collectionSlug;
-
-      expect(() => updateCollection(params))
-        .toThrow(/collectionSlug is required/);
-    });
-
-    it('requires user parameter', () => {
-      const params = getParams();
-      delete params.user;
-
-      expect(() => updateCollection(params))
-        .toThrow(/user is required/);
-    });
-
     it('changes update state', () => {
       const collectionSlug = 'some-collection';
 
-      const state = reducer(initialState, updateCollection(getParams({
+      const state = reducer(initialState, updateCollection({
+        errorHandlerId: 'error-handler-id',
         collectionSlug,
-      })));
+        user: 'some-user-name',
+      }));
 
       expect(state.collectionUpdates[collectionSlug].updating)
         .toEqual(true);

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -401,6 +401,7 @@ describe(__filename, () => {
 
         // TODO: Instead of this we should probably update the collectionUpdates state,
         // and wait for that.
+        // See https://github.com/mozilla/addons-frontend/issues/4717
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
           `/${lang}/${clientApp}/collections/${user}/${params.slug}/`
@@ -435,6 +436,7 @@ describe(__filename, () => {
 
         // TODO: Instead of this we should probably update the collectionUpdates state,
         // and wait for that.
+        // See https://github.com/mozilla/addons-frontend/issues/4717
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
           `/${lang}/${clientApp}/collections/${user}/${collectionSlug}/`

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -435,13 +435,12 @@ describe(__filename, () => {
 
       it('begins and finishes a form submit', async () => {
         mockApi.expects('updateCollection').returns(Promise.resolve());
-        _updateCollection({ formOverlayId });
+        _updateCollection();
 
         for (const expectedAction of [
           beginFormOverlaySubmit(formOverlayId),
           finishFormOverlaySubmit(formOverlayId),
         ]) {
-          // eslint-disable-next-line no-await-in-loop
           const action = await sagaTester.waitFor(expectedAction.type);
           expect(action).toEqual(expectedAction);
         }
@@ -450,7 +449,7 @@ describe(__filename, () => {
       it('closes the form overlay', async () => {
         mockApi.expects('updateCollection').returns(Promise.resolve());
 
-        _updateCollection({ formOverlayId });
+        _updateCollection();
 
         const expectedAction = closeFormOverlay(formOverlayId);
 
@@ -465,7 +464,7 @@ describe(__filename, () => {
           .expects('updateCollection')
           .returns(Promise.reject(error));
 
-        _updateCollection({ formOverlayId });
+        _updateCollection();
 
         const expectedAction = errorHandler.createErrorAction(error);
         const action = await sagaTester.waitFor(expectedAction.type);


### PR DESCRIPTION
Fixes #4505

This adds code to reducers and sagas for creating a collection, as well as refactoring the code for updating a collection so that create/update can share some code.

It also removes `collectionUpdates` from state as it is never used.