### PR TITLE
Make the search box bigger on small mobile screens

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -7,7 +7,7 @@
 .Header {
   background: $ink-90;
   display: grid;
-  grid-template-columns: auto min-content;
+  grid-template-columns: auto auto auto min-content;
   min-height: 112px;
   padding: 0 12px;
 
@@ -89,7 +89,7 @@
 .Header-user-and-external-links {
   @include text-align-end();
 
-  grid-column: 3 / span 2;
+  grid-column: 4;
   grid-row: 1 / 2;
   margin-top: 10px;
 
@@ -132,6 +132,10 @@
 }
 
 .Header-authenticate-button {
+  @include margin-start(6px);
+
+  white-space: nowrap;
+
   .DropdownMenu-button {
     padding: 0;
   }
@@ -177,11 +181,11 @@
 }
 
 .Header-search-form {
-  grid-column: 1 / 2;
+  grid-column: 1 / span 3;
   grid-row: 1 / 3;
   justify-self: end;
   margin: 10px 0 0;
-  min-width: 144px;
+  width: 100%;
 
   @include respond-to(medium) {
     grid-column: 3 / 3;

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -7,7 +7,7 @@
 .Header {
   background: $ink-90;
   display: grid;
-  grid-template-columns: min-content auto;
+  grid-template-columns: auto min-content;
   min-height: 112px;
   padding: 0 12px;
 
@@ -132,7 +132,13 @@
 }
 
 .Header-authenticate-button {
-  @include margin-start(12px);
+  .DropdownMenu-button {
+    padding: 0;
+  }
+
+  @include respond-to(medium) {
+    @include margin-start(12px);
+  }
 }
 
 .Header-SectionLinks {

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -7,7 +7,7 @@
 .Header {
   background: $ink-90;
   display: grid;
-  grid-template-columns: auto auto auto min-content;
+  grid-template-columns: repeat(3, auto) min-content;
   min-height: 112px;
   padding: 0 12px;
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5306

Autocomplete search results on mobile are too small. This maximizes them in the current layout as a simple solution. A more complex solution would be to make the search box go full width when you focus on it (and hide the login button) but that requires a lot of new state management logic (I think).

## Before

<img width="324" alt="screenshot 2018-06-18 11 33 48" src="https://user-images.githubusercontent.com/55398/41550675-2d0aa43c-72ef-11e8-8fd7-1f68a144df63.png">
<img width="322" alt="screenshot 2018-06-18 11 32 07" src="https://user-images.githubusercontent.com/55398/41550677-2f2776fa-72ef-11e8-8599-950fe7a60d95.png">

## After

<img width="323" alt="screenshot 2018-06-18 11 43 51" src="https://user-images.githubusercontent.com/55398/41556774-5d351b6c-7301-11e8-9d1f-6395021065fd.png">
<img width="322" alt="screenshot 2018-06-18 11 44 28" src="https://user-images.githubusercontent.com/55398/41556795-5fe92d12-7301-11e8-8906-e7668cdbb48a.png">



This improvement will look more dramatic on wider screen devices, such as Android Pixels.