### PR TITLE
UI for user notifications (readonly)

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -9,6 +9,7 @@ import { compose } from 'redux';
 
 import Link from 'amo/components/Link';
 import NotFound from 'amo/components/ErrorPage/NotFound';
+import UserProfileEditNotifications from 'amo/components/UserProfileEditNotifications';
 import UserProfileEditPicture from 'amo/components/UserProfileEditPicture';
 import {
   editUserAccount,
@@ -440,7 +441,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
               className="UserProfileEdit--Card"
               header={i18n.gettext('Profile')}
             >
-              <p className="UserProfileEdit-aside">
+              <p className="UserProfileEdit-profile-aside">
                 {isEditingCurrentUser ? i18n.gettext(
                   `Tell users a bit more information about yourself. These
                   fields are optional, but they'll help other users get to know
@@ -563,6 +564,33 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                   ].join(' '),
                 })}
               </p>
+            </Card>
+
+            <Card
+              className="UserProfileEdit--Card"
+              header={i18n.gettext('Notifications')}
+            >
+              <p className="UserProfileEdit-notifications-aside">
+                {isEditingCurrentUser ? i18n.gettext(
+                  `From time to time, Mozilla may send you email about upcoming
+                  releases and add-on events. Please select the topics you are
+                  interested in.`
+                ) : i18n.gettext(
+                  `From time to time, Mozilla may send this user email about
+                  upcoming releases and add-on events. Please select the
+                  topics this user may be interested in.`
+                )}
+              </p>
+
+              <UserProfileEditNotifications user={user} />
+
+              {isEditingCurrentUser && (
+                <p className="UserProfileEdit-notifications--help">
+                  {i18n.gettext(`Mozilla reserves the right to contact you
+                    individually about specific concerns with your hosted
+                    add-ons.`)}
+                </p>
+              )}
             </Card>
 
             <div className="UserProfileEdit-buttons-wrapper">

--- a/src/amo/components/UserProfileEdit/styles.scss
+++ b/src/amo/components/UserProfileEdit/styles.scss
@@ -42,7 +42,8 @@ $font-size-aside: 10px;
   margin-bottom: $padding-page;
 }
 
-.UserProfileEdit-aside {
+.UserProfileEdit-notifications-aside,
+.UserProfileEdit-profile-aside {
   color: $grey-50;
   font-size: $font-size-aside;
   margin-top: 0;
@@ -65,11 +66,18 @@ $font-size-aside: 10px;
 
 .UserProfileEdit-biography--help,
 .UserProfileEdit-email--help,
-.UserProfileEdit-homepage--help {
+.UserProfileEdit-homepage--help,
+.UserProfileEdit-notifications--help {
   color: $grey-50;
   display: block;
   font-size: $font-size-aside;
   margin-top: 4px;
+}
+
+.UserProfileEdit-notifications--help {
+  @include respond-to(large) {
+    width: 60%;
+  }
 }
 
 .UserProfileEdit input,

--- a/src/amo/components/UserProfileEditNotifications/index.js
+++ b/src/amo/components/UserProfileEditNotifications/index.js
@@ -1,0 +1,120 @@
+/* @flow */
+import makeClassName from 'classnames';
+import * as React from 'react';
+import { compose } from 'redux';
+import invariant from 'invariant';
+
+import translate from 'core/i18n/translate';
+import LoadingText from 'ui/components/LoadingText';
+import type { UserType } from 'amo/reducers/users';
+import type { I18nType } from 'core/types/i18n';
+
+import './styles.scss';
+
+
+// We disable the eslint rule below because Flow complains about unreachable
+// code if we add a `return` statement in the `default` case.
+// eslint-disable-next-line consistent-return
+export const getLabelText = (i18n: I18nType, name: string): string => {
+  switch (name) {
+    case 'announcements':
+      return i18n.gettext(`stay up-to-date with news and events relevant to
+        add-on developers (including the about:addons newsletter)`);
+    case 'individual_contact':
+      return i18n.gettext(`Mozilla needs to contact me about my individual
+        add-on`);
+    case 'new_features':
+      return i18n.gettext('new add-ons or Firefox features are available');
+    case 'new_review':
+      return i18n.gettext('someone writes a review of my add-on');
+    case 'reply':
+      return i18n.gettext('an add-on developer replies to my review');
+    case 'reviewer_reviewed':
+      return i18n.gettext('my add-on is reviewed by a reviewer');
+    case 'sdk_upgrade_fail':
+      return i18n.gettext('my sdk-based add-on cannot be upgraded');
+    case 'sdk_upgrade_success':
+      return i18n.gettext('my sdk-based add-on is upgraded successfully');
+    case 'upgrade_fail':
+      return i18n.gettext(`my add-on's compatibility cannot be upgraded`);
+    case 'upgrade_success':
+      return i18n.gettext(`my add-on's compatibility is upgraded successfully`);
+    default:
+      invariant(false, `No corresponding label for notification "${name}"`);
+  }
+};
+
+type CreateNotificationParams = {|
+  enabled: boolean,
+  label: React.Element<typeof LoadingText> | string,
+  mandatory: boolean,
+  name: string,
+|};
+
+const createNotification = ({
+  enabled,
+  label,
+  mandatory,
+  name,
+}: CreateNotificationParams) => (
+  <p
+    className={makeClassName('UserProfileEditNotification', {
+      'UserProfileEditNotification--disabled': mandatory,
+    })}
+    key={name}
+  >
+    <label htmlFor={name}>
+      <input
+        className="UserProfileEditNotification-input"
+        defaultChecked={enabled}
+        disabled={mandatory}
+        id={name}
+        name={name}
+        type="checkbox"
+      />
+      <span className="UserProfileEditNotification-checkbox" />
+      {label}
+    </label>
+  </p>
+);
+
+type Props = {|
+  i18n: I18nType,
+  user: UserType | null,
+|};
+
+export const UserProfileEditNotificationsBase = ({
+  i18n,
+  user,
+}: Props) => {
+  let notifications = [];
+  if (!user || !user.notifications) {
+    for (let i = 0; i < 2; i++) {
+      const name = `loading-notification-${i}`;
+
+      notifications.push(createNotification({
+        name,
+        mandatory: true,
+        enabled: false,
+        label: <LoadingText />,
+      }));
+    }
+  } else {
+    notifications = user.notifications.map(
+      (notification) => createNotification({
+        ...notification,
+        label: getLabelText(i18n, notification.name),
+      })
+    );
+  }
+
+  return (
+    <div className="UserProfileEditNotifications">
+      {notifications}
+    </div>
+  );
+};
+
+export default compose(
+  translate(),
+)(UserProfileEditNotificationsBase);

--- a/src/amo/components/UserProfileEditNotifications/styles.scss
+++ b/src/amo/components/UserProfileEditNotifications/styles.scss
@@ -1,0 +1,80 @@
+@import "~photon-colors/photon-colors";
+
+@import "~amo/css/inc/vars";
+@import "~core/css/inc/mixins";
+@import "~ui/css/vars";
+
+$input-height: 16px;
+
+.UserProfileEditNotifications {
+  .UserProfileEditNotification {
+    line-height: $input-height;
+
+    label {
+      @include padding-start(12px);
+
+      cursor: pointer;
+      position: relative;
+      user-select: none;
+    }
+  }
+
+  .UserProfileEditNotification--disabled label {
+    cursor: not-allowed;
+  }
+
+  .UserProfileEditNotification-input {
+    opacity: 0;
+    width: initial;
+    z-index: -1;
+
+    &:checked ~ .UserProfileEditNotification-checkbox {
+      background-color: $blue-50;
+
+      &::before {
+        opacity: 1;
+        transform: translateX(-50%) rotate(45deg) scale(1);
+      }
+    }
+  }
+
+  .UserProfileEditNotification-checkbox {
+    background-color: $grey-30;
+    border: 0;
+    border-radius: 4px;
+    display: inline-block;
+    height: $input-height;
+    left: 0;
+    position: absolute;
+    top: 0;
+    transition: all $transition-short cubic-bezier(0.77, 0, 0.175, 1);
+    width: $input-height;
+
+    [dir=rtl] & {
+      right: 0;
+    }
+
+    // This creates a white tick.
+    &::before {
+      background-color: transparent;
+      border-bottom: 2px solid $white;
+      border-right: 2px solid $white;
+      content: "";
+      display: block;
+      height: 55%;
+      left: 50%;
+      opacity: 0;
+      position: absolute;
+      top: 15%;
+      transform: translateX(-50%) rotate(45deg) scale(0);
+      transition: all $transition-short ease-in-out;
+      width: 40%;
+    }
+  }
+
+  .LoadingText {
+    @include respond-to(large) {
+      max-width: 50%;
+    }
+  }
+}

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -7,6 +7,7 @@ import UserProfileEdit, {
   extractId,
   UserProfileEditBase,
 } from 'amo/components/UserProfileEdit';
+import UserProfileEditNotifications from 'amo/components/UserProfileEditNotifications';
 import UserProfileEditPicture from 'amo/components/UserProfileEditPicture';
 import {
   deleteUserPicture,
@@ -118,14 +119,19 @@ describe(__filename, () => {
 
     expect(root.find('.UserProfileEdit--Card').first())
       .toHaveProp('header', 'Account');
-    expect(root.find('.UserProfileEdit-email--help')).toHaveLength(1);
-    expect(root.find('.UserProfileEdit-aside')).toHaveText(oneLine`Tell users a
-      bit more information about yourself. These fields are optional, but
-      they'll help other users get to know you better.`
+    expect(root.find('.UserProfileEdit-profile-aside')).toHaveText(oneLine`Tell
+      users a bit more information about yourself. These fields are optional,
+      but they'll help other users get to know you better.`
     );
     expect(root.find({ htmlFor: 'biography' }))
       .toHaveText('Introduce yourself to the community if you like');
     expect(root.find(UserProfileEditPicture)).toHaveLength(1);
+
+    expect(root.find('.UserProfileEdit-notifications-aside'))
+      .toHaveText(oneLine`From time to time, Mozilla may send you email about
+        upcoming releases and add-on events. Please select the topics you are
+        interested in.`);
+    expect(root.find(UserProfileEditNotifications)).toHaveLength(1);
   });
 
   it('dispatches fetchUserAccount and fetchUserNotifications actions if username is not found', () => {
@@ -346,6 +352,11 @@ describe(__filename, () => {
       oneLine`Some HTML supported: <abbr title> <acronym title> <b>
       <blockquote> <code> <em> <i> <li> <ol> <strong> <ul>. Links are
       forbidden.`
+    );
+
+    expect(root.find('.UserProfileEdit-notifications--help')).toHaveText(
+      oneLine`Mozilla reserves the right to contact you individually about
+      specific concerns with your hosted add-ons.`
     );
   });
 
@@ -755,15 +766,23 @@ describe(__filename, () => {
     expect(root.find('.UserProfileEdit--Card').first())
       .toHaveProp('header', 'Account for willdurand');
 
-    expect(root.find('.UserProfileEdit--help-email')).toHaveLength(0);
+    // We do not display these help messages when current logged-in user edits
+    // another user.
+    expect(root.find('.UserProfileEdit-email--help')).toHaveLength(0);
+    expect(root.find('.UserProfileEdit-notifications--help')).toHaveLength(0);
 
-    expect(root.find('.UserProfileEdit-aside')).toHaveText(oneLine`Tell users a
-      bit more information about this user. These fields are optional, but
-      they'll help other users get to know willdurand better.`
+    expect(root.find('.UserProfileEdit-profile-aside')).toHaveText(oneLine`Tell
+      users a bit more information about this user. These fields are optional,
+      but they'll help other users get to know willdurand better.`
     );
 
     expect(root.find({ htmlFor: 'biography' }))
       .toHaveText('Introduce willdurand to the community');
+
+    expect(root.find('.UserProfileEdit-notifications-aside'))
+      .toHaveText(oneLine`From time to time, Mozilla may send this user email
+        about upcoming releases and add-on events. Please select the topics
+        this user may be interested in.`);
   });
 
   it('renders errors', () => {

--- a/tests/unit/amo/components/TestUserProfileEditNotifications.js
+++ b/tests/unit/amo/components/TestUserProfileEditNotifications.js
@@ -30,8 +30,7 @@ describe(__filename, () => {
   };
 
   it('renders loading notifications without a user', () => {
-    const name = 'some-input-name';
-    const root = render({ name, user: null });
+    const root = render({ user: null });
 
     expect(root.find('.UserProfileEditNotifications')).toHaveLength(1);
 
@@ -96,5 +95,22 @@ describe(__filename, () => {
       expect(p.hasClass('UserProfileEditNotification--disabled'))
         .toEqual(notification.mandatory);
     });
+  });
+
+  it('does not render a notification if there is no corresponding label', () => {
+    const username = 'johnedoe';
+    const notifications = [
+      { name: 'invalid-notification-name', enabled: true, mandatory: false },
+    ];
+
+    const { store } = dispatchSignInActions({ userProps: { username } });
+    store.dispatch(loadUserNotifications({ username, notifications }));
+
+    const { users } = store.getState();
+    const user = getCurrentUser(users);
+
+    const root = render({ user });
+
+    expect(root.find('.UserProfileEditNotification')).toHaveLength(0);
   });
 });

--- a/tests/unit/amo/components/TestUserProfileEditNotifications.js
+++ b/tests/unit/amo/components/TestUserProfileEditNotifications.js
@@ -1,0 +1,100 @@
+import * as React from 'react';
+
+import UserProfileEditNotifications, {
+  getLabelText,
+  UserProfileEditNotificationsBase,
+} from 'amo/components/UserProfileEditNotifications';
+import {
+  getCurrentUser,
+  loadUserNotifications,
+} from 'amo/reducers/users';
+import LoadingText from 'ui/components/LoadingText';
+import { dispatchSignInActions } from 'tests/unit/amo/helpers';
+import {
+  createUserNotificationsResponse,
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  const render = ({ i18n = fakeI18n(), ...props } = {}) => {
+    return shallowUntilTarget(
+      <UserProfileEditNotifications
+        i18n={i18n}
+        user={null}
+        {...props}
+      />,
+      UserProfileEditNotificationsBase,
+    );
+  };
+
+  it('renders loading notifications without a user', () => {
+    const name = 'some-input-name';
+    const root = render({ name, user: null });
+
+    expect(root.find('.UserProfileEditNotifications')).toHaveLength(1);
+
+    expect(root.find('.UserProfileEditNotification')).toHaveLength(2);
+    expect(root.find('.UserProfileEditNotification--disabled')).toHaveLength(2);
+
+    expect(root.find(LoadingText)).toHaveLength(2);
+    expect(root.find('.UserProfileEditNotification-input')).toHaveLength(2);
+    expect(root.find('.UserProfileEditNotification-checkbox')).toHaveLength(2);
+
+    root.find('.UserProfileEditNotification-input').forEach((input, index) => {
+      expect(input).toHaveProp('defaultChecked', false);
+      expect(input).toHaveProp('disabled', true);
+      expect(input).toHaveProp('name', `loading-notification-${index}`);
+    });
+  });
+
+  it(`renders loading notifications when user's notifications are not loaded`, () => {
+    const username = 'johnedoe';
+    const { store } = dispatchSignInActions({ userProps: { username } });
+    const { users } = store.getState();
+
+    const user = getCurrentUser(users);
+    const root = render({ user });
+
+    expect(root.find('.UserProfileEditNotification')).toHaveLength(2);
+    expect(root.find(LoadingText)).toHaveLength(2);
+  });
+
+  it(`renders notifications when the user's notifications are loaded`, () => {
+    const username = 'johnedoe';
+    const notifications = createUserNotificationsResponse();
+
+    const { store } = dispatchSignInActions({ userProps: { username } });
+    store.dispatch(loadUserNotifications({ username, notifications }));
+
+    const { users } = store.getState();
+    const user = getCurrentUser(users);
+
+    const root = render({ user });
+
+    expect(root.find('.UserProfileEditNotification'))
+      .toHaveLength(notifications.length);
+    expect(root.find(LoadingText)).toHaveLength(0);
+
+    const i18n = fakeI18n();
+    notifications.forEach((notification) => {
+      // Find element by ID.
+      const input = root.find({ id: notification.name });
+
+      expect(input).toHaveProp('defaultChecked', notification.enabled);
+      expect(input).toHaveProp('disabled', notification.mandatory);
+      expect(input).toHaveProp('name', notification.name);
+
+      const label = input.parent();
+      expect(label.shallow()).toHaveText(
+        getLabelText(i18n, notification.name)
+      );
+
+      const p = input.closest('p');
+      expect(p).toHaveClassName('UserProfileEditNotification');
+      expect(p.hasClass('UserProfileEditNotification--disabled'))
+        .toEqual(notification.mandatory);
+    });
+  });
+});

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -605,10 +605,5 @@ export const createUserNotificationsResponse = () => {
       enabled: false,
       mandatory: false,
     },
-    {
-      name: 'announcements',
-      enabled: false,
-      mandatory: false,
-    },
   ];
 };


### PR DESCRIPTION
Fix #5127 – Refs #5000 – ~~Depends on #5071~~

---

It is read-only for now.


## Screenshots

Loading state: I chose to display only two notifications because that's what users who are not developers will see anyway.

<img width="660" alt="screen shot 2018-05-28 at 16 25 53" src="https://user-images.githubusercontent.com/217628/40621252-eebb6fc4-6293-11e8-991c-bff13af5f9cb.png">

List of all the notifications returned by the API:

<img width="725" alt="screen shot 2018-05-28 at 16 13 08" src="https://user-images.githubusercontent.com/217628/40621249-ee4dc690-6293-11e8-889d-73bd31bb3735.png">

Small screens:

<img width="449" alt="screen shot 2018-05-28 at 16 13 16" src="https://user-images.githubusercontent.com/217628/40621250-ee6bdf36-6293-11e8-8a44-8b55ef79e3f9.png">

RTL:

<img width="659" alt="screen shot 2018-05-28 at 16 18 09" src="https://user-images.githubusercontent.com/217628/40621251-ee97033c-6293-11e8-8175-a7277ef2df5b.png">
