### PR TITLE
I5181 persona style fix in header

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -146,6 +146,7 @@
 
   .Addon-persona & {
     height: 100px;
+    object-position: top right;
   }
 
   @include respond-to(extraExtraLarge) {


### PR DESCRIPTION
fixes #5181 

before - left aligned (mobile)        |  after - right aligned (mobile)
:-------------------------:|:-------------------------:
![Alt text](https://monosnap.com/image/VXejTgjNZXL9YmEvZfrOzghk4lZQHB.png) | ![Alt text](https://monosnap.com/image/qKtTaYGKn3IfUIw1hA1f8BDXsfbwH3.png)
