### PR TITLE
Hide notifications information for non-developer users

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -20,6 +20,7 @@ import {
   getCurrentUser,
   getUserByUsername,
   hasPermission,
+  isDeveloper,
   logOutUser,
 } from 'amo/reducers/users';
 import AuthenticateButton from 'core/components/AuthenticateButton';
@@ -662,7 +663,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 user={user}
               />
 
-              {isEditingCurrentUser && (
+              {(isEditingCurrentUser && isDeveloper(user)) && (
                 <p className="UserProfileEdit-notifications--help">
                   {i18n.gettext(`Mozilla reserves the right to contact you
                     individually about specific concerns with your hosted

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -359,6 +359,14 @@ export const getCurrentUser = (users: UsersStateType) => {
   return currentUser;
 };
 
+export const isDeveloper = (user: UserType | null): boolean => {
+  if (!user) {
+    return false;
+  }
+
+  return user.is_addon_developer || user.is_artist;
+};
+
 export const hasPermission = (
   state: { users: UsersStateType }, permission: string,
 ): boolean => {

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -360,6 +360,31 @@ describe(__filename, () => {
       forbidden.`
     );
 
+    expect(root.find('.UserProfileEdit-notifications--help')).toHaveLength(0);
+  });
+
+  it('renders a help text about add-on notifications for users who are developers', () => {
+    const root = renderUserProfileEdit({
+      userProps: {
+        ...defaultUserProps,
+        is_addon_developer: true,
+      },
+    });
+
+    expect(root.find('.UserProfileEdit-notifications--help')).toHaveText(
+      oneLine`Mozilla reserves the right to contact you individually about
+      specific concerns with your hosted add-ons.`
+    );
+  });
+
+  it('renders a help text about add-on notifications for users who are artists', () => {
+    const root = renderUserProfileEdit({
+      userProps: {
+        ...defaultUserProps,
+        is_artist: true,
+      },
+    });
+
     expect(root.find('.UserProfileEdit-notifications--help')).toHaveText(
       oneLine`Mozilla reserves the right to contact you individually about
       specific concerns with your hosted add-ons.`

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -1,13 +1,14 @@
 import reducer, {
   LOAD_USER_ACCOUNT,
-  finishEditUserAccount,
   editUserAccount,
+  finishEditUserAccount,
   getCurrentUser,
   getUserById,
   getUserByUsername,
   hasAnyReviewerRelatedPermission,
   hasPermission,
   initialState,
+  isDeveloper,
   loadCurrentUserAccount,
   loadUserAccount,
   loadUserNotifications,
@@ -356,6 +357,34 @@ describe(__filename, () => {
 
       expect(getUserByUsername(state.users, 'tupac'))
         .toEqual(state.users.byID[500]);
+    });
+  });
+
+  describe('isDeveloper', () => {
+    it('returns false when user is null', () => {
+      expect(isDeveloper(null)).toEqual(false);
+    });
+
+    it('returns true when user is an artist', () => {
+      const user = createUserAccountResponse({
+        is_artist: true,
+      });
+
+      expect(isDeveloper(user)).toEqual(true);
+    });
+
+    it('returns true when user is an add-on developer', () => {
+      const user = createUserAccountResponse({
+        is_addon_developer: true,
+      });
+
+      expect(isDeveloper(user)).toEqual(true);
+    });
+
+    it('returns false when user is not a developer', () => {
+      const user = createUserAccountResponse();
+
+      expect(isDeveloper(user)).toEqual(false);
     });
   });
 });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -381,6 +381,8 @@ export function createUserAccountResponse({
   /* eslint-disable camelcase */
   average_addon_rating = 4.3,
   display_name = null,
+  is_addon_developer = false,
+  is_artist = false,
   num_addons_listed = 1,
   picture_url = `${config.get('amoCDN')}/static/img/zamboni/anon_user.png`,
   picture_type = '',
@@ -397,8 +399,8 @@ export function createUserAccountResponse({
     display_name,
     homepage,
     id,
-    is_addon_developer: false,
-    is_artist: false,
+    is_addon_developer,
+    is_artist,
     location,
     // This is the API behavior.
     // eslint-disable-next-line camelcase


### PR DESCRIPTION
Fix #5206

---

This PR introduces a `isDeveloper()` selector to quickly determine
whether a user is an artist or add-on developer.


Before:

![](https://user-images.githubusercontent.com/31961530/41023236-803cb5ca-6974-11e8-92c0-a3b9b4bf7b35.png)

After:

![screen shot 2018-06-06 at 11 52 17](https://user-images.githubusercontent.com/217628/41031152-445ec1d6-6980-11e8-9f18-c67cd98fc675.png)
