### PR TITLE
I4645 - fix autocomplete height in collection

### DIFF
--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -31,6 +31,12 @@
   word-wrap: break-word;
 }
 
+.Collection-detail {
+  .Card-contents {
+    overflow: visible;
+  }
+}
+
 .Collection-author-name-value {
   overflow-x: hidden;
   text-overflow: ellipsis;

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -13,11 +13,6 @@
     }
   }
 
-  .AutoSearchInput-suggestions-list {
-    max-height: 90px;
-    overflow-y: auto;
-  }
-
   label {
     display: block;
     font-size: $font-size-s;

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -13,6 +13,11 @@
     }
   }
 
+  .AutoSearchInput-suggestions-list {
+    max-height: 90px;
+    overflow-y: auto;
+  }
+
   label {
     display: block;
     font-size: $font-size-s;


### PR DESCRIPTION
#4645 

The `overflow` of `card-contents` is hidden that causes the issue, limiting `AutoSearchInput` to `max-height: 90px` that is 3 addon.

Before:
<img width="538" alt="screen shot 2018-04-01 at 7 27 00 pm" src="https://user-images.githubusercontent.com/5318732/38173904-dd4545cc-35e2-11e8-80a3-8182753d9381.png">

After:
<img width="1424" alt="screen shot 2018-04-02 at 8 39 03 pm" src="https://user-images.githubusercontent.com/5318732/38201449-f588d2e2-36b5-11e8-9bd1-2ed4e0729164.png">
