### PR TITLE
Delete a add-on from a collection

### DIFF
--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -333,3 +333,27 @@ export const updateCollectionAddon = ({
     action: 'update', addonId, api, collectionSlug, notes, user,
   });
 };
+export type RemoveAddonFromCollectionParams = {|
+  addonId: number,
+  api: ApiStateType,
+  slug: string,
+  user: string | number,
+|};
+
+export const removeAddonFromCollection = (
+  { addonId, api, slug, user }: RemoveAddonFromCollectionParams
+): Promise<void> => {
+  invariant(addonId, 'The addonId parameter is required');
+  invariant(api, 'The api parameter is required');
+  invariant(slug, 'The slug parameter is required');
+  invariant(user, 'The user parameter is required');
+
+  return callApi({
+    auth: true,
+    endpoint:
+      `accounts/account/${user}/collections/${slug}/addons/${addonId}`,
+    method: 'DELETE',
+    state: api,
+  });
+};
+

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -7,6 +7,7 @@ import EditableCollectionAddon from 'amo/components/EditableCollectionAddon';
 import SearchResult from 'amo/components/SearchResult';
 import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import CardList from 'ui/components/CardList';
+import type { RemoveCollectionAddonFunc } from 'amo/components/Collection';
 import type { AddonType } from 'core/types/addons';
 
 import './styles.scss';
