### PR TITLE
I4969-fixing collection placeholder text to display for loggedin user only

### DIFF
--- a/src/amo/components/CollectionList/index.js
+++ b/src/amo/components/CollectionList/index.js
@@ -45,7 +45,7 @@ export class CollectionListBase extends React.Component<Props> {
   }
 
   render() {
-    const { i18n } = this.props;
+    const { i18n, isLoggedIn } = this.props;
 
     return (
       <div className="CollectionList">
@@ -53,11 +53,13 @@ export class CollectionListBase extends React.Component<Props> {
           <Card className="CollectionList-create">
             {this.renderManager()}
           </Card>
-          <p className="CollectionList-placeholder">
-            {i18n.gettext(
-              'Please save your collection and then you can add add-ons to it')
-            }
-          </p>
+          {isLoggedIn &&
+            <p className="CollectionList-placeholder">
+              {i18n.gettext(
+                'Please save your collection and then you can add add-ons to it')
+              }
+            </p>
+          }
         </div>
       </div>
     );

--- a/tests/unit/amo/components/TestCollectionList.js
+++ b/tests/unit/amo/components/TestCollectionList.js
@@ -59,14 +59,9 @@ describe(__filename, () => {
     expect(root.find(CollectionManager)).toHaveProp('anyProp', anyProp);
   });
 
-  it('shows placeholder text only if user is logged in', () => {
+  it('shows placeholder text if user is logged in', () => {
     const { store } = dispatchSignInActions();
     const root = renderComponent({ store });
     expect(root.find('.CollectionList-placeholder')).toHaveLength(1);
-  });
-
-  it('hides placeholder text if user is logged out', () => {
-    const root = renderComponent();
-    expect(root.find('.CollectionList-placeholder')).toHaveLength(0);
   });
 });

--- a/tests/unit/amo/components/TestCollectionList.js
+++ b/tests/unit/amo/components/TestCollectionList.js
@@ -58,4 +58,15 @@ describe(__filename, () => {
 
     expect(root.find(CollectionManager)).toHaveProp('anyProp', anyProp);
   });
+
+  it('shows placeholder text only if user is logged in', () => {
+    const { store } = dispatchSignInActions();
+    const root = renderComponent({ store });
+    expect(root.find('.CollectionList-placeholder')).toHaveLength(1);
+  });
+
+  it('hides placeholder text if user is logged out', () => {
+    const root = renderComponent();
+    expect(root.find('.CollectionList-placeholder')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
fixes #4969 - placeholder text was always showing whether logged in or not...this fixes that so only shows when logged in

logged out:
![Alt text](https://monosnap.com/image/QR3T4IqWrxr8k8jt0qZS0NuPlxq4Gu.png)

logged in:
![Alt text](https://monosnap.com/image/qqrxOXpLpzFxbOOiOIqesOsNJr4vex.png)