### PR TITLE
Fetch user notifications after profile picture deletion

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -170,6 +170,13 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     }
 
     if (oldUser && oldUser.picture_url && newUser && !newUser.picture_url) {
+      if (!newUser.notifications) {
+        dispatch(fetchUserNotifications({
+          errorHandlerId: errorHandler.id,
+          username: newUsername,
+        }));
+      }
+
       this.setState({
         picture: null,
         pictureData: null,

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -1081,6 +1081,39 @@ describe(__filename, () => {
     expect(root).toHaveState('pictureData', null);
   });
 
+  it('fetches the user notifications after having deleted a profile picture', () => {
+    const username = 'tofumatt';
+    const { store } = dispatchSignInActions({
+      userProps: {
+        ...defaultUserProps,
+        picture_url: 'https://example.org/pp.png',
+        username,
+      },
+    });
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const errorHandler = createStubErrorHandler();
+
+    const root = renderUserProfileEdit({ errorHandler, store });
+    const user = getCurrentUser(store.getState().users);
+
+    dispatchSpy.reset();
+    sinon.assert.notCalled(dispatchSpy);
+
+    // The user profile picture has been successfully deleted.
+    root.setProps({
+      user: {
+        ...user,
+        picture_url: null,
+      },
+    });
+
+    sinon.assert.calledOnce(dispatchSpy);
+    sinon.assert.calledWith(dispatchSpy, fetchUserNotifications({
+      errorHandlerId: errorHandler.id,
+      username,
+    }));
+  });
+
   it('displays a modal when user clicks the delete profile button', () => {
     const { store } = signInUserWithUsername('tofumatt');
     const preventDefaultSpy = sinon.spy();


### PR DESCRIPTION
Fix #5214

---

This PR guarantees that the user notifications are (re)loaded after the
user has deleted their profile picture. It was not the case before this
PR because, after the profile picture deletion, we load the new user
data (from the `DELETE` API call response), thus removing the stored
user notifications for this user.