### PR TITLE
Wrap unbroken strings in profile page biography

### DIFF
--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -85,3 +85,7 @@ $avatar-size: 64px;
     max-width: calc(65% - 12px);
   }
 }
+
+.UserProfile-biography {
+  word-break: break-all;
+}


### PR DESCRIPTION
Fixes #5020 

Added word break property to user profile biography section.

Change successfully run locally in FF browser 61.0b6 Ubuntu and works on all media breakpoints.

Before:
![unwrapped-string](https://user-images.githubusercontent.com/34794189/40365523-a50868c6-5dcc-11e8-96fd-a7fb76dea00e.png)

After: 
![wrapped-string](https://user-images.githubusercontent.com/34794189/40365520-a4d3d2aa-5dcc-11e8-8ce2-2190ccffa86e.png)

