### PR TITLE
Use fixed error handler in user profile page

### DIFF
--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -23,7 +23,7 @@ import {
   ADDON_TYPE_THEME,
   USERS_EDIT,
 } from 'core/constants';
-import { withErrorHandler } from 'core/errorHandler';
+import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import { removeProtocolFromURL, sanitizeUserHTML } from 'core/utils';
@@ -55,6 +55,11 @@ type Props = {|
 export class UserProfileBase extends React.Component<Props> {
   componentWillMount() {
     const { dispatch, errorHandler, params, user } = this.props;
+
+    if (errorHandler.hasError()) {
+      log.warn('Not loading data because of an error.');
+      return;
+    }
 
     if (!user) {
       dispatch(fetchUserAccount({
@@ -264,8 +269,12 @@ export function mapStateToProps(
   };
 }
 
+export const extractId = (ownProps: Props) => {
+  return ownProps.params.username;
+};
+
 export default compose(
   connect(mapStateToProps),
   translate(),
-  withErrorHandler({ name: 'UserProfile' }),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
 )(UserProfileBase);

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import AddonsByAuthorsCard from 'amo/components/AddonsByAuthorsCard';
-import UserProfile, { UserProfileBase } from 'amo/components/UserProfile';
+import UserProfile, {
+  extractId,
+  UserProfileBase,
+} from 'amo/components/UserProfile';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import {
@@ -517,5 +520,31 @@ describe(__filename, () => {
     const root = renderUserProfile({ params, store });
 
     expect(root.find('.UserProfile-edit-link')).toHaveLength(0);
+  });
+
+  it('does not dispatch any action when there is an error', () => {
+    const { store } = dispatchClientMetadata();
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: fakeDispatch,
+    });
+    errorHandler.handle(new Error('unexpected error'));
+
+    fakeDispatch.reset();
+
+    renderUserProfile({ errorHandler, store });
+
+    sinon.assert.notCalled(fakeDispatch);
+  });
+
+  describe('errorHandler - extractId', () => {
+    it('returns a unique ID based on params', () => {
+      const username = 'foo';
+      const params = { username };
+
+      expect(extractId({ params })).toEqual(username);
+    });
   });
 });


### PR DESCRIPTION
Fix #5060

---

This PR fixes the behavior observed in https://github.com/mozilla/addons-frontend/issues/5036#issuecomment-390570679 by using a "fixed" error handler, which is the handler we should be using on most of our "page level components".

It allows to synchronize the errors between the server and the client, thus avoiding unnecessary data re-fetching on the client if the server gets an error.