### PR TITLE
Consistently use username as the user identifier in collections reducers and sagas

### DIFF
--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -15,7 +15,7 @@ import type {
 export type GetCollectionParams = {|
   api: ApiStateType,
   slug: string,
-  user: string | number,
+  user: string,
 |};
 
 export const getCollectionDetail = (
@@ -92,7 +92,7 @@ export const getAllCollectionAddons = async (
 type ListCollectionsParams = {|
   api: ApiStateType,
   nextURL?: string,
-  user: string | number,
+  user: string,
 |};
 
 export const listCollections = (
@@ -260,7 +260,7 @@ type ModifyCollectionAddonBaseParams = {|
   addonId: number,
   api: ApiStateType,
   slug: string,
-  user: string | number,
+  user: string,
   _modifyCollectionAddon?: (any) => Promise<void>,
 |};
 
@@ -337,7 +337,7 @@ export type RemoveAddonFromCollectionParams = {|
   addonId: number,
   api: ApiStateType,
   slug: string,
-  user: string | number,
+  user: string,
 |};
 
 export const removeAddonFromCollection = (

--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -15,22 +15,22 @@ import type {
 export type GetCollectionParams = {|
   api: ApiStateType,
   slug: string,
-  user: string,
+  username: string,
 |};
 
 export const getCollectionDetail = (
-  { api, slug, user }: GetCollectionParams
+  { api, slug, username }: GetCollectionParams
 ): Promise<ExternalCollectionDetail> => {
   if (!slug) {
     throw new Error('slug is required');
   }
-  if (!user) {
-    throw new Error('user is required');
+  if (!username) {
+    throw new Error('username is required');
   }
 
   return callApi({
     auth: true,
-    endpoint: `accounts/account/${user}/collections/${slug}`,
+    endpoint: `accounts/account/${username}/collections/${slug}`,
     state: api,
   });
 };
@@ -42,19 +42,19 @@ export type GetCollectionAddonsParams = {|
 |};
 
 export const getCollectionAddons = (
-  { api, nextURL, page, slug, user }: GetCollectionAddonsParams
+  { api, nextURL, page, slug, username }: GetCollectionAddonsParams
 ): Promise<PaginatedApiResponse<ExternalCollectionAddon>> => {
   if (!slug) {
     throw new Error('slug is required');
   }
-  if (!user) {
-    throw new Error('user is required');
+  if (!username) {
+    throw new Error('username is required');
   }
 
   const request = {
     auth: true,
     endpoint:
-      nextURL || `accounts/account/${user}/collections/${slug}/addons`,
+      nextURL || `accounts/account/${username}/collections/${slug}/addons`,
     params: undefined,
     state: api,
   };
@@ -78,13 +78,13 @@ export const getAllCollectionAddons = async (
   {
     api,
     slug,
-    user,
+    username,
     _allPages = allPages,
     _getCollectionAddons = getCollectionAddons,
   }: GetAllCollectionAddonsParams
 ): Promise<Array<ExternalCollectionAddon>> => {
   const { results } = await _allPages(
-    (nextURL) => _getCollectionAddons({ api, nextURL, slug, user })
+    (nextURL) => _getCollectionAddons({ api, nextURL, slug, username })
   );
   return results;
 };
@@ -92,16 +92,16 @@ export const getAllCollectionAddons = async (
 type ListCollectionsParams = {|
   api: ApiStateType,
   nextURL?: string,
-  user: string,
+  username: string,
 |};
 
 export const listCollections = (
-  { api, nextURL, user }: ListCollectionsParams
+  { api, nextURL, username }: ListCollectionsParams
 ): Promise<PaginatedApiResponse<ExternalCollectionDetail>> => {
-  if (!user) {
-    throw new Error('The user parameter is required');
+  if (!username) {
+    throw new Error('The username parameter is required');
   }
-  const endpoint = nextURL || `accounts/account/${user}/collections`;
+  const endpoint = nextURL || `accounts/account/${username}/collections`;
 
   return callApi({ auth: true, endpoint, state: api });
 };
@@ -115,13 +115,13 @@ export type GetAllUserCollectionsParams = {|
 export const getAllUserCollections = async (
   {
     api,
-    user,
+    username,
     _allPages = allPages,
     _listCollections = listCollections,
   }: GetAllUserCollectionsParams
 ): Promise<Array<ExternalCollectionDetail>> => {
   const { results } = await _allPages(
-    (nextURL) => _listCollections({ api, nextURL, user })
+    (nextURL) => _listCollections({ api, nextURL, username })
   );
   return results;
 };
@@ -132,7 +132,7 @@ type ModifyCollectionParams = {|
   description: ?LocalizedString,
   // Even though the API accepts string|number, we need to always use
   // string usernames. This helps keep public-facing URLs consistent.
-  user: string,
+  username: string,
   // eslint-disable-next-line no-use-before-define
   _modifyCollection?: typeof modifyCollection,
   _validateLocalizedString?: typeof validateLocalizedString,
@@ -172,14 +172,14 @@ export const modifyCollection = (
     description,
     name,
     slug,
-    user,
+    username,
     _validateLocalizedString = validateLocalizedString,
   } = params;
 
   const creating = action === 'create';
 
   invariant(api, 'The api parameter is required');
-  invariant(user, 'The user parameter is required');
+  invariant(username, 'The username parameter is required');
   if (creating) {
     invariant(slug, 'The slug parameter is required when creating');
   } else {
@@ -206,7 +206,7 @@ export const modifyCollection = (
       // should cut down on unexpected bugs.
     },
     endpoint:
-      `accounts/account/${user}/collections/${creating ? '' : collectionSlug}`,
+      `accounts/account/${username}/collections/${creating ? '' : collectionSlug}`,
     method: creating ? 'POST' : 'PATCH',
     state: api,
   });
@@ -219,7 +219,7 @@ export const updateCollection = ({
   description,
   name,
   slug,
-  user,
+  username,
   _modifyCollection = modifyCollection,
   _validateLocalizedString = validateLocalizedString,
 }: UpdateCollectionParams): Promise<void> => {
@@ -230,7 +230,7 @@ export const updateCollection = ({
     description,
     name,
     slug,
-    user,
+    username,
     _validateLocalizedString,
   });
 };
@@ -241,7 +241,7 @@ export const createCollection = ({
   description,
   name,
   slug,
-  user,
+  username,
   _modifyCollection = modifyCollection,
   _validateLocalizedString = validateLocalizedString,
 }: CreateCollectionParams): Promise<void> => {
@@ -251,7 +251,7 @@ export const createCollection = ({
     description,
     name,
     slug,
-    user,
+    username,
     _validateLocalizedString,
   });
 };
@@ -260,7 +260,7 @@ type ModifyCollectionAddonBaseParams = {|
   addonId: number,
   api: ApiStateType,
   slug: string,
-  user: string,
+  username: string,
   _modifyCollectionAddon?: (any) => Promise<void>,
 |};
 
@@ -283,18 +283,18 @@ type ModifyCollectionAddonParams =
 export const modifyCollectionAddon = (
   params: ModifyCollectionAddonParams,
 ): Promise<void> => {
-  const { action, addonId, api, slug, user } = params;
+  const { action, addonId, api, slug, username } = params;
 
   invariant(action, 'The action parameter is required');
   invariant(addonId, 'The addonId parameter is required');
   invariant(api, 'The api parameter is required');
   invariant(slug, 'The slug parameter is required');
-  invariant(user, 'The user parameter is required');
+  invariant(username, 'The username parameter is required');
 
   let method = 'POST';
   const body = { addon: addonId, notes: params.notes };
   let endpoint =
-    `accounts/account/${user}/collections/${slug}/addons`;
+    `accounts/account/${username}/collections/${slug}/addons`;
 
   if (action === 'update') {
     // TODO: once `notes` can be null, we can check for `undefined` values
@@ -313,11 +313,11 @@ export const createCollectionAddon = ({
   api,
   slug,
   notes,
-  user,
+  username,
   _modifyCollectionAddon = modifyCollectionAddon,
 }: CreateCollectionAddonParams): Promise<void> => {
   return _modifyCollectionAddon({
-    action: 'create', addonId, api, slug, notes, user,
+    action: 'create', addonId, api, notes, slug, username,
   });
 };
 
@@ -326,32 +326,32 @@ export const updateCollectionAddon = ({
   api,
   slug,
   notes,
-  user,
+  username,
   _modifyCollectionAddon = modifyCollectionAddon,
 }: UpdateCollectionAddonParams): Promise<void> => {
   return _modifyCollectionAddon({
-    action: 'update', addonId, api, slug, notes, user,
+    action: 'update', addonId, api, notes, slug, username,
   });
 };
 export type RemoveAddonFromCollectionParams = {|
   addonId: number,
   api: ApiStateType,
   slug: string,
-  user: string,
+  username: string,
 |};
 
 export const removeAddonFromCollection = (
-  { addonId, api, slug, user }: RemoveAddonFromCollectionParams
+  { addonId, api, slug, username }: RemoveAddonFromCollectionParams
 ): Promise<void> => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(api, 'The api parameter is required');
   invariant(slug, 'The slug parameter is required');
-  invariant(user, 'The user parameter is required');
+  invariant(username, 'The username parameter is required');
 
   return callApi({
     auth: true,
     endpoint:
-      `accounts/account/${user}/collections/${slug}/addons/${addonId}`,
+      `accounts/account/${username}/collections/${slug}/addons/${addonId}`,
     method: 'DELETE',
     state: api,
   });

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -93,7 +93,7 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
 
     if (currentUsername && !loadingUserCollections && !userCollections) {
       dispatch(fetchUserCollections({
-        errorHandlerId: errorHandler.id, user: currentUsername,
+        errorHandlerId: errorHandler.id, username: currentUsername,
       }));
     }
   }
@@ -125,7 +125,7 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
       collectionId: collection.id,
       slug: collection.slug,
       errorHandlerId: errorHandler.id,
-      user: currentUsername,
+      username: currentUsername,
     }));
   }
 

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -56,7 +56,7 @@ export type Props = {|
   location: ReactRouterLocation,
   params: {|
     slug: string,
-    user: string,
+    username: string,
   |},
 |};
 
@@ -111,7 +111,7 @@ export class CollectionBase extends React.Component<Props> {
 
     if (collection && (
       collection.slug !== params.slug ||
-      collection.authorUsername.toLowerCase() !== params.user.toLowerCase()
+      collection.authorUsername.toLowerCase() !== params.username.toLowerCase()
     )) {
       collectionChanged = true;
     }
@@ -121,7 +121,7 @@ export class CollectionBase extends React.Component<Props> {
         errorHandlerId: errorHandler.id,
         page: location.query.page,
         slug: params.slug,
-        user: params.user,
+        username: params.username,
       }));
 
       return;
@@ -132,7 +132,7 @@ export class CollectionBase extends React.Component<Props> {
         errorHandlerId: errorHandler.id,
         page: location.query.page || 1,
         slug: params.slug,
-        user: params.user,
+        username: params.username,
       }));
     }
   }
@@ -140,7 +140,7 @@ export class CollectionBase extends React.Component<Props> {
   url() {
     const { params } = this.props;
 
-    return `/collections/${params.user}/${params.slug}/`;
+    return `/collections/${params.username}/${params.slug}/`;
   }
 
   editUrl() {
@@ -187,19 +187,19 @@ export class CollectionBase extends React.Component<Props> {
 
     const {
       slug,
-      authorUsername: user,
+      authorUsername: username,
     } = collection;
 
     invariant(query, 'query is required');
     invariant(slug, 'slug is required');
-    invariant(user, 'page is required');
+    invariant(username, 'page is required');
 
     dispatch(removeAddonFromCollection({
       addonId,
       errorHandlerId: errorHandler.id,
       page: query.page || 1,
       slug,
-      user,
+      username,
     }));
   };
 
@@ -356,7 +356,7 @@ export const mapStateToProps = (
 
 export const extractId = (ownProps: Props) => {
   return [
-    ownProps.params.user,
+    ownProps.params.username,
     ownProps.params.slug,
     ownProps.location.query.page,
   ].join('/');

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -174,7 +174,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
       dispatch(createCollection({
         ...payload,
         defaultLocale: siteLang,
-        user: currentUsername,
+        username: currentUsername,
       }));
     } else {
       invariant(collection,
@@ -183,7 +183,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
         ...payload,
         collectionSlug: collection.slug,
         defaultLocale: collection.defaultLocale,
-        user: collection.authorUsername,
+        username: collection.authorUsername,
       }));
     }
   };
@@ -241,7 +241,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
       editing: true,
       errorHandlerId: errorHandler.id,
       page: page || 1,
-      user: currentUsername,
+      username: currentUsername,
     }));
     this.setState({ addonAddedStatus: ADDON_ADDED_STATUS_PENDING });
   };

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -66,7 +66,6 @@ type Props = {|
   router: ReactRouterType,
   setTimeout: Function,
   siteLang: ?string,
-  siteUserId: number | null,
 |};
 
 type State = {|
@@ -224,13 +223,15 @@ export class CollectionManagerBase extends React.Component<Props, State> {
   };
 
   onAddonSelected = (suggestion: SuggestionType) => {
-    const { collection, errorHandler, dispatch, page, siteUserId } = this.props;
+    const {
+      collection, currentUsername, dispatch, errorHandler, page,
+    } = this.props;
     const { addonId } = suggestion;
 
     invariant(addonId, 'addonId cannot be empty');
     invariant(collection,
       'A collection must be loaded before you can add an add-on to it');
-    invariant(siteUserId,
+    invariant(currentUsername,
       'Cannot add to collection because you are not signed in');
 
     dispatch(addAddonToCollection({
@@ -240,7 +241,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
       editing: true,
       errorHandlerId: errorHandler.id,
       page: page || 1,
-      userId: siteUserId,
+      user: currentUsername,
     }));
     this.setState({ addonAddedStatus: ADDON_ADDED_STATUS_PENDING });
   };
@@ -419,7 +420,6 @@ export const mapStateToProps = (
     currentUsername: currentUser && currentUser.username,
     isCollectionBeingModified: state.collections.isCollectionBeingModified,
     siteLang: state.api.lang,
-    siteUserId: state.users.currentUserID,
   };
 };
 

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -24,9 +24,9 @@ import './styles.scss';
 
 
 export const COLLECTIONS_TO_FETCH = [
-  { slug: 'change-up-your-tabs', user: 'mozilla' },
-  { slug: 'essential-extensions', user: 'mozilla' },
-  { slug: 'translation-tools', user: 'mozilla' },
+  { slug: 'change-up-your-tabs', username: 'mozilla' },
+  { slug: 'essential-extensions', username: 'mozilla' },
+  { slug: 'translation-tools', username: 'mozilla' },
 ];
 
 export class HomeBase extends React.Component {
@@ -217,7 +217,7 @@ export class HomeBase extends React.Component {
             i18n.gettext('See more tab extensions')
           }
           footerLink={
-            `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`
+            `/collections/${COLLECTIONS_TO_FETCH[0].username}/${COLLECTIONS_TO_FETCH[0].slug}/`
           }
           loading={resultsLoaded === false}
         />
@@ -244,7 +244,7 @@ export class HomeBase extends React.Component {
           header={i18n.gettext('Essential extensions')}
           footerText={i18n.gettext('See more essential extensions')}
           footerLink={
-            `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`
+            `/collections/${COLLECTIONS_TO_FETCH[1].username}/${COLLECTIONS_TO_FETCH[1].slug}/`
           }
           loading={resultsLoaded === false}
         />
@@ -255,7 +255,7 @@ export class HomeBase extends React.Component {
           header={i18n.gettext('Translation tools')}
           footerText={i18n.gettext('See more translation tools')}
           footerLink={
-            `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`
+            `/collections/${COLLECTIONS_TO_FETCH[2].username}/${COLLECTIONS_TO_FETCH[2].slug}/`
           }
           loading={resultsLoaded === false}
         />

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -70,14 +70,14 @@ export type CollectionsState = {
     loading: boolean,
   |},
   userCollections: {
-    [userId: number]: {|
+    [user: string]: {|
       // This is a list of all collections belonging to the user.
       collections: Array<CollectionId> | null,
       loading: boolean,
     |};
   },
   addonInCollections: {
-    [userId: number]: {
+    [user: string]: {
       [addonId: number]: {|
         // This is a list of all user collections that the add-on
         // is a part of.
@@ -104,7 +104,7 @@ type FetchCurrentCollectionParams = {|
   errorHandlerId: string,
   page?: number,
   slug: string,
-  user: number | string,
+  user: string,
 |};
 
 export type FetchCurrentCollectionAction = {|
@@ -130,7 +130,7 @@ export const fetchCurrentCollection = ({
 
 type FetchUserCollectionsParams = {|
   errorHandlerId: string,
-  userId: number,
+  user: string,
 |};
 
 export type FetchUserCollectionsAction = {|
@@ -139,23 +139,23 @@ export type FetchUserCollectionsAction = {|
 |};
 
 export const fetchUserCollections = ({
-  errorHandlerId, userId,
+  errorHandlerId, user,
 }: FetchUserCollectionsParams = {}): FetchUserCollectionsAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
-  if (!userId) {
-    throw new Error('userId is required');
+  if (!user) {
+    throw new Error('user is required');
   }
 
   return {
     type: FETCH_USER_COLLECTIONS,
-    payload: { errorHandlerId, userId },
+    payload: { errorHandlerId, user },
   };
 };
 
 type AbortFetchUserCollectionsParams = {|
-  userId: number,
+  user: string,
 |};
 
 type AbortFetchUserCollectionsAction = {|
@@ -164,21 +164,21 @@ type AbortFetchUserCollectionsAction = {|
 |};
 
 export const abortFetchUserCollections = (
-  { userId }: AbortFetchUserCollectionsParams = {}
+  { user }: AbortFetchUserCollectionsParams = {}
 ): AbortFetchUserCollectionsAction => {
-  if (!userId) {
-    throw new Error('userId is required');
+  if (!user) {
+    throw new Error('user is required');
   }
 
   return {
     type: ABORT_FETCH_USER_COLLECTIONS,
-    payload: { userId },
+    payload: { user },
   };
 };
 
 type AbortAddAddonToCollectionParams = {|
-  userId: number,
   addonId: number,
+  user: string,
 |};
 
 type AbortAddAddonToCollectionAction = {|
@@ -187,10 +187,10 @@ type AbortAddAddonToCollectionAction = {|
 |};
 
 export const abortAddAddonToCollection = (
-  { userId, addonId }: AbortAddAddonToCollectionParams = {}
+  { addonId, user }: AbortAddAddonToCollectionParams = {}
 ): AbortAddAddonToCollectionAction => {
-  if (!userId) {
-    throw new Error('userId is required');
+  if (!user) {
+    throw new Error('user is required');
   }
   if (!addonId) {
     throw new Error('addonId is required');
@@ -198,7 +198,7 @@ export const abortAddAddonToCollection = (
 
   return {
     type: ABORT_ADD_ADDON_TO_COLLECTION,
-    payload: { userId, addonId },
+    payload: { user, addonId },
   };
 };
 
@@ -353,8 +353,8 @@ export const loadCollectionAddons = ({
 };
 
 type LoadUserCollectionsParams = {|
-  userId: number,
   collections: Array<ExternalCollectionDetail>,
+  user: string,
 |};
 
 type LoadUserCollectionsAction = {|
@@ -363,10 +363,10 @@ type LoadUserCollectionsAction = {|
 |};
 
 export const loadUserCollections = (
-  { userId, collections }: LoadUserCollectionsParams = {}
+  { collections, user }: LoadUserCollectionsParams = {}
 ): LoadUserCollectionsAction => {
-  if (!userId) {
-    throw new Error('The userId parameter is required');
+  if (!user) {
+    throw new Error('The user parameter is required');
   }
   if (!collections) {
     throw new Error('The collections parameter is required');
@@ -374,14 +374,14 @@ export const loadUserCollections = (
 
   return {
     type: LOAD_USER_COLLECTIONS,
-    payload: { userId, collections },
+    payload: { user, collections },
   };
 };
 
 type AddonAddedToCollectionParams = {|
   addonId: number,
-  userId: number,
   collectionId: CollectionId,
+  user: string,
 |};
 
 type AddonAddedToCollectionAction = {|
@@ -390,13 +390,13 @@ type AddonAddedToCollectionAction = {|
 |};
 
 export const addonAddedToCollection = (
-  { addonId, userId, collectionId }: AddonAddedToCollectionParams = {}
+  { addonId, collectionId, user }: AddonAddedToCollectionParams = {}
 ): AddonAddedToCollectionAction => {
   if (!addonId) {
     throw new Error('The addonId parameter is required');
   }
-  if (!userId) {
-    throw new Error('The userId parameter is required');
+  if (!user) {
+    throw new Error('The user parameter is required');
   }
   if (!collectionId) {
     throw new Error('The collectionId parameter is required');
@@ -404,7 +404,7 @@ export const addonAddedToCollection = (
 
   return {
     type: ADDON_ADDED_TO_COLLECTION,
-    payload: { addonId, userId, collectionId },
+    payload: { addonId, collectionId, user },
   };
 };
 
@@ -424,7 +424,7 @@ type AddAddonToCollectionParams = {|
   errorHandlerId: string,
   notes?: string,
   page?: number,
-  userId: number,
+  user: string,
 |};
 
 export type AddAddonToCollectionAction = {|
@@ -433,13 +433,13 @@ export type AddAddonToCollectionAction = {|
 |};
 
 export const addAddonToCollection = ({
-  addonId, collectionId, slug, editing, errorHandlerId, notes, page, userId,
+  addonId, collectionId, editing, errorHandlerId, notes, page, slug, user,
 }: AddAddonToCollectionParams = {}): AddAddonToCollectionAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(collectionId, 'The collectionId parameter is required');
   invariant(slug, 'The slug parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
-  invariant(userId, 'The userId parameter is required');
+  invariant(user, 'The user parameter is required');
 
   if (editing) {
     invariant(page, 'The page parameter is required when editing');
@@ -448,7 +448,7 @@ export const addAddonToCollection = ({
   return {
     type: ADD_ADDON_TO_COLLECTION,
     payload: {
-      addonId, collectionId, slug, editing, errorHandlerId, notes, page, userId,
+      addonId, collectionId, editing, errorHandlerId, notes, page, slug, user,
     },
   };
 };
@@ -711,22 +711,22 @@ export const loadCollectionIntoState = (
 
 type ChangeAddonCollectionsLoadingFlagParams = {|
   addonId: number,
-  userId: number,
-  state: CollectionsState,
   loading: boolean,
+  state: CollectionsState,
+  user: string,
 |};
 
 export const changeAddonCollectionsLoadingFlag = ({
-  addonId, userId, state, loading,
+  addonId, loading, state, user,
 }: ChangeAddonCollectionsLoadingFlagParams = {}): CollectionsState => {
-  const userState = state.addonInCollections[userId];
+  const userState = state.addonInCollections[user];
   const addonState = userState && userState[addonId];
 
   return {
     ...state,
     addonInCollections: {
       ...state.addonInCollections,
-      [userId]: {
+      [user]: {
         ...userState,
         [addonId]: {
           collections: addonState ? addonState.collections : null,
@@ -896,13 +896,13 @@ const reducer = (
       };
 
     case FETCH_USER_COLLECTIONS: {
-      const { userId } = action.payload;
+      const { user } = action.payload;
 
       return {
         ...state,
         userCollections: {
           ...state.userCollections,
-          [userId]: {
+          [user]: {
             collections: null,
             loading: true,
           },
@@ -911,13 +911,13 @@ const reducer = (
     }
 
     case ABORT_FETCH_USER_COLLECTIONS: {
-      const { userId } = action.payload;
+      const { user } = action.payload;
 
       return {
         ...state,
         userCollections: {
           ...state.userCollections,
-          [userId]: {
+          [user]: {
             collections: null,
             loading: false,
           },
@@ -926,7 +926,7 @@ const reducer = (
     }
 
     case LOAD_USER_COLLECTIONS: {
-      const { collections, userId } = action.payload;
+      const { collections, user } = action.payload;
 
       let newState = { ...state };
       collections.forEach((collection) => {
@@ -939,7 +939,7 @@ const reducer = (
         ...newState,
         userCollections: {
           ...state.userCollections,
-          [userId]: {
+          [user]: {
             collections: collections.map((collection) => collection.id),
             loading: false,
           },
@@ -948,15 +948,15 @@ const reducer = (
     }
 
     case ADDON_ADDED_TO_COLLECTION: {
-      const { addonId, collectionId, userId } = action.payload;
+      const { addonId, collectionId, user } = action.payload;
       const { addonInCollections } = state;
       let collections = [];
       if (
-        addonInCollections[userId] &&
-        addonInCollections[userId][addonId]
+        addonInCollections[user] &&
+        addonInCollections[user][addonId]
       ) {
         const existingCollections =
-          addonInCollections[userId][addonId].collections;
+          addonInCollections[user][addonId].collections;
         if (existingCollections) {
           collections = existingCollections;
         }
@@ -966,8 +966,8 @@ const reducer = (
         ...state,
         addonInCollections: {
           ...state.addonInCollections,
-          [userId]: {
-            ...state.addonInCollections[userId],
+          [user]: {
+            ...state.addonInCollections[user],
             [addonId]: {
               collections: collections.concat([collectionId]),
               loading: false,
@@ -979,11 +979,11 @@ const reducer = (
     }
 
     case ADD_ADDON_TO_COLLECTION: {
-      const { addonId, userId } = action.payload;
+      const { addonId, user } = action.payload;
 
       const newState = changeAddonCollectionsLoadingFlag({
         addonId,
-        userId,
+        user,
         state,
         loading: true,
       });
@@ -994,11 +994,11 @@ const reducer = (
     }
 
     case ABORT_ADD_ADDON_TO_COLLECTION: {
-      const { addonId, userId } = action.payload;
+      const { addonId, user } = action.payload;
 
       const newState = changeAddonCollectionsLoadingFlag({
         addonId,
-        userId,
+        user,
         state,
         loading: false,
       });

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -70,14 +70,14 @@ export type CollectionsState = {
     loading: boolean,
   |},
   userCollections: {
-    [user: string]: {|
+    [username: string]: {|
       // This is a list of all collections belonging to the user.
       collections: Array<CollectionId> | null,
       loading: boolean,
     |};
   },
   addonInCollections: {
-    [user: string]: {
+    [username: string]: {
       [addonId: number]: {|
         // This is a list of all user collections that the add-on
         // is a part of.
@@ -104,7 +104,7 @@ type FetchCurrentCollectionParams = {|
   errorHandlerId: string,
   page?: number,
   slug: string,
-  user: string,
+  username: string,
 |};
 
 export type FetchCurrentCollectionAction = {|
@@ -116,21 +116,21 @@ export const fetchCurrentCollection = ({
   errorHandlerId,
   page,
   slug,
-  user,
+  username,
 }: FetchCurrentCollectionParams = {}): FetchCurrentCollectionAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(slug, 'slug is required');
-  invariant(user, 'user is required');
+  invariant(username, 'username is required');
 
   return {
     type: FETCH_CURRENT_COLLECTION,
-    payload: { errorHandlerId, page, slug, user },
+    payload: { errorHandlerId, page, slug, username },
   };
 };
 
 type FetchUserCollectionsParams = {|
   errorHandlerId: string,
-  user: string,
+  username: string,
 |};
 
 export type FetchUserCollectionsAction = {|
@@ -139,23 +139,23 @@ export type FetchUserCollectionsAction = {|
 |};
 
 export const fetchUserCollections = ({
-  errorHandlerId, user,
+  errorHandlerId, username,
 }: FetchUserCollectionsParams = {}): FetchUserCollectionsAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
   }
-  if (!user) {
-    throw new Error('user is required');
+  if (!username) {
+    throw new Error('username is required');
   }
 
   return {
     type: FETCH_USER_COLLECTIONS,
-    payload: { errorHandlerId, user },
+    payload: { errorHandlerId, username },
   };
 };
 
 type AbortFetchUserCollectionsParams = {|
-  user: string,
+  username: string,
 |};
 
 type AbortFetchUserCollectionsAction = {|
@@ -164,21 +164,21 @@ type AbortFetchUserCollectionsAction = {|
 |};
 
 export const abortFetchUserCollections = (
-  { user }: AbortFetchUserCollectionsParams = {}
+  { username }: AbortFetchUserCollectionsParams = {}
 ): AbortFetchUserCollectionsAction => {
-  if (!user) {
-    throw new Error('user is required');
+  if (!username) {
+    throw new Error('username is required');
   }
 
   return {
     type: ABORT_FETCH_USER_COLLECTIONS,
-    payload: { user },
+    payload: { username },
   };
 };
 
 type AbortAddAddonToCollectionParams = {|
   addonId: number,
-  user: string,
+  username: string,
 |};
 
 type AbortAddAddonToCollectionAction = {|
@@ -187,10 +187,10 @@ type AbortAddAddonToCollectionAction = {|
 |};
 
 export const abortAddAddonToCollection = (
-  { addonId, user }: AbortAddAddonToCollectionParams = {}
+  { addonId, username }: AbortAddAddonToCollectionParams = {}
 ): AbortAddAddonToCollectionAction => {
-  if (!user) {
-    throw new Error('user is required');
+  if (!username) {
+    throw new Error('username is required');
   }
   if (!addonId) {
     throw new Error('addonId is required');
@@ -198,7 +198,7 @@ export const abortAddAddonToCollection = (
 
   return {
     type: ABORT_ADD_ADDON_TO_COLLECTION,
-    payload: { user, addonId },
+    payload: { username, addonId },
   };
 };
 
@@ -216,7 +216,7 @@ export const fetchCurrentCollectionPage = ({
   errorHandlerId,
   page,
   slug,
-  user,
+  username,
 }: FetchCurrentCollectionPageParams = {}): FetchCurrentCollectionPageAction => {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId is required');
@@ -224,8 +224,8 @@ export const fetchCurrentCollectionPage = ({
   if (!slug) {
     throw new Error('slug is required');
   }
-  if (!user) {
-    throw new Error('user is required');
+  if (!username) {
+    throw new Error('username is required');
   }
   if (!page) {
     throw new Error('page is required');
@@ -233,7 +233,7 @@ export const fetchCurrentCollectionPage = ({
 
   return {
     type: FETCH_CURRENT_COLLECTION_PAGE,
-    payload: { errorHandlerId, page, slug, user },
+    payload: { errorHandlerId, page, slug, username },
   };
 };
 
@@ -354,7 +354,7 @@ export const loadCollectionAddons = ({
 
 type LoadUserCollectionsParams = {|
   collections: Array<ExternalCollectionDetail>,
-  user: string,
+  username: string,
 |};
 
 type LoadUserCollectionsAction = {|
@@ -363,10 +363,10 @@ type LoadUserCollectionsAction = {|
 |};
 
 export const loadUserCollections = (
-  { collections, user }: LoadUserCollectionsParams = {}
+  { collections, username }: LoadUserCollectionsParams = {}
 ): LoadUserCollectionsAction => {
-  if (!user) {
-    throw new Error('The user parameter is required');
+  if (!username) {
+    throw new Error('The username parameter is required');
   }
   if (!collections) {
     throw new Error('The collections parameter is required');
@@ -374,14 +374,14 @@ export const loadUserCollections = (
 
   return {
     type: LOAD_USER_COLLECTIONS,
-    payload: { user, collections },
+    payload: { username, collections },
   };
 };
 
 type AddonAddedToCollectionParams = {|
   addonId: number,
   collectionId: CollectionId,
-  user: string,
+  username: string,
 |};
 
 type AddonAddedToCollectionAction = {|
@@ -390,13 +390,13 @@ type AddonAddedToCollectionAction = {|
 |};
 
 export const addonAddedToCollection = (
-  { addonId, collectionId, user }: AddonAddedToCollectionParams = {}
+  { addonId, collectionId, username }: AddonAddedToCollectionParams = {}
 ): AddonAddedToCollectionAction => {
   if (!addonId) {
     throw new Error('The addonId parameter is required');
   }
-  if (!user) {
-    throw new Error('The user parameter is required');
+  if (!username) {
+    throw new Error('The username parameter is required');
   }
   if (!collectionId) {
     throw new Error('The collectionId parameter is required');
@@ -404,7 +404,7 @@ export const addonAddedToCollection = (
 
   return {
     type: ADDON_ADDED_TO_COLLECTION,
-    payload: { addonId, collectionId, user },
+    payload: { addonId, collectionId, username },
   };
 };
 
@@ -424,7 +424,7 @@ type AddAddonToCollectionParams = {|
   errorHandlerId: string,
   notes?: string,
   page?: number,
-  user: string,
+  username: string,
 |};
 
 export type AddAddonToCollectionAction = {|
@@ -433,13 +433,13 @@ export type AddAddonToCollectionAction = {|
 |};
 
 export const addAddonToCollection = ({
-  addonId, collectionId, editing, errorHandlerId, notes, page, slug, user,
+  addonId, collectionId, editing, errorHandlerId, notes, page, slug, username,
 }: AddAddonToCollectionParams = {}): AddAddonToCollectionAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(collectionId, 'The collectionId parameter is required');
   invariant(slug, 'The slug parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
-  invariant(user, 'The user parameter is required');
+  invariant(username, 'The username parameter is required');
 
   if (editing) {
     invariant(page, 'The page parameter is required when editing');
@@ -448,14 +448,14 @@ export const addAddonToCollection = ({
   return {
     type: ADD_ADDON_TO_COLLECTION,
     payload: {
-      addonId, collectionId, editing, errorHandlerId, notes, page, slug, user,
+      addonId, collectionId, editing, errorHandlerId, notes, page, slug, username,
     },
   };
 };
 
 export type RequiredModifyCollectionParams = {|
   errorHandlerId: string,
-  user: string,
+  username: string,
 |};
 
 export type OptionalModifyCollectionParams = {|
@@ -494,10 +494,10 @@ export const createCollection = ({
   description,
   name,
   slug,
-  user,
+  username,
 }: CreateCollectionParams = {}): CreateCollectionAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(user, 'user is required');
+  invariant(username, 'username is required');
   invariant(name, 'name is required when creating a collection');
   invariant(slug, 'slug is required when creating a collection');
 
@@ -509,7 +509,7 @@ export const createCollection = ({
       description,
       name,
       slug,
-      user,
+      username,
     },
   };
 };
@@ -521,10 +521,10 @@ export const updateCollection = ({
   description,
   name,
   slug,
-  user,
+  username,
 }: UpdateCollectionParams = {}): UpdateCollectionAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(user, 'user is required');
+  invariant(username, 'username is required');
   invariant(collectionSlug, 'collectionSlug is required when updating');
 
   return {
@@ -536,7 +536,7 @@ export const updateCollection = ({
       description,
       name,
       slug,
-      user,
+      username,
     },
   };
 };
@@ -590,7 +590,7 @@ type RemoveAddonFromCollectionParams = {|
   errorHandlerId: string,
   page: number,
   slug: string,
-  user: string,
+  username: string,
 |};
 
 export type RemoveAddonFromCollectionAction = {|
@@ -599,18 +599,18 @@ export type RemoveAddonFromCollectionAction = {|
 |};
 
 export const removeAddonFromCollection = ({
-  addonId, errorHandlerId, page, slug, user,
+  addonId, errorHandlerId, page, slug, username,
 }: RemoveAddonFromCollectionParams = {}): RemoveAddonFromCollectionAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
   invariant(page, 'The page parameter is required');
   invariant(slug, 'The slug parameter is required');
-  invariant(user, 'The user parameter is required');
+  invariant(username, 'The username parameter is required');
 
   return {
     type: REMOVE_ADDON_FROM_COLLECTION,
     payload: {
-      addonId, errorHandlerId, page, slug, user,
+      addonId, errorHandlerId, page, slug, username,
     },
   };
 };
@@ -713,20 +713,20 @@ type ChangeAddonCollectionsLoadingFlagParams = {|
   addonId: number,
   loading: boolean,
   state: CollectionsState,
-  user: string,
+  username: string,
 |};
 
 export const changeAddonCollectionsLoadingFlag = ({
-  addonId, loading, state, user,
+  addonId, loading, state, username,
 }: ChangeAddonCollectionsLoadingFlagParams = {}): CollectionsState => {
-  const userState = state.addonInCollections[user];
+  const userState = state.addonInCollections[username];
   const addonState = userState && userState[addonId];
 
   return {
     ...state,
     addonInCollections: {
       ...state.addonInCollections,
-      [user]: {
+      [username]: {
         ...userState,
         [addonId]: {
           collections: addonState ? addonState.collections : null,
@@ -896,13 +896,13 @@ const reducer = (
       };
 
     case FETCH_USER_COLLECTIONS: {
-      const { user } = action.payload;
+      const { username } = action.payload;
 
       return {
         ...state,
         userCollections: {
           ...state.userCollections,
-          [user]: {
+          [username]: {
             collections: null,
             loading: true,
           },
@@ -911,13 +911,13 @@ const reducer = (
     }
 
     case ABORT_FETCH_USER_COLLECTIONS: {
-      const { user } = action.payload;
+      const { username } = action.payload;
 
       return {
         ...state,
         userCollections: {
           ...state.userCollections,
-          [user]: {
+          [username]: {
             collections: null,
             loading: false,
           },
@@ -926,7 +926,7 @@ const reducer = (
     }
 
     case LOAD_USER_COLLECTIONS: {
-      const { collections, user } = action.payload;
+      const { collections, username } = action.payload;
 
       let newState = { ...state };
       collections.forEach((collection) => {
@@ -939,7 +939,7 @@ const reducer = (
         ...newState,
         userCollections: {
           ...state.userCollections,
-          [user]: {
+          [username]: {
             collections: collections.map((collection) => collection.id),
             loading: false,
           },
@@ -948,15 +948,15 @@ const reducer = (
     }
 
     case ADDON_ADDED_TO_COLLECTION: {
-      const { addonId, collectionId, user } = action.payload;
+      const { addonId, collectionId, username } = action.payload;
       const { addonInCollections } = state;
       let collections = [];
       if (
-        addonInCollections[user] &&
-        addonInCollections[user][addonId]
+        addonInCollections[username] &&
+        addonInCollections[username][addonId]
       ) {
         const existingCollections =
-          addonInCollections[user][addonId].collections;
+          addonInCollections[username][addonId].collections;
         if (existingCollections) {
           collections = existingCollections;
         }
@@ -966,8 +966,8 @@ const reducer = (
         ...state,
         addonInCollections: {
           ...state.addonInCollections,
-          [user]: {
-            ...state.addonInCollections[user],
+          [username]: {
+            ...state.addonInCollections[username],
             [addonId]: {
               collections: collections.concat([collectionId]),
               loading: false,
@@ -979,11 +979,11 @@ const reducer = (
     }
 
     case ADD_ADDON_TO_COLLECTION: {
-      const { addonId, user } = action.payload;
+      const { addonId, username } = action.payload;
 
       const newState = changeAddonCollectionsLoadingFlag({
         addonId,
-        user,
+        username,
         state,
         loading: true,
       });
@@ -994,11 +994,11 @@ const reducer = (
     }
 
     case ABORT_ADD_ADDON_TO_COLLECTION: {
-      const { addonId, user } = action.payload;
+      const { addonId, username } = action.payload;
 
       const newState = changeAddonCollectionsLoadingFlag({
         addonId,
-        user,
+        username,
         state,
         loading: false,
       });

--- a/src/amo/routes.js
+++ b/src/amo/routes.js
@@ -51,10 +51,10 @@ export default (
         </React.Fragment>
       )}
       <Route
-        path="collections/:user/:slug/edit/"
+        path="collections/:username/:slug/edit/"
         component={CollectionEdit}
       />
-      <Route path="collections/:user/:slug/" component={Collection} />
+      <Route path="collections/:username/:slug/" component={Collection} />
       {config.get('enableNewCollectionsUI') ?
         <Route
           path="collections/add/"

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -124,7 +124,7 @@ export function* fetchCurrentCollectionPage({
 }
 
 export function* fetchUserCollections({
-  payload: { errorHandlerId, userId },
+  payload: { errorHandlerId, user },
 }: FetchUserCollectionsAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -133,21 +133,21 @@ export function* fetchUserCollections({
     const state = yield select(getState);
 
     const params: GetAllUserCollectionsParams = {
-      api: state.api, user: userId,
+      api: state.api, user,
     };
     const collections = yield call(api.getAllUserCollections, params);
 
-    yield put(loadUserCollections({ userId, collections }));
+    yield put(loadUserCollections({ user, collections }));
   } catch (error) {
     log.warn(`Failed to fetch user collections: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortFetchUserCollections({ userId }));
+    yield put(abortFetchUserCollections({ user }));
   }
 }
 
 export function* addAddonToCollection({
   payload: {
-    addonId, collectionId, slug, editing, errorHandlerId, notes, page, userId,
+    addonId, collectionId, editing, errorHandlerId, notes, page, slug, user,
   },
 }: AddAddonToCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -161,7 +161,7 @@ export function* addAddonToCollection({
       api: state.api,
       slug,
       notes,
-      user: userId,
+      user,
     };
     yield call(api.createCollectionAddon, params);
 
@@ -172,16 +172,16 @@ export function* addAddonToCollection({
         page,
         errorHandlerId: errorHandler.id,
         slug,
-        user: userId,
+        user,
       }));
     }
     yield put(addonAddedToCollection({
-      addonId, userId, collectionId,
+      addonId, user, collectionId,
     }));
   } catch (error) {
     log.warn(`Failed to add add-on to collection: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortAddAddonToCollection({ addonId, userId }));
+    yield put(abortAddAddonToCollection({ addonId, user }));
   }
 }
 

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -55,7 +55,7 @@ export function* fetchCurrentCollection({
     errorHandlerId,
     page,
     slug,
-    user,
+    username,
   },
 }: FetchCurrentCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -68,7 +68,7 @@ export function* fetchCurrentCollection({
     const baseParams = {
       api: state.api,
       slug,
-      user,
+      username,
     };
 
     const detailParams: $Shape<GetCollectionParams> = {
@@ -97,7 +97,7 @@ export function* fetchCurrentCollectionPage({
     errorHandlerId,
     page,
     slug,
-    user,
+    username,
   },
 }: FetchCurrentCollectionPageAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -111,7 +111,7 @@ export function* fetchCurrentCollectionPage({
       api: state.api,
       page,
       slug,
-      user,
+      username,
     };
     const addons = yield call(api.getCollectionAddons, params);
 
@@ -124,7 +124,7 @@ export function* fetchCurrentCollectionPage({
 }
 
 export function* fetchUserCollections({
-  payload: { errorHandlerId, user },
+  payload: { errorHandlerId, username },
 }: FetchUserCollectionsAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -133,21 +133,21 @@ export function* fetchUserCollections({
     const state = yield select(getState);
 
     const params: GetAllUserCollectionsParams = {
-      api: state.api, user,
+      api: state.api, username,
     };
     const collections = yield call(api.getAllUserCollections, params);
 
-    yield put(loadUserCollections({ user, collections }));
+    yield put(loadUserCollections({ username, collections }));
   } catch (error) {
     log.warn(`Failed to fetch user collections: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortFetchUserCollections({ user }));
+    yield put(abortFetchUserCollections({ username }));
   }
 }
 
 export function* addAddonToCollection({
   payload: {
-    addonId, collectionId, editing, errorHandlerId, notes, page, slug, user,
+    addonId, collectionId, editing, errorHandlerId, notes, page, slug, username,
   },
 }: AddAddonToCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -161,7 +161,7 @@ export function* addAddonToCollection({
       api: state.api,
       slug,
       notes,
-      user,
+      username,
     };
     yield call(api.createCollectionAddon, params);
 
@@ -172,16 +172,16 @@ export function* addAddonToCollection({
         page,
         errorHandlerId: errorHandler.id,
         slug,
-        user,
+        username,
       }));
     }
     yield put(addonAddedToCollection({
-      addonId, user, collectionId,
+      addonId, username, collectionId,
     }));
   } catch (error) {
     log.warn(`Failed to add add-on to collection: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortAddAddonToCollection({ addonId, user }));
+    yield put(abortAddAddonToCollection({ addonId, username }));
   }
 }
 
@@ -197,7 +197,7 @@ export function* modifyCollection(
     errorHandlerId,
     name,
     slug,
-    user,
+    username,
   } = payload;
 
   yield put(beginCollectionModification());
@@ -218,7 +218,7 @@ export function* modifyCollection(
       api: state.api,
       defaultLocale,
       description,
-      user,
+      username,
     };
 
     if (creating) {
@@ -247,7 +247,7 @@ export function* modifyCollection(
     invariant(effectiveSlug,
       'Both slug and collectionSlug cannot be empty');
     const newLocation =
-      `/${lang}/${clientApp}/collections/${user}/${effectiveSlug}/`;
+      `/${lang}/${clientApp}/collections/${username}/${effectiveSlug}/`;
 
     if (creating) {
       invariant(response, 'response is required when creating');
@@ -283,7 +283,7 @@ export function* modifyCollection(
 
 export function* removeAddonFromCollection({
   payload: {
-    addonId, errorHandlerId, page, slug, user,
+    addonId, errorHandlerId, page, slug, username,
   },
 }: RemoveAddonFromCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -296,7 +296,7 @@ export function* removeAddonFromCollection({
       addonId,
       api: state.api,
       slug,
-      user,
+      username,
     };
     yield call(api.removeAddonFromCollection, params);
 
@@ -304,7 +304,7 @@ export function* removeAddonFromCollection({
       page,
       errorHandlerId: errorHandler.id,
       slug,
-      user,
+      username,
     }));
   } catch (error) {
     log.warn(`Failed to remove add-on from collection: ${error}`);

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -34,7 +34,7 @@ export function* fetchHomeAddons({
         api: state.api,
         page: 1,
         slug: collection.slug,
-        user: collection.user,
+        username: collection.username,
       });
       collections.push(result);
     }

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -33,7 +33,7 @@ describe(__filename, () => {
     return {
       api: apiState,
       slug: 'some-slug',
-      user: 'user-id-or-name',
+      username: 'some-user',
       ...otherParams,
     };
   };
@@ -53,13 +53,13 @@ describe(__filename, () => {
       }).toThrow('slug is required');
     });
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const params = getParams();
-      delete params.user;
+      delete params.username;
 
       expect(() => {
         getCollectionDetail(params);
-      }).toThrow('user is required');
+      }).toThrow('username is required');
     });
 
     it('calls the collection detail API', async () => {
@@ -69,7 +69,7 @@ describe(__filename, () => {
         .expects('callApi')
         .withArgs({
           auth: true,
-          endpoint: 'accounts/account/user-id-or-name/collections/some-slug',
+          endpoint: 'accounts/account/some-user/collections/some-slug',
           state: apiState,
         })
         .once()
@@ -90,13 +90,13 @@ describe(__filename, () => {
       }).toThrow('slug is required');
     });
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const params = getParams();
-      delete params.user;
+      delete params.username;
 
       expect(() => {
         getCollectionAddons(params);
-      }).toThrow('user is required');
+      }).toThrow('username is required');
     });
 
     it('calls the collection add-ons list API', async () => {
@@ -108,7 +108,7 @@ describe(__filename, () => {
         .withArgs({
           auth: true,
           endpoint:
-            'accounts/account/user-id-or-name/collections/some-slug/addons',
+            'accounts/account/some-user/collections/some-slug/addons',
           params: queryParams,
           state: apiState,
         })
@@ -122,7 +122,7 @@ describe(__filename, () => {
 
   describe('getAllCollectionAddons', () => {
     it('gets all pages of the collection add-ons list API', async () => {
-      const user = 'example-username';
+      const username = 'example-username';
       const slug = 'example-collection-slug';
       const addonResults = createFakeCollectionAddonsListResponse().results;
 
@@ -135,7 +135,7 @@ describe(__filename, () => {
 
       const addons = await getAllCollectionAddons({
         api: apiState,
-        user,
+        username,
         slug,
         _allPages,
         _getCollectionAddons,
@@ -144,7 +144,7 @@ describe(__filename, () => {
       expect(addons).toEqual(addonResults);
       sinon.assert.called(_getCollectionAddons);
       expect(_getCollectionAddons.firstCall.args[0]).toEqual({
-        api: apiState, user, slug, nextURL,
+        api: apiState, username, slug, nextURL,
       });
     });
   });
@@ -153,33 +153,33 @@ describe(__filename, () => {
     const getListParams = (params = {}) => {
       return {
         api: apiState,
-        user: 'user-id-or-string',
+        username: 'some-user',
         ...params,
       };
     };
 
-    it('throws an error when the user parameter is missing', () => {
+    it('throws an error when the username parameter is missing', () => {
       const params = getListParams();
-      delete params.user;
+      delete params.username;
 
       expect(() => listCollections(params))
-        .toThrow(/user parameter is required/);
+        .toThrow(/username parameter is required/);
     });
 
     it('calls the list collections API', async () => {
-      const user = 'some-user-id';
+      const username = 'some-user';
 
       mockApi
         .expects('callApi')
         .withArgs({
           auth: true,
-          endpoint: `accounts/account/${user}/collections`,
+          endpoint: `accounts/account/${username}/collections`,
           state: apiState,
         })
         .once()
         .returns(createApiResponse());
 
-      const params = getListParams({ user });
+      const params = getListParams({ username });
       await listCollections(params);
       mockApi.verify();
     });
@@ -187,7 +187,7 @@ describe(__filename, () => {
 
   describe('getAllUserCollections', () => {
     it('returns collections from multiple pages', async () => {
-      const user = 'some-user-id';
+      const username = 'some-user';
 
       const collectionResults = [
         createFakeCollectionDetail({ slug: 'first' }),
@@ -203,13 +203,13 @@ describe(__filename, () => {
       const _allPages = sinon.spy((nextPage) => nextPage(nextURL));
 
       const collections = await getAllUserCollections({
-        api: apiState, user, _allPages, _listCollections,
+        api: apiState, username, _allPages, _listCollections,
       });
 
       expect(collections).toEqual(collectionResults);
       sinon.assert.called(_listCollections);
       expect(_listCollections.firstCall.args[0]).toEqual({
-        api: apiState, user, nextURL,
+        api: apiState, username, nextURL,
       });
     });
   });
@@ -222,7 +222,7 @@ describe(__filename, () => {
       return {
         api: apiState,
         name,
-        user: 'user-id-or-username',
+        username: 'some-user',
         ...params,
       };
     };
@@ -261,7 +261,7 @@ describe(__filename, () => {
       const params = defaultParams({ slug });
 
       const endpoint =
-        `accounts/account/${params.user}/collections/`;
+        `accounts/account/${params.username}/collections/`;
       mockApi
         .expects('callApi')
         .withArgs({
@@ -288,7 +288,7 @@ describe(__filename, () => {
       const params = defaultParams({ collectionSlug: slug });
 
       const endpoint =
-        `accounts/account/${params.user}/collections/${slug}`;
+        `accounts/account/${params.username}/collections/${slug}`;
       mockApi
         .expects('callApi')
         .withArgs({
@@ -323,7 +323,7 @@ describe(__filename, () => {
         description: undefined,
         name: undefined,
         slug: undefined,
-        user: 'user-id-or-username',
+        username: 'some-user',
         _validateLocalizedString: validator,
       };
       const updateParams = {
@@ -347,7 +347,7 @@ describe(__filename, () => {
         description: undefined,
         name: undefined,
         slug: 'collection-slug',
-        user: 'user-id-or-username',
+        username: 'some-user',
         _validateLocalizedString: validator,
       };
       const createParams = {
@@ -368,7 +368,7 @@ describe(__filename, () => {
         addonId: 123458,
         api: apiState,
         slug: 'some-collection',
-        user: 'user-id-or-username',
+        username: 'some-user',
         ...params,
       };
     };
@@ -378,11 +378,11 @@ describe(__filename, () => {
         action: 'create',
         addonId: 987675,
         slug: 'my-collection',
-        user: 'my-user',
+        username: 'some-user',
       });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.user}/collections/
+        accounts/account/${params.username}/collections/
         ${params.slug}/addons
       `;
       mockApi
@@ -407,7 +407,7 @@ describe(__filename, () => {
       const params = defaultParams({ action: 'create', notes });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.user}/collections/
+        accounts/account/${params.username}/collections/
         ${params.slug}/addons
       `;
       mockApi
@@ -431,11 +431,11 @@ describe(__filename, () => {
         addonId: 987675,
         slug: 'my-collection',
         notes,
-        user: 'my-user',
+        username: 'some-user',
       });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.user}/collections/
+        accounts/account/${params.username}/collections/
         ${params.slug}/addons/${params.addonId}
       `;
       mockApi
@@ -460,7 +460,7 @@ describe(__filename, () => {
       const params = defaultParams({ action: 'update', notes });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.user}/collections/
+        accounts/account/${params.username}/collections/
         ${params.slug}/addons/${params.addonId}
       `;
       mockApi
@@ -485,7 +485,7 @@ describe(__filename, () => {
         api: apiState,
         slug: 'the-collection',
         notes: 'Beware of this one weird bug',
-        user: 'the-user',
+        username: 'some-user',
       };
 
       const modifier = sinon.spy(() => Promise.resolve());
@@ -505,7 +505,7 @@ describe(__filename, () => {
         api: apiState,
         slug: 'cool-collection',
         notes: 'This add-on speaks to my soul',
-        user: 'cool-user',
+        username: 'cool-user',
       };
 
       const modifier = sinon.spy(() => Promise.resolve());
@@ -522,9 +522,9 @@ describe(__filename, () => {
     it('sends a request to remove an add-on from a collection', async () => {
       const addonId = 123;
       const slug = 'my-collection';
-      const user = 'my-user';
+      const username = 'my-user';
 
-      const endpoint = `accounts/account/${user}/collections/${slug}/addons/${addonId}`;
+      const endpoint = `accounts/account/${username}/collections/${slug}/addons/${addonId}`;
 
       mockApi
         .expects('callApi')
@@ -541,7 +541,7 @@ describe(__filename, () => {
         addonId,
         api,
         slug,
-        user,
+        username,
       });
 
       mockApi.verify();

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -52,25 +52,25 @@ describe(__filename, () => {
 
   const signInAndDispatchCollections = ({
     userId = 1,
-    user = 'some-user',
+    username = 'some-user',
     collections = [
-      createFakeCollectionDetail({ authorUsername: user }),
+      createFakeCollectionDetail({ authorUsername: username }),
     ],
   } = {}) => {
     dispatchSignInActions({
       store,
       userId,
-      userProps: { username: user },
+      userProps: { username },
     });
-    store.dispatch(loadUserCollections({ user, collections }));
+    store.dispatch(loadUserCollections({ username, collections }));
   };
 
-  const createSomeCollections = ({ user = 'some-user' } = {}) => {
+  const createSomeCollections = ({ username = 'some-user' } = {}) => {
     const firstCollection = createFakeCollectionDetail({
-      authorUsername: user, name: 'first',
+      authorUsername: username, name: 'first',
     });
     const secondCollection = createFakeCollectionDetail({
-      authorUsername: user, name: 'second',
+      authorUsername: username, name: 'second',
     });
 
     return { firstCollection, secondCollection };
@@ -85,13 +85,13 @@ describe(__filename, () => {
 
   describe('fetching user collections', () => {
     it('fetches user collections on first render', () => {
-      const user = 'some-user';
-      dispatchSignInActions({ store, userProps: { username: user } });
+      const username = 'some-user';
+      dispatchSignInActions({ store, userProps: { username } });
       const dispatchSpy = sinon.spy(store, 'dispatch');
       const root = render();
 
       sinon.assert.calledWith(dispatchSpy, fetchUserCollections({
-        errorHandlerId: root.instance().props.errorHandler.id, user,
+        errorHandlerId: root.instance().props.errorHandler.id, username,
       }));
     });
 
@@ -101,12 +101,12 @@ describe(__filename, () => {
       const root = render();
       dispatchSpy.reset();
 
-      const user = 'user-two';
-      dispatchSignInActions({ store, userProps: { username: user } });
+      const username = 'user-two';
+      dispatchSignInActions({ store, userProps: { username } });
       root.setProps(mapStateToProps(store.getState(), {}));
 
       sinon.assert.calledWith(dispatchSpy, fetchUserCollections({
-        errorHandlerId: root.instance().props.errorHandler.id, user,
+        errorHandlerId: root.instance().props.errorHandler.id, username,
       }));
     });
 
@@ -141,10 +141,10 @@ describe(__filename, () => {
 
     it('does not fetch user collections while loading', () => {
       const addon = createInternalAddon(fakeAddon);
-      const user = 'some-user';
-      dispatchSignInActions({ store, userProps: { username: user } });
+      const username = 'some-user';
+      dispatchSignInActions({ store, userProps: { username } });
       store.dispatch(fetchUserCollections({
-        errorHandlerId: 'some-id', user,
+        errorHandlerId: 'some-id', username,
       }));
 
       const dispatchSpy = sinon.spy(store, 'dispatch');
@@ -163,10 +163,10 @@ describe(__filename, () => {
     };
 
     it('renders a disabled select when loading user collections', () => {
-      const user = 'some-user';
-      dispatchSignInActions({ store, userProps: { username: user } });
+      const username = 'some-user';
+      dispatchSignInActions({ store, userProps: { username } });
       store.dispatch(fetchUserCollections({
-        errorHandlerId: 'some-id', user,
+        errorHandlerId: 'some-id', username,
       }));
 
       const root = render();
@@ -178,11 +178,11 @@ describe(__filename, () => {
 
     it('renders a disabled select when adding add-on to collection', () => {
       const addon = createInternalAddon(fakeAddon);
-      const user = 'some-user';
-      dispatchSignInActions({ store, userProps: { username: user } });
+      const username = 'some-user';
+      dispatchSignInActions({ store, userProps: { username } });
       store.dispatch(addAddonToCollection({
         addonId: addon.id,
-        user,
+        username,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
@@ -204,13 +204,13 @@ describe(__filename, () => {
 
     it('lets you select a collection', () => {
       const addon = createInternalAddon({ ...fakeAddon, id: 234 });
-      const user = 'some-user';
+      const username = 'some-user';
 
       const { firstCollection, secondCollection } =
-        createSomeCollections({ user });
+        createSomeCollections({ username });
 
       signInAndDispatchCollections({
-        user,
+        username,
         collections: [firstCollection, secondCollection],
       });
       const dispatchStub = sinon.stub(store, 'dispatch');
@@ -231,20 +231,20 @@ describe(__filename, () => {
         addonId: addon.id,
         collectionId: secondCollection.id,
         slug: secondCollection.slug,
-        user,
+        username,
       }));
     });
 
     it('sorts collection by name in select box', () => {
       const addon = createInternalAddon({ ...fakeAddon, id: 234 });
-      const user = 'some-user';
+      const username = 'some-user';
 
       const { firstCollection, secondCollection } =
-        createSomeCollections({ user });
+        createSomeCollections({ username });
 
       // inserting secondCollection first in array
       signInAndDispatchCollections({
-        user,
+        username,
         collections: [secondCollection, firstCollection],
       });
 
@@ -256,16 +256,16 @@ describe(__filename, () => {
 
     it('shows a notice that you added to a collection', () => {
       const addon = createInternalAddon(fakeAddon);
-      const user = 'some-user';
+      const username = 'some-user';
 
-      const { firstCollection } = createSomeCollections({ user });
+      const { firstCollection } = createSomeCollections({ username });
 
       signInAndDispatchCollections({
-        user, collections: [firstCollection],
+        username, collections: [firstCollection],
       });
       store.dispatch(addonAddedToCollection({
         addonId: addon.id,
-        user,
+        username,
         collectionId: firstCollection.id,
       }));
 
@@ -278,17 +278,17 @@ describe(__filename, () => {
 
     it('shows notices for each target collection', () => {
       const addon = createInternalAddon(fakeAddon);
-      const user = 'some-user';
+      const username = 'some-user';
 
       const { firstCollection, secondCollection } =
-        createSomeCollections({ user });
+        createSomeCollections({ username });
 
       signInAndDispatchCollections({
-        user,
+        username,
         collections: [firstCollection, secondCollection],
       });
 
-      const addParams = { addonId: addon.id, user };
+      const addParams = { addonId: addon.id, username };
 
       // Add the add-on to both collections.
       store.dispatch(addonAddedToCollection({
@@ -410,10 +410,10 @@ describe(__filename, () => {
 
     it('renders an ID with an add-on ID and user', () => {
       const addon = createInternalAddon({ ...fakeAddon, id: 5432 });
-      const user = 'some-user';
-      dispatchSignInActions({ store, userProps: { username: user } });
+      const username = 'some-user';
+      dispatchSignInActions({ store, userProps: { username } });
       expect(extractId(_props({ addon })))
-        .toEqual(`${addon.id}-${user}`);
+        .toEqual(`${addon.id}-${username}`);
     });
   });
 });

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -52,20 +52,25 @@ describe(__filename, () => {
 
   const signInAndDispatchCollections = ({
     userId = 1,
+    user = 'some-user',
     collections = [
-      createFakeCollectionDetail({ authorId: userId }),
+      createFakeCollectionDetail({ authorUsername: user }),
     ],
   } = {}) => {
-    dispatchSignInActions({ store, userId });
-    store.dispatch(loadUserCollections({ userId, collections }));
+    dispatchSignInActions({
+      store,
+      userId,
+      userProps: { username: user },
+    });
+    store.dispatch(loadUserCollections({ user, collections }));
   };
 
-  const createSomeCollections = ({ authorId = 1 } = {}) => {
+  const createSomeCollections = ({ user = 'some-user' } = {}) => {
     const firstCollection = createFakeCollectionDetail({
-      authorId, name: 'first',
+      authorUsername: user, name: 'first',
     });
     const secondCollection = createFakeCollectionDetail({
-      authorId, name: 'second',
+      authorUsername: user, name: 'second',
     });
 
     return { firstCollection, secondCollection };
@@ -80,28 +85,28 @@ describe(__filename, () => {
 
   describe('fetching user collections', () => {
     it('fetches user collections on first render', () => {
-      const userId = 5543;
-      dispatchSignInActions({ store, userId });
+      const user = 'some-user';
+      dispatchSignInActions({ store, userProps: { username: user } });
       const dispatchSpy = sinon.spy(store, 'dispatch');
       const root = render();
 
       sinon.assert.calledWith(dispatchSpy, fetchUserCollections({
-        errorHandlerId: root.instance().props.errorHandler.id, userId,
+        errorHandlerId: root.instance().props.errorHandler.id, user,
       }));
     });
 
     it('fetches user collections on update', () => {
-      dispatchSignInActions({ store, userId: 1 });
+      dispatchSignInActions({ store, userProps: { username: 'user-one' } });
       const dispatchSpy = sinon.spy(store, 'dispatch');
       const root = render();
       dispatchSpy.reset();
 
-      const userId = 2;
-      dispatchSignInActions({ store, userId });
+      const user = 'user-two';
+      dispatchSignInActions({ store, userProps: { username: user } });
       root.setProps(mapStateToProps(store.getState(), {}));
 
       sinon.assert.calledWith(dispatchSpy, fetchUserCollections({
-        errorHandlerId: root.instance().props.errorHandler.id, userId,
+        errorHandlerId: root.instance().props.errorHandler.id, user,
       }));
     });
 
@@ -136,10 +141,10 @@ describe(__filename, () => {
 
     it('does not fetch user collections while loading', () => {
       const addon = createInternalAddon(fakeAddon);
-      const userId = 5543;
-      dispatchSignInActions({ store, userId });
+      const user = 'some-user';
+      dispatchSignInActions({ store, userProps: { username: user } });
       store.dispatch(fetchUserCollections({
-        errorHandlerId: 'some-id', userId,
+        errorHandlerId: 'some-id', user,
       }));
 
       const dispatchSpy = sinon.spy(store, 'dispatch');
@@ -158,10 +163,10 @@ describe(__filename, () => {
     };
 
     it('renders a disabled select when loading user collections', () => {
-      const userId = 5543;
-      dispatchSignInActions({ store, userId });
+      const user = 'some-user';
+      dispatchSignInActions({ store, userProps: { username: user } });
       store.dispatch(fetchUserCollections({
-        errorHandlerId: 'some-id', userId,
+        errorHandlerId: 'some-id', user,
       }));
 
       const root = render();
@@ -173,11 +178,11 @@ describe(__filename, () => {
 
     it('renders a disabled select when adding add-on to collection', () => {
       const addon = createInternalAddon(fakeAddon);
-      const userId = 5543;
-      dispatchSignInActions({ store, userId });
+      const user = 'some-user';
+      dispatchSignInActions({ store, userProps: { username: user } });
       store.dispatch(addAddonToCollection({
         addonId: addon.id,
-        userId,
+        user,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
@@ -199,13 +204,13 @@ describe(__filename, () => {
 
     it('lets you select a collection', () => {
       const addon = createInternalAddon({ ...fakeAddon, id: 234 });
-      const authorId = 1;
+      const user = 'some-user';
 
       const { firstCollection, secondCollection } =
-        createSomeCollections({ authorId });
+        createSomeCollections({ user });
 
       signInAndDispatchCollections({
-        userId: authorId,
+        user,
         collections: [firstCollection, secondCollection],
       });
       const dispatchStub = sinon.stub(store, 'dispatch');
@@ -226,20 +231,20 @@ describe(__filename, () => {
         addonId: addon.id,
         collectionId: secondCollection.id,
         slug: secondCollection.slug,
-        userId: authorId,
+        user,
       }));
     });
 
     it('sorts collection by name in select box', () => {
       const addon = createInternalAddon({ ...fakeAddon, id: 234 });
-      const authorId = 1;
+      const user = 'some-user';
 
       const { firstCollection, secondCollection } =
-        createSomeCollections({ authorId });
+        createSomeCollections({ user });
 
       // inserting secondCollection first in array
       signInAndDispatchCollections({
-        userId: authorId,
+        user,
         collections: [secondCollection, firstCollection],
       });
 
@@ -251,16 +256,16 @@ describe(__filename, () => {
 
     it('shows a notice that you added to a collection', () => {
       const addon = createInternalAddon(fakeAddon);
-      const authorId = 1;
+      const user = 'some-user';
 
-      const { firstCollection } = createSomeCollections({ authorId });
+      const { firstCollection } = createSomeCollections({ user });
 
       signInAndDispatchCollections({
-        userId: authorId, collections: [firstCollection],
+        user, collections: [firstCollection],
       });
       store.dispatch(addonAddedToCollection({
         addonId: addon.id,
-        userId: authorId,
+        user,
         collectionId: firstCollection.id,
       }));
 
@@ -273,17 +278,17 @@ describe(__filename, () => {
 
     it('shows notices for each target collection', () => {
       const addon = createInternalAddon(fakeAddon);
-      const authorId = 1;
+      const user = 'some-user';
 
       const { firstCollection, secondCollection } =
-        createSomeCollections({ authorId });
+        createSomeCollections({ user });
 
       signInAndDispatchCollections({
-        userId: authorId,
+        user,
         collections: [firstCollection, secondCollection],
       });
 
-      const addParams = { addonId: addon.id, userId: authorId };
+      const addParams = { addonId: addon.id, user };
 
       // Add the add-on to both collections.
       store.dispatch(addonAddedToCollection({
@@ -399,16 +404,16 @@ describe(__filename, () => {
       };
     };
 
-    it('renders an ID without an add-on or user ID', () => {
+    it('renders an ID without an add-on or user', () => {
       expect(extractId(_props({ addon: null }))).toEqual('-');
     });
 
-    it('renders an ID with an add-on ID and user ID', () => {
+    it('renders an ID with an add-on ID and user', () => {
       const addon = createInternalAddon({ ...fakeAddon, id: 5432 });
-      const userId = 1234;
-      dispatchSignInActions({ store, userId });
+      const user = 'some-user';
+      dispatchSignInActions({ store, userProps: { username: user } });
       expect(extractId(_props({ addon })))
-        .toEqual(`${addon.id}-${userId}`);
+        .toEqual(`${addon.id}-${user}`);
     });
   });
 });

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -49,7 +49,7 @@ describe(__filename, () => {
     i18n: fakeI18n(),
     location: fakeRouterLocation(),
     params: {
-      user: defaultUser,
+      username: defaultUser,
       slug: defaultSlug,
     },
     store: dispatchClientMetadata().store,
@@ -146,16 +146,16 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const user = 'some-user';
+    const username = 'some-user';
 
-    renderComponent({ errorHandler, params: { slug, user }, store });
+    renderComponent({ errorHandler, params: { slug, username }, store });
 
     sinon.assert.callCount(fakeDispatch, 1);
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       page: undefined,
       slug,
-      user,
+      username,
     }));
   });
 
@@ -182,13 +182,13 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const user = 'some-user';
+    const username = 'some-user';
     const page = 123;
 
     renderComponent({
       errorHandler,
       location: fakeRouterLocation({ query: { page } }),
-      params: { slug, user },
+      params: { slug, username },
       store,
     });
 
@@ -197,7 +197,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       page,
       slug,
-      user,
+      username,
     }));
   });
 
@@ -245,12 +245,12 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const user = 'some-user';
+    const username = 'some-user';
 
     store.dispatch(fetchCurrentCollection({
       errorHandlerId: errorHandler.id,
       slug,
-      user,
+      username,
     }));
 
     fakeDispatch.reset();
@@ -265,13 +265,13 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const user = 'some-user';
+    const username = 'some-user';
 
     store.dispatch(fetchCurrentCollectionPage({
       errorHandlerId: errorHandler.id,
       page: 123,
       slug,
-      user,
+      username,
     }));
 
     fakeDispatch.reset();
@@ -305,24 +305,24 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const user = 'some-user';
+    const username = 'some-user';
     const page = 123;
 
     const location = fakeRouterLocation({
-      pathname: `/collections/${user}/${slug}/`,
+      pathname: `/collections/${username}/${slug}/`,
       query: { page },
     });
 
     const newSlug = 'other-collection';
     const newLocation = {
       ...location,
-      pathname: `/collections/${user}/${newSlug}/`,
+      pathname: `/collections/${username}/${newSlug}/`,
     };
 
     const wrapper = renderComponent({
       errorHandler,
       location,
-      params: { slug, user },
+      params: { slug, username },
       store,
     });
     fakeDispatch.reset();
@@ -330,7 +330,7 @@ describe(__filename, () => {
     // This will trigger the componentWillReceiveProps() method.
     wrapper.setProps({
       location: newLocation,
-      params: { slug: newSlug, user },
+      params: { slug: newSlug, username },
     });
 
     sinon.assert.callCount(fakeDispatch, 1);
@@ -338,7 +338,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       page,
       slug: newSlug,
-      user,
+      username,
     }));
   });
 
@@ -370,7 +370,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollectionPage({
       errorHandlerId: errorHandler.id,
       page,
-      user: defaultUser,
+      username: defaultUser,
       slug: defaultSlug,
     }));
   });
@@ -407,7 +407,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeDispatch, fetchCurrentCollectionPage({
       errorHandlerId: errorHandler.id,
       page: 1,
-      user: defaultUser,
+      username: defaultUser,
       slug: defaultSlug,
     }));
   });
@@ -430,7 +430,7 @@ describe(__filename, () => {
 
     const newParams = {
       slug: defaultSlug,
-      user: 'another-user',
+      username: 'another-user',
     };
     wrapper.setProps({ params: newParams });
 
@@ -442,14 +442,14 @@ describe(__filename, () => {
     }));
   });
 
-  it('compares user values in lower case', () => {
-    const user = 'Mozilla';
+  it('compares username values in lower case', () => {
+    const username = 'Mozilla';
     const errorHandler = createStubErrorHandler();
     const { store } = dispatchClientMetadata();
 
     store.dispatch(loadCurrentCollection({
       addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail({ authorUsername: user }),
+      detail: createFakeCollectionDetail({ authorUsername: username }),
     }));
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
@@ -457,7 +457,7 @@ describe(__filename, () => {
     fakeDispatch.reset();
 
     wrapper.setProps({
-      params: { slug: defaultSlug, user: user.toLowerCase() },
+      params: { slug: defaultSlug, username: username.toLowerCase() },
     });
 
     sinon.assert.notCalled(fakeDispatch);
@@ -481,7 +481,7 @@ describe(__filename, () => {
 
     const newParams = {
       slug: 'some-other-collection-slug',
-      user: defaultUser,
+      username: defaultUser,
     };
     wrapper.setProps({ params: newParams });
 
@@ -559,7 +559,7 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const { slug } = defaultCollectionDetail;
-    const user = defaultUser;
+    const username = defaultUser;
 
     // User loads the collection page.
     store.dispatch(loadCurrentCollection({
@@ -569,7 +569,7 @@ describe(__filename, () => {
 
     const wrapper = renderComponent({
       errorHandler,
-      params: { slug, user },
+      params: { slug, username },
       store,
     });
 
@@ -580,7 +580,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       page: 2,
       slug,
-      user,
+      username,
     }));
 
     // This is needed because shallowUntilTarget() does not trigger any
@@ -843,7 +843,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       page,
       slug: collectionDetail.slug,
-      user: collectionDetail.author.username,
+      username: collectionDetail.author.username,
     }));
   });
 
@@ -882,7 +882,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       page: 1,
       slug: collectionDetail.slug,
-      user: collectionDetail.author.username,
+      username: collectionDetail.author.username,
     }));
   });
 
@@ -890,7 +890,7 @@ describe(__filename, () => {
     it('returns a unique ID based on params', () => {
       const props = getProps({
         params: {
-          user: 'foo',
+          username: 'foo',
           slug: 'collection-bar',
         },
         location: fakeRouterLocation(),
@@ -902,7 +902,7 @@ describe(__filename, () => {
     it('adds the page as part of unique ID', () => {
       const props = getProps({
         params: {
-          user: 'foo',
+          username: 'foo',
           slug: 'collection-bar',
         },
         location: fakeRouterLocation({ query: { page: 124 } }),

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -302,7 +302,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       name: { [lang]: name },
       slug,
-      user: signedInUsername,
+      username: signedInUsername,
     }));
   });
 
@@ -333,7 +333,7 @@ describe(__filename, () => {
       errorHandlerId: errorHandler.id,
       name: { [lang]: name },
       slug,
-      user: signedInUsername,
+      username: signedInUsername,
     }));
   });
 
@@ -439,7 +439,7 @@ describe(__filename, () => {
       errorHandlerId: root.instance().props.errorHandler.id,
       name: { [lang]: name },
       slug,
-      user: signedInUsername,
+      username: signedInUsername,
     }));
   });
 
@@ -522,7 +522,7 @@ describe(__filename, () => {
       errorHandlerId: root.instance().props.errorHandler.id,
       name: { [lang]: collection.name },
       slug: collection.slug,
-      user: signedInUsername,
+      username: signedInUsername,
     }));
   });
 
@@ -665,7 +665,7 @@ describe(__filename, () => {
       editing: true,
       errorHandlerId: errorHandler.id,
       page,
-      user: signedInUsername,
+      username: signedInUsername,
     }));
   });
 
@@ -693,7 +693,7 @@ describe(__filename, () => {
       editing: true,
       errorHandlerId: errorHandler.id,
       page: 1,
-      user: signedInUsername,
+      username: signedInUsername,
     }));
   });
 

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -665,7 +665,7 @@ describe(__filename, () => {
       editing: true,
       errorHandlerId: errorHandler.id,
       page,
-      userId: signedInUserId,
+      user: signedInUsername,
     }));
   });
 
@@ -693,7 +693,7 @@ describe(__filename, () => {
       editing: true,
       errorHandlerId: errorHandler.id,
       page: 1,
-      userId: signedInUserId,
+      user: signedInUsername,
     }));
   });
 

--- a/tests/unit/amo/containers/TestHome.js
+++ b/tests/unit/amo/containers/TestHome.js
@@ -67,7 +67,7 @@ describe(__filename, () => {
     expect(shelf).toHaveProp('header', 'Tame your tabs');
     expect(shelf).toHaveProp('footerText', 'See more tab extensions');
     expect(shelf).toHaveProp('footerLink',
-      `/collections/${COLLECTIONS_TO_FETCH[0].user}/${COLLECTIONS_TO_FETCH[0].slug}/`
+      `/collections/${COLLECTIONS_TO_FETCH[0].username}/${COLLECTIONS_TO_FETCH[0].slug}/`
     );
     expect(shelf).toHaveProp('loading', true);
   });
@@ -82,7 +82,7 @@ describe(__filename, () => {
     expect(shelf).toHaveProp('footerText',
       'See more essential extensions');
     expect(shelf).toHaveProp('footerLink',
-      `/collections/${COLLECTIONS_TO_FETCH[1].user}/${COLLECTIONS_TO_FETCH[1].slug}/`
+      `/collections/${COLLECTIONS_TO_FETCH[1].username}/${COLLECTIONS_TO_FETCH[1].slug}/`
     );
     expect(shelf).toHaveProp('loading', true);
   });
@@ -97,7 +97,7 @@ describe(__filename, () => {
     expect(shelf).toHaveProp('footerText',
       'See more translation tools');
     expect(shelf).toHaveProp('footerLink',
-      `/collections/${COLLECTIONS_TO_FETCH[2].user}/${COLLECTIONS_TO_FETCH[2].slug}/`
+      `/collections/${COLLECTIONS_TO_FETCH[2].username}/${COLLECTIONS_TO_FETCH[2].slug}/`
     );
     expect(shelf).toHaveProp('loading', true);
   });

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -48,7 +48,7 @@ describe(__filename, () => {
       const state = reducer(undefined, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
-        user: 'some-user-id-or-name',
+        user: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -60,7 +60,7 @@ describe(__filename, () => {
         errorHandlerId: createStubErrorHandler().id,
         page: pageToFetch,
         slug: 'some-collection-slug',
-        user: 'some-user-id-or-name',
+        user: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -79,7 +79,7 @@ describe(__filename, () => {
         errorHandlerId: createStubErrorHandler().id,
         page: pageToFetch,
         slug: collectionDetail.slug,
-        user: 'some-user-id-or-name',
+        user: 'some-user',
       }));
 
       expect(getCurrentCollection(state).addons).toEqual([]);
@@ -118,7 +118,7 @@ describe(__filename, () => {
       state = reducer(state, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
-        user: 'some-user-id-or-name',
+        user: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -140,7 +140,7 @@ describe(__filename, () => {
         errorHandlerId: createStubErrorHandler().id,
         page: pageToFetch,
         slug: 'some-collection-slug',
-        user: 'some-user-id-or-name',
+        user: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -188,7 +188,7 @@ describe(__filename, () => {
       const state = reducer(undefined, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
-        user: 'some-user-id-or-name',
+        user: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -222,44 +222,44 @@ describe(__filename, () => {
     });
 
     it('sets a loading flag when fetching user collections', () => {
-      const userId = 321;
+      const user = 'some-user';
 
       const state = reducer(undefined, fetchUserCollections({
         errorHandlerId: 'some-error-id',
-        userId,
+        user,
       }));
 
-      const userState = state.userCollections[userId];
+      const userState = state.userCollections[user];
       expect(userState).toBeDefined();
       expect(userState.loading).toEqual(true);
       expect(userState.collections).toEqual(null);
     });
 
     it('aborts fetching a user collection', () => {
-      const userId = 321;
+      const user = 'some-user';
 
       let state = reducer(undefined, fetchUserCollections({
         errorHandlerId: 'some-error-id',
-        userId,
+        user,
       }));
 
-      state = reducer(state, abortFetchUserCollections({ userId }));
+      state = reducer(state, abortFetchUserCollections({ user }));
 
-      const userState = state.userCollections[userId];
+      const userState = state.userCollections[user];
       expect(userState.loading).toEqual(false);
       expect(userState.collections).toEqual(null);
     });
 
     it('loads user collections by ID', () => {
-      const userId = 321;
+      const user = 'some-user';
       const firstCollection = createFakeCollectionDetail({ id: 1 });
       const secondCollection = createFakeCollectionDetail({ id: 2 });
 
       const state = reducer(undefined, loadUserCollections({
-        userId, collections: [firstCollection, secondCollection],
+        user, collections: [firstCollection, secondCollection],
       }));
 
-      const userState = state.userCollections[userId];
+      const userState = state.userCollections[user];
       expect(userState.loading).toEqual(false);
       expect(userState.collections).toEqual([1, 2]);
 
@@ -270,14 +270,14 @@ describe(__filename, () => {
     });
 
     it('loads user collections by slug', () => {
-      const userId = 321;
+      const user = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       const state = reducer(undefined, loadUserCollections({
-        userId, collections: [collection],
+        user, collections: [collection],
       }));
 
-      const userState = state.userCollections[userId];
+      const userState = state.userCollections[user];
       expect(userState.collections).toEqual([1]);
 
       expect(state.bySlug[collection.slug]).toEqual(collection.id);
@@ -285,17 +285,17 @@ describe(__filename, () => {
 
     it('sets a loading flag when begining to add add-on to collection', () => {
       const addonId = 871;
-      const userId = 321;
+      const user = 'some-user';
 
       const state = reducer(undefined, addAddonToCollection({
         addonId,
-        userId,
+        user,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      const savedState = state.addonInCollections[userId][addonId];
+      const savedState = state.addonInCollections[user][addonId];
       expect(savedState).toBeDefined();
       expect(savedState.loading).toEqual(true);
       expect(savedState.collections).toEqual(null);
@@ -304,7 +304,7 @@ describe(__filename, () => {
     it('sets a hasAddonBeenAdded flag when beginning to add add-on to collection', () => {
       const state = reducer(undefined, addAddonToCollection({
         addonId: 1,
-        userId: 2,
+        user: 'some-user',
         collectionId: 3,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
@@ -315,43 +315,43 @@ describe(__filename, () => {
 
     it('preserves existing collections when adding new ones', () => {
       const addonId = 871;
-      const userId = 321;
+      const user = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       // Add an add-on to a collection
       let state = reducer(undefined, addonAddedToCollection({
-        userId, addonId, collectionId: collection.id,
+        user, addonId, collectionId: collection.id,
       }));
 
       state = reducer(state, addAddonToCollection({
         addonId,
-        userId,
+        user,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      const savedState = state.addonInCollections[userId][addonId];
+      const savedState = state.addonInCollections[user][addonId];
       // The old collections should be preserved.
       expect(savedState.collections).toEqual([collection.id]);
     });
 
     it('aborts adding an add-on to a collection', () => {
       const addonId = 721;
-      const userId = 321;
+      const user = 'some-user';
 
       // Begin adding the add-on to a new collection.
       let state = reducer(undefined, addAddonToCollection({
         addonId,
-        userId,
+        user,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      state = reducer(state, abortAddAddonToCollection({ addonId, userId }));
+      state = reducer(state, abortAddAddonToCollection({ addonId, user }));
 
-      const savedState = state.addonInCollections[userId][addonId];
+      const savedState = state.addonInCollections[user][addonId];
       expect(savedState.collections).toEqual(null);
       expect(savedState.loading).toEqual(false);
       expect(state.hasAddonBeenAdded).toEqual(false);
@@ -359,47 +359,47 @@ describe(__filename, () => {
 
     it('preserves collection data when aborting new additions', () => {
       const addonId = 721;
-      const userId = 321;
+      const user = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       // Add an add-on to a collection
       let state = reducer(undefined, addonAddedToCollection({
-        userId, addonId, collectionId: collection.id,
+        user, addonId, collectionId: collection.id,
       }));
 
       // Begin adding the add-on to a new collection.
       state = reducer(state, addAddonToCollection({
         addonId,
-        userId,
+        user,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      state = reducer(state, abortAddAddonToCollection({ addonId, userId }));
+      state = reducer(state, abortAddAddonToCollection({ addonId, user }));
 
-      const savedState = state.addonInCollections[userId][addonId];
+      const savedState = state.addonInCollections[user][addonId];
       // The old collections should be preserved.
       expect(savedState.collections).toEqual([collection.id]);
     });
 
     it('adds an add-on to a collection', () => {
       const addonId = 611;
-      const userId = 321;
+      const user = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       const state = reducer(undefined, addonAddedToCollection({
-        userId, addonId, collectionId: collection.id,
+        user, addonId, collectionId: collection.id,
       }));
 
-      const savedState = state.addonInCollections[userId][addonId];
+      const savedState = state.addonInCollections[user][addonId];
       expect(savedState.loading).toEqual(false);
       expect(savedState.collections).toEqual([collection.id]);
     });
 
     it('sets a hasAddonBeenAdded flag after an add-on has been added', () => {
       const state = reducer(undefined, addonAddedToCollection({
-        userId: 1, addonId: 2, collectionId: 3,
+        user: 'some-user', addonId: 2, collectionId: 3,
       }));
 
       expect(state.hasAddonBeenAdded).toEqual(true);
@@ -407,18 +407,18 @@ describe(__filename, () => {
 
     it('appends a new add-on to the list of its collections', () => {
       const addonId = 611;
-      const userId = 321;
+      const user = 'some-user';
       const firstCollection = createFakeCollectionDetail({ id: 1 });
       const secondCollection = createFakeCollectionDetail({ id: 2 });
 
       let state = reducer(undefined, addonAddedToCollection({
-        userId, addonId, collectionId: firstCollection.id,
+        user, addonId, collectionId: firstCollection.id,
       }));
       state = reducer(state, addonAddedToCollection({
-        userId, addonId, collectionId: secondCollection.id,
+        user, addonId, collectionId: secondCollection.id,
       }));
 
-      const savedState = state.addonInCollections[userId][addonId];
+      const savedState = state.addonInCollections[user][addonId];
       expect(savedState.collections)
         .toEqual([firstCollection.id, secondCollection.id]);
     });
@@ -450,7 +450,7 @@ describe(__filename, () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
       slug: 'some-collection-slug',
-      user: 'some-user-id-or-name',
+      user: 'some-user',
     };
 
     it('throws an error when errorHandlerId is missing', () => {
@@ -484,15 +484,15 @@ describe(__filename, () => {
   describe('fetchUserCollections', () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
-      userId: 1,
+      user: 'some-user',
     };
 
-    it('throws an error when userId is missing', () => {
+    it('throws an error when user is missing', () => {
       const params = { ...defaultParams };
-      delete params.userId;
+      delete params.user;
 
       expect(() => fetchUserCollections(params))
-        .toThrow(/userId is required/);
+        .toThrow(/user is required/);
     });
 
     it('throws an error when errorHandlerId is missing', () => {
@@ -505,26 +505,26 @@ describe(__filename, () => {
   });
 
   describe('abortFetchUserCollections', () => {
-    const defaultParams = { userId: 1 };
+    const defaultParams = { user: 'some-user' };
 
-    it('throws an error when userId is missing', () => {
+    it('throws an error when user is missing', () => {
       const params = { ...defaultParams };
-      delete params.userId;
+      delete params.user;
 
       expect(() => abortFetchUserCollections(params))
-        .toThrow(/userId is required/);
+        .toThrow(/user is required/);
     });
   });
 
   describe('abortAddAddonToCollection', () => {
-    const defaultParams = { userId: 1, addonId: 2 };
+    const defaultParams = { user: 'some-user', addonId: 2 };
 
-    it('throws an error when userId is missing', () => {
+    it('throws an error when user is missing', () => {
       const params = { ...defaultParams };
-      delete params.userId;
+      delete params.user;
 
       expect(() => abortAddAddonToCollection(params))
-        .toThrow(/userId is required/);
+        .toThrow(/user is required/);
     });
 
     it('throws an error when addonId is missing', () => {
@@ -538,7 +538,7 @@ describe(__filename, () => {
 
   describe('loadUserCollections', () => {
     const defaultParams = {
-      userId: 4321,
+      user: 'some-user',
       collections: [createFakeCollectionDetail()],
     };
 
@@ -550,19 +550,19 @@ describe(__filename, () => {
         .toThrow(/collections parameter is required/);
     });
 
-    it('throws an error when userId is missing', () => {
+    it('throws an error when user is missing', () => {
       const params = { ...defaultParams };
-      delete params.userId;
+      delete params.user;
 
       expect(() => loadUserCollections(params))
-        .toThrow(/userId parameter is required/);
+        .toThrow(/user parameter is required/);
     });
   });
 
   describe('addonAddedToCollection', () => {
     const defaultParams = {
       addonId: 2221,
-      userId: 4321,
+      user: 'some-user',
       collectionId: 2345,
     };
 
@@ -574,12 +574,12 @@ describe(__filename, () => {
         .toThrow(/collectionId parameter is required/);
     });
 
-    it('throws an error when userId is missing', () => {
+    it('throws an error when user is missing', () => {
       const params = { ...defaultParams };
-      delete params.userId;
+      delete params.user;
 
       expect(() => addonAddedToCollection(params))
-        .toThrow(/userId parameter is required/);
+        .toThrow(/user parameter is required/);
     });
 
     it('throws an error when addonId is missing', () => {
@@ -621,7 +621,7 @@ describe(__filename, () => {
       errorHandlerId: 'some-error-handler-id',
       page: 123,
       slug: 'some-collection-slug',
-      user: 'some-user-id-or-name',
+      user: 'some-user',
     };
 
     it('throws an error when errorHandlerId is missing', () => {

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -48,7 +48,7 @@ describe(__filename, () => {
       const state = reducer(undefined, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
-        user: 'some-user',
+        username: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -60,7 +60,7 @@ describe(__filename, () => {
         errorHandlerId: createStubErrorHandler().id,
         page: pageToFetch,
         slug: 'some-collection-slug',
-        user: 'some-user',
+        username: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -79,7 +79,7 @@ describe(__filename, () => {
         errorHandlerId: createStubErrorHandler().id,
         page: pageToFetch,
         slug: collectionDetail.slug,
-        user: 'some-user',
+        username: 'some-user',
       }));
 
       expect(getCurrentCollection(state).addons).toEqual([]);
@@ -118,7 +118,7 @@ describe(__filename, () => {
       state = reducer(state, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
-        user: 'some-user',
+        username: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -140,7 +140,7 @@ describe(__filename, () => {
         errorHandlerId: createStubErrorHandler().id,
         page: pageToFetch,
         slug: 'some-collection-slug',
-        user: 'some-user',
+        username: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -188,7 +188,7 @@ describe(__filename, () => {
       const state = reducer(undefined, fetchCurrentCollection({
         errorHandlerId: createStubErrorHandler().id,
         slug: 'some-collection-slug',
-        user: 'some-user',
+        username: 'some-user',
       }));
 
       expect(state.current.loading).toEqual(true);
@@ -222,44 +222,44 @@ describe(__filename, () => {
     });
 
     it('sets a loading flag when fetching user collections', () => {
-      const user = 'some-user';
+      const username = 'some-user';
 
       const state = reducer(undefined, fetchUserCollections({
         errorHandlerId: 'some-error-id',
-        user,
+        username,
       }));
 
-      const userState = state.userCollections[user];
+      const userState = state.userCollections[username];
       expect(userState).toBeDefined();
       expect(userState.loading).toEqual(true);
       expect(userState.collections).toEqual(null);
     });
 
     it('aborts fetching a user collection', () => {
-      const user = 'some-user';
+      const username = 'some-user';
 
       let state = reducer(undefined, fetchUserCollections({
         errorHandlerId: 'some-error-id',
-        user,
+        username,
       }));
 
-      state = reducer(state, abortFetchUserCollections({ user }));
+      state = reducer(state, abortFetchUserCollections({ username }));
 
-      const userState = state.userCollections[user];
+      const userState = state.userCollections[username];
       expect(userState.loading).toEqual(false);
       expect(userState.collections).toEqual(null);
     });
 
     it('loads user collections by ID', () => {
-      const user = 'some-user';
+      const username = 'some-user';
       const firstCollection = createFakeCollectionDetail({ id: 1 });
       const secondCollection = createFakeCollectionDetail({ id: 2 });
 
       const state = reducer(undefined, loadUserCollections({
-        user, collections: [firstCollection, secondCollection],
+        username, collections: [firstCollection, secondCollection],
       }));
 
-      const userState = state.userCollections[user];
+      const userState = state.userCollections[username];
       expect(userState.loading).toEqual(false);
       expect(userState.collections).toEqual([1, 2]);
 
@@ -270,14 +270,14 @@ describe(__filename, () => {
     });
 
     it('loads user collections by slug', () => {
-      const user = 'some-user';
+      const username = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       const state = reducer(undefined, loadUserCollections({
-        user, collections: [collection],
+        username, collections: [collection],
       }));
 
-      const userState = state.userCollections[user];
+      const userState = state.userCollections[username];
       expect(userState.collections).toEqual([1]);
 
       expect(state.bySlug[collection.slug]).toEqual(collection.id);
@@ -285,17 +285,17 @@ describe(__filename, () => {
 
     it('sets a loading flag when begining to add add-on to collection', () => {
       const addonId = 871;
-      const user = 'some-user';
+      const username = 'some-user';
 
       const state = reducer(undefined, addAddonToCollection({
         addonId,
-        user,
+        username,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      const savedState = state.addonInCollections[user][addonId];
+      const savedState = state.addonInCollections[username][addonId];
       expect(savedState).toBeDefined();
       expect(savedState.loading).toEqual(true);
       expect(savedState.collections).toEqual(null);
@@ -304,7 +304,7 @@ describe(__filename, () => {
     it('sets a hasAddonBeenAdded flag when beginning to add add-on to collection', () => {
       const state = reducer(undefined, addAddonToCollection({
         addonId: 1,
-        user: 'some-user',
+        username: 'some-user',
         collectionId: 3,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
@@ -315,43 +315,43 @@ describe(__filename, () => {
 
     it('preserves existing collections when adding new ones', () => {
       const addonId = 871;
-      const user = 'some-user';
+      const username = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       // Add an add-on to a collection
       let state = reducer(undefined, addonAddedToCollection({
-        user, addonId, collectionId: collection.id,
+        username, addonId, collectionId: collection.id,
       }));
 
       state = reducer(state, addAddonToCollection({
         addonId,
-        user,
+        username,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      const savedState = state.addonInCollections[user][addonId];
+      const savedState = state.addonInCollections[username][addonId];
       // The old collections should be preserved.
       expect(savedState.collections).toEqual([collection.id]);
     });
 
     it('aborts adding an add-on to a collection', () => {
       const addonId = 721;
-      const user = 'some-user';
+      const username = 'some-user';
 
       // Begin adding the add-on to a new collection.
       let state = reducer(undefined, addAddonToCollection({
         addonId,
-        user,
+        username,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      state = reducer(state, abortAddAddonToCollection({ addonId, user }));
+      state = reducer(state, abortAddAddonToCollection({ addonId, username }));
 
-      const savedState = state.addonInCollections[user][addonId];
+      const savedState = state.addonInCollections[username][addonId];
       expect(savedState.collections).toEqual(null);
       expect(savedState.loading).toEqual(false);
       expect(state.hasAddonBeenAdded).toEqual(false);
@@ -359,47 +359,47 @@ describe(__filename, () => {
 
     it('preserves collection data when aborting new additions', () => {
       const addonId = 721;
-      const user = 'some-user';
+      const username = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       // Add an add-on to a collection
       let state = reducer(undefined, addonAddedToCollection({
-        user, addonId, collectionId: collection.id,
+        username, addonId, collectionId: collection.id,
       }));
 
       // Begin adding the add-on to a new collection.
       state = reducer(state, addAddonToCollection({
         addonId,
-        user,
+        username,
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
-      state = reducer(state, abortAddAddonToCollection({ addonId, user }));
+      state = reducer(state, abortAddAddonToCollection({ addonId, username }));
 
-      const savedState = state.addonInCollections[user][addonId];
+      const savedState = state.addonInCollections[username][addonId];
       // The old collections should be preserved.
       expect(savedState.collections).toEqual([collection.id]);
     });
 
     it('adds an add-on to a collection', () => {
       const addonId = 611;
-      const user = 'some-user';
+      const username = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
       const state = reducer(undefined, addonAddedToCollection({
-        user, addonId, collectionId: collection.id,
+        username, addonId, collectionId: collection.id,
       }));
 
-      const savedState = state.addonInCollections[user][addonId];
+      const savedState = state.addonInCollections[username][addonId];
       expect(savedState.loading).toEqual(false);
       expect(savedState.collections).toEqual([collection.id]);
     });
 
     it('sets a hasAddonBeenAdded flag after an add-on has been added', () => {
       const state = reducer(undefined, addonAddedToCollection({
-        user: 'some-user', addonId: 2, collectionId: 3,
+        username: 'some-user', addonId: 2, collectionId: 3,
       }));
 
       expect(state.hasAddonBeenAdded).toEqual(true);
@@ -407,18 +407,18 @@ describe(__filename, () => {
 
     it('appends a new add-on to the list of its collections', () => {
       const addonId = 611;
-      const user = 'some-user';
+      const username = 'some-user';
       const firstCollection = createFakeCollectionDetail({ id: 1 });
       const secondCollection = createFakeCollectionDetail({ id: 2 });
 
       let state = reducer(undefined, addonAddedToCollection({
-        user, addonId, collectionId: firstCollection.id,
+        username, addonId, collectionId: firstCollection.id,
       }));
       state = reducer(state, addonAddedToCollection({
-        user, addonId, collectionId: secondCollection.id,
+        username, addonId, collectionId: secondCollection.id,
       }));
 
-      const savedState = state.addonInCollections[user][addonId];
+      const savedState = state.addonInCollections[username][addonId];
       expect(savedState.collections)
         .toEqual([firstCollection.id, secondCollection.id]);
     });
@@ -450,7 +450,7 @@ describe(__filename, () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
       slug: 'some-collection-slug',
-      user: 'some-user',
+      username: 'some-user',
     };
 
     it('throws an error when errorHandlerId is missing', () => {
@@ -471,28 +471,28 @@ describe(__filename, () => {
       }).toThrow('slug is required');
     });
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const partialParams = { ...defaultParams };
-      delete partialParams.user;
+      delete partialParams.username;
 
       expect(() => {
         fetchCurrentCollection(partialParams);
-      }).toThrow('user is required');
+      }).toThrow('username is required');
     });
   });
 
   describe('fetchUserCollections', () => {
     const defaultParams = {
       errorHandlerId: 'some-error-handler-id',
-      user: 'some-user',
+      username: 'some-user',
     };
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const params = { ...defaultParams };
-      delete params.user;
+      delete params.username;
 
       expect(() => fetchUserCollections(params))
-        .toThrow(/user is required/);
+        .toThrow(/username is required/);
     });
 
     it('throws an error when errorHandlerId is missing', () => {
@@ -505,26 +505,26 @@ describe(__filename, () => {
   });
 
   describe('abortFetchUserCollections', () => {
-    const defaultParams = { user: 'some-user' };
+    const defaultParams = { username: 'some-user' };
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const params = { ...defaultParams };
-      delete params.user;
+      delete params.username;
 
       expect(() => abortFetchUserCollections(params))
-        .toThrow(/user is required/);
+        .toThrow(/username is required/);
     });
   });
 
   describe('abortAddAddonToCollection', () => {
-    const defaultParams = { user: 'some-user', addonId: 2 };
+    const defaultParams = { username: 'some-user', addonId: 2 };
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const params = { ...defaultParams };
-      delete params.user;
+      delete params.username;
 
       expect(() => abortAddAddonToCollection(params))
-        .toThrow(/user is required/);
+        .toThrow(/username is required/);
     });
 
     it('throws an error when addonId is missing', () => {
@@ -538,7 +538,7 @@ describe(__filename, () => {
 
   describe('loadUserCollections', () => {
     const defaultParams = {
-      user: 'some-user',
+      username: 'some-user',
       collections: [createFakeCollectionDetail()],
     };
 
@@ -550,19 +550,19 @@ describe(__filename, () => {
         .toThrow(/collections parameter is required/);
     });
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const params = { ...defaultParams };
-      delete params.user;
+      delete params.username;
 
       expect(() => loadUserCollections(params))
-        .toThrow(/user parameter is required/);
+        .toThrow(/username parameter is required/);
     });
   });
 
   describe('addonAddedToCollection', () => {
     const defaultParams = {
       addonId: 2221,
-      user: 'some-user',
+      username: 'some-user',
       collectionId: 2345,
     };
 
@@ -574,12 +574,12 @@ describe(__filename, () => {
         .toThrow(/collectionId parameter is required/);
     });
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const params = { ...defaultParams };
-      delete params.user;
+      delete params.username;
 
       expect(() => addonAddedToCollection(params))
-        .toThrow(/user parameter is required/);
+        .toThrow(/username parameter is required/);
     });
 
     it('throws an error when addonId is missing', () => {
@@ -621,7 +621,7 @@ describe(__filename, () => {
       errorHandlerId: 'some-error-handler-id',
       page: 123,
       slug: 'some-collection-slug',
-      user: 'some-user',
+      username: 'some-user',
     };
 
     it('throws an error when errorHandlerId is missing', () => {
@@ -642,13 +642,13 @@ describe(__filename, () => {
       }).toThrow('slug is required');
     });
 
-    it('throws an error when user is missing', () => {
+    it('throws an error when username is missing', () => {
       const partialParams = { ...defaultParams };
-      delete partialParams.user;
+      delete partialParams.username;
 
       expect(() => {
         fetchCurrentCollectionPage(partialParams);
-      }).toThrow('user is required');
+      }).toThrow('username is required');
     });
 
     it('throws an error when page is missing', () => {

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -33,7 +33,7 @@ import {
 
 
 describe(__filename, () => {
-  const user = 'user-id-or-name';
+  const user = 'some-user';
   const slug = 'collection-slug';
   const page = 1;
 
@@ -193,13 +193,12 @@ describe(__filename, () => {
     const _fetchUserCollections = (params) => {
       sagaTester.dispatch(fetchUserCollections({
         errorHandlerId: errorHandler.id,
-        userId: 321,
+        user: 'some-user',
         ...params,
       }));
     };
 
     it('calls the API to fetch user collections', async () => {
-      const userId = 43321;
       const state = sagaTester.getState();
 
       const firstCollection = createFakeCollectionDetail({ id: 1 });
@@ -210,15 +209,15 @@ describe(__filename, () => {
         .expects('getAllUserCollections')
         .withArgs({
           api: state.api,
-          user: userId,
+          user,
         })
         .once()
         .returns(Promise.resolve(externalCollections));
 
-      _fetchUserCollections({ userId });
+      _fetchUserCollections({ user });
 
       const expectedLoadAction = loadUserCollections({
-        userId, collections: externalCollections,
+        user, collections: externalCollections,
       });
 
       const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
@@ -236,7 +235,6 @@ describe(__filename, () => {
     });
 
     it('dispatches an error', async () => {
-      const userId = 55432;
       const error = new Error('some API error maybe');
 
       mockApi
@@ -244,13 +242,13 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchUserCollections({ userId });
+      _fetchUserCollections({ user });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
       expect(sagaTester.getCalledActions()[3])
-        .toEqual(abortFetchUserCollections({ userId }));
+        .toEqual(abortFetchUserCollections({ user }));
     });
   });
 
@@ -261,7 +259,7 @@ describe(__filename, () => {
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: errorHandler.id,
-        userId: 321,
+        user: 'some-user',
         ...params,
       }));
     };
@@ -271,7 +269,7 @@ describe(__filename, () => {
         addonId: 123,
         collectionId: 5432,
         slug: 'a-collection',
-        userId: 543,
+        user: 'some-user',
       };
       const state = sagaTester.getState();
 
@@ -282,7 +280,7 @@ describe(__filename, () => {
           api: state.api,
           slug: params.slug,
           notes: undefined,
-          user: params.userId,
+          user: params.user,
         })
         .once()
         .returns(Promise.resolve());
@@ -292,7 +290,7 @@ describe(__filename, () => {
       const expectedAddedAction = addonAddedToCollection({
         addonId: params.addonId,
         collectionId: params.collectionId,
-        userId: params.userId,
+        user: params.user,
       });
 
       const addedAction = await sagaTester.waitFor(expectedAddedAction.type);
@@ -302,7 +300,7 @@ describe(__filename, () => {
         page: 1,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        user: params.userId,
+        user: params.user,
       });
 
       expect(sagaTester.wasCalled(unexpectedFetchAction.type)).toEqual(false);
@@ -316,7 +314,7 @@ describe(__filename, () => {
         slug: 'a-collection',
         editing: true,
         page: 1,
-        userId: 543,
+        user: 'some-user',
       };
       const state = sagaTester.getState();
 
@@ -327,7 +325,7 @@ describe(__filename, () => {
           api: state.api,
           slug: params.slug,
           notes: undefined,
-          user: params.userId,
+          user: params.user,
         })
         .once()
         .returns(Promise.resolve());
@@ -338,7 +336,7 @@ describe(__filename, () => {
         page: params.page,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        user: params.userId,
+        user: params.user,
       });
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);
@@ -347,7 +345,7 @@ describe(__filename, () => {
       const expectedAddedAction = addonAddedToCollection({
         addonId: params.addonId,
         collectionId: params.collectionId,
-        userId: params.userId,
+        user: params.user,
       });
 
       const addedAction = await sagaTester.waitFor(expectedAddedAction.type);
@@ -367,20 +365,19 @@ describe(__filename, () => {
 
     it('dispatches an error', async () => {
       const addonId = 8876;
-      const userId = 12334;
       const error = new Error('some API error maybe');
 
       mockApi
         .expects('createCollectionAddon')
         .returns(Promise.reject(error));
 
-      _addAddonToCollection({ addonId, userId });
+      _addAddonToCollection({ addonId, user });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
       expect(sagaTester.getCalledActions()[3])
-        .toEqual(abortAddAddonToCollection({ addonId, userId }));
+        .toEqual(abortAddAddonToCollection({ addonId, user }));
     });
   });
 

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -33,7 +33,7 @@ import {
 
 
 describe(__filename, () => {
-  const user = 'some-user';
+  const username = 'some-user';
   const slug = 'collection-slug';
   const page = 1;
 
@@ -75,7 +75,7 @@ describe(__filename, () => {
         .withArgs({
           api: state.api,
           slug,
-          user,
+          username,
         })
         .once()
         .returns(Promise.resolve(collectionDetail));
@@ -86,12 +86,12 @@ describe(__filename, () => {
           api: state.api,
           page,
           slug,
-          user,
+          username,
         })
         .once()
         .returns(Promise.resolve(collectionAddons));
 
-      _fetchCurrentCollection({ page, slug, user });
+      _fetchCurrentCollection({ page, slug, username });
 
       const expectedLoadAction = loadCurrentCollection({
         addons: collectionAddons.results,
@@ -104,7 +104,7 @@ describe(__filename, () => {
     });
 
     it('clears the error handler', async () => {
-      _fetchCurrentCollection({ slug, user });
+      _fetchCurrentCollection({ slug, username });
 
       const expectedAction = errorHandler.createClearingAction();
 
@@ -120,7 +120,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchCurrentCollection({ slug, user });
+      _fetchCurrentCollection({ slug, username });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
@@ -147,12 +147,12 @@ describe(__filename, () => {
           api: state.api,
           page,
           slug,
-          user,
+          username,
         })
         .once()
         .returns(Promise.resolve(collectionAddons));
 
-      _fetchCurrentCollectionPage({ page, slug, user });
+      _fetchCurrentCollectionPage({ page, slug, username });
 
       const expectedLoadAction = loadCurrentCollectionPage({
         addons: collectionAddons.results,
@@ -164,7 +164,7 @@ describe(__filename, () => {
     });
 
     it('clears the error handler', async () => {
-      _fetchCurrentCollectionPage({ page, slug, user });
+      _fetchCurrentCollectionPage({ page, slug, username });
 
       const expectedAction = errorHandler.createClearingAction();
 
@@ -180,7 +180,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchCurrentCollectionPage({ page, slug, user });
+      _fetchCurrentCollectionPage({ page, slug, username });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
@@ -193,7 +193,7 @@ describe(__filename, () => {
     const _fetchUserCollections = (params) => {
       sagaTester.dispatch(fetchUserCollections({
         errorHandlerId: errorHandler.id,
-        user: 'some-user',
+        username: 'some-user',
         ...params,
       }));
     };
@@ -209,15 +209,15 @@ describe(__filename, () => {
         .expects('getAllUserCollections')
         .withArgs({
           api: state.api,
-          user,
+          username,
         })
         .once()
         .returns(Promise.resolve(externalCollections));
 
-      _fetchUserCollections({ user });
+      _fetchUserCollections({ username });
 
       const expectedLoadAction = loadUserCollections({
-        user, collections: externalCollections,
+        username, collections: externalCollections,
       });
 
       const loadAction = await sagaTester.waitFor(expectedLoadAction.type);
@@ -242,13 +242,13 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchUserCollections({ user });
+      _fetchUserCollections({ username });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
       expect(sagaTester.getCalledActions()[3])
-        .toEqual(abortFetchUserCollections({ user }));
+        .toEqual(abortFetchUserCollections({ username }));
     });
   });
 
@@ -259,7 +259,7 @@ describe(__filename, () => {
         collectionId: 321,
         slug: 'some-collection',
         errorHandlerId: errorHandler.id,
-        user: 'some-user',
+        username: 'some-user',
         ...params,
       }));
     };
@@ -269,7 +269,7 @@ describe(__filename, () => {
         addonId: 123,
         collectionId: 5432,
         slug: 'a-collection',
-        user: 'some-user',
+        username: 'some-user',
       };
       const state = sagaTester.getState();
 
@@ -280,7 +280,7 @@ describe(__filename, () => {
           api: state.api,
           slug: params.slug,
           notes: undefined,
-          user: params.user,
+          username: params.username,
         })
         .once()
         .returns(Promise.resolve());
@@ -290,7 +290,7 @@ describe(__filename, () => {
       const expectedAddedAction = addonAddedToCollection({
         addonId: params.addonId,
         collectionId: params.collectionId,
-        user: params.user,
+        username: params.username,
       });
 
       const addedAction = await sagaTester.waitFor(expectedAddedAction.type);
@@ -300,7 +300,7 @@ describe(__filename, () => {
         page: 1,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        user: params.user,
+        username: params.username,
       });
 
       expect(sagaTester.wasCalled(unexpectedFetchAction.type)).toEqual(false);
@@ -314,7 +314,7 @@ describe(__filename, () => {
         slug: 'a-collection',
         editing: true,
         page: 1,
-        user: 'some-user',
+        username: 'some-user',
       };
       const state = sagaTester.getState();
 
@@ -325,7 +325,7 @@ describe(__filename, () => {
           api: state.api,
           slug: params.slug,
           notes: undefined,
-          user: params.user,
+          username: params.username,
         })
         .once()
         .returns(Promise.resolve());
@@ -336,7 +336,7 @@ describe(__filename, () => {
         page: params.page,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        user: params.user,
+        username: params.username,
       });
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);
@@ -345,7 +345,7 @@ describe(__filename, () => {
       const expectedAddedAction = addonAddedToCollection({
         addonId: params.addonId,
         collectionId: params.collectionId,
-        user: params.user,
+        username: params.username,
       });
 
       const addedAction = await sagaTester.waitFor(expectedAddedAction.type);
@@ -371,13 +371,13 @@ describe(__filename, () => {
         .expects('createCollectionAddon')
         .returns(Promise.reject(error));
 
-      _addAddonToCollection({ addonId, user });
+      _addAddonToCollection({ addonId, username });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
       expect(sagaTester.getCalledActions()[3])
-        .toEqual(abortAddAddonToCollection({ addonId, user }));
+        .toEqual(abortAddAddonToCollection({ addonId, username }));
     });
   });
 
@@ -387,7 +387,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         name: 'some-collection-name',
         slug,
-        user,
+        username,
         ...params,
       }));
     };
@@ -397,7 +397,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         collectionSlug: 'some-collection',
         slug,
-        user,
+        username,
         ...params,
       }));
     };
@@ -480,7 +480,7 @@ describe(__filename, () => {
           description: { 'en-US': 'New collection description' },
           name: { 'en-US': 'New collection name' },
           slug: 'new-slug',
-          user,
+          username,
         };
         const state = sagaTester.getState();
 
@@ -493,7 +493,7 @@ describe(__filename, () => {
             description: params.description,
             name: params.name,
             slug: params.slug,
-            user,
+            username,
           })
           .once()
           .returns(Promise.resolve());
@@ -545,12 +545,12 @@ describe(__filename, () => {
         const collectionSlug = 'some-collection';
         // Update everything except the slug.
         _updateCollection({
-          collectionSlug, user, slug: undefined,
+          collectionSlug, username, slug: undefined,
         });
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${user}/${collectionSlug}/`
+          `/${lang}/${clientApp}/collections/${username}/${collectionSlug}/`
         );
 
         const action = await sagaTester.waitFor(expectedAction.type);
@@ -563,11 +563,11 @@ describe(__filename, () => {
         mockApi.expects('updateCollection').returns(Promise.resolve());
 
         const newSlug = 'new-slug';
-        _updateCollection({ user, slug: newSlug });
+        _updateCollection({ username, slug: newSlug });
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${user}/${newSlug}/`
+          `/${lang}/${clientApp}/collections/${username}/${newSlug}/`
         );
 
         const action = await sagaTester.waitFor(expectedAction.type);
@@ -582,7 +582,7 @@ describe(__filename, () => {
           description: { [lang]: 'Collection description' },
           name: { [lang]: 'Collection name' },
           slug,
-          user,
+          username,
         };
       };
 
@@ -600,7 +600,7 @@ describe(__filename, () => {
             description: params.description,
             name: params.name,
             slug,
-            user,
+            username,
           })
           .once()
           .returns(Promise.resolve(collectionDetailResponse));
@@ -620,7 +620,7 @@ describe(__filename, () => {
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${user}/${slug}/edit/`
+          `/${lang}/${clientApp}/collections/${username}/${slug}/edit/`
         );
 
         await sagaTester.waitFor(expectedAction.type);
@@ -642,7 +642,7 @@ describe(__filename, () => {
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${user}/${slug}/edit/`
+          `/${lang}/${clientApp}/collections/${username}/${slug}/edit/`
         );
 
         const action = await sagaTester.waitFor(expectedAction.type);
@@ -660,7 +660,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         page: 1,
         slug: 'some-collection',
-        user: 'some-user',
+        username: 'some-user',
         ...params,
       }));
     };
@@ -670,7 +670,7 @@ describe(__filename, () => {
         addonId: 123,
         page: 2,
         slug: 'some-other-slug',
-        user: 'some-other-user',
+        username: 'some-other-user',
       };
       const state = sagaTester.getState();
 
@@ -680,7 +680,7 @@ describe(__filename, () => {
           addonId: params.addonId,
           api: state.api,
           slug: params.slug,
-          user: params.user,
+          username: params.username,
         })
         .once()
         .returns(Promise.resolve());
@@ -691,7 +691,7 @@ describe(__filename, () => {
         page: params.page,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        user: params.user,
+        username: params.username,
       });
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -74,7 +74,7 @@ describe(__filename, () => {
           ...baseArgs,
           page: 1,
           slug: firstCollectionSlug,
-          user: firstCollectionUser,
+          username: firstCollectionUser,
         })
         .returns(Promise.resolve(firstCollection));
       mockCollectionsApi
@@ -83,7 +83,7 @@ describe(__filename, () => {
           ...baseArgs,
           page: 1,
           slug: secondCollectionSlug,
-          user: secondCollectionUser,
+          username: secondCollectionUser,
         })
         .returns(Promise.resolve(secondCollection));
       const collections = [firstCollection, secondCollection];
@@ -120,8 +120,8 @@ describe(__filename, () => {
 
       _fetchHomeAddons({
         collectionsToFetch: [
-          { slug: firstCollectionSlug, user: firstCollectionUser },
-          { slug: secondCollectionSlug, user: secondCollectionUser },
+          { slug: firstCollectionSlug, username: firstCollectionUser },
+          { slug: secondCollectionSlug, username: secondCollectionUser },
         ],
       });
 


### PR DESCRIPTION
Fixes #5142 

I decided to use the string `username` as the identifier in all cases, rather than the numeric `userId`, mainly because of this [comment](https://github.com/mozilla/addons-frontend/blob/38c186ed9a33f950db1ebbeb09b6cb386fd9d1fd/src/amo/api/collections.js#L133), which has to do with the fact that we sometimes redirect to a URL and want that URL to be username-based.

Sorry for the large PR. It's *mostly* just direct changes from `userId` to `user` in a lot of places, but there are a few places I had to change some logic as well, mostly in the components.