### PR TITLE
Fix getAddonsForUsernames so it will work consistently with multiple usernames

### DIFF
--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -135,20 +135,18 @@ export const getAddonsForUsernames = (
   const ids = usernames.map((username) => {
     return state.byUsername[username];
   }).reduce((array, addonIds) => {
-    if (!addonIds || !array) {
-      return null;
-    }
-
-    for (const addonId of addonIds) {
-      if (!array.includes(addonId)) {
-        array.push(addonId);
+    if (addonIds) {
+      for (const addonId of addonIds) {
+        if (!array.includes(addonId)) {
+          array.push(addonId);
+        }
       }
     }
 
     return array;
   }, []);
 
-  return ids ? (ids
+  return ids.length ? (ids
     .map((id) => {
       return state.byAddonId[id];
     })

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -446,6 +446,19 @@ describe(__filename, () => {
       ]);
     });
 
+    it('returns addons for multiple authors when only one has a loaded add-on', () => {
+      const addons = fakeAddons();
+      const state = reducer(undefined, loadAddonsByAuthors({
+        addons: Object.values(addons),
+        authorNames: ['fakeUsername'],
+      }));
+
+      expect(getAddonsForUsernames(state, ['test2', 'no-addons-user'])).toEqual([
+        createInternalAddon(addons.firstAddon),
+        createInternalAddon(addons.secondAddon),
+      ]);
+    });
+
     it('returns addons for multiple authors of different add-ons', () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({


### PR DESCRIPTION
Fixes #4818 

Prior to this fix, if one of the usernames passed didn't have any add-ons loaded, then the
whole function returned null, even if there were some add-ons loaded for some of the
usernames. This situation can arise because when add-ons are fetched for a set of
usernames not all add-ons are fetched and loaded, so we can end up with a username
without any loaded add-ons.
