### PR TITLE
Disable confirm button when user to delete has add-ons

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -747,6 +747,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
               <Button
                 buttonType="alert"
                 className="UserProfileEdit-button UserProfileEdit-confirm-button"
+                disabled={user && user.num_addons_listed > 0}
                 onClick={this.onConfirmProfileDeletion}
                 puffy
               >

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -1151,7 +1151,7 @@ describe(__filename, () => {
     expect(root.find('.UserProfileEdit-cancel-button')).toHaveLength(1);
   });
 
-  it('disables the confirm button is user has listed add-ons', () => {
+  it('disables the confirm button if user has listed add-ons', () => {
     const { store } = dispatchSignInActions({
       userProps: {
         ...defaultUserProps,

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -53,6 +53,7 @@ describe(__filename, () => {
     display_name: 'Matt MacTofu',
     homepage: 'https://example.org',
     location: 'Earth',
+    num_addons_listed: 0,
     occupation: 'Superman',
     userId: 500,
     username: 'tofumatt',
@@ -1145,7 +1146,29 @@ describe(__filename, () => {
     expect(root.find('.UserProfileEdit-confirm-button')).toHaveLength(1);
     expect(root.find('.UserProfileEdit-confirm-button').children())
       .toHaveText('Yes, delete my profile');
+    expect(root.find('.UserProfileEdit-confirm-button'))
+      .toHaveProp('disabled', false);
     expect(root.find('.UserProfileEdit-cancel-button')).toHaveLength(1);
+  });
+
+  it('disables the confirm button is user has listed add-ons', () => {
+    const { store } = dispatchSignInActions({
+      userProps: {
+        ...defaultUserProps,
+        num_addons_listed: 1,
+      },
+    });
+
+    const root = renderUserProfileEdit({ store });
+
+    // Open the modal.
+    root.find('.UserProfileEdit-delete-button').simulate(
+      'click',
+      createFakeEvent()
+    );
+
+    expect(root.find('.UserProfileEdit-confirm-button'))
+      .toHaveProp('disabled', true);
   });
 
   it('renders different information in the modal when user to be deleted is not the current logged-in user', () => {


### PR DESCRIPTION
Fix #5207
Fix #5211

---

This PR disables the confirm button to avoid a user or admin to delete a
user profile that owns add-ons.

### After

regular user:

![screen shot 2018-06-06 at 11 59 30](https://user-images.githubusercontent.com/217628/41031890-270ce0d4-6982-11e8-9318-92c74838e011.png)

admin:

![screen shot 2018-06-06 at 12 04 34](https://user-images.githubusercontent.com/217628/41031891-272e0e58-6982-11e8-995b-e515d70e1ecd.png)