### PR TITLE
Css fix for add ons (extensions) detail page

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -72,7 +72,7 @@
   margin: 0 0 $padding-page-l;
   width: 100%;
   word-wrap: break-word;
-  
+
   .Addon-persona & {
     margin: $padding-page-l 0;
   }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -70,8 +70,9 @@
   grid-column: 1 / span 2;
   margin: 0 0 $padding-page-l;
   width: 100%;
-  word-wrap: break-word;
   line-height: normal;
+  word-wrap: break-word;
+  
 
   .Addon-persona & {
     margin: $padding-page-l 0;
@@ -86,8 +87,9 @@
   @include font-light();
 
   display: block;
-  word-wrap: break-word;
   line-height: 1.5;
+  word-wrap: break-word;
+  
 
   &,
   a,

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -86,6 +86,7 @@
 
   display: block;
   word-wrap: break-word;
+  line-height: 1.5;
 
   &,
   a,

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -86,7 +86,7 @@
   @include font-light();
 
   display: block;
-  line-height: 1.5;
+  line-height: 1.3;
   word-wrap: break-word;
 
   &,

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -71,6 +71,7 @@
   margin: 0 0 $padding-page-l;
   width: 100%;
   word-wrap: break-word;
+  line-height: normal;
 
   .Addon-persona & {
     margin: $padding-page-l 0;

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -86,7 +86,7 @@
   @include font-light();
 
   display: block;
-  line-height: 1.3;
+  padding-top: 3px;
   word-wrap: break-word;
 
   &,

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -68,12 +68,11 @@
   color: $black;
   font-size: $font-size-l;
   grid-column: 1 / span 2;
+  line-height: 1.5;
   margin: 0 0 $padding-page-l;
   width: 100%;
-  line-height: normal;
   word-wrap: break-word;
   
-
   .Addon-persona & {
     margin: $padding-page-l 0;
   }
@@ -89,7 +88,6 @@
   display: block;
   line-height: 1.5;
   word-wrap: break-word;
-  
 
   &,
   a,

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -68,7 +68,7 @@
   color: $black;
   font-size: $font-size-l;
   grid-column: 1 / span 2;
-  line-height: 1.5;
+  line-height: 1.1;
   margin: 0 0 $padding-page-l;
   width: 100%;
   word-wrap: break-word;


### PR DESCRIPTION
Fixes #4878 

This PR introduces css changes to the details page of individual add ons. 

The original issue was opened to fix the line containing the author, which at times would overlap with the title (depending on the letters contained in the title, such as `g, y, p, q` and the size of screen) like so: 
<p align="center">
  <img src="https://user-images.githubusercontent.com/26360553/39890090-b7d34368-5467-11e8-82b7-0737954bad77.png">
</p><br/>

To fix this problem, I just added a `line-height` of `1.5` to the `Addon-author` class:
<p align="center">
  <img src="https://user-images.githubusercontent.com/26360553/39890120-d7cbc7d0-5467-11e8-95c1-29c1bf353c58.png">
</p><br/>

While implementing this change and testing the results, I also noticed that at times the title itself ran into the same problem: 
<p align="center">
  <img src = "https://user-images.githubusercontent.com/26360553/39889283-7a37113a-5465-11e8-819f-00eeac5e0818.png">
</p>
and another example: 
<p align="center">
  <img src="https://user-images.githubusercontent.com/26360553/39889317-8a16719a-5465-11e8-9e5d-00e4f5b2b8fe.png">
</p><br/>

So I added a `line-height` property to the `Addon-title` class as well, with a value of `normal` (1.5 was too much for the title): 
<p align="center">
  <img src="https://user-images.githubusercontent.com/26360553/39889463-f3fa90c8-5465-11e8-9671-0125a16d97eb.png">
</p><br/>

There were no tests found for the files I modified, so I ran `yarn lint` and corrected any formatting errors. 