### PR TITLE
Make sure we never pass null to a textarea

### DIFF
--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -35,7 +35,8 @@ export function editUserAccount({ api, picture, userId, ...editableFields }: {|
     const form = new FormData();
     // Add all the editable fields, one by one.
     Object.keys(editableFields).forEach((key: string) => {
-      form.set(key, editableFields[key]);
+      // We cannot send `null` values, only string values.
+      form.set(key, editableFields[key] === null ? '' : editableFields[key]);
     });
     // Add the picture file.
     form.set('picture_upload', picture);

--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -35,8 +35,9 @@ export function editUserAccount({ api, picture, userId, ...editableFields }: {|
     const form = new FormData();
     // Add all the editable fields, one by one.
     Object.keys(editableFields).forEach((key: string) => {
-      // We cannot send `null` values, only string values.
-      form.set(key, editableFields[key] === null ? '' : editableFields[key]);
+      // We cannot send `null` values, so we send empty string values instead.
+      const value = editableFields[key];
+      form.set(key, value === null ? '' : value);
     });
     // Add the picture file.
     form.set('picture_upload', picture);

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -610,7 +610,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 id="biography"
                 name="biography"
                 onChange={this.onFieldChange}
-                value={this.state.biography}
+                value={this.state.biography || ''}
               />
               <p className="UserProfileEdit-biography--help">
                 {i18n.sprintf(i18n.gettext(

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -106,6 +106,32 @@ describe(__filename, () => {
       await editUserAccount(params);
       mockApi.verify();
     });
+
+    it('converts null values to empty strings when sending FormData body', async () => {
+      const editableFields = {
+        biography: null,
+        location: 'some location',
+      };
+      const picture = new File([], 'image.png');
+      const params = getParams({ picture, ...editableFields });
+
+      const expectedBody = new FormData();
+      expectedBody.set('biography', '');
+      expectedBody.set('location', editableFields.location);
+      expectedBody.set('picture_upload', picture);
+
+      mockApi.expects('callApi')
+        .withArgs(sinon.match(({ body }) => {
+          return deepEqual(
+            Array.from(body.entries()),
+            Array.from(expectedBody.entries())
+          );
+        }))
+        .returns(mockResponse());
+
+      await editUserAccount(params);
+      mockApi.verify();
+    });
   });
 
   describe('userAccount', () => {

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -462,6 +462,20 @@ describe(__filename, () => {
       .toHaveProp('value', biography);
   });
 
+  // See: https://github.com/mozilla/addons-frontend/issues/5212
+  it('sets the biography value to empty string if user has no biography', () => {
+    const biography = null;
+    const root = renderUserProfileEdit({
+      userProps: {
+        ...defaultUserProps,
+        biography,
+      },
+    });
+
+    expect(root.find('.UserProfileEdit-biography')).toHaveLength(1);
+    expect(root.find('.UserProfileEdit-biography')).toHaveProp('value', '');
+  });
+
   it('captures input field changes ', () => {
     const fields = [
       'biography',


### PR DESCRIPTION
Fix #5212

---

This PR fixes an issue caused by a `textarea` component, which does not
accept `null` as a valid value. It outputs a warning in the dev tools
but also converts `null` to `"null"` (string) on submit, causing the
issue reported in #5212.