### PR TITLE
Do not reset notifications in users reducer

### DIFF
--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -428,11 +428,15 @@ export const addUserToState = ({ state, user } : {
 |} => {
   invariant(user, 'user is required');
 
+  const existingUser = getUserById(state, user.id) || {
+    notifications: null,
+  };
+
   const byID = {
     ...state.byID,
     [user.id]: {
+      ...existingUser,
       ...user,
-      notifications: null,
     },
   };
   const byUsername = {

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -113,7 +113,7 @@ describe(__filename, () => {
   });
 
   describe('loadUserAccount', () => {
-    it('sets notifications to `null` when loading a user', () => {
+    it('sets notifications to `null` when loading a new user', () => {
       const user = createUserAccountResponse({ id: 12345, username: 'john' });
       const action = loadUserAccount({ user });
 
@@ -125,6 +125,35 @@ describe(__filename, () => {
       expect(state.byID[user.id]).toEqual({
         ...user,
         notifications: null,
+      });
+    });
+
+    it('does not change the notifications when loading a user who was already in the state', () => {
+      const user = createUserAccountResponse({ id: 12345, username: 'john' });
+      const notifications = createUserNotificationsResponse();
+
+      const prevState = reducer(
+        // 1. load the user
+        reducer(initialState, loadUserAccount({ user })),
+        // 2. load their notifications
+        loadUserNotifications({ notifications, username: user.username })
+      );
+
+      expect(prevState.byID[user.id]).toEqual({
+        ...user,
+        notifications,
+      });
+
+      const updatedUser = {
+        ...user,
+        biography: 'some new biography',
+      };
+
+      const state = reducer(prevState, loadUserAccount({ user: updatedUser }));
+
+      expect(state.byID[user.id]).toEqual({
+        ...updatedUser,
+        notifications,
       });
     });
   });


### PR DESCRIPTION
Fix #5214

---

By not resetting the `notifications` property of a user when updating
this user in the state, we don't have to reload the notifications for
this user and there is no problem of notifications being stuck in a
loading state as described in #5214.