### PR TITLE
Add name to each travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,30 +22,32 @@ cache:
   yarn: true
   directories:
   - node_modules
+
+# Allow to display job names on Travis-CI, see:
+# https://github.com/travis-ci/travis-ci/issues/5898#issuecomment-362490313
+script: yarn $COMMAND
 jobs:
   include:
     # Test the build process.
     - stage:
       <<: *node-prod
-      env: ADDONS_FRONTEND_BUILD_ALL=1
-      script: yarn build
+      env: ADDONS_FRONTEND_BUILD_ALL=1 COMMAND=build
     - stage:
       <<: *node-next
-      env: ADDONS_FRONTEND_BUILD_ALL=1
-      script: yarn build
+      env: ADDONS_FRONTEND_BUILD_ALL=1 COMMAND=build
     # Run the unit/integration tests.
     - stage:
       <<: *node-prod
-      script: yarn test-ci
+      env: COMMAND=test-ci
     - stage:
       <<: *node-next
-      script: yarn test-ci
+      env: COMMAND=test-ci
     - stage:
       <<: *node-prod
-      script: yarn lint
+      env: COMMAND=lint
     - stage:
       <<: *node-prod
-      script: yarn nsp-check
+      env: COMMAND=nsp-check
     # Run the functional tests.
     - stage:
       <<: *tox


### PR DESCRIPTION
I had to open each job to select the one I actually wanted to browse, this patch adds a way to know which job runs which tool.

Before:

![screen shot 2018-05-04 at 14 06 37](https://user-images.githubusercontent.com/217628/39626975-646ef3ce-4fa4-11e8-8cb5-1bcf6d7d6aee.png)

After:

![screen shot 2018-05-04 at 14 06 26](https://user-images.githubusercontent.com/217628/39626974-64543b1a-4fa4-11e8-80ac-cbbc184042a2.png)

