### PR TITLE
fix: Don't show next UserProfile when config disabled

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -66,7 +66,7 @@ export class HeaderBase extends React.Component {
 
     const viewProfileURL = siteUser ? `/user/${siteUser.username}/` : null;
     const viewProfileLinkProps = config.get('enableUserProfile') ?
-      { href: viewProfileURL } : { to: viewProfileURL };
+      { to: viewProfileURL } : { href: viewProfileURL };
 
     return (
       <header className="Header">


### PR DESCRIPTION
Fixes #4619 

I cleaned these up after an r+wc and just mixed up the props/ternary. Easy r?–I'm dumb.