### PR TITLE
fix: #4621 regressions

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -490,7 +490,7 @@ export class AddonBase extends React.Component {
                 authorNames={addon.authors.map((author) => author.username)}
                 className="Addon-MoreAddonsCard"
                 forAddonSlug={addon.slug}
-                numberOfAddons={3}
+                numberOfAddons={6}
               />
             )}
 
@@ -524,7 +524,7 @@ export class AddonBase extends React.Component {
               authorNames={addon.authors.map((author) => author.username)}
               className="Addon-MoreAddonsCard"
               forAddonSlug={addon.slug}
-              numberOfAddons={4}
+              numberOfAddons={6}
             />
           )}
         </div>

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1123,6 +1123,9 @@ describe(__filename, () => {
         { ...fakeAddon, slug: 'addon-1', id: 1 },
         { ...fakeAddon, slug: 'addon-2', id: 2 },
         { ...fakeAddon, slug: 'addon-3', id: 3 },
+        { ...fakeAddon, slug: 'addon-4', id: 4 },
+        { ...fakeAddon, slug: 'addon-5', id: 5 },
+        { ...fakeAddon, slug: 'addon-6', id: 6 },
       ];
 
       const root = renderMoreAddons({ addon, addonsByAuthors });
@@ -1133,15 +1136,18 @@ describe(__filename, () => {
       );
       expect(root).toHaveProp('addonType', addon.type);
       expect(root).toHaveProp('forAddonSlug', addon.slug);
-      expect(root).toHaveProp('numberOfAddons', 4);
+      expect(root).toHaveProp('numberOfAddons', 6);
     });
 
     it('displays more add-ons by authors when add-on is a theme', () => {
-      const addon = createInternalAddon({ ...fakeAddon, type: ADDON_TYPE_THEME });
+      const addon = createInternalAddon({ ...fakeTheme });
       const addonsByAuthors = [
-        { ...fakeAddon, slug: 'addon-1', id: 1 },
-        { ...fakeAddon, slug: 'addon-2', id: 2 },
-        { ...fakeAddon, slug: 'addon-3', id: 3 },
+        { ...fakeTheme, slug: 'theme-1', id: 1 },
+        { ...fakeTheme, slug: 'theme-2', id: 2 },
+        { ...fakeTheme, slug: 'theme-3', id: 3 },
+        { ...fakeTheme, slug: 'theme-4', id: 4 },
+        { ...fakeTheme, slug: 'theme-5', id: 5 },
+        { ...fakeTheme, slug: 'theme-6', id: 6 },
       ];
 
       const root = renderMoreAddons({ addon, addonsByAuthors });
@@ -1152,7 +1158,7 @@ describe(__filename, () => {
       );
       expect(root).toHaveProp('addonType', addon.type);
       expect(root).toHaveProp('forAddonSlug', addon.slug);
-      expect(root).toHaveProp('numberOfAddons', 3);
+      expect(root).toHaveProp('numberOfAddons', 6);
     });
 
     it('adds a CSS class to the main component when there are add-ons', () => {


### PR DESCRIPTION
Closes #4621.

Restores the correct number of add-ons to the "more add-ons by authors" cards on the add-on details.

### Before
![morebyauthornumberextensions](https://user-images.githubusercontent.com/1583842/38317399-ad26d0f4-3835-11e8-972c-472eb52448f8.gif)
![morebyauthornumber](https://user-images.githubusercontent.com/1583842/38316761-1e333c30-3834-11e8-97c4-7006b8a1ed01.gif)

### After
<img width="1361" alt="screenshot 2018-04-05 15 17 34" src="https://user-images.githubusercontent.com/90871/38371575-b2c093b0-38e4-11e8-8045-4008861580a9.png">
<img width="1361" alt="screenshot 2018-04-05 15 17 26" src="https://user-images.githubusercontent.com/90871/38371577-b2f175fc-38e4-11e8-8f25-0f1806fbfae7.png">