### PR TITLE
i 4367 empty review not updating fix

### DIFF
--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -100,7 +100,10 @@ export class AddonReviewBase extends React.Component<Props, State> {
     event.preventDefault();
     event.stopPropagation();
 
-    const newReviewParams = { body: reviewBody || undefined };
+    // If reviewBody text is null, we'll assign it as &nbsp;
+    // which will show as hidden in html and api will follow thru
+    // with the update since there is a value
+    const newReviewParams = { body: reviewBody || '&nbsp;' };
     const updatedReview = { ...review, ...newReviewParams };
 
     const params = {
@@ -218,7 +221,7 @@ export class AddonReviewBase extends React.Component<Props, State> {
               className="AddonReview-textarea"
               onInput={this.onBodyInput}
               name="review"
-              value={reviewBody}
+              value={reviewBody === '&nbsp;' ? '' : reviewBody}
               placeholder={placeholder}
             />
           </div>

--- a/tests/unit/amo/components/TestAddonReview.js
+++ b/tests/unit/amo/components/TestAddonReview.js
@@ -126,6 +126,29 @@ describe(__filename, () => {
       });
   });
 
+  it('a review without text feedback will show as no text in textarea and &nbsp; in review list display', () => {
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+    const updateReviewText = sinon.spy(() => Promise.resolve());
+    const root = render({ updateReviewText });
+
+    root.find('.AddonReview-textarea').simulate('input', createFakeEvent({
+      target: { value: '' },
+    }));
+
+    const event = createFakeEvent();
+    return root.instance().onSubmit(event)
+      .then(() => {
+        sinon.assert.called(event.preventDefault);
+
+        sinon.assert.calledWith(fakeDispatch, setDenormalizedReview({
+          ...defaultReview, body: '&nbsp;',
+        }));
+
+        const params = updateReviewText.firstCall.args[0];
+        expect(params.body).toEqual('&nbsp;');
+      });
+  });
+
   it('focuses the review text on mount', () => {
     const root = mountRender();
     // This checks that reviewTextarea.focus() was called.


### PR DESCRIPTION
fixes #4367 - updates the review whether textarea is empty or not.  It still saves as review regardless if text is added (this latter part still might need to be discussed, imo - unless i am missing something - it should still be a review. is there someone who i should reach out for this question?)

hey @bobsilverberg  - please take a look at this approach and let me know what you think : )

note - i wasn't 100% sure about the test update and if this was enough