### PR TITLE
Fixes #4626: added spacing between 'featured' badge and theme preview in Theme details page

### DIFF
--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -12,9 +12,13 @@
 }
 
 .AddonBadges .Badge {
+  margin: 0 0 0 6px;
+
   @include text-align-start();
 
   @include respond-to(large) {
+    margin: 0 0 0 12px;
+
     @include text-align-end();
   }
 }

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -12,13 +12,11 @@
 }
 
 .AddonBadges .Badge {
-  margin: 0 0 0 6px;
-
+  @include margin-start(6px);
   @include text-align-start();
 
   @include respond-to(large) {
-    margin: 0 0 0 12px;
-
+    @include margin-start(12px);
     @include text-align-end();
   }
 }


### PR DESCRIPTION
I have added spacing between 'featured' badge and theme preview in Theme details page. 
I have modified left margins only by 6px and 12px based on the screen size. #4626 

Before:
<img width="809" alt="screen shot 2018-04-02 at 9 54 22 am" src="https://user-images.githubusercontent.com/31850821/38198935-b51c1a6a-365c-11e8-8846-0a425008487a.png">

After:
<img width="829" alt="screen shot 2018-04-02 at 9 53 24 am" src="https://user-images.githubusercontent.com/31850821/38198927-b09634c6-365c-11e8-82c0-c2c01dfe99a4.png">

 
