### PR TITLE
Fix delete picture button style

### DIFF
--- a/src/amo/components/UserProfileEditPicture/styles.scss
+++ b/src/amo/components/UserProfileEditPicture/styles.scss
@@ -46,14 +46,19 @@ $picture-size: 128px;
   }
 
   .UserProfileEditPicture-delete-button {
-    margin: 12px 0;
+    margin: 24px 0 12px;
 
     .ConfirmButton-default-button {
-      width: $picture-size;
+      height: auto;
+      width: 100%;
     }
 
     @include respond-to(medium) {
-      width: $picture-size;
+      width: 290px;
+    }
+
+    @include respond-to(large) {
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
Fix #5189

---

I made the button larger and centered under the picture + "upload" button.

![2018-06-05 15 43 16](https://user-images.githubusercontent.com/217628/40979921-74fdb59e-68d7-11e8-9988-3f16f9e1f67f.gif)
