### PR TITLE
Add a ConfirmButton and use it to delete a profile picture

### DIFF
--- a/src/amo/components/UserProfileEditPicture/index.js
+++ b/src/amo/components/UserProfileEditPicture/index.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';
-import Button from 'ui/components/Button';
+import ConfirmButton from 'ui/components/ConfirmButton';
 import UserAvatar from 'ui/components/UserAvatar';
 import type { UserType } from 'amo/reducers/users';
 import type { I18nType } from 'core/types/i18n';
@@ -68,14 +68,14 @@ export const UserProfileEditPictureBase = ({
       </label>
 
       {(user && user.picture_url) && (
-        <p>
-          <Button
-            className="UserProfileEditPicture-delete-button"
-            onClick={onDelete}
-          >
-            {i18n.gettext('Delete this picture')}
-          </Button>
-        </p>
+        <ConfirmButton
+          buttonType="cancel"
+          className="UserProfileEditPicture-delete-button"
+          message={i18n.gettext('Do you really want to delete this picture?')}
+          onConfirm={onDelete}
+        >
+          {i18n.gettext('Delete this picture')}
+        </ConfirmButton>
       )}
     </section>
   );

--- a/src/amo/components/UserProfileEditPicture/styles.scss
+++ b/src/amo/components/UserProfileEditPicture/styles.scss
@@ -46,7 +46,14 @@ $picture-size: 128px;
   }
 
   .UserProfileEditPicture-delete-button {
-    cursor: pointer;
-    width: $picture-size;
+    margin: 12px 0;
+
+    .ConfirmButton-default-button {
+      width: $picture-size;
+    }
+
+    @include respond-to(medium) {
+      width: $picture-size;
+    }
   }
 }

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -11,13 +11,13 @@ import './styles.scss';
 
 
 type Props = {|
-  buttonType?: string,
-  cancelButtonText?: string,
-  cancelButtonType?: string,
+  buttonType: string,
+  cancelButtonText: string,
+  cancelButtonType: string,
   children: React.Element<any>,
   className?: string,
-  confirmButtonText?: string,
-  confirmButtonType?: string,
+  confirmButtonText: string,
+  confirmButtonType: string,
   i18n: I18nType,
   message: string,
   onConfirm: Function,

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -1,0 +1,122 @@
+/* @flow */
+import makeClassName from 'classnames';
+import * as React from 'react';
+import { compose } from 'redux';
+
+import translate from 'core/i18n/translate';
+import Button from 'ui/components/Button';
+import type { I18nType } from 'core/types/i18n';
+
+import './styles.scss';
+
+
+type Props = {|
+  buttonType?: string,
+  cancelButtonText?: string,
+  cancelButtonType?: string,
+  children: React.Element<any>,
+  className?: string,
+  confirmButtonText?: string,
+  confirmButtonType?: string,
+  i18n: I18nType,
+  message: string,
+  onConfirm: Function,
+|};
+
+type State = {|
+  showConfirmation: boolean,
+|};
+
+export class ConfirmButtonBase extends React.Component<Props, State> {
+  static defaultProps = {
+    buttonType: 'neutral',
+    cancelButtonText: null,
+    cancelButtonType: 'cancel',
+    confirmButtonText: null,
+    confirmButtonType: 'alert',
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      showConfirmation: false,
+    };
+  }
+
+  onConfirm = (e: SyntheticEvent<HTMLButtonElement>) => {
+    this.setState({ showConfirmation: false });
+    this.props.onConfirm(e);
+  }
+
+  toggleConfirmation = (e: SyntheticEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    this.setState((prevState) => ({
+      showConfirmation: !prevState.showConfirmation,
+    }));
+  }
+
+  render() {
+    const {
+      buttonType,
+      cancelButtonText,
+      cancelButtonType,
+      children,
+      className,
+      confirmButtonText,
+      confirmButtonType,
+      i18n,
+      message,
+    } = this.props;
+
+    const { showConfirmation } = this.state;
+
+    const classNames = makeClassName('ConfirmButton', className, {
+      'ConfirmButton--show-confirmation': showConfirmation,
+    });
+
+    if (showConfirmation) {
+      return (
+        <div className={classNames}>
+          <span className="ConfirmButton-message">
+            {message}
+          </span>
+
+          <div className="ConfirmButton-buttons">
+            <Button
+              buttonType={confirmButtonType}
+              className="ConfirmButton-confirm-button"
+              onClick={this.onConfirm}
+            >
+              {confirmButtonText || i18n.gettext('Confirm')}
+            </Button>
+            <Button
+              buttonType={cancelButtonType}
+              className="ConfirmButton-cancel-button"
+              onClick={this.toggleConfirmation}
+            >
+              {cancelButtonText || i18n.gettext('Cancel')}
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className={classNames}>
+        <Button
+          buttonType={buttonType}
+          className="ConfirmButton-default-button"
+          onClick={this.toggleConfirmation}
+        >
+          {children}
+        </Button>
+      </div>
+    );
+  }
+}
+
+export default compose(
+  translate(),
+)(ConfirmButtonBase);

--- a/src/ui/components/ConfirmButton/styles.scss
+++ b/src/ui/components/ConfirmButton/styles.scss
@@ -1,0 +1,17 @@
+@import "~core/css/inc/mixins";
+@import "~ui/css/vars";
+
+.ConfirmButton-buttons {
+  align-items: center;
+  display: flex;
+  flex-flow: column;
+  justify-content: space-between;
+
+  .Button {
+    margin-top: $padding-page;
+  }
+
+  @include respond-to(medium) {
+    flex-flow: row-reverse;
+  }
+}

--- a/tests/unit/amo/components/TestUserProfileEditPicture.js
+++ b/tests/unit/amo/components/TestUserProfileEditPicture.js
@@ -4,6 +4,7 @@ import UserProfileEditPicture, {
   UserProfileEditPictureBase,
 } from 'amo/components/UserProfileEditPicture';
 import { getCurrentUser } from 'amo/reducers/users';
+import ConfirmButton from 'ui/components/ConfirmButton';
 import UserAvatar from 'ui/components/UserAvatar';
 import {
   dispatchSignInActions,
@@ -101,22 +102,29 @@ describe(__filename, () => {
     sinon.assert.callCount(onSelect, 1);
   });
 
-  it('renders a "delete" button when user has a picture URL', () => {
+  it('renders a "delete" ConfirmButton when user has a picture URL', () => {
     const { state } = dispatchSignInActions({
       userProps: {
         picture_url: 'https://example.org/pp.png',
       },
     });
     const user = getCurrentUser(state.users);
+    const onDelete = sinon.stub();
 
-    const root = render({ user });
+    const root = render({ user, onDelete });
 
-    expect(root.find('.UserProfileEditPicture-delete-button')).toHaveLength(1);
-    expect(root.find('.UserProfileEditPicture-delete-button').children())
+    expect(root.find(ConfirmButton)).toHaveLength(1);
+    expect(root.find(ConfirmButton))
+      .toHaveClassName('UserProfileEditPicture-delete-button');
+    expect(root.find(ConfirmButton))
+      .toHaveProp('message', 'Do you really want to delete this picture?');
+    expect(root.find(ConfirmButton))
+      .toHaveProp('onConfirm', onDelete);
+    expect(root.find(ConfirmButton).children())
       .toHaveText('Delete this picture');
   });
 
-  it('does not render a "delete" button when user has no picture URL', () => {
+  it('does not render a "delete" ConfirmButton when user has no picture URL', () => {
     const { state } = dispatchSignInActions({
       userProps: {
         picture_url: null,
@@ -126,7 +134,7 @@ describe(__filename, () => {
 
     const root = render({ user });
 
-    expect(root.find('.UserProfileEditPicture-delete-button')).toHaveLength(0);
+    expect(root.find(ConfirmButton)).toHaveLength(0);
   });
 
   it('calls the onDelete() prop when a user deletes the picture', () => {
@@ -142,7 +150,9 @@ describe(__filename, () => {
 
     sinon.assert.notCalled(onDelete);
 
-    root.find('.UserProfileEditPicture-delete-button').simulate('click');
+    // We assume the user confirms picture deletion.
+    const onConfirm = root.find(ConfirmButton).prop('onConfirm');
+    onConfirm();
 
     sinon.assert.callCount(onDelete, 1);
   });

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -1,0 +1,140 @@
+import * as React from 'react';
+
+import Button from 'ui/components/Button';
+import ConfirmButton, { ConfirmButtonBase } from 'ui/components/ConfirmButton';
+import {
+  createFakeEvent,
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+
+
+describe(__filename, () => {
+  const render = ({ children, i18n = fakeI18n(), ...props } = {}) => {
+    return shallowUntilTarget(
+      <ConfirmButton
+        i18n={i18n}
+        message="some warning message"
+        onConfirm={sinon.stub()}
+        {...props}
+      >
+        {children || 'the default text of this button'}
+      </ConfirmButton>,
+      ConfirmButtonBase
+    );
+  };
+
+  it('renders a button', () => {
+    const root = render();
+
+    expect(root).toHaveClassName('ConfirmButton');
+    expect(root.find(Button)).toHaveLength(1);
+    expect(root.find(Button)).toHaveClassName('ConfirmButton-default-button');
+    expect(root.find(Button)).toHaveProp('buttonType', 'neutral');
+  });
+
+  it('passes the buttonType prop to the button', () => {
+    const buttonType = 'alert';
+    const root = render({ buttonType });
+
+    expect(root.find(Button)).toHaveProp('buttonType', buttonType);
+  });
+
+  it('passes the children prop to the button', () => {
+    const children = 'this is the text of the button shown by default';
+    const root = render({ children });
+
+    expect(root.find(Button).children()).toHaveText(children);
+  });
+
+  it('shows a confirmation panel when button is clicked', () => {
+    const message = 'this action is risky, are you sure?';
+    const root = render({ message });
+
+    expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+
+    root.find(Button).simulate('click', createFakeEvent());
+
+    expect(root).toHaveClassName('ConfirmButton--show-confirmation');
+
+    expect(root.find('.ConfirmButton-message')).toHaveLength(1);
+    expect(root.find('.ConfirmButton-message')).toHaveText(message);
+
+    expect(root.find(Button)).toHaveLength(2);
+
+    const confirmButton = root.find(Button).at(0);
+    expect(confirmButton).toHaveClassName('ConfirmButton-confirm-button');
+    expect(confirmButton).toHaveProp('buttonType', 'alert');
+    expect(confirmButton.children()).toHaveText('Confirm');
+
+    const cancelButton = root.find(Button).at(1);
+    expect(cancelButton).toHaveClassName('ConfirmButton-cancel-button');
+    expect(cancelButton).toHaveProp('buttonType', 'cancel');
+    expect(cancelButton.children()).toHaveText('Cancel');
+  });
+
+  it('passes props to the confirm button in the confirmation panel', () => {
+    const confirmButtonText = 'neutral confirm button';
+    const confirmButtonType = 'neutral';
+    const root = render({ confirmButtonText, confirmButtonType });
+
+    // Show the confirmation panel.
+    root.find(Button).simulate('click', createFakeEvent());
+
+    expect(root.find('.ConfirmButton-confirm-button'))
+      .toHaveProp('buttonType', confirmButtonType);
+    expect(root.find('.ConfirmButton-confirm-button').children())
+      .toHaveText(confirmButtonText);
+  });
+
+  it('passes props to the cancel button in the confirmation panel', () => {
+    const cancelButtonText = 'neutral cancel button';
+    const cancelButtonType = 'neutral';
+    const root = render({ cancelButtonText, cancelButtonType });
+
+    // Show the confirmation panel.
+    root.find(Button).simulate('click', createFakeEvent());
+
+    expect(root.find('.ConfirmButton-cancel-button'))
+      .toHaveProp('buttonType', cancelButtonType);
+    expect(root.find('.ConfirmButton-cancel-button').children())
+      .toHaveText(cancelButtonText);
+  });
+
+  it('closes the confirmation panel on cancel ', () => {
+    const root = render();
+
+    expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+
+    // Show the confirmation panel.
+    root.find(Button).simulate('click', createFakeEvent());
+
+    expect(root).toHaveClassName('ConfirmButton--show-confirmation');
+
+    root.find('.ConfirmButton-cancel-button').simulate(
+      'click',
+      createFakeEvent()
+    );
+
+    expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+  });
+
+  it('calls the onConfirm prop when user clicks the "confirm" button', () => {
+    const onConfirmSpy = sinon.spy();
+    const root = render({ onConfirm: onConfirmSpy });
+
+    expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+
+    // Show the confirmation panel.
+    root.find(Button).simulate('click', createFakeEvent());
+
+    expect(root).toHaveClassName('ConfirmButton--show-confirmation');
+    sinon.assert.notCalled(onConfirmSpy);
+
+    const event = createFakeEvent();
+    root.find('.ConfirmButton-confirm-button').simulate('click', event);
+
+    expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+    sinon.assert.calledWith(onConfirmSpy, event);
+  });
+});

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -102,7 +102,8 @@ describe(__filename, () => {
   });
 
   it('closes the confirmation panel on cancel ', () => {
-    const root = render();
+    const onConfirmSpy = sinon.spy();
+    const root = render({ onConfirm: onConfirmSpy });
 
     expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
 
@@ -110,6 +111,7 @@ describe(__filename, () => {
     root.find(Button).simulate('click', createFakeEvent());
 
     expect(root).toHaveClassName('ConfirmButton--show-confirmation');
+    sinon.assert.notCalled(onConfirmSpy);
 
     root.find('.ConfirmButton-cancel-button').simulate(
       'click',
@@ -117,6 +119,7 @@ describe(__filename, () => {
     );
 
     expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+    sinon.assert.notCalled(onConfirmSpy);
   });
 
   it('calls the onConfirm prop when user clicks the "confirm" button', () => {


### PR DESCRIPTION
Fix #5151

---

Notes:

- I chose to hide this action on small screens. I am not sure we really need it on a smartphone...
- The "cancel" style for the button is fixed in another PR (#5140)

## Gif

![2018-05-31 13 38 20](https://user-images.githubusercontent.com/217628/40782832-790c8dc0-64d8-11e8-9d0e-09631cebf96b.gif)
