### PR TITLE
Allow to send a user picture along with editable fields

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,9 @@
     "HTMLTextAreaElement": true,
     "Node": true,
     // This is used to send form data to the API.
-    "FormData": true
+    "FormData": true,
+    // This is used to upload files in the browser.
+    "File": true
   },
   "parser": "babel-eslint",
   "plugins": [

--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -16,17 +16,32 @@ export function currentUserAccount({ api }: {| api: ApiStateType |}) {
   });
 }
 
-export function editUserAccount({ api, userId, ...editableFields }: {|
+export function editUserAccount({ api, userId, picture, ...editableFields }: {|
   api: ApiStateType,
   editableFields: UserEditableFieldsType,
+  picture?: File | null,
   userId: number,
 |}) {
   invariant(api, 'api state is required.');
   invariant(userId, 'userId is required.');
 
+  let body = editableFields;
+
+  if (picture) {
+    const form = new FormData();
+    // Add all the editable fields, one by one.
+    Object.keys(editableFields).forEach((key: string) => {
+      form.set(key, editableFields[key]);
+    });
+    // Add the picture file.
+    form.set('picture_upload', picture);
+    // Set the API body to be the form.
+    body = form;
+  }
+
   return callApi({
     auth: true,
-    body: editableFields,
+    body,
     endpoint: `accounts/account/${userId}`,
     method: 'PATCH',
     state: api,

--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -16,7 +16,7 @@ export function currentUserAccount({ api }: {| api: ApiStateType |}) {
   });
 }
 
-export function editUserAccount({ api, userId, picture, ...editableFields }: {|
+export function editUserAccount({ api, picture, userId, ...editableFields }: {|
   api: ApiStateType,
   editableFields: UserEditableFieldsType,
   picture?: File | null,

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -148,7 +148,7 @@ export const editUserAccount = ({
 
   return {
     type: EDIT_USER_ACCOUNT,
-    payload: { errorHandlerId, userFields, picture, userId },
+    payload: { errorHandlerId, picture, userFields, userId },
   };
 };
 

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -129,6 +129,7 @@ export const finishEditUserAccount = (): FinishEditUserAccountAction => {
 
 type EditUserAccountParams = {|
   errorHandlerId: string,
+  picture?: File | null,
   userFields: UserEditableFieldsType,
   userId: UserId,
 |};
@@ -139,7 +140,7 @@ type EditUserAccountAction = {|
 |};
 
 export const editUserAccount = ({
-  errorHandlerId, userFields, userId,
+  errorHandlerId, picture, userFields, userId,
 }: EditUserAccountParams): EditUserAccountAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(userFields, 'userFields are required');
@@ -147,7 +148,7 @@ export const editUserAccount = ({
 
   return {
     type: EDIT_USER_ACCOUNT,
-    payload: { errorHandlerId, userFields, userId },
+    payload: { errorHandlerId, userFields, picture, userId },
   };
 };
 

--- a/src/amo/sagas/users.js
+++ b/src/amo/sagas/users.js
@@ -37,6 +37,7 @@ export function* fetchCurrentUserAccount({ payload }) {
 export function* editUserAccount({
   payload: {
     errorHandlerId,
+    picture,
     userFields,
     userId,
   },
@@ -50,6 +51,7 @@ export function* editUserAccount({
 
     const user = yield call(editUserAccountApi, {
       api: state.api,
+      picture,
       userId,
       ...userFields,
     });

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -1,3 +1,5 @@
+import deepEqual from 'deep-eql';
+
 import * as api from 'core/api';
 import {
   currentUserAccount,
@@ -75,6 +77,30 @@ describe(__filename, () => {
           state: params.api,
         })
         .returns(mockResponse(editableFields));
+
+      await editUserAccount(params);
+      mockApi.verify();
+    });
+
+    it('sends a FormData body when a picture file is supplied', async () => {
+      const editableFields = {
+        biography: 'I am a cool tester.',
+      };
+      const picture = new File([], 'image.png');
+      const params = getParams({ picture, ...editableFields });
+
+      const expectedBody = new FormData();
+      expectedBody.set('biography', editableFields.biography);
+      expectedBody.set('picture_upload', picture);
+
+      mockApi.expects('callApi')
+        .withArgs(sinon.match(({ body }) => {
+          return deepEqual(
+            Array.from(body.entries()),
+            Array.from(expectedBody.entries())
+          );
+        }))
+        .returns(mockResponse());
 
       await editUserAccount(params);
       mockApi.verify();

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -158,6 +158,44 @@ describe(__filename, () => {
       expect(calledFinishAction.payload).toEqual({});
     });
 
+    it('optionally takes a picture file', async () => {
+      const state = sagaTester.getState();
+      const user = createUserAccountResponse({ id: 5001 });
+
+      const picture = new File([], 'some-image.png');
+      const userFields = {
+        biography: 'I fell into a burning ring of fire.',
+        location: 'Folsom Prison',
+      };
+
+      mockApi
+        .expects('editUserAccount')
+        .withArgs({
+          api: state.api,
+          userId: user.id,
+          picture,
+          ...userFields,
+        })
+        .once()
+        .returns(Promise.resolve({ ...user, ...userFields }));
+
+      sagaTester.dispatch(editUserAccount({
+        errorHandlerId: errorHandler.id,
+        picture,
+        userFields,
+        userId: user.id,
+      }));
+
+      const expectedCalledAction = loadUserAccount({
+        user: { ...user, ...userFields },
+      });
+
+      const calledAction = await sagaTester.waitFor(expectedCalledAction.type);
+
+      mockApi.verify();
+      expect(calledAction).toEqual(expectedCalledAction);
+    });
+
     it('cancels the edit and dispatches an error when fails', async () => {
       const user = createUserAccountResponse({ id: 5001 });
       const userFields = {


### PR DESCRIPTION
Fix #5029 – Refs #4276 – ⚠️ Depends on #5013 

---

This PR allows to send a picture file along with editable fields when editing a user profile. Only the second comment is relevant.