### PR TITLE
issue 4830 profile style fix

### DIFF
--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -20,7 +20,7 @@
       display: grid;
       grid-auto-flow: initial;
       grid-gap: 6px;
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(3, minmax(32%, 1fr));
     }
   }
 }

--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -14,8 +14,11 @@ $avatar-size: 64px;
 }
 
 .UserProfile-wrapper {
-  display: flex;
-  justify-content: flex-start;
+
+  @include respond-to(large) {
+    display: flex;
+    justify-content: flex-start;
+  }
 }
 
 .UserProfile-user-info {
@@ -63,8 +66,17 @@ $avatar-size: 64px;
 }
 
 .UserProfile-addons-by-author {
-  @include margin(0, 0, 0, 12px);
+  @include margin(12px, 0, 0, 0);
 
-  max-width: 60%;
   width: 100%;
+
+  @include respond-to(large) {
+    @include margin(0, 0, 0, 12px);
+
+    max-width: calc(100% - 300px - 12px);
+  }
+
+  @include respond-to(extraLarge) {
+    max-width: calc(65% - 12px);
+  }
 }


### PR DESCRIPTION
fixes #4830 - user profile page style fixes

BEFORE EX:
![before fixes](https://user-images.githubusercontent.com/33448286/38875366-e02b9dd6-4262-11e8-89a5-64666aa95b6d.png)

AFTER EX:
![After fixes](https://monosnap.com/image/usitfaksEUt8O7rvJarynC0yV1wAUB)


@bobsilverberg @muffinresearch  