### PR TITLE
Revert "fixed long extension names on the homepage (#4856)"

### DIFF
--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -78,12 +78,6 @@
         grid-row: 2 / 2;
       }
 
-      .SearchResult-name {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
       .SearchResult-users,
       .SearchResult-metadata {
         height: 24px;


### PR DESCRIPTION
This reverts commit d758b5be960d83ebc6abed6acb221e6f69a952c0.

I'm reverting this since using truncation is not something we're currently doing for long strings.

Truncating a string with an ellipsis has some issues related to accessibility and it's preferable to keep the wrapping of the string so it's fully readable. 