### PR TITLE
I5176 badge in header style fix

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -140,7 +140,7 @@
   border-radius: $border-radius-default;
   display: block;
   height: $theme-height-default;
-  max-width: 680px;
+  max-width: $theme-width-default;
   object-fit: cover;
   object-position: top left;
   width: 100%;

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -140,6 +140,7 @@
   border-radius: $border-radius-default;
   display: block;
   height: $theme-height-default;
+  max-width: 680px;
   object-fit: cover;
   object-position: top left;
   width: 100%;
@@ -147,10 +148,6 @@
   .Addon-persona & {
     height: 100px;
     object-position: top right;
-  }
-
-  @include respond-to(extraExtraLarge) {
-    width: auto;
   }
 }
 

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -45,5 +45,6 @@ $padding-page-l: 24px;
 // Restrict the max-width of modals.
 $max-modal-width: 768px;
 
-// Theme height
+// Theme image dimensions
 $theme-height-default: 92px;
+$theme-width-default: 680px;


### PR DESCRIPTION
fixes #5176 - fixes style issue seen when theme has a badge associated with it

before (badge text wraps here):
![Alt text](https://monosnap.com/image/KTm8slwEH6wN26ZUsHG68UtX2ijfg4.png)

after (no wrapping badge text):
![Alt text](https://monosnap.com/image/cIlaHtxeDLg1GML0LvGmjSrbanJvNB.png)