### PR TITLE
Flow types to prevent misuse of component props, part 1

### DIFF
--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -320,8 +320,10 @@ export const extractId = (ownProps: Props) => {
   return `${addon ? addon.id : ''}-${currentUsername || ''}`;
 };
 
-export default compose(
+const AddAddonToCollection: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
   translate(),
   withFixedErrorHandler({ fileName: __filename, extractId }),
 )(AddAddonToCollectionBase);
+
+export default AddAddonToCollection;

--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -74,6 +74,8 @@ export const AddonBadgesBase = (props: Props) => {
   );
 };
 
-export default compose(
+const AddonBadges: React.ComponentType<Props> = compose(
   translate(),
 )(AddonBadgesBase);
+
+export default AddonBadges;

--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -79,6 +79,8 @@ export class AddonMetaBase extends React.Component<Props> {
   }
 }
 
-export default compose(
+const AddonMeta: React.ComponentType<Props> = compose(
   translate(),
 )(AddonMetaBase);
+
+export default AddonMeta;

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -252,7 +252,9 @@ export const mapStateToProps = (state: {| users: UsersStateType |}) => {
   };
 };
 
-export default compose(
+const AddonMoreInfo: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
   translate(),
 )(AddonMoreInfoBase);
+
+export default AddonMoreInfo;

--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -192,8 +192,10 @@ const mapStateToProps = (
   return { recommendations };
 };
 
-export default compose(
+const AddonRecommendations: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
   translate(),
   withErrorHandler({ name: 'AddonRecommendations' }),
 )(AddonRecommendationsBase);
+
+export default AddonRecommendations;

--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -324,9 +324,11 @@ export const extractId = (ownProps: Props) => {
   return `${params.addonSlug}-${location.query.page || ''}`;
 };
 
-export default compose(
+const AddonReviewList: React.ComponentType<Props> = compose(
   withRouter,
   connect(mapStateToProps),
   translate(),
   withFixedErrorHandler({ fileName: __filename, extractId }),
 )(AddonReviewListBase);
+
+export default AddonReviewList;

--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -264,7 +264,9 @@ export function mapDispatchToProps(dispatch: DispatchFunc) {
   };
 }
 
-export default compose(
+const App: React.ComponentType<Props> = compose(
   connect(mapStateToProps, mapDispatchToProps),
   translate(),
 )(AppBase);
+
+export default App;

--- a/src/amo/components/CategoriesPage/index.js
+++ b/src/amo/components/CategoriesPage/index.js
@@ -19,6 +19,8 @@ export class CategoriesPageBase extends React.Component<Props> {
   }
 }
 
-export default compose(
+const CategoriesPage: React.ComponentType<Props> = compose(
   translate({ withRef: true }),
 )(CategoriesPageBase);
+
+export default CategoriesPage;

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -496,8 +496,10 @@ export const extractId = (ownProps: Props) => {
   ].join('/');
 };
 
-export default compose(
+const Collection: React.ComponentType<Props> = compose(
   translate(),
   withFixedErrorHandler({ fileName: __filename, extractId }),
   connect(mapStateToProps),
 )(CollectionBase);
+
+export default Collection;

--- a/src/amo/components/ContributeCard/index.js
+++ b/src/amo/components/ContributeCard/index.js
@@ -95,6 +95,8 @@ export const ContributeCardBase = ({ addon, i18n }: Props) => {
   );
 };
 
-export default compose(
+const ContributeCard: React.ComponentType<Props> = compose(
   translate()
 )(ContributeCardBase);
+
+export default ContributeCard;

--- a/src/amo/components/DownloadFirefoxButton/index.js
+++ b/src/amo/components/DownloadFirefoxButton/index.js
@@ -51,7 +51,9 @@ export function mapStateToProps(state: StateType) {
   };
 }
 
-export default compose(
+const DownloadFirefoxButton: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
   translate(),
 )(DownloadFirefoxButtonBase);
+
+export default DownloadFirefoxButton;

--- a/src/amo/components/ErrorPage/NotAuthorized/index.js
+++ b/src/amo/components/ErrorPage/NotAuthorized/index.js
@@ -52,6 +52,8 @@ export class NotAuthorizedBase extends React.Component<Props> {
   }
 }
 
