### PR TITLE
I4917 screenshot size fix

### DIFF
--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -8,8 +8,6 @@ import 'react-photoswipe/lib/photoswipe.css';
 
 import 'amo/css/ScreenShots.scss';
 
-export const HEIGHT = 1024;
-export const WIDTH = 1366; // This is the same as our $max-content-width;
 const PHOTO_SWIPE_OPTIONS = {
   closeEl: true,
   captionEl: true,
@@ -37,14 +35,14 @@ const formatPreviews = (previews) => (
   previews.map((preview) => ({
     src: preview.image_url,
     thumbnail_src: preview.thumbnail_url,
-    h: HEIGHT,
-    w: WIDTH,
+    h: preview.image_size[1],
+    w: preview.image_size[0],
     title: preview.caption,
   }))
 );
 
 export const thumbnailContent = (item) => (
-  <img src={item.src} className="ScreenShots-image" height={HEIGHT} width={WIDTH} alt="" title={item.title} />
+  <img src={item.src} className="ScreenShots-image" height={item.h} width={item.w} alt="" title={item.title} />
 );
 
 export default class ScreenShots extends React.Component {

--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -42,7 +42,7 @@ const formatPreviews = (previews) => (
 );
 
 export const thumbnailContent = (item) => (
-  <img src={item.src} className="ScreenShots-image" height={item.h} width={item.w} alt="" title={item.title} />
+  <img src={item.src} className="ScreenShots-image" height={item.h} width={item.w} alt={item.title} title={item.title} />
 );
 
 export default class ScreenShots extends React.Component {

--- a/src/amo/components/ScreenShots.js
+++ b/src/amo/components/ScreenShots.js
@@ -42,7 +42,14 @@ const formatPreviews = (previews) => (
 );
 
 export const thumbnailContent = (item) => (
-  <img src={item.src} className="ScreenShots-image" height={item.h} width={item.w} alt={item.title} title={item.title} />
+  <img
+    alt={item.title}
+    className="ScreenShots-image"
+    height={item.h}
+    src={item.src}
+    title={item.title}
+    width={item.w}
+  />
 );
 
 export default class ScreenShots extends React.Component {

--- a/src/amo/css/ScreenShots.scss
+++ b/src/amo/css/ScreenShots.scss
@@ -7,8 +7,14 @@ $screenshot-height: 220px;
 $image-height: $screenshot-height - 20px;
 $screenshot-width: 320px;
 
-.ScreenShots .pswp-thumbnails {
-  line-height: 0;
+.ScreenShots {
+  .pswp-thumbnails {
+    line-height: 0;
+  }
+
+  .pswp__caption__center {
+    text-align: center;
+  }
 }
 
 .ScreenShots-viewport {
@@ -51,3 +57,4 @@ $screenshot-width: 320px;
 .ScreenShots-list .pswp__caption {
   overflow-wrap: break-word;
 }
+

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -53,13 +53,16 @@ describe(__filename, () => {
   });
 
   it('renders custom thumbnail', () => {
-    const item = { src: 'https://foo.com/img.png', title: 'test title', h: 123, w: 1234 };
+    const h = 123;
+    const w = 1234;
+
+    const item = { src: 'https://foo.com/img.png', title: 'test title', h, w };
     const thumbnail = shallow(thumbnailContent(item));
 
     expect(thumbnail.type()).toEqual('img');
     expect(thumbnail.prop('src')).toEqual('https://foo.com/img.png');
-    expect(thumbnail.prop('height')).toEqual(123);
-    expect(thumbnail.prop('width')).toEqual(1234);
+    expect(thumbnail.prop('height')).toEqual(h);
+    expect(thumbnail.prop('width')).toEqual(w);
     expect(thumbnail.prop('alt')).toEqual('test title');
     expect(thumbnail.prop('title')).toEqual('test title');
   });

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -4,10 +4,11 @@ import { renderIntoDocument } from 'react-dom/test-utils';
 import { PhotoSwipeGallery } from 'react-photoswipe';
 
 import ScreenShots, {
-  HEIGHT,
-  WIDTH,
   thumbnailContent,
 } from 'amo/components/ScreenShots';
+
+const HEIGHT = 400;
+const WIDTH = 200;
 
 describe('<ScreenShots />', () => {
   const previews = [
@@ -15,11 +16,15 @@ describe('<ScreenShots />', () => {
       caption: 'A screenshot',
       image_url: 'http://img.com/one',
       thumbnail_url: 'http://img.com/1',
+      image_size: [WIDTH, HEIGHT],
+      thumbnail_size: [WIDTH, HEIGHT],
     },
     {
       caption: 'Another screenshot',
       image_url: 'http://img.com/two',
       thumbnail_url: 'http://img.com/2',
+      image_size: [WIDTH, HEIGHT],
+      thumbnail_size: [WIDTH, HEIGHT],
     },
   ];
 
@@ -49,7 +54,7 @@ describe('<ScreenShots />', () => {
   });
 
   it('renders custom thumbnail', () => {
-    const item = { src: 'https://foo.com/img.png', title: 'test title' };
+    const item = { src: 'https://foo.com/img.png', title: 'test title', h: HEIGHT, w: WIDTH };
     const thumbnail = shallow(thumbnailContent(item));
 
     expect(thumbnail.type()).toEqual('img');

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -1,6 +1,5 @@
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import * as React from 'react';
-import { renderIntoDocument } from 'react-dom/test-utils';
 import { PhotoSwipeGallery } from 'react-photoswipe';
 
 import ScreenShots, {
@@ -10,7 +9,7 @@ import ScreenShots, {
 const HEIGHT = 400;
 const WIDTH = 200;
 
-describe('<ScreenShots />', () => {
+describe(__filename, () => {
   const previews = [
     {
       caption: 'A screenshot',
@@ -54,14 +53,14 @@ describe('<ScreenShots />', () => {
   });
 
   it('renders custom thumbnail', () => {
-    const item = { src: 'https://foo.com/img.png', title: 'test title', h: HEIGHT, w: WIDTH };
+    const item = { src: 'https://foo.com/img.png', title: 'test title', h: 123, w: 1234 };
     const thumbnail = shallow(thumbnailContent(item));
 
     expect(thumbnail.type()).toEqual('img');
     expect(thumbnail.prop('src')).toEqual('https://foo.com/img.png');
-    expect(thumbnail.prop('height')).toEqual(HEIGHT);
-    expect(thumbnail.prop('width')).toEqual(WIDTH);
-    expect(thumbnail.prop('alt')).toEqual('');
+    expect(thumbnail.prop('height')).toEqual(123);
+    expect(thumbnail.prop('width')).toEqual(1234);
+    expect(thumbnail.prop('alt')).toEqual('test title');
     expect(thumbnail.prop('title')).toEqual('test title');
   });
 
@@ -70,16 +69,17 @@ describe('<ScreenShots />', () => {
     const newPreviews = previews.map((preview) => (
       { ...preview, image_url: onePixelImage }
     ));
-    const root = renderIntoDocument(<ScreenShots previews={newPreviews} />);
+
+    const root = mount(<ScreenShots previews={newPreviews} />);
     const item = { getBoundingClientRect: () => ({ x: 500 }) };
     const list = {
       children: [null, item],
       getBoundingClientRect: () => ({ x: 55 }),
       scrollLeft: 0,
     };
-    sinon.stub(root.viewport, 'querySelector').returns(list);
+    sinon.stub(root.instance().viewport, 'querySelector').returns(list);
     const photoswipe = { getCurrentIndex: () => 1 };
-    root.onClose(photoswipe);
+    root.instance().onClose(photoswipe);
     // 0 += 500 - 55
     expect(list.scrollLeft).toEqual(445);
   });

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -95,6 +95,8 @@ export const fakeAddon = Object.freeze({
     caption: 'Chill out control panel',
     image_url: 'https://addons.cdn.mozilla.net/123/image.png',
     thumbnail_url: 'https://addons.cdn.mozilla.net/7123/image.png',
+    image_size: [400, 200],
+    thumbnail_size: [200, 100],
   }],
   public_stats: true,
   ratings: {


### PR DESCRIPTION
fixes #4197 - 

instead of scaling up we are now we are using the actual image size. My understanding is that eventually we want to use srcset when the images are all set up (let me know if this assumption is not correct)

With the smaller image it looks a little odd so I have also centered the caption a bit more (it was left aligned in it's container which was centered). 


before:
![Alt text](https://monosnap.com/image/Nl3YUs9m4F8ohNywggncCbkwJ3rem8.png)

after:
![Alt text](https://monosnap.com/image/eWzHctEgcSrPkgJaLpelPDTaOZ9kku.png)