### PR TITLE
Fixes #4070: fixed unbroken long addon names on the homepage

### DIFF
--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -78,6 +78,12 @@
         grid-row: 2 / 2;
       }
 
+      .SearchResult-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
       .SearchResult-users,
       .SearchResult-metadata {
         height: 24px;


### PR DESCRIPTION
I have truncated addon names on the homepage as requested in #4070.
Please let me know if any additional changes are required.
<img width="479" alt="screen shot 2018-04-20 at 11 22 06 pm" src="https://user-images.githubusercontent.com/31850821/39079951-bcd6cea4-44f2-11e8-8e01-70fc4a2cc63c.png">
