### PR TITLE
Fixes:4770 Fixing "s" for setting in Control browser proxy settings permission

### DIFF
--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -38,7 +38,7 @@ export class PermissionUtils {
       nativeMessaging: i18n.gettext('Exchange messages with programs other than Firefox'),
       notifications: i18n.gettext('Display notifications to you'),
       pkcs11: i18n.gettext('Provide cryptographic authentication services'),
-      proxy: i18n.gettext('Control browser proxy setting'),
+      proxy: i18n.gettext('Control browser proxy settings'),
       privacy: i18n.gettext('Read and modify privacy settings'),
       sessions: i18n.gettext('Access recently closed tabs'),
       tabs: i18n.gettext('Access browser tabs'),


### PR DESCRIPTION
Fixing #4770 

![screenshot-2018-4-11 all of the permissions add-ons for firefox](https://user-images.githubusercontent.com/22130317/38578617-12d6d516-3d22-11e8-966f-e788646390d6.png)