-export default compose(
+const NotAuthorized: React.ComponentType<Props> = compose(
   translate({ withRef: true }),
 )(NotAuthorizedBase);
+
+export default NotAuthorized;

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -22,16 +22,21 @@ import type { ReactRouterLocation } from 'core/types/router';
 
 
 type Props = {|
-  i18n: I18nType,
   isDeveloperReply?: boolean,
   location: ReactRouterLocation,
   openerClass?: string,
   review: UserReviewType,
+|};
+
+type InjectedProps = {|
+  i18n: I18nType,
   siteUser: UserType | null,
   wasFlagged: boolean,
 |};
 
-export class FlagReviewMenuBase extends React.Component<Props> {
+type InternalProps = { ...Props, ...InjectedProps };
+
+export class FlagReviewMenuBase extends React.Component<InternalProps> {
   static defaultProps = {
     isDeveloperReply: false,
   };
@@ -154,7 +159,9 @@ const mapStateToProps = (
   };
 };
 
-export default compose(
+const FlagReviewMenu: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
   translate(),
 )(FlagReviewMenuBase);
+
+export default FlagReviewMenu;

--- a/src/amo/components/HomeHeroBanner/index.js
+++ b/src/amo/components/HomeHeroBanner/index.js
@@ -258,6 +258,8 @@ export class HomeHeroBannerBase extends React.Component<Props> {
   }
 }
 
-export default compose(
+const HomeHeroBanner: React.ComponentType<Props> = compose(
   translate(),
 )(HomeHeroBannerBase);
+
+export default HomeHeroBanner;

--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -253,8 +253,10 @@ export const mapStateToProps = (
   };
 };
 
-export default compose(
+const LanguageTools: React.ComponentType<Props> = compose(
   withErrorHandler({ name: 'LanguageTools' }),
   connect(mapStateToProps),
   translate(),
 )(LanguageToolsBase);
+
+export default LanguageTools;

--- a/src/amo/components/PermissionsCard/index.js
+++ b/src/amo/components/PermissionsCard/index.js
@@ -73,7 +73,9 @@ export const mapStateToProps = (state: {| api: ApiStateType |}) => {
   };
 };
 
-export default compose(
+const PermissionsCard: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
   translate(),
 )(PermissionsCardBase);
+
+export default PermissionsCard;

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -73,8 +73,10 @@ export function mapStateToProps(
   return { apiLang: api.lang, clientApp: api.clientApp };
 }
 
-export default compose(
+const SearchForm: React.ComponentType<Props> = compose(
   withRouter,
   connect(mapStateToProps),
   translate(),
 )(SearchFormBase);
+
+export default SearchForm;

--- a/src/amo/components/SearchPage/index.js
+++ b/src/amo/components/SearchPage/index.js
@@ -129,6 +129,8 @@ export function mapStateToProps(state: any, ownProps: Props) {
   };
 }
 
-export default compose(
+const SearchPage: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
 )(SearchPageBase);
+
+export default SearchPage;

--- a/src/amo/components/SearchResults/index.js
+++ b/src/amo/components/SearchResults/index.js
@@ -76,6 +76,8 @@ export class SearchResultsBase extends React.Component<Props> {
   }
 }
 
-export default compose(
+const SearchResults: React.ComponentType<Props> = compose(
   translate(),
 )(SearchResultsBase);
+
+export default SearchResults;

--- a/src/amo/components/SearchTools/index.js
+++ b/src/amo/components/SearchTools/index.js
@@ -42,6 +42,8 @@ export function mapStateToProps() {
   return { filters };
 }
 
-export default compose(
+const SearchTools: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
 )(SearchToolsBase);
+
+export default SearchTools;

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -170,8 +170,10 @@ export function mapStateToProps(
   };
 }
 
