### PR TITLE
Returns a 404 when loading a non-existent user edit page

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -18,7 +18,7 @@ import {
 } from 'amo/reducers/users';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import { USERS_EDIT } from 'core/constants';
-import { withErrorHandler } from 'core/errorHandler';
+import { withFixedErrorHandler } from 'core/errorHandler';
 import log from 'core/logger';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
@@ -77,9 +77,10 @@ export class UserProfileEditBase extends React.Component<Props, State> {
   }
 
   componentWillMount() {
-    const { currentUser, dispatch, errorHandler, username, user } = this.props;
+    const { dispatch, errorHandler, username, user } = this.props;
 
-    if (!currentUser) {
+    if (errorHandler.hasError()) {
+      log.warn('Not loading data because of an error.');
       return;
     }
 
@@ -523,9 +524,13 @@ export function mapStateToProps(
   };
 }
 
+export const extractId = (ownProps: Props) => {
+  return ownProps.params.username;
+};
+
 export default compose(
   withRouter,
   connect(mapStateToProps),
   translate(),
-  withErrorHandler({ name: 'UserProfileEdit' }),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
 )(UserProfileEditBase);

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Link from 'amo/components/Link';
 import UserProfileEdit, {
+  extractId,
   UserProfileEditBase,
 } from 'amo/components/UserProfileEdit';
 import {
@@ -738,18 +739,6 @@ describe(__filename, () => {
     expect(root.find(AuthenticateButton)).toHaveLength(1);
   });
 
-  it('does not dispatch fetchUserAccount() when current user is not logged-in and loads a user edit page', () => {
-    const { store } = dispatchClientMetadata();
-    const dispatchSpy = sinon.spy(store, 'dispatch');
-
-    renderUserProfileEdit({
-      store,
-      params: { username: 'willdurand' },
-    });
-
-    sinon.assert.notCalled(dispatchSpy);
-  });
-
   it('does not dispatch fetchUserAccount() when user logs out on a user edit page', () => {
     const username = 'logged-in-user';
     const { store } = dispatchSignInActions({
@@ -795,5 +784,31 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({ errorHandler, store });
 
     expect(root.find(NotFound)).toHaveLength(1);
+  });
+
+  it('does not dispatch any action when there is an error', () => {
+    const { store } = dispatchClientMetadata();
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: fakeDispatch,
+    });
+    errorHandler.handle(new Error('unexpected error'));
+
+    fakeDispatch.reset();
+
+    renderUserProfileEdit({ errorHandler, store });
+
+    sinon.assert.notCalled(fakeDispatch);
+  });
+
+  describe('errorHandler - extractId', () => {
+    it('returns a unique ID based on params', () => {
+      const username = 'foo';
+      const params = { username };
+
+      expect(extractId({ params })).toEqual(username);
+    });
   });
 });


### PR DESCRIPTION
Fix #5056

---

This PR makes sure the server returns a 404 when loading a non-existent
user edit page. It is achieved by a "fixed" error handler, which
synchronizes error handling between the server and the client. That is
also why there is no need to check whether there is a current user
logged-in or not anymore.