### PR TITLE
chore: Allow fetchAddonsByAuthors to search for add-ons without specifying an `exclude_addon` param

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -97,6 +97,7 @@ module.exports = {
     'defaultLang',
     'enableClientConsole',
     'enableCollectionEdit',
+    'enableUserProfile',
     'fxaConfig',
     'isDeployed',
     'isDevelopment',
@@ -288,4 +289,9 @@ module.exports = {
 
   // If true, show a link to the beta versions page on the listing page.
   betaVersions: true,
+
+  // Show and link to User Profiles using the front-end. These pages
+  // are still in development so this should only be enabled locally and
+  // on `-dev`.
+  enableUserProfile: false,
 };

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -28,4 +28,5 @@ module.exports = {
   betaVersions: true,
 
   enableCollectionEdit: true,
+  enableUserProfile: true,
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -12,4 +12,5 @@ module.exports = {
   trackingEnabled: false,
   enableCollectionEdit: true,
   betaVersions: true,
+  enableUserProfile: true,
 };

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -166,7 +166,7 @@ export class AddonBase extends React.Component {
       addonType: addon.type,
       authors: addon.authors.map((author) => author.username),
       errorHandlerId: errorHandler.id,
-      slug: addon.slug,
+      excludeAddonBySlug: addon.slug,
     }));
   }
 

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -20,7 +20,7 @@ import PermissionsCard from 'amo/components/PermissionsCard';
 import DefaultRatingManager from 'amo/components/RatingManager';
 import ScreenShots from 'amo/components/ScreenShots';
 import Link from 'amo/components/Link';
