### PR TITLE
i-4886 Line height less in 320*480 dimension of Webpage

### DIFF
--- a/src/ui/components/HeroSection/styles.scss
+++ b/src/ui/components/HeroSection/styles.scss
@@ -56,7 +56,7 @@
 
   display: block;
   font-size: $font-size-m-smaller;
-  line-height: 1;
+  line-height: initial;
   margin: 10px 0 0;
   padding: 0;
   width: 100%;


### PR DESCRIPTION
Fixes #4886 
The line-height between lines is small, which impact reading experience.
Before:
Screen width under 500px:
![image](https://user-images.githubusercontent.com/6767433/39635425-1338bf0c-4ff0-11e8-94a3-a280d63cd980.png)
Screen width over 500px:
![image](https://user-images.githubusercontent.com/6767433/39664490-3a58109e-50b6-11e8-9913-22cc9a65ce6a.png)

After:
Screen width under 500px:
![image](https://user-images.githubusercontent.com/6767433/39663837-c4967dae-50ac-11e8-88b9-50ec69e44294.png)
Screen width over 500px:
![image](https://user-images.githubusercontent.com/6767433/39674717-c4eb998e-5182-11e8-9058-0509203e1bff.png)


The issue creator indicated to change the `line-height` from 1 to initial, I think the default line-height looks better, 1.5 seems too big. However, I am not sure if there is any concerns for changing it. 
Please correct me if I miss something. Thanks!
