### PR TITLE
Update SimulateClientError to trigger render errors

### DIFF
--- a/src/core/components/ErrorPage/index.js
+++ b/src/core/components/ErrorPage/index.js
@@ -1,28 +1,35 @@
+/* @flow */
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import log from 'core/logger';
 import { getErrorComponent as getErrorComponentDefault } from 'core/utils';
 import { loadErrorPage } from 'core/reducers/errorPage';
+import type { ErrorPageState } from 'core/reducers/errorPage';
+import type { DispatchFunc } from 'core/types/redux';
 
 
-export class ErrorPageBase extends React.Component {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    dispatch: PropTypes.func.isRequired,
-    errorPage: PropTypes.object,
-    getErrorComponent: PropTypes.func,
-  }
+type Props = {|
+  children: React.Node,
+  dispatch: DispatchFunc,
+  errorPage: {
+    error: Error,
+    hasError: boolean,
+    statusCode: number,
+  },
+  getErrorComponent: Function,
+|};
 
+export class ErrorPageBase extends React.Component<Props> {
   static defaultProps = {
     errorPage: {},
     getErrorComponent: getErrorComponentDefault,
   }
 
-  componentDidCatch(error, info) {
+  componentDidCatch(error: Error, info: Object) {
     const { dispatch } = this.props;
+
     dispatch(loadErrorPage({ error }));
     log.error('Caught application error:', error, info);
   }
@@ -41,8 +48,7 @@ export class ErrorPageBase extends React.Component {
   }
 }
 
-
-export const mapStateToProps = (state) => ({
+export const mapStateToProps = (state: {| errorPage: ErrorPageState |}) => ({
   errorPage: state.errorPage,
 });
 

--- a/src/core/components/ErrorPage/index.js
+++ b/src/core/components/ErrorPage/index.js
@@ -13,12 +13,8 @@ import type { DispatchFunc } from 'core/types/redux';
 type Props = {|
   children: React.Node,
   dispatch: DispatchFunc,
-  errorPage: {
-    error: Error,
-    hasError: boolean,
-    statusCode: number,
-  },
-  getErrorComponent: Function,
+  errorPage: ErrorPageState,
+  getErrorComponent: typeof getErrorComponentDefault,
 |};
 
 export class ErrorPageBase extends React.Component<Props> {

--- a/src/core/containers/error-simulation/SimulateClientError.js
+++ b/src/core/containers/error-simulation/SimulateClientError.js
@@ -9,21 +9,41 @@ import './SimulateClientError.scss';
 export class SimulateClientErrorBase extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { buttonClicked: false };
+
+    this.state = {
+      buttonClicked: false,
+      throwRenderError: false,
+    };
   }
 
   onClick = () => {
     this.setState({ buttonClicked: true });
     setTimeout(() => this.setState({ buttonClicked: false }), 3000);
+
     throw new Error('This is a simulated client error');
+  }
+
+  throwRenderError = () => {
+    this.setState({ throwRenderError: true });
   }
 
   render() {
     const prompt = this.state.buttonClicked ?
       'Nice! Check Sentry' : '💣 Go ahead, trigger an error';
+
+    if (this.state.throwRenderError) {
+      throw new Error('This is a simulated client render error');
+    }
+
     return (
       <div className="SimulateClientError">
-        <Button buttonType="neutral" onClick={this.onClick}>{prompt}</Button>
+        <Button buttonType="neutral" onClick={this.onClick}>
+          {prompt}
+        </Button>
+
+        <Button buttonType="alert" onClick={this.throwRenderError}>
+          Trigger a render error
+        </Button>
       </div>
     );
   }

--- a/src/core/containers/error-simulation/SimulateClientError.js
+++ b/src/core/containers/error-simulation/SimulateClientError.js
@@ -37,13 +37,52 @@ export class SimulateClientErrorBase extends React.Component {
 
     return (
       <div className="SimulateClientError">
-        <Button buttonType="neutral" onClick={this.onClick}>
-          {prompt}
-        </Button>
+        <div>
+          <p>
+            This page allows you to simulate client errors, mainly to test our
+            integration with Sentry. If Sentry is enabled (by configuring a
+            DSN), the errors produced by clicking the buttons should appear in
+            the interface.
+          </p>
+          <p>
+            There are two available behaviors:
+          </p>
 
-        <Button buttonType="alert" onClick={this.throwRenderError}>
-          Trigger a render error
-        </Button>
+          <ul>
+            <li>
+              The grey button allows to throw an error in the button handler
+              (<code>onClick()</code>) and can be used multiple times. It
+              throws unhandled errors, which should be automatically logged by
+              Sentry.
+            </li>
+            <li>
+              The red button allows to throw an error in
+              the <code>render()</code> method and is not recoverable because
+              the error will be handled in the <code>ErrorPage</code> component,
+              which should log the error with <code>log.error()</code>. On the
+              client, <code>log.error</code> is bound to <code>console.error</code>,
+              which should automatically send errors to Sentry.
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <Button
+            buttonType="neutral"
+            className="SimulateClientError-error"
+            onClick={this.onClick}
+          >
+            {prompt}
+          </Button>
+
+          <Button
+            buttonType="alert"
+            className="SimulateClientError-render-error"
+            onClick={this.throwRenderError}
+          >
+            Trigger a render error
+          </Button>
+        </div>
       </div>
     );
   }

--- a/src/core/containers/error-simulation/SimulateClientError.scss
+++ b/src/core/containers/error-simulation/SimulateClientError.scss
@@ -1,10 +1,15 @@
 .SimulateClientError {
   align-items: center;
   display: flex;
+  flex-direction: column;
   height: 300px;
   justify-content: center;
 
   .Button {
     margin: 10px;
+  }
+
+  div {
+    flex: 1;
   }
 }

--- a/src/core/containers/error-simulation/SimulateClientError.scss
+++ b/src/core/containers/error-simulation/SimulateClientError.scss
@@ -3,4 +3,8 @@
   display: flex;
   height: 300px;
   justify-content: center;
+
+  .Button {
+    margin: 10px;
+  }
 }

--- a/src/core/reducers/errorPage.js
+++ b/src/core/reducers/errorPage.js
@@ -1,15 +1,38 @@
+/* @flow */
 import { LOCATION_CHANGE } from 'react-router-redux';
 
-const LOAD_ERROR_PAGE = 'LOAD_ERROR_PAGE';
+const LOAD_ERROR_PAGE: 'LOAD_ERROR_PAGE' = 'LOAD_ERROR_PAGE';
 
-export const initialState = {
+export type ErrorPageState = {|
+  clearOnNext: boolean,
+  error: Object | null,
+  hasError: boolean,
+  statusCode: number | null,
+|};
+
+export const initialState: ErrorPageState = {
   clearOnNext: false,
   error: null,
   hasError: false,
   statusCode: null,
 };
 
-export const loadErrorPage = ({ error } = {}) => {
+type LoadErrorPageParams = {|
+  error: Error | {
+    response?: {
+      status?: number,
+    },
+  },
+|};
+
+type LoadErrorPageAction = {|
+  type: typeof LOAD_ERROR_PAGE,
+  payload: LoadErrorPageParams,
+|};
+
+export const loadErrorPage = (
+  { error }: LoadErrorPageParams = {}
+): LoadErrorPageAction => {
   if (!error) {
     throw new Error('error is required');
   }
@@ -20,7 +43,13 @@ export const loadErrorPage = ({ error } = {}) => {
   };
 };
 
-export default function errorPage(state = initialState, action) {
+type Action =
+  | LoadErrorPageAction;
+
+export default function errorPage(
+  state: ErrorPageState = initialState,
+  action: Action
+) {
   const { payload } = action;
 
   switch (action.type) {

--- a/src/core/reducers/errorPage.js
+++ b/src/core/reducers/errorPage.js
@@ -3,9 +3,17 @@ import { LOCATION_CHANGE } from 'react-router-redux';
 
 const LOAD_ERROR_PAGE: 'LOAD_ERROR_PAGE' = 'LOAD_ERROR_PAGE';
 
+export type ErrorType = Error & {
+  apiURL?: string,
+  response?: {
+    status?: number,
+  },
+  jsonResponse?: Object,
+};
+
 export type ErrorPageState = {|
   clearOnNext: boolean,
-  error: Object | null,
+  error: ErrorType | null,
   hasError: boolean,
   statusCode: number | null,
 |};
@@ -18,11 +26,7 @@ export const initialState: ErrorPageState = {
 };
 
 type LoadErrorPageParams = {|
-  error: Error | {
-    response?: {
-      status?: number,
-    },
-  },
+  error: ErrorType,
 |};
 
 type LoadErrorPageAction = {|

--- a/tests/unit/core/containers/error-simulation/TestSimulateClientError.js
+++ b/tests/unit/core/containers/error-simulation/TestSimulateClientError.js
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { findDOMNode } from 'react-dom';
-import {
-  Simulate,
-  renderIntoDocument,
-} from 'react-dom/test-utils';
 
-import { SimulateClientErrorBase } from
-  'core/containers/error-simulation/SimulateClientError';
+import SimulateClientError, {
+  SimulateClientErrorBase,
+} from 'core/containers/error-simulation/SimulateClientError';
+import Button from 'ui/components/Button';
+import { shallowUntilTarget } from 'tests/unit/helpers';
 
-describe('SimulateClientError', () => {
+
+describe(__filename, () => {
   let clock;
 
   beforeEach(() => {
@@ -20,27 +19,49 @@ describe('SimulateClientError', () => {
   });
 
   function render(props = {}) {
-    return findDOMNode(
-      renderIntoDocument(<SimulateClientErrorBase {...props} />));
+    return shallowUntilTarget(
+      <SimulateClientError {...props} />,
+      SimulateClientErrorBase
+    );
   }
 
   it('lets you trigger an error', () => {
     const root = render();
-    const button = root.querySelector('button');
-    expect(() => Simulate.click(button)).toThrowError(/simulated client error/);
+
+    expect(() => {
+      root.find(Button).at(0).simulate('click');
+    }).toThrowError(/simulated client error/);
   });
 
   it('toggles the trigger prompt', () => {
     const root = render();
-    const button = root.querySelector('button');
-    const triggerPrompt = '💣 Go ahead, trigger an error';
 
-    expect(button.textContent).toEqual(triggerPrompt);
-    expect(() => Simulate.click(button)).toThrowError();
-    expect(button.textContent).toEqual('Nice! Check Sentry');
+    const triggerPrompt = '💣 Go ahead, trigger an error';
+    expect(root.find(Button).at(0).children()).toHaveText(triggerPrompt);
+
+    expect(() => {
+      root.find(Button).at(0).simulate('click');
+    }).toThrow();
+
+    root.update();
+    expect(root.find(Button).at(0).children()).toHaveText('Nice! Check Sentry');
 
     // Trigger the setTimeout() callback:
     clock.tick(3000);
-    expect(button.textContent).toEqual(triggerPrompt);
+    root.update();
+
+    expect(root.find(Button).at(0).children()).toHaveText(triggerPrompt);
+  });
+
+  it('can throw a render error', () => {
+    const root = render();
+
+    expect(root).toHaveState('throwRenderError', false);
+
+    expect(() => {
+      root.find(Button).at(1).simulate('click');
+    }).toThrowError(/simulated client render error/);
+
+    expect(root).toHaveState('throwRenderError', true);
   });
 });

--- a/tests/unit/core/containers/error-simulation/TestSimulateClientError.js
+++ b/tests/unit/core/containers/error-simulation/TestSimulateClientError.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import SimulateClientError, {
   SimulateClientErrorBase,
 } from 'core/containers/error-simulation/SimulateClientError';
-import Button from 'ui/components/Button';
 import { shallowUntilTarget } from 'tests/unit/helpers';
 
 
@@ -29,7 +28,7 @@ describe(__filename, () => {
     const root = render();
 
     expect(() => {
-      root.find(Button).at(0).simulate('click');
+      root.find('.SimulateClientError-error').simulate('click');
     }).toThrowError(/simulated client error/);
   });
 
@@ -37,20 +36,23 @@ describe(__filename, () => {
     const root = render();
 
     const triggerPrompt = '💣 Go ahead, trigger an error';
-    expect(root.find(Button).at(0).children()).toHaveText(triggerPrompt);
+    expect(root.find('.SimulateClientError-error').children())
+      .toHaveText(triggerPrompt);
 
     expect(() => {
-      root.find(Button).at(0).simulate('click');
+      root.find('.SimulateClientError-error').simulate('click');
     }).toThrow();
 
     root.update();
-    expect(root.find(Button).at(0).children()).toHaveText('Nice! Check Sentry');
+    expect(root.find('.SimulateClientError-error').children())
+      .toHaveText('Nice! Check Sentry');
 
     // Trigger the setTimeout() callback:
     clock.tick(3000);
     root.update();
 
-    expect(root.find(Button).at(0).children()).toHaveText(triggerPrompt);
+    expect(root.find('.SimulateClientError-error').children())
+      .toHaveText(triggerPrompt);
   });
 
   it('can throw a render error', () => {
@@ -59,7 +61,7 @@ describe(__filename, () => {
     expect(root).toHaveState('throwRenderError', false);
 
     expect(() => {
-      root.find(Button).at(1).simulate('click');
+      root.find('.SimulateClientError-render-error').simulate('click');
     }).toThrowError(/simulated client render error/);
 
     expect(root).toHaveState('throwRenderError', true);


### PR DESCRIPTION
Fix #5278 

---

This PR adds a new button to the `SimulateClientError` that throws an error in the `render()` method, in order to test our integration with Sentry (and `componentDidCatch()` in `ErrorPage`). It also adds more Flow coverage.