### PR TITLE
Allow "Featured add-ons only" checkbox to be selected more easily

### DIFF
--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -200,20 +200,22 @@ export class SearchFiltersBase extends React.Component {
             })}
           </Select>
 
-          <input
-            className="SearchFilters-Featured"
-            checked={!!filters.featured}
-            id="SearchFilters-Featured"
-            name="featured"
-            onChange={this.onChangeCheckbox}
-            type="checkbox"
-          />
-          <label
-            className="SearchFilters-label SearchFilters-Featured-label"
-            htmlFor="SearchFilters-Featured"
-          >
-            {i18n.gettext('Featured add-ons only')}
-          </label>
+          <div id="SearchFilters-Checkbox">
+            <input
+              className="SearchFilters-Featured"
+              checked={!!filters.featured}
+              id="SearchFilters-Featured"
+              name="featured"
+              onChange={this.onChangeCheckbox}
+              type="checkbox"
+            />
+            <label
+              className="SearchFilters-label SearchFilters-Featured-label"
+              htmlFor="SearchFilters-Featured"
+            >
+              {i18n.gettext('Featured add-ons only')}
+            </label>
+          </div>
         </form>
       </ExpandableCard>
     );

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -200,7 +200,10 @@ export class SearchFiltersBase extends React.Component {
             })}
           </Select>
 
-          <div id="SearchFilters-Checkbox">
+          <label
+            className="SearchFilters-label SearchFilters-Featured-label"
+            htmlFor="SearchFilters-Featured"
+          >
             <input
               className="SearchFilters-Featured"
               checked={!!filters.featured}
@@ -209,13 +212,8 @@ export class SearchFiltersBase extends React.Component {
               onChange={this.onChangeCheckbox}
               type="checkbox"
             />
-            <label
-              className="SearchFilters-label SearchFilters-Featured-label"
-              htmlFor="SearchFilters-Featured"
-            >
-              {i18n.gettext('Featured add-ons only')}
-            </label>
-          </div>
+            {i18n.gettext('Featured add-ons only')}
+          </label>
         </form>
       </ExpandableCard>
     );

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -10,22 +10,16 @@
 
 .SearchFilters-select {
   margin: 0 0 5px;
-  width: 100%;
 }
 
 .SearchFilters-Featured-label {
-  @include margin-start(5px);
-
   display: inline-block;
   font-size: 14px;
-  width: 90%;
-}
-
-#SearchFilters-Checkbox {
-  margin: 20px 0 0 0;
+  padding: 20px 0 0 0;
+  padding-right: 25%;
+  width: 100%;
 }
 
 #SearchFilters-Featured {
-  height: 17px;
-  width: 17px;
+  margin: 0 10px 0 0;
 }

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -20,5 +20,5 @@
 }
 
 #SearchFilters-Featured {
-  margin: 0 10px 0 0;
+  @include margin-end(10px);
 }

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -14,7 +14,6 @@
 
 .SearchFilters-Featured-label {
   display: inline-block;
-  font-size: 14px;
   padding: 20px 0 0 0;
   width: 100%;
 }

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -17,4 +17,15 @@
   @include margin-start(5px);
 
   display: inline-block;
+  font-size: 14px;
+  width: 90%;
+}
+
+#SearchFilters-Checkbox {
+  margin: 20px 0 0 0;
+}
+
+#SearchFilters-Featured {
+  height: 17px;
+  width: 17px;
 }

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -16,7 +16,6 @@
   display: inline-block;
   font-size: 14px;
   padding: 20px 0 0 0;
-  padding-right: 25%;
   width: 100%;
 }
 


### PR DESCRIPTION
Fixes #4188: Improved styling for the `Featured add-ons only` checkbox to be easier to click for users in responsive views.

Changes include:

1. The `label` element now wraps the `checkbox`
2. `padding-right` has been added to increase the click target for users in both desktop and mobile viewports
3. Increased the `font-size` and `height`/`width` of both the `label` text as well as the `checkbox` for easier readability

### Non-responsive layout

<img width="618" alt="updated_regular_checkbox_styling" src="https://user-images.githubusercontent.com/13009507/38962797-f4235704-433c-11e8-88c4-9ffcad9a4320.png">

### Vertical responsive layout GIF

![updated_vertical_checkbox_styling](https://user-images.githubusercontent.com/13009507/38962808-021085c6-433d-11e8-9519-03533557c3ba.gif)


### Horizontal responsive layout GIF

![updated_horizontal_checkbox_styling](https://user-images.githubusercontent.com/13009507/38962816-143609b0-433d-11e8-8e08-1c1af671026d.gif)
