### PR TITLE
Add a more intuitive tool-tip for each add-ons rating star

### DIFF
--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -50,7 +50,7 @@ export class RatingBase extends React.Component {
   }
 
   renderRatings() {
-    const { readOnly, i18n } = this.props;
+    const { i18n, readOnly } = this.props;
     // Accept falsey values as if they are zeroes.
     const rating = this.props.rating || 0;
 
@@ -64,14 +64,12 @@ export class RatingBase extends React.Component {
         id: `Rating-rating-${thisRating}`,
         key: `rating-${thisRating}`,
         ref: (ref) => { this.ratingElements[thisRating] = ref; },
-        title: rating ? i18n.sprintf(i18n.gettext(`Update your rating to %(thisRating)s out of 5.`), { thisRating }) :
+        title: (rating && !readOnly) ? i18n.sprintf(i18n.gettext(`Update your rating to %(thisRating)s out of 5.`), { thisRating }) :
           i18n.sprintf(i18n.gettext(`Rate this add-on %(thisRating)s out of 5.`), { thisRating }),
       };
 
       if (readOnly) {
-        props.title = rating ? i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
-          { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) }) :
-          i18n.gettext(`This add-on has not been rated yet.`);
+        props.title = null;
         return <div {...props} />;
       }
 
@@ -87,11 +85,18 @@ export class RatingBase extends React.Component {
   }
 
   render() {
-    const { className, readOnly, styleSize, isOwner } = this.props;
+    const { className, i18n, isOwner, rating, readOnly, styleSize } = this.props;
     if (!RATING_STYLE_SIZES.includes(styleSize)) {
       throw new Error(
         `styleSize=${styleSize} is not a valid value; ` +
         `possible values: ${RATING_STYLE_SIZES.join(', ')}`);
+    }
+
+    let description = null;
+    if (rating && readOnly) {
+      description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'), { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
+    } else {
+      description = i18n.gettext('This add-on has not been rated yet.');
     }
 
     const allClassNames = makeClassName(
@@ -104,9 +109,11 @@ export class RatingBase extends React.Component {
       <div
         className={allClassNames}
         ref={(ref) => { this.element = ref; }}
+        title={description}
       >
         <span className="Rating-star-group">
           {this.renderRatings()}
+          <span className="visually-hidden">{description}</span>
         </span>
       </div>
     );

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -50,7 +50,7 @@ export class RatingBase extends React.Component {
   }
 
   renderRatings() {
-    const { readOnly } = this.props;
+    const { readOnly, i18n } = this.props;
     // Accept falsey values as if they are zeroes.
     const rating = this.props.rating || 0;
 
@@ -64,9 +64,14 @@ export class RatingBase extends React.Component {
         id: `Rating-rating-${thisRating}`,
         key: `rating-${thisRating}`,
         ref: (ref) => { this.ratingElements[thisRating] = ref; },
+        title: rating ? i18n.sprintf(i18n.gettext(`Update your rating to %(thisRating)s out of 5.`), { thisRating }) :
+          i18n.sprintf(i18n.gettext(`Rate this add-on %(thisRating)s out of 5.`), { thisRating }),
       };
 
       if (readOnly) {
+        props.title = rating ? i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
+          { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) }) :
+          i18n.gettext(`This add-on has not been rated yet.`);
         return <div {...props} />;
       }
 
@@ -82,18 +87,11 @@ export class RatingBase extends React.Component {
   }
 
   render() {
-    const { className, i18n, rating, readOnly, styleSize, isOwner } = this.props;
+    const { className, readOnly, styleSize, isOwner } = this.props;
     if (!RATING_STYLE_SIZES.includes(styleSize)) {
       throw new Error(
         `styleSize=${styleSize} is not a valid value; ` +
         `possible values: ${RATING_STYLE_SIZES.join(', ')}`);
-    }
-    let description = i18n.gettext('This add-on has no ratings.');
-    if (rating) {
-      description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5'),
-        { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
-    } else if (!readOnly) {
-      description = i18n.gettext('Click to rate this add-on');
     }
 
     const allClassNames = makeClassName(
@@ -106,11 +104,9 @@ export class RatingBase extends React.Component {
       <div
         className={allClassNames}
         ref={(ref) => { this.element = ref; }}
-        title={description}
       >
         <span className="Rating-star-group">
           {this.renderRatings()}
-          <span className="visually-hidden">{description}</span>
         </span>
       </div>
     );

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -53,18 +53,19 @@ export class RatingBase extends React.Component {
   // for each individual star, as well as the wrapper
   // that surrounds the read-only set of stars
   renderTitle = (i18n, rating, readOnly, starRating) => {
-    if (!readOnly && !rating) {
-      return i18n.sprintf(i18n.gettext(
-        `Rate this add-on %(starRating)s out of 5.`), { starRating });
-    } else if (!readOnly && rating) {
+    if (readOnly) {
+      if (rating) {
+        return i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
+          { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
+      }
+      return i18n.gettext('This add-on has not been rated yet.');
+    }
+    if (rating) {
       return i18n.sprintf(i18n.gettext(
         `Update your rating to %(starRating)s out of 5.`), { starRating });
-    } else if (readOnly && rating) {
-      return i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
-        { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
     }
-    // If it's read only with no rating present
-    return i18n.gettext('This add-on has not been rated yet.');
+    return i18n.sprintf(i18n.gettext(
+      `Rate this add-on %(starRating)s out of 5.`), { starRating });
   }
 
   renderRatings() {

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -51,7 +51,7 @@ export class RatingBase extends React.Component {
 
   // Helper function used to render title attributes
   // for each individual star, as well as the wrapper
-  // that surrounds the read-only set of stars
+  // that surrounds the read-only set of stars.
   renderTitle = (rating, readOnly, starRating) => {
     const { i18n } = this.props;
 
@@ -62,10 +62,12 @@ export class RatingBase extends React.Component {
       }
       return i18n.gettext('This add-on has not been rated yet.');
     }
+
     if (rating) {
       return i18n.sprintf(i18n.gettext(
         `Update your rating to %(starRating)s out of 5.`), { starRating });
     }
+
     return i18n.sprintf(i18n.gettext(
       `Rate this add-on %(starRating)s out of 5.`), { starRating });
   }
@@ -112,7 +114,7 @@ export class RatingBase extends React.Component {
     }
 
     // Wrap read only ratings with a description to maintain functionality
-    // for the "Average rating of developer’s add-ons" tooltip
+    // for the "Average rating of developer’s add-ons" tooltip.
     const description = readOnly ? this.renderTitle(rating, readOnly, null) : null;
 
     const allClassNames = makeClassName(

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -93,10 +93,8 @@ export class RatingBase extends React.Component {
     }
 
     let description = null;
-    if (rating && readOnly) {
-      description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'), { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
-    } else {
-      description = i18n.gettext('This add-on has not been rated yet.');
+    if (readOnly) {
+      description = rating ? description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'), { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) }) : i18n.gettext('This add-on has not been rated yet.');
     }
 
     const allClassNames = makeClassName(

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -64,12 +64,14 @@ export class RatingBase extends React.Component {
         id: `Rating-rating-${thisRating}`,
         key: `rating-${thisRating}`,
         ref: (ref) => { this.ratingElements[thisRating] = ref; },
-        title: (rating && !readOnly) ? i18n.sprintf(i18n.gettext(`Update your rating to %(thisRating)s out of 5.`), { thisRating }) :
-          i18n.sprintf(i18n.gettext(`Rate this add-on %(thisRating)s out of 5.`), { thisRating }),
+        title: !readOnly ? i18n.sprintf(i18n.gettext(`Rate this add-on %(thisRating)s out of 5.`), { thisRating }) : null,
       };
 
+      if (rating && !readOnly) {
+        props.title = i18n.sprintf(i18n.gettext(`Update your rating to %(thisRating)s out of 5.`), { thisRating });
+      }
+
       if (readOnly) {
-        props.title = null;
         return <div {...props} />;
       }
 
@@ -93,8 +95,12 @@ export class RatingBase extends React.Component {
     }
 
     let description = null;
+    // Wrap readOnly ratings with a description to maintain functionality
+    // for the "Average rating of developer’s add-ons" tooltip
     if (readOnly) {
-      description = rating ? description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'), { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) }) : i18n.gettext('This add-on has not been rated yet.');
+      description = rating ? i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
+        { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) }) :
+        i18n.gettext('This add-on has not been rated yet.');
     }
 
     const allClassNames = makeClassName(

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -52,7 +52,9 @@ export class RatingBase extends React.Component {
   // Helper function used to render title attributes
   // for each individual star, as well as the wrapper
   // that surrounds the read-only set of stars
-  renderTitle = (i18n, rating, readOnly, starRating) => {
+  renderTitle = (rating, readOnly, starRating) => {
+    const { i18n } = this.props;
+
     if (readOnly) {
       if (rating) {
         return i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
@@ -69,7 +71,7 @@ export class RatingBase extends React.Component {
   }
 
   renderRatings() {
-    const { i18n, readOnly } = this.props;
+    const { readOnly } = this.props;
     // Accept falsey values as if they are zeroes.
     const rating = this.props.rating || 0;
 
@@ -83,7 +85,7 @@ export class RatingBase extends React.Component {
         id: `Rating-rating-${thisRating}`,
         key: `rating-${thisRating}`,
         ref: (ref) => { this.ratingElements[thisRating] = ref; },
-        title: this.renderTitle(i18n, rating, readOnly, thisRating),
+        title: this.renderTitle(rating, readOnly, thisRating),
       };
 
       if (readOnly) {
@@ -102,7 +104,7 @@ export class RatingBase extends React.Component {
   }
 
   render() {
-    const { className, i18n, isOwner, rating, readOnly, styleSize } = this.props;
+    const { className, isOwner, rating, readOnly, styleSize } = this.props;
     if (!RATING_STYLE_SIZES.includes(styleSize)) {
       throw new Error(
         `styleSize=${styleSize} is not a valid value; ` +
@@ -111,7 +113,7 @@ export class RatingBase extends React.Component {
 
     // Wrap read only ratings with a description to maintain functionality
     // for the "Average rating of developer’s add-ons" tooltip
-    const description = readOnly ? this.renderTitle(i18n, rating, readOnly, null) : null;
+    const description = readOnly ? this.renderTitle(rating, readOnly, null) : null;
 
     const allClassNames = makeClassName(
       'Rating', `Rating--${styleSize}`, className, {

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -49,6 +49,24 @@ export class RatingBase extends React.Component {
     this.props.onSelectRating(rating);
   }
 
+  // Helper function used to render title attributes
+  // for each individual star, as well as the wrapper
+  // that surrounds the read-only set of stars
+  renderTitle = (i18n, rating, readOnly, starRating) => {
+    if (!readOnly && !rating) {
+      return i18n.sprintf(i18n.gettext(
+        `Rate this add-on %(starRating)s out of 5.`), { starRating });
+    } else if (!readOnly && rating) {
+      return i18n.sprintf(i18n.gettext(
+        `Update your rating to %(starRating)s out of 5.`), { starRating });
+    } else if (readOnly && rating) {
+      return i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
+        { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
+    }
+    // If it's read only with no rating present
+    return i18n.gettext('This add-on has not been rated yet.');
+  }
+
   renderRatings() {
     const { i18n, readOnly } = this.props;
     // Accept falsey values as if they are zeroes.
@@ -64,12 +82,8 @@ export class RatingBase extends React.Component {
         id: `Rating-rating-${thisRating}`,
         key: `rating-${thisRating}`,
         ref: (ref) => { this.ratingElements[thisRating] = ref; },
-        title: !readOnly ? i18n.sprintf(i18n.gettext(`Rate this add-on %(thisRating)s out of 5.`), { thisRating }) : null,
+        title: this.renderTitle(i18n, rating, readOnly, thisRating),
       };
-
-      if (rating && !readOnly) {
-        props.title = i18n.sprintf(i18n.gettext(`Update your rating to %(thisRating)s out of 5.`), { thisRating });
-      }
 
       if (readOnly) {
         return <div {...props} />;
@@ -98,9 +112,7 @@ export class RatingBase extends React.Component {
     // Wrap readOnly ratings with a description to maintain functionality
     // for the "Average rating of developer’s add-ons" tooltip
     if (readOnly) {
-      description = rating ? i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5.'),
-        { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) }) :
-        i18n.gettext('This add-on has not been rated yet.');
+      description = this.renderTitle(i18n, rating, readOnly, null);
     }
 
     const allClassNames = makeClassName(

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -108,12 +108,9 @@ export class RatingBase extends React.Component {
         `possible values: ${RATING_STYLE_SIZES.join(', ')}`);
     }
 
-    let description = null;
-    // Wrap readOnly ratings with a description to maintain functionality
+    // Wrap read only ratings with a description to maintain functionality
     // for the "Average rating of developer’s add-ons" tooltip
-    if (readOnly) {
-      description = this.renderTitle(i18n, rating, readOnly, null);
-    }
+    const description = readOnly ? this.renderTitle(i18n, rating, readOnly, null) : null;
 
     const allClassNames = makeClassName(
       'Rating', `Rating--${styleSize}`, className, {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -109,23 +109,6 @@ describe(__filename, () => {
         expect(root.ratingElements[rating].className).toEqual('Rating-choice');
       });
     };
-  });
-  
-  it('renders an appropriate title when updating a rating', () => {
-    const root = render({ rating: 3 });
-
-    [1, 2, 3].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice Rating-selected-star');
-      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
-    });
-    [4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice');
-      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
-    });
-  });
-
-  it('renders selected stars corresponding to rating number', () => {
-    const root = render({ rating: 3 });
 
     // Exact rating.
     let root = render({ rating: 3 });
@@ -157,6 +140,19 @@ describe(__filename, () => {
     // Should round down to a half star.
     root = render({ rating: 3.749 });
     verifyRating(root);
+  });
+
+  it('renders an appropriate title when updating a rating', () => {
+    const root = render({ rating: 3 });
+
+    [1, 2, 3].forEach((rating) => {
+      expect(root.ratingElements[rating].className).toEqual('Rating-choice Rating-selected-star');
+      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
+    });
+    [4, 5].forEach((rating) => {
+      expect(root.ratingElements[rating].className).toEqual('Rating-choice');
+      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
+    });
   });
 
   it('rounds ratings to nearest 0.5 multiple', () => {
@@ -244,7 +240,7 @@ describe(__filename, () => {
     const root = render({ rating: 3, readOnly: true });
 
     [1, 2, 3, 4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].title).toEqual('');
+      expect(root.ratingElements[rating].title).toEqual('Rated 3 out of 5.');
     });
   });
 

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -142,17 +142,6 @@ describe(__filename, () => {
     verifyRating(root);
   });
 
-  it('renders an appropriate title when updating a rating', () => {
-    const root = render({ rating: 3 });
-
-    [1, 2, 3].forEach((rating) => {
-      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
-    });
-    [4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
-    });
-  });
-
   it('rounds ratings to nearest 0.5 multiple', () => {
     // This should be treated like a rating of 3.5 in text.
     const root = render({ rating: 3.60001, readOnly: true });
@@ -196,37 +185,11 @@ describe(__filename, () => {
     });
   });
 
-  it('renders an accessible description for null ratings and readOnly', () => {
-    const root = render({ rating: null, readOnly: true });
-
-    expect(findDOMNode(root).title).toContain('This add-on has not been rated yet.');
-  });
-
-  it('renders an accessible description for ratings', () => {
-    const root = render({ rating: 2 });
+  it('renders an appropriate title when updating a rating', () => {
+    const root = render({ rating: 3 });
 
     [1, 2, 3, 4, 5].forEach((rating) => {
       expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
-    });
-  });
-
-  it('renders an accessible description for read-only ratings', () => {
-    const root = render({ rating: 3, readOnly: true });
-
-    [1, 2, 3, 4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].title).toEqual('Rated 3 out of 5.');
-    });
-  });
-
-  it('renders read-only selected stars', () => {
-    const root = render({ rating: 3, readOnly: true });
-
-    // Make sure only the first 3 stars are selected.
-    [1, 2, 3].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice Rating-selected-star');
-    });
-    [4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice');
     });
   });
 
@@ -299,6 +262,33 @@ describe(__filename, () => {
 
       expect(findDOMNode(root).title).toEqual('Rated 3.8 out of 5.');
     });
+
+    it('renders an accessible description for null ratings and read-only', () => {
+      const root = render({ rating: null, readOnly: true });
+
+      expect(findDOMNode(root).title).toContain('This add-on has not been rated yet.');
+    });
+
+    it('renders read-only selected stars', () => {
+      const root = render({ rating: 3, readOnly: true });
+
+      // Make sure only the first 3 stars are selected.
+      [1, 2, 3].forEach((rating) => {
+        expect(root.ratingElements[rating].className).toEqual(
+          'Rating-choice Rating-selected-star');
+      });
+      [4, 5].forEach((rating) => {
+        expect(root.ratingElements[rating].className).toEqual('Rating-choice');
+      });
+    });
+
+    it('renders an accessible description for read-only ratings', () => {
+      const root = render({ rating: 3, readOnly: true });
+
+      [1, 2, 3, 4, 5].forEach((rating) => {
+        expect(root.ratingElements[rating].title).toEqual('Rated 3 out of 5.');
+      });
+    });
   });
 
   describe('rating counts', () => {
@@ -314,7 +304,8 @@ describe(__filename, () => {
     });
 
     it('renders empty ratings', () => {
-      expect(getRating({ rating: null, readOnly: true })).toEqual('This add-on has not been rated yet.');
+      expect(getRating({ rating: null, readOnly: true })).toEqual(
+        'This add-on has not been rated yet.');
     });
   });
 });

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -146,11 +146,9 @@ describe(__filename, () => {
     const root = render({ rating: 3 });
 
     [1, 2, 3].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice Rating-selected-star');
       expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
     });
     [4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice');
       expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
     });
   });
@@ -160,30 +158,6 @@ describe(__filename, () => {
     const root = render({ rating: 3.60001, readOnly: true });
 
     expect(findDOMNode(root).title).toContain('3.6 out of 5');
-  });
-
-  it('converts rating numbers to a float', () => {
-    const rootWithInteger = render({ rating: 3, readOnly: true });
-    const rootWithString = render({ rating: '3.60001', readOnly: true });
-
-    expect(findDOMNode(rootWithInteger).title).toContain('3 out of 5');
-    expect(findDOMNode(rootWithString).title).toContain('3.6 out of 5');
-  });
-
-  it('rounds readOnly average ratings to nearest 0.5 multiple', () => {
-    // This should be treated like a rating of 3.5.
-    const root = render({ rating: 3.6, readOnly: true });
-
-    // The first three stars are fully highlighted
-    [1, 2, 3].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice Rating-selected-star');
-    });
-    [4].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice Rating-half-star');
-    });
-    [5].forEach((rating) => {
-      expect(root.ratingElements[rating].className).toEqual('Rating-choice');
-    });
   });
 
   it('renders 0 selected stars for empty ratings', () => {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -160,7 +160,7 @@ describe(__filename, () => {
   });
 
   it('rounds ratings to nearest 0.5 multiple', () => {
-    // This should be treated like a rating of 3.6 in text.
+    // This should be treated like a rating of 3.5 in text.
     const root = render({ rating: 3.60001, readOnly: true });
 
     expect(findDOMNode(root).title).toContain('3.6 out of 5');
@@ -226,7 +226,7 @@ describe(__filename, () => {
     });
   });
 
-  it('renders "This add-on has not been rated yet." if no rating and readOnly', () => {
+  it('renders an accessible description for null ratings and readOnly', () => {
     const root = render({ rating: null, readOnly: true });
 
     expect(findDOMNode(root).title).toContain('This add-on has not been rated yet.');
@@ -238,9 +238,14 @@ describe(__filename, () => {
     [1, 2, 3, 4, 5].forEach((rating) => {
       expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
     });
+  });
 
-    const rootReadOnly = render({ rating: 2, readOnly: true });
-    expect(findDOMNode(rootReadOnly).title).toContain('Rated 2 out of 5');
+  it('renders an accessible description for read-only ratings', () => {
+    const root = render({ rating: 3, readOnly: true });
+
+    [1, 2, 3, 4, 5].forEach((rating) => {
+      expect(root.ratingElements[rating].title).toEqual('');
+    });
   });
 
   it('renders read-only selected stars', () => {
@@ -320,9 +325,9 @@ describe(__filename, () => {
     });
 
     it('renders an appropriate title with a given rating when read-only', () => {
-      const root = render({ rating: 3, readOnly: true });
+      const root = render({ rating: 3.8, readOnly: true });
 
-      expect(findDOMNode(root).title).toEqual('Rated 3 out of 5.');
+      expect(findDOMNode(root).title).toEqual('Rated 3.8 out of 5.');
     });
   });
 


### PR DESCRIPTION
#Fixes #4692 - Each rating star should have its own title attribute with the rating number respective to it.