### PR TITLE
Fixes #4648: changed anonymous profile picture size

### DIFF
--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -31,6 +31,11 @@ $avatar-size: 64px;
   width: $avatar-size;
 }
 
+.UserProfile-avatar .Icon {
+  height: $avatar-size;
+  width: $avatar-size;
+}
+
 .UserProfile-name {
   @include font-regular();
 

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -80,9 +80,6 @@
 
 .Icon-anonymous-user {
   @include icon($name: "anonymous-user");
-
-  height: 50px;
-  width: 50px;
 }
 
 .Icon-user {

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -80,6 +80,8 @@
 
 .Icon-anonymous-user {
   @include icon($name: "anonymous-user");
+  height:50px;
+  width:50px;
 }
 
 .Icon-user {

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -80,8 +80,9 @@
 
 .Icon-anonymous-user {
   @include icon($name: "anonymous-user");
-  height:50px;
-  width:50px;
+
+  height: 50px;
+  width: 50px;
 }
 
 .Icon-user {


### PR DESCRIPTION
Hello,
I have changed the default profile picture's size to 50px #4648. 
Here is a screenshot of what it looks like right now:
<img width="470" alt="screen shot 2018-03-28 at 12 21 03 pm" src="https://user-images.githubusercontent.com/31850821/38042784-440c7720-3283-11e8-804c-409470112b55.png">

Please let me know if that is the desired picture size and I will change it if required.