### PR TITLE
Remove validation for collection name from CollectionManager form

### DIFF
--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -87,7 +87,6 @@ export class CollectionManagerBase extends React.Component<Props, State> {
       collection,
       errorHandler,
       dispatch,
-      i18n,
       siteLang,
     } = this.props;
     event.preventDefault();
@@ -104,14 +103,6 @@ export class CollectionManagerBase extends React.Component<Props, State> {
       // a user will not likely see this.
       throw new Error(
         'The form cannot be submitted without a site language');
-    }
-
-    // Do some form validation.
-    if (!this.state.name) {
-      errorHandler.addMessage(
-        i18n.gettext('Collection name cannot be blank')
-      );
-      return;
     }
 
     dispatch(updateCollection({

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -8,7 +8,6 @@ import {
   createInternalCollection, updateCollection,
 } from 'amo/reducers/collections';
 import { setLang } from 'core/actions';
-import { setErrorMessage } from 'core/actions/errors';
 import { CLIENT_APP_FIREFOX } from 'core/constants';
 import { createInternalSuggestion } from 'core/reducers/autocomplete';
 import { decodeHtmlEntities } from 'core/utils';
@@ -237,23 +236,6 @@ describe(__filename, () => {
     const root = render({ errorHandler });
 
     expect(root.find(ErrorList)).toHaveLength(1);
-  });
-
-  it('reports an error when the name is blank', () => {
-    dispatchSignInActions({ store });
-    const dispatchSpy = sinon.spy(store, 'dispatch');
-    const root = render();
-
-    // Enter in a blank collection name.
-    typeInput({ root, name: 'name', text: '' });
-
-    dispatchSpy.reset();
-    simulateSubmit(root);
-
-    sinon.assert.calledWith(dispatchSpy, setErrorMessage({
-      id: root.instance().props.errorHandler.id,
-      message: 'Collection name cannot be blank',
-    }));
   });
 
   it('disables submit button when the name is blank', () => {


### PR DESCRIPTION
Fixes #4720 
Removed validation code. 
As described by @bobsilverberg in issue #4720, validation was insufficient, as it allowed a name which consisted of only blanks. This validation is no longer needed after PR #4698 addressed the issue by preventing the form from being submitted with a blank collection name.