### PR TITLE
Fixes #4318: Made 'Log in to flag review' button shorter and less weird

### DIFF
--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -14,6 +14,10 @@
   .ErrorList {
     margin-top: 6px;
   }
+
+  .TooltipMenu {
+    width: 220px;
+  }
 }
 
 .AddonReviewListItem-review-header {

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -16,7 +16,7 @@
   }
 
   .TooltipMenu {
-    width: 220px;
+    width: fit-content;
   }
 }
 


### PR DESCRIPTION
#4318 : The button was centered already, so I have fixed width of the pop-up window and made it less 'weird' as was suggested in comments. Please let me know if that is something you were looking for or if you would like to make it shorter.

Before:
<img width="809" alt="screen shot 2018-04-02 at 1 08 24 pm" src="https://user-images.githubusercontent.com/31850821/38206715-73866cb4-3679-11e8-89c8-7fc37720763d.png">

After:
<img width="810" alt="screen shot 2018-04-02 at 1 07 47 pm" src="https://user-images.githubusercontent.com/31850821/38206722-7a549c00-3679-11e8-8755-6498b419f27b.png">

