### PR TITLE
Fixes #3231 - Hovering over a star shows the tooltip "No ratings"

### DIFF
--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -97,7 +97,7 @@ export class RatingBase extends React.Component {
       description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5'),
         { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
     } else {
-      description = i18n.gettext('Click the stars to rate this add-on');
+      description = i18n.gettext('Click to rate this add-on');
     }
 
     const allClassNames = makeClassName(

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -97,7 +97,7 @@ export class RatingBase extends React.Component {
       description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5'),
         { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
     } else {
-      description = i18n.gettext('No ratings');
+      description = i18n.gettext('Click the stars to rate this add-on');
     }
 
     const allClassNames = makeClassName(

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -180,12 +180,12 @@ describe(__filename, () => {
 
   it('renders an accessible description for null stars', () => {
     const root = render({ rating: null });
-    expect(findDOMNode(root).textContent).toEqual('No ratings');
+    expect(findDOMNode(root).textContent).toEqual('Click the stars to rate this add-on');
   });
 
   it('renders an accessible description for 0 stars', () => {
     const root = render({ rating: 0 });
-    expect(findDOMNode(root).textContent).toEqual('No ratings');
+    expect(findDOMNode(root).textContent).toEqual('Click the stars to rate this add-on');
   });
 
   it('renders an accessible description for ratings', () => {
@@ -271,7 +271,7 @@ describe(__filename, () => {
     });
 
     it('renders empty ratings', () => {
-      expect(getRating({ rating: null })).toEqual('No ratings');
+      expect(getRating({ rating: null })).toEqual('Click the stars to rate this add-on');
     });
   });
 });

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -180,12 +180,12 @@ describe(__filename, () => {
 
   it('renders an accessible description for null stars', () => {
     const root = render({ rating: null });
-    expect(findDOMNode(root).textContent).toEqual('Click the stars to rate this add-on');
+    expect(findDOMNode(root).textContent).toEqual('Click to rate this add-on');
   });
 
   it('renders an accessible description for 0 stars', () => {
     const root = render({ rating: 0 });
-    expect(findDOMNode(root).textContent).toEqual('Click the stars to rate this add-on');
+    expect(findDOMNode(root).textContent).toEqual('Click to rate this add-on');
   });
 
   it('renders an accessible description for ratings', () => {
@@ -271,7 +271,7 @@ describe(__filename, () => {
     });
 
     it('renders empty ratings', () => {
-      expect(getRating({ rating: null })).toEqual('Click the stars to rate this add-on');
+      expect(getRating({ rating: null })).toEqual('Click to rate this add-on');
     });
   });
 });


### PR DESCRIPTION
Fixes #3231 - Let's display a more appropriate tool-tip when the user has not rated the current add-on.

**Before:**

![tooltip_before](https://user-images.githubusercontent.com/13009507/38159538-6ef38fd6-3478-11e8-8fd1-068cffa85776.gif)


**After:**

![tooltip_after](https://user-images.githubusercontent.com/13009507/38159539-71a8f0e0-3478-11e8-8d46-fa60208a8d34.gif)


