### PR TITLE
Fixes #4633: changed color of "Download Firefox" message bar

### DIFF
--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -98,7 +98,7 @@ export class AddonCompatibilityErrorBase extends React.Component {
     // Make the "you should download firefox" error message less scary than
     // the rest of them: https://github.com/mozilla/addons-frontend/issues/4547
     const noticeType = reason === INCOMPATIBLE_NOT_FIREFOX ?
-      'generic' : 'error';
+      'success' : 'error';
 
     return (
       <Notice type={noticeType} className="AddonCompatibilityError">

--- a/tests/unit/amo/components/TestAddonCompatibilityError.js
+++ b/tests/unit/amo/components/TestAddonCompatibilityError.js
@@ -76,7 +76,7 @@ describe(__filename, () => {
     const root = render({ reason: INCOMPATIBLE_NOT_FIREFOX });
 
     expect(root.find('.AddonCompatibilityError').find(Notice)).toHaveProp(
-      'type', 'generic');
+      'type', 'success');
   });
 
   it('renders an error notice for other reasons than non-Firefox', () => {


### PR DESCRIPTION
Hello, 
I have changed the color of the "Download Firefox" message bar from the grey to green, as requested in #4633. Here is a screenshot of how the message looks right now:
<img width="725" alt="screen shot 2018-03-25 at 8 34 06 pm" src="https://user-images.githubusercontent.com/31850821/37881975-d85974a0-306c-11e8-85e3-e45060ccbc17.png">

