### PR TITLE
Use slug instead of collectionSlug everywhere except for modifying a collection

### DIFF
--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -259,7 +259,7 @@ export const createCollection = ({
 type ModifyCollectionAddonBaseParams = {|
   addonId: number,
   api: ApiStateType,
-  collectionSlug: string,
+  slug: string,
   user: string | number,
   _modifyCollectionAddon?: (any) => Promise<void>,
 |};
@@ -283,18 +283,18 @@ type ModifyCollectionAddonParams =
 export const modifyCollectionAddon = (
   params: ModifyCollectionAddonParams,
 ): Promise<void> => {
-  const { action, addonId, api, collectionSlug, user } = params;
+  const { action, addonId, api, slug, user } = params;
 
   invariant(action, 'The action parameter is required');
   invariant(addonId, 'The addonId parameter is required');
   invariant(api, 'The api parameter is required');
-  invariant(collectionSlug, 'The collectionSlug parameter is required');
+  invariant(slug, 'The slug parameter is required');
   invariant(user, 'The user parameter is required');
 
   let method = 'POST';
   const body = { addon: addonId, notes: params.notes };
   let endpoint =
-    `accounts/account/${user}/collections/${collectionSlug}/addons`;
+    `accounts/account/${user}/collections/${slug}/addons`;
 
   if (action === 'update') {
     // TODO: once `notes` can be null, we can check for `undefined` values
@@ -311,26 +311,26 @@ export const modifyCollectionAddon = (
 export const createCollectionAddon = ({
   addonId,
   api,
-  collectionSlug,
+  slug,
   notes,
   user,
   _modifyCollectionAddon = modifyCollectionAddon,
 }: CreateCollectionAddonParams): Promise<void> => {
   return _modifyCollectionAddon({
-    action: 'create', addonId, api, collectionSlug, notes, user,
+    action: 'create', addonId, api, slug, notes, user,
   });
 };
 
 export const updateCollectionAddon = ({
   addonId,
   api,
-  collectionSlug,
+  slug,
   notes,
   user,
   _modifyCollectionAddon = modifyCollectionAddon,
 }: UpdateCollectionAddonParams): Promise<void> => {
   return _modifyCollectionAddon({
-    action: 'update', addonId, api, collectionSlug, notes, user,
+    action: 'update', addonId, api, slug, notes, user,
   });
 };
 export type RemoveAddonFromCollectionParams = {|

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -122,7 +122,7 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
     dispatch(addAddonToCollection({
       addonId: addon.id,
       collectionId: collection.id,
-      collectionSlug: collection.slug,
+      slug: collection.slug,
       errorHandlerId: errorHandler.id,
       userId: siteUserId,
     }));

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -236,7 +236,7 @@ export class CollectionManagerBase extends React.Component<Props, State> {
     dispatch(addAddonToCollection({
       addonId,
       collectionId: collection.id,
-      collectionSlug: collection.slug,
+      slug: collection.slug,
       editing: true,
       errorHandlerId: errorHandler.id,
       page: page || 1,

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -328,7 +328,7 @@ export const loadCurrentCollectionPage = ({
 
 type LoadCollectionAddonsParams = {|
   addons: ExternalCollectionAddons,
-  collectionSlug: string,
+  slug: string,
 |};
 
 type LoadCollectionAddonsAction = {|
@@ -337,18 +337,18 @@ type LoadCollectionAddonsAction = {|
 |};
 
 export const loadCollectionAddons = ({
-  addons, collectionSlug,
+  addons, slug,
 }: LoadCollectionAddonsParams = {}): LoadCollectionAddonsAction => {
   if (!addons) {
     throw new Error('The addons parameter is required');
   }
-  if (!collectionSlug) {
-    throw new Error('The collectionSlug parameter is required');
+  if (!slug) {
+    throw new Error('The slug parameter is required');
   }
 
   return {
     type: LOAD_COLLECTION_ADDONS,
-    payload: { addons, collectionSlug },
+    payload: { addons, slug },
   };
 };
 
@@ -419,7 +419,7 @@ export const abortFetchCurrentCollection = (): AbortFetchCurrentCollection => {
 type AddAddonToCollectionParams = {|
   addonId: number,
   collectionId: CollectionId,
-  collectionSlug: string,
+  slug: string,
   editing?: boolean,
   errorHandlerId: string,
   notes?: string,
@@ -433,11 +433,11 @@ export type AddAddonToCollectionAction = {|
 |};
 
 export const addAddonToCollection = ({
-  addonId, collectionId, collectionSlug, editing, errorHandlerId, notes, page, userId,
+  addonId, collectionId, slug, editing, errorHandlerId, notes, page, userId,
 }: AddAddonToCollectionParams = {}): AddAddonToCollectionAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(collectionId, 'The collectionId parameter is required');
-  invariant(collectionSlug, 'The collectionSlug parameter is required');
+  invariant(slug, 'The slug parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
   invariant(userId, 'The userId parameter is required');
 
@@ -448,7 +448,7 @@ export const addAddonToCollection = ({
   return {
     type: ADD_ADDON_TO_COLLECTION,
     payload: {
-      addonId, collectionId, collectionSlug, editing, errorHandlerId, notes, page, userId,
+      addonId, collectionId, slug, editing, errorHandlerId, notes, page, userId,
     },
   };
 };
@@ -864,13 +864,13 @@ const reducer = (
     }
 
     case LOAD_COLLECTION_ADDONS: {
-      const { addons, collectionSlug } = action.payload;
+      const { addons, slug } = action.payload;
 
-      const collectionId = state.bySlug[collectionSlug];
+      const collectionId = state.bySlug[slug];
       if (!collectionId) {
         throw new Error(
           oneLine`Cannot load add-ons for collection
-          "${collectionSlug}" because the collection has not
+          "${slug}" because the collection has not
           been loaded yet`);
       }
       const collection = state.byId[collectionId];

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -147,7 +147,7 @@ export function* fetchUserCollections({
 
 export function* addAddonToCollection({
   payload: {
-    addonId, collectionId, collectionSlug, editing, errorHandlerId, notes, page, userId,
+    addonId, collectionId, slug, editing, errorHandlerId, notes, page, userId,
   },
 }: AddAddonToCollectionAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -159,7 +159,7 @@ export function* addAddonToCollection({
     const params: CreateCollectionAddonParams = {
       addonId,
       api: state.api,
-      collectionSlug,
+      slug,
       notes,
       user: userId,
     };
@@ -171,7 +171,7 @@ export function* addAddonToCollection({
       yield put(fetchCurrentCollectionPageAction({
         page,
         errorHandlerId: errorHandler.id,
-        slug: collectionSlug,
+        slug,
         user: userId,
       }));
     }

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -367,7 +367,7 @@ describe(__filename, () => {
         action: 'create',
         addonId: 123458,
         api: apiState,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         user: 'user-id-or-username',
         ...params,
       };
@@ -377,13 +377,13 @@ describe(__filename, () => {
       const params = defaultParams({
         action: 'create',
         addonId: 987675,
-        collectionSlug: 'my-collection',
+        slug: 'my-collection',
         user: 'my-user',
       });
 
       const endpoint = oneLineTrim`
         accounts/account/${params.user}/collections/
-        ${params.collectionSlug}/addons
+        ${params.slug}/addons
       `;
       mockApi
         .expects('callApi')
@@ -408,7 +408,7 @@ describe(__filename, () => {
 
       const endpoint = oneLineTrim`
         accounts/account/${params.user}/collections/
-        ${params.collectionSlug}/addons
+        ${params.slug}/addons
       `;
       mockApi
         .expects('callApi')
@@ -429,14 +429,14 @@ describe(__filename, () => {
       const params = defaultParams({
         action: 'update',
         addonId: 987675,
-        collectionSlug: 'my-collection',
+        slug: 'my-collection',
         notes,
         user: 'my-user',
       });
 
       const endpoint = oneLineTrim`
         accounts/account/${params.user}/collections/
-        ${params.collectionSlug}/addons/${params.addonId}
+        ${params.slug}/addons/${params.addonId}
       `;
       mockApi
         .expects('callApi')
@@ -461,7 +461,7 @@ describe(__filename, () => {
 
       const endpoint = oneLineTrim`
         accounts/account/${params.user}/collections/
-        ${params.collectionSlug}/addons/${params.addonId}
+        ${params.slug}/addons/${params.addonId}
       `;
       mockApi
         .expects('callApi')
@@ -483,7 +483,7 @@ describe(__filename, () => {
       const params = {
         addonId: 1122432,
         api: apiState,
-        collectionSlug: 'the-collection',
+        slug: 'the-collection',
         notes: 'Beware of this one weird bug',
         user: 'the-user',
       };
@@ -503,7 +503,7 @@ describe(__filename, () => {
       const params = {
         addonId: 1122432,
         api: apiState,
-        collectionSlug: 'cool-collection',
+        slug: 'cool-collection',
         notes: 'This add-on speaks to my soul',
         user: 'cool-user',
       };

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -179,7 +179,7 @@ describe(__filename, () => {
         addonId: addon.id,
         userId,
         collectionId: 321,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
@@ -225,7 +225,7 @@ describe(__filename, () => {
         errorHandlerId: root.instance().props.errorHandler.id,
         addonId: addon.id,
         collectionId: secondCollection.id,
-        collectionSlug: secondCollection.slug,
+        slug: secondCollection.slug,
         userId: authorId,
       }));
     });

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -661,7 +661,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(dispatchSpy, addAddonToCollection({
       addonId: suggestion.addonId,
       collectionId: collection.id,
-      collectionSlug: collection.slug,
+      slug: collection.slug,
       editing: true,
       errorHandlerId: errorHandler.id,
       page,
@@ -689,7 +689,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(dispatchSpy, addAddonToCollection({
       addonId: suggestion.addonId,
       collectionId: collection.id,
-      collectionSlug: collection.slug,
+      slug: collection.slug,
       editing: true,
       errorHandlerId: errorHandler.id,
       page: 1,

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -291,7 +291,7 @@ describe(__filename, () => {
         addonId,
         userId,
         collectionId: 321,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
@@ -306,7 +306,7 @@ describe(__filename, () => {
         addonId: 1,
         userId: 2,
         collectionId: 3,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
@@ -327,7 +327,7 @@ describe(__filename, () => {
         addonId,
         userId,
         collectionId: 321,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
@@ -345,7 +345,7 @@ describe(__filename, () => {
         addonId,
         userId,
         collectionId: 321,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
@@ -372,7 +372,7 @@ describe(__filename, () => {
         addonId,
         userId,
         collectionId: 321,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         errorHandlerId: 'error-handler',
       }));
 
@@ -742,7 +742,7 @@ describe(__filename, () => {
     const getParams = (params = {}) => {
       return {
         addons: createFakeCollectionAddons(),
-        collectionSlug: 'my-collection',
+        slug: 'my-collection',
         ...params,
       };
     };
@@ -764,7 +764,7 @@ describe(__filename, () => {
       });
       state = reducer(state, loadCollectionAddons({
         addons: newAddons,
-        collectionSlug: collectionDetail.slug,
+        slug: collectionDetail.slug,
       }));
 
       expect(state.byId[collectionDetail.id].addons)
@@ -777,7 +777,7 @@ describe(__filename, () => {
         reducer(undefined, loadCollectionAddons({
           addons,
           // This collection has not been loaded into state yet.
-          collectionSlug: 'a-collection',
+          slug: 'a-collection',
         }));
       })
         .toThrow(/Cannot load add-ons for collection/);
@@ -793,10 +793,10 @@ describe(__filename, () => {
 
     it('requires a collectionId parameter', () => {
       const params = getParams();
-      delete params.collectionSlug;
+      delete params.slug;
 
       expect(() => loadCollectionAddons(params))
-        .toThrow(/collectionSlug parameter is required/);
+        .toThrow(/slug parameter is required/);
     });
   });
 

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -259,7 +259,7 @@ describe(__filename, () => {
       sagaTester.dispatch(addAddonToCollection({
         addonId: 543,
         collectionId: 321,
-        collectionSlug: 'some-collection',
+        slug: 'some-collection',
         errorHandlerId: errorHandler.id,
         userId: 321,
         ...params,
@@ -267,11 +267,10 @@ describe(__filename, () => {
     };
 
     it('posts an add-on to a collection', async () => {
-      const collectionSlug = 'a-collection';
       const params = {
         addonId: 123,
         collectionId: 5432,
-        collectionSlug,
+        slug: 'a-collection',
         userId: 543,
       };
       const state = sagaTester.getState();
@@ -281,7 +280,7 @@ describe(__filename, () => {
         .withArgs({
           addonId: params.addonId,
           api: state.api,
-          collectionSlug,
+          slug: params.slug,
           notes: undefined,
           user: params.userId,
         })
@@ -302,7 +301,7 @@ describe(__filename, () => {
       const unexpectedFetchAction = fetchCurrentCollectionPage({
         page: 1,
         errorHandlerId: errorHandler.id,
-        slug: collectionSlug,
+        slug: params.slug,
         user: params.userId,
       });
 
@@ -311,11 +310,10 @@ describe(__filename, () => {
     });
 
     it('posts an add-on to a collection while the collection is being edited', async () => {
-      const collectionSlug = 'a-collection';
       const params = {
         addonId: 123,
         collectionId: 5432,
-        collectionSlug,
+        slug: 'a-collection',
         editing: true,
         page: 1,
         userId: 543,
@@ -327,7 +325,7 @@ describe(__filename, () => {
         .withArgs({
           addonId: params.addonId,
           api: state.api,
-          collectionSlug,
+          slug: params.slug,
           notes: undefined,
           user: params.userId,
         })
@@ -339,7 +337,7 @@ describe(__filename, () => {
       const expectedFetchAction = fetchCurrentCollectionPage({
         page: params.page,
         errorHandlerId: errorHandler.id,
-        slug: collectionSlug,
+        slug: params.slug,
         user: params.userId,
       });
 


### PR DESCRIPTION
Fixes #5164 

Note that this patch is pretty much all just renames. I don't believe any logic had to change anywhere to make this work.
