### PR TITLE
i-4951 hide search addon field before collection saved

### DIFF
--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -272,15 +272,17 @@ export class CollectionManagerBase extends React.Component<Props, State> {
             value={this.state.slug}
           />
         </div>
-        <AutoSearchInput
-          inputName="collection-addon-query"
-          inputPlaceholder={
-            i18n.gettext('Find an add-on to include in this collection')
-          }
-          onSearch={this.onSearchAddon}
-          onSuggestionSelected={this.onAddonSelected}
-          selectSuggestionText={i18n.gettext('Add to collection')}
-        />
+        {!creating &&
+          <AutoSearchInput
+            inputName="collection-addon-query"
+            inputPlaceholder={
+              i18n.gettext('Find an add-on to include in this collection')
+            }
+            onSearch={this.onSearchAddon}
+            onSuggestionSelected={this.onAddonSelected}
+            selectSuggestionText={i18n.gettext('Add to collection')}
+          />
+        }
         <footer className="CollectionManager-footer">
           {/*
             type=button is necessary to override the default

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -251,6 +251,12 @@ describe(__filename, () => {
     expect(root.find('#collectionSlug')).toHaveProp('value', 'new-slug');
   });
 
+  it('hides search add-on select when creating a collection', () => {
+    const root = render({ collection: null, creating: true });
+
+    expect(root.find(AutoSearchInput)).toHaveLength(0);
+  });
+
   it('creates a collection on submit', () => {
     const errorHandler = createStubErrorHandler();
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4951

Because only if a collection is saved, it is able to search add-ons. Thus, this PR hide the add-on search field when a collection is creating.

On adding a collection:
![image](https://user-images.githubusercontent.com/6767433/39819419-feba0150-53d5-11e8-91be-dd7acd8fe0d1.png)

On editing a collection:
![image](https://user-images.githubusercontent.com/6767433/39819675-992e97b4-53d6-11e8-81d1-cab35b8a4179.png)
