### PR TITLE
Always show the authenticate button

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -395,7 +395,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     if (!currentUser) {
       return (
         <div className="UserProfileEdit">
-          <Card className="UserProfileEdit-user-links">
+          <Card className="UserProfileEdit-authenticate">
             <AuthenticateButton
               noIcon
               location={router.location}

--- a/src/amo/components/UserProfileEdit/styles.scss
+++ b/src/amo/components/UserProfileEdit/styles.scss
@@ -13,6 +13,7 @@ $font-size-aside: 10px;
   }
 }
 
+.UserProfileEdit-authenticate,
 .UserProfileEdit-user-links {
   display: none;
 
@@ -35,6 +36,10 @@ $font-size-aside: 10px;
       list-style-type: none;
     }
   }
+}
+
+.UserProfileEdit-authenticate {
+  display: block;
 }
 
 .UserProfileEdit-form-messages .Notice,


### PR DESCRIPTION
Fix #5314

---

This PR fixes a CSS mistake that hides the Authenticate button on small screens.

Before:

![screen shot 2018-06-20 at 12 01 35](https://user-images.githubusercontent.com/217628/41651850-dc403ce4-7481-11e8-8238-d085bc377ea7.png)

After:

![screen shot 2018-06-20 at 12 01 21](https://user-images.githubusercontent.com/217628/41651849-dc0af8d6-7481-11e8-85c6-b38ff9b875cb.png)