### PR TITLE
Fixed height issues with Screenshots section

### DIFF
--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,5 +1,6 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
+
 $screenshot-height: 220px;
 $image-height: $screenshot-height - 20px;
 $screenshot-width: 320px;

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,6 +1,7 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
 
+//image-height has to be 20px smaller to ensure it doesn't overflow in the screenshots section.
 // See: https://github.com/mozilla/addons-frontend/issues/4887
 $image-height: $screenshot-height - 20px;
 $screenshot-height: 220px;

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,6 +1,7 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
-
+// screenshot-height value was increased to handle issue #4887
+// image-height is used to ensure that the image's height is always 20px less than screenshot-height for #4887 fix.
 $screenshot-height: 220px;
 $image-height: $screenshot-height - 20px;
 $screenshot-width: 320px;

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,6 +1,7 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
-$screenshot-height: 200px;
+$screenshot-height: 220px;
+$image-height: $screenshot-height - 20px;
 $screenshot-width: 320px;
 
 .ScreenShots .pswp-thumbnails {
@@ -34,7 +35,7 @@ $screenshot-width: 320px;
 .ScreenShots-image {
   cursor: pointer;
   display: inline-block;
-  height: $screenshot-height;
+  height: $image-height;
   width: $screenshot-width;
 }
 

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,7 +1,9 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
-// screenshot-height value was increased to handle issue #4887
+// screenshot-height value was increased for 
+// https://github.com/mozilla/addons-frontend/issues/4887
 // image-height ensures the image is always 20px less than screenshot-height
+// 20px accounts for the approx size of the horizontal scrollbar
 $screenshot-height: 220px;
 $image-height: $screenshot-height - 20px;
 $screenshot-width: 320px;

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,10 +1,10 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
 
-//image-height has to be 20px smaller to ensure it doesn't overflow in the screenshots section.
+// image-height has to be 20px smaller to prevent screenshot overflow.
 // See: https://github.com/mozilla/addons-frontend/issues/4887
-$image-height: $screenshot-height - 20px;
 $screenshot-height: 220px;
+$image-height: $screenshot-height - 20px;
 $screenshot-width: 320px;
 
 .ScreenShots .pswp-thumbnails {

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,11 +1,9 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
-// screenshot-height value was increased for 
-// https://github.com/mozilla/addons-frontend/issues/4887
-// image-height ensures the image is always 20px less than screenshot-height
-// 20px accounts for the approx size of the horizontal scrollbar
-$screenshot-height: 220px;
+
+// See: https://github.com/mozilla/addons-frontend/issues/4887
 $image-height: $screenshot-height - 20px;
+$screenshot-height: 220px;
 $screenshot-width: 320px;
 
 .ScreenShots .pswp-thumbnails {

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -1,7 +1,7 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
 // screenshot-height value was increased to handle issue #4887
-// image-height is used to ensure that the image's height is always 20px less than screenshot-height for #4887 fix.
+// image-height ensures the image is always 20px less than screenshot-height
 $screenshot-height: 220px;
 $image-height: $screenshot-height - 20px;
 $screenshot-width: 320px;


### PR DESCRIPTION
Changed the display of the ScreenShots by extending the height of the psw-thumbnails section to 220px and same for the viewport height as recommended by @rebmullin . This is related to issue #4887. 

More details regarding the fix:
After testing I realized the two suggestions work hand in hand. They are both based on the height variable defined earlier in that file as 200px. So changing this to 220px changes both values and this resolves the display issue. However, the screenshot image's height is also reliant on this variable so when this value is changed to 220px it does not fix the issue. So the suggested fix is to make this image's height be 20px less of the variable's height and change the variable value to 220px. This 20px less fix is calculated at runtime by performing this operation on a new variable $image-height as opposed to hardcoding it. :+1