### PR TITLE
Send credentials when deleting user account

### DIFF
--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -121,6 +121,7 @@ export function deleteUserAccount({ api, userId }: {|
 
   return callApi({
     auth: true,
+    credentials: true,
     endpoint: `accounts/account/${userId}`,
     method: 'DELETE',
     state: api,

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -178,6 +178,7 @@ describe(__filename, () => {
       mockApi.expects('callApi')
         .withArgs({
           auth: true,
+          credentials: true,
           endpoint: `accounts/account/${params.userId}`,
           method: 'DELETE',
           state: params.api,


### PR DESCRIPTION
Fix #5190 

---

This is needed to configure `fetch` to send credentials (`include`) so that cookies can be set. We want this because the API sets new (empty) cookies when the current logged-in user deletes their profile in order to log out this user successfully.