### PR TITLE
WIP: Sort add-ons in a collection

### DIFF
--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -3,6 +3,7 @@ import invariant from 'invariant';
 
 import { callApi, allPages, validateLocalizedString } from 'core/api';
 import type {
+  CollectionFilters,
   ExternalCollectionAddon,
   ExternalCollectionDetail,
 } from 'amo/reducers/collections';
@@ -37,13 +38,13 @@ export const getCollectionDetail = ({
 export type GetCollectionAddonsParams = {|
   ...GetCollectionParams,
   nextURL?: string,
-  page?: number,
+  filters?: CollectionFilters,
 |};
 
 export const getCollectionAddons = ({
   api,
+  filters,
   nextURL,
-  page,
   slug,
   username,
 }: GetCollectionAddonsParams): Promise<
@@ -63,11 +64,11 @@ export const getCollectionAddons = ({
     params: undefined,
     state: api,
   };
-  // If a page is requested explicitly, pass it to callApi().
+  // If filters are requested explicitly, pass them to callApi().
   // By default, this code does not define request.params because doing so
   // would overwrite any query string params in nextURL.
-  if (page) {
-    request.params = { page };
+  if (filters) {
+    request.params = filters;
   }
 
   return callApi(request);

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -59,6 +59,7 @@ type Props = {|
   // This is accessibility text for what selecting a suggestion will do.
   selectSuggestionText: string,
   showInputLabel?: boolean,
+  useFiltersFromLocation: boolean,
 |};
 
 type MappedProps = {|
@@ -193,7 +194,9 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
       return;
     }
 
-    const filters = this.createFiltersFromQuery(value);
+    const filters = this.props.useFiltersFromLocation
+      ? this.createFiltersFromQuery(value)
+      : {};
 
     this.setState({ autocompleteIsOpen: true });
 

--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -44,6 +44,19 @@
   white-space: nowrap;
 }
 
+.Collection-sort {
+  margin-top: 12px;
+}
+
+.Sort-label {
+  color: $grey-50;
+  display: block;
+}
+
+.Sort-select {
+  margin: 0 0 5px;
+}
+
 @include respond-to(large) {
   .Collection-wrapper {
     display: grid;
@@ -52,7 +65,7 @@
     grid-template-columns: minmax(300px, 35%) 1fr;
     margin: 10px 0 0;
 
-    .Collection-detail {
+    .Collection-detail-wrapper {
       grid-column: 1;
     }
 

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -28,6 +28,7 @@ import type {
   SuggestionType,
 } from 'amo/components/AutoSearchInput';
 import type {
+  CollectionFilters,
   CollectionsState,
   CollectionType,
 } from 'amo/reducers/collections';
@@ -56,7 +57,8 @@ export type AddonAddedStatusType =
 type Props = {|
   collection: CollectionType | null,
   creating: boolean,
-  page: number | null,
+  filters: CollectionFilters,
+  setTimeout?: Function,
 |};
 
 type InternalProps = {|
@@ -257,7 +259,7 @@ export class CollectionManagerBase extends React.Component<
       currentUsername,
       dispatch,
       errorHandler,
-      page,
+      filters,
     } = this.props;
     const { addonId } = suggestion;
 
@@ -275,10 +277,10 @@ export class CollectionManagerBase extends React.Component<
       addAddonToCollection({
         addonId,
         collectionId: collection.id,
-        slug: collection.slug,
         editing: true,
         errorHandlerId: errorHandler.id,
-        page: page || 1,
+        filters,
+        slug: collection.slug,
         username: currentUsername,
       }),
     );
@@ -413,6 +415,7 @@ export class CollectionManagerBase extends React.Component<
             onSearch={this.onSearchAddon}
             onSuggestionSelected={this.onAddonSelected}
             selectSuggestionText={i18n.gettext('Add to collection')}
+            useFiltersFromLocation={false}
           />
         )}
         <footer className="CollectionManager-footer">

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -61,6 +61,7 @@ export class SearchFormBase extends React.Component<Props> {
           query={query}
           selectSuggestionText={i18n.gettext('Go to the add-on page')}
           showInputLabel={false}
+          useFiltersFromLocation
         />
       </form>
     );

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -2,6 +2,7 @@
 import { oneLine } from 'common-tags';
 import invariant from 'invariant';
 
+import type { CollectionAddonsSortType } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import type { CollectionAddonType, ExternalAddonType } from 'core/types/addons';
 import type { LocalizedString } from 'core/types/api';
@@ -45,6 +46,11 @@ export const UPDATE_COLLECTION_ADDON: 'UPDATE_COLLECTION_ADDON' =
   'UPDATE_COLLECTION_ADDON';
 export const DELETE_COLLECTION_ADDON_NOTES: 'DELETE_COLLECTION_ADDON_NOTES' =
   'DELETE_COLLECTION_ADDON_NOTES';
+
+export type CollectionFilters = {|
+  page: number,
+  sort?: CollectionAddonsSortType,
+|};
 
 export type CollectionType = {
   addons: Array<CollectionAddonType> | null,
@@ -107,7 +113,7 @@ export const initialState: CollectionsState = {
 
 type FetchCurrentCollectionParams = {|
   errorHandlerId: string,
-  page?: number,
+  filters?: CollectionFilters,
   slug: string,
   username: string,
 |};
@@ -119,7 +125,7 @@ export type FetchCurrentCollectionAction = {|
 
 export const fetchCurrentCollection = ({
   errorHandlerId,
-  page,
+  filters,
   slug,
   username,
 }: FetchCurrentCollectionParams = {}): FetchCurrentCollectionAction => {
@@ -129,7 +135,7 @@ export const fetchCurrentCollection = ({
 
   return {
     type: FETCH_CURRENT_COLLECTION,
-    payload: { errorHandlerId, page, slug, username },
+    payload: { errorHandlerId, filters, slug, username },
   };
 };
 
@@ -209,22 +215,17 @@ export const abortAddAddonToCollection = ({
   };
 };
 
-type FetchCurrentCollectionPageParams = {|
-  ...FetchCurrentCollectionParams,
-  page: number,
-|};
-
 export type FetchCurrentCollectionPageAction = {|
   type: typeof FETCH_CURRENT_COLLECTION_PAGE,
-  payload: FetchCurrentCollectionPageParams,
+  payload: FetchCurrentCollectionParams,
 |};
 
 export const fetchCurrentCollectionPage = ({
   errorHandlerId,
-  page,
+  filters,
   slug,
   username,
-}: FetchCurrentCollectionPageParams = {}): FetchCurrentCollectionPageAction => {
+}: FetchCurrentCollectionParams = {}): FetchCurrentCollectionPageAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
@@ -234,13 +235,10 @@ export const fetchCurrentCollectionPage = ({
   if (!username) {
     throw new Error('username is required');
   }
-  if (!page) {
-    throw new Error('page is required');
-  }
 
   return {
     type: FETCH_CURRENT_COLLECTION_PAGE,
-    payload: { errorHandlerId, page, slug, username },
+    payload: { errorHandlerId, filters, slug, username },
   };
 };
 
@@ -434,11 +432,11 @@ export const abortFetchCurrentCollection = (): AbortFetchCurrentCollection => {
 type AddAddonToCollectionParams = {|
   addonId: number,
   collectionId: CollectionId,
-  slug: string,
   editing?: boolean,
   errorHandlerId: string,
+  filters?: CollectionFilters,
   notes?: string,
-  page?: number,
+  slug: string,
   username: string,
 |};
 
@@ -452,8 +450,8 @@ export const addAddonToCollection = ({
   collectionId,
   editing,
   errorHandlerId,
+  filters,
   notes,
-  page,
   slug,
   username,
 }: AddAddonToCollectionParams = {}): AddAddonToCollectionAction => {
@@ -464,7 +462,7 @@ export const addAddonToCollection = ({
   invariant(username, 'The username parameter is required');
 
   if (editing) {
-    invariant(page, 'The page parameter is required when editing');
+    invariant(filters, 'The filters parameter is required when editing');
   }
 
   return {
@@ -474,8 +472,8 @@ export const addAddonToCollection = ({
       collectionId,
       editing,
       errorHandlerId,
+      filters,
       notes,
-      page,
       slug,
       username,
     },
@@ -615,7 +613,7 @@ export const unloadCollectionBySlug = (
 type RemoveAddonFromCollectionParams = {|
   addonId: number,
   errorHandlerId: string,
-  page: number,
+  filters: CollectionFilters,
   slug: string,
   username: string,
 |};
@@ -628,13 +626,13 @@ export type RemoveAddonFromCollectionAction = {|
 export const removeAddonFromCollection = ({
   addonId,
   errorHandlerId,
-  page,
+  filters,
   slug,
   username,
 }: RemoveAddonFromCollectionParams = {}): RemoveAddonFromCollectionAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
-  invariant(page, 'The page parameter is required');
+  invariant(filters, 'The filters parameter is required');
   invariant(slug, 'The slug parameter is required');
   invariant(username, 'The username parameter is required');
 
@@ -643,7 +641,7 @@ export const removeAddonFromCollection = ({
     payload: {
       addonId,
       errorHandlerId,
-      page,
+      filters,
       slug,
       username,
     },
@@ -683,8 +681,8 @@ export const deleteCollection = ({
 type UpdateCollectionAddonParams = {|
   addonId: number,
   errorHandlerId: string,
+  filters: CollectionFilters,
   notes: string,
-  page: number,
   slug: string,
   username: string,
 |};
@@ -698,7 +696,7 @@ export const updateCollectionAddon = ({
   addonId,
   errorHandlerId,
   notes,
-  page,
+  filters,
   slug,
   username,
 }: UpdateCollectionAddonParams = {}): UpdateCollectionAddonAction => {
@@ -708,7 +706,7 @@ export const updateCollectionAddon = ({
     notes !== undefined && notes !== null,
     'The notes parameter is required',
   );
-  invariant(page, 'The page parameter is required');
+  invariant(filters, 'The filters parameter is required');
   invariant(slug, 'The slug parameter is required');
   invariant(username, 'The username parameter is required');
 
@@ -718,7 +716,7 @@ export const updateCollectionAddon = ({
       addonId,
       errorHandlerId,
       notes,
-      page,
+      filters,
       slug,
       username,
     },
@@ -728,7 +726,7 @@ export const updateCollectionAddon = ({
 type DeleteCollectionAddonNotesParams = {|
   addonId: number,
   errorHandlerId: string,
-  page: number,
+  filters: CollectionFilters,
   slug: string,
   username: string,
 |};
@@ -741,13 +739,13 @@ export type DeleteCollectionAddonNotesAction = {|
 export const deleteCollectionAddonNotes = ({
   addonId,
   errorHandlerId,
-  page,
+  filters,
   slug,
   username,
 }: DeleteCollectionAddonNotesParams = {}): DeleteCollectionAddonNotesAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
-  invariant(page, 'The page parameter is required');
+  invariant(filters, 'The filters parameter is required');
   invariant(slug, 'The slug parameter is required');
   invariant(username, 'The username parameter is required');
 
@@ -758,8 +756,8 @@ export const deleteCollectionAddonNotes = ({
     payload: {
       addonId,
       errorHandlerId,
+      filters,
       notes: '',
-      page,
       slug,
       username,
     },

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -59,7 +59,7 @@ import type {
 } from 'amo/reducers/collections';
 
 export function* fetchCurrentCollection({
-  payload: { errorHandlerId, page, slug, username },
+  payload: { errorHandlerId, filters, slug, username },
 }: FetchCurrentCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -79,7 +79,7 @@ export function* fetchCurrentCollection({
     };
     const addonsParams: $Shape<GetCollectionAddonsParams> = {
       ...baseParams,
-      page,
+      filters,
     };
     const { detail, addons } = yield all({
       detail: call(api.getCollectionDetail, detailParams),
@@ -96,7 +96,7 @@ export function* fetchCurrentCollection({
 }
 
 export function* fetchCurrentCollectionPage({
-  payload: { errorHandlerId, page, slug, username },
+  payload: { errorHandlerId, filters, slug, username },
 }: FetchCurrentCollectionPageAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -107,7 +107,7 @@ export function* fetchCurrentCollectionPage({
 
     const params: GetCollectionAddonsParams = {
       api: state.api,
-      page,
+      filters,
       slug,
       username,
     };
@@ -155,8 +155,8 @@ export function* addAddonToCollection({
     collectionId,
     editing,
     errorHandlerId,
+    filters,
     notes,
-    page,
     slug,
     username,
   },
@@ -177,12 +177,12 @@ export function* addAddonToCollection({
     yield call(api.createCollectionAddon, params);
 
     if (editing) {
-      invariant(page, 'A page parameter is required when editing');
+      invariant(filters, 'A filters parameter is required when editing');
 
       yield put(
         fetchCurrentCollectionPageAction({
-          page,
           errorHandlerId: errorHandler.id,
+          filters,
           slug,
           username,
         }),
@@ -299,7 +299,7 @@ export function* modifyCollection(
 }
 
 export function* removeAddonFromCollection({
-  payload: { addonId, errorHandlerId, page, slug, username },
+  payload: { addonId, errorHandlerId, filters, slug, username },
 }: RemoveAddonFromCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -317,8 +317,8 @@ export function* removeAddonFromCollection({
 
     yield put(
       fetchCurrentCollectionPageAction({
-        page,
         errorHandlerId: errorHandler.id,
+        filters,
         slug,
         username,
       }),
@@ -367,7 +367,7 @@ export function* deleteCollection({
 }
 
 export function* updateCollectionAddon({
-  payload: { addonId, errorHandlerId, notes, page, slug, username },
+  payload: { addonId, errorHandlerId, filters, notes, slug, username },
 }: UpdateCollectionAddonAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -386,8 +386,8 @@ export function* updateCollectionAddon({
 
     yield put(
       fetchCurrentCollectionPageAction({
-        page,
         errorHandlerId: errorHandler.id,
+        filters,
         slug,
         username,
       }),

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -133,6 +133,18 @@ export const SEARCH_SORT_RANDOM = 'random';
 export const SEARCH_SORT_RELEVANCE = 'relevance';
 export const SEARCH_SORT_UPDATED = 'updated';
 
+// Collection add-ons sort values
+export const COLLECTION_ADDONS_SORT_DATE_ADDED = 'added';
+export const COLLECTION_ADDONS_SORT_DATE_ADDED_DESCENDING = '-added';
+export const COLLECTION_ADDONS_SORT_NAME = 'name';
+export const COLLECTION_ADDONS_SORT_POPULARITY = 'popularity';
+
+export type CollectionAddonsSortType =
+  | typeof COLLECTION_ADDONS_SORT_DATE_ADDED
+  | typeof COLLECTION_ADDONS_SORT_DATE_ADDED_DESCENDING
+  | typeof COLLECTION_ADDONS_SORT_NAME
+  | typeof COLLECTION_ADDONS_SORT_POPULARITY;
+
 // Operating system for add-ons and files
 export const OS_ALL = 'all';
 export const OS_WINDOWS = 'windows';

--- a/src/ui/components/Button/index.js
+++ b/src/ui/components/Button/index.js
@@ -27,7 +27,7 @@ export default class Button extends React.Component {
     href: PropTypes.string,
     micro: PropTypes.bool,
     puffy: PropTypes.bool,
-    to: PropTypes.string,
+    to: PropTypes.string || PropTypes.object,
   };
 
   static defaultProps = {

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -16,6 +16,7 @@ import {
   updateCollection,
   updateCollectionAddon,
 } from 'amo/api/collections';
+import { COLLECTION_ADDONS_SORT_DATE_ADDED } from 'core/constants';
 import { apiResponsePage, createApiResponse } from 'tests/unit/helpers';
 import {
   createFakeCollectionAddonsListResponse,
@@ -98,15 +99,18 @@ describe(__filename, () => {
     });
 
     it('calls the collection add-ons list API', async () => {
-      const queryParams = { page: 1 };
-      const params = getParams({ ...queryParams });
+      const filters = {
+        page: 1,
+        sort: COLLECTION_ADDONS_SORT_DATE_ADDED,
+      };
+      const params = getParams({ filters });
 
       mockApi
         .expects('callApi')
         .withArgs({
           auth: true,
           endpoint: 'accounts/account/some-user/collections/some-slug/addons',
-          params: queryParams,
+          params: filters,
           state: apiState,
         })
         .once()

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -45,6 +45,7 @@ describe(__filename, () => {
       onSuggestionSelected: sinon.stub(),
       selectSuggestionText: 'Go to the extension detail page',
       store,
+      useFiltersFromLocation: true,
       ...customProps,
     };
   };
@@ -277,8 +278,9 @@ describe(__filename, () => {
       const dispatch = sinon.spy(store, 'dispatch');
       const locationQuery = { type: ADDON_TYPE_EXTENSION };
       const root = render({
-        store,
         location: fakeRouterLocation({ query: locationQuery }),
+        store,
+        useFiltersFromLocation: true,
       });
 
       const query = 'ad blocker';
@@ -293,6 +295,28 @@ describe(__filename, () => {
             operatingSystem: OS_WINDOWS,
             query,
           },
+        }),
+      );
+    });
+
+    it('ignores filters from the location', () => {
+      const { store } = dispatchClientMetadata();
+      const dispatch = sinon.spy(store, 'dispatch');
+      const locationQuery = { type: ADDON_TYPE_EXTENSION };
+      const root = render({
+        location: fakeRouterLocation({ query: locationQuery }),
+        store,
+        useFiltersFromLocation: false,
+      });
+
+      const query = 'ad blocker';
+      fetchSuggestions({ root, query });
+
+      sinon.assert.calledWith(
+        dispatch,
+        autocompleteStart({
+          errorHandlerId: root.instance().props.errorHandler.id,
+          filters: {},
         }),
       );
     });

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -74,6 +74,7 @@ describe(__filename, () => {
     return {
       collection,
       creating: false,
+      filters: {},
       i18n: fakeI18n(),
       router,
       store,
@@ -688,14 +689,14 @@ describe(__filename, () => {
   });
 
   it('dispatches addAddonToCollection when selecting an add-on', () => {
-    const page = 2;
+    const filters = { page: 2 };
     const errorHandler = createStubErrorHandler();
 
     const collection = createInternalCollection({
       detail: createFakeCollectionDetail({ authorUsername: signedInUsername }),
     });
     const dispatchSpy = sinon.spy(store, 'dispatch');
-    const root = render({ collection, errorHandler, page });
+    const root = render({ collection, errorHandler, filters });
 
     const suggestion = createInternalSuggestion(
       createFakeAutocompleteResult({ name: 'uBlock Origin' }),
@@ -714,39 +715,7 @@ describe(__filename, () => {
         slug: collection.slug,
         editing: true,
         errorHandlerId: errorHandler.id,
-        page,
-        username: signedInUsername,
-      }),
-    );
-  });
-
-  it('dispatches addAddonToCollection with a default page of 1 when selecting an add-on', () => {
-    const errorHandler = createStubErrorHandler();
-
-    const collection = createInternalCollection({
-      detail: createFakeCollectionDetail({ authorUsername: signedInUsername }),
-    });
-    const dispatchSpy = sinon.spy(store, 'dispatch');
-    const root = render({ collection, errorHandler, page: undefined });
-
-    const suggestion = createInternalSuggestion(
-      createFakeAutocompleteResult({ name: 'uBlock Origin' }),
-    );
-    const selectSuggestion = simulateAutoSearchCallback({
-      root,
-      propName: 'onSuggestionSelected',
-    });
-    selectSuggestion(suggestion);
-
-    sinon.assert.calledWith(
-      dispatchSpy,
-      addAddonToCollection({
-        addonId: suggestion.addonId,
-        collectionId: collection.id,
-        slug: collection.slug,
-        editing: true,
-        errorHandlerId: errorHandler.id,
-        page: 1,
+        filters,
         username: signedInUsername,
       }),
     );

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -32,8 +32,6 @@ import {
 
 describe(__filename, () => {
   describe('reducer', () => {
-    const pageToFetch = 2;
-
     it('initializes properly', () => {
       const state = reducer(undefined, {});
       expect(state).toEqual(initialState);
@@ -63,7 +61,6 @@ describe(__filename, () => {
         undefined,
         fetchCurrentCollectionPage({
           errorHandlerId: createStubErrorHandler().id,
-          page: pageToFetch,
           slug: 'some-collection-slug',
           username: 'some-user',
         }),
@@ -88,7 +85,6 @@ describe(__filename, () => {
         state,
         fetchCurrentCollectionPage({
           errorHandlerId: createStubErrorHandler().id,
-          page: pageToFetch,
           slug: collectionDetail.slug,
           username: 'some-user',
         }),
@@ -166,7 +162,6 @@ describe(__filename, () => {
         state,
         fetchCurrentCollectionPage({
           errorHandlerId: createStubErrorHandler().id,
-          page: pageToFetch,
           slug: 'some-collection-slug',
           username: 'some-user',
         }),
@@ -770,7 +765,6 @@ describe(__filename, () => {
   describe('fetchCurrentCollectionPage()', () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
-      page: 123,
       slug: 'some-collection-slug',
       username: 'some-user',
     };
@@ -800,15 +794,6 @@ describe(__filename, () => {
       expect(() => {
         fetchCurrentCollectionPage(partialParams);
       }).toThrow('username is required');
-    });
-
-    it('throws an error when page is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.page;
-
-      expect(() => {
-        fetchCurrentCollectionPage(partialParams);
-      }).toThrow('page is required');
     });
   });
 

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -12,7 +12,6 @@ import collectionsReducer, {
   createCollection,
   deleteCollection,
   deleteCollectionAddonNotes,
-  fetchCurrentCollection,
   fetchCurrentCollectionPage,
   fetchUserCollections,
   finishCollectionModification,
@@ -37,7 +36,7 @@ import {
 describe(__filename, () => {
   const username = 'some-user';
   const slug = 'collection-slug';
-  const page = 1;
+  const filters = { page: 1 };
 
   let clientData;
   let errorHandler;
@@ -58,82 +57,82 @@ describe(__filename, () => {
     sagaTester.start(collectionsSaga);
   });
 
-  describe('fetchCurrentCollection', () => {
-    function _fetchCurrentCollection(params) {
-      sagaTester.dispatch(
-        fetchCurrentCollection({
-          errorHandlerId: errorHandler.id,
-          ...params,
-        }),
-      );
-    }
-
-    it('calls the API to fetch a collection', async () => {
-      const state = sagaTester.getState();
-
-      const collectionAddons = createFakeCollectionAddonsListResponse();
-      const collectionDetail = createFakeCollectionDetail();
-
-      mockApi
-        .expects('getCollectionDetail')
-        .withArgs({
-          api: state.api,
-          slug,
-          username,
-        })
-        .once()
-        .returns(Promise.resolve(collectionDetail));
-
-      mockApi
-        .expects('getCollectionAddons')
-        .withArgs({
-          api: state.api,
-          page,
-          slug,
-          username,
-        })
-        .once()
-        .returns(Promise.resolve(collectionAddons));
-
-      _fetchCurrentCollection({ page, slug, username });
-
-      const expectedLoadAction = loadCurrentCollection({
-        addons: collectionAddons.results,
-        detail: collectionDetail,
-      });
-
-      const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
-      expect(loadAction).toEqual(expectedLoadAction);
-      mockApi.verify();
-    });
-
-    it('clears the error handler', async () => {
-      _fetchCurrentCollection({ slug, username });
-
-      const expectedAction = errorHandler.createClearingAction();
-
-      const action = await sagaTester.waitFor(expectedAction.type);
-      expect(action).toEqual(expectedAction);
-    });
-
-    it('dispatches an error', async () => {
-      const error = new Error('some API error maybe');
-
-      mockApi
-        .expects('getCollectionDetail')
-        .once()
-        .returns(Promise.reject(error));
-
-      _fetchCurrentCollection({ slug, username });
-
-      const expectedAction = errorHandler.createErrorAction(error);
-      const action = await sagaTester.waitFor(expectedAction.type);
-      expect(expectedAction).toEqual(action);
-      expect(sagaTester.getCalledActions()[3]).toEqual(
-        abortFetchCurrentCollection(),
-      );
-    });
-  });
+  // describe('fetchCurrentCollection', () => {
+  //   function _fetchCurrentCollection(params) {
+  //     sagaTester.dispatch(
+  //       fetchCurrentCollection({
+  //         errorHandlerId: errorHandler.id,
+  //         ...params,
+  //       }),
+  //     );
+  //   }
+  //
+  //   it('calls the API to fetch a collection', async () => {
+  //     const state = sagaTester.getState();
+  //
+  //     const collectionAddons = createFakeCollectionAddonsListResponse();
+  //     const collectionDetail = createFakeCollectionDetail();
+  //
+  //     mockApi
+  //       .expects('getCollectionDetail')
+  //       .withArgs({
+  //         api: state.api,
+  //         slug,
+  //         username,
+  //       })
+  //       .once()
+  //       .returns(Promise.resolve(collectionDetail));
+  //
+  //     mockApi
+  //       .expects('getCollectionAddons')
+  //       .withArgs({
+  //         api: state.api,
+  //         filters,
+  //         slug,
+  //         username,
+  //       })
+  //       .once()
+  //       .returns(Promise.resolve(collectionAddons));
+  //
+  //     _fetchCurrentCollection({ filters, slug, username });
+  //
+  //     const expectedLoadAction = loadCurrentCollection({
+  //       addons: collectionAddons.results,
+  //       detail: collectionDetail,
+  //     });
+  //
+  //     const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
+  //     expect(loadAction).toEqual(expectedLoadAction);
+  //     mockApi.verify();
+  //   });
+  //
+  //   it('clears the error handler', async () => {
+  //     _fetchCurrentCollection({ slug, username });
+  //
+  //     const expectedAction = errorHandler.createClearingAction();
+  //
+  //     const action = await sagaTester.waitFor(expectedAction.type);
+  //     expect(action).toEqual(expectedAction);
+  //   });
+  //
+  //   it('dispatches an error', async () => {
+  //     const error = new Error('some API error maybe');
+  //
+  //     mockApi
+  //       .expects('getCollectionDetail')
+  //       .once()
+  //       .returns(Promise.reject(error));
+  //
+  //     _fetchCurrentCollection({ slug, username });
+  //
+  //     const expectedAction = errorHandler.createErrorAction(error);
+  //     const action = await sagaTester.waitFor(expectedAction.type);
+  //     expect(expectedAction).toEqual(action);
+  //     expect(sagaTester.getCalledActions()[3]).toEqual(
+  //       abortFetchCurrentCollection(),
+  //     );
+  //   });
+  // });
 
   describe('fetchCurrentCollectionPage', () => {
     function _fetchCurrentCollectionPage(params) {
@@ -153,14 +152,14 @@ describe(__filename, () => {
         .expects('getCollectionAddons')
         .withArgs({
           api: state.api,
-          page,
+          filters,
           slug,
           username,
         })
         .once()
         .returns(Promise.resolve(collectionAddons));
 
-      _fetchCurrentCollectionPage({ page, slug, username });
+      _fetchCurrentCollectionPage({ filters, slug, username });
 
       const expectedLoadAction = loadCurrentCollectionPage({
         addons: collectionAddons.results,
@@ -173,7 +172,7 @@ describe(__filename, () => {
     });
 
     it('clears the error handler', async () => {
-      _fetchCurrentCollectionPage({ page, slug, username });
+      _fetchCurrentCollectionPage({ filters, slug, username });
 
       const expectedAction = errorHandler.createClearingAction();
 
@@ -189,7 +188,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchCurrentCollectionPage({ page, slug, username });
+      _fetchCurrentCollectionPage({ filters, slug, username });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
@@ -314,7 +313,7 @@ describe(__filename, () => {
       expect(addedAction).toEqual(expectedAddedAction);
 
       const unexpectedFetchAction = fetchCurrentCollectionPage({
-        page: 1,
+        filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
         username: params.username,
@@ -330,7 +329,7 @@ describe(__filename, () => {
         collectionId: 5432,
         slug: 'a-collection',
         editing: true,
-        page: 1,
+        filters: { page: 1 },
         username: 'some-user',
       };
       const state = sagaTester.getState();
@@ -350,7 +349,7 @@ describe(__filename, () => {
       _addAddonToCollection(params);
 
       const expectedFetchAction = fetchCurrentCollectionPage({
-        page: params.page,
+        filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
         username: params.username,
@@ -676,7 +675,7 @@ describe(__filename, () => {
         removeAddonFromCollection({
           addonId: 543,
           errorHandlerId: errorHandler.id,
-          page: 1,
+          filters: { page: 1 },
           slug: 'some-collection',
           username: 'some-user',
           ...params,
@@ -687,7 +686,7 @@ describe(__filename, () => {
     it('deletes an add-on from a collection', async () => {
       const params = {
         addonId: 123,
-        page: 2,
+        filters: { page: 2 },
         slug: 'some-other-slug',
         username: 'some-other-user',
       };
@@ -707,7 +706,7 @@ describe(__filename, () => {
       _removeAddonFromCollection(params);
 
       const expectedFetchAction = fetchCurrentCollectionPage({
-        page: params.page,
+        filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
         username: params.username,
@@ -823,7 +822,7 @@ describe(__filename, () => {
           addonId: 543,
           errorHandlerId: errorHandler.id,
           notes: '',
-          page: 1,
+          filters: { page: 1 },
           slug: 'some-collection',
           username: 'some-user',
           ...params,
@@ -835,7 +834,7 @@ describe(__filename, () => {
       const params = {
         addonId: 123,
         notes: 'Here are some notes',
-        page: 2,
+        filters: { page: 2 },
         slug: 'some-other-slug',
         username: 'some-other-user',
       };
@@ -856,7 +855,7 @@ describe(__filename, () => {
       _updateCollectionAddon(params);
 
       const expectedFetchAction = fetchCurrentCollectionPage({
-        page: params.page,
+        filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
         username: params.username,
@@ -893,7 +892,7 @@ describe(__filename, () => {
     it('deletes notes for a collection add-on by updating the notes to an empty string', async () => {
       const params = {
         addonId: 123,
-        page: 2,
+        filters: { page: 2 },
         slug: 'some-other-slug',
         username: 'some-other-user',
       };
@@ -919,7 +918,7 @@ describe(__filename, () => {
       );
 
       const expectedFetchAction = fetchCurrentCollectionPage({
-        page: params.page,
+        filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
         username: params.username,


### PR DESCRIPTION
Fixes #3991 

Depends on https://github.com/mozilla/addons-server/issues/8354

This is still a work in progress, although I think it's close. The problem (other than the fact I haven't written tests yet) is that it's not actually working.

When I select a sort order from the Select box, it does dispatch `fetchCurrentCollectionPage`, and I can see that the API code calls the API with the expected `sort` query parameter, and I can also see that `loadCurrentCollectionPage` is run after the query returns, but it doesn't update the list of add-ons on the page. I would have thought that would happen automatically after  `loadCurrentCollectionPage` completes, but apparently not.

@willdurand could you take a look and see if there's something obvious that I've not done/done wrong?


