### PR TITLE
I4947-addonrecommendations-style-update

### DIFF
--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -26,6 +26,8 @@ import type { I18nType } from 'core/types/i18n';
 import type { AddonType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
 
+import './styles.scss';
+
 export const TAAR_IMPRESSION_CATEGORY = 'AMO Addon / Recommendations Shown';
 export const TAAR_COHORT_COOKIE_NAME = 'taar_cohort';
 export const TAAR_COHORT_INCLUDED: 'TAAR_COHORT_INCLUDED'

--- a/src/amo/components/AddonRecommendations/styles.scss
+++ b/src/amo/components/AddonRecommendations/styles.scss
@@ -1,0 +1,52 @@
+@import "~core/css/inc/mixins";
+@import "~amo/css/inc/vars";
+@import "~ui/css/vars";
+
+.AddonRecommendations {
+
+  // stylelint-disable max-nesting-depth
+  @include respond-to(large) {
+    &.AddonsCard--horizontal {
+      ul.AddonsCard-list {
+
+        // overriding default Search Results styles
+        .SearchResult {
+          padding: 12px 34px 12px 14px;
+
+          &:hover {
+            background-color: $grey-10;
+            border-radius: $border-radius-default;
+            cursor: pointer;
+
+            .SearchResult-name {
+              color: $link-color;
+            }
+
+            .SearchResult-users {
+              display: none;
+            }
+
+            .SearchResult-metadata {
+              display: block;
+            }
+          }
+        }
+
+        .SearchResult-link {
+          padding: 0;
+
+          &:hover,
+          &:focus {
+            background-color: transparent;
+          }
+        }
+
+        .SearchResult-users,
+        .SearchResult-metadata {
+          height: auto;
+          min-height: 24px;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
fixes #4947 - addresses a few style issues for addon recommendations noted in this issue

many user style fix:
![Alt text](https://monosnap.com/image/RP8UWgL7VOHCOXebam66vtDEwSyLEt.png)

Loading style fix:
![Alt text](https://monosnap.com/image/59t2EOLoDdeZzjZIy9fpj40WjJLaiz.png)

Also - on a separate but related issue:

I see this for iPad / ~768px - 1024 sizes:
![Alt text](https://monosnap.com/image/QCxugIsICiGpDmMUjO2is8g6bGopKN.png)
![Alt text](https://monosnap.com/image/i6YUvQYwZ5xuaa93s4X2ssBT6yyBbv.png)

basically b/c the device is smaller but column is still on the right there is not a enough room really. I am wondering if could make this look more like the mobile version or if we could maybe go to 3 columns (each col approx ~ 33%) and adjust the padding slightly so it’s not so squished. I just wasn't sure - should I open a new issue for this (assuming there isn’t one open already for this (I’ll check)), or just ask about it here?

@bobsilverberg 