### PR TITLE
I5173 static theme persona style fix

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -64,10 +64,7 @@
 
   .SearchResult--persona & {
     height: 100px;
-  }
-
-  .AddonsCard--horizontal .SearchResult--persona & {
-    height: $theme-height-default;
+    object-position: top right;
   }
 }
 


### PR DESCRIPTION
fixes #5173 

for persona theme images, i am reverting back to `top right` styles so nothing is cut off and to give better sense of the theme style