### PR TITLE
Change the workflow for Add A Collection to leave the user at the edit screen

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -24,6 +24,7 @@ import log from 'core/logger';
 import { getCurrentUser, hasPermission } from 'amo/reducers/users';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
+import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
@@ -160,9 +161,14 @@ export class CollectionBase extends React.Component<Props> {
     }
 
     return (
-      <p className="Collection-edit-link">
-        <Link {...props}>{i18n.gettext('Edit this collection')}</Link>
-      </p>
+      <Button
+        className="Collection-edit-link"
+        buttonType="neutral"
+        puffy
+        {...props}
+      >
+        {i18n.gettext('Edit this collection')}
+      </Button>
     );
   }
 

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -127,7 +127,7 @@ export class CollectionBase extends React.Component<Props> {
       return;
     }
 
-    if (collection && addonsPageChanged) {
+    if (collection && addonsPageChanged && collection.numberOfAddons) {
       this.props.dispatch(fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         page: location.query.page || 1,

--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -81,3 +81,8 @@
     padding: 0;
   }
 }
+
+.Collection-edit-link {
+  margin-top: $padding-page;
+  width: 100%;
+}

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -239,6 +239,8 @@ export class CollectionManagerBase extends React.Component<Props, State> {
     const isNameBlank = !(name && name.trim().length);
     const isSlugBlank = !(slug && slug.trim().length);
     const isSubmitDisabled = formIsDisabled || isNameBlank || isSlugBlank;
+    const buttonText = creating ?
+      i18n.gettext('Create collection') : i18n.gettext('Save collection');
 
     return (
       <form
@@ -330,7 +332,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
             type="submit"
             puffy
           >
-            {i18n.gettext('Save Collection')}
+            {buttonText}
           </Button>
         </footer>
       </form>

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -260,6 +260,12 @@ export type ExternalCollectionDetail = {|
   uuid: string,
 |};
 
+export type ExternalCollectionDetailWithLocalizedStrings = {|
+  description: {[lang: string]: string} | null,
+  name: {[lang: string]: string},
+  ...ExternalCollectionDetail
+|};
+
 export type CollectionAddonsListResponse = {|
   count: number,
   next: string,
@@ -694,6 +700,24 @@ export const changeAddonCollectionsLoadingFlag = ({
         },
       },
     },
+  };
+};
+
+type LocalizeCollectionDetailParams = {|
+  detail: ExternalCollectionDetailWithLocalizedStrings,
+  lang: string,
+|};
+
+export const localizeCollectionDetail = (
+  { detail, lang }: LocalizeCollectionDetailParams
+): ExternalCollectionDetail => {
+  invariant(detail, 'detail is required for localizeCollectionDetail');
+  invariant(lang, 'lang is required for localizeCollectionDetail');
+
+  return {
+    ...detail,
+    description: detail.description && detail.description[lang],
+    name: detail.name[lang],
   };
 };
 

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -261,9 +261,9 @@ export type ExternalCollectionDetail = {|
 |};
 
 export type ExternalCollectionDetailWithLocalizedStrings = {|
+  ...ExternalCollectionDetail,
   description: {[lang: string]: string} | null,
   name: {[lang: string]: string},
-  ...ExternalCollectionDetail
 |};
 
 export type CollectionAddonsListResponse = {|
@@ -715,9 +715,17 @@ export const localizeCollectionDetail = (
   invariant(lang, 'lang is required for localizeCollectionDetail');
 
   return {
-    ...detail,
+    addon_count: detail.addon_count,
+    author: detail.author,
+    default_locale: detail.default_locale,
     description: detail.description && detail.description[lang],
+    id: detail.id,
+    modified: detail.modified,
     name: detail.name[lang],
+    public: detail.public,
+    slug: detail.slug,
+    url: detail.url,
+    uuid: detail.uuid,
   };
 };
 

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -262,8 +262,8 @@ export type ExternalCollectionDetail = {|
 
 export type ExternalCollectionDetailWithLocalizedStrings = {|
   ...ExternalCollectionDetail,
-  description: {[lang: string]: string} | null,
-  name: {[lang: string]: string},
+  description: LocalizedString | null,
+  name: LocalizedString,
 |};
 
 export type CollectionAddonsListResponse = {|
@@ -714,11 +714,13 @@ export const localizeCollectionDetail = (
   invariant(detail, 'detail is required for localizeCollectionDetail');
   invariant(lang, 'lang is required for localizeCollectionDetail');
 
+  // Flow will not allow us to use the spread operator here, so we have
+  // to repeat all the fields.
   return {
     addon_count: detail.addon_count,
     author: detail.author,
     default_locale: detail.default_locale,
-    description: detail.description && detail.description[lang],
+    description: detail.description ? detail.description[lang] : null,
     id: detail.id,
     modified: detail.modified,
     name: detail.name[lang],

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -24,6 +24,7 @@ import {
   loadUserCollections,
   beginCollectionModification,
   finishCollectionModification,
+  localizeCollectionDetail,
   fetchCurrentCollectionPage as fetchCurrentCollectionPageAction,
 } from 'amo/reducers/collections';
 import * as api from 'amo/api/collections';
@@ -250,11 +251,8 @@ export function* modifyCollection(
       invariant(response, 'response is required when creating');
       // If a new collection was just created, load it so that it will
       // be available when the user arrives at the collection edit screen.
-      yield put(loadCurrentCollection({ addons: [], detail: response }));
-      // TODO: There's a problem however that the collection isn't being recognized
-      // when we get to the edit page. If we let the edit page call fetchCurrentCollection
-      // it works, but then we get the flash of content. Ideally we can find a way to tell
-      // the Collection component that this collection is there for it.
+      const localizedDetail = localizeCollectionDetail({ detail: response, lang });
+      yield put(loadCurrentCollection({ addons: [], detail: localizedDetail }));
       yield put(pushLocation(`${newLocation}edit/`));
     } else {
       // TODO: invalidate the stored collection instead of redirecting.

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -209,6 +209,7 @@ export function* modifyCollection(
 
   try {
     const state = yield select(getState);
+    let response;
 
     const baseApiParams = {
       api: state.api,
@@ -225,7 +226,7 @@ export function* modifyCollection(
         slug,
         ...baseApiParams,
       };
-      yield call(api.createCollection, apiParams);
+      response = yield call(api.createCollection, apiParams);
     } else {
       invariant(collectionSlug,
         'collectionSlug cannot be empty when updating');
@@ -242,22 +243,35 @@ export function* modifyCollection(
     const effectiveSlug = slug || collectionSlug;
     invariant(effectiveSlug,
       'Both slug and collectionSlug cannot be empty');
-    // TODO: invalidate the stored collection instead of redirecting.
-    // Ultimately, we just want to invalidate the old collection data.
-    // This redirect is in place to handle slug changes but it causes
-    // a race condition if we mix it with deleting old collection data.
-    // If we could move to an ID based URL then we won't have to redirect.
-    // See https://github.com/mozilla/addons-server/issues/7529
-    yield put(pushLocation(
-      `/${lang}/${clientApp}/collections/${user}/${effectiveSlug}/`
-    ));
+    const newLocation =
+      `/${lang}/${clientApp}/collections/${user}/${effectiveSlug}/`;
 
-    const slugWasEdited = !creating && slug && slug !== collectionSlug;
-    if (!slugWasEdited) {
-      // Invalidate the stored collection object. This will force each
-      // component to re-fetch the collection. This is only necessary
-      // when the slug hasn't changed.
-      yield put(deleteCollectionBySlug(effectiveSlug));
+    if (creating) {
+      invariant(response, 'response is required when creating');
+      // If a new collection was just created, load it so that it will
+      // be available when the user arrives at the collection edit screen.
+      yield put(loadCurrentCollection({ addons: [], detail: response }));
+      // TODO: There's a problem however that the collection isn't being recognized
+      // when we get to the edit page. If we let the edit page call fetchCurrentCollection
+      // it works, but then we get the flash of content. Ideally we can find a way to tell
+      // the Collection component that this collection is there for it.
+      yield put(pushLocation(`${newLocation}edit/`));
+    } else {
+      // TODO: invalidate the stored collection instead of redirecting.
+      // Ultimately, we just want to invalidate the old collection data.
+      // This redirect is in place to handle slug changes but it causes
+      // a race condition if we mix it with deleting old collection data.
+      // If we could move to an ID based URL then we won't have to redirect.
+      // See https://github.com/mozilla/addons-server/issues/7529
+      yield put(pushLocation(newLocation));
+
+      const slugWasEdited = slug && slug !== collectionSlug;
+      if (!slugWasEdited) {
+        // Invalidate the stored collection object. This will force each
+        // component to re-fetch the collection. This is only necessary
+        // when the slug hasn't changed.
+        yield put(deleteCollectionBySlug(effectiveSlug));
+      }
     }
   } catch (error) {
     log.warn(`Failed to ${type}: ${error}`);

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -18,14 +18,14 @@ import {
   abortFetchCurrentCollection,
   abortFetchUserCollections,
   addonAddedToCollection,
+  beginCollectionModification,
   deleteCollectionBySlug,
+  finishCollectionModification,
+  fetchCurrentCollectionPage as fetchCurrentCollectionPageAction,
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
-  beginCollectionModification,
-  finishCollectionModification,
   localizeCollectionDetail,
-  fetchCurrentCollectionPage as fetchCurrentCollectionPageAction,
 } from 'amo/reducers/collections';
 import * as api from 'amo/api/collections';
 import log from 'core/logger';

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -7,10 +7,10 @@ import Collection, {
 } from 'amo/components/Collection';
 import AddonsCard from 'amo/components/AddonsCard';
 import CollectionManager from 'amo/components/CollectionManager';
-import Link from 'amo/components/Link';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import Paginate from 'core/components/Paginate';
+import Button from 'ui/components/Button';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
@@ -680,7 +680,7 @@ describe(__filename, () => {
 
     const wrapper = renderComponent({ store, _config: fakeConfig });
 
-    const editLink = wrapper.find('.Collection-edit-link').find(Link);
+    const editLink = wrapper.find('.Collection-edit-link').find(Button);
     expect(editLink).toHaveLength(1);
     expect(editLink).toHaveProp('href',
       `/collections/${defaultUser}/${defaultCollectionDetail.slug}/edit/`);
@@ -700,7 +700,7 @@ describe(__filename, () => {
 
     const wrapper = renderComponent({ store, _config: fakeConfig });
 
-    const editLink = wrapper.find('.Collection-edit-link').find(Link);
+    const editLink = wrapper.find('.Collection-edit-link').find(Button);
     expect(editLink).toHaveLength(1);
     expect(editLink).toHaveProp('to',
       `/collections/${defaultUser}/${defaultCollectionDetail.slug}/edit/`);

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -112,6 +112,20 @@ describe(__filename, () => {
       .toHaveProp('disabled', true);
   });
 
+  it('displays the correct button for create', () => {
+    const root = render({ collection: null, creating: true });
+
+    expect(root.find('.CollectionManager-submit').children())
+      .toHaveText('Create collection');
+  });
+
+  it('displays the correct button for edit', () => {
+    const root = render({ collection: null, creating: false });
+
+    expect(root.find('.CollectionManager-submit').children())
+      .toHaveText('Save collection');
+  });
+
   it('can render an empty form for create', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const newLang = 'de';

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -4,12 +4,14 @@ import reducer, {
   abortFetchUserCollections,
   addAddonToCollection,
   addonAddedToCollection,
+  beginCollectionModification,
   createInternalAddons,
   createInternalCollection,
   deleteCollectionBySlug,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   fetchUserCollections,
+  finishCollectionModification,
   getCollectionById,
   getCurrentCollection,
   initialState,
@@ -18,8 +20,7 @@ import reducer, {
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
-  beginCollectionModification,
-  finishCollectionModification,
+  localizeCollectionDetail,
 } from 'amo/reducers/collections';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 import {
@@ -844,6 +845,24 @@ describe(__filename, () => {
           detail: collection1Detail,
           items: collection1Addons,
         }));
+    });
+  });
+
+  describe('localizeCollectionDetail', () => {
+    it('localizes collection detail', () => {
+      const lang = 'en-US';
+      const collectionDetail = createFakeCollectionDetail();
+      const collectionDetailWithLocalizedStrings = {
+        ...collectionDetail,
+        description: { [lang]: collectionDetail.description },
+        name: { [lang]: collectionDetail.name },
+      };
+      const localizedDetail = localizeCollectionDetail({
+        detail: collectionDetailWithLocalizedStrings,
+        lang,
+      });
+
+      expect(localizedDetail).toEqual(collectionDetail);
     });
   });
 });

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -524,20 +524,20 @@ describe(__filename, () => {
     });
 
     describe('create logic', () => {
-      const params = {
-        description: { 'en-US': 'Collection description' },
-        name: { 'en-US': 'Collection name' },
-        slug,
-        user,
-      };
-      const collectionDetail = createFakeCollectionDetail();
-      const collectionDetailResponse = {
-        ...collectionDetail,
-        ...params,
+      const getParams = ({ lang }) => {
+        return {
+          description: { [lang]: 'Collection description' },
+          name: { [lang]: 'Collection name' },
+          slug,
+          user,
+        };
       };
 
       it('sends a request to the collections API', async () => {
         const state = sagaTester.getState();
+        const params = getParams({ lang: state.api.lang });
+
+        const collectionDetailResponse = createFakeCollectionDetail(params);
 
         mockApi
           .expects('createCollection')
@@ -557,7 +557,8 @@ describe(__filename, () => {
         const expectedLoadAction = loadCurrentCollection({
           addons: [],
           detail: localizeCollectionDetail({
-            detail: collectionDetailResponse, lang: state.api.lang,
+            detail: collectionDetailResponse,
+            lang: state.api.lang,
           }),
         });
 
@@ -574,7 +575,16 @@ describe(__filename, () => {
       });
 
       it('redirects to the collection edit screen after create', async () => {
-        mockApi.expects('createCollection').returns(Promise.resolve(collectionDetailResponse));
+        const state = sagaTester.getState();
+        const params = getParams({ lang: state.api.lang });
+
+        const collectionDetailResponse = createFakeCollectionDetail(params);
+
+        mockApi
+          .expects('createCollection')
+          .once()
+          .returns(Promise.resolve(collectionDetailResponse));
+
         _createCollection(params);
 
         const { lang, clientApp } = clientData.state.api;

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -8,17 +8,18 @@ import collectionsReducer, {
   abortFetchUserCollections,
   addAddonToCollection,
   addonAddedToCollection,
+  beginCollectionModification,
   createCollection,
   deleteCollectionBySlug,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   fetchUserCollections,
+  finishCollectionModification,
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
+  localizeCollectionDetail,
   updateCollection,
-  beginCollectionModification,
-  finishCollectionModification,
 } from 'amo/reducers/collections';
 import collectionsSaga from 'amo/sagas/collections';
 import apiReducer from 'core/reducers/api';
@@ -555,7 +556,9 @@ describe(__filename, () => {
 
         const expectedLoadAction = loadCurrentCollection({
           addons: [],
-          detail: collectionDetailResponse,
+          detail: localizeCollectionDetail({
+            detail: collectionDetailResponse, lang: state.api.lang,
+          }),
         });
 
         const loadAction = await sagaTester.waitFor(expectedLoadAction.type);


### PR DESCRIPTION
Fixes #4977 
Also fixes #4978

This addresses the main issue, but I think the UX can be improved. Implementing #4978 will help, and I may just roll that into this PR.

I am also having a problem with coordinating the finishing of the create action with the redirection to the edit page. The initial problem was that, when the user is redirected to the edit page, it has to fetch and load the collection first, so the loading gifs on the right show up causing a flash of content that then gets replaced by the placeholder text.

I've tried a few things and cannot get it quite right. I could use some advice. My current attempt has me loading the collection in the saga after creating it (because we have access to the details after creating it), but that doesn't seem to make the collection available to the Collection component (or it doesn't know it's available). I thought about going a different route and adding yet another flag to the collections redux state to indicate that we just created a new collection, but I don't really like that idea. Maybe that's the proper way to do it?

@willdurand If you can take a look and pass on any advice you have I would appreciate it.

