### PR TITLE
Fixed Paginate section on AddonReviewList page

### DIFF
--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -276,7 +276,8 @@ export class AddonReviewListBase extends React.Component<Props> {
               );
             })}
           </ul>
-
+        </CardList>
+      </div>
           {addon && reviewCount ?
             <Paginate
               LinkComponent={Link}
@@ -286,8 +287,6 @@ export class AddonReviewListBase extends React.Component<Props> {
             />
             : null
           }
-        </CardList>
-      </div>
     );
   }
 }

--- a/src/core/components/Paginate/Paginate.scss
+++ b/src/core/components/Paginate/Paginate.scss
@@ -20,3 +20,10 @@
 .Paginate .Paginate-item {
   min-width: 48%;
 }
+
+//Temporary fix for paginate section on addonreviewlist page
+
+.App-content-wrapper .Paginate {
+  padding-right: 60px;
+  padding-left: 385px;
+}


### PR DESCRIPTION
Fixes #5266

I had to do some code refractoring and add a CSS class styling in order to make the `Paginate` section very similar to the `Paginate` section on other pages. 

What I did was to first move the `Paginate` section outside of the `addOnReviewList CardList` section, since it is suppose to be seperate from this section in the first place. 

This helped to fix the `border-radius` issue and font style, however the section took up the entire page which is incorrect. This was so because the other pages were sectioned off with a nicely formatted grid column layout unlike this page. Therefore I decided to create a temporary CSS class rule to accommodate the styling of the section.

Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.

Please delete anything that isn't relevant to your patch.

* [x] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [x] Add `Fixes #ISSUENUM` at the top of your PR.
* [x] Add a description of the the changes introduced in this PR.
* [x] The change has been successfully run locally.
* [x] Add before and after screenshots (Only for changes that impact the UI).

The before screenshot can be seen below:

![wrong](https://user-images.githubusercontent.com/25648267/41310233-f5aae1b8-6e4e-11e8-91db-f3fd1a763bfa.PNG)



The after can be seen here:

![after](https://user-images.githubusercontent.com/25648267/41310257-00a160e2-6e4f-11e8-83ab-2daa31b1864a.PNG)

