### PR TITLE
fix: Make "Download Firefox" notice less red

### DIFF
--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -95,8 +95,13 @@ export class AddonCompatibilityErrorBase extends React.Component {
       ), { downloadUrl });
     }
 
+    // Make the "you should download firefox" error message less scary than
+    // the rest of them: https://github.com/mozilla/addons-frontend/issues/4547
+    const noticeType = reason === INCOMPATIBLE_NOT_FIREFOX ?
+      'generic' : 'error';
+
     return (
-      <Notice type="error" className="AddonCompatibilityError">
+      <Notice type={noticeType} className="AddonCompatibilityError">
         <span dangerouslySetInnerHTML={sanitizeHTML(message, ['a'])} />
       </Notice>
     );

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -7,8 +7,9 @@ import Button from 'ui/components/Button';
 import './styles.scss';
 
 const errorType: 'error' = 'error';
+const genericType: 'generic' = 'generic';
 const successType: 'success' = 'success';
-const validTypes = [errorType, successType];
+const validTypes = [errorType, genericType, successType];
 
 type Props = {
   action?: Function,
@@ -22,11 +23,9 @@ type Props = {
  * A Photon style notification bar.
  *
  * See https://design.firefox.com/photon/components/message-bars.html
- *
- * TODO: implement generic notices and warnings.
  */
 const Notice = ({
-  action, actionText, children, className, type,
+  action, actionText, children, className, type = 'generic',
 }: Props) => {
   if (!validTypes.includes(type)) {
     throw new Error(`Unknown type: ${type}`);

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -25,7 +25,7 @@ type Props = {
  * See https://design.firefox.com/photon/components/message-bars.html
  */
 const Notice = ({
-  action, actionText, children, className, type = 'generic',
+  action, actionText, children, className, type,
 }: Props) => {
   if (!validTypes.includes(type)) {
     throw new Error(`Unknown type: ${type}`);

--- a/src/ui/components/Notice/media/generic-info-mark.svg
+++ b/src/ui/components/Notice/media/generic-info-mark.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="context-fill" fill-rule="evenodd" d="M8 1a7 7 0 1 1-7 7 7 7 0 0 1 7-7zm0 3a1 1 0 1 1-1 1 1 1 0 0 1 1-1zm0 3a1 1 0 0 1 1 1v3a1 1 0 0 1-2 0V8a1 1 0 0 1 1-1z"></path>
+</svg>

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -76,6 +76,31 @@
   }
 }
 
+.Notice-generic {
+  .Notice-button {
+    @include button(
+      $background: $blue-60,
+      $background-active: $blue-80,
+      $background-hover: $blue-70,
+      $color: $grey-90
+    );
+    @include notice_button();
+  }
+
+  .Notice-icon {
+    background-image: url("./media/generic-info-mark.svg");
+  }
+
+  background-color: $grey-20;
+
+  &,
+  :link,
+  :hover,
+  :active {
+    color: $grey-90;
+  }
+}
+
 .Notice-success {
   .Notice-button {
     @include button(

--- a/tests/unit/amo/components/TestAddonCompatibilityError.js
+++ b/tests/unit/amo/components/TestAddonCompatibilityError.js
@@ -79,7 +79,7 @@ describe(__filename, () => {
       'type', 'generic');
   });
 
-  it('renders an error notice for other reasons browsers', () => {
+  it('renders an error notice for other reasons than non-Firefox', () => {
     _dispatchClientMetadata({
       userAgent: userAgentsByPlatform.mac.firefox57,
     });

--- a/tests/unit/amo/components/TestAddonCompatibilityError.js
+++ b/tests/unit/amo/components/TestAddonCompatibilityError.js
@@ -12,6 +12,7 @@ import {
   INCOMPATIBLE_UNDER_MIN_VERSION,
   INCOMPATIBLE_UNSUPPORTED_PLATFORM,
 } from 'core/constants';
+import Notice from 'ui/components/Notice';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import {
   fakeI18n, shallowUntilTarget, userAgentsByPlatform,
@@ -66,6 +67,26 @@ describe(__filename, () => {
     expect(
       root.find('.AddonCompatibilityError').render().text()
     ).toContain('You need to download Firefox to install this add-on.');
+  });
+
+  it('renders a generic notice for non-Firefox browsers', () => {
+    _dispatchClientMetadata({
+      userAgent: userAgentsByPlatform.mac.chrome41,
+    });
+    const root = render({ reason: INCOMPATIBLE_NOT_FIREFOX });
+
+    expect(root.find('.AddonCompatibilityError').find(Notice)).toHaveProp(
+      'type', 'generic');
+  });
+
+  it('renders an error notice for other reasons browsers', () => {
+    _dispatchClientMetadata({
+      userAgent: userAgentsByPlatform.mac.firefox57,
+    });
+    const root = render({ reason: INCOMPATIBLE_OVER_MAX_VERSION });
+
+    expect(root.find('.AddonCompatibilityError').find(Notice)).toHaveProp(
+      'type', 'error');
   });
 
   it('renders a notice if add-on is over maxVersion/compat is strict', () => {


### PR DESCRIPTION
Fix #4547.

### Before
<img width="691" alt="screen shot 2018-03-13 at 8 45 23 am" src="https://user-images.githubusercontent.com/6797635/37352667-0605be58-269b-11e8-9e29-fe676fd6b4af.png">

### After
<img width="786" alt="screenshot 2018-03-13 16 19 41" src="https://user-images.githubusercontent.com/90871/37355071-fba316dc-26da-11e8-8452-f18bed8ba77b.png">