### PR TITLE
I4744 adding key fixes ssr bug (seen on addon detail in AddonsByAuthorsCard)

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -388,12 +388,14 @@ export class AddonBase extends React.Component {
       return null;
     }
 
-    {/* Adding wrapping divs here seems to address what we think is a
+    {
+      /* Adding wrapping divs here seems to address what we think is a
       reconcillation issue —— which causes the classname to not always get added
       correctly (e.g.: when the page is refreshed and the addon has
       a description).
       See https://github.com/mozilla/addons-frontend/issues/4744
-    */}
+    */
+    }
     return (
       <div>
         <AddonsByAuthorsCard

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -388,15 +388,23 @@ export class AddonBase extends React.Component {
       return null;
     }
 
+    {/* Adding wrapping divs here seems to address what we think is a
+      reconcillation issue —— which causes the classname to not always get added
+      correctly (e.g.: when the page is refreshed and the addon has
+      a description).
+      See https://github.com/mozilla/addons-frontend/issues/4744
+    */}
     return (
-      <AddonsByAuthorsCard
-        addonType={addon.type}
-        authorDisplayName={addon.authors[0].name}
-        authorUsernames={addon.authors.map((author) => author.username)}
-        className="Addon-MoreAddonsCard"
-        forAddonSlug={addon.slug}
-        numberOfAddons={6}
-      />
+      <div>
+        <AddonsByAuthorsCard
+          addonType={addon.type}
+          authorDisplayName={addon.authors[0].name}
+          authorUsernames={addon.authors.map((author) => author.username)}
+          className="Addon-MoreAddonsCard"
+          forAddonSlug={addon.slug}
+          numberOfAddons={6}
+        />
+      </div>
     );
   }
 

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -388,14 +388,13 @@ export class AddonBase extends React.Component {
       return null;
     }
 
-    {
-      /* Adding wrapping divs here seems to address what we think is a
+    /* Adding wrapping divs here seems to address what we think is a
       reconcillation issue —— which causes the classname to not always get added
       correctly (e.g.: when the page is refreshed and the addon has
       a description).
       See https://github.com/mozilla/addons-frontend/issues/4744
     */
-    }
+
     return (
       <div>
         <AddonsByAuthorsCard

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -47,7 +47,6 @@ export default class AddonsCard extends React.Component<Props> {
 <<<<<<< HEAD
 =======
   cardContainer: React.ElementRef<any> | null;
-  keyCount: number;
 
 >>>>>>> fixing flow stuff
   static defaultProps = {
@@ -120,7 +119,6 @@ export default class AddonsCard extends React.Component<Props> {
     );
     return (
       <CardList
-        key={addons && addons.length}
         {...otherProps}
         className={allClassNames}
         ref={(ref) => { this.cardContainer = ref; }}

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -56,16 +56,6 @@ export default class AddonsCard extends React.Component<Props> {
     placeholderCount: DEFAULT_API_PAGE_SIZE,
   };
 
-  constructor(props: Props) {
-    super(props);
-
-    this.keyCount = 0;
-  }
-
-  getKey = () => {
-    return this.keyCount++;
-  }
-
   render() {
     const {
       addonInstallSource,
@@ -130,7 +120,7 @@ export default class AddonsCard extends React.Component<Props> {
     );
     return (
       <CardList
-        key={`AddonsCard${this.getKey()}`}
+        key={addons && addons.length}
         {...otherProps}
         className={allClassNames}
         ref={(ref) => { this.cardContainer = ref; }}

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -50,6 +50,16 @@ export default class AddonsCard extends React.Component<Props> {
     placeholderCount: DEFAULT_API_PAGE_SIZE,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.keyCount = 0;
+  }
+
+  getKey = () => {
+    return this.keyCount++;
+  }
+
   render() {
     const {
       addonInstallSource,
@@ -114,7 +124,7 @@ export default class AddonsCard extends React.Component<Props> {
     );
     return (
       <CardList
-        key={`cardList-${addonElements.length}`}
+        key={`AddonsCard${this.getKey()}`}
         {...otherProps}
         className={allClassNames}
         ref={(ref) => { this.cardContainer = ref; }}

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -113,7 +113,12 @@ export default class AddonsCard extends React.Component<Props> {
       type && `AddonsCard--${type}`,
     );
     return (
-      <CardList {...otherProps} className={allClassNames}>
+      <CardList
+        key={`cardList-${addonElements.length}`}
+        {...otherProps}
+        className={allClassNames}
+        ref={(ref) => { this.cardContainer = ref; }}
+      >
         {children}
         {addonElements.length ? (
           <ul className="AddonsCard-list">{addonElements}</ul>

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -44,13 +44,19 @@ type Props = {|
 |};
 
 export default class AddonsCard extends React.Component<Props> {
+<<<<<<< HEAD
+=======
+  cardContainer: React.ElementRef<any> | null;
+  keyCount: number;
+
+>>>>>>> fixing flow stuff
   static defaultProps = {
     editing: false,
     loading: false,
     placeholderCount: DEFAULT_API_PAGE_SIZE,
   };
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
 
     this.keyCount = 0;

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -44,11 +44,6 @@ type Props = {|
 |};
 
 export default class AddonsCard extends React.Component<Props> {
-<<<<<<< HEAD
-=======
-  cardContainer: React.ElementRef<any> | null;
-
->>>>>>> fixing flow stuff
   static defaultProps = {
     editing: false,
     loading: false,
@@ -118,11 +113,7 @@ export default class AddonsCard extends React.Component<Props> {
       type && `AddonsCard--${type}`,
     );
     return (
-      <CardList
-        {...otherProps}
-        className={allClassNames}
-        ref={(ref) => { this.cardContainer = ref; }}
-      >
+      <CardList {...otherProps} className={allClassNames}>
         {children}
         {addonElements.length ? (
           <ul className="AddonsCard-list">{addonElements}</ul>


### PR DESCRIPTION
fixes #4744 

if the theme has a description/summary, the ShowMoreCard would be displayed which uses the Card component. I think b/c there were no keys here it was not acting in an unexpected way.  By adding a varying key value, this looks to be fixed..

Both screenshots are after refreshing the page (SSR bug)

Before (everything looks like it's using AddsonByAuthorsCard except the section classes are wrong):
![Alt text](https://monosnap.com/image/MnbAeBkgOnyWcgaa4Gi2gtXAOlMiIS.png)

After:
![Alt text](https://monosnap.com/image/fPycpAmtBeTvqWoVi3JjL0Sgk3hE2U.png)


*Note*: i wasn't loving this key name but i didn't see a lot of options here. We might need to find a more unique name..
