### PR TITLE
Delete a collection - UI portion

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -289,9 +289,11 @@ export class CollectionBase extends React.Component<Props> {
 
   renderDeleteButton() {
     const { hasEditPermission, i18n } = this.props;
+
     if (!hasEditPermission) {
       return null;
     }
+
     return (
       <ConfirmButton
         buttonType="cancel"

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -10,6 +10,7 @@ import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
 import {
   removeAddonFromCollection,
+  deleteCollection,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   getCurrentCollection,
@@ -28,6 +29,7 @@ import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
 import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
+import ConfirmButton from 'ui/components/ConfirmButton';
 import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
 import type {
@@ -74,6 +76,28 @@ export class CollectionBase extends React.Component<Props> {
 
   componentWillReceiveProps(nextProps: Props) {
     this.loadDataIfNeeded(nextProps);
+  }
+
+  onDelete = (event: SyntheticEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+
+    const { dispatch, errorHandler, collection } = this.props;
+
+    invariant(collection, 'collection is required');
+
+    const {
+      slug,
+      authorUsername: username,
+    } = collection;
+
+    invariant(slug, 'slug is required');
+    invariant(username, 'username is required');
+
+    dispatch(deleteCollection({
+      errorHandlerId: errorHandler.id,
+      slug,
+      username,
+    }));
   }
 
   loadDataIfNeeded(nextProps?: Props) {
@@ -263,6 +287,23 @@ export class CollectionBase extends React.Component<Props> {
     /* eslint-enable react/no-danger */
   }
 
+  renderDeleteButton() {
+    const { hasEditPermission, i18n } = this.props;
+    if (!hasEditPermission) {
+      return null;
+    }
+    return (
+      <ConfirmButton
+        buttonType="cancel"
+        className="Collection-delete-button"
+        message={i18n.gettext('Do you really want to delete this collection?')}
+        onConfirm={this.onDelete}
+      >
+        {i18n.gettext('Delete this collection')}
+      </ConfirmButton>
+    );
+  }
+
   renderCollection() {
     const {
       collection,
@@ -278,6 +319,7 @@ export class CollectionBase extends React.Component<Props> {
       <div className="Collection-wrapper">
         <Card className="Collection-detail">
           {this.renderCardContents()}
+          {this.renderDeleteButton()}
         </Card>
         <div className="Collection-items">
           <AddonsCard

--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -86,3 +86,11 @@
   margin-top: $padding-page;
   width: 100%;
 }
+
+.Collection-delete-button {
+  margin: 12px 0;
+
+  .ConfirmButton-default-button {
+    width: 100%;
+  }
+}

--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -88,7 +88,7 @@
 }
 
 .Collection-delete-button {
-  margin: 12px 0;
+  margin-top: 16px;
 
   .ConfirmButton-default-button {
     width: 100%;

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -326,6 +326,7 @@ export function* deleteCollection({
 
   try {
     const state = yield select(getState);
+    const { lang, clientApp } = state.api;
 
     const params: DeleteCollectionParams = {
       api: state.api,
@@ -338,6 +339,10 @@ export function* deleteCollection({
       errorHandlerId: errorHandler.id,
       username,
     }));
+    // Eventually we will redirect to the user's list of collections,
+    // but for now we'll just redirect to the home page.
+    // See:https://github.com/mozilla/addons-frontend/issues/3142
+    yield put(pushLocation(`/${lang}/${clientApp}`));
   } catch (error) {
     log.warn(`Failed to delete collection: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -335,6 +335,9 @@ export function* deleteCollection({
     };
     yield call(api.deleteCollection, params);
 
+    // Unload the collection from state.
+    yield put(deleteCollectionBySlug(slug));
+
     yield put(fetchUserCollectionsAction({
       errorHandlerId: errorHandler.id,
       username,

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -341,7 +341,7 @@ export function* deleteCollection({
     }));
     // Eventually we will redirect to the user's list of collections,
     // but for now we'll just redirect to the home page.
-    // See:https://github.com/mozilla/addons-frontend/issues/3142
+    // See: https://github.com/mozilla/addons-frontend/issues/3142
     yield put(pushLocation(`/${lang}/${clientApp}`));
   } catch (error) {
     log.warn(`Failed to delete collection: ${error}`);

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -680,16 +680,12 @@ describe(__filename, () => {
     const { onDelete } = wrapper.instance();
     const button = wrapper.find(ConfirmButton);
     expect(button).toHaveLength(1);
-    expect(button)
-      .toHaveClassName('Collection-delete-button');
-    expect(button)
-      .toHaveProp('buttonType', 'cancel');
+    expect(button).toHaveClassName('Collection-delete-button');
+    expect(button).toHaveProp('buttonType', 'cancel');
     expect(button)
       .toHaveProp('message', 'Do you really want to delete this collection?');
-    expect(button)
-      .toHaveProp('onConfirm', onDelete);
-    expect(button.children())
-      .toHaveText('Delete this collection');
+    expect(button).toHaveProp('onConfirm', onDelete);
+    expect(button.children()).toHaveText('Delete this collection');
   });
 
   it('links to a Collection edit page', () => {
@@ -787,7 +783,7 @@ describe(__filename, () => {
     expect(wrapper.find(ConfirmButton)).toHaveLength(1);
   });
 
-  it('Does not render a delete button when user does not have permission', () => {
+  it('does not render a delete button when user does not have permission', () => {
     const authorUserId = 11;
     const { store } = dispatchSignInActions({ userId: authorUserId });
 
@@ -971,7 +967,8 @@ describe(__filename, () => {
     dispatchSpy.reset();
 
     // This emulates a user clicking the delete button and confirming.
-    wrapper.instance().onDelete(
+    const onDelete = wrapper.find(ConfirmButton).prop('onConfirm');
+    onDelete(
       createFakeEvent({ preventDefault: preventDefaultSpy })
     );
 

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -11,19 +11,22 @@ import NotFound from 'amo/components/ErrorPage/NotFound';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import Paginate from 'core/components/Paginate';
 import Button from 'ui/components/Button';
+import ConfirmButton from 'ui/components/ConfirmButton';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
 import MetadataCard from 'ui/components/MetadataCard';
 import {
-  removeAddonFromCollection,
+  deleteCollection,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
   loadCurrentCollection,
+  removeAddonFromCollection,
 } from 'amo/reducers/collections';
 import { createApiError } from 'core/api/index';
 import { COLLECTIONS_EDIT } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
 import {
+  createFakeEvent,
   createStubErrorHandler,
   fakeI18n,
   fakeRouterLocation,
@@ -661,6 +664,34 @@ describe(__filename, () => {
     expect(wrapper.find('.Collection-edit-link')).toHaveLength(1);
   });
 
+  it('renders a delete button when user has `Collections:Edit` permission', () => {
+    const { store } = dispatchSignInActions({
+      userProps: {
+        permissions: [COLLECTIONS_EDIT],
+      },
+    });
+
+    store.dispatch(loadCurrentCollection({
+      addons: createFakeCollectionAddons(),
+      detail: defaultCollectionDetail,
+    }));
+
+    const wrapper = renderComponent({ store });
+    const { onDelete } = wrapper.instance();
+    const button = wrapper.find(ConfirmButton);
+    expect(button).toHaveLength(1);
+    expect(button)
+      .toHaveClassName('Collection-delete-button');
+    expect(button)
+      .toHaveProp('buttonType', 'cancel');
+    expect(button)
+      .toHaveProp('message', 'Do you really want to delete this collection?');
+    expect(button)
+      .toHaveProp('onConfirm', onDelete);
+    expect(button.children())
+      .toHaveText('Delete this collection');
+  });
+
   it('links to a Collection edit page', () => {
     // Turn off the enableNewCollectionsUI feature so that the component renders a link.
     const fakeConfig = getFakeConfig({ enableNewCollectionsUI: false });
@@ -739,6 +770,36 @@ describe(__filename, () => {
 
     const wrapper = renderComponent({ store });
     expect(wrapper.find('.Collection-edit-link')).toHaveLength(1);
+  });
+
+  it('renders a delete button when user is the collection owner', () => {
+    const authorUserId = 11;
+    const { store } = dispatchSignInActions({ userId: authorUserId });
+
+    store.dispatch(loadCurrentCollection({
+      addons: createFakeCollectionAddons(),
+      detail: createFakeCollectionDetail({
+        authorId: authorUserId,
+      }),
+    }));
+
+    const wrapper = renderComponent({ store });
+    expect(wrapper.find(ConfirmButton)).toHaveLength(1);
+  });
+
+  it('Does not render a delete button when user does not have permission', () => {
+    const authorUserId = 11;
+    const { store } = dispatchSignInActions({ userId: authorUserId });
+
+    store.dispatch(loadCurrentCollection({
+      addons: createFakeCollectionAddons(),
+      detail: createFakeCollectionDetail({
+        authorId: 99,
+      }),
+    }));
+
+    const wrapper = renderComponent({ store });
+    expect(wrapper.find(ConfirmButton)).toHaveLength(0);
   });
 
   it('passes a collection to CollectionManager when editing', () => {
@@ -883,6 +944,43 @@ describe(__filename, () => {
       page: 1,
       slug: collectionDetail.slug,
       username: collectionDetail.author.username,
+    }));
+  });
+
+  it('dispatches deleteCollection when onDelete is called', () => {
+    const authorUserId = 11;
+    const slug = 'some-slug';
+    const username = 'some-username';
+    const { store } = dispatchSignInActions({ userId: authorUserId });
+
+    store.dispatch(loadCurrentCollection({
+      addons: createFakeCollectionAddons(),
+      detail: createFakeCollectionDetail({
+        authorId: authorUserId,
+        authorUsername: username,
+        slug,
+      }),
+    }));
+
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const preventDefaultSpy = sinon.spy();
+    const errorHandler = createStubErrorHandler();
+
+    const wrapper = renderComponent({ errorHandler, store });
+
+    dispatchSpy.reset();
+
+    // This emulates a user clicking the delete button and confirming.
+    wrapper.instance().onDelete(
+      createFakeEvent({ preventDefault: preventDefaultSpy })
+    );
+
+    sinon.assert.calledOnce(preventDefaultSpy);
+    sinon.assert.callCount(dispatchSpy, 1);
+    sinon.assert.calledWith(dispatchSpy, deleteCollection({
+      errorHandlerId: errorHandler.id,
+      slug,
+      username,
     }));
   });
 

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -754,6 +754,11 @@ describe(__filename, () => {
 
       _deleteCollection(params);
 
+      const expectedUnloadAction = deleteCollectionBySlug(params.slug);
+
+      const unloadAction = await sagaTester.waitFor(expectedUnloadAction.type);
+      expect(unloadAction).toEqual(expectedUnloadAction);
+
       const expectedFetchAction = fetchUserCollections({
         errorHandlerId: errorHandler.id,
         username: params.username,

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -740,6 +740,7 @@ describe(__filename, () => {
         username: 'some-other-user',
       };
       const state = sagaTester.getState();
+      const { lang, clientApp } = state.api;
 
       mockApi
         .expects('deleteCollection')
@@ -760,6 +761,11 @@ describe(__filename, () => {
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);
       expect(fetchAction).toEqual(expectedFetchAction);
+
+      const expectedPushAction = pushLocation(`/${lang}/${clientApp}`);
+
+      const pushAction = await sagaTester.waitFor(expectedPushAction.type);
+      expect(pushAction).toEqual(expectedPushAction);
       mockApi.verify();
     });
 


### PR DESCRIPTION
Fixes #4195 

Depends on #5161 

This adds a "Delete this collection" button to the Collection screen, both in display and edit mode, which only appears if the user has access to delete the collection. For now I have styled it similar to the "Delete this picture" button on the User Profile.

Detail screen:

<img width="481" alt="screenshot 2018-06-04 13 30 18" src="https://user-images.githubusercontent.com/142755/40932170-7252477e-67fb-11e8-91f3-f3fe38a35716.png">

With confirmation:

<img width="467" alt="screenshot 2018-06-04 13 31 57" src="https://user-images.githubusercontent.com/142755/40932238-b3f32158-67fb-11e8-9c8b-5fa4c6a7dd13.png">

Edit screen:

<img width="472" alt="screenshot 2018-06-04 13 30 48" src="https://user-images.githubusercontent.com/142755/40932189-831925e6-67fb-11e8-82c0-270e54533125.png">

With confirmation:

<img width="469" alt="screenshot 2018-06-04 13 32 32" src="https://user-images.githubusercontent.com/142755/40932267-c8a5a332-67fb-11e8-831d-9b9f9edafeea.png">

