### PR TITLE
Fix margin in user profile edit page

### DIFF
--- a/src/amo/components/UserProfileEdit/styles.scss
+++ b/src/amo/components/UserProfileEdit/styles.scss
@@ -37,7 +37,7 @@ $font-size-aside: 10px;
   }
 }
 
-.UserProfileEdit-form-messages,
+.UserProfileEdit-form-messages .Notice,
 .UserProfileEdit--Card {
   margin-bottom: $padding-page;
 }


### PR DESCRIPTION
Fix #5035

---

Before:

![](https://user-images.githubusercontent.com/31961530/40222405-09348d4a-5a88-11e8-8f90-5f18614ec0d9.png)

After:

<img width="1392" alt="screen shot 2018-05-18 at 10 42 04" src="https://user-images.githubusercontent.com/217628/40225046-4a127020-5a88-11e8-9908-f90ed02615ea.png">
