### PR TITLE
Login button user edit

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -228,7 +228,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
             <AuthenticateButton
               noIcon
               location={router.location}
-              logInText={i18n.gettext('Log in to continue')}
+              logInText={i18n.gettext('Log in to edit the profile')}
             />
           </Card>
         </div>

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -19,6 +19,7 @@ import {
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import { USERS_EDIT } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
+import log from 'core/logger';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
 import Button from 'ui/components/Button';
@@ -234,6 +235,17 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       );
     }
 
+    let errorMessage;
+    if (errorHandler.hasError()) {
+      log.warn('Captured API Error:', errorHandler.capturedError);
+
+      if (errorHandler.capturedError.responseStatusCode === 404) {
+        return <NotFound errorCode={errorHandler.capturedError.code} />;
+      }
+
+      errorMessage = errorHandler.renderError();
+    }
+
     if (user && !hasEditPermission) {
       return <NotFound />;
     }
@@ -275,7 +287,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
         <form className="UserProfileEdit-form" onSubmit={this.onSubmit}>
           <div className="UserProfileEdit-form-messages">
-            {errorHandler.renderErrorIfPresent()}
+            {errorMessage}
 
             {this.state.displaySuccessMessage && (
               <Notice type="success">

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -16,6 +16,7 @@ import {
   getUserByUsername,
   hasPermission,
 } from 'amo/reducers/users';
+import AuthenticateButton from 'core/components/AuthenticateButton';
 import { USERS_EDIT } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -75,7 +76,11 @@ export class UserProfileEditBase extends React.Component<Props, State> {
   }
 
   componentWillMount() {
-    const { dispatch, errorHandler, username, user } = this.props;
+    const { currentUser, dispatch, errorHandler, username, user } = this.props;
+
+    if (!currentUser) {
+      return;
+    }
 
     if (!user && username) {
       dispatch(fetchUserAccount({
@@ -100,7 +105,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     } = props;
 
     if (oldUsername !== newUsername) {
-      if (!newUser) {
+      if (!newUser && newUsername) {
         dispatch(fetchUserAccount({
           errorHandlerId: errorHandler.id,
           username: newUsername,
@@ -210,11 +215,26 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       hasEditPermission,
       i18n,
       isUpdating,
+      router,
       user,
       username,
     } = this.props;
 
-    if (!currentUser || (currentUser && user && !hasEditPermission)) {
+    if (!currentUser) {
+      return (
+        <div className="UserProfileEdit">
+          <Card className="UserProfileEdit-user-links">
+            <AuthenticateButton
+              noIcon
+              location={router.location}
+              logInText={i18n.gettext('Log in to continue')}
+            />
+          </Card>
+        </div>
+      );
+    }
+
+    if (user && !hasEditPermission) {
       return <NotFound />;
     }
 

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -13,6 +13,7 @@ import {
   getCurrentUser,
   loadUserAccount,
 } from 'amo/reducers/users';
+import { createApiError } from 'core/api';
 import {
   CLIENT_APP_FIREFOX,
   USERS_EDIT,
@@ -767,5 +768,22 @@ describe(__filename, () => {
     sinon.assert.notCalled(dispatchSpy);
     // We should also see an AuthenticateButton when this use case happens.
     expect(root.find(AuthenticateButton)).toHaveLength(1);
+  });
+
+  it('renders a not found page if the API request is a 404', () => {
+    const { store } = dispatchSignInActions();
+    const errorHandler = new ErrorHandler({
+      id: 'some-error-handler-id',
+      dispatch: store.dispatch,
+    });
+    errorHandler.handle(createApiError({
+      response: { status: 404 },
+      apiURL: 'https://some/api/endpoint',
+      jsonResponse: { message: 'not found' },
+    }));
+
+    const root = renderUserProfileEdit({ errorHandler, store });
+
+    expect(root.find(NotFound)).toHaveLength(1);
   });
 });

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -702,7 +702,7 @@ describe(__filename, () => {
 
     expect(root.find(AuthenticateButton)).toHaveLength(1);
     expect(root.find(AuthenticateButton))
-      .toHaveProp('logInText', 'Log in to continue');
+      .toHaveProp('logInText', 'Log in to edit the profile');
   });
 
   it('displays an AuthenticateButton if current user is not logged-in and loads a user edit page', () => {
@@ -751,19 +751,29 @@ describe(__filename, () => {
   });
 
   it('does not dispatch fetchUserAccount() when user logs out on a user edit page', () => {
-    const username = 'some-user';
+    const username = 'logged-in-user';
+    const { store } = dispatchSignInActions({
+      userProps: {
+        ...defaultUserProps,
+        username,
+        permissions: [USERS_EDIT],
+      },
+    });
 
-    const { store } = signInUserWithUsername(username);
     const dispatchSpy = sinon.spy(store, 'dispatch');
 
-    // The user edits their profile.
-    const root = renderUserProfileEdit({ params: { username }, store });
+    // Create a user with another username.
+    const user = createUserAccountResponse({ username: 'willdurand' });
+    store.dispatch(loadUserAccount({ user }));
+
+    dispatchSpy.reset();
+
+    // The current logged-in user edits the profile of the other `user`.
+    const params = { username: user.username };
+    const root = renderUserProfileEdit({ params, store });
 
     // The user logs out.
-    root.setProps({
-      currentUser: null,
-      params: { username },
-    });
+    root.setProps({ currentUser: null, params });
 
     sinon.assert.notCalled(dispatchSpy);
     // We should also see an AuthenticateButton when this use case happens.


### PR DESCRIPTION
Fix #5034
Fix #4965

---

I have added a login button to the user profile edit page:

![screen shot 2018-05-18 at 14 44 09](https://user-images.githubusercontent.com/217628/40235248-ff2e19c0-5aa9-11e8-86aa-00b98cfea213.png)

Important: the button is named "Log in to continue" because we don't know if the user is going to edit their profile, another profile (admin) or get a 404 because the user cannot access this page.
