### PR TITLE
chore: Add edit user reducer actions (#4668)

### DIFF
--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -1,6 +1,6 @@
 import reducer, {
   LOAD_USER_ACCOUNT,
-  cancelEditUserAccount,
+  finishEditUserAccount,
   editUserAccount,
   getCurrentUser,
   getDisplayName,
@@ -12,8 +12,6 @@ import reducer, {
   loadCurrentUserAccount,
   loadUserAccount,
   logOutUser,
-  setUserAsEditing,
-  setUserAsNotEditing,
 } from 'amo/reducers/users';
 import {
   ADDONS_POSTREVIEW,
@@ -55,9 +53,7 @@ describe(__filename, () => {
 
       expect(action.type).toEqual(LOAD_USER_ACCOUNT);
       expect(action.payload).toEqual({ user });
-      expect(state.isEditingById).toMatchObject({
-        [user.id]: false,
-      });
+      expect(state.isEditing).toEqual(false);
     });
 
     it('handles LOG_OUT_USER', () => {
@@ -70,7 +66,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('cancelEditUserAccount', () => {
+  describe('finishEditUserAccount', () => {
     it('sets a user account to not editing', () => {
       const user = createUserAccountResponse();
       const userFields = { biography: 'Punk rock music fan' };
@@ -80,11 +76,9 @@ describe(__filename, () => {
         userFields,
         userId: user.id,
       }));
-      state = reducer(state, cancelEditUserAccount({ userId: user.id }));
+      state = reducer(state, finishEditUserAccount());
 
-      expect(state.isEditingById).toMatchObject({
-        [user.id]: false,
-      });
+      expect(state.isEditing).toEqual(false);
     });
   });
 
@@ -99,9 +93,7 @@ describe(__filename, () => {
         userId: user.id,
       }));
 
-      expect(state.isEditingById).toMatchObject({
-        [user.id]: true,
-      });
+      expect(state.isEditing).toEqual(true);
     });
   });
 
@@ -292,30 +284,6 @@ describe(__filename, () => {
       });
 
       expect(getUserByUsername(state.users, 'Biggie')).toBeUndefined();
-    });
-  });
-
-  describe('setUserAsEditing helper', () => {
-    it('sets a user as editing', () => {
-      const { state } = dispatchSignInActions({
-        userProps: { id: 500, username: 'Tupac' },
-      });
-
-      expect(setUserAsEditing({ state, userId: 500 })).toEqual({
-        isEditingById: { 500: true },
-      });
-    });
-  });
-
-  describe('setUserAsNotEditing helper', () => {
-    it('sets a user as not editing', () => {
-      const { state } = dispatchSignInActions({
-        userProps: { id: 500, username: 'Tupac' },
-      });
-
-      expect(setUserAsNotEditing({ state, userId: 500 })).toEqual({
-        isEditingById: { 500: false },
-      });
     });
   });
 });

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -1,15 +1,19 @@
 import reducer, {
   LOAD_USER_ACCOUNT,
+  cancelEditUserAccount,
+  editUserAccount,
   getCurrentUser,
   getDisplayName,
+  getUserById,
   getUserByUsername,
-  fetchUserAccount,
   hasAnyReviewerRelatedPermission,
   hasPermission,
   initialState,
   loadCurrentUserAccount,
   loadUserAccount,
   logOutUser,
+  setUserAsEditing,
+  setUserAsNotEditing,
 } from 'amo/reducers/users';
 import {
   ADDONS_POSTREVIEW,
@@ -25,10 +29,7 @@ import {
   dispatchClientMetadata,
   dispatchSignInActions,
 } from 'tests/unit/amo/helpers';
-import {
-  createStubErrorHandler,
-  createUserAccountResponse,
-} from 'tests/unit/helpers';
+import { createUserAccountResponse } from 'tests/unit/helpers';
 
 
 describe(__filename, () => {
@@ -47,37 +48,16 @@ describe(__filename, () => {
       expect(newState).toEqual(state);
     });
 
-    it('throws when no errorHandlerId is passed to fetchUserAccount', () => {
-      expect(() => {
-        fetchUserAccount({ username: 'Cool Kat' });
-      }).toThrowError('errorHandlerId is required');
-    });
-
-    it('throws when no username is passed to fetchUserAccount', () => {
-      const errorHandlerId = createStubErrorHandler().id;
-      expect(() => {
-        fetchUserAccount({ errorHandlerId });
-      }).toThrowError('username is required');
-    });
-
-    it('requires user for loadCurrentUserAccount', () => {
-      expect(() => {
-        loadCurrentUserAccount({});
-      }).toThrowError('user is required');
-    });
-
     it('loadUserAccount returns a user', () => {
-      const user = createUserAccountResponse();
+      const user = createUserAccountResponse({ id: 12345, username: 'john' });
       const action = loadUserAccount({ user });
+      const state = reducer(initialState, action);
 
       expect(action.type).toEqual(LOAD_USER_ACCOUNT);
       expect(action.payload).toEqual({ user });
-    });
-
-    it('throws when no username is passed to loadUserAccount', () => {
-      expect(() => {
-        loadUserAccount({});
-      }).toThrowError('user is required');
+      expect(state.isEditingById).toMatchObject({
+        [user.id]: false,
+      });
     });
 
     it('handles LOG_OUT_USER', () => {
@@ -87,6 +67,41 @@ describe(__filename, () => {
       const { currentUserID } = reducer(state, logOutUser());
 
       expect(currentUserID).toEqual(null);
+    });
+  });
+
+  describe('cancelEditUserAccount', () => {
+    it('sets a user account to not editing', () => {
+      const user = createUserAccountResponse();
+      const userFields = { biography: 'Punk rock music fan' };
+
+      let state = reducer(initialState, editUserAccount({
+        errorHandlerId: 'fake-error-id',
+        userFields,
+        userId: user.id,
+      }));
+      state = reducer(state, cancelEditUserAccount({ userId: user.id }));
+
+      expect(state.isEditingById).toMatchObject({
+        [user.id]: false,
+      });
+    });
+  });
+
+  describe('editUserAccount', () => {
+    it('sets user account to editing', () => {
+      const user = createUserAccountResponse();
+      const userFields = { biography: 'Punk rock music fan' };
+
+      const state = reducer(initialState, editUserAccount({
+        errorHandlerId: 'fake-error-id',
+        userFields,
+        userId: user.id,
+      }));
+
+      expect(state.isEditingById).toMatchObject({
+        [user.id]: true,
+      });
     });
   });
 
@@ -102,20 +117,6 @@ describe(__filename, () => {
       const { state } = dispatchClientMetadata();
 
       expect(getCurrentUser(state.users)).toEqual(null);
-    });
-
-    it('throws if currentUserID exists but user does not', () => {
-      // This signifies a bug in our app:
-      // https://github.com/mozilla/addons-frontend/pull/4031#discussion_r155665367
-      const { state } = dispatchSignInActions();
-      const buggyUsersState = {
-        ...state,
-        users: { ...state.users, byID: {}, byUsername: {} },
-      };
-
-      expect(() => {
-        getCurrentUser(buggyUsersState.users);
-      }).toThrowError(/currentUserID is defined but no matching user found/);
     });
   });
 
@@ -151,7 +152,6 @@ describe(__filename, () => {
     it('returns `true` when user is admin', () => {
       const permissions = [ALL_SUPER_POWERS];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
-
 
       expect(hasPermission(state, THEMES_REVIEW)).toEqual(true);
     });
@@ -258,6 +258,24 @@ describe(__filename, () => {
     });
   });
 
+  describe('getUserById selector', () => {
+    it('returns a user from state', () => {
+      const { state } = dispatchSignInActions({
+        userProps: { id: 500, username: 'Tupac' },
+      });
+
+      expect(getUserById(state.users, 500)).toEqual(state.users.byID[500]);
+    });
+
+    it('returns undefined if no user is found', () => {
+      const { state } = dispatchSignInActions({
+        userProps: { id: 500, username: 'Tupac' },
+      });
+
+      expect(getUserById(state.users, 441)).toBeUndefined();
+    });
+  });
+
   describe('getUserByUsername selector', () => {
     it('returns a user from state', () => {
       const { state } = dispatchSignInActions({
@@ -268,12 +286,36 @@ describe(__filename, () => {
         .toEqual(state.users.byID[500]);
     });
 
-    it('returns null if no user is found', () => {
+    it('returns undefined if no user is found', () => {
       const { state } = dispatchSignInActions({
         userProps: { id: 500, username: 'Tupac' },
       });
 
       expect(getUserByUsername(state.users, 'Biggie')).toBeUndefined();
+    });
+  });
+
+  describe('setUserAsEditing helper', () => {
+    it('sets a user as editing', () => {
+      const { state } = dispatchSignInActions({
+        userProps: { id: 500, username: 'Tupac' },
+      });
+
+      expect(setUserAsEditing({ state, userId: 500 })).toEqual({
+        isEditingById: { 500: true },
+      });
+    });
+  });
+
+  describe('setUserAsNotEditing helper', () => {
+    it('sets a user as not editing', () => {
+      const { state } = dispatchSignInActions({
+        userProps: { id: 500, username: 'Tupac' },
+      });
+
+      expect(setUserAsNotEditing({ state, userId: 500 })).toEqual({
+        isEditingById: { 500: false },
+      });
     });
   });
 });


### PR DESCRIPTION
Part of #4668.

This adds the reducer code needed to allow us to edit users. The `editUserAccount` action will be used to dispatch an action to a saga that will call the edit API.

That API returns the updated edit user object, so we'll just use the existing `loadUserAccount` action to update the user account in state after editing.