### PR TITLE
Cachebust all JS files via locale build modification.

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -78,6 +78,10 @@ for (const appName of appsBuildList) {
       localeObject._momentDefineLocale = defineLocale;
     }
 
+    // This is used to force cache-busting of the JS via changing all locale JS.
+    // DO NOT REMOVE! See https://github.com/mozilla/addons-frontend/issues/4927
+    localeObject._cacheBust = '2018.05.04';
+
     fs.writeFileSync(
       localeOutputFilePath, `module.exports = ${toSource(localeObject)}`);
   });


### PR DESCRIPTION
Fixes #4927

See this spreadsheet for a before and after https://docs.google.com/spreadsheets/d/1im9GjQu4Sl_dpsGZjwB5cmrTvNSUH00XystddmTm7qQ/edit#gid=0

This will cache-bust AMO and disco pane's JS