### PR TITLE
Fixes 4689 - icon size in permissions box

### DIFF
--- a/src/amo/components/PermissionsCard/styles.scss
+++ b/src/amo/components/PermissionsCard/styles.scss
@@ -29,7 +29,7 @@
       @include margin-end(12px);
 
       height: 24px;
-      width: 24px;
+      min-width: 24px;
     }
   }
 }


### PR DESCRIPTION
Fixes #4689 

`display: flex` doesn't respect the `width` so enforcing consistent it with `min-width`

Before:
<img width="425" alt="screen shot 2018-03-31 at 10 04 39 am" src="https://user-images.githubusercontent.com/5318732/38159672-1ac24daa-34cb-11e8-9968-eba365dade37.png">

After:
<img width="384" alt="screen shot 2018-03-31 at 10 03 14 am" src="https://user-images.githubusercontent.com/5318732/38159673-2000524e-34cb-11e8-8de8-7b09fb024f49.png">
