### PR TITLE
fix: Do not show rating option when readOnly set

### DIFF
--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -92,7 +92,7 @@ export class RatingBase extends React.Component {
         `styleSize=${styleSize} is not a valid value; ` +
         `possible values: ${RATING_STYLE_SIZES.join(', ')}`);
     }
-    let description;
+    let description = i18n.gettext('This add-on has no ratings.');
     if (rating) {
       description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5'),
         { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -96,7 +96,7 @@ export class RatingBase extends React.Component {
     if (rating) {
       description = i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5'),
         { rating: i18n.formatNumber(parseFloat(rating).toFixed(1)) });
-    } else {
+    } else if (!readOnly) {
       description = i18n.gettext('Click to rate this add-on');
     }
 

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -190,7 +190,7 @@ describe(__filename, () => {
 
   it('renders nothing if no rating and readOnly', () => {
     const root = render({ rating: null, readOnly: true });
-    expect(findDOMNode(root).textContent).toEqual('');
+    expect(findDOMNode(root).textContent).toEqual('This add-on has no ratings.');
   });
 
   it('renders an accessible description for ratings', () => {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -188,7 +188,7 @@ describe(__filename, () => {
     expect(findDOMNode(root).textContent).toEqual('Click to rate this add-on');
   });
 
-  it('renders nothing if no rating and readOnly', () => {
+  it('renders "no ratings" if no rating and readOnly', () => {
     const root = render({ rating: null, readOnly: true });
     expect(findDOMNode(root).textContent).toEqual('This add-on has no ratings.');
   });

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -188,6 +188,11 @@ describe(__filename, () => {
     expect(findDOMNode(root).textContent).toEqual('Click to rate this add-on');
   });
 
+  it('renders nothing if no rating and readOnly', () => {
+    const root = render({ rating: null, readOnly: true });
+    expect(findDOMNode(root).textContent).toEqual('');
+  });
+
   it('renders an accessible description for ratings', () => {
     const root = render({ rating: 2 });
     expect(findDOMNode(root).textContent).toEqual('Rated 2 out of 5');
@@ -203,6 +208,7 @@ describe(__filename, () => {
     [4, 5].forEach((rating) => {
       expect(root.ratingElements[rating].className).toEqual('Rating-choice');
     });
+    expect(findDOMNode(root).textContent).toEqual('Rated 3 out of 5');
   });
 
   it('prevents form submission when selecting a rating', () => {


### PR DESCRIPTION
fix #4706

### Before
![image](https://user-images.githubusercontent.com/31961530/38190180-cbc63746-366b-11e8-971f-5090ef214a30.png)

### After
<img width="185" alt="screenshot 2018-04-03 10 23 48" src="https://user-images.githubusercontent.com/90871/38241045-1c7c838a-3729-11e8-8357-32a168503310.png">
