### PR TITLE
Fixes #4584: truncated homepage url

### DIFF
--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -48,6 +48,12 @@ $avatar-size: 64px;
   }
 }
 
+.UserProfile-homepage {
+  text-overflow: ellipsis;
+  display: block;
+  overflow: hidden;
+}
+
 .UserProfile-rating-average .Rating {
   @include margin(0, 0, 0, -3px);
 

--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -49,9 +49,9 @@ $avatar-size: 64px;
 }
 
 .UserProfile-homepage {
-  text-overflow: ellipsis;
   display: block;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .UserProfile-rating-average .Rating {


### PR DESCRIPTION
Hello, 

I have noticed that description is already fixed(broken into several lines), but on the screenshot in the issue #4584, I saw that homepage url also looks a bit out of place. I have truncated it.
<img width="367" alt="screen shot 2018-04-20 at 11 03 42 pm" src="https://user-images.githubusercontent.com/31850821/39079778-5705a922-44ef-11e8-944f-dd6edf7a3e3e.png">

