### PR TITLE
feat: Add extensions and themes to profile

### DIFF
--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -42,7 +42,7 @@ type Props = {|
 
   // AddonCards prop this component also accepts
   showSummary?: boolean,
-  type?: 'horizontal',
+  type?: 'horizontal' | 'vertical',
 |};
 
 export class AddonsByAuthorsCardBase extends React.Component<Props> {

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -6,16 +6,21 @@
   margin-top: 0;
 
   .Card-contents .AddonsCard-list {
-    background-color: $white;
-    display: grid;
-    grid-auto-flow: initial;
-    grid-gap: 6px;
-    grid-template-columns: repeat(2, 1fr);
     margin: 0;
     padding: 0;
 
     .SearchResult-metadata {
       display: none;
+    }
+  }
+
+  &.AddonsCard--horizontal {
+    .Card-contents .AddonsCard-list {
+      background-color: $white;
+      display: grid;
+      grid-auto-flow: initial;
+      grid-gap: 6px;
+      grid-template-columns: repeat(3, 1fr);
     }
   }
 }

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -19,7 +19,7 @@ type Props = {|
   // When loading, this is the number of placeholders
   // that will be rendered.
   placeholderCount: number,
-  type?: 'horizontal',
+  type?: 'horizontal' | 'vertical',
   showMetadata?: boolean,
   showSummary?: boolean,
 
@@ -74,9 +74,8 @@ export default class AddonsCard extends React.Component<Props> {
       }
     }
 
-    const allClassNames = makeClassName('AddonsCard', className, {
-      'AddonsCard--horizontal': type === 'horizontal',
-    });
+    const allClassNames = makeClassName('AddonsCard', className,
+      type && `AddonsCard--${type}`);
     return (
       <CardList
         {...otherProps}

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -4,9 +4,14 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import AddonsByAuthorsCard from 'amo/components/AddonsByAuthorsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import { fetchUserAccount, getUserByUsername } from 'amo/reducers/users';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
+} from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
@@ -150,6 +155,24 @@ export class UserProfileBase extends React.Component<Props> {
 
             <ReportUserAbuse className="UserProfile-abuse-button" user={user} />
           </Card>
+
+          {user && user.username && (
+            <div className="UserProfile-addons-by-author">
+              <AddonsByAuthorsCard
+                addonType={ADDON_TYPE_EXTENSION}
+                authorNames={[user.username]}
+                numberOfAddons={3}
+                showSummary
+                type="vertical"
+              />
+
+              <AddonsByAuthorsCard
+                addonType={ADDON_TYPE_THEME}
+                authorNames={[user.username]}
+                numberOfAddons={6}
+              />
+            </div>
+          )}
         </div>
       </div>
     );

--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -15,6 +15,7 @@ $avatar-size: 64px;
 
 .UserProfile-wrapper {
   display: flex;
+  justify-content: flex-start;
 }
 
 .UserProfile-user-info {
@@ -53,6 +54,17 @@ $avatar-size: 64px;
   justify-content: start;
 }
 
-.UserProfile-abuse-button .ReportUserAbuse-show-more {
+.UserProfile-abuse-button {
+  margin-top: 24px;
+
+  .ReportUserAbuse-show-more {
+    width: 100%;
+  }
+}
+
+.UserProfile-addons-by-author {
+  @include margin(0, 0, 0, 12px);
+
+  max-width: 60%;
   width: 100%;
 }

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
+import AddonsByAuthorsCard from 'amo/components/AddonsByAuthorsCard';
 import UserProfile, { UserProfileBase } from 'amo/components/UserProfile';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import { fetchUserAccount, getCurrentUser } from 'amo/reducers/users';
 import { createApiError } from 'core/api';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
+} from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
@@ -288,6 +293,32 @@ describe(__filename, () => {
     const root = renderUserProfile({ params: { username: 'not-loaded' } });
 
     expect(root.find(ReportUserAbuse)).toHaveLength(1);
+  });
+
+  it('renders two AddonsByAuthorsCard', () => {
+    const root = renderUserProfile();
+
+    expect(root.find(AddonsByAuthorsCard)).toHaveLength(2);
+  });
+
+  it('renders AddonsByAuthorsCard for extensions', () => {
+    const root = renderUserProfile();
+
+    expect(root.find(AddonsByAuthorsCard).at(0))
+      .toHaveProp('addonType', ADDON_TYPE_EXTENSION);
+  });
+
+  it('renders AddonsByAuthorsCard for themes', () => {
+    const root = renderUserProfile();
+
+    expect(root.find(AddonsByAuthorsCard).at(1))
+      .toHaveProp('addonType', ADDON_TYPE_THEME);
+  });
+
+  it('renders no AddonsByAuthorsCard if no user found', () => {
+    const root = renderUserProfile({ params: { username: 'not-loaded' } });
+
+    expect(root.find(AddonsByAuthorsCard)).toHaveLength(0);
   });
 
   it('renders a not found page if the API request is a 404', () => {


### PR DESCRIPTION
Fix #4280
Fix #4281

Screenshots:

<img width="1361" alt="screenshot 2018-04-06 15 27 54" src="https://user-images.githubusercontent.com/90871/38428264-514570d6-39b3-11e8-8fd8-8819ef7a15b3.png">
<img width="1361" alt="screenshot 2018-04-06 15 27 52" src="https://user-images.githubusercontent.com/90871/38428265-5184fb5c-39b3-11e8-91d9-f3246127a510.png">

(they would both show for a user with both extensions and themes, but I couldn't find one 😆)