### PR TITLE
Remove trailing period from rating tooltip message

### DIFF
--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -65,11 +65,11 @@ export class RatingBase extends React.Component {
 
     if (rating) {
       return i18n.sprintf(i18n.gettext(
-        `Update your rating to %(starRating)s out of 5.`), { starRating });
+        `Update your rating to %(starRating)s out of 5`), { starRating });
     }
 
     return i18n.sprintf(i18n.gettext(
-      `Rate this add-on %(starRating)s out of 5.`), { starRating });
+      `Rate this add-on %(starRating)s out of 5`), { starRating });
   }
 
   renderRatings() {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -173,7 +173,7 @@ describe(__filename, () => {
     const root = render({ rating: null });
 
     [1, 2, 3, 4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].title).toEqual(`Rate this add-on ${rating} out of 5.`);
+      expect(root.ratingElements[rating].title).toEqual(`Rate this add-on ${rating} out of 5`);
     });
   });
 
@@ -181,7 +181,7 @@ describe(__filename, () => {
     const root = render({ rating: 0 });
 
     [1, 2, 3, 4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].title).toEqual(`Rate this add-on ${rating} out of 5.`);
+      expect(root.ratingElements[rating].title).toEqual(`Rate this add-on ${rating} out of 5`);
     });
   });
 
@@ -189,7 +189,7 @@ describe(__filename, () => {
     const root = render({ rating: 3 });
 
     [1, 2, 3, 4, 5].forEach((rating) => {
-      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5.`);
+      expect(root.ratingElements[rating].title).toEqual(`Update your rating to ${rating} out of 5`);
     });
   });
 


### PR DESCRIPTION
Fixes #4995 - remove the trailing period from rating tooltip messages as it makes the tooltip text instructive/imperative rather than infinitive, which negatively affects a number of localizations.