### PR TITLE
Add a confirmation when adding add-ons to a collection

### DIFF
--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -323,7 +323,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
         </div>
         {this.state.addAddonStatus === ADDON_ADDED_STATE_SUCCESS && (
           <Notice type="success">
-            {i18n.gettext('Add-on added')}
+            {i18n.gettext('Added to collection')}
           </Notice>
         )}
         {!creating &&

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -38,15 +38,14 @@ import type { ReactRouterType } from 'core/types/router';
 
 import './styles.scss';
 
-export const ADDON_ADDED_STATE_PENDING: 'ADDON_ADDED_STATE_PENDING'
-  = 'ADDON_ADDED_STATE_PENDING';
-export const ADDON_ADDED_STATE_SUCCESS: 'ADDON_ADDED_STATE_SUCCESS'
-  = 'ADDON_ADDED_STATE_SUCCESS';
+export const ADDON_ADDED_STATUS_PENDING: 'ADDON_ADDED_STATUS_PENDING'
+  = 'ADDON_ADDED_STATUS_PENDING';
+export const ADDON_ADDED_STATUS_SUCCESS: 'ADDON_ADDED_STATUS_SUCCESS'
+  = 'ADDON_ADDED_STATUS_SUCCESS';
 
-export type AddonAddedStatusType = |
-  typeof ADDON_ADDED_STATE_PENDING |
-  typeof ADDON_ADDED_STATE_SUCCESS |
-  null;
+export type AddonAddedStatusType =
+  | typeof ADDON_ADDED_STATUS_PENDING
+  | typeof ADDON_ADDED_STATUS_SUCCESS;
 
 type Props = {|
   hasAddonBeenAdded: boolean,
@@ -65,7 +64,7 @@ type Props = {|
 |};
 
 type State = {|
-  addAddonStatus: AddonAddedStatusType,
+  addonAddedStatus: AddonAddedStatusType | null,
   customSlug?: boolean,
   description?: string | null,
   name?: string | null,
@@ -75,11 +74,7 @@ type State = {|
 export class CollectionManagerBase extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    const state = this.propsToState(props);
-    this.state = {
-      ...state,
-      addAddonStatus: null,
-    };
+    this.state = this.propsToState(props);
   }
 
   componentWillReceiveProps(props: Props) {
@@ -92,8 +87,8 @@ export class CollectionManagerBase extends React.Component<Props, State> {
     }
     if (this.props.hasAddonBeenAdded !== props.hasAddonBeenAdded) {
       this.setState({
-        addAddonStatus: props.hasAddonBeenAdded ?
-          ADDON_ADDED_STATE_SUCCESS : null,
+        addonAddedStatus: props.hasAddonBeenAdded ?
+          ADDON_ADDED_STATUS_SUCCESS : null,
       });
     }
   }
@@ -228,12 +223,13 @@ export class CollectionManagerBase extends React.Component<Props, State> {
       page: page || 1,
       userId: siteUserId,
     }));
-    this.setState({ addAddonStatus: ADDON_ADDED_STATE_PENDING });
+    this.setState({ addonAddedStatus: ADDON_ADDED_STATUS_PENDING });
   };
 
   propsToState(props: Props) {
     // Decode HTML entities so the user sees real symbols in the form.
     return {
+      addonAddedStatus: null,
       customSlug: false,
       description: props.collection &&
         decodeHtmlEntities(props.collection.description),
@@ -321,7 +317,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
             value={this.state.slug}
           />
         </div>
-        {this.state.addAddonStatus === ADDON_ADDED_STATE_SUCCESS && (
+        {this.state.addonAddedStatus === ADDON_ADDED_STATUS_SUCCESS && (
           <Notice type="success">
             {i18n.gettext('Added to collection')}
           </Notice>

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -19,6 +19,10 @@
     padding: 24px 0 6px;
   }
 
+  .Notice {
+    margin-top: 24px;
+  }
+
   .CollectionManager-collectionName {
     padding-top: 0;
   }

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -85,6 +85,7 @@ export type CollectionsState = {
     },
   },
   isCollectionBeingModified: boolean,
+  hasAddonBeenAdded: boolean,
 };
 
 export const initialState: CollectionsState = {
@@ -94,6 +95,7 @@ export const initialState: CollectionsState = {
   userCollections: {},
   addonInCollections: {},
   isCollectionBeingModified: false,
+  hasAddonBeenAdded: false,
 };
 
 type FetchCurrentCollectionParams = {|
@@ -906,29 +908,38 @@ const reducer = (
             },
           },
         },
+        hasAddonBeenAdded: true,
       };
     }
 
     case ADD_ADDON_TO_COLLECTION: {
       const { addonId, userId } = action.payload;
 
-      return changeAddonCollectionsLoadingFlag({
+      const newState = changeAddonCollectionsLoadingFlag({
         addonId,
         userId,
         state,
         loading: true,
       });
+      return {
+        ...newState,
+        hasAddonBeenAdded: false,
+      };
     }
 
     case ABORT_ADD_ADDON_TO_COLLECTION: {
       const { addonId, userId } = action.payload;
 
-      return changeAddonCollectionsLoadingFlag({
+      const newState = changeAddonCollectionsLoadingFlag({
         addonId,
         userId,
         state,
         loading: false,
       });
+      return {
+        ...newState,
+        hasAddonBeenAdded: false,
+      };
     }
 
     case BEGIN_COLLECTION_MODIFICATION: {

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -170,11 +170,10 @@ export function* addAddonToCollection({
         slug: collectionSlug,
         user: userId,
       }));
-    } else {
-      yield put(addonAddedToCollection({
-        addonId, userId, collectionId,
-      }));
     }
+    yield put(addonAddedToCollection({
+      addonId, userId, collectionId,
+    }));
   } catch (error) {
     log.warn(`Failed to add add-on to collection: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -715,6 +715,8 @@ describe(__filename, () => {
 
     expect(root.find(Notice)).toHaveLength(0);
 
+    // Setting this simulates an add-on having been added previously, which
+    // will cause the notification to appear.
     root.setProps({ hasAddonBeenAdded: true });
 
     expect(root.find(Notice)).toHaveLength(1);

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -34,6 +34,7 @@ import {
 } from 'tests/unit/amo/helpers';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
+import Notice from 'ui/components/Notice';
 
 const simulateAutoSearchCallback = (props = {}) => {
   return simulateComponentCallback({
@@ -693,6 +694,17 @@ describe(__filename, () => {
 
     const newState = root.state();
     expect(newState.addAddonStatus).toEqual(ADDON_ADDED_STATE_PENDING);
+  });
+
+  it('displays a notification after an add-on has been added', () => {
+    const root = render({});
+
+    expect(root.find(Notice)).toHaveLength(0);
+
+    root.setProps({ hasAddonBeenAdded: true });
+
+    expect(root.find(Notice)).toHaveLength(1);
+    expect(root.find(Notice).children()).toHaveText('Added to collection');
   });
 
   describe('extractId', () => {

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import AutoSearchInput from 'amo/components/AutoSearchInput';
 import CollectionManager, {
-  ADDON_ADDED_STATE_PENDING,
+  ADDON_ADDED_STATUS_PENDING,
   extractId,
   CollectionManagerBase,
 } from 'amo/components/CollectionManager';
@@ -522,6 +522,7 @@ describe(__filename, () => {
     simulateCancel(root);
 
     const state = root.state();
+    expect(state.addonAddedStatus).toEqual(null);
     expect(state.name).toEqual(collection.name);
     expect(state.description).toEqual(collection.description);
   });
@@ -580,6 +581,7 @@ describe(__filename, () => {
     root.setProps({ collection });
 
     const state = root.state();
+    expect(state.addonAddedStatus).toEqual(null);
     expect(state.name).toEqual(collection.name);
     expect(state.description).toEqual(collection.description);
   });
@@ -606,6 +608,7 @@ describe(__filename, () => {
     root.setProps({ collection: secondCollection });
 
     const state = root.state();
+    expect(state.addonAddedStatus).toEqual(null);
     expect(state.name).toEqual(secondCollection.name);
     expect(state.description).toEqual(secondCollection.description);
   });
@@ -678,11 +681,11 @@ describe(__filename, () => {
     }));
   });
 
-  it('sets the addAddonStatus state to pending when selecting an add-on', () => {
+  it('sets the addonAddedStatus state to pending when selecting an add-on', () => {
     const root = render({});
 
     const state = root.state();
-    expect(state.addAddonStatus).toEqual(null);
+    expect(state.addonAddedStatus).toEqual(null);
 
     const suggestion = createInternalSuggestion(
       createFakeAutocompleteResult({ name: 'uBlock Origin' })
@@ -693,7 +696,7 @@ describe(__filename, () => {
     selectSuggestion(suggestion);
 
     const newState = root.state();
-    expect(newState.addAddonStatus).toEqual(ADDON_ADDED_STATE_PENDING);
+    expect(newState.addonAddedStatus).toEqual(ADDON_ADDED_STATUS_PENDING);
   });
 
   it('displays a notification after an add-on has been added', () => {
@@ -705,6 +708,20 @@ describe(__filename, () => {
 
     expect(root.find(Notice)).toHaveLength(1);
     expect(root.find(Notice).children()).toHaveText('Added to collection');
+  });
+
+  it('removes the notification after a new add-on has been selected', () => {
+    const root = render({});
+
+    expect(root.find(Notice)).toHaveLength(0);
+
+    root.setProps({ hasAddonBeenAdded: true });
+
+    expect(root.find(Notice)).toHaveLength(1);
+
+    root.setProps({ hasAddonBeenAdded: false });
+
+    expect(root.find(Notice)).toHaveLength(0);
   });
 
   describe('extractId', () => {

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -719,7 +719,13 @@ describe(__filename, () => {
 
     expect(root.find(Notice)).toHaveLength(1);
 
-    root.setProps({ hasAddonBeenAdded: false });
+    const suggestion = createInternalSuggestion(
+      createFakeAutocompleteResult({ name: 'uBlock Origin' })
+    );
+    const selectSuggestion = simulateAutoSearchCallback({
+      root, propName: 'onSuggestionSelected',
+    });
+    selectSuggestion(suggestion);
 
     expect(root.find(Notice)).toHaveLength(0);
   });

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -300,7 +300,7 @@ describe(__filename, () => {
       expect(savedState.collections).toEqual(null);
     });
 
-    it('sets a hasAddonBeenAdded flag when begining to add add-on to collection', () => {
+    it('sets a hasAddonBeenAdded flag when beginning to add add-on to collection', () => {
       const state = reducer(undefined, addAddonToCollection({
         addonId: 1,
         userId: 2,

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -300,6 +300,18 @@ describe(__filename, () => {
       expect(savedState.collections).toEqual(null);
     });
 
+    it('sets a hasAddonBeenAdded flag when begining to add add-on to collection', () => {
+      const state = reducer(undefined, addAddonToCollection({
+        addonId: 1,
+        userId: 2,
+        collectionId: 3,
+        collectionSlug: 'some-collection',
+        errorHandlerId: 'error-handler',
+      }));
+
+      expect(state.hasAddonBeenAdded).toEqual(false);
+    });
+
     it('preserves existing collections when adding new ones', () => {
       const addonId = 871;
       const userId = 321;
@@ -341,6 +353,7 @@ describe(__filename, () => {
       const savedState = state.addonInCollections[userId][addonId];
       expect(savedState.collections).toEqual(null);
       expect(savedState.loading).toEqual(false);
+      expect(state.hasAddonBeenAdded).toEqual(false);
     });
 
     it('preserves collection data when aborting new additions', () => {
@@ -381,6 +394,14 @@ describe(__filename, () => {
       const savedState = state.addonInCollections[userId][addonId];
       expect(savedState.loading).toEqual(false);
       expect(savedState.collections).toEqual([collection.id]);
+    });
+
+    it('sets a hasAddonBeenAdded flag after an add-on has been added', () => {
+      const state = reducer(undefined, addonAddedToCollection({
+        userId: 1, addonId: 2, collectionId: 3,
+      }));
+
+      expect(state.hasAddonBeenAdded).toEqual(true);
     });
 
     it('appends a new add-on to the list of its collections', () => {

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -308,7 +308,7 @@ describe(__filename, () => {
       mockApi.verify();
     });
 
-    it('posts an add-on to a collection in edit mode', async () => {
+    it('posts an add-on to a collection while the collection is being edited', async () => {
       const collectionSlug = 'a-collection';
       const params = {
         addonId: 123,


### PR DESCRIPTION
Fixes #4979 

Also fixes #4982 

Note that the message does not currently fade out. I'm going to open a follow-up issue about that. I also think the placement could be improved as well, which can also be dealt with in a follow-up.

Pending @pwalm's response to https://github.com/mozilla/addons-frontend/issues/4979#issuecomment-389245823, it just uses a generic message rather than one customized by add-on type.
 
Screenshot of message:

<img width="489" alt="screenshot 2018-05-15 16 18 44" src="https://user-images.githubusercontent.com/142755/40081335-aa0c6a82-585b-11e8-8e9e-376d4a4fd96d.png">