-import { fetchOtherAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
+import { fetchAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
 import {
   fetchAddon,
   getAddonByID,
@@ -119,7 +119,7 @@ export class AddonBase extends React.Component {
         }
 
         dispatch(setViewContext(addon.type));
-        this.dispatchFetchOtherAddonsByAuthors({ addon });
+        this.dispatchFetchAddonsByAuthors({ addon });
       } else {
         dispatch(fetchAddon({ slug: params.slug, errorHandler }));
       }
@@ -139,7 +139,7 @@ export class AddonBase extends React.Component {
     }
 
     if (newAddon && oldAddon !== newAddon) {
-      this.dispatchFetchOtherAddonsByAuthors({ addon: newAddon });
+      this.dispatchFetchAddonsByAuthors({ addon: newAddon });
     }
   }
 
@@ -159,10 +159,10 @@ export class AddonBase extends React.Component {
     this.props.toggleThemePreview(event.currentTarget);
   }
 
-  dispatchFetchOtherAddonsByAuthors({ addon }) {
+  dispatchFetchAddonsByAuthors({ addon }) {
     const { dispatch, errorHandler } = this.props;
 
-    dispatch(fetchOtherAddonsByAuthors({
+    dispatch(fetchAddonsByAuthors({
       addonType: addon.type,
       authors: addon.authors.map((author) => author.username),
       errorHandlerId: errorHandler.id,

--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -101,9 +102,15 @@ export class HeaderBase extends React.Component {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem>
-                <Link href={`/user/${siteUser.username}/`}>
-                  {i18n.gettext('View Profile')}
-                </Link>
+                {config.get('enableUserProfile') ? (
+                  <Link href={`/user/${siteUser.username}/`}>
+                    {i18n.gettext('View Profile')}
+                  </Link>
+                ) : (
+                  <Link to={`/user/${siteUser.username}/`}>
+                    {i18n.gettext('View Profile')}
+                  </Link>
+                )}
               </DropdownMenuItem>
               <DropdownMenuItem>
                 <Link href="/users/edit">

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -1,0 +1,176 @@
+/* @flow */
+import * as React from 'react';
+import Helmet from 'react-helmet';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import NotFound from 'amo/components/ErrorPage/NotFound';
+import ReportUserAbuse from 'amo/components/ReportUserAbuse';
+import { fetchUserAccount } from 'amo/reducers/users';
+import { withErrorHandler } from 'core/errorHandler';
+import translate from 'core/i18n/translate';
+import log from 'core/logger';
+import { sanitizeUserHTML } from 'core/utils';
+import Card from 'ui/components/Card';
+import DefinitionList, { Definition } from 'ui/components/DefinitionList';
+import LoadingText from 'ui/components/LoadingText';
+import Rating from 'ui/components/Rating';
+import UserAvatar from 'ui/components/UserAvatar';
+import type { UsersStateType } from 'amo/reducers/users';
+import type { DispatchFunc } from 'core/types/redux';
+import type { ErrorHandlerType } from 'core/errorHandler';
+import type { I18nType } from 'core/types/i18n';
+
+import './styles.scss';
+
+
+type UserProfileParams = {| username: string |};
+
+type Props = {|
+  dispatch: DispatchFunc,
+  errorHandler: ErrorHandlerType,
+  i18n: I18nType,
+  params: UserProfileParams,
+  users: UsersStateType,
+|};
+
+export class UserProfileBase extends React.Component<Props> {
+  componentWillMount() {
+    const { dispatch, errorHandler, params } = this.props;
+
+    const user = this.getUser(params.username);
+
+    if (!user) {
+      dispatch(fetchUserAccount({
+        errorHandlerId: errorHandler.id,
+        username: params.username,
+      }));
+    }
+  }
+
+  componentWillReceiveProps({ params: newParams }: { params: UserProfileParams }) {
+    const { dispatch, errorHandler, params: oldParams } = this.props;
+
+    if (oldParams.username !== newParams.username) {
+      dispatch(fetchUserAccount({
+        errorHandlerId: errorHandler.id,
+        username: newParams.username,
+      }));
+    }
+  }
+
+  getUser(username: string) {
+    const { users } = this.props;
+
+    return users.byID[users.byUsername[username]];
+  }
+
+  render() {
+    const {
+      errorHandler,
+      i18n,
+      params,
+    } = this.props;
+
+    const user = this.getUser(params.username);
+
+    if (errorHandler.hasError()) {
+      log.warn('Captured API Error:', errorHandler.capturedError);
+
+      if (errorHandler.capturedError.responseStatusCode === 404) {
+        return <NotFound errorCode={errorHandler.capturedError.code} />;
+      }
+    }
+
+    const userProfileHeader = (
+      <React.Fragment>
+        <UserAvatar className="UserProfile-avatar" user={user} />
+
+        <h1 className="UserProfile-name">
+          {user ? user.displayName : <LoadingText />}
+        </h1>
+      </React.Fragment>
+    );
+    const userProfileTitle = i18n.sprintf(
+      i18n.gettext('User Profile for %(user)s'), {
+        user: user ? user.displayName : params.username,
+      }
+    );
+
+    return (
+      <div className="UserProfile">
+        <Helmet>
+          <title>{userProfileTitle}</title>
+        </Helmet>
+
+        {errorHandler.renderErrorIfPresent()}
+
+        <div className="UserProfile-wrapper">
+          <Card
+            className="UserProfile-user-info"
+            header={userProfileHeader}
+          >
+            <DefinitionList className="UserProfile-dl">
+              {user && user.homepage ? (
+                <Definition
+                  className="UserProfile-homepage"
+                  term={i18n.gettext('Homepage')}
+                >
+                  {/* TODO: Make a helper that strips https?:\/\/ from text */}
+                  <a href={user.homepage}>{user.homepage.replace(/^https?:\/\//, '')}</a>
+                </Definition>
+              ) : null}
+              <Definition
+                className="UserProfile-user-since"
+                term={i18n.gettext('User since')}
+              >
+                {user ? i18n.moment(user.created).format('ll')
+                      : <LoadingText />}
+              </Definition>
+              <Definition
+                className="UserProfile-number-of-addons"
+                term={i18n.gettext('Number of add-ons')}
+              >
+                {user ? user.num_addons_listed : <LoadingText />}
+              </Definition>
+              <Definition
+                className="UserProfile-rating-average"
+                term={i18n.gettext('Average rating of developer’s add-ons')}
+              >
+                {user ? (
+                  <Rating
+                    rating={parseFloat(user.average_addon_rating)}
+                    readOnly
+                    styleName="small"
+                  />
+                ) : <LoadingText />}
+              </Definition>
+            </DefinitionList>
+
+            {user && user.biography && user.biography.length ? (
+              <div
+                className="UserProfile-biography"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={sanitizeUserHTML(user.biography)}
+              />
+            ) : null}
+
+            <ReportUserAbuse className="UserProfile-abuse-button" user={user} />
+          </Card>
+        </div>
+      </div>
+    );
+  }
+}
+
+export function mapStateToProps(state: {| users: UsersStateType |}) {
+  return {
+    users: state.users,
+  };
+}
+
+export default compose(
+  connect(mapStateToProps),
+  translate(),
+  withErrorHandler({ name: 'UserProfile' }),
+)(UserProfileBase);

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import NotFound from 'amo/components/ErrorPage/NotFound';
+import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import { fetchUserAccount } from 'amo/reducers/users';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -153,6 +154,8 @@ export class UserProfileBase extends React.Component<Props> {
                 dangerouslySetInnerHTML={sanitizeUserHTML(user.biography)}
               />
             ) : null}
+
+            <ReportUserAbuse className="UserProfile-abuse-button" user={user} />
           </Card>
         </div>
       </div>

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import NotFound from 'amo/components/ErrorPage/NotFound';
-import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import { fetchUserAccount } from 'amo/reducers/users';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -154,8 +153,6 @@ export class UserProfileBase extends React.Component<Props> {
                 dangerouslySetInnerHTML={sanitizeUserHTML(user.biography)}
               />
             ) : null}
-
-            <ReportUserAbuse className="UserProfile-abuse-button" user={user} />
           </Card>
         </div>
       </div>

--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -1,0 +1,49 @@
+@import "~amo/css/inc/vars";
+@import "~core/css/inc/mixins";
+@import "~ui/css/vars";
+
+$avatar-size: 64px;
+
+.UserProfile {
+  margin: $padding-page;
+}
+
+.UserProfile-wrapper {
+  display: flex;
+}
+
+.UserProfile-user-info {
+  @include respond-to(large) {
+    min-width: 300px;
+    width: 35%;
+  }
+}
+
+.UserProfile-avatar {
+  display: block;
+  height: $avatar-size;
+  margin: 0 0 12px;
+  width: $avatar-size;
+}
+
+.UserProfile-name {
+  @include font-regular();
+
+  font-size: $font-size-l;
+  margin: 0;
+
+  @include respond-to(medium) {
+    font-size: $font-size-xl;
+  }
+}
+
+.UserProfile-rating-average .Rating {
+  @include margin-start(-3px);
+
+  justify-content: start;
+  margin: 0;
+}
+
+.UserProfile-abuse-button .ReportUserAbuse-show-more {
+  width: 100%;
+}

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -11,30 +11,30 @@ export const initialState: State = {
   byAddonSlug: {},
 };
 
-export const OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE = 6;
+export const ADDONS_BY_AUTHORS_PAGE_SIZE = 6;
 
 // For further information about this notation, see:
 // https://github.com/mozilla/addons-frontend/pull/3027#discussion_r137661289
-export const FETCH_OTHER_ADDONS_BY_AUTHORS: 'FETCH_OTHER_ADDONS_BY_AUTHORS'
-  = 'FETCH_OTHER_ADDONS_BY_AUTHORS';
-export const LOAD_OTHER_ADDONS_BY_AUTHORS: 'LOAD_OTHER_ADDONS_BY_AUTHORS'
-  = 'LOAD_OTHER_ADDONS_BY_AUTHORS';
+export const FETCH_ADDONS_BY_AUTHORS: 'FETCH_ADDONS_BY_AUTHORS'
+  = 'FETCH_ADDONS_BY_AUTHORS';
+export const LOAD_ADDONS_BY_AUTHORS: 'LOAD_ADDONS_BY_AUTHORS'
+  = 'LOAD_ADDONS_BY_AUTHORS';
 
-type FetchOtherAddonsByAuthorsParams = {|
+type FetchAddonsByAuthorsParams = {|
   addonType: string,
   authors: Array<string>,
   errorHandlerId: string,
   slug: string,
 |};
 
-type FetchOtherAddonsByAuthorsAction = {|
-  type: typeof FETCH_OTHER_ADDONS_BY_AUTHORS,
-  payload: FetchOtherAddonsByAuthorsParams,
+type FetchAddonsByAuthorsAction = {|
+  type: typeof FETCH_ADDONS_BY_AUTHORS,
+  payload: FetchAddonsByAuthorsParams,
 |};
 
-export const fetchOtherAddonsByAuthors = (
-  { addonType, authors, errorHandlerId, slug }: FetchOtherAddonsByAuthorsParams
-): FetchOtherAddonsByAuthorsAction => {
+export const fetchAddonsByAuthors = (
+  { addonType, authors, errorHandlerId, slug }: FetchAddonsByAuthorsParams
+): FetchAddonsByAuthorsAction => {
   if (!errorHandlerId) {
     throw new Error('An errorHandlerId is required');
   }
@@ -56,7 +56,7 @@ export const fetchOtherAddonsByAuthors = (
   }
 
   return {
-    type: FETCH_OTHER_ADDONS_BY_AUTHORS,
+    type: FETCH_ADDONS_BY_AUTHORS,
     payload: {
       addonType,
       authors,
@@ -66,19 +66,19 @@ export const fetchOtherAddonsByAuthors = (
   };
 };
 
-type LoadOtherAddonsByAuthorsParams = {|
+type LoadAddonsByAuthorsParams = {|
   slug: string,
   addons: Array<ExternalAddonType>,
 |};
 
-type LoadOtherAddonsByAuthorsAction = {|
-  type: typeof LOAD_OTHER_ADDONS_BY_AUTHORS,
-  payload: LoadOtherAddonsByAuthorsParams,
+type LoadAddonsByAuthorsAction = {|
+  type: typeof LOAD_ADDONS_BY_AUTHORS,
+  payload: LoadAddonsByAuthorsParams,
 |};
 
-export const loadOtherAddonsByAuthors = (
-  { addons, slug }: LoadOtherAddonsByAuthorsParams
-): LoadOtherAddonsByAuthorsAction => {
+export const loadAddonsByAuthors = (
+  { addons, slug }: LoadAddonsByAuthorsParams
+): LoadAddonsByAuthorsAction => {
   if (!slug) {
     throw new Error('An add-on slug is required.');
   }
@@ -88,21 +88,21 @@ export const loadOtherAddonsByAuthors = (
   }
 
   return {
-    type: LOAD_OTHER_ADDONS_BY_AUTHORS,
+    type: LOAD_ADDONS_BY_AUTHORS,
     payload: { slug, addons },
   };
 };
 
 type Action =
-  | FetchOtherAddonsByAuthorsAction
-  | LoadOtherAddonsByAuthorsAction;
+  | FetchAddonsByAuthorsAction
+  | LoadAddonsByAuthorsAction;
 
 const reducer = (
   state: State = initialState,
   action: Action
 ): State => {
   switch (action.type) {
-    case FETCH_OTHER_ADDONS_BY_AUTHORS:
+    case FETCH_ADDONS_BY_AUTHORS:
       return {
         ...state,
         byAddonSlug: {
@@ -110,13 +110,13 @@ const reducer = (
           [action.payload.slug]: undefined,
         },
       };
-    case LOAD_OTHER_ADDONS_BY_AUTHORS:
+    case LOAD_ADDONS_BY_AUTHORS:
       return {
         ...state,
         byAddonSlug: {
           ...state.byAddonSlug,
           [action.payload.slug]: action.payload.addons
-            .slice(0, OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE)
+            .slice(0, ADDONS_BY_AUTHORS_PAGE_SIZE)
             .map((addon) => createInternalAddon(addon)),
         },
       };

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -2,6 +2,22 @@ import config from 'config';
 import * as React from 'react';
 import { IndexRoute, Route } from 'react-router';
 
+import About from 'amo/components/StaticPages/About';
+import Addon from 'amo/components/Addon';
+import AddonReviewList from 'amo/components/AddonReviewList';
+import App from 'amo/components/App';
+import CategoriesPage from 'amo/components/CategoriesPage';
+import Category from 'amo/components/Category';
+import Home from 'amo/components/Home';
+import LandingPage from 'amo/components/LandingPage';
+import LanguageTools from 'amo/components/LanguageTools';
+import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
+import NotFound from 'amo/components/ErrorPage/NotFound';
+import ReviewGuide from 'amo/components/StaticPages/ReviewGuide';
+import SearchPage from 'amo/components/SearchPage';
+import ServerError from 'amo/components/ErrorPage/ServerError';
+import Collection from 'amo/components/Collection';
+import UserProfile from 'amo/components/UserProfile';
 import SimulateAsyncError from
   'core/containers/error-simulation/SimulateAsyncError';
 import SimulateClientError from
@@ -9,27 +25,11 @@ import SimulateClientError from
 import SimulateSyncError from
   'core/containers/error-simulation/SimulateSyncError';
 
-import About from './components/StaticPages/About';
-import Addon from './components/Addon';
-import AddonReviewList from './components/AddonReviewList';
-import App from './components/App';
-import CategoriesPage from './components/CategoriesPage';
-import Category from './components/Category';
-import Home from './components/Home';
-import LandingPage from './components/LandingPage';
-import LanguageTools from './components/LanguageTools';
-import NotAuthorized from './components/ErrorPage/NotAuthorized';
-import NotFound from './components/ErrorPage/NotFound';
-import ReviewGuide from './components/StaticPages/ReviewGuide';
-import SearchPage from './components/SearchPage';
-import ServerError from './components/ErrorPage/ServerError';
-import Collection from './components/Collection';
-
 // If you add a new route here, check that the nginx rules maintained by ops
 // are in sync. See:
 // https://github.com/mozilla-services/puppet-config/tree/master/amo
 export default (
-  <div>
+  <React.Fragment>
     <Route path="/:lang" component={App}>
       <Route path="about" component={About} />
       { /* TODO: Post launch update this URL and redirect see #3374/ */ }
@@ -39,6 +39,8 @@ export default (
       <IndexRoute component={Home} />
       <Route path="addon/:slug/" component={Addon} />
       <Route path="addon/:addonSlug/reviews/" component={AddonReviewList} />
+      {config.get('enableUserProfile') &&
+        <Route path="user/:username/" component={UserProfile} />}
       <Route path="collections/:user/:slug/" component={Collection} />
       <Route path=":visibleAddonType/categories/" component={CategoriesPage} />
       <Route path=":visibleAddonType/:slug/" component={Category} />
@@ -59,5 +61,5 @@ export default (
       <Route path=":visibleAddonType/" component={LandingPage} />
       <Route path="*" component={NotFound} />
     </Route>
-  </div>
+  </React.Fragment>
 );

--- a/src/amo/sagas/addonsByAuthors.js
+++ b/src/amo/sagas/addonsByAuthors.js
@@ -11,7 +11,7 @@ import { createErrorHandler, getState } from 'core/sagas/utils';
 
 
 export function* fetchAddonsByAuthors({ payload }) {
-  const { errorHandlerId, authors, slug, addonType } = payload;
+  const { errorHandlerId, authors, addonType, excludeAddonBySlug } = payload;
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -24,7 +24,7 @@ export function* fetchAddonsByAuthors({ payload }) {
       filters: {
         addonType,
         author: authors.join(','),
-        exclude_addons: slug,
+        exclude_addons: excludeAddonBySlug,
         page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
         sort: SEARCH_SORT_TRENDING,
       },
@@ -34,7 +34,7 @@ export function* fetchAddonsByAuthors({ payload }) {
     // https://github.com/mozilla/addons-frontend/issues/2917 is done.
     const addons = Object.values(response.entities.addons || {});
 
-    yield put(loadAddonsByAuthors({ addons, slug }));
+    yield put(loadAddonsByAuthors({ addons, excludeAddonBySlug }));
   } catch (error) {
     log.warn(`Search for addons by authors results failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/src/amo/sagas/addonsByAuthors.js
+++ b/src/amo/sagas/addonsByAuthors.js
@@ -1,16 +1,16 @@
 import { call, put, select, takeLatest } from 'redux-saga/effects';
 import { SEARCH_SORT_TRENDING } from 'core/constants';
 import {
-  FETCH_OTHER_ADDONS_BY_AUTHORS,
-  OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
-  loadOtherAddonsByAuthors,
+  FETCH_ADDONS_BY_AUTHORS,
+  ADDONS_BY_AUTHORS_PAGE_SIZE,
+  loadAddonsByAuthors,
 } from 'amo/reducers/addonsByAuthors';
 import { search as searchApi } from 'core/api/search';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 
 
-export function* fetchOtherAddonsByAuthors({ payload }) {
+export function* fetchAddonsByAuthors({ payload }) {
   const { errorHandlerId, authors, slug, addonType } = payload;
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -25,7 +25,7 @@ export function* fetchOtherAddonsByAuthors({ payload }) {
         addonType,
         author: authors.join(','),
         exclude_addons: slug,
-        page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
+        page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
         sort: SEARCH_SORT_TRENDING,
       },
     });
@@ -34,7 +34,7 @@ export function* fetchOtherAddonsByAuthors({ payload }) {
     // https://github.com/mozilla/addons-frontend/issues/2917 is done.
     const addons = Object.values(response.entities.addons || {});
 
-    yield put(loadOtherAddonsByAuthors({ addons, slug }));
+    yield put(loadAddonsByAuthors({ addons, slug }));
   } catch (error) {
     log.warn(`Search for addons by authors results failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));
@@ -42,5 +42,5 @@ export function* fetchOtherAddonsByAuthors({ payload }) {
 }
 
 export default function* addonsByAuthorsSaga() {
-  yield takeLatest(FETCH_OTHER_ADDONS_BY_AUTHORS, fetchOtherAddonsByAuthors);
+  yield takeLatest(FETCH_ADDONS_BY_AUTHORS, fetchAddonsByAuthors);
 }

--- a/src/ui/components/Card/index.js
+++ b/src/ui/components/Card/index.js
@@ -2,7 +2,7 @@ import makeClassName from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import './Card.scss';
+import './styles.scss';
 
 
 export default class Card extends React.Component {
@@ -56,7 +56,12 @@ export default class Card extends React.Component {
         ref={(ref) => { this.cardContainer = ref; }}
       >
         {header ? (
-          <h2 className="Card-header" ref={(ref) => { this.header = ref; }}>{header}</h2>
+          <header
+            className="Card-header"
+            ref={(ref) => { this.header = ref; }}
+          >
+            {header}
+          </header>
         ) : null}
 
         {children ? (

--- a/src/ui/components/Card/styles.scss
+++ b/src/ui/components/Card/styles.scss
@@ -6,6 +6,7 @@ $footer-padding: 10px;
 
 .Card-header {
   @include addonSection();
+  @include font-bold();
   @include text-align-start();
 
   border-top-left-radius: $border-radius-default;

--- a/src/ui/components/DefinitionList/index.js
+++ b/src/ui/components/DefinitionList/index.js
@@ -24,7 +24,7 @@ export const Definition = (
 
 type DefinitionListProps = {|
   className?: string,
-  children: React.ChildrenArray<React.Element<typeof Definition>>,
+  children: React.ChildrenArray<React.Element<typeof Definition> | null>,
 |};
 
 const DefinitionList = ({ className, children }: DefinitionListProps) => {

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -78,6 +78,10 @@
   width: 10px;
 }
 
+.Icon-anonymous-user {
+  @include icon($name: "anonymous-user");
+}
+
 .Icon-user {
   @include icon($name: "user");
 }

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -142,8 +142,8 @@ describe(__filename, () => {
 
   const _loadAddonsByAuthors = ({ addon, addonsByAuthors }) => {
     return loadAddonsByAuthors({
-      slug: addon.slug,
       addons: addonsByAuthors,
+      excludeAddonBySlug: addon.slug,
     });
   };
 
@@ -1077,6 +1077,11 @@ describe(__filename, () => {
       return root.find('.AddonDescription-more-addons');
     };
 
+    const defaultAddonsByAuthors = [{
+      ...fakeAddon,
+      excludeAddonBySlug: 'another-slug',
+    }];
+
     it('fetches the other add-ons by authors', () => {
       const addon = fakeAddon;
       const { store } = dispatchAddonData({ addon });
@@ -1140,7 +1145,7 @@ describe(__filename, () => {
       const addon = fakeTheme;
       const { store } = dispatchAddonData({
         addon,
-        addonsByAuthors: [{ ...fakeTheme, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
 
       const root = renderComponent({ params: { slug: addon.slug }, store });
@@ -1153,7 +1158,7 @@ describe(__filename, () => {
       const addon = fakeAddon;
       const { store } = dispatchAddonData({
         addon,
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: [{ ...fakeAddon, excludeAddonBySlug: 'another-slug' }],
       });
 
       const root = renderComponent({ params: { slug: addon.slug }, store });
@@ -1209,7 +1214,7 @@ describe(__filename, () => {
     it('displays the artist name when add-on is a theme', () => {
       const root = renderMoreAddons({
         addon: fakeTheme,
-        addonsByAuthors: [{ ...fakeTheme, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More themes by MaDonna');
     });
@@ -1239,7 +1244,7 @@ describe(__filename, () => {
           ...fakeTheme,
           authors: Array(2).fill(fakeTheme.authors[0]),
         },
-        addonsByAuthors: [{ ...fakeTheme, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More themes by these artists');
     });

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -31,8 +31,8 @@ import {
   createInternalAddon, fetchAddon as fetchAddonAction, loadAddons,
 } from 'core/reducers/addons';
 import {
-  fetchOtherAddonsByAuthors,
-  loadOtherAddonsByAuthors,
+  fetchAddonsByAuthors,
+  loadAddonsByAuthors,
 } from 'amo/reducers/addonsByAuthors';
 import { setError } from 'core/actions/errors';
 import { setInstallState } from 'core/actions/installations';
@@ -140,8 +140,8 @@ describe(__filename, () => {
     return loadAddons(createFetchAddonResult(addon).entities);
   };
 
-  const _loadOtherAddonsByAuthors = ({ addon, addonsByAuthors }) => {
-    return loadOtherAddonsByAuthors({
+  const _loadAddonsByAuthors = ({ addon, addonsByAuthors }) => {
+    return loadAddonsByAuthors({
       slug: addon.slug,
       addons: addonsByAuthors,
     });
@@ -1064,7 +1064,7 @@ describe(__filename, () => {
       store.dispatch(_loadAddons({ addon }));
 
       if (addonsByAuthors) {
-        store.dispatch(_loadOtherAddonsByAuthors({ addon, addonsByAuthors }));
+        store.dispatch(_loadAddonsByAuthors({ addon, addonsByAuthors }));
       }
 
       return { store };
@@ -1084,7 +1084,7 @@ describe(__filename, () => {
 
       renderComponent({ params: { slug: addon.slug }, store });
 
-      sinon.assert.calledWith(fakeDispatch, fetchOtherAddonsByAuthors({
+      sinon.assert.calledWith(fakeDispatch, fetchAddonsByAuthors({
         addonType: addon.type,
         authors: addon.authors.map((author) => author.username),
         errorHandlerId: createStubErrorHandler().id,
@@ -1128,7 +1128,7 @@ describe(__filename, () => {
       ).addon;
       root.setProps({ addon: addonFromState });
 
-      sinon.assert.calledWith(fakeDispatch, fetchOtherAddonsByAuthors({
+      sinon.assert.calledWith(fakeDispatch, fetchAddonsByAuthors({
         addonType: newAddon.type,
         authors: newAddon.authors.map((author) => author.username),
         errorHandlerId: createStubErrorHandler().id,

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1093,7 +1093,7 @@ describe(__filename, () => {
         addonType: addon.type,
         authors: addon.authors.map((author) => author.username),
         errorHandlerId: createStubErrorHandler().id,
-        slug: addon.slug,
+        excludeAddonBySlug: addon.slug,
       }));
     });
 
@@ -1137,7 +1137,7 @@ describe(__filename, () => {
         addonType: newAddon.type,
         authors: newAddon.authors.map((author) => author.username),
         errorHandlerId: createStubErrorHandler().id,
-        slug: newAddon.slug,
+        excludeAddonBySlug: newAddon.slug,
       }));
     });
 
@@ -1190,7 +1190,7 @@ describe(__filename, () => {
     it('displays the developer name when add-on is an extension', () => {
       const root = renderMoreAddons({
         addon: fakeAddon,
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More extensions by Krupa');
     });
@@ -1198,7 +1198,7 @@ describe(__filename, () => {
     it('displays the translator name when add-on is a dictionary', () => {
       const root = renderMoreAddons({
         addon: { ...fakeAddon, type: ADDON_TYPE_DICT },
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More dictionaries by Krupa');
     });
@@ -1206,7 +1206,7 @@ describe(__filename, () => {
     it('displays the translator name when add-on is a language pack', () => {
       const root = renderMoreAddons({
         addon: { ...fakeAddon, type: ADDON_TYPE_LANG },
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More language packs by Krupa');
     });
@@ -1222,7 +1222,7 @@ describe(__filename, () => {
     it('displays the author name in any other cases', () => {
       const root = renderMoreAddons({
         addon: { ...fakeAddon, type: ADDON_TYPE_OPENSEARCH },
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More add-ons by Krupa');
     });
@@ -1233,7 +1233,7 @@ describe(__filename, () => {
           ...fakeAddon,
           authors: Array(2).fill(fakeAddon.authors[0]),
         },
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More extensions by these developers');
     });
@@ -1256,7 +1256,7 @@ describe(__filename, () => {
           authors: Array(2).fill(fakeAddon.authors[0]),
           type: ADDON_TYPE_LANG,
         },
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root)
         .toHaveProp('header', 'More language packs by these translators');
@@ -1269,7 +1269,7 @@ describe(__filename, () => {
           authors: Array(2).fill(fakeAddon.authors[0]),
           type: ADDON_TYPE_DICT,
         },
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root)
         .toHaveProp('header', 'More dictionaries by these translators');
@@ -1282,7 +1282,7 @@ describe(__filename, () => {
           authors: Array(2).fill(fakeAddon.authors[0]),
           type: ADDON_TYPE_OPENSEARCH,
         },
-        addonsByAuthors: [{ ...fakeAddon, slug: 'another-slug' }],
+        addonsByAuthors: defaultAddonsByAuthors,
       });
       expect(root).toHaveProp('header', 'More add-ons by these developers');
     });

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -1,0 +1,289 @@
+import * as React from 'react';
+
+import UserProfile, { UserProfileBase } from 'amo/components/UserProfile';
+import NotFound from 'amo/components/ErrorPage/NotFound';
+import ReportAbuseButton from 'amo/components/ReportAbuseButton';
+import UserAvatar from 'amo/components/UserAvatar';
+import { fetchUserAccount, getCurrentUser } from 'amo/reducers/users';
+import { ErrorHandler } from 'core/errorHandler';
+import ErrorList from 'ui/components/ErrorList';
+import LoadingText from 'ui/components/LoadingText';
+import Rating from 'ui/components/Rating';
+import { dispatchSignInActions } from 'tests/unit/amo/helpers';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  function renderUserProfile({
+    i18n = fakeI18n(),
+    params = { username: 'tofumatt' },
+    store = dispatchSignInActions({
+      display_name: 'Matt MacTofu',
+      userId: 500,
+      username: 'tofumatt',
+    }).store,
+    ...props
+  // eslint-disable-next-line padded-blocks
+  } = {}) {
+
+    return shallowUntilTarget(
+      <UserProfile i18n={i18n} params={params} store={store} {...props} />,
+      UserProfileBase,
+    );
+  }
+
+  it('renders user profile page', () => {
+    const root = renderUserProfile();
+
+    expect(root.find('.UserProfile')).toHaveLength(1);
+  });
+
+  it('dispatches fetchUserAccount action if username is not found', () => {
+    const { store } = dispatchSignInActions();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const username = 'i-am-not-in-the-store';
+
+    const root = renderUserProfile({ params: { username }, store });
+
+    sinon.assert.calledWith(dispatchSpy, fetchUserAccount({
+      errorHandlerId: root.instance().props.errorHandler.id,
+      username,
+    }));
+  });
+
+  it('dispatches fetchUserAccount action if username param changes', () => {
+    const { store } = dispatchSignInActions({ username: 'black-panther' });
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    const root = renderUserProfile({
+      params: { username: 'black-panther' },
+      store,
+    });
+
+    sinon.assert.notCalled(dispatchSpy);
+
+    root.setProps({ params: { username: 'killmonger' } });
+
+    sinon.assert.calledWith(dispatchSpy, fetchUserAccount({
+      errorHandlerId: root.instance().props.errorHandler.id,
+      username: 'killmonger',
+    }));
+  });
+
+  it('does not dispatch fetchUserAccount if username does not change', () => {
+    const { store } = dispatchSignInActions({ username: 'black-panther' });
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    const root = renderUserProfile({
+      params: { username: 'black-panther' },
+      store,
+    });
+
+    sinon.assert.notCalled(dispatchSpy);
+
+    root.setProps({ params: { username: 'black-panther' } });
+
+    sinon.assert.notCalled(dispatchSpy);
+  });
+
+  it('renders the user avatar', () => {
+    const root = renderUserProfile();
+
+    expect(root.find('.UserProfile-user-info').shallow().find(UserAvatar))
+      .toHaveProp(
+        'user',
+        getCurrentUser(root.instance().props.store.getState().users)
+      );
+  });
+
+  it('renders a placeholder avatar while user is loading', () => {
+    const root = renderUserProfile({ params: { username: 'not-ready' } });
+
+    expect(
+      root.find('.UserProfile-user-info').shallow().find(UserAvatar)
+    ).toHaveProp('user', undefined);
+  });
+
+  it("renders the user's name", () => {
+    const root = renderUserProfile();
+
+    expect(
+      root.find('.UserProfile-user-info').shallow().find('.UserProfile-name')
+    ).toHaveText('Matt MacTofu');
+  });
+
+  it('renders LoadingText when user name is not ready', () => {
+    const root = renderUserProfile({ params: { username: 'not-ready' } });
+
+    expect(
+      root
+        .find('.UserProfile-user-info')
+        .shallow()
+        .find('.UserProfile-name')
+        .find(LoadingText)
+    ).toHaveLength(1);
+  });
+
+  it("renders the user's username if no display name exists", () => {
+    const { store } = dispatchSignInActions({
+      userId: 500,
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(
+      root.find('.UserProfile-user-info').shallow().find('.UserProfile-name')
+    ).toHaveText('tofumatt');
+  });
+
+  it("renders the user's homepage", () => {
+    const { store } = dispatchSignInActions({
+      homepage: 'http://hamsterdance.com/',
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-homepage')).toHaveLength(1);
+    expect(root.find('.UserProfile-homepage').children())
+      .toHaveText('hamsterdance.com/');
+  });
+
+  it("omits homepage if the user doesn't have one set", () => {
+    const { store } = dispatchSignInActions({
+      homepage: null,
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-homepage')).toHaveLength(0);
+  });
+
+  it("renders the user's account creation date", () => {
+    const { store } = dispatchSignInActions({
+      created: '2000-08-15T12:01:13Z',
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-user-since')).toHaveLength(1);
+    expect(root.find('.UserProfile-user-since').children())
+      .toHaveText('Aug 15, 2000');
+  });
+
+  it('renders LoadingText for account creation date while loading', () => {
+    const root = renderUserProfile({ params: { username: 'not-tofu' } });
+
+    expect(root.find('.UserProfile-user-since')).toHaveLength(1);
+    expect(root.find('.UserProfile-user-since').find(LoadingText))
+      .toHaveLength(1);
+  });
+
+  it("renders the user's number of add-ons", () => {
+    const { store } = dispatchSignInActions({
+      num_addons_listed: 70,
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-number-of-addons')).toHaveLength(1);
+    expect(root.find('.UserProfile-number-of-addons').children())
+      .toHaveText('70');
+  });
+
+  it('renders LoadingText for number of add-ons while loading', () => {
+    const root = renderUserProfile({ params: { username: 'not-tofu' } });
+
+    expect(root.find('.UserProfile-number-of-addons')).toHaveLength(1);
+    expect(root.find('.UserProfile-number-of-addons').find(LoadingText))
+      .toHaveLength(1);
+  });
+
+  it("renders the user's average add-on rating", () => {
+    const { store } = dispatchSignInActions({
+      average_addon_rating: 4.1,
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-rating-average')).toHaveLength(1);
+    expect(root.find('.UserProfile-rating-average').find(Rating))
+      .toHaveProp('rating', 4.1);
+  });
+
+  it('renders LoadingText for average add-on rating while loading', () => {
+    const root = renderUserProfile({ params: { username: 'not-tofu' } });
+
+    expect(root.find('.UserProfile-rating-average')).toHaveLength(1);
+    expect(root.find('.UserProfile-rating-average').find(LoadingText))
+      .toHaveLength(1);
+  });
+
+  it("renders the user's biography", () => {
+    const { store } = dispatchSignInActions({
+      biography: 'Not even vegan!',
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-biography').render().html())
+      .toContain('Not even vegan!');
+  });
+
+  it('omits a null biography', () => {
+    const { store } = dispatchSignInActions({
+      biography: null,
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-biography')).toHaveLength(0);
+  });
+
+  it('omits an empty biography', () => {
+    const { store } = dispatchSignInActions({
+      biography: '',
+      username: 'tofumatt',
+    });
+    const root = renderUserProfile({ store });
+
+    expect(root.find('.UserProfile-biography')).toHaveLength(0);
+  });
+
+  it('renders a report abuse button if user is loaded', () => {
+    const root = renderUserProfile();
+
+    expect(root.find(ReportAbuseButton)).toHaveLength(1);
+  });
+
+  it('renders no report abuse button if user is not loaded', () => {
+    const root = renderUserProfile({ params: { username: 'not-loaded' } });
+
+    expect(root.find(ReportAbuseButton)).toHaveLength(0);
+  });
+
+  it('renders a not found page if the API request is a 404', () => {
+    const { store } = dispatchSignInActions();
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      capturedError: { responseStatusCode: 404 },
+      dispatch: store.dispatch,
+    });
+
+    const root = renderUserProfile({ errorHandler, store });
+
+    expect(root.find(NotFound)).toHaveLength(1);
+  });
+
+  it('renders errors', () => {
+    const { store } = dispatchSignInActions();
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: store.dispatch,
+    });
+    errorHandler.handle(new Error('unexpected error'));
+
+    const root = renderUserProfile({ errorHandler, store });
+
+    expect(root.find(ErrorList)).toHaveLength(1);
+  });
+});

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import UserProfile, { UserProfileBase } from 'amo/components/UserProfile';
 import NotFound from 'amo/components/ErrorPage/NotFound';
-// import ReportAbuseButton from 'amo/components/ReportAbuseButton';
+import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import { fetchUserAccount, getCurrentUser } from 'amo/reducers/users';
 import { ErrorHandler } from 'core/errorHandler';
 import ErrorList from 'ui/components/ErrorList';
@@ -92,23 +92,23 @@ describe(__filename, () => {
     sinon.assert.notCalled(dispatchSpy);
   });
 
-  // it('renders the user avatar', () => {
-  //   const root = renderUserProfile();
+  it('renders the user avatar', () => {
+    const root = renderUserProfile();
 
-  //   expect(root.find('.UserProfile-user-info').shallow().find(UserAvatar))
-  //     .toHaveProp(
-  //       'user',
-  //       getCurrentUser(root.instance().props.store.getState().users)
-  //     );
-  // });
+    expect(root.find('.UserProfile-user-info').shallow().find(UserAvatar))
+      .toHaveProp(
+        'user',
+        getCurrentUser(root.instance().props.store.getState().users)
+      );
+  });
 
-  // it('renders a placeholder avatar while user is loading', () => {
-  //   const root = renderUserProfile({ params: { username: 'not-ready' } });
+  it('renders a placeholder avatar while user is loading', () => {
+    const root = renderUserProfile({ params: { username: 'not-ready' } });
 
-  //   expect(
-  //     root.find('.UserProfile-user-info').shallow().find(UserAvatar)
-  //   ).toHaveProp('user', undefined);
-  // });
+    expect(
+      root.find('.UserProfile-user-info').shallow().find(UserAvatar)
+    ).toHaveProp('user', undefined);
+  });
 
   it("renders the user's name", () => {
     const root = renderUserProfile();
@@ -273,17 +273,19 @@ describe(__filename, () => {
     expect(root.find('.UserProfile-biography')).toHaveLength(0);
   });
 
-  // it('renders a report abuse button if user is loaded', () => {
-  //   const root = renderUserProfile();
+  it('renders a report abuse button if user is loaded', () => {
+    const root = renderUserProfile();
 
-  //   expect(root.find(ReportAbuseButton)).toHaveLength(1);
-  // });
-  //
-  // it('renders no report abuse button if user is not loaded', () => {
-  //   const root = renderUserProfile({ params: { username: 'not-loaded' } });
+    expect(root.find(ReportUserAbuse)).toHaveLength(1);
+  });
+  
+  it('still renders a report abuse component if user is not loaded', () => {
+    // The ReportUserAbuse handles an empty `user` object so we should
+    // always pass the `user` prop to it.
+    const root = renderUserProfile({ params: { username: 'not-loaded' } });
 
-  //   expect(root.find(ReportAbuseButton)).toHaveLength(0);
-  // });
+    expect(root.find(ReportUserAbuse)).toHaveLength(1);
+  });
 
   it('renders a not found page if the API request is a 404', () => {
     const { store } = dispatchSignInActions();

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -2,13 +2,13 @@ import * as React from 'react';
 
 import UserProfile, { UserProfileBase } from 'amo/components/UserProfile';
 import NotFound from 'amo/components/ErrorPage/NotFound';
-import ReportAbuseButton from 'amo/components/ReportAbuseButton';
-import UserAvatar from 'amo/components/UserAvatar';
+// import ReportAbuseButton from 'amo/components/ReportAbuseButton';
 import { fetchUserAccount, getCurrentUser } from 'amo/reducers/users';
 import { ErrorHandler } from 'core/errorHandler';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
+import UserAvatar from 'ui/components/UserAvatar';
 import { dispatchSignInActions } from 'tests/unit/amo/helpers';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
@@ -18,9 +18,11 @@ describe(__filename, () => {
     i18n = fakeI18n(),
     params = { username: 'tofumatt' },
     store = dispatchSignInActions({
-      display_name: 'Matt MacTofu',
-      userId: 500,
-      username: 'tofumatt',
+      userProps: {
+        display_name: 'Matt MacTofu',
+        userId: 500,
+        username: 'tofumatt',
+      },
     }).store,
     ...props
   // eslint-disable-next-line padded-blocks
@@ -60,6 +62,8 @@ describe(__filename, () => {
       store,
     });
 
+    dispatchSpy.reset();
+
     sinon.assert.notCalled(dispatchSpy);
 
     root.setProps({ params: { username: 'killmonger' } });
@@ -79,6 +83,8 @@ describe(__filename, () => {
       store,
     });
 
+    dispatchSpy.reset();
+
     sinon.assert.notCalled(dispatchSpy);
 
     root.setProps({ params: { username: 'black-panther' } });
@@ -86,23 +92,23 @@ describe(__filename, () => {
     sinon.assert.notCalled(dispatchSpy);
   });
 
-  it('renders the user avatar', () => {
-    const root = renderUserProfile();
+  // it('renders the user avatar', () => {
+  //   const root = renderUserProfile();
 
-    expect(root.find('.UserProfile-user-info').shallow().find(UserAvatar))
-      .toHaveProp(
-        'user',
-        getCurrentUser(root.instance().props.store.getState().users)
-      );
-  });
+  //   expect(root.find('.UserProfile-user-info').shallow().find(UserAvatar))
+  //     .toHaveProp(
+  //       'user',
+  //       getCurrentUser(root.instance().props.store.getState().users)
+  //     );
+  // });
 
-  it('renders a placeholder avatar while user is loading', () => {
-    const root = renderUserProfile({ params: { username: 'not-ready' } });
+  // it('renders a placeholder avatar while user is loading', () => {
+  //   const root = renderUserProfile({ params: { username: 'not-ready' } });
 
-    expect(
-      root.find('.UserProfile-user-info').shallow().find(UserAvatar)
-    ).toHaveProp('user', undefined);
-  });
+  //   expect(
+  //     root.find('.UserProfile-user-info').shallow().find(UserAvatar)
+  //   ).toHaveProp('user', undefined);
+  // });
 
   it("renders the user's name", () => {
     const root = renderUserProfile();
@@ -126,8 +132,10 @@ describe(__filename, () => {
 
   it("renders the user's username if no display name exists", () => {
     const { store } = dispatchSignInActions({
-      userId: 500,
-      username: 'tofumatt',
+      userProps: {
+        userId: 500,
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -138,8 +146,10 @@ describe(__filename, () => {
 
   it("renders the user's homepage", () => {
     const { store } = dispatchSignInActions({
-      homepage: 'http://hamsterdance.com/',
-      username: 'tofumatt',
+      userProps: {
+        homepage: 'http://hamsterdance.com/',
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -150,8 +160,10 @@ describe(__filename, () => {
 
   it("omits homepage if the user doesn't have one set", () => {
     const { store } = dispatchSignInActions({
-      homepage: null,
-      username: 'tofumatt',
+      userProps: {
+        homepage: null,
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -160,8 +172,10 @@ describe(__filename, () => {
 
   it("renders the user's account creation date", () => {
     const { store } = dispatchSignInActions({
-      created: '2000-08-15T12:01:13Z',
-      username: 'tofumatt',
+      userProps: {
+        created: '2000-08-15T12:01:13Z',
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -180,8 +194,10 @@ describe(__filename, () => {
 
   it("renders the user's number of add-ons", () => {
     const { store } = dispatchSignInActions({
-      num_addons_listed: 70,
-      username: 'tofumatt',
+      userProps: {
+        num_addons_listed: 70,
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -200,8 +216,10 @@ describe(__filename, () => {
 
   it("renders the user's average add-on rating", () => {
     const { store } = dispatchSignInActions({
-      average_addon_rating: 4.1,
-      username: 'tofumatt',
+      userProps: {
+        average_addon_rating: 4.1,
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -220,8 +238,10 @@ describe(__filename, () => {
 
   it("renders the user's biography", () => {
     const { store } = dispatchSignInActions({
-      biography: 'Not even vegan!',
-      username: 'tofumatt',
+      userProps: {
+        biography: 'Not even vegan!',
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -231,8 +251,10 @@ describe(__filename, () => {
 
   it('omits a null biography', () => {
     const { store } = dispatchSignInActions({
-      biography: null,
-      username: 'tofumatt',
+      userProps: {
+        biography: null,
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
@@ -241,25 +263,27 @@ describe(__filename, () => {
 
   it('omits an empty biography', () => {
     const { store } = dispatchSignInActions({
-      biography: '',
-      username: 'tofumatt',
+      userProps: {
+        biography: '',
+        username: 'tofumatt',
+      },
     });
     const root = renderUserProfile({ store });
 
     expect(root.find('.UserProfile-biography')).toHaveLength(0);
   });
 
-  it('renders a report abuse button if user is loaded', () => {
-    const root = renderUserProfile();
+  // it('renders a report abuse button if user is loaded', () => {
+  //   const root = renderUserProfile();
 
-    expect(root.find(ReportAbuseButton)).toHaveLength(1);
-  });
+  //   expect(root.find(ReportAbuseButton)).toHaveLength(1);
+  // });
+  //
+  // it('renders no report abuse button if user is not loaded', () => {
+  //   const root = renderUserProfile({ params: { username: 'not-loaded' } });
 
-  it('renders no report abuse button if user is not loaded', () => {
-    const root = renderUserProfile({ params: { username: 'not-loaded' } });
-
-    expect(root.find(ReportAbuseButton)).toHaveLength(0);
-  });
+  //   expect(root.find(ReportAbuseButton)).toHaveLength(0);
+  // });
 
   it('renders a not found page if the API request is a 404', () => {
     const { store } = dispatchSignInActions();

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -278,7 +278,7 @@ describe(__filename, () => {
 
     expect(root.find(ReportUserAbuse)).toHaveLength(1);
   });
-  
+
   it('still renders a report abuse component if user is not loaded', () => {
     // The ReportUserAbuse handles an empty `user` object so we should
     // always pass the `user` prop to it.

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -1,9 +1,9 @@
 import { ADDON_TYPE_THEME } from 'core/constants';
 import reducer, {
-  OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
-  fetchOtherAddonsByAuthors,
+  ADDONS_BY_AUTHORS_PAGE_SIZE,
+  fetchAddonsByAuthors,
   initialState,
-  loadOtherAddonsByAuthors,
+  loadAddonsByAuthors,
 } from 'amo/reducers/addonsByAuthors';
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon } from 'tests/unit/amo/helpers';
@@ -19,7 +19,7 @@ describe(__filename, () => {
     it('ignores unrelated actions', () => {
       // Load some initial state to be sure that an unrelated action does not
       // change it.
-      const state = reducer(undefined, loadOtherAddonsByAuthors({
+      const state = reducer(undefined, loadAddonsByAuthors({
         slug: fakeAddon.slug,
         addons: [fakeAddon],
       }));
@@ -28,7 +28,7 @@ describe(__filename, () => {
     });
 
     it('allows an empty list of add-ons', () => {
-      const state = reducer(undefined, loadOtherAddonsByAuthors({
+      const state = reducer(undefined, loadAddonsByAuthors({
         slug: 'addon-slug',
         addons: [],
       }));
@@ -38,7 +38,7 @@ describe(__filename, () => {
     });
 
     it('adds related add-ons by slug', () => {
-      const state = reducer(undefined, loadOtherAddonsByAuthors({
+      const state = reducer(undefined, loadAddonsByAuthors({
         slug: 'addon-slug',
         addons: [fakeAddon],
       }));
@@ -49,26 +49,26 @@ describe(__filename, () => {
 
     it('always ensures the page size is consistent', () => {
       const slug = 'addon-slug';
-      const state = reducer(undefined, loadOtherAddonsByAuthors({
+      const state = reducer(undefined, loadAddonsByAuthors({
         slug,
         // This is the case where there are more add-ons loaded than needed.
-        addons: Array(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
+        addons: Array(ADDONS_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
       }));
       expect(state.byAddonSlug[slug])
-        .toHaveLength(OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE);
+        .toHaveLength(ADDONS_BY_AUTHORS_PAGE_SIZE);
     });
 
     it('resets the loaded add-ons', () => {
       const slug = 'addon-slug';
 
-      const previousState = reducer(undefined, loadOtherAddonsByAuthors({
+      const previousState = reducer(undefined, loadAddonsByAuthors({
         addons: [fakeAddon],
         slug,
       }));
       expect(previousState.byAddonSlug)
         .toEqual({ 'addon-slug': [createInternalAddon(fakeAddon)] });
 
-      const state = reducer(previousState, fetchOtherAddonsByAuthors({
+      const state = reducer(previousState, fetchAddonsByAuthors({
         authors: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
@@ -79,7 +79,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('fetchOtherAddonsByAuthors()', () => {
+  describe('fetchAddonsByAuthors()', () => {
     const getParams = () => {
       return {
         authors: ['user1', 'user2'],
@@ -93,7 +93,7 @@ describe(__filename, () => {
       const params = getParams();
       delete params.errorHandlerId;
       expect(() => {
-        fetchOtherAddonsByAuthors(params);
+        fetchAddonsByAuthors(params);
       }).toThrow(/An errorHandlerId is required/);
     });
 
@@ -101,7 +101,7 @@ describe(__filename, () => {
       const params = getParams();
       delete params.slug;
       expect(() => {
-        fetchOtherAddonsByAuthors(params);
+        fetchAddonsByAuthors(params);
       }).toThrow(/An add-on slug is required/);
     });
 
@@ -109,7 +109,7 @@ describe(__filename, () => {
       const params = getParams();
       delete params.addonType;
       expect(() => {
-        fetchOtherAddonsByAuthors(params);
+        fetchAddonsByAuthors(params);
       }).toThrow(/An add-on type is required/);
     });
 
@@ -117,7 +117,7 @@ describe(__filename, () => {
       const params = getParams();
       delete params.authors;
       expect(() => {
-        fetchOtherAddonsByAuthors(params);
+        fetchAddonsByAuthors(params);
       }).toThrow(/Authors are required/);
     });
 
@@ -125,12 +125,12 @@ describe(__filename, () => {
       const params = getParams();
       params.authors = 'invalid-type';
       expect(() => {
-        fetchOtherAddonsByAuthors(params);
+        fetchAddonsByAuthors(params);
       }).toThrow(/The authors parameter must be an array/);
     });
   });
 
-  describe('loadOtherAddonsByAuthors()', () => {
+  describe('loadAddonsByAuthors()', () => {
     const getParams = () => {
       return {
         addons: [fakeAddon],
@@ -142,7 +142,7 @@ describe(__filename, () => {
       const params = getParams();
       delete params.slug;
       expect(() => {
-        loadOtherAddonsByAuthors(params);
+        loadAddonsByAuthors(params);
       }).toThrow(/An add-on slug is required/);
     });
 
@@ -150,7 +150,7 @@ describe(__filename, () => {
       const params = getParams();
       delete params.addons;
       expect(() => {
-        loadOtherAddonsByAuthors(params);
+        loadAddonsByAuthors(params);
       }).toThrow(/A set of add-ons is required/);
     });
   });

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -99,57 +99,6 @@ describe(__filename, () => {
     });
   });
 
-  // describe('fetchAddonsByAuthors()', () => {
-  //   const getParams = () => {
-  //     return {
-  //       authors: ['user1', 'user2'],
-  //       addonType: ADDON_TYPE_THEME,
-  //       errorHandlerId: 'error-handler-id',
-  //       excludeAddonBySlug: 'addon-slug',
-  //     };
-  //   };
-
-  //   it('requires an error id', () => {
-  //     const params = getParams();
-  //     delete params.errorHandlerId;
-  //     expect(() => {
-  //       fetchAddonsByAuthors(params);
-  //     }).toThrow(/An errorHandlerId is required/);
-  //   });
-
-  //   it('requires a slug', () => {
-  //     const params = getParams();
-  //     delete params.slug;
-  //     expect(() => {
-  //       fetchAddonsByAuthors(params);
-  //     }).toThrow(/An add-on slug is required/);
-  //   });
-
-  //   it('requires an add-on type', () => {
-  //     const params = getParams();
-  //     delete params.addonType;
-  //     expect(() => {
-  //       fetchAddonsByAuthors(params);
-  //     }).toThrow(/An add-on type is required/);
-  //   });
-
-  //   it('requires some authors', () => {
-  //     const params = getParams();
-  //     delete params.authors;
-  //     expect(() => {
-  //       fetchAddonsByAuthors(params);
-  //     }).toThrow(/Authors are required/);
-  //   });
-
-  //   it('requires an array of authors', () => {
-  //     const params = getParams();
-  //     params.authors = 'invalid-type';
-  //     expect(() => {
-  //       fetchAddonsByAuthors(params);
-  //     }).toThrow(/The authors parameter must be an array/);
-  //   });
-  // });
-
   describe('loadAddonsByAuthors()', () => {
     const getParams = () => {
       return {

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -59,6 +59,40 @@ describe(__filename, () => {
         filters: {
           addonType: ADDON_TYPE_THEME,
           author: authors.join(','),
+          exclude_addons: undefined, // `callApi` will internally unset this
+          page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
+          sort: SEARCH_SORT_TRENDING,
+        },
+      })
+      .once()
+      .returns(Promise.resolve(createAddonsApiResult(addons)));
+
+    _fetchAddonsByAuthors({ authors });
+
+    const expectedLoadAction = loadAddonsByAuthors({
+      addons,
+      excludeAddonBySlug: undefined,
+    });
+
+    const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
+    mockApi.verify();
+
+    expect(loadAction).toEqual(expectedLoadAction);
+  });
+
+  it('sends `exclude_addons` param if `excludeAddonBySlug` is set', async () => {
+    const addons = [fakeAddon];
+    const authors = ['mozilla', 'johnedoe'];
+    const { slug } = fakeAddon;
+    const state = sagaTester.getState();
+
+    mockApi
+      .expects('search')
+      .withArgs({
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_THEME,
+          author: authors.join(','),
           exclude_addons: slug,
           page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -1,9 +1,9 @@
 import SagaTester from 'redux-saga-tester';
 
 import addonsByAuthorsReducer, {
-  OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
-  fetchOtherAddonsByAuthors,
-  loadOtherAddonsByAuthors,
+  ADDONS_BY_AUTHORS_PAGE_SIZE,
+  fetchAddonsByAuthors,
+  loadAddonsByAuthors,
 } from 'amo/reducers/addonsByAuthors';
 import addonsByAuthorsSaga from 'amo/sagas/addonsByAuthors';
 import {
@@ -38,8 +38,8 @@ describe(__filename, () => {
     sagaTester.start(addonsByAuthorsSaga);
   });
 
-  function _fetchOtherAddonsByAuthors(params) {
-    sagaTester.dispatch(fetchOtherAddonsByAuthors({
+  function _fetchAddonsByAuthors(params) {
+    sagaTester.dispatch(fetchAddonsByAuthors({
       errorHandlerId: errorHandler.id,
       addonType: ADDON_TYPE_THEME,
       ...params,
@@ -60,16 +60,16 @@ describe(__filename, () => {
           addonType: ADDON_TYPE_THEME,
           author: authors.join(','),
           exclude_addons: slug,
-          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
+          page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,
         },
       })
       .once()
       .returns(Promise.resolve(createAddonsApiResult(addons)));
 
-    _fetchOtherAddonsByAuthors({ authors, slug });
+    _fetchAddonsByAuthors({ authors, slug });
 
-    const expectedLoadAction = loadOtherAddonsByAuthors({ addons, slug });
+    const expectedLoadAction = loadAddonsByAuthors({ addons, slug });
 
     await sagaTester.waitFor(expectedLoadAction.type);
     mockApi.verify();
@@ -79,7 +79,7 @@ describe(__filename, () => {
   });
 
   it('clears the error handler', async () => {
-    _fetchOtherAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
+    _fetchAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
 
     const expectedAction = errorHandler.createClearingAction();
 
@@ -95,7 +95,7 @@ describe(__filename, () => {
       .once()
       .returns(Promise.reject(error));
 
-    _fetchOtherAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
+    _fetchAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
 
     const errorAction = errorHandler.createErrorAction(error);
     await sagaTester.waitFor(errorAction.type);
@@ -116,16 +116,16 @@ describe(__filename, () => {
           addonType: ADDON_TYPE_THEME,
           author: authors.join(','),
           exclude_addons: slug,
-          page_size: OTHER_ADDONS_BY_AUTHORS_PAGE_SIZE,
+          page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,
         },
       })
       .once()
       .returns(Promise.resolve(createAddonsApiResult(addons)));
 
-    _fetchOtherAddonsByAuthors({ authors, slug });
+    _fetchAddonsByAuthors({ authors, slug });
 
-    const expectedLoadAction = loadOtherAddonsByAuthors({ addons, slug });
+    const expectedLoadAction = loadAddonsByAuthors({ addons, slug });
 
     await sagaTester.waitFor(expectedLoadAction.type);
     mockApi.verify();

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -67,25 +67,27 @@ describe(__filename, () => {
       .once()
       .returns(Promise.resolve(createAddonsApiResult(addons)));
 
-    _fetchAddonsByAuthors({ authors, slug });
+    _fetchAddonsByAuthors({ authors, excludeAddonBySlug: slug });
 
-    const expectedLoadAction = loadAddonsByAuthors({ addons, slug });
+    const expectedLoadAction = loadAddonsByAuthors({
+      addons,
+      excludeAddonBySlug: slug,
+    });
 
-    await sagaTester.waitFor(expectedLoadAction.type);
+    const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
     mockApi.verify();
 
-    const loadAction = sagaTester.getCalledActions()[2];
     expect(loadAction).toEqual(expectedLoadAction);
   });
 
   it('clears the error handler', async () => {
-    _fetchAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
+    _fetchAddonsByAuthors({ authors: [], excludeAddonBySlug: fakeAddon.slug });
 
     const expectedAction = errorHandler.createClearingAction();
 
-    await sagaTester.waitFor(expectedAction.type);
-    expect(sagaTester.getCalledActions()[1])
-      .toEqual(errorHandler.createClearingAction());
+    const errorAction = await sagaTester.waitFor(expectedAction.type);
+
+    expect(errorAction).toEqual(errorHandler.createClearingAction());
   });
 
   it('dispatches an error', async () => {
@@ -95,11 +97,12 @@ describe(__filename, () => {
       .once()
       .returns(Promise.reject(error));
 
-    _fetchAddonsByAuthors({ authors: [], slug: fakeAddon.slug });
+    _fetchAddonsByAuthors({ authors: [], excludeAddonBySlug: fakeAddon.slug });
 
     const errorAction = errorHandler.createErrorAction(error);
-    await sagaTester.waitFor(errorAction.type);
-    expect(sagaTester.getCalledActions()[2]).toEqual(errorAction);
+    const calledErrorAction = await sagaTester.waitFor(errorAction.type);
+
+    expect(calledErrorAction).toEqual(errorAction);
   });
 
   it('handles no API results', async () => {
@@ -123,14 +126,16 @@ describe(__filename, () => {
       .once()
       .returns(Promise.resolve(createAddonsApiResult(addons)));
 
-    _fetchAddonsByAuthors({ authors, slug });
+    _fetchAddonsByAuthors({ authors, excludeAddonBySlug: slug });
 
-    const expectedLoadAction = loadAddonsByAuthors({ addons, slug });
+    const expectedLoadAction = loadAddonsByAuthors({
+      addons,
+      excludeAddonBySlug: slug,
+    });
 
-    await sagaTester.waitFor(expectedLoadAction.type);
+    const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
     mockApi.verify();
 
-    const loadAction = sagaTester.getCalledActions()[2];
     expect(loadAction).toEqual(expectedLoadAction);
   });
 });


### PR DESCRIPTION
Part of #4280.

Fixes #4556.

Depends on #4469.

Allows `addonsByAuthor` to fetch an author's add-ons without an `exclude_addon` prop sent to the API. This allows a user's add-ons to be show on the user profile without needing to write a whole new reducer; it just makes the slug here optional and names it a bit more clearly.