@@ -19,6 +20,8 @@ type Props = {|
   className?: string,
   editing?: boolean,
   loading?: boolean,
+  // This is passed through to EditableCollectionAddon.
+  removeAddon?: RemoveCollectionAddonFunc,
   // When loading, this is the number of placeholders
   // that will be rendered.
   placeholderCount: number,
@@ -49,6 +52,7 @@ export default class AddonsCard extends React.Component<Props> {
       className,
       editing,
       loading,
+      removeAddon,
       placeholderCount,
       showMetadata,
       showSummary,
@@ -65,6 +69,7 @@ export default class AddonsCard extends React.Component<Props> {
             <EditableCollectionAddon
               addon={addon}
               key={addon.slug}
+              removeAddon={removeAddon}
             />
           );
         } else {

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import config from 'config';
+import invariant from 'invariant';
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
@@ -8,6 +9,7 @@ import { compose } from 'redux';
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
 import {
+  removeAddonFromCollection,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   getCurrentCollection,
@@ -57,6 +59,8 @@ export type Props = {|
     user: string,
   |},
 |};
+
+export type RemoveCollectionAddonFunc = (addonId: number) => void;
 
 export class CollectionBase extends React.Component<Props> {
   static defaultProps = {
@@ -171,6 +175,34 @@ export class CollectionBase extends React.Component<Props> {
     );
   }
 
+  removeAddon: RemoveCollectionAddonFunc = (addonId: number) => {
+    const {
+      collection,
+      dispatch,
+      errorHandler,
+      location: { query },
+    } = this.props;
+
+    invariant(collection, 'collection is required');
+
+    const {
+      slug,
+      authorUsername: user,
+    } = collection;
+
+    invariant(query, 'query is required');
+    invariant(slug, 'slug is required');
+    invariant(user, 'page is required');
+
+    dispatch(removeAddonFromCollection({
+      addonId,
+      errorHandlerId: errorHandler.id,
+      page: query.page || 1,
+      slug,
+      user,
+    }));
+  };
+
   renderCardContents() {
     const {
       collection, editing, hasEditPermission, i18n, isLoggedIn, location,
@@ -253,6 +285,7 @@ export class CollectionBase extends React.Component<Props> {
             addons={addons}
             editing={editing}
             loading={!collection || loading}
+            removeAddon={this.removeAddon}
           />
           {!loading && addons && addons.length === 0 &&
             <p className="Collection-placeholder">{ i18n.gettext(

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -1,13 +1,14 @@
 /* @flow */
 import makeClassName from 'classnames';
+import invariant from 'invariant';
 import * as React from 'react';
 import { compose } from 'redux';
 
-import log from 'core/logger';
 import { getAddonIconUrl } from 'core/imageUtils';
 import translate from 'core/i18n/translate';
 import Button from 'ui/components/Button';
 import Icon from 'ui/components/Icon';
+import type { RemoveCollectionAddonFunc } from 'amo/components/Collection';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 
@@ -17,18 +18,19 @@ type Props = {|
   addon: AddonType,
   className?: string,
   i18n: I18nType,
+  removeAddon: RemoveCollectionAddonFunc,
 |};
 
 export class EditableCollectionAddonBase extends React.Component<Props> {
   onRemoveAddon = (event: SyntheticEvent<any>) => {
-    const { addon } = this.props;
+    const { addon: { id: addonId }, removeAddon } = this.props;
 
     event.preventDefault();
     event.stopPropagation();
 
-    // TODO: implement onRemoveAddon
-    // https://github.com/mozilla/addons-frontend/issues/4577
-    log.debug('TODO: handle removing an add-on', addon.id);
+    invariant(addonId, 'addonId is required');
+
+    removeAddon(addonId);
   };
 
   render() {

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -38,6 +38,8 @@ export const BEGIN_COLLECTION_MODIFICATION: 'BEGIN_COLLECTION_MODIFICATION'
   = 'BEGIN_COLLECTION_MODIFICATION';
 export const FINISH_COLLECTION_MODIFICATION: 'FINISH_COLLECTION_MODIFICATION'
   = 'FINISH_COLLECTION_MODIFICATION';
+export const REMOVE_ADDON_FROM_COLLECTION: 'REMOVE_ADDON_FROM_COLLECTION'
+  = 'REMOVE_ADDON_FROM_COLLECTION';
 
 export type CollectionType = {
   addons: Array<AddonType> | null,
@@ -580,6 +582,36 @@ export const deleteCollectionBySlug = (
   return {
     type: DELETE_COLLECTION_BY_SLUG,
     payload: { slug },
+  };
+};
+
+type RemoveAddonFromCollectionParams = {|
+  addonId: number,
+  errorHandlerId: string,
+  page: number,
+  slug: string,
+  user: string,
+|};
+
+export type RemoveAddonFromCollectionAction = {|
+  type: typeof REMOVE_ADDON_FROM_COLLECTION,
+  payload: RemoveAddonFromCollectionParams,
+|};
+
+export const removeAddonFromCollection = ({
+  addonId, errorHandlerId, page, slug, user,
+}: RemoveAddonFromCollectionParams = {}): RemoveAddonFromCollectionAction => {
+  invariant(addonId, 'The addonId parameter is required');
+  invariant(errorHandlerId, 'The errorHandlerId parameter is required');
+  invariant(page, 'The page parameter is required');
+  invariant(slug, 'The slug parameter is required');
+  invariant(user, 'The user parameter is required');
+
+  return {
+    type: REMOVE_ADDON_FROM_COLLECTION,
+    payload: {
+      addonId, errorHandlerId, page, slug, user,
+    },
   };
 };
 

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -168,7 +168,9 @@ export function callApi({
 
   return fetch(apiURL, options)
     .then((response) => {
-      const contentType = response.headers.get('Content-Type').toLowerCase();
+      // There isn't always a 'Content-Type' in headers, e.g., with a DELETE method.
+      let contentType = response.headers.get('Content-Type');
+      contentType = contentType && contentType.toLowerCase();
 
       // This is a bit paranoid, but we ensure the API returns a JSON response
       // (see https://github.com/mozilla/addons-frontend/issues/1701).

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -4,6 +4,7 @@ import * as api from 'core/api';
 import {
   createCollection,
   createCollectionAddon,
+  removeAddonFromCollection,
   getAllCollectionAddons,
   getAllUserCollections,
   getCollectionAddons,
@@ -514,6 +515,36 @@ describe(__filename, () => {
       });
 
       sinon.assert.calledWith(modifier, { action: 'update', ...params });
+    });
+  });
+
+  describe('removeAddonFromCollection', () => {
+    it('sends a request to remove an add-on from a collection', async () => {
+      const addonId = 123;
+      const slug = 'my-collection';
+      const user = 'my-user';
+
+      const endpoint = `accounts/account/${user}/collections/${slug}/addons/${addonId}`;
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          auth: true,
+          endpoint,
+          method: 'DELETE',
+          state: api,
+        })
+        .once()
+        .returns(Promise.resolve());
+
+      await removeAddonFromCollection({
+        addonId,
+        api,
+        slug,
+        user,
+      });
+
+      mockApi.verify();
     });
   });
 });

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -54,6 +54,18 @@ describe(__filename, () => {
     expect(list.children().map((c) => c.prop('addon'))).toEqual(addons);
   });
 
+  it('passes a removeAddon function to editable add-ons', () => {
+    const removeAddon = sinon.stub();
+    const root = render({ addons, editing: true, removeAddon });
+    const list = root.childAt(0);
+
+
+    expect.assertions(list.children().length);
+    list.children().forEach((editableCollectionAddon) => {
+      expect(editableCollectionAddon).toHaveProp('removeAddon', removeAddon);
+    });
+  });
+
   it('renders children', () => {
     const root = render({ addons, children: (<div>I am content</div>) });
     expect(root.childAt(0).type()).toEqual('div');

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -59,7 +59,6 @@ describe(__filename, () => {
     const root = render({ addons, editing: true, removeAddon });
     const list = root.childAt(0);
 
-
     expect.assertions(list.children().length);
     list.children().forEach((editableCollectionAddon) => {
       expect(editableCollectionAddon).toHaveProp('removeAddon', removeAddon);

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -15,6 +15,7 @@ import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
 import {
+  removeAddonFromCollection,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   loadCurrentCollection,
@@ -804,6 +805,85 @@ describe(__filename, () => {
     expect(root.find('.Collection-title')).toHaveLength(0);
     expect(root.find('.Collection-description')).toHaveLength(0);
     expect(root.find(MetadataCard)).toHaveLength(0);
+  });
+
+  it('dispatches removeAddonFromCollection when removeAddon is called', () => {
+    const { store } = dispatchSignInActions({
+      userProps: {
+        permissions: [COLLECTIONS_EDIT],
+      },
+    });
+
+    const addons = createFakeCollectionAddons();
+    const addonId = addons[0].addon.id;
+    const collectionDetail = createFakeCollectionDetail();
+    const errorHandler = createStubErrorHandler();
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+    const page = 123;
+
+    store.dispatch(loadCurrentCollection({
+      addons,
+      detail: collectionDetail,
+    }));
+    const root = renderComponent({
+      editing: true,
+      errorHandler,
+      location: fakeRouterLocation({ query: { page } }),
+      store,
+    });
+
+    fakeDispatch.reset();
+
+    // This simulates the user clicking the "Remove" button on the
+    // EditableCollectionAddon component.
+    root.instance().removeAddon(addonId);
+    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.calledWith(fakeDispatch, removeAddonFromCollection({
+      addonId,
+      errorHandlerId: errorHandler.id,
+      page,
+      slug: collectionDetail.slug,
+      user: collectionDetail.author.username,
+    }));
+  });
+
+  it('dispatches removeAddonFromCollection when removeAddon is called without a page defined', () => {
+    const { store } = dispatchSignInActions({
+      userProps: {
+        permissions: [COLLECTIONS_EDIT],
+      },
+    });
+
+    const addons = createFakeCollectionAddons();
+    const addonId = addons[0].addon.id;
+    const collectionDetail = createFakeCollectionDetail();
+    const errorHandler = createStubErrorHandler();
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+
+    store.dispatch(loadCurrentCollection({
+      addons,
+      detail: collectionDetail,
+    }));
+    const root = renderComponent({
+      editing: true,
+      errorHandler,
+      location: fakeRouterLocation({ query: { } }),
+      store,
+    });
+
+    fakeDispatch.reset();
+
+    // This simulates the user clicking the "Remove" button on the
+    // EditableCollectionAddon component.
+    root.instance().removeAddon(addonId);
+    sinon.assert.callCount(fakeDispatch, 1);
+    sinon.assert.calledWith(fakeDispatch, removeAddonFromCollection({
+      addonId,
+      errorHandlerId: errorHandler.id,
+      page: 1,
+      slug: collectionDetail.slug,
+      user: collectionDetail.author.username,
+    }));
   });
 
   describe('errorHandler - extractId', () => {

--- a/tests/unit/amo/components/TestEditableCollectionAddon.js
+++ b/tests/unit/amo/components/TestEditableCollectionAddon.js
@@ -7,6 +7,7 @@ import fallbackIcon from 'amo/img/icons/default-64.png';
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 import {
+  createFakeEvent,
   fakeI18n,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
@@ -19,6 +20,7 @@ describe(__filename, () => {
       <EditableCollectionAddon
         addon={props.addon || createInternalAddon(fakeAddon)}
         i18n={fakeI18n()}
+        removeAddon={sinon.stub()}
         {...props}
       />,
       EditableCollectionAddonBase
@@ -59,5 +61,19 @@ describe(__filename, () => {
     const button = root.find(Button);
     expect(button).toHaveProp('name', addon.id);
     expect(button.prop('children')).toEqual('Remove');
+  });
+
+  it('calls the removeAddon function when the remove button is clicked', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const removeAddon = sinon.spy();
+    const root = render({ addon, removeAddon });
+
+    const removeButton = root.find(Button);
+    const clickEvent = createFakeEvent();
+    removeButton.simulate('click', clickEvent);
+
+    sinon.assert.called(clickEvent.preventDefault);
+    sinon.assert.called(clickEvent.stopPropagation);
+    sinon.assert.calledWith(removeAddon, addon.id);
   });
 });

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -159,6 +159,19 @@ describe(__filename, () => {
       expect(responseData).toEqual({});
     });
 
+    it('handles responses without a Content-Type', async () => {
+      mockWindow.expects('fetch').returns(createApiResponse({
+        headers: generateHeaders({}),
+        text() {
+          return Promise.resolve();
+        },
+      }));
+
+      const responseData = await api.callApi({ endpoint: 'resource' });
+      mockWindow.verify();
+      expect(responseData).toEqual({});
+    });
+
     it('handles any fetch error', async () => {
       mockWindow.expects('fetch').returns(Promise.reject(new Error(
         'this could be any error'


### PR DESCRIPTION
Fixes #4577 

This is pretty much complete, except that I couldn't figure out a good way to test the code that lives in `removeAddon` in the `Collection` component. Ideally we'd check that it dispatches a `deleteCollectionAddon` call, but the problem is that it's triggered by a button in a component a could of levels down. I guess we could do it by fully rendering the component, rather than doing a shallow render, but it bothers me that we need to interact with a different component in order to test this one. Any suggestions you have would be appreciated.