### PR TITLE
Set max-width to the parent container (theme header)

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -120,6 +120,7 @@
 .Addon-theme-header {
   border-radius: $border-radius-default;
   height: $theme-height-default;
+  max-width: $theme-width-default;
   order: -1;
   overflow-y: hidden;
   position: relative;
@@ -140,7 +141,6 @@
   border-radius: $border-radius-default;
   display: block;
   height: $theme-height-default;
-  max-width: $theme-width-default;
   object-fit: cover;
   object-position: top left;
   width: 100%;


### PR DESCRIPTION
Fix #5226

---

The PR sets the `max-width` to the theme image header container so that all other elements are still contained inside (especially the install button that goes out of the container in RTL mode, sometimes).

### Screenshots AFTER

<img width="1392" alt="screen shot 2018-06-07 at 10 16 38" src="https://user-images.githubusercontent.com/217628/41087276-85a02bd2-6a3c-11e8-94e8-3a8b6cab293f.png">
<img width="1392" alt="screen shot 2018-06-07 at 10 16 44" src="https://user-images.githubusercontent.com/217628/41087277-85bf0084-6a3c-11e8-952e-67e54e5120d8.png">
<img width="1392" alt="screen shot 2018-06-07 at 10 16 53" src="https://user-images.githubusercontent.com/217628/41087278-85dd7aaa-6a3c-11e8-80b8-a164d18f1bdb.png">
<img width="535" alt="screen shot 2018-06-07 at 10 17 42" src="https://user-images.githubusercontent.com/217628/41087281-861807ce-6a3c-11e8-8efb-9854c1143b2f.png">
<img width="535" alt="screen shot 2018-06-07 at 10 17 51" src="https://user-images.githubusercontent.com/217628/41087282-8635ecda-6a3c-11e8-8902-8a43267a0270.png">
