### PR TITLE
Temporarily disable Disco Pane tests on Travis (#4747)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,24 +47,26 @@ jobs:
       <<: *node-prod
       script: yarn nsp-check
     # Run the functional tests.
-    - stage:
-      <<: *tox
-      addons:
-        firefox: latest-nightly
-        hosts: example.com
-      env: TOXENV=discopane-ui-tests GECKODRIVER=0.19.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
-      install:
-        - yarn
-        - yarn start-func-test-server &
-      before_script:
-        - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER/geckodriver-v$GECKODRIVER-linux64.tar.gz
-        - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver
-        - export PATH=$HOME/geckodriver:$PATH
-        - firefox --version
-        - geckodriver --version
-        - pip install tox
-        # Wait for server to be available
-        - until $(curl --output /dev/null --silent --head --fail -k https://example.com:4000); do printf '.'; sleep 5; done
+    # HACK: Commented out because of
+    # https://github.com/mozilla/addons-frontend/issues/4747
+    # - stage:
+    #   <<: *tox
+    #   addons:
+    #     firefox: latest-nightly
+    #     hosts: example.com
+    #   env: TOXENV=discopane-ui-tests GECKODRIVER=0.19.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
+    #   install:
+    #     - yarn
+    #     - yarn start-func-test-server &
+    #   before_script:
+    #     - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER/geckodriver-v$GECKODRIVER-linux64.tar.gz
+    #     - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver
+    #     - export PATH=$HOME/geckodriver:$PATH
+    #     - firefox --version
+    #     - geckodriver --version
+    #     - pip install tox
+    #     # Wait for server to be available
+    #     - until $(curl --output /dev/null --silent --head --fail -k https://example.com:4000); do printf '.'; sleep 5; done
     - stage:
       <<: *tox
       env: TOXENV=flake8


### PR DESCRIPTION
More of a band-aid than a fix, but right now the constantly failing master builds are making it too easy to ignore an actual failing build.