### PR TITLE
Output the author's displayName rather than their username on the AddonsByAuthorsCard

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -488,7 +488,8 @@ export class AddonBase extends React.Component {
             {addon && addonType === ADDON_TYPE_THEME && (
               <AddonsByAuthorsCard
                 addonType={addonType}
-                authorNames={addon.authors.map((author) => author.username)}
+                authorDisplayName={addon.authors[0].name}
+                authorUsernames={addon.authors.map((author) => author.username)}
                 className="Addon-MoreAddonsCard"
                 forAddonSlug={addon.slug}
                 numberOfAddons={6}
@@ -522,7 +523,8 @@ export class AddonBase extends React.Component {
           {addon && addonType !== ADDON_TYPE_THEME && (
             <AddonsByAuthorsCard
               addonType={addonType}
-              authorNames={addon.authors.map((author) => author.username)}
+              authorDisplayName={addon.authors[0].name}
+              authorUsernames={addon.authors.map((author) => author.username)}
               className="Addon-MoreAddonsCard"
               forAddonSlug={addon.slug}
               numberOfAddons={6}

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -31,7 +31,8 @@ import './styles.scss';
 type Props = {|
   addons?: Array<AddonType>,
   addonType?: string,
-  authorNames: Array<string>,
+  authorDisplayName: string,
+  authorUsernames: Array<string>,
   className?: string,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
@@ -52,21 +53,21 @@ export class AddonsByAuthorsCardBase extends React.Component<Props> {
   }
 
   componentWillMount() {
-    const { addons, addonType, authorNames, forAddonSlug } = this.props;
+    const { addons, addonType, authorUsernames, forAddonSlug } = this.props;
 
     if (!addons) {
-      this.dispatchFetchAddonsByAuthors({ addonType, authorNames, forAddonSlug });
+      this.dispatchFetchAddonsByAuthors({ addonType, authorUsernames, forAddonSlug });
     }
   }
 
   componentWillReceiveProps({
     addonType: newAddonType,
-    authorNames: newAuthorNames,
+    authorUsernames: newAuthorNames,
     forAddonSlug: newForAddonSlug,
   }: Props) {
     const {
       addonType: oldAddonType,
-      authorNames: oldAuthorNames,
+      authorUsernames: oldAuthorNames,
       forAddonSlug: oldForAddonSlug,
     } = this.props;
 
@@ -77,16 +78,16 @@ export class AddonsByAuthorsCardBase extends React.Component<Props> {
     ) {
       this.dispatchFetchAddonsByAuthors({
         addonType: newAddonType,
-        authorNames: newAuthorNames,
+        authorUsernames: newAuthorNames,
         forAddonSlug: newForAddonSlug,
       });
     }
   }
 
-  dispatchFetchAddonsByAuthors({ addonType, authorNames, forAddonSlug }: Object) {
+  dispatchFetchAddonsByAuthors({ addonType, authorUsernames, forAddonSlug }: Object) {
     this.props.dispatch(fetchAddonsByAuthors({
       addonType,
-      authorNames,
+      authorUsernames,
       forAddonSlug,
       errorHandlerId: this.props.errorHandler.id,
     }));
@@ -96,7 +97,8 @@ export class AddonsByAuthorsCardBase extends React.Component<Props> {
     const {
       addons,
       addonType,
-      authorNames,
+      authorDisplayName,
+      authorUsernames,
       className,
       i18n,
       loading,
@@ -115,50 +117,50 @@ export class AddonsByAuthorsCardBase extends React.Component<Props> {
         header = i18n.ngettext(
           i18n.sprintf(
             i18n.gettext('More dictionaries by %(author)s'),
-            { author: authorNames[0] }
+            { author: authorDisplayName }
           ),
           i18n.gettext('More dictionaries by these translators'),
-          authorNames.length
+          authorUsernames.length
         );
         break;
       case ADDON_TYPE_EXTENSION:
         header = i18n.ngettext(
           i18n.sprintf(
             i18n.gettext('More extensions by %(author)s'),
-            { author: authorNames[0] }
+            { author: authorDisplayName }
           ),
           i18n.gettext('More extensions by these developers'),
-          authorNames.length
+          authorUsernames.length
         );
         break;
       case ADDON_TYPE_LANG:
         header = i18n.ngettext(
           i18n.sprintf(
             i18n.gettext('More language packs by %(author)s'),
-            { author: authorNames[0] }
+            { author: authorDisplayName }
           ),
           i18n.gettext('More language packs by these translators'),
-          authorNames.length
+          authorUsernames.length
         );
         break;
       case ADDON_TYPE_THEME:
         header = i18n.ngettext(
           i18n.sprintf(
             i18n.gettext('More themes by %(author)s'),
-            { author: authorNames[0] }
+            { author: authorDisplayName }
           ),
           i18n.gettext('More themes by these artists'),
-          authorNames.length
+          authorUsernames.length
         );
         break;
       default:
         header = i18n.ngettext(
           i18n.sprintf(
             i18n.gettext('More add-ons by %(author)s'),
-            { author: authorNames[0] }
+            { author: authorDisplayName }
           ),
           i18n.gettext('More add-ons by these developers'),
-          authorNames.length
+          authorUsernames.length
         );
     }
 
@@ -184,14 +186,14 @@ export class AddonsByAuthorsCardBase extends React.Component<Props> {
 export const mapStateToProps = (
   state: {| addonsByAuthors: AddonsByAuthorsState |}, ownProps: Props
 ) => {
-  const { addonType, authorNames, forAddonSlug, numberOfAddons } = ownProps;
+  const { addonType, authorUsernames, forAddonSlug, numberOfAddons } = ownProps;
 
   let addons = getAddonsForUsernames(
-    state.addonsByAuthors, authorNames, addonType, forAddonSlug);
+    state.addonsByAuthors, authorUsernames, addonType, forAddonSlug);
   addons = addons ?
     addons.slice(0, numberOfAddons) : addons;
   const loading = getLoadingForAuthorNames(
-    state.addonsByAuthors, authorNames, addonType);
+    state.addonsByAuthors, authorUsernames, addonType);
 
   return { addons, loading };
 };

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -160,7 +160,8 @@ export class UserProfileBase extends React.Component<Props> {
             <div className="UserProfile-addons-by-author">
               <AddonsByAuthorsCard
                 addonType={ADDON_TYPE_EXTENSION}
-                authorNames={[user.username]}
+                authorDisplayName={[user.displayName]}
+                authorUsernames={[user.username]}
                 numberOfAddons={3}
                 showSummary
                 type="vertical"
@@ -168,7 +169,8 @@ export class UserProfileBase extends React.Component<Props> {
 
               <AddonsByAuthorsCard
                 addonType={ADDON_TYPE_THEME}
-                authorNames={[user.username]}
+                authorDisplayName={[user.displayName]}
+                authorUsernames={[user.username]}
                 numberOfAddons={6}
               />
             </div>

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -45,7 +45,7 @@ export const LOAD_ADDONS_BY_AUTHORS: 'LOAD_ADDONS_BY_AUTHORS'
 
 type FetchAddonsByAuthorsParams = {|
   addonType?: string,
-  authorNames: Array<string>,
+  authorUsernames: Array<string>,
   errorHandlerId: string,
   forAddonSlug?: string,
 |};
@@ -56,18 +56,18 @@ type FetchAddonsByAuthorsAction = {|
 |};
 
 export const fetchAddonsByAuthors = (
-  { addonType, authorNames, errorHandlerId, forAddonSlug }: FetchAddonsByAuthorsParams
+  { addonType, authorUsernames, errorHandlerId, forAddonSlug }: FetchAddonsByAuthorsParams
 ): FetchAddonsByAuthorsAction => {
   invariant(errorHandlerId, 'An errorHandlerId is required');
-  invariant(authorNames, 'authorNames are required.');
-  invariant(Array.isArray(authorNames),
-    'The authorNames parameter must be an array.');
+  invariant(authorUsernames, 'authorUsernames are required.');
+  invariant(Array.isArray(authorUsernames),
+    'The authorUsernames parameter must be an array.');
 
   return {
     type: FETCH_ADDONS_BY_AUTHORS,
     payload: {
       addonType,
-      authorNames,
+      authorUsernames,
       errorHandlerId,
       forAddonSlug,
     },
@@ -77,7 +77,7 @@ export const fetchAddonsByAuthors = (
 type LoadAddonsByAuthorsParams = {|
   addons: Array<ExternalAddonType>,
   addonType?: string,
-  authorNames: Array<string>,
+  authorUsernames: Array<string>,
   forAddonSlug?: string,
 |};
 
@@ -87,28 +87,28 @@ type LoadAddonsByAuthorsAction = {|
 |};
 
 export const loadAddonsByAuthors = (
-  { addons, addonType, authorNames, forAddonSlug }: LoadAddonsByAuthorsParams
+  { addons, addonType, authorUsernames, forAddonSlug }: LoadAddonsByAuthorsParams
 ): LoadAddonsByAuthorsAction => {
   invariant(addons, 'A set of add-ons is required.');
-  invariant(authorNames, 'A list of authorNames is required.');
+  invariant(authorUsernames, 'A list of authorUsernames is required.');
 
   return {
     type: LOAD_ADDONS_BY_AUTHORS,
-    payload: { addons, addonType, authorNames, forAddonSlug },
+    payload: { addons, addonType, authorUsernames, forAddonSlug },
   };
 };
 
 export const joinAuthorNamesAndAddonType = (
-  authorNames: Array<string>, addonType?: string
+  authorUsernames: Array<string>, addonType?: string
 ) => {
-  return authorNames.sort().join('-') + (addonType ? `-${addonType}` : '');
+  return authorUsernames.sort().join('-') + (addonType ? `-${addonType}` : '');
 };
 
 export const getLoadingForAuthorNames = (
-  state: AddonsByAuthorsState, authorNames: Array<string>, addonType?: string
+  state: AddonsByAuthorsState, authorUsernames: Array<string>, addonType?: string
 ) => {
   return (
-    state.loadingFor[joinAuthorNamesAndAddonType(authorNames, addonType)] ||
+    state.loadingFor[joinAuthorNamesAndAddonType(authorUsernames, addonType)] ||
     null
   );
 };
@@ -179,9 +179,9 @@ const reducer = (
       }
 
       newState.loadingFor[joinAuthorNamesAndAddonType(
-        action.payload.authorNames, action.payload.addonType)] = true;
+        action.payload.authorUsernames, action.payload.addonType)] = true;
       newState.byAuthorNamesAndAddonType[joinAuthorNamesAndAddonType(
-        action.payload.authorNames, action.payload.addonType)] = null;
+        action.payload.authorUsernames, action.payload.addonType)] = null;
 
       return newState;
     }
@@ -200,7 +200,7 @@ const reducer = (
         .map((addon) => createInternalAddon(addon));
 
       const authorNamesWithAddonType = joinAuthorNamesAndAddonType(
-        action.payload.authorNames, action.payload.addonType);
+        action.payload.authorUsernames, action.payload.addonType);
 
       newState.byAuthorNamesAndAddonType[authorNamesWithAddonType] = [];
       newState.loadingFor[authorNamesWithAddonType] = false;

--- a/src/amo/sagas/addonsByAuthors.js
+++ b/src/amo/sagas/addonsByAuthors.js
@@ -11,7 +11,7 @@ import { createErrorHandler, getState } from 'core/sagas/utils';
 
 
 export function* fetchAddonsByAuthors({ payload }) {
-  const { errorHandlerId, authorNames, addonType, forAddonSlug } = payload;
+  const { errorHandlerId, authorUsernames, addonType, forAddonSlug } = payload;
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -23,7 +23,7 @@ export function* fetchAddonsByAuthors({ payload }) {
       api: state.api,
       filters: {
         addonType,
-        author: authorNames.sort().join(','),
+        author: authorUsernames.sort().join(','),
         exclude_addons: forAddonSlug,
         page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
         sort: SEARCH_SORT_TRENDING,
@@ -37,7 +37,7 @@ export function* fetchAddonsByAuthors({ payload }) {
     yield put(loadAddonsByAuthors({
       addons,
       addonType,
-      authorNames,
+      authorUsernames,
       forAddonSlug,
     }));
   } catch (error) {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -141,7 +141,7 @@ describe(__filename, () => {
   const _loadAddonsByAuthors = ({ addon, addonsByAuthors }) => {
     return loadAddonsByAuthors({
       addons: addonsByAuthors,
-      authorNames: ['foo'],
+      authorUsernames: ['foo'],
       forAddonSlug: addon.slug,
     });
   };
@@ -1143,7 +1143,7 @@ describe(__filename, () => {
       const root = renderMoreAddons({ addon, addonsByAuthors });
 
       expect(root).toHaveClassName('.Addon-MoreAddonsCard');
-      expect(root).toHaveProp('authorNames',
+      expect(root).toHaveProp('authorUsernames',
         addon.authors.map((author) => (author.username))
       );
       expect(root).toHaveProp('addonType', addon.type);
@@ -1165,7 +1165,7 @@ describe(__filename, () => {
       const root = renderMoreAddons({ addon, addonsByAuthors });
 
       expect(root).toHaveClassName('.Addon-MoreAddonsCard');
-      expect(root).toHaveProp('authorNames',
+      expect(root).toHaveProp('authorUsernames',
         addon.authors.map((author) => (author.username))
       );
       expect(root).toHaveProp('addonType', addon.type);

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -56,7 +56,7 @@ describe(__filename, () => {
     return { firstAddon, secondAddon, thirdAddon };
   }
 
-  function fakeAuthorNames() {
+  function fakeAuthorUsernames() {
     return [
       fakeAuthorOne.username,
       fakeAuthorTwo.username,
@@ -85,13 +85,14 @@ describe(__filename, () => {
         },
       ],
       addonType,
-      authorNames: multipleAuthors ?
+      authorUsernames: multipleAuthors ?
         [fakeAuthorOne.username, fakeAuthorTwo.username] : [fakeAuthorOne.username],
     });
   }
 
   function render(customProps = {}) {
     const props = {
+      authorDisplayName: fakeAuthorOne.name,
       numberOfAddons: 4,
       i18n: fakeI18n(),
       store: dispatchClientMetadata().store,
@@ -105,24 +106,29 @@ describe(__filename, () => {
   }
 
   function renderAddonsWithType({ addonType, multipleAuthors = false } = {}) {
-    const authorNames = multipleAuthors ?
+    const authorUsernames = multipleAuthors ?
       [fakeAuthorOne.username, fakeAuthorTwo.username] : [fakeAuthorOne.username];
     const { store } = dispatchClientMetadata();
     const errorHandler = createStubErrorHandler();
     store.dispatch(addonsWithAuthorsOfType({ addonType, multipleAuthors }));
 
-    return render({ addonType, authorNames, errorHandler, store });
+    return render({
+      addonType,
+      authorUsernames,
+      errorHandler,
+      store,
+    });
   }
 
   it('should render a card', () => {
     const { store } = dispatchClientMetadata();
-    const authorNames = fakeAuthorNames();
+    const authorUsernames = fakeAuthorUsernames();
     const addons = Object.values(fakeAddons()).sort();
-    store.dispatch(loadAddonsByAuthors({ addons, authorNames }));
+    store.dispatch(loadAddonsByAuthors({ addons, authorUsernames }));
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames,
+      authorUsernames,
       numberOfAddons: 4,
       store,
     });
@@ -146,15 +152,15 @@ describe(__filename, () => {
 
   it('should render a className', () => {
     const { store } = dispatchClientMetadata();
-    const authorNames = fakeAuthorNames();
+    const authorUsernames = fakeAuthorUsernames();
     store.dispatch(loadAddonsByAuthors({
       addons: Object.values(fakeAddons()),
-      authorNames,
+      authorUsernames,
     }));
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames,
+      authorUsernames,
       className: 'foo',
       store,
     });
@@ -164,13 +170,13 @@ describe(__filename, () => {
 
   it('should render nothing if there are no add-ons', () => {
     const { store } = dispatchClientMetadata();
-    const authorNames = fakeAuthorNames();
+    const authorUsernames = fakeAuthorUsernames();
     store.dispatch(loadAddonsByAuthors({
       addons: [],
-      authorNames,
+      authorUsernames,
     }));
 
-    const root = render({ authorNames, store });
+    const root = render({ authorUsernames, store });
 
     expect(root).not.toHaveClassName('AddonsByAuthorsCard');
     expect(root.html()).toBeNull();
@@ -179,7 +185,7 @@ describe(__filename, () => {
   it('should render nothing if add-ons are null', () => {
     const root = render({
       addons: null,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
     });
 
     expect(root).not.toHaveClassName('AddonsByAuthorsCard');
@@ -191,13 +197,13 @@ describe(__filename, () => {
     const errorHandler = createStubErrorHandler();
     store.dispatch(fetchAddonsByAuthors({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
     }));
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandler,
       store,
     });
@@ -213,26 +219,26 @@ describe(__filename, () => {
 
     render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandler,
       store,
     });
 
     sinon.assert.calledWith(dispatchSpy, fetchAddonsByAuthors({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
     }));
   });
 
-  it('should dispatch a fetch action if authorNames are updated', () => {
+  it('should dispatch a fetch action if authorUsernames are updated', () => {
     const { store } = dispatchClientMetadata();
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandler,
       store,
     });
@@ -241,27 +247,27 @@ describe(__filename, () => {
 
     root.setProps({
       addonType: ADDON_TYPE_THEME,
-      authorNames: ['test1'],
+      authorUsernames: ['test1'],
     });
 
     sinon.assert.calledWith(dispatchSpy, fetchAddonsByAuthors({
       addonType: ADDON_TYPE_THEME,
-      authorNames: ['test1'],
+      authorUsernames: ['test1'],
       errorHandlerId: errorHandler.id,
     }));
 
-    // Make sure an authorNames update even with the same addonType dispatches
+    // Make sure an authorUsernames update even with the same addonType dispatches
     // a fetch action.
     dispatchSpy.reset();
 
     root.setProps({
       addonType: ADDON_TYPE_THEME,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
     });
 
     sinon.assert.calledWith(dispatchSpy, fetchAddonsByAuthors({
       addonType: ADDON_TYPE_THEME,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
     }));
   });
@@ -273,7 +279,7 @@ describe(__filename, () => {
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandler,
       store,
     });
@@ -282,12 +288,12 @@ describe(__filename, () => {
 
     root.setProps({
       addonType: ADDON_TYPE_OPENSEARCH,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
     });
 
     sinon.assert.calledWith(dispatchSpy, fetchAddonsByAuthors({
       addonType: ADDON_TYPE_OPENSEARCH,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
     }));
   });
@@ -299,7 +305,7 @@ describe(__filename, () => {
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandler,
       store,
     });
@@ -312,7 +318,7 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(dispatchSpy, fetchAddonsByAuthors({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
       forAddonSlug: 'testing',
     }));
@@ -325,7 +331,7 @@ describe(__filename, () => {
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
       errorHandler,
       store,
     });
@@ -334,7 +340,7 @@ describe(__filename, () => {
 
     root.setProps({
       addonType: ADDON_TYPE_EXTENSION,
-      authorNames: ['test2'],
+      authorUsernames: ['test2'],
     });
 
     sinon.assert.notCalled(dispatchSpy);
@@ -347,7 +353,7 @@ describe(__filename, () => {
     });
 
     expect(root.find(AddonsCard))
-      .toHaveProp('header', `More dictionaries by ${fakeAuthor.username}`);
+      .toHaveProp('header', `More dictionaries by ${fakeAuthor.name}`);
   });
 
   it('shows dictionaries in header for ADDON_TYPE_DICT with multiple authors', () => {
@@ -367,7 +373,7 @@ describe(__filename, () => {
     });
 
     expect(root.find(AddonsCard))
-      .toHaveProp('header', `More extensions by ${fakeAuthor.username}`);
+      .toHaveProp('header', `More extensions by ${fakeAuthor.name}`);
   });
 
   it('shows extensions in header for ADDON_TYPE_EXTENSION with multiple authors', () => {
@@ -387,7 +393,7 @@ describe(__filename, () => {
     });
 
     expect(root.find(AddonsCard))
-      .toHaveProp('header', `More language packs by ${fakeAuthor.username}`);
+      .toHaveProp('header', `More language packs by ${fakeAuthor.name}`);
   });
 
   it('shows extensions in header for ADDON_TYPE_LANG with multiple authors', () => {
@@ -407,7 +413,7 @@ describe(__filename, () => {
     });
 
     expect(root.find(AddonsCard))
-      .toHaveProp('header', `More themes by ${fakeAuthor.username}`);
+      .toHaveProp('header', `More themes by ${fakeAuthor.name}`);
   });
 
   it('shows extensions in header for ADDON_TYPE_THEME with multiple authors', () => {
@@ -427,7 +433,7 @@ describe(__filename, () => {
     });
 
     expect(root.find(AddonsCard))
-      .toHaveProp('header', `More add-ons by ${fakeAuthor.username}`);
+      .toHaveProp('header', `More add-ons by ${fakeAuthor.name}`);
   });
 
   it('shows add-ons in header if no specific addonType found with multiple authors', () => {

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -53,7 +53,7 @@ describe(__filename, () => {
       // change it.
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: [fakeAddon],
-        authorNames: [fakeAddon.authors[0].username],
+        authorUsernames: [fakeAddon.authors[0].username],
         forAddonSlug: fakeAddon.slug,
       }));
       const newState = reducer(state, { type: 'UNRELATED' });
@@ -65,7 +65,7 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         forAddonSlug: 'addon-slug',
         addons: [],
-        authorNames: [fakeAddon.authors[0].username],
+        authorUsernames: [fakeAddon.authors[0].username],
       }));
 
       expect(state.byAddonSlug).toEqual({
@@ -77,7 +77,7 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         forAddonSlug: 'addon-slug',
         addons: [fakeAddon],
-        authorNames: [fakeAddon.authors[0].username],
+        authorUsernames: [fakeAddon.authors[0].username],
       }));
 
       expect(state.byAddonSlug).toEqual({
@@ -91,7 +91,7 @@ describe(__filename, () => {
         forAddonSlug,
         // This is the case where there are more add-ons loaded than needed.
         addons: Array(ADDONS_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
-        authorNames: [fakeAddon.authors[0].username],
+        authorUsernames: [fakeAddon.authors[0].username],
       }));
       expect(state.byAddonSlug[forAddonSlug])
         .toHaveLength(ADDONS_BY_AUTHORS_PAGE_SIZE);
@@ -102,7 +102,7 @@ describe(__filename, () => {
 
       const previousState = reducer(undefined, loadAddonsByAuthors({
         addons: [fakeAddon],
-        authorNames: [fakeAddon.authors[0].username],
+        authorUsernames: [fakeAddon.authors[0].username],
         forAddonSlug,
       }));
 
@@ -110,7 +110,7 @@ describe(__filename, () => {
         .toEqual({ 'addon-slug': [fakeAddon.id] });
 
       const state = reducer(previousState, fetchAddonsByAuthors({
-        authorNames: ['author2'],
+        authorUsernames: ['author2'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
       }));
@@ -123,14 +123,14 @@ describe(__filename, () => {
 
       const firstState = reducer(undefined, loadAddonsByAuthors({
         addons: [fakeAddon],
-        authorNames: [fakeAddon.authors[0].username],
+        authorUsernames: [fakeAddon.authors[0].username],
         forAddonSlug,
       }));
 
       expect(firstState.byAddonSlug).toEqual({ 'addon-slug': [fakeAddon.id] });
 
       const state = reducer(firstState, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
         forAddonSlug,
@@ -142,9 +142,9 @@ describe(__filename, () => {
       expect(state.byUsername).toMatchObject(firstState.byUsername);
     });
 
-    it('sets the byAuthorNamesAndAddonType state for authorNames on fetch', () => {
+    it('sets the byAuthorNamesAndAddonType state for authorUsernames on fetch', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
       }));
 
@@ -153,9 +153,9 @@ describe(__filename, () => {
       });
     });
 
-    it('sets the byAuthorNamesAndAddonType state for authorNames + addonType on fetch', () => {
+    it('sets the byAuthorNamesAndAddonType state for authorUsernames + addonType on fetch', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
       }));
@@ -165,9 +165,9 @@ describe(__filename, () => {
       });
     });
 
-    it('sets the loading state for authorNames on fetch', () => {
+    it('sets the loading state for authorUsernames on fetch', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
       }));
 
@@ -176,9 +176,9 @@ describe(__filename, () => {
       });
     });
 
-    it('sets the loading state for authorNames + addonType on fetch', () => {
+    it('sets the loading state for authorUsernames + addonType on fetch', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
       }));
@@ -193,7 +193,7 @@ describe(__filename, () => {
     const getParams = (extra = {}) => {
       return {
         addons: [],
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
         forAddonSlug: fakeAddon.slug,
         ...extra,
       };
@@ -202,12 +202,12 @@ describe(__filename, () => {
     it('adds each add-on to each author array', () => {
       const firstAuthor = { ...fakeAuthor, id: 50, username: 'first' };
       const secondAuthor = { ...fakeAuthor, id: 60, username: 'second' };
-      const authorNames = [firstAuthor.username, secondAuthor.username];
+      const authorUsernames = [firstAuthor.username, secondAuthor.username];
       const multiAuthorAddon = {
         ...fakeAddon,
         authors: [firstAuthor, secondAuthor],
       };
-      const params = getParams({ addons: [multiAuthorAddon], authorNames });
+      const params = getParams({ addons: [multiAuthorAddon], authorUsernames });
 
       const newState = reducer(undefined, loadAddonsByAuthors(params));
 
@@ -220,27 +220,27 @@ describe(__filename, () => {
     it('sets the authorName request list when loaded', () => {
       const firstAuthor = { ...fakeAuthor, id: 50, username: 'first' };
       const secondAuthor = { ...fakeAuthor, id: 60, username: 'second' };
-      const authorNames = [firstAuthor.username, secondAuthor.username];
+      const authorUsernames = [firstAuthor.username, secondAuthor.username];
       const multiAuthorAddon = {
         ...fakeAddon,
         authors: [firstAuthor, secondAuthor],
       };
       const params = getParams({
         addons: [multiAuthorAddon],
-        authorNames,
+        authorUsernames,
       });
 
       const newState = reducer(undefined, loadAddonsByAuthors(params));
 
       expect(newState.byAuthorNamesAndAddonType).toEqual({
-        [joinAuthorNamesAndAddonType(authorNames)]: [multiAuthorAddon.id],
+        [joinAuthorNamesAndAddonType(authorUsernames)]: [multiAuthorAddon.id],
       });
     });
 
     it('sets the authorName + addonType request list when loaded', () => {
       const firstAuthor = { ...fakeAuthor, id: 50, username: 'first' };
       const secondAuthor = { ...fakeAuthor, id: 60, username: 'second' };
-      const authorNames = [firstAuthor.username, secondAuthor.username];
+      const authorUsernames = [firstAuthor.username, secondAuthor.username];
       const multiAuthorAddon = {
         ...fakeAddon,
         authors: [firstAuthor, secondAuthor],
@@ -248,13 +248,13 @@ describe(__filename, () => {
       const params = getParams({
         addons: [multiAuthorAddon],
         addonType: ADDON_TYPE_EXTENSION,
-        authorNames,
+        authorUsernames,
       });
 
       const newState = reducer(undefined, loadAddonsByAuthors(params));
 
       expect(newState.byAuthorNamesAndAddonType).toEqual({
-        [joinAuthorNamesAndAddonType(authorNames, ADDON_TYPE_EXTENSION)]: [multiAuthorAddon.id],
+        [joinAuthorNamesAndAddonType(authorUsernames, ADDON_TYPE_EXTENSION)]: [multiAuthorAddon.id],
       });
     });
 
@@ -262,7 +262,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const params = getParams({
         addons: Object.values(addons),
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
         forAddonSlug: undefined,
       });
 
@@ -283,7 +283,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const params = getParams({
         addons: Object.values(addons),
-        authorNames: ['test', 'test2', 'test3'],
+        authorUsernames: ['test', 'test2', 'test3'],
         forAddonSlug: undefined,
       });
 
@@ -365,9 +365,9 @@ describe(__filename, () => {
       });
     });
 
-    it('sets the loading state for authorNames once loaded', () => {
+    it('sets the loading state for authorUsernames once loaded', () => {
       let state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
       }));
 
@@ -377,7 +377,7 @@ describe(__filename, () => {
 
       state = reducer(state, loadAddonsByAuthors({
         addons: [fakeAddon],
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
       }));
 
       expect(state.loadingFor).toMatchObject({
@@ -385,9 +385,9 @@ describe(__filename, () => {
       });
     });
 
-    it('sets the loading state for authorNames + addonType once loaded', () => {
+    it('sets the loading state for authorUsernames + addonType once loaded', () => {
       let state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
       }));
@@ -395,7 +395,7 @@ describe(__filename, () => {
       state = reducer(state, loadAddonsByAuthors({
         addons: [fakeAddon],
         addonType: ADDON_TYPE_THEME,
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
       }));
 
       expect(state.loadingFor).toMatchObject({
@@ -409,7 +409,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
         forAddonSlug: 'test',
       }));
 
@@ -424,7 +424,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
         forAddonSlug: 'test',
       }));
 
@@ -437,7 +437,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
       }));
 
       expect(getAddonsForUsernames(state, ['test2'])).toEqual([
@@ -450,7 +450,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
       }));
 
       expect(getAddonsForUsernames(state, ['test2', 'no-addons-user'])).toEqual([
@@ -463,7 +463,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
       }));
 
       expect(getAddonsForUsernames(state, ['test', 'test3'])).toEqual([
@@ -476,7 +476,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
-        authorNames: ['test', 'test2'],
+        authorUsernames: ['test', 'test2'],
       }));
 
       expect(getAddonsForUsernames(state, ['test', 'test2'])).toEqual([
@@ -494,15 +494,15 @@ describe(__filename, () => {
       // to prevent an add-on from appearing in its own "by this author"
       // list.
       const addons = fakeAddons();
-      const authorNames = ['test', 'test2', 'test3'];
+      const authorUsernames = ['test', 'test2', 'test3'];
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         addonType: ADDON_TYPE_EXTENSION,
-        authorNames,
+        authorUsernames,
       }));
 
       expect(getAddonsForUsernames(
-        state, authorNames, ADDON_TYPE_EXTENSION, addons.firstAddon.slug
+        state, authorUsernames, ADDON_TYPE_EXTENSION, addons.firstAddon.slug
       )).toEqual([
         createInternalAddon(addons.secondAddon),
         createInternalAddon(addons.thirdAddon),
@@ -513,7 +513,7 @@ describe(__filename, () => {
       const addons = fakeAddons();
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
-        authorNames: ['fakeUsername'],
+        authorUsernames: ['fakeUsername'],
       }));
 
       expect(getAddonsForUsernames(state, ['nobody'])).toBeNull();
@@ -521,18 +521,18 @@ describe(__filename, () => {
   });
 
   describe('getLoadingForAuthorNames', () => {
-    it('returns loading for just authorNames', () => {
+    it('returns loading for just authorUsernames', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
       }));
 
       expect(getLoadingForAuthorNames(state, ['author1'])).toEqual(true);
     });
 
-    it('returns loading for authorNames + addonType', () => {
+    it('returns loading for authorUsernames + addonType', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
       }));
@@ -543,16 +543,16 @@ describe(__filename, () => {
 
     it('returns null when there is no match', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
       }));
 
       expect(getLoadingForAuthorNames(state, ['author2'])).toEqual(null);
     });
 
-    it('returns null when no authorNames provided', () => {
+    it('returns null when no authorUsernames provided', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorNames: ['author1'],
+        authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
       }));
 
@@ -561,12 +561,12 @@ describe(__filename, () => {
   });
 
   describe('joinAuthorNamesAndAddonType', () => {
-    it('returns authorNames', () => {
+    it('returns authorUsernames', () => {
       expect(joinAuthorNamesAndAddonType(['author1', 'author2']))
         .toEqual('author1-author2');
     });
 
-    it('returns authorNames + addonType', () => {
+    it('returns authorUsernames + addonType', () => {
       expect(joinAuthorNamesAndAddonType(['author1', 'author2'], ADDON_TYPE_THEME))
         .toEqual(`author1-author2-${ADDON_TYPE_THEME}`);
     });

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -47,7 +47,7 @@ describe(__filename, () => {
 
   it('calls the API with addonType if set', async () => {
     const addons = [fakeAddon];
-    const authorNames = ['mozilla'];
+    const authorUsernames = ['mozilla'];
     const state = sagaTester.getState();
 
     mockApi
@@ -56,7 +56,7 @@ describe(__filename, () => {
         api: state.api,
         filters: {
           addonType: ADDON_TYPE_THEME,
-          author: authorNames.sort().join(','),
+          author: authorUsernames.sort().join(','),
           exclude_addons: undefined, // `callApi` will internally unset this
           page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,
@@ -65,12 +65,12 @@ describe(__filename, () => {
       .once()
       .returns(Promise.resolve(createAddonsApiResult(addons)));
 
-    _fetchAddonsByAuthors({ authorNames, addonType: ADDON_TYPE_THEME });
+    _fetchAddonsByAuthors({ authorUsernames, addonType: ADDON_TYPE_THEME });
 
     const expectedLoadAction = loadAddonsByAuthors({
       addons,
       addonType: ADDON_TYPE_THEME,
-      authorNames,
+      authorUsernames,
       forAddonSlug: undefined,
     });
 
@@ -82,7 +82,7 @@ describe(__filename, () => {
 
   it('sends `exclude_addons` param if `forAddonSlug` is set', async () => {
     const addons = [fakeAddon];
-    const authorNames = ['mozilla', 'johnedoe'];
+    const authorUsernames = ['mozilla', 'johnedoe'];
     const { slug } = fakeAddon;
     const state = sagaTester.getState();
 
@@ -92,7 +92,7 @@ describe(__filename, () => {
         api: state.api,
         filters: {
           addonType: undefined,
-          author: authorNames.sort().join(','),
+          author: authorUsernames.sort().join(','),
           exclude_addons: slug,
           page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,
@@ -101,11 +101,11 @@ describe(__filename, () => {
       .once()
       .returns(Promise.resolve(createAddonsApiResult(addons)));
 
-    _fetchAddonsByAuthors({ authorNames, forAddonSlug: slug });
+    _fetchAddonsByAuthors({ authorUsernames, forAddonSlug: slug });
 
     const expectedLoadAction = loadAddonsByAuthors({
       addons,
-      authorNames,
+      authorUsernames,
       forAddonSlug: slug,
     });
 
@@ -116,7 +116,7 @@ describe(__filename, () => {
   });
 
   it('clears the error handler', async () => {
-    _fetchAddonsByAuthors({ authorNames: [], forAddonSlug: fakeAddon.slug });
+    _fetchAddonsByAuthors({ authorUsernames: [], forAddonSlug: fakeAddon.slug });
 
     const expectedAction = errorHandler.createClearingAction();
 
@@ -132,7 +132,7 @@ describe(__filename, () => {
       .once()
       .returns(Promise.reject(error));
 
-    _fetchAddonsByAuthors({ authorNames: [], forAddonSlug: fakeAddon.slug });
+    _fetchAddonsByAuthors({ authorUsernames: [], forAddonSlug: fakeAddon.slug });
 
     const errorAction = errorHandler.createErrorAction(error);
     const calledErrorAction = await sagaTester.waitFor(errorAction.type);
@@ -142,7 +142,7 @@ describe(__filename, () => {
 
   it('handles no API results', async () => {
     const addons = [];
-    const authorNames = ['mozilla', 'johnedoe'];
+    const authorUsernames = ['mozilla', 'johnedoe'];
     const { slug } = fakeAddon;
     const state = sagaTester.getState();
 
@@ -152,7 +152,7 @@ describe(__filename, () => {
         api: state.api,
         filters: {
           addonType: undefined,
-          author: authorNames.sort().join(','),
+          author: authorUsernames.sort().join(','),
           exclude_addons: slug,
           page_size: ADDONS_BY_AUTHORS_PAGE_SIZE,
           sort: SEARCH_SORT_TRENDING,
@@ -161,11 +161,11 @@ describe(__filename, () => {
       .once()
       .returns(Promise.resolve(createAddonsApiResult(addons)));
 
-    _fetchAddonsByAuthors({ authorNames, forAddonSlug: slug });
+    _fetchAddonsByAuthors({ authorUsernames, forAddonSlug: slug });
 
     const expectedLoadAction = loadAddonsByAuthors({
       addons,
-      authorNames,
+      authorUsernames,
       forAddonSlug: slug,
     });
 


### PR DESCRIPTION
Fixes #4806 

Note that this is built on top of the commit in PR #4828, so only the 2nd commit in this PR needs to be looked at.

This fixes the issue both on the User Profile page and on the Addon Details page.

Before:

<img width="1064" alt="screenshot 2018-04-16 11 34 59" src="https://user-images.githubusercontent.com/142755/38882906-73c73336-4239-11e8-8710-8605125bd0a5.png">

After:

<img width="1061" alt="screenshot 2018-04-16 11 31 02" src="https://user-images.githubusercontent.com/142755/38882926-7e3363bc-4239-11e8-8f28-fcc31096049e.png">

Before:

![apr-16-2018 11-34-30](https://user-images.githubusercontent.com/142755/38882819-368efce2-4239-11e8-8f42-92c6d23d6ffb.gif)

After:

![apr-16-2018 11-33-15](https://user-images.githubusercontent.com/142755/38882865-55a99682-4239-11e8-8e77-ff0f68010f45.gif)
