### PR TITLE
Revert "Fix border radius in the about this extension card (#5050)"

### DIFF
--- a/src/ui/components/Card/styles.scss
+++ b/src/ui/components/Card/styles.scss
@@ -23,11 +23,6 @@ $footer-padding: 10px;
   font-size: $font-size-s;
   margin: 0;
 
-  @include respond-to(large) {
-    border-bottom-left-radius: $border-radius-default;
-    border-bottom-right-radius: $border-radius-default;
-  }
-
   .Card--no-header & {
     border-top-left-radius: $border-radius-default;
     border-top-right-radius: $border-radius-default;


### PR DESCRIPTION
Fix https://github.com/mozilla/addons-frontend/issues/5199

---

## Before

The reverted commit creates another bug on some cards (see the corners below the grey button):

![screen shot 2018-06-05 at 18 57 14](https://user-images.githubusercontent.com/217628/40990890-7d311f1a-68f2-11e8-9d12-b75caf13ff6c.png)

The UI bug fixed by the reverted commit was almost invisible whereas this one is quite visible... That's why I think it makes sense to revert the patch and work on the original issue later.

Original issue is: https://github.com/mozilla/addons-frontend/issues/4884

## After

![screen shot 2018-06-05 at 19 10 12](https://user-images.githubusercontent.com/217628/40991468-2958677a-68f4-11e8-9524-a435f6add75f.png)


