### PR TITLE
I4871: fixes duplicate site permissions

### DIFF
--- a/src/ui/components/HostPermissions/index.js
+++ b/src/ui/components/HostPermissions/index.js
@@ -138,6 +138,9 @@ export class HostPermissionsBase extends React.Component<Props> {
       }
     }
 
+    const uniqueWildcards = [...new Set(wildcards)];
+    const uniqueSites = [...new Set(sites)];
+
     // Format the host permissions. If we have a wildcard for all urls,
     // a single string will suffice.  Otherwise, show domain wildcards
     // first, then individual host permissions.
@@ -151,10 +154,10 @@ export class HostPermissionsBase extends React.Component<Props> {
       );
     } else {
       hostPermissions.push(...this.generateHostPermissions({
-        permissions: wildcards, messageType: domainMessageType,
+        permissions: uniqueWildcards, messageType: domainMessageType,
       }));
       hostPermissions.push(...this.generateHostPermissions({
-        permissions: sites, messageType: siteMessageType,
+        permissions: uniqueSites, messageType: siteMessageType,
       }));
     }
     return (

--- a/tests/unit/ui/components/TestHostPermissions.js
+++ b/tests/unit/ui/components/TestHostPermissions.js
@@ -92,16 +92,32 @@ describe(__filename, () => {
     expect(root.find(Permission)).toHaveLength(0);
   });
 
-  it('formats and clubs site permissions with wildcards', () => {
+  it('deduplicates domain and site permissions', () => {
     const permissions = [
       'https://*.okta.com/',
       'https://*.okta.com/login/login.htm*',
       'https://*.okta.com/signin/verify/okta/push',
       'https://*.okta.com/signin/verify/okta/sms',
+      'https://trishulgoel.com/about',
+      'https://trishulgoel.com/speaker',
+      '*://*.mozilla.org/*',
+      '*://*.mozilla.com/*',
+      '*://*.mozilla.ca/*',
+      '*://*.mozilla.us/*',
+      '*://*.mozilla.co.nz/*',
+      '*://*.mozilla.co.uk/*',
     ];
     const root = render({ permissions });
-    expect(root.find(Permission)).toHaveLength(1);
+    expect(root.find(Permission)).toHaveLength(5);
     expectPermission(root.childAt(0),
       'Access your data for sites in the okta.com domain');
+    expectPermission(root.childAt(1),
+      'Access your data for sites in the mozilla.org domain');
+    expectPermission(root.childAt(2),
+      'Access your data for sites in the mozilla.com domain');
+    expectPermission(root.childAt(3),
+      'Access your data in 4 other domains');
+    expectPermission(root.childAt(4),
+      'Access your data for trishulgoel.com');
   });
 });

--- a/tests/unit/ui/components/TestHostPermissions.js
+++ b/tests/unit/ui/components/TestHostPermissions.js
@@ -91,4 +91,17 @@ describe(__filename, () => {
     const root = render({ permissions: ['*'] });
     expect(root.find(Permission)).toHaveLength(0);
   });
+
+  it('formats and clubs site permissions with wildcards', () => {
+    const permissions = [
+      'https://*.okta.com/',
+      'https://*.okta.com/login/login.htm*',
+      'https://*.okta.com/signin/verify/okta/push',
+      'https://*.okta.com/signin/verify/okta/sms',
+    ];
+    const root = render({ permissions });
+    expect(root.find(Permission)).toHaveLength(1);
+    expectPermission(root.childAt(0),
+      'Access your data for sites in the okta.com domain');
+  });
 });


### PR DESCRIPTION
Fixes #4871 

Before: 
<img width="585" alt="screen shot 2018-04-29 at 12 28 13 am" src="https://user-images.githubusercontent.com/5318732/39399913-4bb21294-4b44-11e8-9c31-23e46b64072f.png">

After:
<img width="570" alt="screen shot 2018-04-29 at 12 27 28 am" src="https://user-images.githubusercontent.com/5318732/39399917-516f2a32-4b44-11e8-83c5-650ce497cfff.png">
