### PR TITLE
Add an add-on to a collection from the edit screen

### DIFF
--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -5,6 +5,7 @@ import * as React from 'react';
 
 import EditableCollectionAddon from 'amo/components/EditableCollectionAddon';
 import SearchResult from 'amo/components/SearchResult';
+import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import CardList from 'ui/components/CardList';
 import type { AddonType } from 'core/types/addons';
 
@@ -37,8 +38,7 @@ export default class AddonsCard extends React.Component<Props> {
   static defaultProps = {
     editing: false,
     loading: false,
-    // Set this to the default API page size.
-    placeholderCount: 25,
+    placeholderCount: DEFAULT_API_PAGE_SIZE,
   }
 
   render() {

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -123,7 +123,7 @@ export class CollectionBase extends React.Component<Props> {
 
     if (!collection || collectionChanged) {
       this.props.dispatch(fetchCurrentCollection({
-        allAddons: editing,
+        fetchAllAddons: editing,
         errorHandlerId: errorHandler.id,
         page: location.query.page,
         slug: params.slug,

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -14,6 +14,7 @@ import {
 } from 'amo/reducers/collections';
 import CollectionManager from 'amo/components/CollectionManager';
 import NotFound from 'amo/components/ErrorPage/NotFound';
+import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import {
   COLLECTIONS_EDIT, INSTALL_SOURCE_COLLECTION,
@@ -72,7 +73,7 @@ export class CollectionBase extends React.Component<Props> {
   }
 
   loadDataIfNeeded(nextProps?: Props) {
-    const { collection, errorHandler, loading, params } = {
+    const { collection, editing, errorHandler, loading, params } = {
       ...this.props,
       ...nextProps,
     };
@@ -89,6 +90,15 @@ export class CollectionBase extends React.Component<Props> {
     let collectionChanged = false;
     let addonsPageChanged = false;
     let { location } = this.props;
+
+    // When editing we want to load all add-ons into the collection, so if
+    // we've switched into or out of editing we need to check the size of the
+    // collection.addons array and re-fetch the collection if necessary.
+    if (collection && collection.addons &&
+      ((editing && collection.addons.length !== collection.numberOfAddons) ||
+      (!editing && collection.addons.length > DEFAULT_API_PAGE_SIZE))) {
+      collectionChanged = true;
+    }
 
     if (nextProps && nextProps.location) {
       const nextLocation = nextProps.location;
@@ -113,6 +123,7 @@ export class CollectionBase extends React.Component<Props> {
 
     if (!collection || collectionChanged) {
       this.props.dispatch(fetchCurrentCollection({
+        allAddons: editing,
         errorHandlerId: errorHandler.id,
         page: location.query.page,
         slug: params.slug,
@@ -238,7 +249,7 @@ export class CollectionBase extends React.Component<Props> {
             editing={editing}
             loading={!collection || loading}
           />
-          {collection && collection.numberOfAddons > 0 && (
+          {collection && collection.numberOfAddons > 0 && !editing && (
             <Paginate
               LinkComponent={Link}
               count={collection.numberOfAddons}

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -9,6 +9,7 @@ import config from 'config';
 
 import AutoSearchInput from 'amo/components/AutoSearchInput';
 import {
+  addAddonToCollection,
   createCollection,
   updateCollection,
 } from 'amo/reducers/collections';
@@ -47,6 +48,7 @@ type Props = {|
   isCollectionBeingModified: boolean,
   router: ReactRouterType,
   siteLang: ?string,
+  siteUserId: number | null,
 |};
 
 type State = {|
@@ -162,9 +164,24 @@ export class CollectionManagerBase extends React.Component<Props, State> {
   };
 
   onAddonSelected = (suggestion: SuggestionType) => {
-    // TODO: implement onAddonSelected
-    // https://github.com/mozilla/addons-frontend/issues/4590
-    log.debug('TODO: handle selecting an add-on', suggestion);
+    // TODO: This works, but it doesn't update the list of addons on the right.
+    const { collection, errorHandler, dispatch, siteUserId } = this.props;
+    const { addonId } = suggestion;
+
+    invariant(addonId, 'addonId cannot be empty');
+    invariant(collection,
+      'A collection must be loaded before you can add an add-on to it');
+    invariant(siteUserId,
+      'Cannot add to collection because you are not signed in');
+
+    dispatch(addAddonToCollection({
+      addonId,
+      collectionId: collection.id,
+      collectionSlug: collection.slug,
+      editing: true,
+      errorHandlerId: errorHandler.id,
+      userId: siteUserId,
+    }));
   };
 
   propsToState(props: Props) {
@@ -310,9 +327,10 @@ export const mapStateToProps = (
   const currentUser = getCurrentUser(state.users);
   return {
     clientApp: state.api.clientApp,
-    siteLang: state.api.lang,
-    isCollectionBeingModified: state.collections.isCollectionBeingModified,
     currentUsername: currentUser && currentUser.username,
+    isCollectionBeingModified: state.collections.isCollectionBeingModified,
+    siteLang: state.api.lang,
+    siteUserId: state.users.currentUserID,
   };
 };
 

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -164,7 +164,6 @@ export class CollectionManagerBase extends React.Component<Props, State> {
   };
 
   onAddonSelected = (suggestion: SuggestionType) => {
-    // TODO: This works, but it doesn't update the list of addons on the right.
     const { collection, errorHandler, dispatch, siteUserId } = this.props;
     const { addonId } = suggestion;
 

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -97,7 +97,7 @@ export const initialState: CollectionsState = {
 };
 
 type FetchCurrentCollectionParams = {|
-  allAddons?: boolean,
+  fetchAllAddons?: boolean,
   errorHandlerId: string,
   page?: number,
   slug: string,
@@ -110,7 +110,7 @@ export type FetchCurrentCollectionAction = {|
 |};
 
 export const fetchCurrentCollection = ({
-  allAddons,
+  fetchAllAddons,
   errorHandlerId,
   page,
   slug,
@@ -122,7 +122,7 @@ export const fetchCurrentCollection = ({
 
   return {
     type: FETCH_CURRENT_COLLECTION,
-    payload: { allAddons, errorHandlerId, page, slug, user },
+    payload: { fetchAllAddons, errorHandlerId, page, slug, user },
   };
 };
 

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -97,6 +97,7 @@ export const initialState: CollectionsState = {
 };
 
 type FetchCurrentCollectionParams = {|
+  allAddons?: boolean,
   errorHandlerId: string,
   page?: number,
   slug: string,
@@ -109,24 +110,19 @@ export type FetchCurrentCollectionAction = {|
 |};
 
 export const fetchCurrentCollection = ({
+  allAddons,
   errorHandlerId,
   page,
   slug,
   user,
 }: FetchCurrentCollectionParams = {}): FetchCurrentCollectionAction => {
-  if (!errorHandlerId) {
-    throw new Error('errorHandlerId is required');
-  }
-  if (!slug) {
-    throw new Error('slug is required');
-  }
-  if (!user) {
-    throw new Error('user is required');
-  }
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(slug, 'slug is required');
+  invariant(user, 'user is required');
 
   return {
     type: FETCH_CURRENT_COLLECTION,
-    payload: { errorHandlerId, page, slug, user },
+    payload: { allAddons, errorHandlerId, page, slug, user },
   };
 };
 
@@ -274,7 +270,7 @@ export type CollectionAddonsListResponse = {|
 |};
 
 type LoadCurrentCollectionParams = {|
-  addons: CollectionAddonsListResponse,
+  addons: ExternalCollectionAddons,
   detail: ExternalCollectionDetail,
 |};
 
@@ -301,7 +297,7 @@ export const loadCurrentCollection = ({
 };
 
 type LoadCurrentCollectionPageParams = {|
-  addons: CollectionAddonsListResponse,
+  addons: ExternalCollectionAddons,
 |};
 
 type LoadCurrentCollectionPageAction = {|
@@ -416,6 +412,7 @@ type AddAddonToCollectionParams = {|
   addonId: number,
   collectionId: CollectionId,
   collectionSlug: string,
+  editing?: boolean,
   errorHandlerId: string,
   notes?: string,
   userId: number,
@@ -427,7 +424,7 @@ export type AddAddonToCollectionAction = {|
 |};
 
 export const addAddonToCollection = ({
-  addonId, collectionId, collectionSlug, errorHandlerId, notes, userId,
+  addonId, collectionId, collectionSlug, editing, errorHandlerId, notes, userId,
 }: AddAddonToCollectionParams = {}): AddAddonToCollectionAction => {
   if (!addonId) {
     throw new Error('The addonId parameter is required');
@@ -448,7 +445,7 @@ export const addAddonToCollection = ({
   return {
     type: ADD_ADDON_TO_COLLECTION,
     payload: {
-      addonId, collectionId, collectionSlug, errorHandlerId, notes, userId,
+      addonId, collectionId, collectionSlug, editing, errorHandlerId, notes, userId,
     },
   };
 };
@@ -768,7 +765,7 @@ const reducer = (
       const { addons, detail } = action.payload;
 
       const newState = loadCollectionIntoState({
-        state, collection: detail, addons: addons.results,
+        state, collection: detail, addons,
       });
 
       return {
@@ -795,7 +792,7 @@ const reducer = (
           ...state.byId,
           [currentCollection.id]: {
             ...currentCollection,
-            addons: createInternalAddons(addons.results),
+            addons: createInternalAddons(addons),
           },
         },
         current: {
@@ -903,6 +900,7 @@ const reducer = (
           collections = existingCollections;
         }
       }
+
       return {
         ...state,
         addonInCollections: {

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -48,7 +48,7 @@ import type {
 
 export function* fetchCurrentCollection({
   payload: {
-    allAddons,
+    fetchAllAddons,
     errorHandlerId,
     page,
     slug,
@@ -77,12 +77,12 @@ export function* fetchCurrentCollection({
     };
     const { detail, addons } = yield all({
       detail: call(api.getCollectionDetail, detailParams),
-      addons: allAddons ?
+      addons: fetchAllAddons ?
         call(api.getAllCollectionAddons, addonsParams) :
         call(api.getCollectionAddons, addonsParams),
     });
 
-    const addonsToLoad = allAddons ? addons : addons.results;
+    const addonsToLoad = fetchAllAddons ? addons : addons.results;
     yield put(loadCurrentCollection({ addons: addonsToLoad, detail }));
   } catch (error) {
     log.warn(`Collection failed to load: ${error}`);
@@ -170,7 +170,7 @@ export function* addAddonToCollection({
 
     if (editing) {
       yield put(fetchCurrentCollectionAction({
-        allAddons: true,
+        fetchAllAddons: true,
         errorHandlerId: errorHandler.id,
         slug: collectionSlug,
         user: userId,

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -24,6 +24,8 @@ import type { ReactRouterLocation } from 'core/types/router';
 const API_BASE = `${config.get('apiHost')}${config.get('apiPath')}`;
 const { Entity } = normalizrSchema;
 
+export const DEFAULT_API_PAGE_SIZE = 25;
+
 export const addon = new Entity('addons', {}, { idAttribute: 'slug' });
 export const category = new Entity('categories', {}, { idAttribute: 'slug' });
 

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
+import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import PaginatorLink from 'core/components/PaginatorLink';
 import translate from 'core/i18n/translate';
 
@@ -29,7 +30,7 @@ export class PaginateBase extends React.Component {
   }
 
   static defaultProps = {
-    perPage: 25, // The default number of results per page returned by the API.
+    perPage: DEFAULT_API_PAGE_SIZE,
     showPages: 0,
   }
 

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -16,7 +16,7 @@ import {
 } from 'amo/api/collections';
 import { apiResponsePage, createApiResponse } from 'tests/unit/helpers';
 import {
-  createFakeCollectionAddons,
+  createFakeCollectionAddonsListResponse,
   createFakeCollectionDetail,
   dispatchClientMetadata,
 } from 'tests/unit/amo/helpers';
@@ -123,7 +123,7 @@ describe(__filename, () => {
     it('gets all pages of the collection add-ons list API', async () => {
       const user = 'example-username';
       const slug = 'example-collection-slug';
-      const addonResults = createFakeCollectionAddons().results;
+      const addonResults = createFakeCollectionAddonsListResponse().results;
 
       const _getCollectionAddons = sinon.spy(
         () => Promise.resolve(apiResponsePage({ results: addonResults }))

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import AddonsCard from 'amo/components/AddonsCard';
 import EditableCollectionAddon from 'amo/components/EditableCollectionAddon';
 import SearchResult from 'amo/components/SearchResult';
+import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
 
@@ -62,7 +63,7 @@ describe(__filename, () => {
   it('renders placeholders when loading addons', () => {
     const root = render({ addons: null, loading: true });
     const results = root.find(SearchResult);
-    expect(results).toHaveLength(25);
+    expect(results).toHaveLength(DEFAULT_API_PAGE_SIZE);
     // Do a quick check to make sure these are rendered as placeholders.
     expect(results.at(0)).not.toHaveProp('addon');
   });

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -119,7 +119,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
-      allAddons: false,
+      fetchAllAddons: false,
       errorHandlerId: errorHandler.id,
       page: undefined,
       slug,
@@ -139,7 +139,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
-      allAddons: true,
+      fetchAllAddons: true,
       errorHandlerId: errorHandler.id,
       page: undefined,
       slug,
@@ -165,7 +165,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
-      allAddons: false,
+      fetchAllAddons: false,
       errorHandlerId: errorHandler.id,
       page,
       slug,
@@ -307,7 +307,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
-      allAddons: false,
+      fetchAllAddons: false,
       errorHandlerId: errorHandler.id,
       page,
       slug: newSlug,
@@ -372,7 +372,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
-      allAddons: false,
+      fetchAllAddons: false,
       errorHandlerId: errorHandler.id,
       page: undefined,
       ...newParams,
@@ -424,7 +424,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
-      allAddons: false,
+      fetchAllAddons: false,
       errorHandlerId: errorHandler.id,
       page: undefined,
       ...newParams,

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -119,6 +119,27 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
+      allAddons: false,
+      errorHandlerId: errorHandler.id,
+      page: undefined,
+      slug,
+      user,
+    }));
+  });
+
+  it('dispatches fetchCurrentCollection with correct params for editing on mount', () => {
+    const { store } = dispatchClientMetadata();
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+
+    const errorHandler = createStubErrorHandler();
+    const slug = 'collection-slug';
+    const user = 'some-user';
+
+    renderComponent({ editing: true, errorHandler, params: { slug, user }, store });
+
+    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
+      allAddons: true,
       errorHandlerId: errorHandler.id,
       page: undefined,
       slug,
@@ -144,6 +165,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
+      allAddons: false,
       errorHandlerId: errorHandler.id,
       page,
       slug,
@@ -285,6 +307,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
+      allAddons: false,
       errorHandlerId: errorHandler.id,
       page,
       slug: newSlug,
@@ -349,6 +372,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
+      allAddons: false,
       errorHandlerId: errorHandler.id,
       page: undefined,
       ...newParams,
@@ -400,6 +424,7 @@ describe(__filename, () => {
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
+      allAddons: false,
       errorHandlerId: errorHandler.id,
       page: undefined,
       ...newParams,

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -24,7 +24,7 @@ import {
 } from 'tests/unit/helpers';
 import {
   createAddonsApiResult,
-  createFakeCollectionAddons,
+  createFakeCollectionAddonsListResponse,
   dispatchClientMetadata,
   fakeAddon,
   fakeTheme,
@@ -205,9 +205,9 @@ describe(__filename, () => {
     const themes = [{ ...fakeTheme }];
 
     const collections = [
-      createFakeCollectionAddons({ addons }),
-      createFakeCollectionAddons({ addons }),
-      createFakeCollectionAddons({ addons }),
+      createFakeCollectionAddonsListResponse({ addons }),
+      createFakeCollectionAddonsListResponse({ addons }),
+      createFakeCollectionAddonsListResponse({ addons }),
     ];
     const featuredExtensions = createAddonsApiResult(addons);
     const featuredThemes = createAddonsApiResult(themes);

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -348,12 +348,16 @@ export const createFakeCollectionDetail = ({
 };
 
 export const createFakeCollectionAddons = ({ addons = [fakeAddon] } = {}) => {
+  return addons.map((addon) => ({
+    addon,
+    downloads: 0,
+    notes: null,
+  }));
+};
+
+export const createFakeCollectionAddonsListResponse = ({ addons = [fakeAddon] } = {}) => {
   return {
     count: addons.length,
-    results: addons.map((addon) => ({
-      addon,
-      downloads: 0,
-      notes: null,
-    })),
+    results: createFakeCollectionAddons({ addons }),
   };
 };

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -98,7 +98,7 @@ describe(__filename, () => {
       expect(loadedCollection).not.toEqual(null);
       expect(loadedCollection).toEqual(createInternalCollection({
         detail: collectionDetail,
-        items: collectionAddons.results,
+        items: collectionAddons,
       }));
       expect(state.current.loading).toEqual(false);
     });
@@ -179,7 +179,7 @@ describe(__filename, () => {
 
       expect(loadedCollection).not.toEqual(null);
       expect(loadedCollection.addons)
-        .toEqual(createInternalAddons(newAddons.results));
+        .toEqual(createInternalAddons(newAddons));
       expect(state.current.loading).toEqual(false);
     });
 
@@ -412,7 +412,7 @@ describe(__filename, () => {
       });
 
       let state = loadCollectionIntoState({
-        state: initialState, collection, addons: addons.results,
+        state: initialState, collection, addons,
       });
 
       // Simulate loading it a second time but without addons.
@@ -420,7 +420,7 @@ describe(__filename, () => {
 
       const collectionInState = state.byId[collection.id];
       expect(collectionInState.addons)
-        .toEqual(createInternalAddons(addons.results));
+        .toEqual(createInternalAddons(addons));
     });
   });
 
@@ -673,7 +673,7 @@ describe(__filename, () => {
       const addons = createFakeCollectionAddons();
       const collectionDetail = createFakeCollectionDetail({ id });
       const internalCollection = createInternalCollection({
-        items: addons.results, detail: collectionDetail,
+        items: addons, detail: collectionDetail,
       });
 
       const state = reducer(undefined, loadCurrentCollection({
@@ -705,7 +705,7 @@ describe(__filename, () => {
       const addons = createFakeCollectionAddons();
       const collectionDetail = createFakeCollectionDetail({ id });
       const internalCollection = createInternalCollection({
-        items: addons.results, detail: collectionDetail,
+        items: addons, detail: collectionDetail,
       });
 
       const state = reducer(undefined, loadCurrentCollection({
@@ -771,7 +771,7 @@ describe(__filename, () => {
   describe('loadCollectionAddons', () => {
     const getParams = (params = {}) => {
       return {
-        addons: createFakeCollectionAddons().results,
+        addons: createFakeCollectionAddons(),
         collectionSlug: 'my-collection',
         ...params,
       };
@@ -793,16 +793,16 @@ describe(__filename, () => {
         addons: [{ ...fakeAddon, id: 2 }],
       });
       state = reducer(state, loadCollectionAddons({
-        addons: newAddons.results,
+        addons: newAddons,
         collectionSlug: collectionDetail.slug,
       }));
 
       expect(state.byId[collectionDetail.id].addons)
-        .toEqual(createInternalAddons(newAddons.results));
+        .toEqual(createInternalAddons(newAddons));
     });
 
     it('requires a loaded collection first', () => {
-      const addons = createFakeCollectionAddons().results;
+      const addons = createFakeCollectionAddons();
       expect(() => {
         reducer(undefined, loadCollectionAddons({
           addons,
@@ -894,7 +894,7 @@ describe(__filename, () => {
       expect(state.byId[collection1Detail.id])
         .toEqual(createInternalCollection({
           detail: collection1Detail,
-          items: collection1Addons.results,
+          items: collection1Addons,
         }));
     });
   });

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -7,7 +7,7 @@ import homeReducer, {
 import { createInternalAddon } from 'core/reducers/addons';
 import {
   createAddonsApiResult,
-  createFakeCollectionAddons,
+  createFakeCollectionAddonsListResponse,
   dispatchClientMetadata,
   fakeAddon,
   fakeTheme,
@@ -30,7 +30,7 @@ describe(__filename, () => {
       const { store } = dispatchClientMetadata();
 
       store.dispatch(loadHomeAddons({
-        collections: [createFakeCollectionAddons({
+        collections: [createFakeCollectionAddonsListResponse({
           addons: Array(10).fill(fakeAddon),
         })],
         featuredExtensions: createAddonsApiResult([fakeAddon]),

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -24,7 +24,7 @@ import collectionsSaga from 'amo/sagas/collections';
 import apiReducer from 'core/reducers/api';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 import {
-  createFakeCollectionAddons,
+  createFakeCollectionAddonsListResponse,
   createFakeCollectionDetail,
   dispatchClientMetadata,
 } from 'tests/unit/amo/helpers';
@@ -65,7 +65,7 @@ describe(__filename, () => {
     it('calls the API to fetch a collection', async () => {
       const state = sagaTester.getState();
 
-      const collectionAddons = createFakeCollectionAddons();
+      const collectionAddons = createFakeCollectionAddonsListResponse();
       const collectionDetail = createFakeCollectionDetail();
 
       mockApi
@@ -92,7 +92,7 @@ describe(__filename, () => {
       _fetchCurrentCollection({ page, slug, user });
 
       const expectedLoadAction = loadCurrentCollection({
-        addons: collectionAddons,
+        addons: collectionAddons.results,
         detail: collectionDetail,
       });
 
@@ -138,7 +138,7 @@ describe(__filename, () => {
     it('calls the API to fetch a collection page', async () => {
       const state = sagaTester.getState();
 
-      const collectionAddons = createFakeCollectionAddons();
+      const collectionAddons = createFakeCollectionAddonsListResponse();
       mockApi
         .expects('getCollectionAddons')
         .withArgs({
@@ -153,7 +153,7 @@ describe(__filename, () => {
       _fetchCurrentCollectionPage({ page, slug, user });
 
       const expectedLoadAction = loadCurrentCollectionPage({
-        addons: collectionAddons,
+        addons: collectionAddons.results,
       });
 
       const loadAction = await sagaTester.waitFor(expectedLoadAction.type);

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -17,7 +17,7 @@ import apiReducer from 'core/reducers/api';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 import {
   createAddonsApiResult,
-  createFakeCollectionAddons,
+  createFakeCollectionAddonsListResponse,
   dispatchClientMetadata,
   fakeAddon,
   fakeTheme,
@@ -66,8 +66,8 @@ describe(__filename, () => {
         page_size: LANDING_PAGE_ADDON_COUNT,
       };
 
-      const firstCollection = createFakeCollectionAddons();
-      const secondCollection = createFakeCollectionAddons();
+      const firstCollection = createFakeCollectionAddonsListResponse();
+      const secondCollection = createFakeCollectionAddonsListResponse();
       mockCollectionsApi
         .expects('getCollectionAddons')
         .withArgs({

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -571,7 +571,7 @@ describe(__filename, () => {
     it('passes through response data', async () => {
       const proxiedResponse = apiResponsePage({
         count: 120,
-        page_size: 25,
+        page_size: api.DEFAULT_API_PAGE_SIZE,
       });
       const response = await api.allPages(
         () => Promise.resolve(proxiedResponse)

--- a/tests/unit/core/components/TestPaginate.js
+++ b/tests/unit/core/components/TestPaginate.js
@@ -1,6 +1,7 @@
 /* global document */
 import * as React from 'react';
 
+import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import Paginate, { PaginateBase } from 'core/components/Paginate';
 import PaginatorLink from 'core/components/PaginatorLink';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
@@ -117,7 +118,7 @@ describe('<Paginate />', () => {
 
         it('will not offset near the end', () => {
           const pages = getVisiblePages({
-            count: 128, perPage: 25, showPages: 9, currentPage: 6,
+            count: 128, perPage: DEFAULT_API_PAGE_SIZE, showPages: 9, currentPage: 6,
           });
           expect(pages).toEqual([1, 2, 3, 4, 5, 6]);
         });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -234,7 +234,11 @@ export const userAgents = {
 };
 
 export function apiResponsePage({
-  count, next, previous, pageSize = 25, results = [],
+  count,
+  next,
+  previous,
+  pageSize = coreApi.DEFAULT_API_PAGE_SIZE,
+  results = [],
 } = {}) {
   return {
     count: typeof count !== 'undefined' ? count : results.length,


### PR DESCRIPTION
Fixes #4590 

Sorry the PR is so large. The changes to support the feature are fairly large, but I also had to touch a bunch of other files because I had to make a couple of other changes to implement my feature.

These are:
- I needed to add a new const, `DEFAULT_API_PAGE_SIZE` and I thought it best to use that const in all places it should be used. 
- I renamed a helper function from  `createFakeCollectionAddons` to  `createFakeCollectionAddonsListResponse`, because the former wasn't really accurate and I needed to create a new one called `createFakeCollectionAddons` which was accurate.

Those changes resulted in a bunch of extra files being touched, but it should be pretty easy to review those changes.