### PR TITLE
Remove childContextTypes in Translate HOC

### DIFF
--- a/src/core/i18n/translate.js
+++ b/src/core/i18n/translate.js
@@ -41,10 +41,6 @@ export default function translate(options = {}) {
       i18n: PropTypes.object.isRequired,
     };
 
-    Translate.childContextTypes = {
-      i18n: PropTypes.object.isRequired,
-    };
-
     Translate.displayName = `Translate[${getDisplayName(WrappedComponent)}]`;
 
     return Translate;


### PR DESCRIPTION
We have many warnings and I don't think we use context to pass the
`i18n` prop anymore. This should remove some warnings in the devtools.