### PR TITLE
update sinon to version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "sass-loader": "^7.0.1",
     "semver": "^5.3.0",
     "shelljs": "^0.8.0",
-    "sinon": "^5.0.0",
+    "sinon": "^6.0.0",
     "snyk": "^1.69.7",
     "style-loader": "^0.21.0",
     "stylelint": "^9.1.1",

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -99,7 +99,7 @@ describe(__filename, () => {
       dispatchSignInActions({ store, userProps: { username: 'user-one' } });
       const dispatchSpy = sinon.spy(store, 'dispatch');
       const root = render();
-      dispatchSpy.reset();
+      dispatchSpy.resetHistory();
 
       const username = 'user-two';
       dispatchSignInActions({ store, userProps: { username } });
@@ -131,7 +131,7 @@ describe(__filename, () => {
 
       const dispatchSpy = sinon.spy(store, 'dispatch');
       const root = render();
-      dispatchSpy.reset();
+      dispatchSpy.resetHistory();
 
       // Pretend this is updating some unrelated props.
       root.setProps({});

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -162,7 +162,7 @@ describe(__filename, () => {
   it('dispatches setViewContext on update', () => {
     const fakeDispatch = sinon.stub();
     const root = shallowRender({ dispatch: fakeDispatch });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     root.setProps({
       addon: createInternalAddon({ ...fakeAddon, type: ADDON_TYPE_THEME }),
     });
@@ -177,7 +177,7 @@ describe(__filename, () => {
     const root = shallowRender({
       addon: null, dispatch: fakeDispatch, params: { slug: 'some-slug' },
     });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     // Update with a new addon
     root.setProps({ addon: createInternalAddon(fakeAddon) });
 
@@ -188,7 +188,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.stub();
     const addon = createInternalAddon(fakeAddon);
     const root = shallowRender({ addon, dispatch: fakeDispatch });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     // Update with the same addon (this apparently happens in real usage).
     root.setProps({ addon });
     // The view context should not be dispatched.
@@ -198,7 +198,7 @@ describe(__filename, () => {
   it('does not update view context unless there is an addon', () => {
     const fakeDispatch = sinon.stub();
     const root = shallowRender({ dispatch: fakeDispatch });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     root.setProps({});
     sinon.assert.notCalled(fakeDispatch);
   });
@@ -279,7 +279,7 @@ describe(__filename, () => {
     const addon = createInternalAddon(fakeAddon);
     const root = shallowRender({ addon, errorHandler, dispatch: fakeDispatch });
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     // Update with the same slug.
     root.setProps({ params: { slug: addon.slug } });
 
@@ -292,7 +292,7 @@ describe(__filename, () => {
     const root = shallowRender({ errorHandler, dispatch: fakeDispatch });
     const slug = 'some-new-slug';
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     // Update with a new slug.
     root.setProps({ params: { slug } });
 

--- a/tests/unit/amo/components/TestAddonRecommendations.js
+++ b/tests/unit/amo/components/TestAddonRecommendations.js
@@ -211,7 +211,7 @@ describe(__filename, () => {
 
     const root = render({ addon, errorHandler, randomizer });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     const newAddon = createInternalAddon({
       ...fakeAddon,
@@ -233,7 +233,7 @@ describe(__filename, () => {
 
     const root = render({ addon });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({ addon });
 
@@ -246,7 +246,7 @@ describe(__filename, () => {
 
     const root = render({ addon });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({ addon: null });
 

--- a/tests/unit/amo/components/TestAddonReviewList.js
+++ b/tests/unit/amo/components/TestAddonReviewList.js
@@ -184,7 +184,7 @@ describe(__filename, () => {
         params: { addonSlug: addon.slug },
       });
 
-      dispatch.reset();
+      dispatch.resetHistory();
       // Simulate how a redux state change will introduce an addon.
       root.setProps({ addon });
 
@@ -244,7 +244,7 @@ describe(__filename, () => {
         location: fakeRouterLocation({ query: { page: 2 } }),
         params: { addonSlug },
       });
-      dispatch.reset();
+      dispatch.resetHistory();
       root.setProps({
         location: fakeRouterLocation({ query: { page: 3 } }),
       });
@@ -298,7 +298,7 @@ describe(__filename, () => {
       const dispatch = sinon.stub(store, 'dispatch');
       const root = render();
 
-      dispatch.reset();
+      dispatch.resetHistory();
       // Update the component with a different addon having the same type.
       root.setProps({
         addon: createInternalAddon({ ...addon1, id: 345 }),
@@ -315,7 +315,7 @@ describe(__filename, () => {
       const dispatch = sinon.stub(store, 'dispatch');
       const root = render();
 
-      dispatch.reset();
+      dispatch.resetHistory();
       root.setProps({ addon: createInternalAddon(addon2) });
 
       sinon.assert.calledWith(dispatch, setViewContext(addon2.type));

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -254,7 +254,7 @@ describe(__filename, () => {
       store,
     });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({
       addonType: ADDON_TYPE_THEME,
@@ -269,7 +269,7 @@ describe(__filename, () => {
 
     // Make sure an authorUsernames update even with the same addonType dispatches
     // a fetch action.
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({
       addonType: ADDON_TYPE_THEME,
@@ -295,7 +295,7 @@ describe(__filename, () => {
       store,
     });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({
       addonType: ADDON_TYPE_OPENSEARCH,
@@ -321,7 +321,7 @@ describe(__filename, () => {
       store,
     });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({
       forAddonSlug: 'testing',
@@ -347,7 +347,7 @@ describe(__filename, () => {
       store,
     });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({
       addonType: ADDON_TYPE_EXTENSION,

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -102,7 +102,7 @@ describe('<Categories />', () => {
     sinon.assert.calledWith(dispatch, setViewContext(ADDON_TYPE_EXTENSION));
     sinon.assert.calledTwice(dispatch);
 
-    dispatch.reset();
+    dispatch.resetHistory();
     root.setProps();
 
     // Dispatch should not be called again because no new props were set.

--- a/tests/unit/amo/components/TestCategory.js
+++ b/tests/unit/amo/components/TestCategory.js
@@ -192,7 +192,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.stub(store, 'dispatch');
 
     const root = render();
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This will trigger the componentWillReceiveProps() method.
     root.setProps();
@@ -207,7 +207,7 @@ describe(__filename, () => {
     const customErrorHandler = root.instance().props.errorHandler;
     customErrorHandler.captureError(new Error('an unexpected error'));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     root.setProps({ errorHandler: customErrorHandler });
 
     sinon.assert.notCalled(fakeDispatch);

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -172,7 +172,7 @@ describe(__filename, () => {
       detail: defaultCollectionDetail,
     }));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     renderComponent({ editing: true, errorHandler, store });
 
@@ -214,7 +214,7 @@ describe(__filename, () => {
     }));
 
     const wrapper = renderComponent({ store });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This will trigger the componentWillReceiveProps() method.
     wrapper.setProps();
@@ -234,7 +234,7 @@ describe(__filename, () => {
     const location = fakeRouterLocation();
 
     const wrapper = renderComponent({ location, store });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This will trigger the componentWillReceiveProps() method.
     wrapper.setProps({ location });
@@ -256,7 +256,7 @@ describe(__filename, () => {
       username,
     }));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     renderComponent({ store });
 
     sinon.assert.notCalled(fakeDispatch);
@@ -277,7 +277,7 @@ describe(__filename, () => {
       username,
     }));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     renderComponent({ store });
 
     sinon.assert.notCalled(fakeDispatch);
@@ -291,7 +291,7 @@ describe(__filename, () => {
     const { errorHandler } = wrapper.instance().props;
     errorHandler.captureError(new Error('an unexpected error'));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     wrapper.setProps({ collection: null, errorHandler });
 
     sinon.assert.notCalled(fakeDispatch);
@@ -328,7 +328,7 @@ describe(__filename, () => {
       params: { slug, username },
       store,
     });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This will trigger the componentWillReceiveProps() method.
     wrapper.setProps({
@@ -364,7 +364,7 @@ describe(__filename, () => {
       location,
       store,
     });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This will trigger the componentWillReceiveProps() method.
     wrapper.setProps({ location: newLocation });
@@ -401,7 +401,7 @@ describe(__filename, () => {
       location,
       store,
     });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This will trigger the componentWillReceiveProps() method.
     wrapper.setProps({ location: newLocation });
@@ -429,7 +429,7 @@ describe(__filename, () => {
       errorHandler,
       store,
     });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     const newParams = {
       slug: defaultSlug,
@@ -457,7 +457,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     const wrapper = renderComponent({ errorHandler, store });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     wrapper.setProps({
       params: { slug: defaultSlug, username: username.toLowerCase() },
@@ -480,7 +480,7 @@ describe(__filename, () => {
       errorHandler,
       store,
     });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     const newParams = {
       slug: 'some-other-collection-slug',
@@ -889,7 +889,7 @@ describe(__filename, () => {
       store,
     });
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This simulates the user clicking the "Remove" button on the
     // EditableCollectionAddon component.
@@ -928,7 +928,7 @@ describe(__filename, () => {
       store,
     });
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // This simulates the user clicking the "Remove" button on the
     // EditableCollectionAddon component.
@@ -964,7 +964,7 @@ describe(__filename, () => {
 
     const wrapper = renderComponent({ errorHandler, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // This emulates a user clicking the delete button and confirming.
     const onDelete = wrapper.find(ConfirmButton).prop('onConfirm');

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -429,7 +429,7 @@ describe(__filename, () => {
     typeInput({ root, name: 'name', text: `  ${name}   ` });
     typeInput({ root, name: 'slug', text: `  ${slug}   ` });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
     simulateSubmit(root);
 
     sinon.assert.calledWith(dispatchSpy, updateCollection({
@@ -512,7 +512,7 @@ describe(__filename, () => {
     // Enter in a blank collection description.
     typeInput({ root, name: 'description', text: '' });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
     simulateSubmit(root);
 
     sinon.assert.calledWith(dispatchSpy, updateCollection({

--- a/tests/unit/amo/components/TestLandingPage.js
+++ b/tests/unit/amo/components/TestLandingPage.js
@@ -77,7 +77,7 @@ describe(__filename, () => {
 
     sinon.assert.calledWith(fakeDispatch, setViewContext(ADDON_TYPE_EXTENSION));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     root.setProps({
       params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
     });
@@ -112,7 +112,7 @@ describe(__filename, () => {
       params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
       store,
     });
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // Now we request extension add-ons.
     root.setProps({
@@ -138,7 +138,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.stub(store, 'dispatch');
     const root = render({ errorHandler, params, store });
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     // We request extension add-ons again.
     root.setProps({ params });
@@ -375,7 +375,7 @@ describe(__filename, () => {
     const fakeDispatch = sinon.stub(store, 'dispatch');
     const root = render({ errorHandler, params, store });
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     root.setProps({ params });
 
     sinon.assert.notCalled(fakeDispatch);
@@ -397,7 +397,7 @@ describe(__filename, () => {
 
     const { context } = store.getState().viewContext;
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
     root.setProps({ context });
 
     sinon.assert.notCalled(fakeDispatch);

--- a/tests/unit/amo/components/TestReportAbuseButton.js
+++ b/tests/unit/amo/components/TestReportAbuseButton.js
@@ -230,7 +230,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(dispatchSpy, enableAbuseButtonUI({ addon }));
 
     // Ensure `enableAbuseButtonUI()` isn't called again.
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // This simulates entering text into the textarea.
     textarea.instance().value = 'Opera did it first! Adding some text!';
@@ -304,8 +304,8 @@ describe(__filename, () => {
     // We enable the button with an empty textarea; this never happens
     // normally but we can force it here for testing.
     store.dispatch(enableAbuseButtonUI({ addon }));
-    dispatchSpy.reset();
-    fakeEvent.preventDefault.reset();
+    dispatchSpy.resetHistory();
+    fakeEvent.preventDefault.resetHistory();
 
     const root = renderMount({ addon, store });
 

--- a/tests/unit/amo/components/TestReportUserAbuse.js
+++ b/tests/unit/amo/components/TestReportUserAbuse.js
@@ -112,7 +112,7 @@ describe(__filename, () => {
     const root = renderShallow({ store, user });
 
     root.find('.ReportUserAbuse-show-more').simulate('click', createFakeEvent());
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     const dismiss = root.find(DismissibleTextForm).prop('onDismiss');
     dismiss();

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -100,7 +100,7 @@ describe(__filename, () => {
 
     const root = renderUserProfile({ params, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({ params: { username: 'killmonger' } });
 
@@ -116,7 +116,7 @@ describe(__filename, () => {
 
     const root = renderUserProfile({ params, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({ params });
 
@@ -532,7 +532,7 @@ describe(__filename, () => {
     });
     errorHandler.handle(new Error('unexpected error'));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     renderUserProfile({ errorHandler, store });
 

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -193,7 +193,7 @@ describe(__filename, () => {
       notifications: createUserNotificationsResponse(),
     }));
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // This happens when loading the user edit profile page of the current
     // logged-in user (e.g., page refresh).
@@ -212,7 +212,7 @@ describe(__filename, () => {
 
     const root = renderUserProfileEdit({ errorHandler, params, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // We set `user` to `null` because that's what `mapStateToProps()` would do
     // because the user is not loaded yet.
@@ -249,7 +249,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({ errorHandler, store });
     const user = getCurrentUser(store.getState().users);
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // We pass the `user` to simulate the case where the user data are already
     // present in the store.
@@ -270,7 +270,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({ errorHandler, store });
     const user = getCurrentUser(store.getState().users);
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // We pass the `user` to simulate the case where the user data are already
     // present in the store.
@@ -291,7 +291,7 @@ describe(__filename, () => {
 
     const root = renderUserProfileEdit({ params, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     root.setProps({ params });
 
@@ -958,7 +958,7 @@ describe(__filename, () => {
     // The user edits their profile.
     const root = renderUserProfileEdit({ params: {}, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // The user logs out.
     root.setProps({
@@ -994,7 +994,7 @@ describe(__filename, () => {
     const params = { username: user.username };
     const root = renderUserProfileEdit({ params, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // The user logs out.
     root.setProps({ currentUser: null, params });
@@ -1031,7 +1031,7 @@ describe(__filename, () => {
     });
     errorHandler.handle(new Error('unexpected error'));
 
-    fakeDispatch.reset();
+    fakeDispatch.resetHistory();
 
     renderUserProfileEdit({ errorHandler, store });
 
@@ -1047,7 +1047,7 @@ describe(__filename, () => {
 
     const root = renderUserProfileEdit({ errorHandler, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     const onDelete = root.find(UserProfileEditPicture).prop('onDelete');
 
@@ -1271,7 +1271,7 @@ describe(__filename, () => {
 
     const root = renderUserProfileEdit({ errorHandler, params, store });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // User opens the modal.
     root.find('.UserProfileEdit-delete-button').simulate(
@@ -1322,7 +1322,7 @@ describe(__filename, () => {
       store,
     });
 
-    dispatchSpy.reset();
+    dispatchSpy.resetHistory();
 
     // User opens the modal.
     root.find('.UserProfileEdit-delete-button').simulate(

--- a/tests/unit/core/TestInstallAddon.js
+++ b/tests/unit/core/TestInstallAddon.js
@@ -612,7 +612,7 @@ describe(`${__filename}: withInstallHelpers`, () => {
       });
       const { setCurrentStatus } = root.instance().props;
 
-      dispatch.reset();
+      dispatch.resetHistory();
       return setCurrentStatus(addon)
         .then(() => {
           sinon.assert.calledWith(
@@ -1120,7 +1120,7 @@ describe(`${__filename}: withInstallHelpers`, () => {
           expect(arg.type).toEqual(SHOW_INFO);
 
           // Test that close action dispatches.
-          dispatch.reset();
+          dispatch.resetHistory();
           arg.payload.closeAction();
           sinon.assert.calledWith(dispatch, {
             type: CLOSE_INFO,

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -463,7 +463,7 @@ describe(__filename, () => {
       label: addon.name,
     });
 
-    _tracking.sendEvent.reset();
+    _tracking.sendEvent.resetHistory();
     // Simulate the InstallTrigger callback.
     const successStatus = 0;
     onInstalled(url, successStatus);

--- a/tests/unit/core/test_tracking.js
+++ b/tests/unit/core/test_tracking.js
@@ -215,7 +215,7 @@ describe('Do Not Track', () => {
     sinon.assert.calledWith(fakeLog.log, 'Do Not Track is enabled');
 
     // Check with `window.doNotTrack` as well, just for completeness.
-    fakeLog.log.reset();
+    fakeLog.log.resetHistory();
     isDoNotTrackEnabled({
       _log: fakeLog,
       _navigator: {},

--- a/tests/unit/ui/components/TestExpandableCard.js
+++ b/tests/unit/ui/components/TestExpandableCard.js
@@ -46,7 +46,7 @@ describe(__filename, () => {
     expect(card()).toHaveClassName('ExpandableCard--expanded');
 
     // Clicking on the toggle again should set the card to be unexpanded.
-    fakeEvent.preventDefault.reset();
+    fakeEvent.preventDefault.resetHistory();
     root.find('.ExpandableCard-ToggleLink').simulate('click', fakeEvent);
 
     sinon.assert.called(fakeEvent.preventDefault);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2611,7 +2611,7 @@ detect-node@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
-diff@^3.1.0, diff@^3.2.0:
+diff@^3.2.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
@@ -3661,12 +3661,6 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
-
-formatio@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
-  dependencies:
-    samsam "1.x"
 
 formidable@^1.1.1:
   version "1.2.1"
@@ -5698,9 +5692,13 @@ loglevelnext@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.4.tgz#0d991d9998180991dac8bd81e73a596a8720a645"
 
-lolex@^2.2.0, lolex@^2.3.2:
+lolex@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.2.tgz#85f9450425103bf9e7a60668ea25dc43274ca807"
+
+lolex@^2.4.2:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.0.tgz#9c087a69ec440e39d3f796767cf1b2cdc43d5ea5"
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -6161,9 +6159,9 @@ next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
-nise@^1.2.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-1.3.2.tgz#fd6fd8dc040dfb3c0a45252feb6ff21832309b14"
+nise@^1.3.3:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.2.tgz#a9a3800e3994994af9e452333d549d60f72b8e8c"
   dependencies:
     "@sinonjs/formatio" "^2.0.0"
     just-extend "^1.1.27"
@@ -8272,7 +8270,7 @@ safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-samsam@1.3.0, samsam@1.x:
+samsam@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
@@ -8549,17 +8547,17 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-sinon@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-5.0.0.tgz#e6de3b3f7fed338b470f8779dc4bab9fca058894"
+sinon@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-6.0.0.tgz#f26627e4830dc34279661474da2c9e784f166215"
   dependencies:
-    diff "^3.1.0"
-    formatio "1.2.0"
+    "@sinonjs/formatio" "^2.0.0"
+    diff "^3.5.0"
     lodash.get "^4.4.2"
-    lolex "^2.2.0"
-    nise "^1.2.0"
-    supports-color "^4.4.0"
-    type-detect "^4.0.5"
+    lolex "^2.4.2"
+    nise "^1.3.3"
+    supports-color "^5.4.0"
+    type-detect "^4.0.8"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -9211,13 +9209,13 @@ supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.2.1, supports-color@^4.4.0:
+supports-color@^4.2.1:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
 
-supports-color@^5.1.0, supports-color@^5.3.0:
+supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
@@ -9511,7 +9509,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 


### PR DESCRIPTION
Closes #5265 

I had to replace calls to `spy.reset()` with calls to `spy.resetHistory()`, which is a bit odd, because apparently `spy.reset()` was removed in version 5, which we were previously on. Maybe it was just deprecated in version 5, and removed entirely in version 6. In any case this fixes the test failures for me locally.