### PR TITLE
Remove getDisplayName() logic and use 'name' API field

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -96,7 +96,7 @@ export class HeaderBase extends React.Component {
 
           {siteUser ? (
             <DropdownMenu
-              text={siteUser.displayName}
+              text={siteUser.name}
               className="Header-authenticate-button Header-button"
             >
               <DropdownMenuItem>{i18n.gettext('My Account')}</DropdownMenuItem>

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -84,13 +84,13 @@ export class UserProfileBase extends React.Component<Props> {
         <UserAvatar className="UserProfile-avatar" user={user} />
 
         <h1 className="UserProfile-name">
-          {user ? user.displayName : <LoadingText />}
+          {user ? user.name : <LoadingText />}
         </h1>
       </React.Fragment>
     );
     const userProfileTitle = i18n.sprintf(
       i18n.gettext('User Profile for %(user)s'), {
-        user: user ? user.displayName : params.username,
+        user: user ? user.name : params.username,
       }
     );
 
@@ -160,7 +160,7 @@ export class UserProfileBase extends React.Component<Props> {
             <div className="UserProfile-addons-by-author">
               <AddonsByAuthorsCard
                 addonType={ADDON_TYPE_EXTENSION}
-                authorDisplayName={[user.displayName]}
+                authorDisplayName={[user.name]}
                 authorUsernames={[user.username]}
                 numberOfAddons={3}
                 showSummary
@@ -170,7 +170,7 @@ export class UserProfileBase extends React.Component<Props> {
 
               <AddonsByAuthorsCard
                 addonType={ADDON_TYPE_THEME}
-                authorDisplayName={[user.displayName]}
+                authorDisplayName={[user.name]}
                 authorUsernames={[user.username]}
                 numberOfAddons={6}
                 showMore={false}

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -230,7 +230,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
             <title>
               {i18n.sprintf(
                 i18n.gettext('User Profile for %(user)s'),
-                { user: user.displayName }
+                { user: user.name }
               )}
             </title>
           </Helmet>

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -54,8 +54,6 @@ export type ExternalUserType = {|
 
 export type UserType = {|
   ...ExternalUserType,
-  // Properties we add to each object.
-  displayName: string | null,
 |};
 
 export type UsersStateType = {
@@ -228,13 +226,6 @@ export const getCurrentUser = (users: UsersStateType) => {
   return currentUser;
 };
 
-export const getDisplayName = (user: ExternalUserType) => {
-  // We fallback to the username if no display name has been defined by the
-  // user.
-  return user.display_name && user.display_name.length ?
-    user.display_name : user.username;
-};
-
 export const hasPermission = (
   state: { users: UsersStateType }, permission: string,
 ): boolean => {
@@ -291,13 +282,8 @@ export const addUserToState = ({ state, user } : {
   user: ExternalUserType,
   state: UsersStateType,
 }): Object => {
-  const newUser: UserType = {
-    ...user,
-    displayName: getDisplayName(user),
-  };
-
-  const byID = { ...state.byID, [newUser.id]: newUser };
-  const byUsername = { ...state.byUsername, [newUser.username]: newUser.id };
+  const byID = { ...state.byID, [user.id]: user };
+  const byUsername = { ...state.byUsername, [user.username]: user.id };
 
   return { byID, byUsername };
 };

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -374,7 +374,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       userFields: {
         biography: user.biography,
-        display_name: user.displayName,
+        display_name: user.display_name,
         homepage: user.homepage,
         location: user.location,
         occupation: user.occupation,
@@ -465,7 +465,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       userFields: {
         biography: user.biography,
-        display_name: user.displayName,
+        display_name: user.display_name,
         homepage: user.homepage,
         location,
         occupation: user.occupation,

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -3,7 +3,6 @@ import reducer, {
   finishEditUserAccount,
   editUserAccount,
   getCurrentUser,
-  getDisplayName,
   getUserById,
   getUserByUsername,
   hasAnyReviewerRelatedPermission,
@@ -197,56 +196,6 @@ describe(__filename, () => {
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
-    });
-  });
-
-  describe('getDisplayName selector', () => {
-    it('sets the display name when user has a display name', () => {
-      const displayName = 'King of the Elephants';
-      const { state } = dispatchSignInActions({
-        userProps: { display_name: displayName },
-      });
-
-      expect(getDisplayName(getCurrentUser(state.users))).toEqual(displayName);
-    });
-
-    it('returns the username when display name is null', () => {
-      const username = 'babar';
-      const displayName = null;
-      const { state } = dispatchSignInActions({
-        userProps: { display_name: displayName, username },
-      });
-
-      expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
-    });
-
-    it('returns the username when display name is undefined', () => {
-      const username = 'babar';
-      const displayName = undefined;
-      const { state } = dispatchSignInActions({
-        userProps: { display_name: displayName, username },
-      });
-
-      expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
-    });
-
-    it('returns the username when display name is an empty string', () => {
-      const username = 'babar';
-      const displayName = '';
-      const { state } = dispatchSignInActions({
-        userProps: { display_name: displayName, username },
-      });
-
-      expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
-    });
-
-    it('returns the username when user did not define a display name', () => {
-      const username = 'babar';
-      const { state } = dispatchSignInActions({
-        userProps: { display_name: undefined, username },
-      });
-
-      expect(getDisplayName(getCurrentUser(state.users))).toEqual(username);
     });
   });
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -400,7 +400,9 @@ export function createUserAccountResponse({
     is_addon_developer: false,
     is_artist: false,
     location,
-    name: '',
+    // This is the API behavior.
+    // eslint-disable-next-line camelcase
+    name: display_name || username,
     num_addons_listed,
     occupation,
     picture_type,


### PR DESCRIPTION
Fix #4958

---

I do not think we should have logic for retrieving the display name
since the API already does that by exposing a `name` field.