### PR TITLE
Fix border radius in the about this extension card

### DIFF
--- a/src/ui/components/Card/styles.scss
+++ b/src/ui/components/Card/styles.scss
@@ -23,6 +23,11 @@ $footer-padding: 10px;
   font-size: $font-size-s;
   margin: 0;
 
+  @include respond-to(large) {
+    border-bottom-left-radius: $border-radius-default;
+    border-bottom-right-radius: $border-radius-default;
+  }
+
   .Card--no-header & {
     border-top-left-radius: $border-radius-default;
     border-top-right-radius: $border-radius-default;


### PR DESCRIPTION
Fixes #4884 

Match upper and bottom border radius on the "about this extension" card.

### Before
![before](https://user-images.githubusercontent.com/34794189/40257206-37510908-5ae5-11e8-873b-6cb733b27779.PNG)

### After
![after](https://user-images.githubusercontent.com/34794189/40257225-4dfe6e8e-5ae5-11e8-935a-df7b3a7e8dc8.png)
