### PR TITLE
I4520 : layout change for addon badges

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -67,6 +67,7 @@
 
   color: $black;
   font-size: $font-size-l;
+  grid-column: 1 / span 2;
   margin: 0 0 $padding-page-l;
   width: 100%;
   word-wrap: break-word;
@@ -100,10 +101,8 @@
 }
 
 .Addon-header {
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-between;
-  position: relative;
+  display: grid;
+  grid-template-columns: 1fr;
 }
 
 .Addon-theme-header {
@@ -131,6 +130,7 @@
 }
 
 .Addon-summary-and-install-button-wrapper {
+  grid-column: 1 / span 2;
   width: 100%;
 
   @include respond-to(medium) {

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -7,19 +7,13 @@
 
   @include respond-to(large) {
     display: flex;
-    flex-flow: row wrap;
+    flex-flow: column;
+    position: absolute;
+    right: 0;
+    width: auto;
   }
 }
 
 .AddonBadges .Badge {
   @include text-align-end();
-
-  @include respond-to(large) {
-    @include margin-end(6px);
-    @include text-align-start();
-  }
-
-  @include respond-to(extraLarge) {
-    @include margin-end($padding-page-l);
-  }
 }

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -12,5 +12,9 @@
 }
 
 .AddonBadges .Badge {
-  @include text-align-end();
+  @include text-align-start();
+
+  @include respond-to(large) {
+    @include text-align-end();
+  }
 }

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -6,11 +6,8 @@
   width: 100%;
 
   @include respond-to(large) {
-    display: flex;
-    flex-flow: column;
-    position: absolute;
-    right: 0;
-    width: auto;
+    grid-column: 2;
+    grid-row: 1;
   }
 }
 

--- a/src/ui/components/Badge/index.js
+++ b/src/ui/components/Badge/index.js
@@ -37,8 +37,8 @@ const Badge = ({ label, type }: Props) => {
 
   return (
     <div className={type ? `Badge Badge-${type}` : 'Badge'}>
-      {label}
       {type && <Icon alt={label} name={getIconNameForType(type)} />}
+      {label}
     </div>
   );
 };

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -9,11 +9,17 @@
   margin: 0 0 6px;
 
   @include respond-to(medium) {
+    display: flex;
+    flex-direction: row-reverse;
     margin: 0 0 12px;
   }
 
   .Icon {
-    @include margin-start(6px);
+    @include margin(0, 6px, 0, 0);
+
+    @include respond-to(medium) {
+      @include margin(0, 0, 0, 6px);
+    }
 
     vertical-align: top;
   }


### PR DESCRIPTION
Fixes #4520 

Before:
<img width="867" alt="screen shot 2018-03-14 at 8 26 49 am" src="https://user-images.githubusercontent.com/5318732/37381216-fa9fa7fa-2761-11e8-81a0-92e5ea1c032b.png">

After:
<img width="866" alt="screen shot 2018-03-14 at 8 27 21 am" src="https://user-images.githubusercontent.com/5318732/37381223-00ac691c-2762-11e8-8716-cd153962e4e0.png">
