### PR TITLE
Add api/saga/reducer to fetch/load user notifications

### DIFF
--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -48,16 +48,29 @@ export function editUserAccount({ api, picture, userId, ...editableFields }: {|
   });
 }
 
-export function userAccount({ api, username }: {|
+type UserApiParams = {|
   api: ApiStateType,
   username: string,
-|}) {
+|};
+
+export function userAccount({ api, username }: UserApiParams) {
   invariant(api, 'api state is required.');
   invariant(username, 'username is required.');
 
   return callApi({
     auth: true,
     endpoint: `accounts/account/${username}`,
+    state: api,
+  });
+}
+
+export function userNotifications({ api, username }: UserApiParams) {
+  invariant(api, 'api state is required.');
+  invariant(username, 'username is required.');
+
+  return callApi({
+    auth: true,
+    endpoint: `accounts/account/${username}/notifications`,
     state: api,
   });
 }

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -14,6 +14,7 @@ import {
   editUserAccount,
   deleteUserPicture,
   fetchUserAccount,
+  fetchUserNotifications,
   getCurrentUser,
   getUserByUsername,
   hasPermission,
@@ -101,6 +102,13 @@ export class UserProfileEditBase extends React.Component<Props, State> {
         username,
       }));
     }
+
+    if ((!user && username) || (user && !user.notifications)) {
+      dispatch(fetchUserNotifications({
+        errorHandlerId: errorHandler.id,
+        username,
+      }));
+    }
   }
 
   componentWillReceiveProps(props: Props) {
@@ -128,6 +136,13 @@ export class UserProfileEditBase extends React.Component<Props, State> {
         dispatch(fetchUserAccount({
           errorHandlerId: errorHandler.id,
           username: newUsername,
+        }));
+      }
+
+      if ((!newUser && newUsername) || (newUser && !newUser.notifications)) {
+        dispatch(fetchUserNotifications({
+          errorHandlerId: errorHandler.id,
+          username: newUser ? newUser.username : newUsername,
         }));
       }
 

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -431,6 +431,7 @@ const reducer = (
       const user = getUserByUsername(state, username);
 
       invariant(user, 'user is required');
+      invariant(notifications, 'notifications are required');
 
       return {
         ...state,

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -6,11 +6,13 @@ import {
   deleteUserPicture,
   editUserAccount,
   userAccount,
+  userNotifications,
 } from 'amo/api/users';
 import { getCurrentUser } from 'amo/reducers/users';
 import {
   createApiResponse,
   createUserAccountResponse,
+  createUserNotificationsResponse,
 } from 'tests/unit/helpers';
 import {
   dispatchSignInActions,
@@ -123,6 +125,28 @@ describe(__filename, () => {
     });
   });
 
+  describe('userNotifications', () => {
+    it('fetches user notifications based on username', async () => {
+      const state = dispatchClientMetadata().store.getState();
+      const params = { api: state.api, username: 'tofumatt' };
+
+      const notificationsResponse = createApiResponse({
+        jsonData: createUserNotificationsResponse(),
+      });
+
+      mockApi.expects('callApi')
+        .withArgs({
+          auth: true,
+          endpoint: `accounts/account/${params.username}/notifications`,
+          state: params.api,
+        })
+        .returns(notificationsResponse);
+
+      await userNotifications(params);
+      mockApi.verify();
+    });
+  });
+
   describe('deleteUserPicture', () => {
     it('deletes a user profile picture for a given user', async () => {
       const state = dispatchSignInActions().store.getState();
@@ -136,7 +160,7 @@ describe(__filename, () => {
           method: 'DELETE',
           state: params.api,
         })
-        .returns(mockResponse());
+        .returns(createApiResponse());
 
       await deleteUserPicture(params);
       mockApi.verify();

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -146,7 +146,7 @@ describe(__filename, () => {
     }));
   });
 
-  it('only dispatches fetchUserNotifications action when the current logged-in user is being edited', () => {
+  it('dispatches fetchUserNotifications and not fetchUserAccount when the current logged-in user is being edited', () => {
     // We do not have access to the user notifications for the current
     // logged-in user because this user is loaded in Redux when authenticated,
     // and we do not automatically load the notifications.
@@ -173,7 +173,6 @@ describe(__filename, () => {
 
     const { store } = signInUserWithUsername(username);
     const dispatchSpy = sinon.spy(store, 'dispatch');
-    const errorHandler = createStubErrorHandler();
 
     store.dispatch(loadUserNotifications({
       username,
@@ -184,7 +183,7 @@ describe(__filename, () => {
 
     // This happens when loading the user edit profile page of the current
     // logged-in user (e.g., page refresh).
-    renderUserProfileEdit({ errorHandler, params: {}, store });
+    renderUserProfileEdit({ params: {}, store });
 
     sinon.assert.notCalled(dispatchSpy);
   });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -552,3 +552,63 @@ export const simulateComponentCallback = ({ Component, root, propName }) => {
     return result;
   };
 };
+
+export const createUserNotificationsResponse = () => {
+  return [
+    {
+      name: 'reply',
+      enabled: true,
+      mandatory: false,
+    },
+    {
+      name: 'new_features',
+      enabled: true,
+      mandatory: false,
+    },
+    {
+      name: 'upgrade_success',
+      enabled: true,
+      mandatory: false,
+    },
+    {
+      name: 'sdk_upgrade_success',
+      enabled: true,
+      mandatory: false,
+    },
+    {
+      name: 'new_review',
+      enabled: true,
+      mandatory: false,
+    },
+    {
+      name: 'upgrade_fail',
+      enabled: true,
+      mandatory: true,
+    },
+    {
+      name: 'sdk_upgrade_fail',
+      enabled: true,
+      mandatory: true,
+    },
+    {
+      name: 'reviewer_reviewed',
+      enabled: true,
+      mandatory: true,
+    },
+    {
+      name: 'individual_contact',
+      enabled: true,
+      mandatory: true,
+    },
+    {
+      name: 'announcements',
+      enabled: false,
+      mandatory: false,
+    },
+    {
+      name: 'announcements',
+      enabled: false,
+      mandatory: false,
+    },
+  ];
+};


### PR DESCRIPTION
Fix #5070

---

This PR adds everything we need to load user notifications when browsing
a user profile edit page. It does not show anything in the UI yet, though.
