### PR TITLE
i-4994-style adjustments on recommendations

### DIFF
--- a/src/amo/components/AddonRecommendations/styles.scss
+++ b/src/amo/components/AddonRecommendations/styles.scss
@@ -15,11 +15,6 @@
         grid-template-columns: repeat(2, 50%);
       }
 
-      @include respond-to(extraLarge) {
-        margin: 0 auto;
-        max-width: 80%;
-      }
-
       .SearchResult {
 
         @include respond-to(large) {


### PR DESCRIPTION
fixes mozilla/addons#11757 - adjusting styles on recommendations - updates on medium and above breakpoints

trying out the 2 per row suggestion noted in issue:


~768px (portrait) breakpoint:
![Alt text](https://monosnap.com/image/4lyMDUfFL5zBinr1qqHy1jx8EzDV71.png)

~1064px (landscape) breakpoint:
![Alt text](https://monosnap.com/image/44LGORyoLAYNY4Hskrf99OIrMs5sV0.png)

desktop:
![Alt text](https://monosnap.com/image/Bz93Wq9YGFD9DHkKevyfF5iIJNRBJ7.png)

cc @pwalm 