-export default compose(
+const SectionLinks: React.ComponentType<Props> = compose(
   withRouter,
   connect(mapStateToProps),
   translate(),
 )(SectionLinksBase);
+
+export default SectionLinks;

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -295,8 +295,10 @@ export const extractId = (ownProps: Props) => {
   return ownProps.params.username;
 };
 
-export default compose(
+const UserProfile: React.ComponentType<Props> = compose(
   connect(mapStateToProps),
   translate(),
   withFixedErrorHandler({ fileName: __filename, extractId }),
 )(UserProfileBase);
+
+export default UserProfile;

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -810,9 +810,11 @@ export const extractId = (ownProps: Props) => {
   return ownProps.params.username;
 };
 
-export default compose(
+const UserProfileEdit: React.ComponentType<Props> = compose(
   withRouter,
   connect(mapStateToProps),
   translate(),
   withFixedErrorHandler({ fileName: __filename, extractId }),
 )(UserProfileEditBase);
+
+export default UserProfileEdit;

--- a/src/amo/components/UserProfileEditNotifications/index.js
+++ b/src/amo/components/UserProfileEditNotifications/index.js
@@ -89,16 +89,19 @@ const createNotification = ({
 };
 
 type Props = {|
-  i18n: I18nType,
   onChange: Function,
   user: UserType | null,
+|};
+
+type InjectedProps = {|
+  i18n: I18nType,
 |};
 
 export const UserProfileEditNotificationsBase = ({
   i18n,
   onChange,
   user,
-}: Props) => {
+}: { ...Props, ...InjectedProps }) => {
   let notifications = [];
   if (!user || !user.notifications) {
     for (let i = 0; i < 2; i++) {
@@ -128,6 +131,8 @@ export const UserProfileEditNotificationsBase = ({
   );
 };
 
-export default compose(
+const UserProfileEditNotifications: React.ComponentType<Props> = compose(
   translate(),
 )(UserProfileEditNotificationsBase);
+
+export default UserProfileEditNotifications;

--- a/src/amo/components/UserProfileEditPicture/index.js
+++ b/src/amo/components/UserProfileEditPicture/index.js
@@ -13,12 +13,15 @@ import './styles.scss';
 
 
 type Props = {|
-  i18n: I18nType,
   name: string,
   onDelete: Function,
   onSelect: Function,
   preview: string | null,
   user: UserType | null,
+|};
+
+type InjectedProps = {|
+  i18n: I18nType,
 |};
 
 export const UserProfileEditPictureBase = ({
@@ -28,7 +31,7 @@ export const UserProfileEditPictureBase = ({
   onSelect,
   preview,
   user,
-}: Props) => {
+}: { ...Props, ...InjectedProps }) => {
   const altText = user ? i18n.sprintf(
     i18n.gettext('Profile picture for %(name)s'), { name: user.name }
   ) : null;
@@ -81,6 +84,8 @@ export const UserProfileEditPictureBase = ({
   );
 };
 
-export default compose(
+const UserProfileEditPicture: React.ComponentType<Props> = compose(
   translate(),
 )(UserProfileEditPictureBase);
+
+export default UserProfileEditPicture;

--- a/src/ui/components/FormOverlay/index.js
+++ b/src/ui/components/FormOverlay/index.js
@@ -170,7 +170,9 @@ const mapStateToProps = (
   };
 };
 
-export default compose(
+const FormOverlay: React.ComponentType<Props> = compose(
   translate(),
   connect(mapStateToProps)
 )(FormOverlayBase);
+
+export default FormOverlay;

--- a/src/ui/components/UserRating/index.js
+++ b/src/ui/components/UserRating/index.js
@@ -12,7 +12,7 @@ import type { UsersStateType } from 'amo/reducers/users';
 type Props = {|
   className?: string,
   isOwner?: boolean,
-  onSelectRating?: (SyntheticEvent<any>) => void,
+  onSelectRating?: (rating: number) => any,
   readOnly?: boolean,
   review?: UserReviewType,
   // eslint-disable-next-line no-undef
@@ -44,7 +44,9 @@ const mapStateToProps = (
   return { isOwner: !!(siteUser && review && review.userId === siteUser.id) };
 };
 
-export default compose(
+const UserRating: React.ComponentType<Props> = compose(
   translate(),
   connect(mapStateToProps)
 )(UserRatingBase);
+
+export default UserRating;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5340

This approach to preventing misuse of Props is a bit of a hack. What it does is *declare* a typehint for what the final component would be. I attempted to do it the right way by adding types for all of our HOC's but that's an uphill battle. This approach works! It produces the Flow errors that I want to see.

The pattern consists of:
* You define the type of your exported component by re-using the `Props` object
* In most cases, you have to make a separation of props that should be regarded as *public* (those that other components will set) and those that are *private* (those used internally which are typically injected by other HOCs). For example, the *i18n* prop is injected by an HOC and never needs to be set by another component.