### PR TITLE
Styles for viewing add-ons within collection manager

### DIFF
--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -197,7 +197,9 @@ export class CollectionManagerBase extends React.Component<Props, State> {
         <div className="CollectionManager-addons">
           {collection && collection.addons && collection.addons.map(
             (addon) => {
-              return <EditableCollectionAddon addon={addon} />;
+              return (
+                <EditableCollectionAddon key={addon.id} addon={addon} />
+              );
             }
           )}
         </div>

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import config from 'config';
 
+import AutoSearchInput from 'amo/components/AutoSearchInput';
+import EditableCollectionAddon
+  from 'amo/components/EditableCollectionAddon';
 import { updateCollection } from 'amo/reducers/collections';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -139,7 +142,10 @@ export class CollectionManagerBase extends React.Component<Props, State> {
         title={i18n.gettext('Edit collection')}
       >
         {errorHandler.renderErrorIfPresent()}
-        <label htmlFor="collectionName">
+        <label
+          className="CollectionManager-collectionName"
+          htmlFor="collectionName"
+        >
           {i18n.gettext('Collection name')}
         </label>
         <input
@@ -178,6 +184,22 @@ export class CollectionManagerBase extends React.Component<Props, State> {
             type="text"
             value={this.state.slug}
           />
+        </div>
+        <AutoSearchInput
+          inputName="collection-addon-query"
+          inputPlaceholder={
+            i18n.gettext('Enter the name of an add-on to include')
+          }
+          onSearch={() => {}}
+          onSuggestionSelected={() => {}}
+          selectSuggestionText={i18n.gettext('Add to collection')}
+        />
+        <div className="CollectionManager-addons">
+          {collection && collection.addons && collection.addons.map(
+            (addon) => {
+              return <EditableCollectionAddon addon={addon} />;
+            }
+          )}
         </div>
       </FormOverlay>
     );

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -9,6 +9,7 @@ import EditableCollectionAddon
   from 'amo/components/EditableCollectionAddon';
 import { updateCollection } from 'amo/reducers/collections';
 import { withFixedErrorHandler } from 'core/errorHandler';
+import log from 'core/logger';
 import translate from 'core/i18n/translate';
 import { decodeHtmlEntities } from 'core/utils';
 import FormOverlay from 'ui/components/FormOverlay';
@@ -113,16 +114,16 @@ export class CollectionManagerBase extends React.Component<Props, State> {
     this.setState({ [event.target.name]: event.target.value });
   }
 
-  // eslint-disable-next-line no-unused-vars
   onSearchAddon = (filters: SearchFilters) => {
     // TODO: implement onSearchAddon
     // https://github.com/mozilla/addons-frontend/issues/4590
+    log.debug('TODO: handle seaching for add-on', filters);
   }
 
-  // eslint-disable-next-line no-unused-vars
   onAddonSelected = (suggestion: SuggestionType) => {
     // TODO: implement onAddonSelected
     // https://github.com/mozilla/addons-frontend/issues/4590
+    log.debug('TODO: handle selecting an add-on', suggestion);
   }
 
   propsToState(props: Props) {
@@ -203,7 +204,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
         <AutoSearchInput
           inputName="collection-addon-query"
           inputPlaceholder={
-            i18n.gettext('Enter the name of an add-on to include')
+            i18n.gettext('Find an add-on to include in this collection')
           }
           onSearch={this.onSearchAddon}
           onSuggestionSelected={this.onAddonSelected}

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -12,6 +12,9 @@ import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import { decodeHtmlEntities } from 'core/utils';
 import FormOverlay from 'ui/components/FormOverlay';
+import type {
+  SearchFilters, SuggestionType,
+} from 'amo/components/AutoSearchInput';
 import type { CollectionType } from 'amo/reducers/collections';
 import type { ApiStateType } from 'core/reducers/api';
 import type { I18nType } from 'core/types/i18n';
@@ -110,6 +113,18 @@ export class CollectionManagerBase extends React.Component<Props, State> {
     this.setState({ [event.target.name]: event.target.value });
   }
 
+  // eslint-disable-next-line no-unused-vars
+  onSearchAddon = (filters: SearchFilters) => {
+    // TODO: implement onSearchAddon
+    // https://github.com/mozilla/addons-frontend/issues/4590
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  onAddonSelected = (suggestion: SuggestionType) => {
+    // TODO: implement onAddonSelected
+    // https://github.com/mozilla/addons-frontend/issues/4590
+  }
+
   propsToState(props: Props) {
     // Decode HTML entities so the user sees real symbols in the form.
     return {
@@ -190,8 +205,8 @@ export class CollectionManagerBase extends React.Component<Props, State> {
           inputPlaceholder={
             i18n.gettext('Enter the name of an add-on to include')
           }
-          onSearch={() => {}}
-          onSuggestionSelected={() => {}}
+          onSearch={this.onSearchAddon}
+          onSuggestionSelected={this.onAddonSelected}
           selectSuggestionText={i18n.gettext('Add to collection')}
         />
         <div className="CollectionManager-addons">

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -1,6 +1,27 @@
 @import "~photon-colors/colors";
 @import "~core/css/inc/mixins";
 @import "~core/css/inc/vars.scss";
+@import "~amo/css/inc/vars";
+
+.CollectionManager {
+  .AutoSearchInput-query {
+    border: 1px solid $grey-50;
+    border-radius: $border-radius-xs;
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
+  .FormOverlay-overlay {
+    height: 90%;
+  }
+}
+
+.CollectionManager .AutoSearchInput--autocompleteIsOpen .AutoSearchInput-query {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
 
 .CollectionManager-slug {
   // Always render the grid left-to-right. This UI involves a URL so
@@ -15,6 +36,17 @@
     border-radius: 0 $border-radius-xs $border-radius-xs 0;
     width: auto;
   }
+}
+
+.FormOverlay-form .CollectionManager-collectionName {
+  // This provides room for an error banner at the top of the form.
+  padding-top: 12px;
+}
+
+.CollectionManager-addons {
+  margin-top: 24px;
+  max-height: 22vh;
+  overflow: auto;
 }
 
 .CollectionManager-slug-url-hint {

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -12,10 +12,6 @@
       box-shadow: none;
     }
   }
-
-  .FormOverlay-overlay {
-    height: 90%;
-  }
 }
 
 .CollectionManager .AutoSearchInput--autocompleteIsOpen .AutoSearchInput-query {
@@ -38,15 +34,13 @@
   }
 }
 
-.FormOverlay-form .CollectionManager-collectionName {
+.FormOverlay-content .CollectionManager-collectionName {
   // This provides room for an error banner at the top of the form.
   padding-top: 12px;
 }
 
 .CollectionManager-addons {
   margin-top: 24px;
-  max-height: 22vh;
-  overflow: auto;
 }
 
 .CollectionManager-slug-url-hint {

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -1,0 +1,26 @@
+/* @flow */
+import makeClassName from 'classnames';
+import * as React from 'react';
+
+import { getAddonIconUrl } from 'core/imageUtils';
+import type { AddonType } from 'core/types/addons';
+
+import './styles.scss';
+
+type Props = {|
+  addon: AddonType,
+|};
+
+const EditableCollectionAddon = ({ addon }: Props) => {
+  const iconURL = getAddonIconUrl(addon);
+  return (
+    <div className="EditableCollectionAddon">
+      <img src={iconURL} alt="" />
+      <h2 className="EditableCollectionAddon-name">
+        {addon.name}
+      </h2>
+    </div>
+  );
+};
+
+export default EditableCollectionAddon;

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -9,12 +9,13 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType,
+  className?: string,
 |};
 
-const EditableCollectionAddon = ({ addon }: Props) => {
+const EditableCollectionAddon = ({ addon, className }: Props) => {
   const iconURL = getAddonIconUrl(addon);
   return (
-    <div className="EditableCollectionAddon">
+    <div className={makeClassName('EditableCollectionAddon', className)}>
       <img src={iconURL} alt="" />
       <h2 className="EditableCollectionAddon-name">
         {addon.name}

--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -1,0 +1,16 @@
+@import "~photon-colors/colors";
+
+.EditableCollectionAddon {
+  border-bottom: 1px solid $grey-30;
+  display: grid;
+  grid-gap: 24px;
+  grid-template-columns: 32px auto;
+  padding: 12px;
+}
+
+.EditableCollectionAddon-name {
+  align-items: center;
+  display: flex;
+  font-size: 16px;
+  margin: 0;
+}

--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -1,4 +1,5 @@
 @import "~photon-colors/colors";
+@import "~core/css/inc/vars";
 
 .EditableCollectionAddon {
   border-bottom: 1px solid $grey-30;
@@ -11,6 +12,6 @@
 .EditableCollectionAddon-name {
   align-items: center;
   display: flex;
-  font-size: 16px;
+  font-size: $font-size-m;
   margin: 0;
 }

--- a/src/ui/components/FormOverlay/index.js
+++ b/src/ui/components/FormOverlay/index.js
@@ -104,52 +104,52 @@ export class FormOverlayBase extends React.Component<Props> {
         className={makeClassName('FormOverlay', className)}
         role="presentation"
       >
-        <div
+        <form
           onClick={this.onClickOverlay}
           className="FormOverlay-overlay"
           role="presentation"
         >
-          <div className="FormOverlay-close-control">
+          <header>
+            <div className="FormOverlay-close-control">
+              <Button
+                className="FormOverlay-close-button"
+                onClick={this.onClickExIcon}
+              >
+                <Icon name="x-mark" alt={i18n.gettext('Click to close')} />
+              </Button>
+            </div>
+            <h3 className="FormOverlay-h3">{title}</h3>
+          </header>
+          <section className="FormOverlay-content">
+            {children}
+          </section>
+          <footer className="FormOverlay-footer">
+            {/*
+              type=button is necessary to override the default
+              of type=submit
+            */}
             <Button
-              className="FormOverlay-close-button"
-              onClick={this.onClickExIcon}
+              buttonType="neutral"
+              disabled={formIsDisabled}
+              onClick={this.onCancel}
+              className="FormOverlay-cancel"
+              puffy
+              type="button"
             >
-              <Icon name="x-mark" alt={i18n.gettext('Click to close')} />
+              {i18n.gettext('Cancel')}
             </Button>
-          </div>
-          <h3 className="FormOverlay-h3">{title}</h3>
-          <div className="FormOverlay-form">
-            <form>
-              {children}
-              <div className="FormOverlay-form-buttons">
-                {/*
-                  type=button is necessary to override the default
-                  of type=submit
-                */}
-                <Button
-                  buttonType="neutral"
-                  disabled={formIsDisabled}
-                  onClick={this.onCancel}
-                  className="FormOverlay-cancel"
-                  puffy
-                  type="button"
-                >
-                  {i18n.gettext('Cancel')}
-                </Button>
-                <Button
-                  buttonType="action"
-                  disabled={formIsDisabled}
-                  className="FormOverlay-submit"
-                  onClick={this.onSubmit}
-                  type="submit"
-                  puffy
-                >
-                  {submitPrompt}
-                </Button>
-              </div>
-            </form>
-          </div>
-        </div>
+            <Button
+              buttonType="action"
+              disabled={formIsDisabled}
+              className="FormOverlay-submit"
+              onClick={this.onSubmit}
+              type="submit"
+              puffy
+            >
+              {submitPrompt}
+            </Button>
+          </footer>
+        </form>
       </div>
     );
   }

--- a/src/ui/components/FormOverlay/styles.scss
+++ b/src/ui/components/FormOverlay/styles.scss
@@ -26,6 +26,11 @@
   padding: 24px;
   width: 95%;
 
+  @include respond-to(extraLarge) {
+    // Set the width to 900px - 22px.
+    width: 876px;
+  }
+
   .ErrorList {
     margin: 0;
   }

--- a/src/ui/components/FormOverlay/styles.scss
+++ b/src/ui/components/FormOverlay/styles.scss
@@ -19,11 +19,12 @@
 .FormOverlay-overlay {
   background-color: $white;
   border-radius: $border-radius-s;
-  display: block;
-  margin: 12px;
-  overflow: auto;
-  min-width: 65%;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  height: 95%;
+  margin: 0;
   padding: 24px;
+  width: 95%;
 
   .ErrorList {
     margin: 0;
@@ -37,7 +38,8 @@
   justify-content: flex-end;
 }
 
-.FormOverlay-form-buttons {
+.FormOverlay-footer {
+  align-items: end;
   display: grid;
   grid-gap: 16px;
   grid-template-columns: min-content min-content;
@@ -57,8 +59,10 @@
   margin: 0 0 12px;
 }
 
-.FormOverlay-form {
-  margin: 0 48px;
+.FormOverlay-content {
+  margin: 0;
+  overflow: auto;
+  padding: 0 48px;
 
   label {
     display: block;

--- a/src/ui/components/FormOverlay/styles.scss
+++ b/src/ui/components/FormOverlay/styles.scss
@@ -21,6 +21,7 @@
   border-radius: $border-radius-s;
   display: block;
   margin: 12px;
+  overflow: auto;
   min-width: 65%;
   padding: 24px;
 
@@ -63,11 +64,6 @@
     display: block;
     font-size: $font-size-s;
     padding: 24px 0 6px;
-  }
-
-  label:first-of-type {
-    // This provides room for an error banner at the top of the form.
-    padding-top: 12px;
   }
 
   input,

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -3,11 +3,14 @@ import * as React from 'react';
 import CollectionManager, {
   extractId, CollectionManagerBase, COLLECTION_OVERLAY,
 } from 'amo/components/CollectionManager';
+import EditableCollectionAddon
+  from 'amo/components/EditableCollectionAddon';
 import {
   createInternalCollection, updateCollection,
 } from 'amo/reducers/collections';
 import { setLang } from 'core/actions';
 import { setErrorMessage } from 'core/actions/errors';
+import { createInternalAddon } from 'core/reducers/addons';
 import { decodeHtmlEntities } from 'core/utils';
 import {
   createFakeEvent,
@@ -16,9 +19,11 @@ import {
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import {
+  createFakeCollectionAddons,
   createFakeCollectionDetail,
   dispatchClientMetadata,
   dispatchSignInActions,
+  fakeAddon,
 } from 'tests/unit/amo/helpers';
 import ErrorList from 'ui/components/ErrorList';
 import FormOverlay from 'ui/components/FormOverlay';
@@ -347,6 +352,26 @@ describe(__filename, () => {
     const state = root.state();
     expect(state.name).toEqual(secondCollection.name);
     expect(state.description).toEqual(secondCollection.description);
+  });
+
+  it('renders editable collection add-ons', () => {
+    const extAddon1 = { ...fakeAddon, name: 'uBlock' };
+    const extAddon2 = { ...fakeAddon, name: 'AdBlockPlus' };
+
+    const collection = createInternalCollection({
+      detail: createFakeCollectionDetail(),
+      items: createFakeCollectionAddons({
+        addons: [extAddon1, extAddon2],
+      }).results,
+    });
+    const root = render({ collection });
+
+    const addons = root.find(EditableCollectionAddon);
+    expect(addons).toHaveLength(2);
+    expect(addons.at(0))
+      .toHaveProp('addon', createInternalAddon(extAddon1));
+    expect(addons.at(1))
+      .toHaveProp('addon', createInternalAddon(extAddon2));
   });
 
   describe('extractId', () => {

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import AutoSearchInput from 'amo/components/AutoSearchInput';
 import CollectionManager, {
   extractId, CollectionManagerBase, COLLECTION_OVERLAY,
 } from 'amo/components/CollectionManager';
@@ -11,14 +12,17 @@ import {
 import { setLang } from 'core/actions';
 import { setErrorMessage } from 'core/actions/errors';
 import { createInternalAddon } from 'core/reducers/addons';
+import { createInternalSuggestion } from 'core/reducers/autocomplete';
 import { decodeHtmlEntities } from 'core/utils';
 import {
   createFakeEvent,
   createStubErrorHandler,
   fakeI18n,
   shallowUntilTarget,
+  simulateComponentCallback,
 } from 'tests/unit/helpers';
 import {
+  createFakeAutocompleteResult,
   createFakeCollectionAddons,
   createFakeCollectionDetail,
   dispatchClientMetadata,
@@ -28,6 +32,11 @@ import {
 import ErrorList from 'ui/components/ErrorList';
 import FormOverlay from 'ui/components/FormOverlay';
 
+const simulateAutoSearchCallback = (props = {}) => {
+  return simulateComponentCallback({
+    Component: AutoSearchInput, ...props,
+  });
+};
 
 describe(__filename, () => {
   let store;
@@ -372,6 +381,31 @@ describe(__filename, () => {
       .toHaveProp('addon', createInternalAddon(extAddon1));
     expect(addons.at(1))
       .toHaveProp('addon', createInternalAddon(extAddon2));
+  });
+
+  it('handles searching for an add-on', () => {
+    const root = render();
+
+    const search = simulateAutoSearchCallback({
+      root, propName: 'onSearch',
+    });
+    search({ query: 'ad blocker' });
+    // TODO: test onSearch
+    // https://github.com/mozilla/addons-frontend/issues/4590
+  });
+
+  it('handles selecting an add-on', () => {
+    const root = render();
+
+    const suggestion = createInternalSuggestion(
+      createFakeAutocompleteResult({ name: 'uBlock Origin' })
+    );
+    const selectSuggestion = simulateAutoSearchCallback({
+      root, propName: 'onSuggestionSelected',
+    });
+    selectSuggestion(suggestion);
+    // TODO: test onSuggestionSelected
+    // https://github.com/mozilla/addons-frontend/issues/4590
   });
 
   describe('extractId', () => {

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -364,13 +364,13 @@ describe(__filename, () => {
   });
 
   it('renders editable collection add-ons', () => {
-    const extAddon1 = { ...fakeAddon, name: 'uBlock' };
-    const extAddon2 = { ...fakeAddon, name: 'AdBlockPlus' };
+    const externalAddon1 = { ...fakeAddon, name: 'uBlock' };
+    const externalAddon2 = { ...fakeAddon, name: 'AdBlockPlus' };
 
     const collection = createInternalCollection({
       detail: createFakeCollectionDetail(),
       items: createFakeCollectionAddons({
-        addons: [extAddon1, extAddon2],
+        addons: [externalAddon1, externalAddon2],
       }).results,
     });
     const root = render({ collection });
@@ -378,9 +378,9 @@ describe(__filename, () => {
     const addons = root.find(EditableCollectionAddon);
     expect(addons).toHaveLength(2);
     expect(addons.at(0))
-      .toHaveProp('addon', createInternalAddon(extAddon1));
+      .toHaveProp('addon', createInternalAddon(externalAddon1));
     expect(addons.at(1))
-      .toHaveProp('addon', createInternalAddon(extAddon2));
+      .toHaveProp('addon', createInternalAddon(externalAddon2));
   });
 
   it('handles searching for an add-on', () => {

--- a/tests/unit/amo/components/TestEditableCollectionAddon.js
+++ b/tests/unit/amo/components/TestEditableCollectionAddon.js
@@ -1,0 +1,38 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import EditableCollectionAddon
+  from 'amo/components/EditableCollectionAddon';
+import { getAddonIconUrl } from 'core/imageUtils';
+import { createInternalAddon } from 'core/reducers/addons';
+import { fakeAddon } from 'tests/unit/amo/helpers';
+
+describe(__filename, () => {
+  const render = ({
+    addon = createInternalAddon(fakeAddon), ...customProps
+  } = {}) => {
+    const props = { addon, ...customProps };
+    return shallow(<EditableCollectionAddon {...props} />);
+  };
+
+  it('renders a custom class name', () => {
+    const root = render({ className: 'MyClass' });
+
+    expect(root).toHaveClassName('MyClass');
+  });
+
+  it('renders an add-on icon', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const root = render({ addon });
+
+    expect(root.find('img')).toHaveProp('src', getAddonIconUrl(addon));
+  });
+
+  it('renders an add-on name', () => {
+    const name = 'uBlock';
+    const addon = createInternalAddon({ ...fakeAddon, name });
+    const root = render({ addon });
+
+    expect(root.find('.EditableCollectionAddon-name')).toHaveText(name);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4579 but check out that issue for a list of what this patch adds. It's pretty much just styles.

![addons-frontend-collection-scroll mov](https://user-images.githubusercontent.com/55398/37620578-a003157a-2b8a-11e8-8624-534c8d9b6ea3.gif)
![addons-frontend-auto-search mov](https://user-images.githubusercontent.com/55398/37620580-a3b8eb22-2b8a-11e8-8392-bde9501a3c99.gif)
