### PR TITLE
I4967-adjusting styles so get-firefox/Install btns look is consistent/align with text

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -8,6 +8,14 @@
   @include respond-to(large) {
     padding: $padding-page-l;
   }
+
+  .Addon-summary-and-install-button-wrapper {
+    .InstallButton {
+      @include respond-to(medium) {
+        align-self: stretch;
+      }
+    }
+  }
 }
 
 .Addon .Card {
@@ -141,11 +149,12 @@
     display: flex;
     justify-content: space-between;
   }
-}
 
-.Button--get-firefox {
-  @include respond-to(extraLarge) {
-    margin-top: 14px;
+  .InstallButton,
+  .Button--get-firefox {
+    @include respond-to(extraLarge) {
+      margin-top: 14px;
+    }
   }
 }
 


### PR DESCRIPTION
fixes #4967 - adjusts both get-firefox and Install btn styles to be consistent and align with their respective text