### PR TITLE
Updating geckodriver for discopane tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
       addons:
         firefox: latest-nightly
         hosts: example.com
-      env: TOXENV=discopane-ui-tests GECKODRIVER=0.19.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
+      env: TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
       install:
         - yarn
         - yarn start-func-test-server &

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -38,7 +38,7 @@ def open_discopane(my_base_url, selenium):
 @pytest.fixture
 def discovery_pane(selenium, my_base_url):
     """Open the discovery pane via the URL."""
-    return DiscoveryPane(selenium, my_base_url).open()
+    return DiscoveryPane(selenium, my_base_url, timeout=30).open()
 
 
 @pytest.fixture


### PR DESCRIPTION
This is an attempt to try and get the discopane tests more stable, first by updating the geckodriver version.