### PR TITLE
changes editUserAccount to updateUserAccount

### DIFF
--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -25,7 +25,7 @@ export function currentUserAccount({
   });
 }
 
-export function editUserAccount({
+export function updateUserAccount({
   api,
   picture,
   userId,

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -15,7 +15,7 @@ import UserProfileEditPicture from 'amo/components/UserProfileEditPicture';
 import {
   deleteUserAccount,
   deleteUserPicture,
-  editUserAccount,
+  updateUserAccount,
   fetchUserAccount,
   fetchUserNotifications,
   getCurrentUser,
@@ -334,7 +334,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     invariant(user, 'user is required');
 
     dispatch(
-      editUserAccount({
+      updateUserAccount({
         errorHandlerId: errorHandler.id,
         notifications,
         picture,

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -12,9 +12,9 @@ import {
   THEMES_REVIEW,
 } from 'core/constants';
 
-export const FINISH_EDIT_USER_ACCOUNT: 'FINISH_EDIT_USER_ACCOUNT' =
-  'FINISH_EDIT_USER_ACCOUNT';
-export const EDIT_USER_ACCOUNT: 'EDIT_USER_ACCOUNT' = 'EDIT_USER_ACCOUNT';
+export const FINISH_UPDATE_USER_ACCOUNT: 'FINISH_UPDATE_USER_ACCOUNT' =
+  'FINISH_UPDATE_USER_ACCOUNT';
+export const UPDATE_USER_ACCOUNT: 'UPDATE_USER_ACCOUNT' = 'UPDATE_USER_ACCOUNT';
 export const LOG_OUT_USER: 'LOG_OUT_USER' = 'LOG_OUT_USER';
 export const LOAD_CURRENT_USER_ACCOUNT: 'LOAD_CURRENT_USER_ACCOUNT' =
   'LOAD_CURRENT_USER_ACCOUNT';
@@ -132,21 +132,21 @@ export const fetchUserAccount = ({
   };
 };
 
-type FinishEditUserAccountParams = {};
+type finishUpdateUserAccountParams = {};
 
-type FinishEditUserAccountAction = {|
-  type: typeof FINISH_EDIT_USER_ACCOUNT,
-  payload: FinishEditUserAccountParams,
+type FinishUpdateUserAccountAction = {|
+  type: typeof FINISH_UPDATE_USER_ACCOUNT,
+  payload: finishUpdateUserAccountParams,
 |};
 
-export const finishEditUserAccount = (): FinishEditUserAccountAction => {
+export const finishUpdateUserAccount = (): FinishUpdateUserAccountAction => {
   return {
-    type: FINISH_EDIT_USER_ACCOUNT,
+    type: FINISH_UPDATE_USER_ACCOUNT,
     payload: {},
   };
 };
 
-type EditUserAccountParams = {|
+type UpdateUserAccountParams = {|
   errorHandlerId: string,
   notifications: NotificationsUpdateType,
   picture: File | null,
@@ -154,18 +154,18 @@ type EditUserAccountParams = {|
   userId: UserId,
 |};
 
-type EditUserAccountAction = {|
-  type: typeof EDIT_USER_ACCOUNT,
-  payload: EditUserAccountParams,
+type UpdateUserAccountAction = {|
+  type: typeof UPDATE_USER_ACCOUNT,
+  payload: UpdateUserAccountParams,
 |};
 
-export const editUserAccount = ({
+export const updateUserAccount = ({
   errorHandlerId,
   notifications,
   picture,
   userFields,
   userId,
-}: EditUserAccountParams): EditUserAccountAction => {
+}: UpdateUserAccountParams): UpdateUserAccountAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(notifications, 'notifications are required');
   invariant(picture !== undefined, 'picture is required');
@@ -173,7 +173,7 @@ export const editUserAccount = ({
   invariant(userId, 'userId is required');
 
   return {
-    type: EDIT_USER_ACCOUNT,
+    type: UPDATE_USER_ACCOUNT,
     payload: { errorHandlerId, notifications, picture, userFields, userId },
   };
 };
@@ -467,8 +467,8 @@ export const addUserToState = ({
 type Action =
   | FetchUserAccountAction
   | FetchUserNotificationsAction
-  | FinishEditUserAccountAction
-  | EditUserAccountAction
+  | FinishUpdateUserAccountAction
+  | UpdateUserAccountAction
   | LoadCurrentUserAccountAction
   | LoadUserAccountAction
   | LoadUserNotificationsAction
@@ -479,12 +479,12 @@ const reducer = (
   action: Action,
 ): UsersStateType => {
   switch (action.type) {
-    case EDIT_USER_ACCOUNT:
+    case UPDATE_USER_ACCOUNT:
       return {
         ...state,
         isUpdating: true,
       };
-    case FINISH_EDIT_USER_ACCOUNT:
+    case FINISH_UPDATE_USER_ACCOUNT:
       return {
         ...state,
         isUpdating: false,

--- a/src/amo/sagas/users.js
+++ b/src/amo/sagas/users.js
@@ -2,10 +2,10 @@ import { call, put, select, takeLatest } from 'redux-saga/effects';
 import {
   DELETE_USER_ACCOUNT,
   DELETE_USER_PICTURE,
-  EDIT_USER_ACCOUNT,
+  UPDATE_USER_ACCOUNT,
   FETCH_USER_ACCOUNT,
   FETCH_USER_NOTIFICATIONS,
-  finishEditUserAccount,
+  finishUpdateUserAccount,
   loadCurrentUserAccount,
   loadUserAccount,
   loadUserNotifications,
@@ -34,7 +34,7 @@ export function* fetchCurrentUserAccount({ payload }) {
   yield put(loadCurrentUserAccount({ user: response }));
 }
 
-export function* editUserAccount({
+export function* updateUserAccount({
   payload: { errorHandlerId, notifications, picture, userFields, userId },
 }) {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -44,7 +44,7 @@ export function* editUserAccount({
   try {
     const state = yield select(getState);
 
-    const user = yield call(api.editUserAccount, {
+    const user = yield call(api.updateUserAccount, {
       api: state.api,
       picture,
       userId,
@@ -68,10 +68,10 @@ export function* editUserAccount({
       );
     }
   } catch (error) {
-    log.warn(`Could not edit user account: ${error}`);
+    log.warn(`Could not update user account: ${error}`);
     yield put(errorHandler.createErrorAction(error));
   } finally {
-    yield put(finishEditUserAccount());
+    yield put(finishUpdateUserAccount());
   }
 }
 
@@ -160,7 +160,7 @@ export function* deleteUserAccount({ payload: { errorHandlerId, userId } }) {
 export default function* usersSaga() {
   yield takeLatest(DELETE_USER_ACCOUNT, deleteUserAccount);
   yield takeLatest(DELETE_USER_PICTURE, deleteUserPicture);
-  yield takeLatest(EDIT_USER_ACCOUNT, editUserAccount);
+  yield takeLatest(UPDATE_USER_ACCOUNT, updateUserAccount);
   yield takeLatest(FETCH_USER_ACCOUNT, fetchUserAccount);
   yield takeLatest(FETCH_USER_NOTIFICATIONS, fetchUserNotifications);
   yield takeLatest(SET_AUTH_TOKEN, fetchCurrentUserAccount);

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -5,7 +5,7 @@ import {
   currentUserAccount,
   deleteUserAccount,
   deleteUserPicture,
-  editUserAccount,
+  updateUserAccount,
   updateUserNotifications,
   userAccount,
   userNotifications,
@@ -51,7 +51,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('editUserAccount', () => {
+  describe('updateUserAccount', () => {
     const getParams = (params = {}) => {
       const state = dispatchSignInActions().store.getState();
       const userId = getCurrentUser(state.users).id;
@@ -59,7 +59,7 @@ describe(__filename, () => {
       return { api: state.api, userId, ...params };
     };
 
-    it('edits a userProfile and returns the new profile', async () => {
+    it('updates a userProfile and returns the new profile', async () => {
       const editableFields = {
         biography: 'I am a cool tester.',
         display_name: 'Super Krupa',
@@ -81,7 +81,7 @@ describe(__filename, () => {
         })
         .returns(mockResponse(editableFields));
 
-      await editUserAccount(params);
+      await updateUserAccount(params);
       mockApi.verify();
     });
 
@@ -108,7 +108,7 @@ describe(__filename, () => {
         )
         .returns(mockResponse());
 
-      await editUserAccount(params);
+      await updateUserAccount(params);
       mockApi.verify();
     });
 
@@ -137,7 +137,7 @@ describe(__filename, () => {
         )
         .returns(mockResponse());
 
-      await editUserAccount(params);
+      await updateUserAccount(params);
       mockApi.verify();
     });
   });

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -12,10 +12,10 @@ import UserProfileEditPicture from 'amo/components/UserProfileEditPicture';
 import {
   deleteUserAccount,
   deleteUserPicture,
-  editUserAccount,
+  updateUserAccount,
   fetchUserAccount,
   fetchUserNotifications,
-  finishEditUserAccount,
+  finishUpdateUserAccount,
   getCurrentUser,
   loadUserAccount,
   loadUserNotifications,
@@ -96,7 +96,7 @@ describe(__filename, () => {
     );
   }
 
-  function _editUserAccount({
+  function _updateUserAccount({
     store,
     notifications = {},
     picture = null,
@@ -105,7 +105,7 @@ describe(__filename, () => {
     errorHandlerId = createStubErrorHandler().id,
   }) {
     store.dispatch(
-      editUserAccount({
+      updateUserAccount({
         errorHandlerId,
         notifications,
         picture,
@@ -553,7 +553,7 @@ describe(__filename, () => {
     });
   });
 
-  it('dispatches editUserAccount action with all fields on submit', () => {
+  it('dispatches updateUserAccount action with all fields on submit', () => {
     const { store } = signInUserWithUsername('tofumatt');
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
@@ -565,7 +565,7 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(
       dispatchSpy,
-      editUserAccount({
+      updateUserAccount({
         errorHandlerId: errorHandler.id,
         notifications: {},
         picture: null,
@@ -625,7 +625,7 @@ describe(__filename, () => {
   it('renders a submit button with a different text when editing', () => {
     const { store } = signInUserWithUsername('tofumatt');
 
-    _editUserAccount({ store });
+    _updateUserAccount({ store });
 
     const root = renderUserProfileEdit({ store });
 
@@ -638,7 +638,7 @@ describe(__filename, () => {
     const { store } = signInUserWithUsername('tofumatt');
     const params = { username: 'another-user' };
 
-    _editUserAccount({ store });
+    _updateUserAccount({ store });
 
     const root = renderUserProfileEdit({ params, store });
 
@@ -664,7 +664,7 @@ describe(__filename, () => {
     );
   });
 
-  it('dispatches editUserAccount action with new field values on submit', () => {
+  it('dispatches updateUserAccount action with new field values on submit', () => {
     const { store } = signInUserWithUsername('tofumatt');
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
@@ -686,7 +686,7 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(
       dispatchSpy,
-      editUserAccount({
+      updateUserAccount({
         errorHandlerId: errorHandler.id,
         notifications: {},
         picture: null,
@@ -703,7 +703,7 @@ describe(__filename, () => {
     );
   });
 
-  it('dispatches editUserAccount action with updated notifications on submit', () => {
+  it('dispatches updateUserAccount action with updated notifications on submit', () => {
     const { store } = signInUserWithUsername('tofumatt');
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
@@ -730,7 +730,7 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(
       dispatchSpy,
-      editUserAccount({
+      updateUserAccount({
         errorHandlerId: errorHandler.id,
         notifications: {
           reply: false,
@@ -765,7 +765,7 @@ describe(__filename, () => {
 
     const occupation = 'new occupation';
 
-    _editUserAccount({
+    _updateUserAccount({
       store,
       userFields: {
         occupation,
@@ -782,7 +782,7 @@ describe(__filename, () => {
     );
 
     // The user profile has been updated.
-    store.dispatch(finishEditUserAccount());
+    store.dispatch(finishUpdateUserAccount());
 
     const { isUpdating } = store.getState().users;
     root.setProps({ isUpdating });
@@ -875,7 +875,7 @@ describe(__filename, () => {
 
     const username = '';
 
-    _editUserAccount({
+    _updateUserAccount({
       errorHandlerId: errorHandler.id,
       store,
       userFields: {
@@ -894,7 +894,7 @@ describe(__filename, () => {
 
     // An error occured while updating the user profile.
     errorHandler.handle(new Error('unexpected error'));
-    store.dispatch(finishEditUserAccount());
+    store.dispatch(finishUpdateUserAccount());
 
     const { isUpdating } = store.getState().users;
     root.setProps({ isUpdating });

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -1,7 +1,7 @@
 import reducer, {
   LOAD_USER_ACCOUNT,
-  editUserAccount,
-  finishEditUserAccount,
+  updateUserAccount,
+  finishUpdateUserAccount,
   getCurrentUser,
   getUserById,
   getUserByUsername,
@@ -88,14 +88,14 @@ describe(__filename, () => {
     });
   });
 
-  describe('finishEditUserAccount', () => {
+  describe('finishUpdateUserAccount', () => {
     it('sets a user account to not editing', () => {
       const user = createUserAccountResponse();
       const userFields = { biography: 'Punk rock music fan' };
 
       let state = reducer(
         initialState,
-        editUserAccount({
+        updateUserAccount({
           errorHandlerId: 'fake-error-id',
           notifications: {},
           picture: null,
@@ -103,20 +103,19 @@ describe(__filename, () => {
           userId: user.id,
         }),
       );
-      state = reducer(state, finishEditUserAccount());
+      state = reducer(state, finishUpdateUserAccount());
 
       expect(state.isUpdating).toEqual(false);
     });
   });
 
-  describe('editUserAccount', () => {
+  describe('updateUserAccount', () => {
     it('sets user account to editing', () => {
       const user = createUserAccountResponse();
       const userFields = { biography: 'Punk rock music fan' };
-
       const state = reducer(
         initialState,
-        editUserAccount({
+        updateUserAccount({
           errorHandlerId: 'fake-error-id',
           notifications: {},
           picture: null,

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -4,10 +4,10 @@ import usersSaga from 'amo/sagas/users';
 import usersReducer, {
   deleteUserAccount,
   deleteUserPicture,
-  editUserAccount,
+  updateUserAccount,
   fetchUserAccount,
   fetchUserNotifications,
-  finishEditUserAccount,
+  finishUpdateUserAccount,
   loadCurrentUserAccount,
   loadUserAccount,
   loadUserNotifications,
@@ -126,8 +126,8 @@ describe(__filename, () => {
     });
   });
 
-  describe('editUserAccount', () => {
-    it('calls the API to edit a user after editUserAccount()', async () => {
+  describe('updateUserAccount', () => {
+    it('calls the API to update a user after updateUserAccount()', async () => {
       const user = createUserAccountResponse({ id: 5001 });
       const userFields = {
         biography: 'I fell into a burning ring of fire.',
@@ -135,12 +135,12 @@ describe(__filename, () => {
       };
 
       mockApi
-        .expects('editUserAccount')
+        .expects('updateUserAccount')
         .once()
         .returns(Promise.resolve({ ...user, ...userFields }));
 
       sagaTester.dispatch(
-        editUserAccount({
+        updateUserAccount({
           errorHandlerId: errorHandler.id,
           notifications: {},
           picture: null,
@@ -165,7 +165,7 @@ describe(__filename, () => {
       expect(calledAction).toEqual(expectedCalledAction);
 
       // Make sure the finish action is also called.
-      const finishAction = finishEditUserAccount();
+      const finishAction = finishUpdateUserAccount();
 
       const calledFinishAction = await sagaTester.waitFor(finishAction.type);
       expect(calledFinishAction.payload).toEqual({});
@@ -182,7 +182,7 @@ describe(__filename, () => {
       };
 
       mockApi
-        .expects('editUserAccount')
+        .expects('updateUserAccount')
         .withArgs({
           api: state.api,
           userId: user.id,
@@ -193,7 +193,7 @@ describe(__filename, () => {
         .returns(Promise.resolve({ ...user, ...userFields }));
 
       sagaTester.dispatch(
-        editUserAccount({
+        updateUserAccount({
           errorHandlerId: errorHandler.id,
           notifications: {},
           picture,
@@ -230,7 +230,7 @@ describe(__filename, () => {
       };
 
       mockApi
-        .expects('editUserAccount')
+        .expects('updateUserAccount')
         .withArgs({
           api: state.api,
           picture: null,
@@ -251,7 +251,7 @@ describe(__filename, () => {
         .returns(Promise.resolve(allNotifications));
 
       sagaTester.dispatch(
-        editUserAccount({
+        updateUserAccount({
           errorHandlerId: errorHandler.id,
           notifications,
           picture: null,
@@ -271,7 +271,7 @@ describe(__filename, () => {
       mockApi.verify();
     });
 
-    it('cancels the edit and dispatches an error when fails', async () => {
+    it('cancels the update and dispatches an error when fails', async () => {
       const user = createUserAccountResponse({ id: 5001 });
       const userFields = {
         biography: 'I fell into a burning ring of fire.',
@@ -279,10 +279,10 @@ describe(__filename, () => {
       };
       const error = new Error('a bad API error');
 
-      mockApi.expects('editUserAccount').returns(Promise.reject(error));
+      mockApi.expects('updateUserAccount').returns(Promise.reject(error));
 
       sagaTester.dispatch(
-        editUserAccount({
+        updateUserAccount({
           errorHandlerId: errorHandler.id,
           notifications: {},
           picture: null,
@@ -291,7 +291,7 @@ describe(__filename, () => {
         }),
       );
 
-      const finishAction = finishEditUserAccount();
+      const finishAction = finishUpdateUserAccount();
 
       const calledFinishAction = await sagaTester.waitFor(finishAction.type);
       expect(calledFinishAction.payload).toEqual({});


### PR DESCRIPTION
Fixes #5195 

changes `editUserAccount` to `updateUserAccount` in all files and tests.
changes all functions and tests that match with `editUser` to `updateUser`

* [X] This PR relates to an existing open issue and there are no existing
      PRs open for the same issue.
* [X] Add `Fixes #ISSUENUM` at the top of your PR.
* [X] Add a description of the the changes introduced in this PR.

Cheers!