### PR TITLE
issue 4813 - fixes collection text style issue

### DIFF
--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -7,22 +7,8 @@
 .EditableCollectionAddon {
   display: grid;
   grid-gap: 24px;
-  grid-template-columns: 32px repeat(auto-fill, minmax(80px, 90px)) 32px 64px;
+  grid-template-columns: 32px minmax(80px, auto) 32px 64px;
   padding: 12px;
-
-  // TODO: look into adding orientation: portrait, landscape breakpt
-  // might help with extra breakpts
-  @include respond-to(medium) {
-    grid-template-columns: 32px repeat(auto-fill, minmax(260px, 260px)) 32px 64px;
-  }
-
-  @include respond-to(large) {
-    grid-template-columns: 32px repeat(auto-fill, minmax(120px, 120px)) 32px 64px;
-  }
-
-  @include respond-to(extraLarge) {
-    grid-template-columns: 32px auto 32px 64px;
-  }
 }
 
 .EditableCollectionAddon-name {

--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -7,17 +7,36 @@
 .EditableCollectionAddon {
   display: grid;
   grid-gap: 24px;
-  grid-template-columns: 32px auto 32px 64px;
+  grid-template-columns: 32px repeat(auto-fill, minmax(80px, 90px)) 32px 64px;
   padding: 12px;
+
+  // TODO: look into adding orientation: portrait, landscape breakpt
+  // might help with extra breakpts
+  @include respond-to(medium) {
+    grid-template-columns: 32px repeat(auto-fill, minmax(260px, 260px)) 32px 64px;
+  }
+
+  @include respond-to(large) {
+    grid-template-columns: 32px repeat(auto-fill, minmax(120px, 120px)) 32px 64px;
+  }
+
+  @include respond-to(extraLarge) {
+    grid-template-columns: 32px auto 32px 64px;
+  }
 }
 
 .EditableCollectionAddon-name {
   @include font-medium();
 
-  align-items: center;
-  display: flex;
   font-size: $font-size-m-smaller;
+  hyphens: auto;
   margin: 0;
+  word-wrap: break-word;
+
+  @include respond-to(extraLarge) {
+    align-items: center;
+    display: flex;
+  }
 }
 
 .EditableCollectionAddon-icon {


### PR DESCRIPTION
Fixes #4813 - addresses style issue in collections text while in editing mode

example of before and after screenshots:

BEFORE EX:
![image](https://user-images.githubusercontent.com/31961530/38817803-d3a1adce-41a1-11e8-9937-125ad7d12ff5.png)

AFTER EX:
![Alt text](https://monosnap.com/image/5TTWYLUSiE6RVM7R3XRF57Ff4iLK32)

@bobsilverberg @muffinresearch 