### PR TITLE
i-4054 remove dev reply url to their own reply

### DIFF
--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -268,7 +268,7 @@ export class AddonReviewListItemBase extends React.Component<Props> {
           }
           {
             review && addon && siteUser &&
-            !replyingToReview && !review.reply &&
+            !replyingToReview && !review.reply && !isReply &&
             (isAddonAuthor({ addon, userId: siteUser.id }) || siteUserHasReplyPerm) &&
             review.userId !== siteUser.id ?
               (

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -526,14 +526,6 @@ describe(__filename, () => {
     expect(root.find('.AddonReviewListItem-begin-reply')).toHaveLength(0);
   });
 
-  it('hides the reply-to-review link on the developer reply', () => {
-    const developerUserId = 3321;
-    const { addon } = signInAsAddonDeveloper({ developerUserId });
-    const { reply } = _setReviewReply();
-    const root = renderReply({ reply, addon });
-    expect(root.find('.AddonReviewListItem-begin-reply')).toHaveLength(0);
-  });
-
   it('ignores other review related view actions', () => {
     const thisReview = _setReview({ ...fakeReview, id: 1 });
     const anotherReview = _setReview({ ...fakeReview, id: 2 });
@@ -630,6 +622,13 @@ describe(__filename, () => {
       expect(replyComponent).toHaveProp('addon', addon);
       expect(replyComponent).toHaveProp('review', reply);
       expect(replyComponent).toHaveProp('isReplyToReviewId', review.id);
+    });
+
+    it('hides the reply-to-review link on the developer reply', () => {
+      const developerUserId = 3321;
+      const { addon } = signInAsAddonDeveloper({ developerUserId });
+      const root = renderReply({ addon });
+      expect(root.find('.AddonReviewListItem-begin-reply')).toHaveLength(0);
     });
 
     it('hides a nested reply when editing it', () => {

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -526,6 +526,14 @@ describe(__filename, () => {
     expect(root.find('.AddonReviewListItem-begin-reply')).toHaveLength(0);
   });
 
+  it('hides the reply-to-review link on the developer reply', () => {
+    const developerUserId = 3321;
+    const { addon } = signInAsAddonDeveloper({ developerUserId });
+    const { reply } = _setReviewReply();
+    const root = renderReply({ reply, addon });
+    expect(root.find('.AddonReviewListItem-begin-reply')).toHaveLength(0);
+  });
+
   it('ignores other review related view actions', () => {
     const thisReview = _setReview({ ...fakeReview, id: 1 });
     const anotherReview = _setReview({ ...fakeReview, id: 2 });


### PR DESCRIPTION
fixes #4054  - remove reply to review link on dev's reply
BEFORE:
![2017-12-07_1210](https://user-images.githubusercontent.com/15685960/33711388-7e8f039c-db4c-11e7-9183-aed481aeb7ac.png)

AFTER:
![Alt text](https://monosnap.com/image/M2K3n36TDiFjtkQkGcqy3wJIfiGV77.png)

@bobsilverberg @muffinresearch 