### PR TITLE
Bump postcss-loader to v2.1.1 from v2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
     "photon-colors": "^1.0.3",
     "piping": "^1.0.0-rc.4",
     "po2json": "^0.4.5",
-    "postcss-loader": "^2.0.6",
+    "postcss-loader": "2.1.1",
     "potools": "^0.2.0",
     "react-hot-loader": "^3.1.1",
     "react-test-renderer": "^16.1.1",


### PR DESCRIPTION
The docker image is being built with a ```postcss-loader``` version that has been [updated](https://github.com/postcss/postcss-loader/pull/346) with a breaking change. This pins the version to a known working state until we can investigate further.
