### PR TITLE
I5174-fix for search listing/mobile context

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -150,11 +150,6 @@ export class AddonBase extends React.Component {
       const previewHeader = addon.previews.length && addon.previews[0];
 
       let previewURL =
-        previewHeader && previewHeader.thumbnail_url
-          ? previewHeader.thumbnail_url
-          : null;
-
-      const previewUrlLarge =
         previewHeader && previewHeader.image_url
           ? previewHeader.image_url
           : null;
@@ -171,23 +166,11 @@ export class AddonBase extends React.Component {
         previewURL = addon.previewURL;
       }
 
-      const imageAtts = {};
-      if (previewUrlLarge) {
-        const imageWidth = previewHeader && previewHeader.image_size[0];
-        const thumbWidth = previewHeader && previewHeader.thumbnail_size[0];
-        if (imageWidth && thumbWidth) {
-          // If viewing on retina, it should only show the larger size with
-          // the current widths available
-          imageAtts.srcSet = `${previewURL} ${thumbWidth}w, ${previewUrlLarge} ${imageWidth}w`;
-        }
-      }
-
       const headerImage = (
         <img
           alt={label}
           className="Addon-theme-header-image"
           src={previewURL}
-          {...imageAtts}
         />
       );
 

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -148,8 +148,16 @@ export class AddonBase extends React.Component {
 
     if (this.addonIsTheme()) {
       const previewHeader = addon.previews.length && addon.previews[0];
-      let previewURL = previewHeader.thumbnail_url || null;
-      const previewURLLarge = previewHeader.image_url || null;
+
+      let previewURL =
+        previewHeader && previewHeader.thumbnail_url
+          ? previewHeader.thumbnail_url
+          : null;
+
+      const previewUrlLarge =
+        previewHeader && previewHeader.image_url
+          ? previewHeader.image_url
+          : null;
 
       const label = addon
         ? i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
@@ -164,13 +172,13 @@ export class AddonBase extends React.Component {
       }
 
       const imageAtts = {};
-      if (previewURLLarge) {
-        const imageSize = previewHeader.image_size[0];
-        const thumbSize = previewHeader.thumbnail_size[0];
-        if (imageSize && thumbSize) {
+      if (previewUrlLarge) {
+        const imageWidth = previewHeader && previewHeader.image_size[0];
+        const thumbWidth = previewHeader && previewHeader.thumbnail_size[0];
+        if (imageWidth && thumbWidth) {
           // If viewing on retina, it should only show the larger size with
           // the current widths available
-          imageAtts.srcSet = `${previewURL} ${thumbSize}w, ${previewURLLarge} ${imageSize}w`;
+          imageAtts.srcSet = `${previewURL} ${thumbWidth}w, ${previewUrlLarge} ${imageWidth}w`;
         }
       }
 

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -147,10 +147,9 @@ export class AddonBase extends React.Component {
     const { addon, i18n } = this.props;
 
     if (this.addonIsTheme()) {
-      let previewURL =
-        addon.previews.length > 0 && addon.previews[0].image_url
-          ? addon.previews[0].image_url
-          : null;
+      const previewHeader = addon.previews.length && addon.previews[0];
+      let previewURL = previewHeader.thumbnail_url || null;
+      const previewURLLarge = previewHeader.image_url || null;
 
       const label = addon
         ? i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
@@ -164,11 +163,24 @@ export class AddonBase extends React.Component {
         previewURL = addon.previewURL;
       }
 
+      const imageAtts = {};
+      if (previewURLLarge) {
+        const imageSize = previewHeader.image_size[0];
+        const thumbSize = previewHeader.thumbnail_size[0];
+        if (imageSize && thumbSize) {
+          // If viewing on retina, it should only show the larger size with
+          // the current widths available
+          imageAtts.srcSet = `${previewURL} ${thumbSize}w, ${previewURLLarge} ${imageSize}w`;
+        }
+      }
+
+      const imageClassName = 'Addon-theme-header-image';
       const headerImage = (
         <img
           alt={label}
-          className="Addon-theme-header-image"
+          className={imageClassName}
           src={previewURL}
+          {...imageAtts}
         />
       );
 

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -182,11 +182,10 @@ export class AddonBase extends React.Component {
         }
       }
 
-      const imageClassName = 'Addon-theme-header-image';
       const headerImage = (
         <img
           alt={label}
-          className={imageClassName}
+          className="Addon-theme-header-image"
           src={previewURL}
           {...imageAtts}
         />

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -125,17 +125,6 @@
   overflow-y: hidden;
   position: relative;
   width: 100%;
-
-  @include respond-to(extraLarge) {
-    height: $theme-height-default;
-  }
-
-  .Addon-persona & {
-
-    @include respond-to(extraLarge) {
-      height: 100px;
-    }
-  }
 }
 
 .Addon-theme-header-label {
@@ -152,18 +141,6 @@
   object-fit: cover;
   object-position: top left;
   width: 100%;
-
-  @include respond-to(extraLarge) {
-    height: $theme-height-default;
-  }
-
-  .Addon-persona & {
-    object-position: top right;
-
-    @include respond-to(extraLarge) {
-      height: 100px;
-    }
-  }
 }
 
 .Addon-summary-and-install-button-wrapper {

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -119,15 +119,22 @@
 
 .Addon-theme-header {
   border-radius: $border-radius-default;
-  height: $theme-height-default;
+  height: auto;
   max-width: $theme-width-default;
   order: -1;
   overflow-y: hidden;
   position: relative;
   width: 100%;
 
+  @include respond-to(extraLarge) {
+    height: $theme-height-default;
+  }
+
   .Addon-persona & {
-    height: 100px;
+
+    @include respond-to(extraLarge) {
+      height: 100px;
+    }
   }
 }
 
@@ -140,14 +147,22 @@
 .Addon-theme-header-image {
   border-radius: $border-radius-default;
   display: block;
-  height: $theme-height-default;
+  height: auto;
+  max-width: $theme-width-default;
   object-fit: cover;
   object-position: top left;
   width: 100%;
 
+  @include respond-to(extraLarge) {
+    height: $theme-height-default;
+  }
+
   .Addon-persona & {
-    height: 100px;
     object-position: top right;
+
+    @include respond-to(extraLarge) {
+      height: 100px;
+    }
   }
 }
 

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -44,7 +44,7 @@
         display: grid;
         grid-auto-flow: initial;
         grid-gap: 6px;
-        grid-template-columns: repeat(3, minmax(32%, 1fr));
+        grid-template-columns: repeat(2, minmax(50%, 1fr));
       }
     }
   }

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -13,6 +13,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import CategoryHeader from 'amo/components/CategoryHeader';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
+import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import { categoriesFetch } from 'core/actions/categories';
 import {
   ADDON_TYPE_EXTENSION,
@@ -252,10 +253,18 @@ export class CategoryBase extends React.Component {
 
     const { html } = this.contentForType(addonType);
 
+    const isAddonTheme = isTheme(addonType);
+
+    const themeProps = {};
+
+    if (isAddonTheme) {
+      themeProps.placeholderCount = LANDING_PAGE_THEME_COUNT;
+    }
+
     return (
       <div
         className={makeClassName('Category', {
-          'Category--theme': isTheme(addonType),
+          'Category--theme': isAddonTheme,
         })}
       >
         {category && (
@@ -278,7 +287,7 @@ export class CategoryBase extends React.Component {
             footerLink={html.featuredFooterLink}
             header={html.featuredHeader}
             loading={loading}
-            isTheme={isTheme(addonType)}
+            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -291,7 +300,7 @@ export class CategoryBase extends React.Component {
             footerText={html.highlyRatedFooterText}
             header={html.highlyRatedHeader}
             loading={loading}
-            isTheme={isTheme(addonType)}
+            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -304,7 +313,7 @@ export class CategoryBase extends React.Component {
             footerText={html.trendingFooterText}
             header={html.trendingHeader}
             loading={loading}
-            isTheme={isTheme(addonType)}
+            {...themeProps}
           />,
         )}
       </div>

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -13,7 +13,6 @@ import { setViewContext } from 'amo/actions/viewContext';
 import CategoryHeader from 'amo/components/CategoryHeader';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
-import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import { categoriesFetch } from 'core/actions/categories';
 import {
   ADDON_TYPE_EXTENSION,
@@ -255,12 +254,6 @@ export class CategoryBase extends React.Component {
 
     const isAddonTheme = isTheme(addonType);
 
-    const themeProps = {};
-
-    if (isAddonTheme) {
-      themeProps.placeholderCount = LANDING_PAGE_THEME_COUNT;
-    }
-
     return (
       <div
         className={makeClassName('Category', {
@@ -286,8 +279,8 @@ export class CategoryBase extends React.Component {
             footerText={html.featuredFooterText}
             footerLink={html.featuredFooterLink}
             header={html.featuredHeader}
+            isTheme={isAddonTheme}
             loading={loading}
-            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -299,8 +292,8 @@ export class CategoryBase extends React.Component {
             footerLink={html.highlyRatedFooterLink}
             footerText={html.highlyRatedFooterText}
             header={html.highlyRatedHeader}
+            isTheme={isAddonTheme}
             loading={loading}
-            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -312,8 +305,8 @@ export class CategoryBase extends React.Component {
             footerLink={html.trendingFooterLink}
             footerText={html.trendingFooterText}
             header={html.trendingHeader}
+            isTheme={isAddonTheme}
             loading={loading}
-            {...themeProps}
           />,
         )}
       </div>

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -278,6 +278,7 @@ export class CategoryBase extends React.Component {
             footerLink={html.featuredFooterLink}
             header={html.featuredHeader}
             loading={loading}
+            isTheme={isTheme(addonType)}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -290,6 +291,7 @@ export class CategoryBase extends React.Component {
             footerText={html.highlyRatedFooterText}
             header={html.highlyRatedHeader}
             loading={loading}
+            isTheme={isTheme(addonType)}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -302,6 +304,7 @@ export class CategoryBase extends React.Component {
             footerText={html.trendingFooterText}
             header={html.trendingHeader}
             loading={loading}
+            isTheme={isTheme(addonType)}
           />,
         )}
       </div>

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/no-unused-prop-types */
+import makeClassName from 'classnames';
 import PropTypes from 'prop-types';
 import config from 'config';
 import * as React from 'react';
@@ -29,6 +30,7 @@ import {
   apiAddonType,
   apiAddonTypeIsValid,
   getAddonTypeFilter,
+  isTheme,
 } from 'core/utils';
 
 import './styles.scss';
@@ -251,7 +253,11 @@ export class CategoryBase extends React.Component {
     const { html } = this.contentForType(addonType);
 
     return (
-      <div className="Category">
+      <div
+        className={makeClassName('Category', {
+          'Category--theme': isTheme(addonType),
+        })}
+      >
         {category && (
           <Helmet>
             <title>{`${category.name} – ${html.title}`}</title>

--- a/src/amo/components/Category/styles.scss
+++ b/src/amo/components/Category/styles.scss
@@ -9,6 +9,14 @@
   }
 }
 
+.Category--theme {
+  .Card-contents {
+    .AddonsCard-list {
+      grid-template-columns: repeat(3, 33%);
+    }
+  }
+}
+
 .Category .ErrorList {
   margin: 10px 10px 0;
 }

--- a/src/amo/components/FeaturedCollectionCard/index.js
+++ b/src/amo/components/FeaturedCollectionCard/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import makeClassNames from 'classnames';
 
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
+import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import { INSTALL_SOURCE_FEATURED_COLLECTION } from 'core/constants';
 import type { AddonType } from 'core/types/addons';
 
@@ -13,17 +14,13 @@ type Props = {|
   className: string,
   footerText: string,
   header: string,
-  isTheme?: boolean,
+  isTheme: boolean,
   loading: boolean,
   slug: string,
   username: string,
 |};
 
 export default class FeaturedCollectionCard extends React.Component<Props> {
-  static defaultProps = {
-    isTheme: false,
-  };
-
   render() {
     const {
       addons,
@@ -36,6 +33,12 @@ export default class FeaturedCollectionCard extends React.Component<Props> {
       username,
     } = this.props;
 
+    const themeProps = {};
+
+    if (isTheme) {
+      themeProps.placeholderCount = LANDING_PAGE_THEME_COUNT;
+    }
+
     return (
       <LandingAddonsCard
         addonInstallSource={INSTALL_SOURCE_FEATURED_COLLECTION}
@@ -46,8 +49,8 @@ export default class FeaturedCollectionCard extends React.Component<Props> {
         header={header}
         footerText={footerText}
         footerLink={`/collections/${username}/${slug}/`}
-        isTheme={isTheme}
         loading={loading}
+        {...themeProps}
       />
     );
   }

--- a/src/amo/components/FeaturedCollectionCard/index.js
+++ b/src/amo/components/FeaturedCollectionCard/index.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import makeClassNames from 'classnames';
 
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
-import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import { INSTALL_SOURCE_FEATURED_COLLECTION } from 'core/constants';
 import type { AddonType } from 'core/types/addons';
 
@@ -33,12 +32,6 @@ export default class FeaturedCollectionCard extends React.Component<Props> {
       username,
     } = this.props;
 
-    const themeProps = {};
-
-    if (isTheme) {
-      themeProps.placeholderCount = LANDING_PAGE_THEME_COUNT;
-    }
-
     return (
       <LandingAddonsCard
         addonInstallSource={INSTALL_SOURCE_FEATURED_COLLECTION}
@@ -50,7 +43,7 @@ export default class FeaturedCollectionCard extends React.Component<Props> {
         footerText={footerText}
         footerLink={`/collections/${username}/${slug}/`}
         loading={loading}
-        {...themeProps}
+        isTheme={isTheme}
       />
     );
   }

--- a/src/amo/components/FeaturedCollectionCard/index.js
+++ b/src/amo/components/FeaturedCollectionCard/index.js
@@ -1,27 +1,36 @@
 /* @flow */
 import * as React from 'react';
+import makeClassNames from 'classnames';
 
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import { INSTALL_SOURCE_FEATURED_COLLECTION } from 'core/constants';
 import type { AddonType } from 'core/types/addons';
+
+import './styles.scss';
 
 type Props = {|
   addons: Array<AddonType>,
   className: string,
   footerText: string,
   header: string,
+  isTheme?: boolean,
   loading: boolean,
   slug: string,
   username: string,
 |};
 
 export default class FeaturedCollectionCard extends React.Component<Props> {
+  static defaultProps = {
+    isTheme: false,
+  };
+
   render() {
     const {
       addons,
       className,
       footerText,
       header,
+      isTheme,
       loading,
       slug,
       username,
@@ -31,10 +40,13 @@ export default class FeaturedCollectionCard extends React.Component<Props> {
       <LandingAddonsCard
         addonInstallSource={INSTALL_SOURCE_FEATURED_COLLECTION}
         addons={addons}
-        className={className}
+        className={makeClassNames(className, {
+          'FeaturedCollection--theme': isTheme,
+        })}
         header={header}
         footerText={footerText}
         footerLink={`/collections/${username}/${slug}/`}
+        isTheme={isTheme}
         loading={loading}
       />
     );

--- a/src/amo/components/FeaturedCollectionCard/styles.scss
+++ b/src/amo/components/FeaturedCollectionCard/styles.scss
@@ -1,0 +1,9 @@
+
+
+.FeaturedCollection--theme {
+  &.AddonsCard--horizontal {
+    ul.AddonsCard-list {
+      grid-template-columns: repeat(3, 33%);
+    }
+  }
+}

--- a/src/amo/components/FeaturedCollectionCard/styles.scss
+++ b/src/amo/components/FeaturedCollectionCard/styles.scss
@@ -1,5 +1,3 @@
-
-
 .FeaturedCollection--theme {
   &.AddonsCard--horizontal {
     ul.AddonsCard-list {

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -10,6 +10,7 @@ import FeaturedCollectionCard from 'amo/components/FeaturedCollectionCard';
 import HomeHeroBanner from 'amo/components/HomeHeroBanner';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
+import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import { fetchHomeAddons } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
@@ -51,25 +52,26 @@ export const getFeaturedCollectionsMetadata = (i18n) => {
         'See more social media customization extensions',
       ),
       header: i18n.gettext('Social media customization'),
+      isTheme: false,
       ...FEATURED_COLLECTIONS[0],
-      isTheme: true,
     },
     {
       footerText: i18n.gettext('See more dynamic downloaders'),
       header: i18n.gettext('Dynamic downloaders'),
+      isTheme: false,
       ...FEATURED_COLLECTIONS[1],
     },
     {
       footerText: i18n.gettext('See more summer themes'),
       header: i18n.gettext('Summer themes'),
-      ...FEATURED_COLLECTIONS[2],
       isTheme: true,
+      ...FEATURED_COLLECTIONS[2],
     },
     {
       footerText: i18n.gettext('See more must-have media extensions'),
       header: i18n.gettext('Must-have media'),
+      isTheme: false,
       ...FEATURED_COLLECTIONS[3],
-      isTheme: true,
     },
   ];
 };
@@ -258,7 +260,6 @@ export class HomeBase extends React.Component {
             addonInstallSource={INSTALL_SOURCE_FEATURED}
             addons={featuredThemes}
             className="Home-FeaturedThemes"
-            header={i18n.gettext('Featured themes')}
             footerText={i18n.gettext('See more featured themes')}
             footerLink={{
               pathname: '/search/',
@@ -269,8 +270,9 @@ export class HomeBase extends React.Component {
                 featured: true,
               },
             }}
+            header={i18n.gettext('Featured themes')}
             loading={loading}
-            isTheme
+            placeholderCount={LANDING_PAGE_THEME_COUNT}
           />
         )}
 

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -52,6 +52,7 @@ export const getFeaturedCollectionsMetadata = (i18n) => {
       ),
       header: i18n.gettext('Social media customization'),
       ...FEATURED_COLLECTIONS[0],
+      isTheme: true,
     },
     {
       footerText: i18n.gettext('See more dynamic downloaders'),
@@ -62,11 +63,13 @@ export const getFeaturedCollectionsMetadata = (i18n) => {
       footerText: i18n.gettext('See more summer themes'),
       header: i18n.gettext('Summer themes'),
       ...FEATURED_COLLECTIONS[2],
+      isTheme: true,
     },
     {
       footerText: i18n.gettext('See more must-have media extensions'),
       header: i18n.gettext('Must-have media'),
       ...FEATURED_COLLECTIONS[3],
+      isTheme: true,
     },
   ];
 };
@@ -267,6 +270,7 @@ export class HomeBase extends React.Component {
               },
             }}
             loading={loading}
+            isTheme
           />
         )}
 
@@ -311,7 +315,6 @@ export class HomeBase extends React.Component {
             },
           }}
           loading={loading}
-          isTheme
         />
 
         {(loading || collections[3]) && (

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -311,6 +311,7 @@ export class HomeBase extends React.Component {
             },
           }}
           loading={loading}
+          isTheme
         />
 
         {(loading || collections[3]) && (

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -10,7 +10,6 @@ import FeaturedCollectionCard from 'amo/components/FeaturedCollectionCard';
 import HomeHeroBanner from 'amo/components/HomeHeroBanner';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
-import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import { fetchHomeAddons } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
@@ -271,8 +270,8 @@ export class HomeBase extends React.Component {
               },
             }}
             header={i18n.gettext('Featured themes')}
+            isTheme
             loading={loading}
-            placeholderCount={LANDING_PAGE_THEME_COUNT}
           />
         )}
 

--- a/src/amo/components/Home/styles.scss
+++ b/src/amo/components/Home/styles.scss
@@ -12,6 +12,14 @@
   }
 }
 
+.Home-FeaturedThemes {
+  .Card-contents {
+    .AddonsCard-list {
+      grid-template-columns: repeat(3, 33%);
+    }
+  }
+}
+
 .Home-SubjectShelf {
   .Card-header {
     display: block;

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -42,7 +42,8 @@ export default class LandingAddonsCard extends React.Component<Props> {
     } = this.props;
 
     let footerLinkHtml = null;
-    if (addons && addons.length >= placeholderCount) {
+    const count = isTheme ? LANDING_PAGE_THEME_COUNT : placeholderCount;
+    if (addons && addons.length >= count) {
       let linkTo = footerLink;
       if (linkTo && typeof linkTo === 'object') {
         // As a convenience, fix the query parameter.
@@ -63,7 +64,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
         header={header}
         type="horizontal"
         loading={loading}
-        placeholderCount={isTheme ? LANDING_PAGE_THEME_COUNT : placeholderCount}
+        placeholderCount={count}
       />
     );
   }

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -4,10 +4,7 @@ import * as React from 'react';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
-import {
-  LANDING_PAGE_EXTENSION_COUNT,
-  LANDING_PAGE_THEME_COUNT,
-} from 'amo/constants';
+import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { AddonType } from 'core/types/addons';
 
@@ -18,13 +15,13 @@ type Props = {|
   footerLink?: Object | string | null,
   footerText?: string,
   header?: React.Node,
-  isTheme?: boolean,
   loading: boolean,
+  placeholderCount: number,
 |};
 
 export default class LandingAddonsCard extends React.Component<Props> {
   static defaultProps = {
-    isTheme: false,
+    placeholderCount: LANDING_PAGE_EXTENSION_COUNT,
   };
 
   render() {
@@ -35,13 +32,9 @@ export default class LandingAddonsCard extends React.Component<Props> {
       footerLink,
       footerText,
       header,
-      isTheme,
       loading,
+      placeholderCount,
     } = this.props;
-
-    const placeholderCount = isTheme
-      ? LANDING_PAGE_THEME_COUNT
-      : LANDING_PAGE_EXTENSION_COUNT;
 
     let footerLinkHtml = null;
     if (addons && addons.length >= placeholderCount) {

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -18,11 +18,15 @@ type Props = {|
   footerLink?: Object | string | null,
   footerText?: string,
   header?: React.Node,
-  isTheme: boolean,
+  isTheme?: boolean,
   loading: boolean,
 |};
 
 export default class LandingAddonsCard extends React.Component<Props> {
+  static defaultProps = {
+    isTheme: false,
+  };
+
   render() {
     const {
       addonInstallSource,

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -34,8 +34,12 @@ export default class LandingAddonsCard extends React.Component<Props> {
       loading,
     } = this.props;
 
-    const filterType = footerLink.query ? footerLink.query.addonType : null;
-    const addonTypeArray = filterType ? filterType.split(',') : [];
+    const filterType =
+      footerLink && footerLink.query && footerLink.query.addonType
+        ? footerLink.query.addonType
+        : null;
+    const addonTypeArray =
+      filterType && typeof filterType === 'string' ? filterType.split(',') : [];
     const placeholderCount = addonTypeArray.find((type) => isTheme(type))
       ? LANDING_PAGE_THEME_ADDON_COUNT
       : LANDING_PAGE_ADDON_COUNT;

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -5,12 +5,11 @@ import * as React from 'react';
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
 import {
-  LANDING_PAGE_ADDON_COUNT,
-  LANDING_PAGE_THEME_ADDON_COUNT,
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { AddonType } from 'core/types/addons';
-import { isTheme } from 'core/utils';
 
 type Props = {|
   addonInstallSource?: string,
@@ -19,6 +18,7 @@ type Props = {|
   footerLink?: Object | string | null,
   footerText?: string,
   header?: React.Node,
+  isTheme: boolean,
   loading: boolean,
 |};
 
@@ -31,18 +31,13 @@ export default class LandingAddonsCard extends React.Component<Props> {
       footerLink,
       footerText,
       header,
+      isTheme,
       loading,
     } = this.props;
 
-    const filterType =
-      footerLink && footerLink.query && footerLink.query.addonType
-        ? footerLink.query.addonType
-        : null;
-    const addonTypeArray =
-      filterType && typeof filterType === 'string' ? filterType.split(',') : [];
-    const placeholderCount = addonTypeArray.find((type) => isTheme(type))
-      ? LANDING_PAGE_THEME_ADDON_COUNT
-      : LANDING_PAGE_ADDON_COUNT;
+    const placeholderCount = isTheme
+      ? LANDING_PAGE_THEME_COUNT
+      : LANDING_PAGE_EXTENSION_COUNT;
 
     let footerLinkHtml = null;
     if (addons && addons.length >= placeholderCount) {

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -4,7 +4,10 @@ import * as React from 'react';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
-import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
+} from 'amo/constants';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { AddonType } from 'core/types/addons';
 
@@ -15,6 +18,7 @@ type Props = {|
   footerLink?: Object | string | null,
   footerText?: string,
   header?: React.Node,
+  isTheme?: boolean,
   loading: boolean,
   placeholderCount: number,
 |};
@@ -32,6 +36,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
       footerLink,
       footerText,
       header,
+      isTheme,
       loading,
       placeholderCount,
     } = this.props;
@@ -58,7 +63,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
         header={header}
         type="horizontal"
         loading={loading}
-        placeholderCount={placeholderCount}
+        placeholderCount={isTheme ? LANDING_PAGE_THEME_COUNT : placeholderCount}
       />
     );
   }

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -4,9 +4,13 @@ import * as React from 'react';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import Link from 'amo/components/Link';
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_ADDON_COUNT,
+  LANDING_PAGE_THEME_ADDON_COUNT,
+} from 'amo/constants';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { AddonType } from 'core/types/addons';
+import { isTheme } from 'core/utils';
 
 type Props = {|
   addonInstallSource?: string,
@@ -16,14 +20,9 @@ type Props = {|
   footerText?: string,
   header?: React.Node,
   loading: boolean,
-  placeholderCount: number,
 |};
 
 export default class LandingAddonsCard extends React.Component<Props> {
-  static defaultProps = {
-    placeholderCount: LANDING_PAGE_ADDON_COUNT,
-  };
-
   render() {
     const {
       addonInstallSource,
@@ -33,8 +32,13 @@ export default class LandingAddonsCard extends React.Component<Props> {
       footerText,
       header,
       loading,
-      placeholderCount,
     } = this.props;
+
+    const filterType = footerLink.query ? footerLink.query.addonType : null;
+    const addonTypeArray = filterType ? filterType.split(',') : [];
+    const placeholderCount = addonTypeArray.find((type) => isTheme(type))
+      ? LANDING_PAGE_THEME_ADDON_COUNT
+      : LANDING_PAGE_ADDON_COUNT;
 
     let footerLinkHtml = null;
     if (addons && addons.length >= placeholderCount) {

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -27,6 +27,7 @@ import {
   apiAddonType,
   apiAddonTypeIsValid,
   getAddonTypeFilter,
+  isTheme,
   visibleAddonType as getVisibleAddonType,
 } from 'core/utils';
 import translate from 'core/i18n/translate';
@@ -230,7 +231,9 @@ export class LandingPageBase extends React.Component {
 
     return (
       <div
-        className={makeClassName('LandingPage', `LandingPage--${addonType}`)}
+        className={makeClassName('LandingPage', `LandingPage--${addonType}`, {
+          'LandingPage--theme': isTheme(addonType),
+        })}
       >
         <Helmet>
           <title>{headingText[addonType]}</title>

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -269,6 +269,7 @@ export class LandingPageBase extends React.Component {
             footerText={html.featuredFooterText}
             footerLink={html.featuredFooterLink}
             header={html.featuredHeader}
+            isTheme={isTheme(addonType)}
             loading={loading}
           />,
         )}
@@ -281,6 +282,7 @@ export class LandingPageBase extends React.Component {
             footerLink={html.highlyRatedFooterLink}
             footerText={html.highlyRatedFooterText}
             header={html.highlyRatedHeader}
+            isTheme={isTheme(addonType)}
             loading={loading}
           />,
         )}
@@ -293,6 +295,7 @@ export class LandingPageBase extends React.Component {
             footerLink={html.trendingFooterLink}
             footerText={html.trendingFooterText}
             header={html.trendingHeader}
+            isTheme={isTheme(addonType)}
             loading={loading}
           />,
         )}

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -12,7 +12,6 @@ import { setViewContext } from 'amo/actions/viewContext';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Categories from 'amo/components/Categories';
-import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -232,12 +231,6 @@ export class LandingPageBase extends React.Component {
 
     const isAddonTheme = isTheme(addonType);
 
-    const themeProps = {};
-
-    if (isAddonTheme) {
-      themeProps.placeholderCount = LANDING_PAGE_THEME_COUNT;
-    }
-
     return (
       <div
         className={makeClassName('LandingPage', `LandingPage--${addonType}`, {
@@ -278,8 +271,8 @@ export class LandingPageBase extends React.Component {
             footerText={html.featuredFooterText}
             footerLink={html.featuredFooterLink}
             header={html.featuredHeader}
+            isTheme={isAddonTheme}
             loading={loading}
-            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -291,8 +284,8 @@ export class LandingPageBase extends React.Component {
             footerLink={html.highlyRatedFooterLink}
             footerText={html.highlyRatedFooterText}
             header={html.highlyRatedHeader}
+            isTheme={isAddonTheme}
             loading={loading}
-            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -304,8 +297,8 @@ export class LandingPageBase extends React.Component {
             footerLink={html.trendingFooterLink}
             footerText={html.trendingFooterText}
             header={html.trendingHeader}
+            isTheme={isAddonTheme}
             loading={loading}
-            {...themeProps}
           />,
         )}
       </div>

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -12,6 +12,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Categories from 'amo/components/Categories';
+import { LANDING_PAGE_THEME_COUNT } from 'amo/constants';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -229,10 +230,18 @@ export class LandingPageBase extends React.Component {
         to customize Firefox and make the browser all your own.`),
     };
 
+    const isAddonTheme = isTheme(addonType);
+
+    const themeProps = {};
+
+    if (isAddonTheme) {
+      themeProps.placeholderCount = LANDING_PAGE_THEME_COUNT;
+    }
+
     return (
       <div
         className={makeClassName('LandingPage', `LandingPage--${addonType}`, {
-          'LandingPage--theme': isTheme(addonType),
+          'LandingPage--theme': isAddonTheme,
         })}
       >
         <Helmet>
@@ -269,8 +278,8 @@ export class LandingPageBase extends React.Component {
             footerText={html.featuredFooterText}
             footerLink={html.featuredFooterLink}
             header={html.featuredHeader}
-            isTheme={isTheme(addonType)}
             loading={loading}
+            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -282,8 +291,8 @@ export class LandingPageBase extends React.Component {
             footerLink={html.highlyRatedFooterLink}
             footerText={html.highlyRatedFooterText}
             header={html.highlyRatedHeader}
-            isTheme={isTheme(addonType)}
             loading={loading}
+            {...themeProps}
           />,
         )}
         {this.renderIfNotEmpty(
@@ -295,8 +304,8 @@ export class LandingPageBase extends React.Component {
             footerLink={html.trendingFooterLink}
             footerText={html.trendingFooterText}
             header={html.trendingHeader}
-            isTheme={isTheme(addonType)}
             loading={loading}
+            {...themeProps}
           />,
         )}
       </div>

--- a/src/amo/components/LandingPage/styles.scss
+++ b/src/amo/components/LandingPage/styles.scss
@@ -10,6 +10,14 @@
   }
 }
 
+.LandingPage--theme {
+  .Card-contents {
+    .AddonsCard-list {
+      grid-template-columns: repeat(3, 33%);
+    }
+  }
+}
+
 .LandingPage-header {
   background-color: $white;
   border-radius: $border-radius-default;

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -70,19 +70,21 @@ export class SearchResultBase extends React.Component<InternalProps> {
           ? previewImage.thumbnail_url
           : null;
 
+      // Let's only worry about setting up srcset if we have the correct
+      // preview for this.
       if (previewSearch) {
-        const themeURLLarge =
+        const themeUrlLarge =
           previewImage && isAllowedOrigin(previewImage.image_url)
             ? previewImage.image_url
             : null;
 
-        if (themeURLLarge) {
+        if (themeUrlLarge) {
           const imageSize = previewImage.image_size[0];
           const thumbSize = previewImage.thumbnail_size[0];
           if (imageSize && thumbSize) {
             // If viewing on retina, it should only show the larger size with
             // the current widths available
-            imageAtts.srcSet = `${themeURL} ${thumbSize}w, ${themeURLLarge} ${imageSize}w`;
+            imageAtts.srcSet = `${themeURL} ${thumbSize}w, ${themeUrlLarge} ${imageSize}w`;
           }
         }
       }
@@ -135,7 +137,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
             <img
               className="SearchResult-icon"
               src={imageURL}
-              alt=""
+              alt={addon ? `${addon.name}` : ''}
               {...imageAtts}
             />
           ) : (

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -8,7 +8,7 @@ import translate from 'core/i18n/translate';
 import { ADDON_TYPE_THEME, ADDON_TYPE_THEMES } from 'core/constants';
 import {
   addQueryParams,
-  isAllowedOrigin,
+  isAllowedOrigin as defaultIsAllowedOrigin,
   nl2br,
   sanitizeHTML,
 } from 'core/utils';
@@ -24,6 +24,7 @@ import './styles.scss';
 type Props = {|
   addon?: AddonType | CollectionAddonType,
   addonInstallSource?: string,
+  isAllowedOrigin: Function,
   showMetadata?: boolean,
   showSummary?: boolean,
 |};
@@ -35,6 +36,7 @@ type InternalProps = {|
 
 export class SearchResultBase extends React.Component<InternalProps> {
   static defaultProps = {
+    isAllowedOrigin: defaultIsAllowedOrigin,
     showMetadata: true,
     showSummary: true,
   };
@@ -45,7 +47,13 @@ export class SearchResultBase extends React.Component<InternalProps> {
   }
 
   renderResult() {
-    const { addon, i18n, showMetadata, showSummary } = this.props;
+    const {
+      addon,
+      i18n,
+      isAllowedOrigin,
+      showMetadata,
+      showSummary,
+    } = this.props;
 
     const isTheme = this.addonIsTheme();
     const averageDailyUsers = addon && addon.average_daily_users;

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -58,11 +58,10 @@ export class SearchResultBase extends React.Component<InternalProps> {
     const imageAtts = {};
 
     if (isTheme) {
-      const hasPreviews = addon.previews.length;
       // Since only newly created static themes will have more than one preview
       // we will set up a fallback for now.
-      const previewFallback = hasPreviews && addon.previews[0];
-      const previewSearch = hasPreviews && addon.previews[1];
+      const previewFallback = addon && addon.previews && addon.previews[0];
+      const previewSearch = addon && addon.previews && addon.previews[1];
       const previewImage = previewSearch || previewFallback;
 
       let themeURL =
@@ -79,9 +78,9 @@ export class SearchResultBase extends React.Component<InternalProps> {
             : null;
 
         if (themeUrlLarge) {
-          const imageSize = previewImage.image_size[0];
-          const thumbSize = previewImage.thumbnail_size[0];
-          if (imageSize && thumbSize) {
+          const imageSize = previewImage && previewImage.image_size[0];
+          const thumbSize = previewImage && previewImage.thumbnail_size[0];
+          if (themeURL && imageSize && thumbSize) {
             // If viewing on retina, it should only show the larger size with
             // the current widths available
             imageAtts.srcSet = `${themeURL} ${thumbSize}w, ${themeUrlLarge} ${imageSize}w`;
@@ -89,7 +88,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
         }
       }
 
-      if (!themeURL && addon.type === ADDON_TYPE_THEME) {
+      if (!themeURL && addon && addon.type === ADDON_TYPE_THEME) {
         themeURL =
           addon.themeData && isAllowedOrigin(addon.themeData.previewURL)
             ? addon.themeData.previewURL

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -63,8 +63,6 @@ export class SearchResultBase extends React.Component<InternalProps> {
 
     let imageURL = iconURL;
 
-    const imageAtts = {};
-
     if (isTheme) {
       // Since only newly created static themes will have more than one preview
       // we will set up a fallback for now.
@@ -73,28 +71,9 @@ export class SearchResultBase extends React.Component<InternalProps> {
       const previewImage = previewSearch || previewFallback;
 
       let themeURL =
-        previewImage && isAllowedOrigin(previewImage.thumbnail_url)
-          ? previewImage.thumbnail_url
+        previewImage && isAllowedOrigin(previewImage.image_url)
+          ? previewImage.image_url
           : null;
-
-      // Let's only worry about setting up srcset if we have the correct
-      // preview for this.
-      if (previewSearch) {
-        const themeUrlLarge =
-          previewImage && isAllowedOrigin(previewImage.image_url)
-            ? previewImage.image_url
-            : null;
-
-        if (themeUrlLarge) {
-          const imageSize = previewImage && previewImage.image_size[0];
-          const thumbSize = previewImage && previewImage.thumbnail_size[0];
-          if (themeURL && imageSize && thumbSize) {
-            // If viewing on retina, it should only show the larger size with
-            // the current widths available
-            imageAtts.srcSet = `${themeURL} ${thumbSize}w, ${themeUrlLarge} ${imageSize}w`;
-          }
-        }
-      }
 
       if (!themeURL && addon && addon.type === ADDON_TYPE_THEME) {
         themeURL =
@@ -145,7 +124,6 @@ export class SearchResultBase extends React.Component<InternalProps> {
               className="SearchResult-icon"
               src={imageURL}
               alt={addon ? `${addon.name}` : ''}
-              {...imageAtts}
             />
           ) : (
             <p className="SearchResult-notheme">

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -24,7 +24,6 @@ import './styles.scss';
 type Props = {|
   addon?: AddonType | CollectionAddonType,
   addonInstallSource?: string,
-  isAllowedOrigin: Function,
   showMetadata?: boolean,
   showSummary?: boolean,
 |};
@@ -32,6 +31,7 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
+  isAllowedOrigin: Function,
 |};
 
 export class SearchResultBase extends React.Component<InternalProps> {

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -8,7 +8,7 @@ import translate from 'core/i18n/translate';
 import { ADDON_TYPE_THEME, ADDON_TYPE_THEMES } from 'core/constants';
 import {
   addQueryParams,
-  isAllowedOrigin as defaultIsAllowedOrigin,
+  isAllowedOrigin,
   nl2br,
   sanitizeHTML,
 } from 'core/utils';
@@ -31,12 +31,12 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
-  isAllowedOrigin: Function,
+  _isAllowedOrigin: Function,
 |};
 
 export class SearchResultBase extends React.Component<InternalProps> {
   static defaultProps = {
-    isAllowedOrigin: defaultIsAllowedOrigin,
+    _isAllowedOrigin: isAllowedOrigin,
     showMetadata: true,
     showSummary: true,
   };
@@ -50,7 +50,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
     const {
       addon,
       i18n,
-      isAllowedOrigin,
+      _isAllowedOrigin,
       showMetadata,
       showSummary,
     } = this.props;
@@ -71,13 +71,13 @@ export class SearchResultBase extends React.Component<InternalProps> {
       const previewImage = previewSearch || previewFallback;
 
       let themeURL =
-        previewImage && isAllowedOrigin(previewImage.image_url)
+        previewImage && _isAllowedOrigin(previewImage.image_url)
           ? previewImage.image_url
           : null;
 
       if (!themeURL && addon && addon.type === ADDON_TYPE_THEME) {
         themeURL =
-          addon.themeData && isAllowedOrigin(addon.themeData.previewURL)
+          addon.themeData && _isAllowedOrigin(addon.themeData.previewURL)
             ? addon.themeData.previewURL
             : null;
       }

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -28,10 +28,6 @@
     margin-bottom: 10px;
     overflow: hidden;
     width: calc(100% + 20px);
-
-    @include respond-to(extraLarge) {
-      min-height: $theme-height-default;
-    }
   }
 
   @include respond-to(large) {
@@ -63,18 +59,6 @@
     object-fit: cover;
     object-position: top left;
     width: 100%;
-
-    @include respond-to(extraLarge) {
-      height: $theme-height-default;
-    }
-  }
-
-  .SearchResult--persona & {
-    object-position: top right;
-
-    @include respond-to(extraLarge) {
-      height: 100px;
-    }
   }
 }
 

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -26,9 +26,12 @@
   .SearchResult--theme & {
     flex-grow: 1;
     margin-bottom: 10px;
-    min-height: $theme-height-default;
     overflow: hidden;
     width: calc(100% + 20px);
+
+    @include respond-to(extraLarge) {
+      min-height: $theme-height-default;
+    }
   }
 
   @include respond-to(large) {
@@ -56,15 +59,22 @@
   .SearchResult--theme & {
     border-radius: $border-radius-default;
     display: block;
-    height: $theme-height-default;
+    height: auto;
     object-fit: cover;
     object-position: top left;
     width: 100%;
+
+    @include respond-to(extraLarge) {
+      height: $theme-height-default;
+    }
   }
 
   .SearchResult--persona & {
-    height: 100px;
     object-position: top right;
+
+    @include respond-to(extraLarge) {
+      height: 100px;
+    }
   }
 }
 

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -42,3 +42,4 @@ export const FEATURED_ADDONS_TO_LOAD = 25;
 // Number of add-ons in the featured, trending, and highest rated landing page
 // sections.
 export const LANDING_PAGE_ADDON_COUNT = 4;
+export const LANDING_PAGE_THEME_ADDON_COUNT = 3;

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -41,5 +41,5 @@ export const FEATURED_ADDONS_TO_LOAD = 25;
 
 // Number of add-ons in the featured, trending, and highest rated landing page
 // sections.
-export const LANDING_PAGE_ADDON_COUNT = 4;
-export const LANDING_PAGE_THEME_ADDON_COUNT = 3;
+export const LANDING_PAGE_EXTENSION_COUNT = 4;
+export const LANDING_PAGE_THEME_COUNT = 3;

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -1,7 +1,7 @@
 /* @flow */
 import invariant from 'invariant';
 
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import type { AddonType, ExternalAddonType } from 'core/types/addons';
 
@@ -128,7 +128,7 @@ const reducer = (
         collections: collections.map((collection) => {
           if (collection) {
             return collection.results
-              .slice(0, LANDING_PAGE_ADDON_COUNT)
+              .slice(0, LANDING_PAGE_EXTENSION_COUNT)
               .map((item) => {
                 return createInternalAddon(item.addon);
               });

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -1,9 +1,13 @@
 /* @flow */
 import invariant from 'invariant';
 
-import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
+} from 'amo/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import type { AddonType, ExternalAddonType } from 'core/types/addons';
+import { isTheme } from 'core/utils';
 
 export const FETCH_HOME_ADDONS: 'FETCH_HOME_ADDONS' = 'FETCH_HOME_ADDONS';
 export const LOAD_HOME_ADDONS: 'LOAD_HOME_ADDONS' = 'LOAD_HOME_ADDONS';
@@ -127,11 +131,12 @@ const reducer = (
         ...state,
         collections: collections.map((collection) => {
           if (collection) {
-            return collection.results
-              .slice(0, LANDING_PAGE_EXTENSION_COUNT)
-              .map((item) => {
-                return createInternalAddon(item.addon);
-              });
+            const sliceEnd = isTheme(collection.results[0].addon.type)
+              ? LANDING_PAGE_THEME_COUNT
+              : LANDING_PAGE_EXTENSION_COUNT;
+            return collection.results.slice(0, sliceEnd).map((item) => {
+              return createInternalAddon(item.addon);
+            });
           }
           return null;
         }),

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -130,7 +130,7 @@ const reducer = (
       return {
         ...state,
         collections: collections.map((collection) => {
-          if (collection) {
+          if (collection && collection.results && collection.results.length) {
             const sliceEnd = isTheme(collection.results[0].addon.type)
               ? LANDING_PAGE_THEME_COUNT
               : LANDING_PAGE_EXTENSION_COUNT;

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -4,8 +4,8 @@ import { oneLine } from 'common-tags';
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 import { getCollectionAddons } from 'amo/api/collections';
 import {
-  LANDING_PAGE_ADDON_COUNT,
-  LANDING_PAGE_THEME_ADDON_COUNT,
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
 import { FETCH_HOME_ADDONS, loadHomeAddons } from 'amo/reducers/home';
 import {
@@ -56,7 +56,7 @@ export function* fetchHomeAddons({
 
   const featuredSearchFilters = {
     featured: true,
-    page_size: LANDING_PAGE_ADDON_COUNT,
+    page_size: LANDING_PAGE_EXTENSION_COUNT,
     sort: SEARCH_SORT_RANDOM,
   };
   const featuredExtensionsParams: SearchParams = {
@@ -71,7 +71,7 @@ export function* fetchHomeAddons({
     filters: {
       addonType: ADDON_TYPE_THEME,
       ...featuredSearchFilters,
-      page_size: LANDING_PAGE_THEME_ADDON_COUNT,
+      page_size: LANDING_PAGE_THEME_COUNT,
     },
   };
 

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -3,7 +3,10 @@ import { oneLine } from 'common-tags';
 
 import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 import { getCollectionAddons } from 'amo/api/collections';
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_ADDON_COUNT,
+  LANDING_PAGE_THEME_ADDON_COUNT,
+} from 'amo/constants';
 import { FETCH_HOME_ADDONS, loadHomeAddons } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
@@ -68,6 +71,7 @@ export function* fetchHomeAddons({
     filters: {
       addonType: ADDON_TYPE_THEME,
       ...featuredSearchFilters,
+      page_size: LANDING_PAGE_THEME_ADDON_COUNT,
     },
   };
 

--- a/src/amo/sagas/landing.js
+++ b/src/amo/sagas/landing.js
@@ -29,7 +29,7 @@ export function* fetchLandingAddons({
     const state = yield select(getState);
     const { api } = state;
 
-    let pageSize = isTheme(addonType)
+    const pageSize = isTheme(addonType)
       ? LANDING_PAGE_THEME_ADDON_COUNT
       : LANDING_PAGE_ADDON_COUNT;
 

--- a/src/amo/sagas/landing.js
+++ b/src/amo/sagas/landing.js
@@ -6,7 +6,10 @@ import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 /* eslint-enable import/order */
 
 import { loadLanding } from 'amo/actions/landing';
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_ADDON_COUNT,
+  LANDING_PAGE_THEME_ADDON_COUNT,
+} from 'amo/constants';
 import { search as searchApi } from 'core/api/search';
 import {
   LANDING_GET,
@@ -16,6 +19,7 @@ import {
 } from 'core/constants';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
+import { isTheme } from 'core/utils';
 
 export function* fetchLandingAddons({
   payload: { addonType, category, errorHandlerId },
@@ -24,9 +28,14 @@ export function* fetchLandingAddons({
   try {
     const state = yield select(getState);
     const { api } = state;
+
+    let pageSize = isTheme(addonType)
+      ? LANDING_PAGE_THEME_ADDON_COUNT
+      : LANDING_PAGE_ADDON_COUNT;
+
     const filters = {
       addonType,
-      page_size: LANDING_PAGE_ADDON_COUNT,
+      page_size: pageSize,
     };
 
     if (category) {

--- a/src/amo/sagas/landing.js
+++ b/src/amo/sagas/landing.js
@@ -7,8 +7,8 @@ import { all, call, put, select, takeLatest } from 'redux-saga/effects';
 
 import { loadLanding } from 'amo/actions/landing';
 import {
-  LANDING_PAGE_ADDON_COUNT,
-  LANDING_PAGE_THEME_ADDON_COUNT,
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
 import { search as searchApi } from 'core/api/search';
 import {
@@ -30,8 +30,8 @@ export function* fetchLandingAddons({
     const { api } = state;
 
     const pageSize = isTheme(addonType)
-      ? LANDING_PAGE_THEME_ADDON_COUNT
-      : LANDING_PAGE_ADDON_COUNT;
+      ? LANDING_PAGE_THEME_COUNT
+      : LANDING_PAGE_EXTENSION_COUNT;
 
     const filters = {
       addonType,

--- a/src/amo/sagas/landing.js
+++ b/src/amo/sagas/landing.js
@@ -28,14 +28,11 @@ export function* fetchLandingAddons({
   try {
     const state = yield select(getState);
     const { api } = state;
-
-    const pageSize = isTheme(addonType)
-      ? LANDING_PAGE_THEME_COUNT
-      : LANDING_PAGE_EXTENSION_COUNT;
-
     const filters = {
       addonType,
-      page_size: pageSize,
+      page_size: isTheme(addonType)
+        ? LANDING_PAGE_THEME_COUNT
+        : LANDING_PAGE_EXTENSION_COUNT,
     };
 
     if (category) {

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -328,9 +328,12 @@ export const decodeHtmlEntities = (string) => {
   return entities.decode(string);
 };
 
+export const isTheme = (addonType) => {
+  return ADDON_TYPE_THEMES.includes(addonType);
+};
+
 export const getAddonTypeFilter = (addonType, { _config = config } = {}) => {
-  const isTheme = ADDON_TYPE_THEMES.includes(addonType);
-  if (!_config.get('enableStaticThemes') || !isTheme) {
+  if (!_config.get('enableStaticThemes') || !isTheme(addonType)) {
     return addonType;
   }
 

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -913,52 +913,33 @@ describe(__filename, () => {
     );
   });
 
-  it('renders image without srcSet if there is no large preview image url', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+  it.each([0, 1])(
+    `renders image without srcSet if there are no preview image sizes or large image %s`,
+    (index) => {
+      const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+      const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
 
-    const root = shallowRender({
-      addon: createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            ...fakePreview,
-            image_url: '',
-            thumbnail_url: headerImageThumb,
-            image_size: [],
-            thumbnail_size: [],
-          },
-        ],
-      }),
-    });
-    const image = root.find('.Addon-theme-header-image');
-    expect(image.prop('src')).toEqual(headerImageThumb);
-    expect(image).not.toHaveProp('srcSet');
-  });
+      const root = shallowRender({
+        addon: createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_STATIC_THEME,
+          previews: [
+            {
+              ...fakePreview,
+              image_url: index === 0 ? '' : headerImageFull,
+              thumbnail_url: headerImageThumb,
+              image_size: index === 0 ? [800, 400] : [],
+              thumbnail_size: index === 0 ? [400, 200] : [],
+            },
+          ],
+        }),
+      });
 
-  it('renders image without srcSet if there are no preview image sizes', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
-
-    const root = shallowRender({
-      addon: createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            ...fakePreview,
-            image_url: headerImageFull,
-            thumbnail_url: headerImageThumb,
-            image_size: [],
-            thumbnail_size: [],
-          },
-        ],
-      }),
-    });
-    const image = root.find('.Addon-theme-header-image');
-    expect(image.prop('src')).toEqual(headerImageThumb);
-    expect(image).not.toHaveProp('srcSet');
-  });
+      const image = root.find('.Addon-theme-header-image');
+      expect(image.prop('src')).toEqual(headerImageThumb);
+      expect(image).not.toHaveProp('srcSet');
+    },
+  );
 
   it('renders the preview image from the previews array if it exists for the lightweight theme', () => {
     const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -65,6 +65,7 @@ import {
   dispatchSignInActions,
   fakeAddon,
   fakeInstalledAddon,
+  fakePreview,
   fakeTheme,
 } from 'tests/unit/amo/helpers';
 import {
@@ -866,21 +867,19 @@ describe(__filename, () => {
   });
 
   it('renders a static theme preview as an image', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/54321.png';
+    const newPreview = [
+      {
+        ...fakePreview,
+        thumbnail_url: headerImageThumb,
+      },
+    ];
+
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
         type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            id: 1,
-            caption: 'Image 1',
-            image_url: 'https://addons.cdn.mozilla.net/full/1.png',
-            thumbnail_url: headerImageThumb,
-            image_size: [400, 200],
-            thumbnail_size: [200, 100],
-          },
-        ],
+        previews: newPreview,
       }),
     });
     const image = root.find('.Addon-theme-header-image');
@@ -891,21 +890,18 @@ describe(__filename, () => {
   });
 
   it('renders the preview image from the previews array if it exists for the lightweight theme', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+    const newPreview = [
+      {
+        ...fakePreview,
+        thumbnail_url: headerImageThumb,
+      },
+    ];
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
         type: ADDON_TYPE_THEME,
-        previews: [
-          {
-            id: 1,
-            caption: 'Image 1',
-            image_url: 'https://addons.cdn.mozilla.net/full/1.png',
-            thumbnail_url: headerImageThumb,
-            image_size: [400, 200],
-            thumbnail_size: [200, 100],
-          },
-        ],
+        previews: newPreview,
       }),
     });
     const image = root.find('.Addon-theme-header-image');

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -913,9 +913,9 @@ describe(__filename, () => {
     );
   });
 
-  it.each([0, 1])(
-    `renders image without srcSet if there are no preview image sizes or large image %s`,
-    (index) => {
+  it.each([{ image_url: '' }, { image_size: [] }, { thumbnail_size: [] }])(
+    `renders image without srcSet if there are no preview image sizes or large image %o`,
+    (propOverride) => {
       const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
       const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
 
@@ -926,10 +926,11 @@ describe(__filename, () => {
           previews: [
             {
               ...fakePreview,
-              image_url: index === 0 ? '' : headerImageFull,
+              image_url: headerImageFull,
               thumbnail_url: headerImageThumb,
-              image_size: index === 0 ? [800, 400] : [],
-              thumbnail_size: index === 0 ? [400, 200] : [],
+              image_size: [800, 400],
+              thumbnail_size: [400, 200],
+              ...propOverride,
             },
           ],
         }),

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -868,18 +868,16 @@ describe(__filename, () => {
 
   it('renders a static theme preview as an image', () => {
     const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/54321.png';
-    const newPreview = [
-      {
-        ...fakePreview,
-        thumbnail_url: headerImageThumb,
-      },
-    ];
-
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
         type: ADDON_TYPE_STATIC_THEME,
-        previews: newPreview,
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url: headerImageThumb,
+          },
+        ],
       }),
     });
     const image = root.find('.Addon-theme-header-image');
@@ -891,17 +889,16 @@ describe(__filename, () => {
 
   it('renders the preview image from the previews array if it exists for the lightweight theme', () => {
     const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-    const newPreview = [
-      {
-        ...fakePreview,
-        thumbnail_url: headerImageThumb,
-      },
-    ];
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
         type: ADDON_TYPE_THEME,
-        previews: newPreview,
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url: headerImageThumb,
+          },
+        ],
       }),
     });
     const image = root.find('.Addon-theme-header-image');

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -876,7 +876,7 @@ describe(__filename, () => {
     expect(image.type()).toEqual('img');
     expect(image).toHaveClassName('Addon-theme-header-image');
     expect(image.prop('src')).toEqual(
-      'https://addons.cdn.mozilla.net/123/image.png',
+      'https://addons.cdn.mozilla.net/7123/image.png',
     );
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
   });
@@ -892,7 +892,7 @@ describe(__filename, () => {
     expect(image.type()).toEqual('img');
     expect(image).toHaveClassName('Addon-theme-header-image');
     expect(image.prop('src')).toEqual(
-      'https://addons.cdn.mozilla.net/123/image.png',
+      'https://addons.cdn.mozilla.net/7123/image.png',
     );
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
   });

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -862,7 +862,6 @@ describe(__filename, () => {
     });
     const image = root.find('.Addon-theme-header-image');
     expect(image.type()).toEqual('img');
-    expect(image).toHaveClassName('Addon-theme-header-image');
     expect(image.prop('src')).toEqual('https://amo/preview.png');
   });
 
@@ -914,6 +913,29 @@ describe(__filename, () => {
     );
   });
 
+  it('renders image without srcSet if there is no large preview image url', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            image_url: '',
+            thumbnail_url: headerImageThumb,
+            image_size: [],
+            thumbnail_size: [],
+          },
+        ],
+      }),
+    });
+    const image = root.find('.Addon-theme-header-image');
+    expect(image.prop('src')).toEqual(headerImageThumb);
+    expect(image).not.toHaveProp('srcSet');
+  });
+
   it('renders image without srcSet if there are no preview image sizes', () => {
     const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
     const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
@@ -954,7 +976,6 @@ describe(__filename, () => {
     });
     const image = root.find('.Addon-theme-header-image');
     expect(image.type()).toEqual('img');
-    expect(image).toHaveClassName('Addon-theme-header-image');
     expect(image.prop('src')).toEqual(headerImageThumb);
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
   });

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -866,34 +866,52 @@ describe(__filename, () => {
   });
 
   it('renders a static theme preview as an image', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
         type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            id: 1,
+            caption: 'Image 1',
+            image_url: 'https://addons.cdn.mozilla.net/full/1.png',
+            thumbnail_url: headerImageThumb,
+            image_size: [400, 200],
+            thumbnail_size: [200, 100],
+          },
+        ],
       }),
     });
     const image = root.find('.Addon-theme-header-image');
     expect(image.type()).toEqual('img');
     expect(image).toHaveClassName('Addon-theme-header-image');
-    expect(image.prop('src')).toEqual(
-      'https://addons.cdn.mozilla.net/7123/image.png',
-    );
+    expect(image.prop('src')).toEqual(headerImageThumb);
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
   });
 
   it('renders the preview image from the previews array if it exists for the lightweight theme', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
         type: ADDON_TYPE_THEME,
+        previews: [
+          {
+            id: 1,
+            caption: 'Image 1',
+            image_url: 'https://addons.cdn.mozilla.net/full/1.png',
+            thumbnail_url: headerImageThumb,
+            image_size: [400, 200],
+            thumbnail_size: [200, 100],
+          },
+        ],
       }),
     });
     const image = root.find('.Addon-theme-header-image');
     expect(image.type()).toEqual('img');
     expect(image).toHaveClassName('Addon-theme-header-image');
-    expect(image.prop('src')).toEqual(
-      'https://addons.cdn.mozilla.net/7123/image.png',
-    );
+    expect(image.prop('src')).toEqual(headerImageThumb);
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
   });
 

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -882,9 +882,60 @@ describe(__filename, () => {
     });
     const image = root.find('.Addon-theme-header-image');
     expect(image.type()).toEqual('img');
-    expect(image).toHaveClassName('Addon-theme-header-image');
     expect(image.prop('src')).toEqual(headerImageThumb);
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
+  });
+
+  it('displays srcSet values if preview has multiple options for its first item', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
+    const thumbWidth = 450;
+    const fullWidth = 900;
+
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            image_url: headerImageFull,
+            thumbnail_url: headerImageThumb,
+            image_size: [fullWidth, 200],
+            thumbnail_size: [thumbWidth, 100],
+          },
+        ],
+      }),
+    });
+
+    const image = root.find('.Addon-theme-header-image');
+    expect(image.prop('srcSet')).toEqual(
+      `${headerImageThumb} ${thumbWidth}w, ${headerImageFull} ${fullWidth}w`,
+    );
+  });
+
+  it('renders image without srcSet if there are no preview image sizes', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
+
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            image_url: headerImageFull,
+            thumbnail_url: headerImageThumb,
+            image_size: [],
+            thumbnail_size: [],
+          },
+        ],
+      }),
+    });
+    const image = root.find('.Addon-theme-header-image');
+    expect(image.prop('src')).toEqual(headerImageThumb);
+    expect(image).not.toHaveProp('srcSet');
   });
 
   it('renders the preview image from the previews array if it exists for the lightweight theme', () => {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -866,7 +866,7 @@ describe(__filename, () => {
   });
 
   it('renders a static theme preview as an image', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/54321.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
@@ -874,76 +874,19 @@ describe(__filename, () => {
         previews: [
           {
             ...fakePreview,
-            thumbnail_url: headerImageThumb,
+            image_url: headerImageFull,
           },
         ],
       }),
     });
     const image = root.find('.Addon-theme-header-image');
     expect(image.type()).toEqual('img');
-    expect(image.prop('src')).toEqual(headerImageThumb);
+    expect(image.prop('src')).toEqual(headerImageFull);
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
   });
 
-  it('displays srcSet values if preview has multiple options for its first item', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
-    const thumbWidth = 450;
-    const fullWidth = 900;
-
-    const root = shallowRender({
-      addon: createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            ...fakePreview,
-            image_url: headerImageFull,
-            thumbnail_url: headerImageThumb,
-            image_size: [fullWidth, 200],
-            thumbnail_size: [thumbWidth, 100],
-          },
-        ],
-      }),
-    });
-
-    const image = root.find('.Addon-theme-header-image');
-    expect(image.prop('srcSet')).toEqual(
-      `${headerImageThumb} ${thumbWidth}w, ${headerImageFull} ${fullWidth}w`,
-    );
-  });
-
-  it.each([{ image_url: '' }, { image_size: [] }, { thumbnail_size: [] }])(
-    `renders image without srcSet if there are no preview image sizes or large image %o`,
-    (propOverride) => {
-      const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-      const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
-
-      const root = shallowRender({
-        addon: createInternalAddon({
-          ...fakeAddon,
-          type: ADDON_TYPE_STATIC_THEME,
-          previews: [
-            {
-              ...fakePreview,
-              image_url: headerImageFull,
-              thumbnail_url: headerImageThumb,
-              image_size: [800, 400],
-              thumbnail_size: [400, 200],
-              ...propOverride,
-            },
-          ],
-        }),
-      });
-
-      const image = root.find('.Addon-theme-header-image');
-      expect(image.prop('src')).toEqual(headerImageThumb);
-      expect(image).not.toHaveProp('srcSet');
-    },
-  );
-
   it('renders the preview image from the previews array if it exists for the lightweight theme', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/12345.png';
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeTheme,
@@ -951,14 +894,14 @@ describe(__filename, () => {
         previews: [
           {
             ...fakePreview,
-            thumbnail_url: headerImageThumb,
+            image_url: headerImageFull,
           },
         ],
       }),
     });
     const image = root.find('.Addon-theme-header-image');
     expect(image.type()).toEqual('img');
-    expect(image.prop('src')).toEqual(headerImageThumb);
+    expect(image.prop('src')).toEqual(headerImageFull);
     expect(image.prop('alt')).toEqual('Preview of Dancing Daisies by MaDonna');
   });
 

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -500,16 +500,9 @@ describe(__filename, () => {
     );
   });
 
-  it('renders isTheme to be true with theme className if type is a theme', () => {
-    _categoriesFetch();
-    _categoriesLoad({
-      result: [{ ...fakeCategory, type: ADDON_TYPE_THEME }],
-    });
-    _getLanding();
-    _loadLanding();
-
+  it('renders a theme class name if type is a theme', () => {
     const root = render(
-      {},
+      { params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) } },
       {
         autoDispatchCategories: false,
         paramOverrides: {
@@ -518,22 +511,12 @@ describe(__filename, () => {
       },
     );
 
-    const landingShelves = root.find(LandingAddonsCard);
-
     expect(root).toHaveClassName('Category--theme');
-    expect(landingShelves.at(0)).toHaveProp('isTheme', true);
   });
 
-  it('renders isTheme to be false without theme className if type is an extension', () => {
-    _categoriesFetch();
-    _categoriesLoad({
-      result: [{ ...fakeCategory, type: ADDON_TYPE_EXTENSION }],
-    });
-    _getLanding();
-    _loadLanding();
-
+  it('renders without a theme class name if type is an extension', () => {
     const root = render(
-      {},
+      { params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) } },
       {
         autoDispatchCategories: false,
         paramOverrides: {
@@ -542,9 +525,7 @@ describe(__filename, () => {
       },
     );
 
-    const landingShelves = root.find(LandingAddonsCard);
     expect(root).not.toHaveClassName('Category--theme');
-    expect(landingShelves.at(0)).toHaveProp('isTheme', false);
   });
 
   it('sets the correct header/footer texts and links for themes', () => {

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -519,29 +519,8 @@ describe(__filename, () => {
     const landingShelves = root.find(LandingAddonsCard);
 
     expect(landingShelves.at(0)).toHaveProp('isTheme', true);
-  });
-
-  it('passes a isTheme prop as false if type is an extension', () => {
-    _categoriesFetch();
-    _categoriesLoad({
-      result: [{ ...fakeCategory, type: ADDON_TYPE_EXTENSION }],
-    });
-    _getLanding();
-    _loadLanding();
-
-    const root = render(
-      {},
-      {
-        autoDispatchCategories: false,
-        paramOverrides: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
-        },
-      },
-    );
-
-    const landingShelves = root.find(LandingAddonsCard);
-
-    expect(landingShelves.at(0)).toHaveProp('isTheme', false);
+    expect(landingShelves.at(1)).toHaveProp('isTheme', true);
+    expect(landingShelves.at(2)).toHaveProp('isTheme', true);
   });
 
   it('renders a theme class name if type is a theme', () => {
@@ -560,11 +539,12 @@ describe(__filename, () => {
 
   it('renders without a theme class name if type is an extension', () => {
     const root = render(
-      {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) },
-      },
+      {},
       {
         autoDispatchCategories: false,
+        paramOverrides: {
+          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+        },
       },
     );
 

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -500,7 +500,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes a isTheme prop as true if type is a theme', () => {
+  it('passes an isTheme prop as true if type is a theme', () => {
     _categoriesFetch();
     _categoriesLoad();
     _getLanding();

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -500,11 +500,58 @@ describe(__filename, () => {
     );
   });
 
-  it('renders a theme class name if type is a theme', () => {
+  it('passes isTheme prop as true if type is a theme', () => {
+    _categoriesFetch();
+    _categoriesLoad();
+    _getLanding();
+    _loadLanding();
+
     const root = render(
-      { params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) } },
+      {},
       {
         autoDispatchCategories: false,
+        paramOverrides: {
+          visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+        },
+      },
+    );
+
+    const landingShelves = root.find(LandingAddonsCard);
+
+    expect(landingShelves.at(0)).toHaveProp('isTheme', true);
+  });
+
+  it('passes isTheme prop as false if type is an extension', () => {
+    _categoriesFetch();
+    _categoriesLoad({
+      result: [{ ...fakeCategory, type: ADDON_TYPE_EXTENSION }],
+    });
+    _getLanding();
+    _loadLanding();
+
+    const root = render(
+      {},
+      {
+        autoDispatchCategories: false,
+        paramOverrides: {
+          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+        },
+      },
+    );
+
+    const landingShelves = root.find(LandingAddonsCard);
+
+    expect(landingShelves.at(0)).toHaveProp('isTheme', false);
+  });
+
+  it('renders a theme class name if type is a theme', () => {
+    const root = render(
+      {},
+      {
+        autoDispatchCategories: false,
+        paramOverrides: {
+          visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+        },
       },
     );
 

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -500,7 +500,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes isTheme prop as true if type is a theme', () => {
+  it('passes a isTheme prop as true if type is a theme', () => {
     _categoriesFetch();
     _categoriesLoad();
     _getLanding();
@@ -521,7 +521,7 @@ describe(__filename, () => {
     expect(landingShelves.at(0)).toHaveProp('isTheme', true);
   });
 
-  it('passes isTheme prop as false if type is an extension', () => {
+  it('passes a isTheme prop as false if type is an extension', () => {
     _categoriesFetch();
     _categoriesLoad({
       result: [{ ...fakeCategory, type: ADDON_TYPE_EXTENSION }],

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -500,7 +500,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes an isTheme prop as true if type is a theme', () => {
+  it('passes an isTheme prop as true to LandingAddonsCard if type is a theme', () => {
     _categoriesFetch();
     _categoriesLoad();
     _getLanding();
@@ -518,9 +518,10 @@ describe(__filename, () => {
 
     const landingShelves = root.find(LandingAddonsCard);
 
-    expect(landingShelves.at(0)).toHaveProp('isTheme', true);
-    expect(landingShelves.at(1)).toHaveProp('isTheme', true);
-    expect(landingShelves.at(2)).toHaveProp('isTheme', true);
+    expect.assertions(3);
+    landingShelves.forEach((shelf) => {
+      expect(shelf).toHaveProp('isTheme', true);
+    });
   });
 
   it('renders a theme class name if type is a theme', () => {

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -500,6 +500,53 @@ describe(__filename, () => {
     );
   });
 
+  it('renders isTheme to be true with theme className if type is a theme', () => {
+    _categoriesFetch();
+    _categoriesLoad({
+      result: [{ ...fakeCategory, type: ADDON_TYPE_THEME }],
+    });
+    _getLanding();
+    _loadLanding();
+
+    const root = render(
+      {},
+      {
+        autoDispatchCategories: false,
+        paramOverrides: {
+          visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+        },
+      },
+    );
+
+    const landingShelves = root.find(LandingAddonsCard);
+
+    expect(root).toHaveClassName('Category--theme');
+    expect(landingShelves.at(0)).toHaveProp('isTheme', true);
+  });
+
+  it('renders isTheme to be false without theme className if type is an extension', () => {
+    _categoriesFetch();
+    _categoriesLoad({
+      result: [{ ...fakeCategory, type: ADDON_TYPE_EXTENSION }],
+    });
+    _getLanding();
+    _loadLanding();
+
+    const root = render(
+      {},
+      {
+        autoDispatchCategories: false,
+        paramOverrides: {
+          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+        },
+      },
+    );
+
+    const landingShelves = root.find(LandingAddonsCard);
+    expect(root).not.toHaveClassName('Category--theme');
+    expect(landingShelves.at(0)).toHaveProp('isTheme', false);
+  });
+
   it('sets the correct header/footer texts and links for themes', () => {
     _categoriesFetch();
     _categoriesLoad();

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -505,9 +505,6 @@ describe(__filename, () => {
       { params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) } },
       {
         autoDispatchCategories: false,
-        paramOverrides: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
-        },
       },
     );
 
@@ -516,12 +513,11 @@ describe(__filename, () => {
 
   it('renders without a theme class name if type is an extension', () => {
     const root = render(
-      { params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) } },
+      {
+        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) },
+      },
       {
         autoDispatchCategories: false,
-        paramOverrides: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
-        },
       },
     );
 

--- a/tests/unit/amo/components/TestFeaturedCollectionCard.js
+++ b/tests/unit/amo/components/TestFeaturedCollectionCard.js
@@ -62,6 +62,16 @@ describe(__filename, () => {
     );
   });
 
+  it('passes isTheme prop as true if type is a theme', () => {
+    const root = render({ isTheme: true });
+    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', true);
+  });
+
+  it('passes isTheme prop as false if type is an extension', () => {
+    const root = render({ isTheme: false });
+    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', false);
+  });
+
   it('does not render a theme class name to LandingAddonsCard when isTheme is false', () => {
     const root = render({ isTheme: false });
     expect(root.find(LandingAddonsCard)).not.toHaveClassName(

--- a/tests/unit/amo/components/TestFeaturedCollectionCard.js
+++ b/tests/unit/amo/components/TestFeaturedCollectionCard.js
@@ -62,21 +62,21 @@ describe(__filename, () => {
     );
   });
 
-  it('passes isTheme prop as true if type is a theme', () => {
-    const root = render({ isTheme: true });
-    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', true);
-  });
-
-  it('passes isTheme prop as false if type is an extension', () => {
-    const root = render({ isTheme: false });
-    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', false);
-  });
-
   it('does not render a theme class name to LandingAddonsCard when isTheme is false', () => {
     const root = render({ isTheme: false });
     expect(root.find(LandingAddonsCard)).not.toHaveClassName(
       'FeaturedCollection--theme',
     );
+  });
+
+  it('passes a isTheme prop as true if type is a theme', () => {
+    const root = render({ isTheme: true });
+    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', true);
+  });
+
+  it('passes a isTheme prop as false if type is an extension', () => {
+    const root = render({ isTheme: false });
+    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', false);
   });
 
   it('passes collection related properties to LandingAddonsCard', () => {

--- a/tests/unit/amo/components/TestFeaturedCollectionCard.js
+++ b/tests/unit/amo/components/TestFeaturedCollectionCard.js
@@ -55,6 +55,20 @@ describe(__filename, () => {
     expect(root.find(LandingAddonsCard)).toHaveProp('className', className);
   });
 
+  it('passes theme className to LandingAddonsCard if collection are theme addons', () => {
+    const root = render({ isTheme: true });
+    expect(root.find(LandingAddonsCard)).toHaveClassName(
+      'FeaturedCollection--theme',
+    );
+  });
+
+  it('does no pass theme className to LandingAddonsCard if collection are extension addons', () => {
+    const root = render({ isTheme: false });
+    expect(root.find(LandingAddonsCard)).not.toHaveClassName(
+      'FeaturedCollection--theme',
+    );
+  });
+
   it('passes collection related properties to LandingAddonsCard', () => {
     const collectionProperties = {
       footerText: 'Custom footer',

--- a/tests/unit/amo/components/TestFeaturedCollectionCard.js
+++ b/tests/unit/amo/components/TestFeaturedCollectionCard.js
@@ -55,14 +55,14 @@ describe(__filename, () => {
     expect(root.find(LandingAddonsCard)).toHaveProp('className', className);
   });
 
-  it('renders a theme class name to LandingAddonsCard if the collection contains theme addons', () => {
+  it("renders a theme class name to LandingAddonsCard if the collection's isTheme property is true", () => {
     const root = render({ isTheme: true });
     expect(root.find(LandingAddonsCard)).toHaveClassName(
       'FeaturedCollection--theme',
     );
   });
 
-  it('does not render a theme class name to LandingAddonsCard if the collection contains extension addons', () => {
+  it("does not render a theme class name to LandingAddonsCard if the collection's isTheme property is false", () => {
     const root = render({ isTheme: false });
     expect(root.find(LandingAddonsCard)).not.toHaveClassName(
       'FeaturedCollection--theme',

--- a/tests/unit/amo/components/TestFeaturedCollectionCard.js
+++ b/tests/unit/amo/components/TestFeaturedCollectionCard.js
@@ -69,14 +69,9 @@ describe(__filename, () => {
     );
   });
 
-  it('passes a isTheme prop as true if type is a theme', () => {
+  it('passes the same isTheme prop value to the landingAddonsCard', () => {
     const root = render({ isTheme: true });
     expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', true);
-  });
-
-  it('passes a isTheme prop as false if type is an extension', () => {
-    const root = render({ isTheme: false });
-    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', false);
   });
 
   it('passes collection related properties to LandingAddonsCard', () => {

--- a/tests/unit/amo/components/TestFeaturedCollectionCard.js
+++ b/tests/unit/amo/components/TestFeaturedCollectionCard.js
@@ -55,14 +55,14 @@ describe(__filename, () => {
     expect(root.find(LandingAddonsCard)).toHaveProp('className', className);
   });
 
-  it("renders a theme class name to LandingAddonsCard if the collection's isTheme property is true", () => {
+  it('renders a theme class name to LandingAddonsCard when isTheme is true', () => {
     const root = render({ isTheme: true });
     expect(root.find(LandingAddonsCard)).toHaveClassName(
       'FeaturedCollection--theme',
     );
   });
 
-  it("does not render a theme class name to LandingAddonsCard if the collection's isTheme property is false", () => {
+  it('does not render a theme class name to LandingAddonsCard when isTheme is false', () => {
     const root = render({ isTheme: false });
     expect(root.find(LandingAddonsCard)).not.toHaveClassName(
       'FeaturedCollection--theme',

--- a/tests/unit/amo/components/TestFeaturedCollectionCard.js
+++ b/tests/unit/amo/components/TestFeaturedCollectionCard.js
@@ -55,14 +55,14 @@ describe(__filename, () => {
     expect(root.find(LandingAddonsCard)).toHaveProp('className', className);
   });
 
-  it('passes theme className to LandingAddonsCard if collection are theme addons', () => {
+  it('renders a theme class name to LandingAddonsCard if the collection contains theme addons', () => {
     const root = render({ isTheme: true });
     expect(root.find(LandingAddonsCard)).toHaveClassName(
       'FeaturedCollection--theme',
     );
   });
 
-  it('does no pass theme className to LandingAddonsCard if collection are extension addons', () => {
+  it('does not render a theme class name to LandingAddonsCard if the collection contains extension addons', () => {
     const root = render({ isTheme: false });
     expect(root.find(LandingAddonsCard)).not.toHaveClassName(
       'FeaturedCollection--theme',

--- a/tests/unit/amo/components/TestHome.js
+++ b/tests/unit/amo/components/TestHome.js
@@ -80,10 +80,11 @@ describe(__filename, () => {
       expect(shelf).toHaveProp('slug', collectionMetadata.slug);
       expect(shelf).toHaveProp('username', collectionMetadata.username);
       expect(shelf).toHaveProp('loading', true);
+      expect(shelf).toHaveProp('isTheme', collectionMetadata.isTheme);
     },
   );
 
-  it('renders a featured extensions shelf', () => {
+  it('passes isTheme prop as false if type is an extension', () => {
     const root = render();
 
     const shelves = root.find(LandingAddonsCard);
@@ -139,6 +140,7 @@ describe(__filename, () => {
       },
     });
     expect(shelf).toHaveProp('loading', true);
+    expect(shelf).toHaveProp('isTheme', true);
   });
 
   it('does not render a featured themes shelf if includeFeaturedThemes is false', () => {

--- a/tests/unit/amo/components/TestHome.js
+++ b/tests/unit/amo/components/TestHome.js
@@ -84,7 +84,7 @@ describe(__filename, () => {
     },
   );
 
-  it('passes isTheme prop as false if type is an extension', () => {
+  it('renders a featured extensions shelf', () => {
     const root = render();
 
     const shelves = root.find(LandingAddonsCard);

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -76,6 +76,25 @@ describe(__filename, () => {
     );
   });
 
+  it('overrides the placeholder prop value when isTheme is passed in', () => {
+    const root = render({ isTheme: true, placeholderCount: 2 });
+
+    expect(root.find(AddonsCard)).toHaveProp(
+      'placeholderCount',
+      LANDING_PAGE_THEME_COUNT,
+    );
+  });
+
+  it('uses the placeholder prop value when isTheme is passed in as false', () => {
+    const placeholderCount = 2;
+    const root = render({ isTheme: false, placeholderCount });
+
+    expect(root.find(AddonsCard)).toHaveProp(
+      'placeholderCount',
+      placeholderCount,
+    );
+  });
+
   it('uses the default placeholder count when there is no override', () => {
     const root = render();
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -3,7 +3,17 @@ import { shallow } from 'enzyme';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_ADDON_COUNT,
+  LANDING_PAGE_THEME_ADDON_COUNT,
+} from 'amo/constants';
+
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
+  ADDON_TYPE_THEMES_FILTER,
+} from 'core/constants';
+
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
@@ -62,6 +72,48 @@ describe(__filename, () => {
   it('sets the number of placeholders to render while loading', () => {
     const root = render({ loading: true });
     expect(root).toHaveProp('placeholderCount', LANDING_PAGE_ADDON_COUNT);
+  });
+
+  it('sets the correct number of placeholders for theme types', () => {
+    const root = render({
+      footerLink: {
+        pathname: '/some-path/',
+        query: { addonType: ADDON_TYPE_THEMES_FILTER },
+      },
+    });
+
+    expect(root.find(AddonsCard)).toHaveProp(
+      'placeholderCount',
+      LANDING_PAGE_THEME_ADDON_COUNT,
+    );
+  });
+
+  it('sets the correct number of placeholders for lightweight theme type', () => {
+    const root = render({
+      footerLink: {
+        pathname: '/some-path/',
+        query: { addonType: ADDON_TYPE_THEME },
+      },
+    });
+
+    expect(root.find(AddonsCard)).toHaveProp(
+      'placeholderCount',
+      LANDING_PAGE_THEME_ADDON_COUNT,
+    );
+  });
+
+  it('sets the correct number of placeholders for an extension type', () => {
+    const root = render({
+      footerLink: {
+        pathname: '/some-path/',
+        query: { addonType: ADDON_TYPE_EXTENSION },
+      },
+    });
+
+    expect(root.find(AddonsCard)).toHaveProp(
+      'placeholderCount',
+      LANDING_PAGE_ADDON_COUNT,
+    );
   });
 
   it('hides the footer link when less add-ons than placeholderCount', () => {

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -109,38 +109,23 @@ describe(__filename, () => {
   });
 
   it('hides the footer link when there are less add-ons than LANDING_PAGE_THEME_COUNT', () => {
-    const addons = [];
-
-    for (let i = 0; i < LANDING_PAGE_THEME_COUNT - 1; i++) {
-      addons.push(
-        createInternalAddon({
-          ...fakeAddon,
-          type: ADDON_TYPE_THEME,
-          slug: `custom-addon-${i}`,
-        }),
-      );
-    }
-    const root = render({ addons, isTheme: true });
+    const root = render({
+      addons: Array(LANDING_PAGE_THEME_COUNT - 1).fill(
+        createInternalAddon({ ...fakeAddon, type: ADDON_TYPE_THEME }),
+      ),
+      isTheme: true,
+    });
     expect(root.find(AddonsCard)).toHaveProp('footerLink', null);
   });
 
   it('shows the footer link when there are more or as many add-ons as LANDING_PAGE_THEME_COUNT', () => {
-    const addons = [];
     const footerLink = 'footer-link-path';
     const footerText = 'footer link text';
 
-    for (let i = 0; i < LANDING_PAGE_THEME_COUNT; i++) {
-      addons.push(
-        createInternalAddon({
-          ...fakeAddon,
-          type: ADDON_TYPE_THEME,
-          slug: `custom-addon-${i}`,
-        }),
-      );
-    }
-
     const root = render({
-      addons,
+      addons: Array(LANDING_PAGE_THEME_COUNT).fill(
+        createInternalAddon({ ...fakeAddon, type: ADDON_TYPE_THEME }),
+      ),
       isTheme: true,
       footerLink,
       footerText,
@@ -152,23 +137,14 @@ describe(__filename, () => {
   });
 
   it('shows the footer link when there are more or as many add-ons as placeholderCount', () => {
-    const addons = [];
     const footerLink = 'footer-link-path';
     const footerText = 'footer link text';
     const placeholderCount = 2;
 
-    for (let i = 0; i < placeholderCount; i++) {
-      addons.push(
-        createInternalAddon({
-          ...fakeAddon,
-          type: ADDON_TYPE_THEME,
-          slug: `custom-addon-${i}`,
-        }),
-      );
-    }
-
     const root = render({
-      addons,
+      addons: Array(placeholderCount).fill(
+        createInternalAddon({ ...fakeAddon, type: ADDON_TYPE_THEME }),
+      ),
       placeholderCount,
       footerLink,
       footerText,

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -124,7 +124,7 @@ describe(__filename, () => {
     expect(root.find(AddonsCard)).toHaveProp('footerLink', null);
   });
 
-  it('shows the footer link when there are more or as many add-ons than LANDING_PAGE_THEME_COUNT', () => {
+  it('shows the footer link when there are more or as many add-ons as LANDING_PAGE_THEME_COUNT', () => {
     const addons = [];
     const footerLink = 'footer-link-path';
     const footerText = 'footer link text';
@@ -151,23 +151,25 @@ describe(__filename, () => {
     );
   });
 
-  it('shows the footer link when there are as many or more add-ons than placeholderCount', () => {
+  it('shows the footer link when there are more or as many add-ons as placeholderCount', () => {
+    const addons = [];
     const footerLink = 'footer-link-path';
     const footerText = 'footer link text';
+    const placeholderCount = 2;
 
-    const addons = [
-      createInternalAddon({
-        ...fakeAddon,
-        slug: 'custom-addon',
-      }),
-      createInternalAddon({
-        ...fakeAddon,
-        slug: 'custom-addon-1',
-      }),
-    ];
+    for (let i = 0; i < placeholderCount; i++) {
+      addons.push(
+        createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_THEME,
+          slug: `custom-addon-${i}`,
+        }),
+      );
+    }
+
     const root = render({
       addons,
-      placeholderCount: 2,
+      placeholderCount,
       footerLink,
       footerText,
     });

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 
 import AddonsCard from 'amo/components/AddonsCard';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
+import Link from 'amo/components/Link';
 import {
   LANDING_PAGE_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
@@ -108,51 +109,52 @@ describe(__filename, () => {
   });
 
   it('hides the footer link when there are less add-ons than LANDING_PAGE_THEME_COUNT', () => {
-    const addons = [
-      createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_THEME,
-        slug: 'custom-addon',
-      }),
-    ];
+    const addons = [];
+
+    for (let i = 0; i < LANDING_PAGE_THEME_COUNT - 1; i++) {
+      addons.push(
+        createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_THEME,
+          slug: `custom-addon-${i}`,
+        }),
+      );
+    }
     const root = render({ addons, isTheme: true });
     expect(root.find(AddonsCard)).toHaveProp('footerLink', null);
   });
 
   it('shows the footer link when there are more or as many add-ons than LANDING_PAGE_THEME_COUNT', () => {
-    const addons = [
-      createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_THEME,
-        slug: 'custom-addon',
-      }),
-      createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_THEME,
-        slug: 'custom-addon-1',
-      }),
-      createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_THEME,
-        slug: 'custom-addon-2',
-      }),
-    ];
-    const root = render({ addons, isTheme: true });
-    expect(root.find(AddonsCard)).not.toHaveProp('footerLink', null);
+    const addons = [];
+    const footerLink = 'footer-link-path';
+    const footerText = 'footer link text';
 
-    expect(root.find(AddonsCard).prop('footerLink')).toMatchObject({
-      key: null,
-      ref: null,
-      props: {
-        to: { pathname: '/some-path/', query: {} },
-        children: 'some text',
-      },
-      _owner: null,
-      _store: {},
+    for (let i = 0; i < LANDING_PAGE_THEME_COUNT; i++) {
+      addons.push(
+        createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_THEME,
+          slug: `custom-addon-${i}`,
+        }),
+      );
+    }
+
+    const root = render({
+      addons,
+      isTheme: true,
+      footerLink,
+      footerText,
     });
+
+    expect(root.find(AddonsCard).prop('footerLink')).toEqual(
+      <Link to={footerLink}>{footerText}</Link>,
+    );
   });
 
   it('shows the footer link when there are as many or more add-ons than placeholderCount', () => {
+    const footerLink = 'footer-link-path';
+    const footerText = 'footer link text';
+
     const addons = [
       createInternalAddon({
         ...fakeAddon,
@@ -163,19 +165,16 @@ describe(__filename, () => {
         slug: 'custom-addon-1',
       }),
     ];
-    const root = render({ addons, placeholderCount: 2 });
-    expect(root.find(AddonsCard)).not.toHaveProp('footerLink', null);
-
-    expect(root.find(AddonsCard).prop('footerLink')).toMatchObject({
-      key: null,
-      ref: null,
-      props: {
-        to: { pathname: '/some-path/', query: {} },
-        children: 'some text',
-      },
-      _owner: null,
-      _store: {},
+    const root = render({
+      addons,
+      placeholderCount: 2,
+      footerLink,
+      footerText,
     });
+
+    expect(root.find(AddonsCard).prop('footerLink')).toEqual(
+      <Link to={footerLink}>{footerText}</Link>,
+    );
   });
 
   it('accepts a string for the footer link', () => {

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -67,8 +67,8 @@ describe(__filename, () => {
     expect(root).toHaveProp('placeholderCount', LANDING_PAGE_EXTENSION_COUNT);
   });
 
-  it('sets the correct number of placeholders for a theme type', () => {
-    const root = render({ isTheme: true });
+  it('overrides the default placeholder value when passed in', () => {
+    const root = render({ placeholderCount: LANDING_PAGE_THEME_COUNT });
 
     expect(root.find(AddonsCard)).toHaveProp(
       'placeholderCount',
@@ -76,8 +76,8 @@ describe(__filename, () => {
     );
   });
 
-  it('sets the correct number of placeholders for an extension type', () => {
-    const root = render({ isTheme: false });
+  it('uses the default placeholder count when there is no override', () => {
+    const root = render();
 
     expect(root.find(AddonsCard)).toHaveProp(
       'placeholderCount',

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -7,13 +7,11 @@ import {
   LANDING_PAGE_ADDON_COUNT,
   LANDING_PAGE_THEME_ADDON_COUNT,
 } from 'amo/constants';
-
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
   ADDON_TYPE_THEMES_FILTER,
 } from 'core/constants';
-
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -4,21 +4,15 @@ import { shallow } from 'enzyme';
 import AddonsCard from 'amo/components/AddonsCard';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import {
-  LANDING_PAGE_ADDON_COUNT,
-  LANDING_PAGE_THEME_ADDON_COUNT,
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
-import {
-  ADDON_TYPE_EXTENSION,
-  ADDON_TYPE_STATIC_THEME,
-  ADDON_TYPE_THEME,
-  ADDON_TYPE_THEMES_FILTER,
-} from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
   function render(customProps = {}) {
-    const addons = Array(LANDING_PAGE_ADDON_COUNT).fill(
+    const addons = Array(LANDING_PAGE_EXTENSION_COUNT).fill(
       createInternalAddon(fakeAddon),
     );
 
@@ -70,62 +64,24 @@ describe(__filename, () => {
 
   it('sets the number of placeholders to render while loading', () => {
     const root = render({ loading: true });
-    expect(root).toHaveProp('placeholderCount', LANDING_PAGE_ADDON_COUNT);
+    expect(root).toHaveProp('placeholderCount', LANDING_PAGE_EXTENSION_COUNT);
   });
 
-  it('sets the correct number of placeholders for lightweight and static theme types', () => {
-    const root = render({
-      footerLink: {
-        pathname: '/some-path/',
-        query: { addonType: ADDON_TYPE_THEMES_FILTER },
-      },
-    });
+  it('sets the correct number of placeholders for a theme type', () => {
+    const root = render({ isTheme: true });
 
     expect(root.find(AddonsCard)).toHaveProp(
       'placeholderCount',
-      LANDING_PAGE_THEME_ADDON_COUNT,
-    );
-  });
-
-  it('sets the correct number of placeholders for a lightweight theme type', () => {
-    const root = render({
-      footerLink: {
-        pathname: '/some-path/',
-        query: { addonType: ADDON_TYPE_THEME },
-      },
-    });
-
-    expect(root.find(AddonsCard)).toHaveProp(
-      'placeholderCount',
-      LANDING_PAGE_THEME_ADDON_COUNT,
-    );
-  });
-
-  it('sets the correct number of placeholders for a static theme type', () => {
-    const root = render({
-      footerLink: {
-        pathname: '/some-path/',
-        query: { addonType: ADDON_TYPE_STATIC_THEME },
-      },
-    });
-
-    expect(root.find(AddonsCard)).toHaveProp(
-      'placeholderCount',
-      LANDING_PAGE_THEME_ADDON_COUNT,
+      LANDING_PAGE_THEME_COUNT,
     );
   });
 
   it('sets the correct number of placeholders for an extension type', () => {
-    const root = render({
-      footerLink: {
-        pathname: '/some-path/',
-        query: { addonType: ADDON_TYPE_EXTENSION },
-      },
-    });
+    const root = render({ isTheme: false });
 
     expect(root.find(AddonsCard)).toHaveProp(
       'placeholderCount',
-      LANDING_PAGE_ADDON_COUNT,
+      LANDING_PAGE_EXTENSION_COUNT,
     );
   });
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -9,6 +9,7 @@ import {
 } from 'amo/constants';
 import {
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
   ADDON_TYPE_THEMES_FILTER,
 } from 'core/constants';
@@ -72,7 +73,7 @@ describe(__filename, () => {
     expect(root).toHaveProp('placeholderCount', LANDING_PAGE_ADDON_COUNT);
   });
 
-  it('sets the correct number of placeholders for theme types', () => {
+  it('sets the correct number of placeholders for lightweight and static theme types', () => {
     const root = render({
       footerLink: {
         pathname: '/some-path/',
@@ -86,11 +87,25 @@ describe(__filename, () => {
     );
   });
 
-  it('sets the correct number of placeholders for lightweight theme type', () => {
+  it('sets the correct number of placeholders for a lightweight theme type', () => {
     const root = render({
       footerLink: {
         pathname: '/some-path/',
         query: { addonType: ADDON_TYPE_THEME },
+      },
+    });
+
+    expect(root.find(AddonsCard)).toHaveProp(
+      'placeholderCount',
+      LANDING_PAGE_THEME_ADDON_COUNT,
+    );
+  });
+
+  it('sets the correct number of placeholders for a static theme type', () => {
+    const root = render({
+      footerLink: {
+        pathname: '/some-path/',
+        query: { addonType: ADDON_TYPE_STATIC_THEME },
       },
     });
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -95,15 +95,6 @@ describe(__filename, () => {
     );
   });
 
-  it('uses the default placeholder count when there is no override', () => {
-    const root = render();
-
-    expect(root.find(AddonsCard)).toHaveProp(
-      'placeholderCount',
-      LANDING_PAGE_EXTENSION_COUNT,
-    );
-  });
-
   it('hides the footer link when less add-ons than placeholderCount', () => {
     const addons = [
       createInternalAddon({

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -7,6 +7,7 @@ import {
   LANDING_PAGE_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
+import { ADDON_TYPE_THEME } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
@@ -95,7 +96,7 @@ describe(__filename, () => {
     );
   });
 
-  it('hides the footer link when less add-ons than placeholderCount', () => {
+  it('hides the footer link when there are less add-ons than placeholderCount', () => {
     const addons = [
       createInternalAddon({
         ...fakeAddon,
@@ -104,6 +105,77 @@ describe(__filename, () => {
     ];
     const root = render({ addons, placeholderCount: 2 });
     expect(root.find(AddonsCard)).toHaveProp('footerLink', null);
+  });
+
+  it('hides the footer link when there are less add-ons than LANDING_PAGE_THEME_COUNT', () => {
+    const addons = [
+      createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        slug: 'custom-addon',
+      }),
+    ];
+    const root = render({ addons, isTheme: true });
+    expect(root.find(AddonsCard)).toHaveProp('footerLink', null);
+  });
+
+  it('shows the footer link when there are more or as many add-ons than LANDING_PAGE_THEME_COUNT', () => {
+    const addons = [
+      createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        slug: 'custom-addon',
+      }),
+      createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        slug: 'custom-addon-1',
+      }),
+      createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        slug: 'custom-addon-2',
+      }),
+    ];
+    const root = render({ addons, isTheme: true });
+    expect(root.find(AddonsCard)).not.toHaveProp('footerLink', null);
+
+    expect(root.find(AddonsCard).prop('footerLink')).toMatchObject({
+      key: null,
+      ref: null,
+      props: {
+        to: { pathname: '/some-path/', query: {} },
+        children: 'some text',
+      },
+      _owner: null,
+      _store: {},
+    });
+  });
+
+  it('shows the footer link when there are as many or more add-ons than placeholderCount', () => {
+    const addons = [
+      createInternalAddon({
+        ...fakeAddon,
+        slug: 'custom-addon',
+      }),
+      createInternalAddon({
+        ...fakeAddon,
+        slug: 'custom-addon-1',
+      }),
+    ];
+    const root = render({ addons, placeholderCount: 2 });
+    expect(root.find(AddonsCard)).not.toHaveProp('footerLink', null);
+
+    expect(root.find(AddonsCard).prop('footerLink')).toMatchObject({
+      key: null,
+      ref: null,
+      props: {
+        to: { pathname: '/some-path/', query: {} },
+        children: 'some text',
+      },
+      _owner: null,
+      _store: {},
+    });
   });
 
   it('accepts a string for the footer link', () => {

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -376,7 +376,10 @@ describe(__filename, () => {
     const addonCardProps = root
       .find(LandingAddonsCard)
       .map((addonCard) => addonCard.props().isTheme);
-    expect(addonCardProps).toContain(true);
+
+    addonCardProps.forEach((cardItem) => {
+      expect(cardItem).toEqual(true);
+    });
   });
 
   it('passes a isTheme prop as false if type is an extension', () => {
@@ -391,7 +394,10 @@ describe(__filename, () => {
     const addonCardProps = root
       .find(LandingAddonsCard)
       .map((addonCard) => addonCard.props().isTheme);
-    expect(addonCardProps).toContain(false);
+
+    addonCardProps.forEach((cardItem) => {
+      expect(cardItem).toEqual(false);
+    });
   });
 
   it('renders a LandingPage with themes HTML', () => {

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -364,6 +364,36 @@ describe(__filename, () => {
     );
   });
 
+  it('passes isTheme prop as true if type is a theme', () => {
+    _getAndLoadLandingAddons({ addonType: ADDON_TYPE_THEME });
+
+    const root = render({
+      params: {
+        visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+      },
+    });
+
+    const addonCardProps = root
+      .find(LandingAddonsCard)
+      .map((addonCard) => addonCard.props().isTheme);
+    expect(addonCardProps).toContain(true);
+  });
+
+  it('passes isTheme prop as false if type is an extension', () => {
+    _getAndLoadLandingAddons({ addonType: ADDON_TYPE_EXTENSION });
+
+    const root = render({
+      params: {
+        visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+      },
+    });
+
+    const addonCardProps = root
+      .find(LandingAddonsCard)
+      .map((addonCard) => addonCard.props().isTheme);
+    expect(addonCardProps).toContain(false);
+  });
+
   it('renders a LandingPage with themes HTML', () => {
     const root = render({
       params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -364,7 +364,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes isTheme prop as true if type is a theme', () => {
+  it('passes a isTheme prop as true if type is a theme', () => {
     _getAndLoadLandingAddons({ addonType: ADDON_TYPE_THEME });
 
     const root = render({
@@ -379,7 +379,7 @@ describe(__filename, () => {
     expect(addonCardProps).toContain(true);
   });
 
-  it('passes isTheme prop as false if type is an extension', () => {
+  it('passes a isTheme prop as false if type is an extension', () => {
     _getAndLoadLandingAddons({ addonType: ADDON_TYPE_EXTENSION });
 
     const root = render({

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -373,11 +373,9 @@ describe(__filename, () => {
       },
     });
 
-    const addonCardProps = root
-      .find(LandingAddonsCard)
-      .map((addonCard) => addonCard.props().isTheme);
-
-    addonCardProps.forEach((cardItem) => expect(cardItem).toEqual(true));
+    root.find(LandingAddonsCard).forEach((card) => {
+      expect(card).toHaveProp('isTheme', true);
+    });
   });
 
   it('passes an isTheme prop as false if type is an extension', () => {
@@ -389,11 +387,9 @@ describe(__filename, () => {
       },
     });
 
-    const addonCardProps = root
-      .find(LandingAddonsCard)
-      .map((addonCard) => addonCard.props().isTheme);
-
-    addonCardProps.forEach((cardItem) => expect(cardItem).toEqual(false));
+    root.find(LandingAddonsCard).forEach((card) => {
+      expect(card).toHaveProp('isTheme', false);
+    });
   });
 
   it('renders a LandingPage with themes HTML', () => {

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -222,19 +222,17 @@ describe(__filename, () => {
     );
   });
 
-  it('does not render a theme className when page type is extensions', () => {
-    const fakeParams = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
-    };
-    const root = render({ params: fakeParams });
+  it('does not render a theme class name when page type is extensions', () => {
+    const root = render({
+      params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) },
+    });
     expect(root).not.toHaveClassName('.LandingPage--theme');
   });
 
-  it('renders a theme className when page type is themes', () => {
-    const fakeParams = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
-    };
-    const root = render({ params: fakeParams });
+  it('renders a theme class name when page type is themes', () => {
+    const root = render({
+      params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
+    });
     expect(root).toHaveClassName('.LandingPage--theme');
   });
 

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -222,6 +222,22 @@ describe(__filename, () => {
     );
   });
 
+  it('does not render a theme className when page type is extensions', () => {
+    const fakeParams = {
+      visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+    };
+    const root = render({ params: fakeParams });
+    expect(root).not.toHaveClassName('.LandingPage--theme');
+  });
+
+  it('renders a theme className when page type is themes', () => {
+    const fakeParams = {
+      visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+    };
+    const root = render({ params: fakeParams });
+    expect(root).toHaveClassName('.LandingPage--theme');
+  });
+
   it('sets the links in each footer for extensions', () => {
     store.dispatch(
       landingActions.loadLanding({

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -364,7 +364,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes a isTheme prop as true if type is a theme', () => {
+  it('passes an isTheme prop as true if type is a theme', () => {
     _getAndLoadLandingAddons({ addonType: ADDON_TYPE_THEME });
 
     const root = render({
@@ -377,12 +377,10 @@ describe(__filename, () => {
       .find(LandingAddonsCard)
       .map((addonCard) => addonCard.props().isTheme);
 
-    addonCardProps.forEach((cardItem) => {
-      expect(cardItem).toEqual(true);
-    });
+    addonCardProps.forEach((cardItem) => expect(cardItem).toEqual(true));
   });
 
-  it('passes a isTheme prop as false if type is an extension', () => {
+  it('passes an isTheme prop as false if type is an extension', () => {
     _getAndLoadLandingAddons({ addonType: ADDON_TYPE_EXTENSION });
 
     const root = render({
@@ -395,9 +393,7 @@ describe(__filename, () => {
       .find(LandingAddonsCard)
       .map((addonCard) => addonCard.props().isTheme);
 
-    addonCardProps.forEach((cardItem) => {
-      expect(cardItem).toEqual(false);
-    });
+    addonCardProps.forEach((cardItem) => expect(cardItem).toEqual(false));
   });
 
   it('renders a LandingPage with themes HTML', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -144,6 +144,50 @@ describe(__filename, () => {
     expect(root).toHaveClassName('SearchResult--theme');
   });
 
+  it('displays the thumbnail image as the default src for static theme', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_STATIC_THEME,
+    });
+    const root = render({ addon });
+    const image = root.find('.SearchResult-icon');
+
+    expect(image.prop('src')).toEqual(
+      'https://addons.cdn.mozilla.net/4444/image.png',
+    );
+  });
+
+  // TODO: This can be removed once migration happens.
+  it('displays srcSet values if preview has multiple images', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_STATIC_THEME,
+    });
+
+    const root = render({ addon });
+    const image = root.find('.SearchResult-icon');
+
+    expect(image.prop('srcSet')).toEqual(
+      'https://addons.cdn.mozilla.net/4444/image.png 200w, https://addons.cdn.mozilla.net/55555/image.png 400w',
+    );
+  });
+
+  // TODO: This can be removed once migration happens.
+  it('displays fallback image for older themes that only had 1 preview option', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      type: ADDON_TYPE_STATIC_THEME,
+    });
+    delete addon.previews[1];
+
+    const root = render({ addon });
+    const image = root.find('.SearchResult-icon');
+
+    expect(image.prop('src')).toEqual(
+      'https://addons.cdn.mozilla.net/7123/image.png',
+    );
+  });
+
   it('displays a message if the lightweight theme preview image is unavailable', () => {
     const addon = createInternalAddon({
       ...fakeAddon,

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -131,15 +131,16 @@ describe(__filename, () => {
   });
 
   it('adds a theme-specific class', () => {
-    const addon = createInternalAddon({
-      ...fakeAddon,
-      type: ADDON_TYPE_THEME,
-      theme_data: {
-        previewURL:
-          'https://addons.cdn.mozilla.net/user-media/addons/334902/preview_large.jpg?1313374873',
-      },
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        theme_data: {
+          previewURL:
+            'https://addons.cdn.mozilla.net/user-media/addons/334902/preview_large.jpg?1313374873',
+        },
+      }),
     });
-    const root = render({ addon });
 
     expect(root).toHaveClassName('SearchResult--theme');
   });
@@ -147,20 +148,19 @@ describe(__filename, () => {
   it('displays the thumbnail image as the default src for static theme', () => {
     const headerImageThumb =
       'https://addons.cdn.mozilla.net/mytestthumb/12345.png';
-    const newPreview = [
-      {
-        ...fakePreview,
-        thumbnail_url: headerImageThumb,
-      },
-    ];
 
-    const addon = createInternalAddon({
-      ...fakeAddon,
-      type: ADDON_TYPE_STATIC_THEME,
-      previews: newPreview,
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url: headerImageThumb,
+          },
+        ],
+      }),
     });
-
-    const root = render({ addon });
     const image = root.find('.SearchResult-icon');
 
     expect(image.prop('src')).toEqual(headerImageThumb);
@@ -172,26 +172,24 @@ describe(__filename, () => {
     const thumbWidth = 450;
     const fullWidth = 900;
 
-    const newPreview = [
-      {
-        ...fakePreview,
-      },
-      {
-        ...fakePreview,
-        image_url: headerImageFull,
-        thumbnail_url: headerImageThumb,
-        image_size: [fullWidth, 200],
-        thumbnail_size: [thumbWidth, 100],
-      },
-    ];
-
-    const addon = createInternalAddon({
-      ...fakeAddon,
-      type: ADDON_TYPE_STATIC_THEME,
-      previews: newPreview,
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+          },
+          {
+            ...fakePreview,
+            image_url: headerImageFull,
+            thumbnail_url: headerImageThumb,
+            image_size: [fullWidth, 200],
+            thumbnail_size: [thumbWidth, 100],
+          },
+        ],
+      }),
     });
-
-    const root = render({ addon });
     const image = root.find('.SearchResult-icon');
 
     expect(image.prop('srcSet')).toEqual(
@@ -203,20 +201,18 @@ describe(__filename, () => {
   it('displays a fallback image for themes that only have 1 preview option', () => {
     const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
 
-    const newPreview = [
-      {
-        ...fakePreview,
-        thumbnail_url: headerImageThumb,
-      },
-    ];
-
-    const addon = createInternalAddon({
-      ...fakeAddon,
-      type: ADDON_TYPE_STATIC_THEME,
-      previews: newPreview,
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url: headerImageThumb,
+          },
+        ],
+      }),
     });
-
-    const root = render({ addon });
     const image = root.find('.SearchResult-icon');
 
     expect(image.prop('src')).toEqual(headerImageThumb);

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -146,7 +146,7 @@ describe(__filename, () => {
   });
 
   it('does not render an image if the isAllowedOrigin is false', () => {
-    const differentOriginalUrl = 'http://example.com';
+    const differentOriginUrl = 'http://example.com';
     const isAllowedOriginSpy = sinon.spy();
     const root = render({
       isAllowedOrigin: isAllowedOriginSpy,
@@ -156,13 +156,13 @@ describe(__filename, () => {
         previews: [
           {
             ...fakePreview,
-            thumbnail_url: differentOriginalUrl,
+            thumbnail_url: differentOriginUrl,
           },
         ],
       }),
     });
 
-    sinon.assert.calledWith(isAllowedOriginSpy, differentOriginalUrl);
+    sinon.assert.calledWith(isAllowedOriginSpy, differentOriginUrl);
     expect(root.find('.SearchResult-icon')).toHaveLength(0);
   });
 
@@ -253,8 +253,8 @@ describe(__filename, () => {
           previews: [
             {
               ...fakePreview,
-              image_url: 'http://not.this.image.full.png',
-              thumbnail_url: 'http://not.this.image.thumb.png',
+              image_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
+              thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
             },
             {
               ...fakePreview,

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -145,7 +145,7 @@ describe(__filename, () => {
     expect(root).toHaveClassName('SearchResult--theme');
   });
 
-  it('does not render image if the isAllowedOrigin is false', () => {
+  it('does not render an image if the isAllowedOrigin is false', () => {
     const root = render({
       addon: createInternalAddon({
         ...fakeAddon,
@@ -153,7 +153,7 @@ describe(__filename, () => {
         previews: [
           {
             ...fakePreview,
-            thumbnail_url: 'http://example.url.com',
+            thumbnail_url: 'http://example.com',
           },
         ],
       }),
@@ -162,7 +162,7 @@ describe(__filename, () => {
     expect(root.find('.SearchResult-icon')).toHaveLength(0);
   });
 
-  it('renders image alt as addon name', () => {
+  it("renders an image's alt attribute as its addon name", () => {
     const alt = 'pretty image';
     const root = render({
       addon: createInternalAddon({
@@ -259,6 +259,35 @@ describe(__filename, () => {
           {
             ...fakePreview,
             image_url: headerImageFull,
+            thumbnail_url: headerImageThumb,
+            image_size: [],
+            thumbnail_size: [],
+          },
+        ],
+      }),
+    });
+    const image = root.find('.SearchResult-icon');
+    expect(image.prop('src')).toEqual(headerImageThumb);
+    expect(image).not.toHaveProp('srcSet');
+  });
+
+  it('renders image without srcSet if there is no large preview image url', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
+
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            image_url: headerImageFull,
+            thumbnail_url: headerImageThumb,
+          },
+          {
+            ...fakePreview,
+            image_url: '',
             thumbnail_url: headerImageThumb,
             image_size: [],
             thumbnail_size: [],

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -146,23 +146,14 @@ describe(__filename, () => {
   });
 
   it('does not render an image if the isAllowedOrigin is false', () => {
-    const differentOriginUrl = 'http://example.com';
-    const isAllowedOriginSpy = sinon.spy();
     const root = render({
-      isAllowedOrigin: isAllowedOriginSpy,
+      isAllowedOrigin: sinon.stub().returns(false),
       addon: createInternalAddon({
         ...fakeAddon,
         type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            ...fakePreview,
-            thumbnail_url: differentOriginUrl,
-          },
-        ],
       }),
     });
 
-    sinon.assert.calledWith(isAllowedOriginSpy, differentOriginUrl);
     expect(root.find('.SearchResult-icon')).toHaveLength(0);
   });
 
@@ -240,9 +231,9 @@ describe(__filename, () => {
     );
   });
 
-  it.each([0, 1])(
-    `renders image without srcSet if there are no preview image sizes or large image %s`,
-    (index) => {
+  it.each([{ image_url: '' }, { image_size: [] }, { thumbnail_size: [] }])(
+    `renders image without srcSet if there are no preview image sizes or large image %o`,
+    (propOverride) => {
       const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
       const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
 
@@ -258,10 +249,11 @@ describe(__filename, () => {
             },
             {
               ...fakePreview,
-              image_url: index === 0 ? headerImageFull : '',
+              image_url: headerImageFull,
               thumbnail_url: headerImageThumb,
-              image_size: index === 1 ? [400, 200] : [],
-              thumbnail_size: index === 1 ? [200, 100] : [],
+              image_size: [400, 200],
+              thumbnail_size: [200, 100],
+              ...propOverride,
             },
           ],
         }),

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -172,11 +172,12 @@ describe(__filename, () => {
   });
 
   // TODO: This can be removed once migration happens.
-  it('displays fallback image for older themes that only have 1 preview option', () => {
+  it('displays a fallback image for themes that only have 1 preview option', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,
     });
+
     delete addon.previews[1];
 
     const root = render({ addon });

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -145,6 +145,51 @@ describe(__filename, () => {
     expect(root).toHaveClassName('SearchResult--theme');
   });
 
+  it('does not render image if the isAllowedOrigin is false', () => {
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url: 'http://example.url.com',
+          },
+        ],
+      }),
+    });
+
+    expect(root.find('.SearchResult-icon')).toHaveLength(0);
+  });
+
+  it('renders image alt as addon name', () => {
+    const alt = 'pretty image';
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        name: alt,
+        type: ADDON_TYPE_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url:
+              'https://addons.cdn.mozilla.net/mytestthumb/12345.png',
+          },
+        ],
+      }),
+    });
+
+    expect(root.find('.SearchResult-icon')).toHaveProp('alt', alt);
+  });
+
+  it('renders an empty string for the image alt tag while there is no addon', () => {
+    const root = render({
+      addon: {},
+    });
+
+    expect(root.find('.SearchResult-icon')).not.toHaveProp('alt', '');
+  });
+
   it('displays the thumbnail image as the default src for static theme', () => {
     const headerImageThumb =
       'https://addons.cdn.mozilla.net/mytestthumb/12345.png';
@@ -179,6 +224,8 @@ describe(__filename, () => {
         previews: [
           {
             ...fakePreview,
+            image_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
+            thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
           },
           {
             ...fakePreview,
@@ -195,6 +242,33 @@ describe(__filename, () => {
     expect(image.prop('srcSet')).toEqual(
       `${headerImageThumb} ${thumbWidth}w, ${headerImageFull} ${fullWidth}w`,
     );
+  });
+
+  it('renders image without srcSet if there are no preview image sizes', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
+
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+          },
+          {
+            ...fakePreview,
+            image_url: headerImageFull,
+            thumbnail_url: headerImageThumb,
+            image_size: [],
+            thumbnail_size: [],
+          },
+        ],
+      }),
+    });
+    const image = root.find('.SearchResult-icon');
+    expect(image.prop('src')).toEqual(headerImageThumb);
+    expect(image).not.toHaveProp('srcSet');
   });
 
   // TODO: This can be removed once migration happens.

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -157,7 +157,6 @@ describe(__filename, () => {
     );
   });
 
-  // TODO: This can be removed once migration happens.
   it('displays srcSet values if preview has multiple images', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
@@ -173,7 +172,7 @@ describe(__filename, () => {
   });
 
   // TODO: This can be removed once migration happens.
-  it('displays fallback image for older themes that only had 1 preview option', () => {
+  it('displays fallback image for older themes that only have 1 preview option', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -145,47 +145,94 @@ describe(__filename, () => {
   });
 
   it('displays the thumbnail image as the default src for static theme', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,
+      previews: [
+        {
+          id: 1,
+          caption: 'Image 1',
+          image_url: 'https://addons.cdn.mozilla.net/full/1.png',
+          thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/1.png',
+          image_size: [400, 200],
+          thumbnail_size: [200, 100],
+        },
+        {
+          id: 2,
+          caption: 'Image 2',
+          image_url: 'https://addons.cdn.mozilla.net/thumb/1.png',
+          thumbnail_url: headerImageThumb,
+          image_size: [400, 200],
+          thumbnail_size: [200, 100],
+        },
+      ],
     });
     const root = render({ addon });
     const image = root.find('.SearchResult-icon');
 
-    expect(image.prop('src')).toEqual(
-      'https://addons.cdn.mozilla.net/4444/image.png',
-    );
+    expect(image.prop('src')).toEqual(headerImageThumb);
   });
 
-  it('displays srcSet values if preview has multiple images', () => {
+  it('displays srcSet values if preview has multiple options', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/1.png';
+    const thumbWidth = 200;
+    const fullWidth = 400;
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,
+      previews: [
+        {
+          id: 1,
+          caption: 'Image 1',
+          image_url: 'https://addons.cdn.mozilla.net/full/1.png',
+          thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/1.png',
+          image_size: [400, 200],
+          thumbnail_size: [200, 100],
+        },
+        {
+          id: 2,
+          caption: 'Image 2',
+          image_url: headerImageFull,
+          thumbnail_url: headerImageThumb,
+          image_size: [fullWidth, 200],
+          thumbnail_size: [thumbWidth, 100],
+        },
+      ],
     });
 
     const root = render({ addon });
     const image = root.find('.SearchResult-icon');
 
     expect(image.prop('srcSet')).toEqual(
-      'https://addons.cdn.mozilla.net/4444/image.png 200w, https://addons.cdn.mozilla.net/55555/image.png 400w',
+      `${headerImageThumb} ${thumbWidth}w, ${headerImageFull} ${fullWidth}w`,
     );
   });
 
   // TODO: This can be removed once migration happens.
   it('displays a fallback image for themes that only have 1 preview option', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,
+      previews: [
+        {
+          id: 1,
+          caption: 'Image 1',
+          image_url: 'https://addons.cdn.mozilla.net/full/1.png',
+          thumbnail_url: headerImageThumb,
+          image_size: [400, 200],
+          thumbnail_size: [200, 100],
+        },
+      ],
     });
-
-    delete addon.previews[1];
 
     const root = render({ addon });
     const image = root.find('.SearchResult-icon');
 
-    expect(image.prop('src')).toEqual(
-      'https://addons.cdn.mozilla.net/7123/image.png',
-    );
+    expect(image.prop('src')).toEqual(headerImageThumb);
+    expect(image.prop('srcSet')).toBeUndefined();
   });
 
   it('displays a message if the lightweight theme preview image is unavailable', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { SearchResultBase } from 'amo/components/SearchResult';
 import { ADDON_TYPE_STATIC_THEME, ADDON_TYPE_THEME } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
-import { fakeAddon, fakeTheme } from 'tests/unit/amo/helpers';
+import { fakeAddon, fakePreview, fakeTheme } from 'tests/unit/amo/helpers';
 import { fakeI18n } from 'tests/unit/helpers';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
@@ -145,29 +145,21 @@ describe(__filename, () => {
   });
 
   it('displays the thumbnail image as the default src for static theme', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
+    const headerImageThumb =
+      'https://addons.cdn.mozilla.net/mytestthumb/12345.png';
+    const newPreview = [
+      {
+        ...fakePreview,
+        thumbnail_url: headerImageThumb,
+      },
+    ];
+
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,
-      previews: [
-        {
-          id: 1,
-          caption: 'Image 1',
-          image_url: 'https://addons.cdn.mozilla.net/full/1.png',
-          thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/1.png',
-          image_size: [400, 200],
-          thumbnail_size: [200, 100],
-        },
-        {
-          id: 2,
-          caption: 'Image 2',
-          image_url: 'https://addons.cdn.mozilla.net/thumb/1.png',
-          thumbnail_url: headerImageThumb,
-          image_size: [400, 200],
-          thumbnail_size: [200, 100],
-        },
-      ],
+      previews: newPreview,
     });
+
     const root = render({ addon });
     const image = root.find('.SearchResult-icon');
 
@@ -175,31 +167,28 @@ describe(__filename, () => {
   });
 
   it('displays srcSet values if preview has multiple options', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
-    const headerImageFull = 'https://addons.cdn.mozilla.net/full/1.png';
-    const thumbWidth = 200;
-    const fullWidth = 400;
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
+    const thumbWidth = 450;
+    const fullWidth = 900;
+
+    const newPreview = [
+      {
+        ...fakePreview,
+      },
+      {
+        ...fakePreview,
+        image_url: headerImageFull,
+        thumbnail_url: headerImageThumb,
+        image_size: [fullWidth, 200],
+        thumbnail_size: [thumbWidth, 100],
+      },
+    ];
+
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,
-      previews: [
-        {
-          id: 1,
-          caption: 'Image 1',
-          image_url: 'https://addons.cdn.mozilla.net/full/1.png',
-          thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/1.png',
-          image_size: [400, 200],
-          thumbnail_size: [200, 100],
-        },
-        {
-          id: 2,
-          caption: 'Image 2',
-          image_url: headerImageFull,
-          thumbnail_url: headerImageThumb,
-          image_size: [fullWidth, 200],
-          thumbnail_size: [thumbWidth, 100],
-        },
-      ],
+      previews: newPreview,
     });
 
     const root = render({ addon });
@@ -213,19 +202,18 @@ describe(__filename, () => {
   // TODO: This can be removed once migration happens.
   it('displays a fallback image for themes that only have 1 preview option', () => {
     const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
+
+    const newPreview = [
+      {
+        ...fakePreview,
+        thumbnail_url: headerImageThumb,
+      },
+    ];
+
     const addon = createInternalAddon({
       ...fakeAddon,
       type: ADDON_TYPE_STATIC_THEME,
-      previews: [
-        {
-          id: 1,
-          caption: 'Image 1',
-          image_url: 'https://addons.cdn.mozilla.net/full/1.png',
-          thumbnail_url: headerImageThumb,
-          image_size: [400, 200],
-          thumbnail_size: [200, 100],
-        },
-      ],
+      previews: newPreview,
     });
 
     const root = render({ addon });

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -147,7 +147,7 @@ describe(__filename, () => {
 
   it('does not render an image if the isAllowedOrigin is false', () => {
     const root = render({
-      isAllowedOrigin: sinon.stub().returns(false),
+      _isAllowedOrigin: sinon.stub().returns(false),
       addon: createInternalAddon({
         ...fakeAddon,
         type: ADDON_TYPE_STATIC_THEME,
@@ -198,6 +198,7 @@ describe(__filename, () => {
   });
 
   // TODO: This can be removed once migration happens.
+  // See: https://github.com/mozilla/addons-frontend/issues/5359
   it('displays a fallback image for themes that only have 1 preview option', () => {
     const headerImageFull = 'https://addons.cdn.mozilla.net/full/1.png';
 

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -146,19 +146,23 @@ describe(__filename, () => {
   });
 
   it('does not render an image if the isAllowedOrigin is false', () => {
+    const differentOriginalUrl = 'http://example.com';
+    const isAllowedOriginSpy = sinon.spy();
     const root = render({
+      isAllowedOrigin: isAllowedOriginSpy,
       addon: createInternalAddon({
         ...fakeAddon,
         type: ADDON_TYPE_STATIC_THEME,
         previews: [
           {
             ...fakePreview,
-            thumbnail_url: 'http://example.com',
+            thumbnail_url: differentOriginalUrl,
           },
         ],
       }),
     });
 
+    sinon.assert.calledWith(isAllowedOriginSpy, differentOriginalUrl);
     expect(root.find('.SearchResult-icon')).toHaveLength(0);
   });
 

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -241,7 +241,7 @@ describe(__filename, () => {
   });
 
   it.each([0, 1])(
-    `renders image without srcSet if there are no preview image sizes or a large image position %s`,
+    `renders image without srcSet if there are no preview image sizes or large image %s`,
     (index) => {
       const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
       const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
@@ -253,16 +253,15 @@ describe(__filename, () => {
           previews: [
             {
               ...fakePreview,
-              image_url: index === 0 ? fakePreview.image_url : headerImageFull,
-              thumbnail_url:
-                index === 0 ? fakePreview.thumbnail_url : headerImageThumb,
+              image_url: 'http://not.this.image.full.png',
+              thumbnail_url: 'http://not.this.image.thumb.png',
             },
             {
               ...fakePreview,
               image_url: index === 0 ? headerImageFull : '',
               thumbnail_url: headerImageThumb,
-              image_size: [],
-              thumbnail_size: [],
+              image_size: index === 1 ? [400, 200] : [],
+              thumbnail_size: index === 1 ? [200, 100] : [],
             },
           ],
         }),

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -168,14 +168,6 @@ describe(__filename, () => {
       addon: createInternalAddon({
         ...fakeAddon,
         name: alt,
-        type: ADDON_TYPE_THEME,
-        previews: [
-          {
-            ...fakePreview,
-            thumbnail_url:
-              'https://addons.cdn.mozilla.net/mytestthumb/12345.png',
-          },
-        ],
       }),
     });
 
@@ -244,61 +236,39 @@ describe(__filename, () => {
     );
   });
 
-  it('renders image without srcSet if there are no preview image sizes', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
+  it.each([0, 1])(
+    `renders image without srcSet if there are no preview image sizes or a large image position %s`,
+    (index) => {
+      const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+      const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
 
-    const root = render({
-      addon: createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            ...fakePreview,
-          },
-          {
-            ...fakePreview,
-            image_url: headerImageFull,
-            thumbnail_url: headerImageThumb,
-            image_size: [],
-            thumbnail_size: [],
-          },
-        ],
-      }),
-    });
-    const image = root.find('.SearchResult-icon');
-    expect(image.prop('src')).toEqual(headerImageThumb);
-    expect(image).not.toHaveProp('srcSet');
-  });
+      const root = render({
+        addon: createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_STATIC_THEME,
+          previews: [
+            {
+              ...fakePreview,
+              image_url: index === 0 ? fakePreview.image_url : headerImageFull,
+              thumbnail_url:
+                index === 0 ? fakePreview.thumbnail_url : headerImageThumb,
+            },
+            {
+              ...fakePreview,
+              image_url: index === 0 ? headerImageFull : '',
+              thumbnail_url: headerImageThumb,
+              image_size: [],
+              thumbnail_size: [],
+            },
+          ],
+        }),
+      });
 
-  it('renders image without srcSet if there is no large preview image url', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
-
-    const root = render({
-      addon: createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            ...fakePreview,
-            image_url: headerImageFull,
-            thumbnail_url: headerImageThumb,
-          },
-          {
-            ...fakePreview,
-            image_url: '',
-            thumbnail_url: headerImageThumb,
-            image_size: [],
-            thumbnail_size: [],
-          },
-        ],
-      }),
-    });
-    const image = root.find('.SearchResult-icon');
-    expect(image.prop('src')).toEqual(headerImageThumb);
-    expect(image).not.toHaveProp('srcSet');
-  });
+      const image = root.find('.SearchResult-icon');
+      expect(image.prop('src')).toEqual(headerImageThumb);
+      expect(image).not.toHaveProp('srcSet');
+    },
+  );
 
   // TODO: This can be removed once migration happens.
   it('displays a fallback image for themes that only have 1 preview option', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -178,96 +178,28 @@ describe(__filename, () => {
   });
 
   it('displays the thumbnail image as the default src for static theme', () => {
-    const headerImageThumb =
-      'https://addons.cdn.mozilla.net/mytestthumb/12345.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/12345.png';
 
     const root = render({
       addon: createInternalAddon({
         ...fakeAddon,
         type: ADDON_TYPE_STATIC_THEME,
         previews: [
-          {
-            ...fakePreview,
-            thumbnail_url: headerImageThumb,
-          },
-        ],
-      }),
-    });
-    const image = root.find('.SearchResult-icon');
-
-    expect(image.prop('src')).toEqual(headerImageThumb);
-  });
-
-  it('displays srcSet values if preview has multiple options', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-    const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
-    const thumbWidth = 450;
-    const fullWidth = 900;
-
-    const root = render({
-      addon: createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-        previews: [
-          {
-            ...fakePreview,
-            image_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
-            thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
-          },
           {
             ...fakePreview,
             image_url: headerImageFull,
-            thumbnail_url: headerImageThumb,
-            image_size: [fullWidth, 200],
-            thumbnail_size: [thumbWidth, 100],
           },
         ],
       }),
     });
     const image = root.find('.SearchResult-icon');
 
-    expect(image.prop('srcSet')).toEqual(
-      `${headerImageThumb} ${thumbWidth}w, ${headerImageFull} ${fullWidth}w`,
-    );
+    expect(image.prop('src')).toEqual(headerImageFull);
   });
-
-  it.each([{ image_url: '' }, { image_size: [] }, { thumbnail_size: [] }])(
-    `renders image without srcSet if there are no preview image sizes or large image %o`,
-    (propOverride) => {
-      const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
-      const headerImageFull = 'https://addons.cdn.mozilla.net/full/54321.png';
-
-      const root = render({
-        addon: createInternalAddon({
-          ...fakeAddon,
-          type: ADDON_TYPE_STATIC_THEME,
-          previews: [
-            {
-              ...fakePreview,
-              image_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
-              thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/notused.png',
-            },
-            {
-              ...fakePreview,
-              image_url: headerImageFull,
-              thumbnail_url: headerImageThumb,
-              image_size: [400, 200],
-              thumbnail_size: [200, 100],
-              ...propOverride,
-            },
-          ],
-        }),
-      });
-
-      const image = root.find('.SearchResult-icon');
-      expect(image.prop('src')).toEqual(headerImageThumb);
-      expect(image).not.toHaveProp('srcSet');
-    },
-  );
 
   // TODO: This can be removed once migration happens.
   it('displays a fallback image for themes that only have 1 preview option', () => {
-    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/1.png';
+    const headerImageFull = 'https://addons.cdn.mozilla.net/full/1.png';
 
     const root = render({
       addon: createInternalAddon({
@@ -276,15 +208,14 @@ describe(__filename, () => {
         previews: [
           {
             ...fakePreview,
-            thumbnail_url: headerImageThumb,
+            image_url: headerImageFull,
           },
         ],
       }),
     });
     const image = root.find('.SearchResult-icon');
 
-    expect(image.prop('src')).toEqual(headerImageThumb);
-    expect(image.prop('srcSet')).toBeUndefined();
+    expect(image.prop('src')).toEqual(headerImageFull);
   });
 
   it('displays a message if the lightweight theme preview image is unavailable', () => {

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -98,6 +98,14 @@ export const fakeAddon = Object.freeze({
       image_size: [400, 200],
       thumbnail_size: [200, 100],
     },
+    {
+      id: 1234779,
+      caption: 'Chillin out',
+      image_url: 'https://addons.cdn.mozilla.net/55555/image.png',
+      thumbnail_url: 'https://addons.cdn.mozilla.net/4444/image.png',
+      image_size: [400, 200],
+      thumbnail_size: [200, 100],
+    },
   ],
   public_stats: true,
   ratings: {

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -32,6 +32,15 @@ import {
   userAuthToken,
 } from 'tests/unit/helpers';
 
+export const fakePreview = Object.freeze({
+  id: 1,
+  caption: 'Image 1',
+  image_url: 'https://addons.cdn.mozilla.net/full/1.png',
+  thumbnail_url: 'https://addons.cdn.mozilla.net/thumb/1.png',
+  image_size: [400, 200],
+  thumbnail_size: [200, 100],
+});
+
 export const fakePlatformFile = Object.freeze({
   created: '2014-11-22T10:09:01Z',
   hash: 'a1b2c3d4',
@@ -89,24 +98,7 @@ export const fakeAddon = Object.freeze({
   is_source_public: true,
   last_updated: '2014-11-22T10:09:01Z',
   name: 'Chill Out',
-  previews: [
-    {
-      id: 1234778,
-      caption: 'Chill out control panel',
-      image_url: 'https://addons.cdn.mozilla.net/123/image.png',
-      thumbnail_url: 'https://addons.cdn.mozilla.net/7123/image.png',
-      image_size: [400, 200],
-      thumbnail_size: [200, 100],
-    },
-    {
-      id: 1234779,
-      caption: 'Chillin out',
-      image_url: 'https://addons.cdn.mozilla.net/55555/image.png',
-      thumbnail_url: 'https://addons.cdn.mozilla.net/4444/image.png',
-      image_size: [400, 200],
-      thumbnail_size: [200, 100],
-    },
-  ],
+  previews: [fakePreview],
   public_stats: true,
   ratings: {
     average: 3.5,

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -118,6 +118,25 @@ describe(__filename, () => {
       expect(homeState.collections[0]).toEqual(null);
     });
 
+    it('returns null for an empty collection', () => {
+      const { store } = dispatchClientMetadata();
+
+      store.dispatch(
+        loadHomeAddons({
+          collections: [
+            {
+              results: [],
+            },
+          ],
+          featuredExtensions: createAddonsApiResult([fakeAddon]),
+          featuredThemes: createAddonsApiResult([fakeTheme]),
+        }),
+      );
+
+      const homeState = store.getState().home;
+      expect(homeState.collections).toEqual([null]);
+    });
+
     it('loads an empty array if featured themes is null', () => {
       const { store } = dispatchClientMetadata();
 

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -123,11 +123,7 @@ describe(__filename, () => {
 
       store.dispatch(
         loadHomeAddons({
-          collections: [
-            {
-              results: [],
-            },
-          ],
+          collections: [{}],
           featuredExtensions: createAddonsApiResult([fakeAddon]),
           featuredThemes: createAddonsApiResult([fakeTheme]),
         }),

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -123,7 +123,11 @@ describe(__filename, () => {
 
       store.dispatch(
         loadHomeAddons({
-          collections: [{}],
+          collections: [
+            createFakeCollectionAddonsListResponse({
+              addons: [],
+            }),
+          ],
           featuredExtensions: createAddonsApiResult([fakeAddon]),
           featuredThemes: createAddonsApiResult([fakeTheme]),
         }),

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -1,10 +1,14 @@
-import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
+} from 'amo/constants';
 import homeReducer, {
   fetchHomeAddons,
   initialState,
   loadHomeAddons,
 } from 'amo/reducers/home';
 import { createInternalAddon } from 'core/reducers/addons';
+import { ADDON_TYPE_THEME } from 'core/constants';
 import {
   createAddonsApiResult,
   createFakeCollectionAddon,
@@ -59,6 +63,42 @@ describe(__filename, () => {
       expect(homeState.featuredThemes).toEqual([
         createInternalAddon(fakeTheme),
       ]);
+    });
+
+    it('loads the the correct amount of theme add-ons in a collection to display on homepage', () => {
+      const { store } = dispatchClientMetadata();
+
+      store.dispatch(
+        loadHomeAddons({
+          collections: [
+            createFakeCollectionAddonsListResponse({
+              addons: Array(10).fill({
+                ...createFakeCollectionAddon({
+                  addon: {
+                    ...fakeAddon,
+                    type: ADDON_TYPE_THEME,
+                  },
+                }),
+              }),
+            }),
+          ],
+          featuredExtensions: createAddonsApiResult([fakeAddon]),
+        }),
+      );
+
+      const homeState = store.getState().home;
+
+      expect(homeState.resultsLoaded).toEqual(true);
+      expect(homeState.collections).toHaveLength(1);
+
+      expect(homeState.collections[0]).toEqual(
+        Array(LANDING_PAGE_THEME_COUNT).fill(
+          createInternalAddon({
+            ...fakeAddon,
+            type: ADDON_TYPE_THEME,
+          }),
+        ),
+      );
     });
 
     it('loads a null for a missing collection', () => {

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -1,4 +1,4 @@
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
 import homeReducer, {
   fetchHomeAddons,
   initialState,
@@ -45,9 +45,13 @@ describe(__filename, () => {
 
       expect(homeState.resultsLoaded).toEqual(true);
       expect(homeState.collections).toHaveLength(1);
-      expect(homeState.collections[0]).toHaveLength(LANDING_PAGE_ADDON_COUNT);
+      expect(homeState.collections[0]).toHaveLength(
+        LANDING_PAGE_EXTENSION_COUNT,
+      );
       expect(homeState.collections[0]).toEqual(
-        Array(LANDING_PAGE_ADDON_COUNT).fill(createInternalAddon(fakeAddon)),
+        Array(LANDING_PAGE_EXTENSION_COUNT).fill(
+          createInternalAddon(fakeAddon),
+        ),
       );
       expect(homeState.featuredExtensions).toEqual([
         createInternalAddon(fakeAddon),

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -2,11 +2,15 @@ import SagaTester from 'redux-saga-tester';
 
 import * as searchApi from 'core/api/search';
 import { getLanding, loadLanding } from 'amo/actions/landing';
-import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
+} from 'amo/constants';
 import landingReducer from 'amo/reducers/landing';
 import landingSaga from 'amo/sagas/landing';
 import {
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_THEME,
   LANDING_LOADED,
   SEARCH_SORT_TRENDING,
   SEARCH_SORT_TOP_RATED,
@@ -54,7 +58,7 @@ describe(__filename, () => {
       );
     }
 
-    it('fetches landing page addons from the API', async () => {
+    it('fetches extensions landing page addons from the API', async () => {
       const addonType = ADDON_TYPE_EXTENSION;
       const baseArgs = { api: apiState };
       const baseFilters = {
@@ -102,6 +106,88 @@ describe(__filename, () => {
       const trending = createAddonsApiResult([
         {
           ...fakeAddon,
+          slug: 'trending-addon',
+        },
+      ]);
+      mockSearchApi
+        .expects('search')
+        .withArgs({
+          ...baseArgs,
+          filters: {
+            ...baseFilters,
+            sort: SEARCH_SORT_TRENDING,
+          },
+          page: 1,
+        })
+        .returns(Promise.resolve(trending));
+
+      _getLanding({ addonType });
+
+      await sagaTester.waitFor(LANDING_LOADED);
+      mockSearchApi.verify();
+
+      const calledActions = sagaTester.getCalledActions();
+      expect(calledActions[1]).toEqual(
+        loadLanding({
+          addonType,
+          featured,
+          highlyRated,
+          trending,
+        }),
+      );
+    });
+
+    it('fetches themes landing page addons from the API', async () => {
+      const addonType = ADDON_TYPE_THEME;
+      const baseArgs = { api: apiState };
+      const baseFilters = {
+        addonType,
+        page_size: LANDING_PAGE_THEME_COUNT,
+      };
+
+      const featured = createAddonsApiResult([
+        {
+          ...fakeAddon,
+          type: addonType,
+          slug: 'featured-addon',
+        },
+      ]);
+      mockSearchApi
+        .expects('search')
+        .withArgs({
+          ...baseArgs,
+          filters: {
+            ...baseFilters,
+            featured: true,
+            sort: SEARCH_SORT_RANDOM,
+          },
+          page: 1,
+        })
+        .returns(Promise.resolve(featured));
+
+      const highlyRated = createAddonsApiResult([
+        {
+          ...fakeAddon,
+          type: addonType,
+          slug: 'highly-rated-addon',
+        },
+      ]);
+      mockSearchApi
+        .expects('search')
+        .withArgs({
+          ...baseArgs,
+          filters: {
+            ...baseFilters,
+            sort: SEARCH_SORT_TOP_RATED,
+          },
+          page: 1,
+        })
+        .returns(Promise.resolve(highlyRated));
+
+      const trending = createAddonsApiResult([
+        {
+          ...fakeAddon,
+          type: addonType,
           slug: 'trending-addon',
         },
       ]);

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -2,7 +2,7 @@ import SagaTester from 'redux-saga-tester';
 
 import * as searchApi from 'core/api/search';
 import { getLanding, loadLanding } from 'amo/actions/landing';
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import { LANDING_PAGE_EXTENSION_COUNT } from 'amo/constants';
 import landingReducer from 'amo/reducers/landing';
 import landingSaga from 'amo/sagas/landing';
 import {
@@ -59,7 +59,7 @@ describe(__filename, () => {
       const baseArgs = { api: apiState };
       const baseFilters = {
         addonType,
-        page_size: LANDING_PAGE_ADDON_COUNT,
+        page_size: LANDING_PAGE_EXTENSION_COUNT,
       };
 
       const featured = createAddonsApiResult([
@@ -156,7 +156,7 @@ describe(__filename, () => {
       const baseFilters = {
         addonType,
         category,
-        page_size: LANDING_PAGE_ADDON_COUNT,
+        page_size: LANDING_PAGE_EXTENSION_COUNT,
       };
 
       const featured = createAddonsApiResult([
@@ -226,7 +226,7 @@ describe(__filename, () => {
       const baseArgs = { api: apiState };
       const baseFilters = {
         addonType,
-        page_size: LANDING_PAGE_ADDON_COUNT,
+        page_size: LANDING_PAGE_EXTENSION_COUNT,
       };
 
       const featured = createAddonsApiResult([

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -58,17 +58,23 @@ describe(__filename, () => {
       );
     }
 
-    it.each([0, 1])(
-      `fetches landing page addons from the API position %s`,
-      async (index) => {
-        const addonType = index === 0 ? ADDON_TYPE_EXTENSION : ADDON_TYPE_THEME;
+    it.each([
+      {
+        addonType: ADDON_TYPE_EXTENSION,
+        pageSize: LANDING_PAGE_EXTENSION_COUNT,
+      },
+      {
+        addonType: ADDON_TYPE_THEME,
+        pageSize: LANDING_PAGE_THEME_COUNT,
+      },
+    ])(
+      `fetches landing page addons from the API for %o`,
+      async (testConfig) => {
+        const { addonType, pageSize } = testConfig;
         const baseArgs = { api: apiState };
         const baseFilters = {
           addonType,
-          page_size:
-            index === 0
-              ? LANDING_PAGE_EXTENSION_COUNT
-              : LANDING_PAGE_THEME_COUNT,
+          page_size: pageSize,
         };
 
         const featured = createAddonsApiResult([

--- a/tests/unit/amo/sagas/testLanding.js
+++ b/tests/unit/amo/sagas/testLanding.js
@@ -58,166 +58,90 @@ describe(__filename, () => {
       );
     }
 
-    it('fetches extensions landing page addons from the API', async () => {
-      const addonType = ADDON_TYPE_EXTENSION;
-      const baseArgs = { api: apiState };
-      const baseFilters = {
-        addonType,
-        page_size: LANDING_PAGE_EXTENSION_COUNT,
-      };
-
-      const featured = createAddonsApiResult([
-        {
-          ...fakeAddon,
-          slug: 'featured-addon',
-        },
-      ]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            ...baseFilters,
-            featured: true,
-            sort: SEARCH_SORT_RANDOM,
-          },
-          page: 1,
-        })
-        .returns(Promise.resolve(featured));
-
-      const highlyRated = createAddonsApiResult([
-        {
-          ...fakeAddon,
-          slug: 'highly-rated-addon',
-        },
-      ]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            ...baseFilters,
-            sort: SEARCH_SORT_TOP_RATED,
-          },
-          page: 1,
-        })
-        .returns(Promise.resolve(highlyRated));
-
-      const trending = createAddonsApiResult([
-        {
-          ...fakeAddon,
-          slug: 'trending-addon',
-        },
-      ]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            ...baseFilters,
-            sort: SEARCH_SORT_TRENDING,
-          },
-          page: 1,
-        })
-        .returns(Promise.resolve(trending));
-
-      _getLanding({ addonType });
-
-      await sagaTester.waitFor(LANDING_LOADED);
-      mockSearchApi.verify();
-
-      const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[1]).toEqual(
-        loadLanding({
+    it.each([0, 1])(
+      `fetches landing page addons from the API position %s`,
+      async (index) => {
+        const addonType = index === 0 ? ADDON_TYPE_EXTENSION : ADDON_TYPE_THEME;
+        const baseArgs = { api: apiState };
+        const baseFilters = {
           addonType,
-          featured,
-          highlyRated,
-          trending,
-        }),
-      );
-    });
+          page_size:
+            index === 0
+              ? LANDING_PAGE_EXTENSION_COUNT
+              : LANDING_PAGE_THEME_COUNT,
+        };
 
-    it('fetches themes landing page addons from the API', async () => {
-      const addonType = ADDON_TYPE_THEME;
-      const baseArgs = { api: apiState };
-      const baseFilters = {
-        addonType,
-        page_size: LANDING_PAGE_THEME_COUNT,
-      };
-
-      const featured = createAddonsApiResult([
-        {
-          ...fakeAddon,
-          type: addonType,
-          slug: 'featured-addon',
-        },
-      ]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            ...baseFilters,
-            featured: true,
-            sort: SEARCH_SORT_RANDOM,
+        const featured = createAddonsApiResult([
+          {
+            ...fakeAddon,
+            slug: 'featured-addon',
           },
-          page: 1,
-        })
-        .returns(Promise.resolve(featured));
+        ]);
+        mockSearchApi
+          .expects('search')
+          .withArgs({
+            ...baseArgs,
+            filters: {
+              ...baseFilters,
+              featured: true,
+              sort: SEARCH_SORT_RANDOM,
+            },
+            page: 1,
+          })
+          .returns(Promise.resolve(featured));
 
-      const highlyRated = createAddonsApiResult([
-        {
-          ...fakeAddon,
-          type: addonType,
-          slug: 'highly-rated-addon',
-        },
-      ]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            ...baseFilters,
-            sort: SEARCH_SORT_TOP_RATED,
+        const highlyRated = createAddonsApiResult([
+          {
+            ...fakeAddon,
+            slug: 'highly-rated-addon',
           },
-          page: 1,
-        })
-        .returns(Promise.resolve(highlyRated));
+        ]);
+        mockSearchApi
+          .expects('search')
+          .withArgs({
+            ...baseArgs,
+            filters: {
+              ...baseFilters,
+              sort: SEARCH_SORT_TOP_RATED,
+            },
+            page: 1,
+          })
+          .returns(Promise.resolve(highlyRated));
 
-      const trending = createAddonsApiResult([
-        {
-          ...fakeAddon,
-          type: addonType,
-          slug: 'trending-addon',
-        },
-      ]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            ...baseFilters,
-            sort: SEARCH_SORT_TRENDING,
+        const trending = createAddonsApiResult([
+          {
+            ...fakeAddon,
+            slug: 'trending-addon',
           },
-          page: 1,
-        })
-        .returns(Promise.resolve(trending));
+        ]);
+        mockSearchApi
+          .expects('search')
+          .withArgs({
+            ...baseArgs,
+            filters: {
+              ...baseFilters,
+              sort: SEARCH_SORT_TRENDING,
+            },
+            page: 1,
+          })
+          .returns(Promise.resolve(trending));
 
-      _getLanding({ addonType });
+        _getLanding({ addonType });
 
-      await sagaTester.waitFor(LANDING_LOADED);
-      mockSearchApi.verify();
+        await sagaTester.waitFor(LANDING_LOADED);
+        mockSearchApi.verify();
 
-      const calledActions = sagaTester.getCalledActions();
-      expect(calledActions[1]).toEqual(
-        loadLanding({
-          addonType,
-          featured,
-          highlyRated,
-          trending,
-        }),
-      );
-    });
+        const calledActions = sagaTester.getCalledActions();
+        expect(calledActions[1]).toEqual(
+          loadLanding({
+            addonType,
+            featured,
+            highlyRated,
+            trending,
+          }),
+        );
+      },
+    );
 
     it('dispatches an error', async () => {
       const error = new Error('some API error maybe');

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -68,9 +68,6 @@ describe(__filename, () => {
       const secondCollectionUser = 'user-id-or-name-2';
 
       const baseArgs = { api: state.api };
-      const baseFilters = {
-        page_size: LANDING_PAGE_EXTENSION_COUNT,
-      };
 
       const firstCollection = createFakeCollectionAddonsListResponse();
       const secondCollection = createFakeCollectionAddonsListResponse();
@@ -98,7 +95,7 @@ describe(__filename, () => {
         .withArgs({
           ...baseArgs,
           filters: {
-            ...baseFilters,
+            page_size: LANDING_PAGE_EXTENSION_COUNT,
             addonType: ADDON_TYPE_EXTENSION,
             featured: true,
             sort: SEARCH_SORT_RANDOM,
@@ -112,7 +109,6 @@ describe(__filename, () => {
         .withArgs({
           ...baseArgs,
           filters: {
-            ...baseFilters,
             page_size: LANDING_PAGE_THEME_COUNT,
             addonType: ADDON_TYPE_THEME,
             featured: true,
@@ -177,9 +173,6 @@ describe(__filename, () => {
         const firstCollectionUser = 'user-id-or-name';
 
         const baseArgs = { api: state.api };
-        const baseFilters = {
-          page_size: LANDING_PAGE_EXTENSION_COUNT,
-        };
 
         mockCollectionsApi
           .expects('getCollectionAddons')
@@ -193,7 +186,7 @@ describe(__filename, () => {
           .withArgs({
             ...baseArgs,
             filters: {
-              ...baseFilters,
+              page_size: LANDING_PAGE_EXTENSION_COUNT,
               addonType: ADDON_TYPE_EXTENSION,
               featured: true,
               sort: SEARCH_SORT_RANDOM,
@@ -207,7 +200,6 @@ describe(__filename, () => {
           .withArgs({
             ...baseArgs,
             filters: {
-              ...baseFilters,
               page_size: LANDING_PAGE_THEME_COUNT,
               addonType: ADDON_TYPE_THEME,
               featured: true,

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -2,8 +2,8 @@ import SagaTester from 'redux-saga-tester';
 
 import * as collectionsApi from 'amo/api/collections';
 import {
-  LANDING_PAGE_ADDON_COUNT,
-  LANDING_PAGE_THEME_ADDON_COUNT,
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
 import homeReducer, {
   fetchHomeAddons,
@@ -69,7 +69,7 @@ describe(__filename, () => {
 
       const baseArgs = { api: state.api };
       const baseFilters = {
-        page_size: LANDING_PAGE_ADDON_COUNT,
+        page_size: LANDING_PAGE_EXTENSION_COUNT,
       };
 
       const firstCollection = createFakeCollectionAddonsListResponse();
@@ -113,7 +113,7 @@ describe(__filename, () => {
           ...baseArgs,
           filters: {
             ...baseFilters,
-            page_size: LANDING_PAGE_THEME_ADDON_COUNT,
+            page_size: LANDING_PAGE_THEME_COUNT,
             addonType: ADDON_TYPE_THEME,
             featured: true,
             sort: SEARCH_SORT_RANDOM,
@@ -178,7 +178,7 @@ describe(__filename, () => {
 
         const baseArgs = { api: state.api };
         const baseFilters = {
-          page_size: LANDING_PAGE_ADDON_COUNT,
+          page_size: LANDING_PAGE_EXTENSION_COUNT,
         };
 
         mockCollectionsApi
@@ -208,7 +208,7 @@ describe(__filename, () => {
             ...baseArgs,
             filters: {
               ...baseFilters,
-              page_size: LANDING_PAGE_THEME_ADDON_COUNT,
+              page_size: LANDING_PAGE_THEME_COUNT,
               addonType: ADDON_TYPE_THEME,
               featured: true,
               sort: SEARCH_SORT_RANDOM,

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -1,7 +1,10 @@
 import SagaTester from 'redux-saga-tester';
 
 import * as collectionsApi from 'amo/api/collections';
-import { LANDING_PAGE_ADDON_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_ADDON_COUNT,
+  LANDING_PAGE_THEME_ADDON_COUNT,
+} from 'amo/constants';
 import homeReducer, {
   fetchHomeAddons,
   loadHomeAddons,
@@ -110,6 +113,7 @@ describe(__filename, () => {
           ...baseArgs,
           filters: {
             ...baseFilters,
+            page_size: LANDING_PAGE_THEME_ADDON_COUNT,
             addonType: ADDON_TYPE_THEME,
             featured: true,
             sort: SEARCH_SORT_RANDOM,
@@ -204,6 +208,7 @@ describe(__filename, () => {
             ...baseArgs,
             filters: {
               ...baseFilters,
+              page_size: LANDING_PAGE_THEME_ADDON_COUNT,
               addonType: ADDON_TYPE_THEME,
               featured: true,
               sort: SEARCH_SORT_RANDOM,

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -36,6 +36,7 @@ import {
   getClientConfig,
   isAddonAuthor,
   isAllowedOrigin,
+  isTheme,
   isValidClientApp,
   ngettext,
   nl2br,
@@ -829,6 +830,20 @@ describe(__filename, () => {
       const filename = 'src/file.js';
 
       expect(normalizeFileNameId(filename)).toEqual(filename);
+    });
+  });
+
+  describe('isTheme', () => {
+    it("returns true if type it's a lightweight theme", () => {
+      expect(isTheme(ADDON_TYPE_THEME)).toEqual(true);
+    });
+
+    it("returns true if type it's a static theme", () => {
+      expect(isTheme(ADDON_TYPE_STATIC_THEME)).toEqual(true);
+    });
+
+    it("returns false if type it's an extension", () => {
+      expect(isTheme(ADDON_TYPE_EXTENSION)).toEqual(false);
     });
   });
 });

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -834,15 +834,15 @@ describe(__filename, () => {
   });
 
   describe('isTheme', () => {
-    it("returns true if type it's a lightweight theme", () => {
+    it('returns true if type is a lightweight theme', () => {
       expect(isTheme(ADDON_TYPE_THEME)).toEqual(true);
     });
 
-    it("returns true if type it's a static theme", () => {
+    it('returns true if type is a static theme', () => {
       expect(isTheme(ADDON_TYPE_STATIC_THEME)).toEqual(true);
     });
 
-    it("returns false if type it's an extension", () => {
+    it('returns false if type is an extension', () => {
       expect(isTheme(ADDON_TYPE_EXTENSION)).toEqual(false);
     });
   });


### PR DESCRIPTION
potential fix/brainstorming for #5174

I was playing around with the styles and thought in these contexts - for the search listing view and detail header (below bp 900px) -  that these looked okay:

search listing:
![Alt text](https://monosnap.com/image/ZQQzTib6bFCATrJCgN8GOOVUn8tpuI.png)

header on detail:
![Alt text](https://monosnap.com/image/XmE4Uon7DtARYIum2DYizo16ATm3bI.png)

any thoughts? or are they too small?

altho, we still need to figure out the following context if the alignment is still left:
![Alt text](https://monosnap.com/image/0tSmqpo1PNsp5M5ye3C8WUx1a7ZIne.png)

there are a few options to maybe help:
-remove or change to height auto (for all breakpoints)
-use a similar listing view as search (or even maybe 2 cols, vs the current 3 for larger bps -if Ux signs off), for eg:
![Alt text](https://monosnap.com/image/5WdV7YGczSlPGO6xSrUUARzysxulzW.png)
-discuss alignment right for static themes?

also we need to look at home, landing pgs, etc where it's 4 cols ..

cc @muffinresearch @eviljeff 



