### PR TITLE
Fix i18n docs to have correct command line for committing changes

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -91,7 +91,7 @@ different line numbers in the source. If so, commit your change and continue
 to the next step:
 
 ```
-git commit -a -m"Extract AMO locales"
+git commit -a -m "Extract AMO locales"
 ```
 
 ### Merging locale files
@@ -118,7 +118,7 @@ member before removing `fuzzy` markers.
 Commit and continue to the next step:
 
 ```
-git commit -a -m"Merged AMO locales"
+git commit -a -m "Merged AMO locales"
 ```
 
 ### Building the debug locales
@@ -130,7 +130,7 @@ Build the debug locale and commit it to your branch:
 
 ```
 NODE_APP_INSTANCE=amo bin/debug-locales
-git commit -a -m"Generated AMO debug locale"
+git commit -a -m "Generated AMO debug locale"
 ```
 
 ### Finalizing the extract/merge process

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -91,7 +91,7 @@ different line numbers in the source. If so, commit your change and continue
 to the next step:
 
 ```
-git commit -a "Extract AMO locales"
+git commit -a -m"Extract AMO locales"
 ```
 
 ### Merging locale files
@@ -118,7 +118,7 @@ member before removing `fuzzy` markers.
 Commit and continue to the next step:
 
 ```
-git commit -a "Merged AMO locales"
+git commit -a -m"Merged AMO locales"
 ```
 
 ### Building the debug locales
@@ -130,7 +130,7 @@ Build the debug locale and commit it to your branch:
 
 ```
 NODE_APP_INSTANCE=amo bin/debug-locales
-git commit -a "Generated AMO debug locale"
+git commit -a -m"Generated AMO debug locale"
 ```
 
 ### Finalizing the extract/merge process


### PR DESCRIPTION
I noticed this error when I started doing the weekly extract/merge, and only now am getting around to updating the docs.