### PR TITLE
Allow for a collection that does not have any add-ons to be viewed

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -209,6 +209,12 @@ export class CollectionBase extends React.Component<Props> {
           {hasEditPermission ? this.editCollectionLink() : null}
         </Card>
         <div className="Collection-items">
+          {!addons || !addons.length ?
+            <Card className="Collection-items-empty">
+              {i18n.gettext('This collection does not have any add-ons yet.')}
+            </Card> :
+            null
+          }
           <AddonsCard
             addonInstallSource={INSTALL_SOURCE_COLLECTION}
             addons={addons}

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -2,7 +2,7 @@
 // Disabled because of
 // https://github.com/benmosher/eslint-plugin-import/issues/793
 /* eslint-disable import/order */
-import { all, call, put, select, takeLatest } from 'redux-saga/effects';
+import { call, put, select, takeLatest } from 'redux-saga/effects';
 import { push as pushLocation } from 'react-router-redux';
 /* eslint-enable import/order */
 
@@ -36,11 +36,16 @@ import type {
 } from 'amo/api/collections';
 import type {
   AddAddonToCollectionAction,
+  CollectionAddonsListResponse,
   FetchCurrentCollectionAction,
   FetchCurrentCollectionPageAction,
   FetchUserCollectionsAction,
   UpdateCollectionAction,
 } from 'amo/reducers/collections';
+
+function emptyAddons(): CollectionAddonsListResponse {
+  return { count: 0, next: '', previous: '', results: [] };
+}
 
 export function* fetchCurrentCollection({
   payload: {
@@ -70,10 +75,10 @@ export function* fetchCurrentCollection({
       ...baseParams,
       page,
     };
-    const { detail, addons } = yield all({
-      detail: call(api.getCollectionDetail, detailParams),
-      addons: call(api.getCollectionAddons, addonsParams),
-    });
+    const detail = yield call(api.getCollectionDetail, detailParams);
+    const addons = detail.addon_count ?
+      yield call(api.getCollectionAddons, addonsParams) :
+      emptyAddons();
 
     yield put(loadCurrentCollection({ addons, detail }));
   } catch (error) {

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -425,7 +425,7 @@ describe(__filename, () => {
     expect(wrapper.find('.Collection-edit-link')).toHaveLength(0);
   });
 
-  it('does not render the pagination when no add-ons in the collection', () => {
+  it('does not render the pagination when no add-ons are in the collection', () => {
     const { store } = dispatchClientMetadata();
 
     const collectionAddons = createFakeCollectionAddons({ addons: [] });
@@ -438,6 +438,19 @@ describe(__filename, () => {
 
     const wrapper = renderComponent({ store });
     expect(wrapper.find(Paginate)).toHaveLength(0);
+  });
+
+  it('renders a message when no add-ons are in the collection', () => {
+    const { store } = dispatchClientMetadata();
+
+    store.dispatch(loadCurrentCollection({
+      addons: createFakeCollectionAddons({ addons: [] }),
+      detail: createFakeCollectionDetail({ count: 0 }),
+    }));
+
+    const wrapper = renderComponent({ store });
+    expect(wrapper.find('.Collection-items-empty').render().text())
+      .toEqual('This collection does not have any add-ons yet.');
   });
 
   it('renders loading indicator on add-ons when fetching next page', () => {

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -345,6 +345,8 @@ export const createFakeCollectionDetail = ({
 export const createFakeCollectionAddons = ({ addons = [fakeAddon] } = {}) => {
   return {
     count: addons.length,
+    previous: '',
+    next: '',
     results: addons.map((addon) => ({
       addon,
       downloads: 0,

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -62,7 +62,7 @@ describe(__filename, () => {
       }));
     }
 
-    it('calls the API to fetch a collection', async () => {
+    it('calls the APIs to fetch a collection and its add-ons', async () => {
       const state = sagaTester.getState();
 
       const collectionAddons = createFakeCollectionAddons();
@@ -88,6 +88,34 @@ describe(__filename, () => {
         })
         .once()
         .returns(Promise.resolve(collectionAddons));
+
+      _fetchCurrentCollection({ page, slug, user });
+
+      const expectedLoadAction = loadCurrentCollection({
+        addons: collectionAddons,
+        detail: collectionDetail,
+      });
+
+      const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
+      expect(loadAction).toEqual(expectedLoadAction);
+      mockApi.verify();
+    });
+
+    it('does not call the API to fetch addons if the collection is empty', async () => {
+      const state = sagaTester.getState();
+
+      const collectionAddons = createFakeCollectionAddons({ addons: [] });
+      const collectionDetail = createFakeCollectionDetail({ count: 0 });
+
+      mockApi
+        .expects('getCollectionDetail')
+        .withArgs({
+          api: state.api,
+          slug,
+          user,
+        })
+        .once()
+        .returns(Promise.resolve(collectionDetail));
 
       _fetchCurrentCollection({ page, slug, user });
 


### PR DESCRIPTION
Fixes #4537 

This allows for the above, which previously resulted in a 404, and also adds a message in the area where the add-ons would normally be informing the user that the collection does not have any add-ons yet.
