### PR TITLE
Fixing Word break in Biography section 

### DIFF
--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -87,5 +87,5 @@ $avatar-size: 64px;
 }
 
 .UserProfile-biography {
-  word-break: break-all;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
Fixes #5268 


Before: 

![before](https://user-images.githubusercontent.com/22130317/41250108-9c213622-6dd3-11e8-897f-0f083bcf720c.png)


After: 
![screenshot-2018-6-11 user profile for madonna add-ons for firefox](https://user-images.githubusercontent.com/22130317/41250117-a1aff754-6dd3-11e8-9136-692777593b8a.png)
