### PR TITLE
Properly implement the collectionUpdates state

### DIFF
--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -34,6 +34,10 @@ export const UPDATE_COLLECTION: 'UPDATE_COLLECTION' = 'UPDATE_COLLECTION';
 export const DELETE_COLLECTION_BY_SLUG: 'DELETE_COLLECTION_BY_SLUG'
   = 'DELETE_COLLECTION_BY_SLUG';
 export const CREATE_COLLECTION: 'CREATE_COLLECTION' = 'CREATE_COLLECTION';
+export const BEGIN_COLLECTION_MODIFICATION: 'BEGIN_COLLECTION_MODIFICATION'
+  = 'BEGIN_COLLECTION_MODIFICATION';
+export const FINISH_COLLECTION_MODIFICATION: 'FINISH_COLLECTION_MODIFICATION'
+  = 'FINISH_COLLECTION_MODIFICATION';
 
 export type CollectionType = {
   addons: Array<AddonType> | null,
@@ -80,9 +84,7 @@ export type CollectionsState = {
       |};
     },
   },
-  collectionUpdates: {
-    [collectionSlug: string]: {| updating: boolean, successful?: boolean |},
-  },
+  isCollectionBeingModified: boolean,
 };
 
 export const initialState: CollectionsState = {
@@ -91,7 +93,7 @@ export const initialState: CollectionsState = {
   current: { id: null, loading: false },
   userCollections: {},
   addonInCollections: {},
-  collectionUpdates: {},
+  isCollectionBeingModified: false,
 };
 
 type FetchCurrentCollectionParams = {|
@@ -539,6 +541,32 @@ export const updateCollection = ({
   };
 };
 
+type BeginCollectionModificationAction = {|
+  type: typeof BEGIN_COLLECTION_MODIFICATION,
+  payload: null,
+|};
+
+export const beginCollectionModification = ():
+  BeginCollectionModificationAction => {
+  return {
+    type: BEGIN_COLLECTION_MODIFICATION,
+    payload: null,
+  };
+};
+
+type FinishCollectionModificationAction = {|
+  type: typeof FINISH_COLLECTION_MODIFICATION,
+  payload: null,
+|};
+
+export const finishCollectionModification = ():
+  FinishCollectionModificationAction => {
+  return {
+    type: FINISH_COLLECTION_MODIFICATION,
+    payload: null,
+  };
+};
+
 type DeleteCollectionBySlugAction = {|
   type: typeof DELETE_COLLECTION_BY_SLUG,
   payload: {| slug: string |},
@@ -694,7 +722,8 @@ type Action =
   | LoadCurrentCollectionAction
   | LoadCurrentCollectionPageAction
   | LoadUserCollectionsAction
-  | UpdateCollectionAction
+  | BeginCollectionModificationAction
+  | FinishCollectionModificationAction
 ;
 
 const reducer = (
@@ -911,17 +940,17 @@ const reducer = (
       });
     }
 
-    case UPDATE_COLLECTION: {
-      const { collectionSlug } = action.payload;
-
+    case BEGIN_COLLECTION_MODIFICATION: {
       return {
         ...state,
-        collectionUpdates: {
-          [collectionSlug]: {
-            ...state.collectionUpdates[collectionSlug],
-            updating: true,
-          },
-        },
+        isCollectionBeingModified: true,
+      };
+    }
+
+    case FINISH_COLLECTION_MODIFICATION: {
+      return {
+        ...state,
+        isCollectionBeingModified: false,
       };
     }
 

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -22,6 +22,8 @@ import {
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
+  beginCollectionModification,
+  finishCollectionModification,
 } from 'amo/reducers/collections';
 import * as api from 'amo/api/collections';
 import log from 'core/logger';
@@ -182,6 +184,8 @@ export function* modifyCollection(
     user,
   } = payload;
 
+  yield put(beginCollectionModification());
+
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
 
@@ -220,6 +224,7 @@ export function* modifyCollection(
       };
       yield call(api.updateCollection, apiParams);
     }
+    yield put(finishCollectionModification());
 
     const { lang, clientApp } = state.api;
     const effectiveSlug = slug || collectionSlug;
@@ -244,6 +249,7 @@ export function* modifyCollection(
     }
   } catch (error) {
     log.warn(`Failed to ${type}: ${error}`);
+    yield put(finishCollectionModification());
     yield put(errorHandler.createErrorAction(error));
   }
 }

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -224,7 +224,6 @@ export function* modifyCollection(
       };
       yield call(api.updateCollection, apiParams);
     }
-    yield put(finishCollectionModification());
 
     const { lang, clientApp } = state.api;
     const effectiveSlug = slug || collectionSlug;
@@ -249,8 +248,9 @@ export function* modifyCollection(
     }
   } catch (error) {
     log.warn(`Failed to ${type}: ${error}`);
-    yield put(finishCollectionModification());
     yield put(errorHandler.createErrorAction(error));
+  } finally {
+    yield put(finishCollectionModification());
   }
 }
 

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -18,7 +18,8 @@ import reducer, {
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
-  updateCollection,
+  beginCollectionModification,
+  finishCollectionModification,
 } from 'amo/reducers/collections';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 import {
@@ -829,18 +830,19 @@ describe(__filename, () => {
     });
   });
 
-  describe('updateCollection', () => {
-    it('changes update state', () => {
-      const collectionSlug = 'some-collection';
+  describe('beginCollectionModification', () => {
+    it('records the beginning of a modification', () => {
+      const state = reducer(initialState, beginCollectionModification());
 
-      const state = reducer(initialState, updateCollection({
-        errorHandlerId: 'error-handler-id',
-        collectionSlug,
-        user: 'some-user-name',
-      }));
+      expect(state.isCollectionBeingModified).toEqual(true);
+    });
+  });
 
-      expect(state.collectionUpdates[collectionSlug].updating)
-        .toEqual(true);
+  describe('finishCollectionModification', () => {
+    it('records the end of a modification', () => {
+      const state = reducer(initialState, finishCollectionModification());
+
+      expect(state.isCollectionBeingModified).toEqual(false);
     });
   });
 


### PR DESCRIPTION
Fixes #4717 

This finishes implementing the collectionUpdates state which is managed by the collections reducer. The state will be set to `updating: true` when an update is started, and to `updating: false` when an update finishes. In addition, the state will have a `successful: true` if there were no errors, and a `successful: false` if there were errors. It also introduces a `getCollectionUpdateStatus` function which will return the current update status of a collection. This will be used on the CollectionManager screen to address issue #4635, which will be completed in a separate PR.