### PR TITLE
Enhance the addonsByAuthors reducer and saga

### DIFF
--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -90,8 +90,9 @@ export class AddonsByAuthorsCardBase extends React.Component<Props> {
     this.props.dispatch(fetchAddonsByAuthors({
       addonType,
       authorUsernames,
-      forAddonSlug,
       errorHandlerId: this.props.errorHandler.id,
+      forAddonSlug,
+      pageSize: this.props.numberOfAddons,
     }));
   }
 

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -2,7 +2,6 @@
 import deepcopy from 'deepcopy';
 import invariant from 'invariant';
 
-import { ADDON_TYPE_THEMES } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import type {
   ExternalAddonType,
@@ -23,7 +22,7 @@ export type AddonsByAuthorsState = {|
   byAddonSlug: { [string]: Array<AddonId> },
   byUserId: { [number]: Array<AddonId> },
   byUsername: { [string]: Array<AddonId> },
-  byAuthorNamesAndAddonType: { [string]: Array<AddonId> | null },
+  countFor: { [string]: number },
   loadingFor: { [string]: boolean },
 |};
 
@@ -32,7 +31,7 @@ export const initialState: AddonsByAuthorsState = {
   byAddonSlug: {},
   byUserId: {},
   byUsername: {},
-  byAuthorNamesAndAddonType: {},
+  countFor: {},
   loadingFor: {},
 };
 
@@ -51,6 +50,9 @@ type FetchAddonsByAuthorsParams = {|
   authorUsernames: Array<string>,
   errorHandlerId: string,
   forAddonSlug?: string,
+  page?: number,
+  pageSize: number,
+  sort?: string,
 |};
 
 type FetchAddonsByAuthorsAction = {|
@@ -58,13 +60,20 @@ type FetchAddonsByAuthorsAction = {|
   payload: FetchAddonsByAuthorsParams,
 |};
 
-export const fetchAddonsByAuthors = (
-  { addonType, authorUsernames, errorHandlerId, forAddonSlug }: FetchAddonsByAuthorsParams
-): FetchAddonsByAuthorsAction => {
+export const fetchAddonsByAuthors = ({
+  addonType,
+  authorUsernames,
+  errorHandlerId,
+  forAddonSlug,
+  page,
+  pageSize,
+  sort,
+}: FetchAddonsByAuthorsParams): FetchAddonsByAuthorsAction => {
   invariant(errorHandlerId, 'An errorHandlerId is required');
   invariant(authorUsernames, 'authorUsernames are required.');
   invariant(Array.isArray(authorUsernames),
     'The authorUsernames parameter must be an array.');
+  invariant(pageSize, 'pageSize is required.');
 
   return {
     type: FETCH_ADDONS_BY_AUTHORS,
@@ -73,15 +82,20 @@ export const fetchAddonsByAuthors = (
       authorUsernames,
       errorHandlerId,
       forAddonSlug,
+      page,
+      pageSize,
+      sort,
     },
   };
 };
 
 type LoadAddonsByAuthorsParams = {|
-  addons: Array<ExternalAddonType>,
   addonType?: string,
+  addons: Array<ExternalAddonType>,
   authorUsernames: Array<string>,
+  count: number,
   forAddonSlug?: string,
+  pageSize: number,
 |};
 
 type LoadAddonsByAuthorsAction = {|
@@ -89,15 +103,29 @@ type LoadAddonsByAuthorsAction = {|
   payload: LoadAddonsByAuthorsParams,
 |};
 
-export const loadAddonsByAuthors = (
-  { addons, addonType, authorUsernames, forAddonSlug }: LoadAddonsByAuthorsParams
-): LoadAddonsByAuthorsAction => {
+export const loadAddonsByAuthors = ({
+  addonType,
+  addons,
+  authorUsernames,
+  count,
+  forAddonSlug,
+  pageSize,
+}: LoadAddonsByAuthorsParams): LoadAddonsByAuthorsAction => {
   invariant(addons, 'A set of add-ons is required.');
   invariant(authorUsernames, 'A list of authorUsernames is required.');
+  invariant(typeof count === 'number', 'count is required.');
+  invariant(pageSize, 'pageSize is required.');
 
   return {
     type: LOAD_ADDONS_BY_AUTHORS,
-    payload: { addons, addonType, authorUsernames, forAddonSlug },
+    payload: {
+      addonType,
+      addons,
+      authorUsernames,
+      count,
+      forAddonSlug,
+      pageSize,
+    },
   };
 };
 
@@ -108,10 +136,21 @@ export const joinAuthorNamesAndAddonType = (
 };
 
 export const getLoadingForAuthorNames = (
+  state: AddonsByAuthorsState,
+  authorUsernames: Array<string>,
+  addonType?: string
+): boolean | null => {
+  return (
+    state.loadingFor[joinAuthorNamesAndAddonType(authorUsernames, addonType)] ||
+    null
+  );
+};
+
+export const getCountForAuthorNames = (
   state: AddonsByAuthorsState, authorUsernames: Array<string>, addonType?: string
 ) => {
   return (
-    state.loadingFor[joinAuthorNamesAndAddonType(authorUsernames, addonType)] ||
+    state.countFor[joinAuthorNamesAndAddonType(authorUsernames, addonType)] ||
     null
   );
 };
@@ -174,7 +213,12 @@ const reducer = (
   switch (action.type) {
     case FETCH_ADDONS_BY_AUTHORS: {
       const newState = deepcopy(state);
-      const { addonType, authorUsernames, forAddonSlug } = action.payload;
+
+      const {
+        addonType,
+        authorUsernames,
+        forAddonSlug,
+      } = action.payload;
 
       if (forAddonSlug) {
         newState.byAddonSlug = {
@@ -183,48 +227,54 @@ const reducer = (
         };
       }
 
-      newState.loadingFor[joinAuthorNamesAndAddonType(
-        authorUsernames, addonType)] = true;
+      const authorNamesWithAddonType = joinAuthorNamesAndAddonType(
+        authorUsernames,
+        addonType
+      );
 
-      newState.byAuthorNamesAndAddonType[joinAuthorNamesAndAddonType(
-        authorUsernames, addonType)] = null;
+      newState.loadingFor[authorNamesWithAddonType] = true;
+      newState.countFor[authorNamesWithAddonType] = null;
 
       return newState;
     }
     case LOAD_ADDONS_BY_AUTHORS: {
       const newState = deepcopy(state);
-      const { addonType, authorUsernames, forAddonSlug } = action.payload;
 
-      const pageSize = ADDON_TYPE_THEMES.includes(addonType) ?
-        THEMES_BY_AUTHORS_PAGE_SIZE : EXTENSIONS_BY_AUTHORS_PAGE_SIZE;
+      const {
+        addonType,
+        addons,
+        authorUsernames,
+        count,
+        forAddonSlug,
+        pageSize,
+      } = action.payload;
 
       if (forAddonSlug) {
         newState.byAddonSlug = {
-          [forAddonSlug]: action.payload.addons
-            .slice(0, pageSize)
-            .map((addon) => addon.id),
+          ...newState.byAddonSlug,
+          [forAddonSlug]: addons.slice(0, pageSize).map((addon) => addon.id),
         };
       }
 
-      const addons = action.payload.addons
-        .map((addon) => createInternalAddon(addon));
-
       const authorNamesWithAddonType = joinAuthorNamesAndAddonType(
-        authorUsernames, addonType);
+        authorUsernames,
+        addonType
+      );
 
-      newState.byAuthorNamesAndAddonType[authorNamesWithAddonType] = [];
+      newState.countFor[authorNamesWithAddonType] = count;
       newState.loadingFor[authorNamesWithAddonType] = false;
 
-      for (const addon of addons) {
+      const internalAddons = addons.map((addon) => createInternalAddon(addon));
+
+      for (const addon of internalAddons) {
         newState.byAddonId[addon.id] = addon;
-        newState.byAuthorNamesAndAddonType[authorNamesWithAddonType]
-          .push(addon.id);
 
         if (addon.authors) {
           for (const author of addon.authors) {
             if (!newState.byUserId[author.id]) {
               newState.byUserId[author.id] = [];
             }
+
             if (!newState.byUsername[author.username]) {
               newState.byUsername[author.username] = [];
             }

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -32,7 +32,10 @@ import createStore from 'amo/store';
 import {
   createInternalAddon, fetchAddon as fetchAddonAction, loadAddons,
 } from 'core/reducers/addons';
-import { loadAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
+import {
+  EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+  loadAddonsByAuthors,
+} from 'amo/reducers/addonsByAuthors';
 import { setError } from 'core/actions/errors';
 import { setInstallState } from 'core/actions/installations';
 import { createApiError } from 'core/api/index';
@@ -148,7 +151,9 @@ describe(__filename, () => {
     return loadAddonsByAuthors({
       addons: addonsByAuthors,
       authorUsernames: ['foo'],
+      count: addonsByAuthors.length,
       forAddonSlug: addon.slug,
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
     });
   };
 

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -68,12 +68,12 @@ describe(__filename, () => {
   }
 
   function addonsWithAuthorsOfType({ addonType, multipleAuthors = false }) {
-    const addonsLength = addonType === ADDON_TYPE_THEME ?
+    const pageSize = addonType === ADDON_TYPE_THEME ?
       THEMES_BY_AUTHORS_PAGE_SIZE : EXTENSIONS_BY_AUTHORS_PAGE_SIZE;
 
     const addons = [];
 
-    for (let i = 0; i < addonsLength; i++) {
+    for (let i = 0; i < pageSize; i++) {
       addons.push({
         ...fakeAddon,
         id: i + 1,
@@ -88,6 +88,8 @@ describe(__filename, () => {
       addonType,
       authorUsernames: multipleAuthors ?
         [fakeAuthorOne.username, fakeAuthorTwo.username] : [fakeAuthorOne.username],
+      count: addons.length,
+      pageSize,
     });
   }
 
@@ -132,7 +134,13 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const authorUsernames = fakeAuthorUsernames();
     const addons = Object.values(fakeAddons()).sort();
-    store.dispatch(loadAddonsByAuthors({ addons, authorUsernames }));
+
+    store.dispatch(loadAddonsByAuthors({
+      addons,
+      authorUsernames,
+      count: addons.length,
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+    }));
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
@@ -161,9 +169,13 @@ describe(__filename, () => {
   it('should render a className', () => {
     const { store } = dispatchClientMetadata();
     const authorUsernames = fakeAuthorUsernames();
+    const addons = Object.values(fakeAddons());
+
     store.dispatch(loadAddonsByAuthors({
-      addons: Object.values(fakeAddons()),
+      addons,
       authorUsernames,
+      count: addons.length,
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
     }));
 
     const root = render({
@@ -182,6 +194,8 @@ describe(__filename, () => {
     store.dispatch(loadAddonsByAuthors({
       addons: [],
       authorUsernames,
+      count: 0,
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
     }));
 
     const root = render({ authorUsernames, store });
@@ -207,6 +221,7 @@ describe(__filename, () => {
       addonType: ADDON_TYPE_EXTENSION,
       authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
     }));
 
     const root = render({
@@ -227,11 +242,13 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
+    const numberOfAddons = 4;
 
     render({
       addonType: ADDON_TYPE_EXTENSION,
       authorUsernames: ['test2'],
       errorHandler,
+      numberOfAddons,
       store,
     });
 
@@ -239,6 +256,7 @@ describe(__filename, () => {
       addonType: ADDON_TYPE_EXTENSION,
       authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
+      pageSize: numberOfAddons,
     }));
   });
 
@@ -246,11 +264,13 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
+    const numberOfAddons = 4;
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
       authorUsernames: ['test2'],
       errorHandler,
+      numberOfAddons,
       store,
     });
 
@@ -265,6 +285,7 @@ describe(__filename, () => {
       addonType: ADDON_TYPE_THEME,
       authorUsernames: ['test1'],
       errorHandlerId: errorHandler.id,
+      pageSize: numberOfAddons,
     }));
 
     // Make sure an authorUsernames update even with the same addonType dispatches
@@ -280,6 +301,7 @@ describe(__filename, () => {
       addonType: ADDON_TYPE_THEME,
       authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
+      pageSize: numberOfAddons,
     }));
   });
 
@@ -287,11 +309,13 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
+    const numberOfAddons = 6;
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
       authorUsernames: ['test2'],
       errorHandler,
+      numberOfAddons,
       store,
     });
 
@@ -306,6 +330,7 @@ describe(__filename, () => {
       addonType: ADDON_TYPE_OPENSEARCH,
       authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
+      pageSize: numberOfAddons,
     }));
   });
 
@@ -313,11 +338,13 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
+    const numberOfAddons = 4;
 
     const root = render({
       addonType: ADDON_TYPE_EXTENSION,
       authorUsernames: ['test2'],
       errorHandler,
+      numberOfAddons,
       store,
     });
 
@@ -332,6 +359,7 @@ describe(__filename, () => {
       authorUsernames: ['test2'],
       errorHandlerId: errorHandler.id,
       forAddonSlug: 'testing',
+      pageSize: numberOfAddons,
     }));
   });
 

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -273,7 +273,12 @@ export function dispatchSearchResults({
 export function createAddonsApiResult(results) {
   // Return a normalized add-ons response just like many utility functions do.
   // For example: core.api.featured(), core.api.search()...
-  return normalize({ results }, { results: [addonSchema] });
+  return normalize({
+    count: results.length,
+    results,
+  }, {
+    results: [addonSchema],
+  });
 }
 
 export function createFakeAutocompleteResult({

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -9,9 +9,10 @@ import reducer, {
   fetchAddonsByAuthors,
   getAddonsForSlug,
   getAddonsForUsernames,
+  getCountForAuthorNames,
   getLoadingForAuthorNames,
-  joinAuthorNamesAndAddonType,
   initialState,
+  joinAuthorNamesAndAddonType,
   loadAddonsByAuthors,
 } from 'amo/reducers/addonsByAuthors';
 import { createInternalAddon } from 'core/reducers/addons';
@@ -61,7 +62,9 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: [fakeAddon],
         authorUsernames: [fakeAddon.authors[0].username],
+        count: 1,
         forAddonSlug: fakeAddon.slug,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
       const newState = reducer(state, { type: 'UNRELATED' });
 
@@ -70,9 +73,11 @@ describe(__filename, () => {
 
     it('allows an empty list of add-ons', () => {
       const state = reducer(undefined, loadAddonsByAuthors({
-        forAddonSlug: 'addon-slug',
         addons: [],
         authorUsernames: [fakeAddon.authors[0].username],
+        count: 0,
+        forAddonSlug: 'addon-slug',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.byAddonSlug).toEqual({
@@ -82,9 +87,11 @@ describe(__filename, () => {
 
     it('adds related add-ons by slug', () => {
       const state = reducer(undefined, loadAddonsByAuthors({
-        forAddonSlug: 'addon-slug',
         addons: [fakeAddon],
         authorUsernames: [fakeAddon.authors[0].username],
+        count: 1,
+        forAddonSlug: 'addon-slug',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.byAddonSlug).toEqual({
@@ -99,7 +106,10 @@ describe(__filename, () => {
         // This is the case where there are more add-ons loaded than needed.
         addons: Array(EXTENSIONS_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
         authorUsernames: [fakeAddon.authors[0].username],
+        count: EXTENSIONS_BY_AUTHORS_PAGE_SIZE + 2,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
+
       expect(state.byAddonSlug[forAddonSlug])
         .toHaveLength(EXTENSIONS_BY_AUTHORS_PAGE_SIZE);
     });
@@ -112,6 +122,8 @@ describe(__filename, () => {
         addons: Array(THEMES_BY_AUTHORS_PAGE_SIZE + 2).fill(fakeAddon),
         authorUsernames: [fakeAddon.authors[0].username],
         addonType: ADDON_TYPE_THEME,
+        count: THEMES_BY_AUTHORS_PAGE_SIZE + 2,
+        pageSize: THEMES_BY_AUTHORS_PAGE_SIZE,
       }));
       expect(state.byAddonSlug[forAddonSlug])
         .toHaveLength(THEMES_BY_AUTHORS_PAGE_SIZE);
@@ -123,7 +135,9 @@ describe(__filename, () => {
       const previousState = reducer(undefined, loadAddonsByAuthors({
         addons: [fakeAddon],
         authorUsernames: [fakeAddon.authors[0].username],
+        count: 1,
         forAddonSlug,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(previousState.byAddonSlug)
@@ -133,6 +147,7 @@ describe(__filename, () => {
         authorUsernames: ['author2'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
+        pageSize: THEMES_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.byAddonSlug).toEqual({ 'addon-slug': [fakeAddon.id] });
@@ -144,16 +159,19 @@ describe(__filename, () => {
       const firstState = reducer(undefined, loadAddonsByAuthors({
         addons: [fakeAddon],
         authorUsernames: [fakeAddon.authors[0].username],
+        count: 1,
         forAddonSlug,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(firstState.byAddonSlug).toEqual({ 'addon-slug': [fakeAddon.id] });
 
       const state = reducer(firstState, fetchAddonsByAuthors({
-        authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
+        authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
         forAddonSlug,
+        pageSize: THEMES_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.byAddonSlug).toMatchObject({ 'addon-slug': undefined });
@@ -162,33 +180,11 @@ describe(__filename, () => {
       expect(state.byUsername).toMatchObject(firstState.byUsername);
     });
 
-    it('sets the byAuthorNamesAndAddonType state for authorUsernames on fetch', () => {
-      const state = reducer(undefined, fetchAddonsByAuthors({
-        authorUsernames: ['author1'],
-        errorHandlerId: 'error-handler-id',
-      }));
-
-      expect(state.byAuthorNamesAndAddonType).toMatchObject({
-        [joinAuthorNamesAndAddonType(['author1'])]: null,
-      });
-    });
-
-    it('sets the byAuthorNamesAndAddonType state for authorUsernames + addonType on fetch', () => {
-      const state = reducer(undefined, fetchAddonsByAuthors({
-        authorUsernames: ['author1'],
-        addonType: ADDON_TYPE_THEME,
-        errorHandlerId: 'error-handler-id',
-      }));
-
-      expect(state.byAuthorNamesAndAddonType).toMatchObject({
-        [joinAuthorNamesAndAddonType(['author1'], ADDON_TYPE_THEME)]: null,
-      });
-    });
-
     it('sets the loading state for authorUsernames on fetch', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
         authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.loadingFor).toMatchObject({
@@ -201,6 +197,7 @@ describe(__filename, () => {
         authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
+        pageSize: THEMES_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.loadingFor).toMatchObject({
@@ -214,7 +211,9 @@ describe(__filename, () => {
       return {
         addons: [],
         authorUsernames: ['fakeUsername'],
+        count: 0,
         forAddonSlug: fakeAddon.slug,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
         ...extra,
       };
     };
@@ -227,7 +226,11 @@ describe(__filename, () => {
         ...fakeAddon,
         authors: [firstAuthor, secondAuthor],
       };
-      const params = getParams({ addons: [multiAuthorAddon], authorUsernames });
+      const params = getParams({
+        addons: [multiAuthorAddon],
+        authorUsernames,
+        count: 1,
+      });
 
       const newState = reducer(undefined, loadAddonsByAuthors(params));
 
@@ -237,52 +240,12 @@ describe(__filename, () => {
       });
     });
 
-    it('sets the authorName request list when loaded', () => {
-      const firstAuthor = { ...fakeAuthor, id: 50, username: 'first' };
-      const secondAuthor = { ...fakeAuthor, id: 60, username: 'second' };
-      const authorUsernames = [firstAuthor.username, secondAuthor.username];
-      const multiAuthorAddon = {
-        ...fakeAddon,
-        authors: [firstAuthor, secondAuthor],
-      };
-      const params = getParams({
-        addons: [multiAuthorAddon],
-        authorUsernames,
-      });
-
-      const newState = reducer(undefined, loadAddonsByAuthors(params));
-
-      expect(newState.byAuthorNamesAndAddonType).toEqual({
-        [joinAuthorNamesAndAddonType(authorUsernames)]: [multiAuthorAddon.id],
-      });
-    });
-
-    it('sets the authorName + addonType request list when loaded', () => {
-      const firstAuthor = { ...fakeAuthor, id: 50, username: 'first' };
-      const secondAuthor = { ...fakeAuthor, id: 60, username: 'second' };
-      const authorUsernames = [firstAuthor.username, secondAuthor.username];
-      const multiAuthorAddon = {
-        ...fakeAddon,
-        authors: [firstAuthor, secondAuthor],
-      };
-      const params = getParams({
-        addons: [multiAuthorAddon],
-        addonType: ADDON_TYPE_EXTENSION,
-        authorUsernames,
-      });
-
-      const newState = reducer(undefined, loadAddonsByAuthors(params));
-
-      expect(newState.byAuthorNamesAndAddonType).toEqual({
-        [joinAuthorNamesAndAddonType(authorUsernames, ADDON_TYPE_EXTENSION)]: [multiAuthorAddon.id],
-      });
-    });
-
     it('adds each different add-on to the byAddonId dictionary', () => {
       const addons = fakeAddons();
       const params = getParams({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
+        count: Object.values(addons).length,
         forAddonSlug: undefined,
       });
 
@@ -304,6 +267,7 @@ describe(__filename, () => {
       const params = getParams({
         addons: Object.values(addons),
         authorUsernames: ['test', 'test2', 'test3'],
+        count: Object.values(addons).length,
         forAddonSlug: undefined,
       });
 
@@ -329,6 +293,8 @@ describe(__filename, () => {
       const params = getParams({
         addons: [fakeAddon],
         forAddonSlug: fakeAddon.slug,
+        count: 1,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
 
       const newState = reducer(undefined, loadAddonsByAuthors(params));
@@ -343,13 +309,19 @@ describe(__filename, () => {
       const firstParams = getParams({
         addons: [addons.firstAddon, addons.secondAddon],
         forAddonSlug: undefined,
+        count: 2,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
+
       let state = reducer(undefined, loadAddonsByAuthors(firstParams));
 
       const secondParams = getParams({
         addons: [addons.thirdAddon],
         forAddonSlug: undefined,
+        count: 1,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
+
       state = reducer(state, loadAddonsByAuthors(secondParams));
 
       expect(state.byUserId).toEqual({
@@ -365,8 +337,12 @@ describe(__filename, () => {
       const firstParams = getParams({
         addons: [addons.firstAddon, addons.secondAddon],
         forAddonSlug: undefined,
+        count: 2,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
+
       let state = reducer(undefined, loadAddonsByAuthors(firstParams));
+
       expect(state.byUsername).toEqual({
         [fakeAuthorOne.username]: [addons.firstAddon.id],
         [fakeAuthorTwo.username]: [addons.firstAddon.id, addons.secondAddon.id],
@@ -375,7 +351,10 @@ describe(__filename, () => {
       const secondParams = getParams({
         addons: [addons.thirdAddon],
         forAddonSlug: undefined,
+        count: 1,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
+
       state = reducer(state, loadAddonsByAuthors(secondParams));
 
       expect(state.byUsername).toEqual({
@@ -389,6 +368,7 @@ describe(__filename, () => {
       let state = reducer(undefined, fetchAddonsByAuthors({
         authorUsernames: ['author1'],
         errorHandlerId: 'error-handler-id',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.loadingFor).toMatchObject({
@@ -398,6 +378,8 @@ describe(__filename, () => {
       state = reducer(state, loadAddonsByAuthors({
         addons: [fakeAddon],
         authorUsernames: ['author1'],
+        count: 1,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.loadingFor).toMatchObject({
@@ -410,16 +392,67 @@ describe(__filename, () => {
         authorUsernames: ['author1'],
         addonType: ADDON_TYPE_THEME,
         errorHandlerId: 'error-handler-id',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       state = reducer(state, loadAddonsByAuthors({
-        addons: [fakeAddon],
         addonType: ADDON_TYPE_THEME,
+        addons: [fakeAddon],
         authorUsernames: ['author1'],
+        count: 1,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(state.loadingFor).toMatchObject({
         [joinAuthorNamesAndAddonType(['author1'], ADDON_TYPE_THEME)]: false,
+      });
+    });
+
+    it('sets the count for authorUsernames once loaded', () => {
+      const count = 1;
+
+      let state = reducer(undefined, fetchAddonsByAuthors({
+        authorUsernames: ['author1'],
+        errorHandlerId: 'error-handler-id',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+      }));
+
+      expect(state.countFor).toMatchObject({
+        [joinAuthorNamesAndAddonType(['author1'])]: null,
+      });
+
+      state = reducer(state, loadAddonsByAuthors({
+        addons: [fakeAddon],
+        authorUsernames: ['author1'],
+        count,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+      }));
+
+      expect(state.countFor).toMatchObject({
+        [joinAuthorNamesAndAddonType(['author1'])]: count,
+      });
+    });
+
+    it('sets the count for authorUsernames + addonType once loaded', () => {
+      const count = 1;
+
+      let state = reducer(undefined, fetchAddonsByAuthors({
+        authorUsernames: ['author1'],
+        addonType: ADDON_TYPE_THEME,
+        errorHandlerId: 'error-handler-id',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+      }));
+
+      state = reducer(state, loadAddonsByAuthors({
+        addonType: ADDON_TYPE_THEME,
+        addons: [fakeAddon],
+        authorUsernames: ['author1'],
+        count,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+      }));
+
+      expect(state.countFor).toMatchObject({
+        [joinAuthorNamesAndAddonType(['author1'], ADDON_TYPE_THEME)]: count,
       });
     });
   });
@@ -430,7 +463,9 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
+        count: Object.values(addons).length,
         forAddonSlug: 'test',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForSlug(state, 'test')).toEqual([
@@ -445,7 +480,9 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
+        count: Object.values(addons).length,
         forAddonSlug: 'test',
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForSlug(state, 'not-a-slug')).toBeNull();
@@ -458,6 +495,8 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
+        count: Object.values(addons).length,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(state, ['test2'])).toEqual([
@@ -471,6 +510,8 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
+        count: Object.values(addons).length,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(state, ['test2', 'no-addons-user'])).toEqual([
@@ -484,6 +525,8 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
+        count: Object.values(addons).length,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(state, ['test', 'test3'])).toEqual([
@@ -497,6 +540,8 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         authorUsernames: ['test', 'test2'],
+        count: Object.values(addons).length,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(state, ['test', 'test2'])).toEqual([
@@ -519,6 +564,8 @@ describe(__filename, () => {
         addons: Object.values(addons),
         addonType: ADDON_TYPE_EXTENSION,
         authorUsernames,
+        count: Object.values(addons).length,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(
@@ -537,6 +584,8 @@ describe(__filename, () => {
         addons: Object.values(addons),
         addonType: ADDON_TYPE_THEME,
         authorUsernames,
+        count: Object.values(addons).length,
+        pageSize: THEMES_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(
@@ -555,6 +604,8 @@ describe(__filename, () => {
         addons: Object.values(addons),
         addonType: ADDON_TYPE_STATIC_THEME,
         authorUsernames,
+        count: Object.values(addons).length,
+        pageSize: THEMES_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(
@@ -573,6 +624,8 @@ describe(__filename, () => {
         addons: Object.values(addons),
         addonType: ADDON_TYPE_EXTENSION,
         authorUsernames,
+        count: Object.values(addons).length,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(
@@ -589,6 +642,8 @@ describe(__filename, () => {
       const state = reducer(undefined, loadAddonsByAuthors({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
+        count: Object.values(addons).length,
+        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       }));
 
       expect(getAddonsForUsernames(state, ['nobody'])).toBeNull();
@@ -596,20 +651,22 @@ describe(__filename, () => {
   });
 
   describe('getLoadingForAuthorNames', () => {
+    const params = {
+      authorUsernames: ['author1'],
+      errorHandlerId: 'error-handler-id',
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+    };
+
     it('returns loading for just authorUsernames', () => {
-      const state = reducer(undefined, fetchAddonsByAuthors({
-        authorUsernames: ['author1'],
-        errorHandlerId: 'error-handler-id',
-      }));
+      const state = reducer(undefined, fetchAddonsByAuthors(params));
 
       expect(getLoadingForAuthorNames(state, ['author1'])).toEqual(true);
     });
 
     it('returns loading for authorUsernames + addonType', () => {
       const state = reducer(undefined, fetchAddonsByAuthors({
-        authorUsernames: ['author1'],
+        ...params,
         addonType: ADDON_TYPE_THEME,
-        errorHandlerId: 'error-handler-id',
       }));
 
       expect(getLoadingForAuthorNames(state, ['author1'], ADDON_TYPE_THEME))
@@ -617,21 +674,80 @@ describe(__filename, () => {
     });
 
     it('returns null when there is no match', () => {
-      const state = reducer(undefined, fetchAddonsByAuthors({
-        authorUsernames: ['author1'],
-        errorHandlerId: 'error-handler-id',
-      }));
+      const state = reducer(undefined, fetchAddonsByAuthors(params));
 
       expect(getLoadingForAuthorNames(state, ['author2'])).toEqual(null);
     });
 
     it('returns null when no authorUsernames provided', () => {
-      const state = reducer(undefined, fetchAddonsByAuthors({
-        authorUsernames: ['author1'],
-        errorHandlerId: 'error-handler-id',
-      }));
+      const state = reducer(undefined, fetchAddonsByAuthors(params));
 
       expect(getLoadingForAuthorNames(state, [])).toEqual(null);
+    });
+  });
+
+  describe('getCountForAuthorNames', () => {
+    const params = {
+      addons: [],
+      authorUsernames: ['author1'],
+      count: 0,
+      errorHandlerId: 'error-handler-id',
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
+    };
+
+    it('returns count for just authorUsernames', () => {
+      const count = 123;
+
+      const state = reducer(undefined, loadAddonsByAuthors({
+        ...params,
+        count,
+      }));
+
+      expect(getCountForAuthorNames(state, ['author1'])).toEqual(count);
+    });
+
+    it('returns count for authorUsernames + addonType', () => {
+      const count = 123;
+
+      const state = reducer(undefined, loadAddonsByAuthors({
+        ...params,
+        addonType: ADDON_TYPE_THEME,
+        count,
+      }));
+
+      expect(getCountForAuthorNames(state, ['author1'], ADDON_TYPE_THEME))
+        .toEqual(count);
+    });
+
+    it('returns null when there is no match', () => {
+      const state = reducer(undefined, loadAddonsByAuthors(params));
+
+      expect(getCountForAuthorNames(state, ['author2'])).toEqual(null);
+    });
+
+    it('returns null when no authorUsernames provided', () => {
+      const state = reducer(undefined, loadAddonsByAuthors(params));
+
+      expect(getCountForAuthorNames(state, [])).toEqual(null);
+    });
+
+    it('resets count when fetching add-ons by authors', () => {
+      const count = 123;
+
+      const prevState = reducer(undefined, loadAddonsByAuthors({
+        ...params,
+        count,
+      }));
+
+      expect(getCountForAuthorNames(prevState, ['author1'])).toEqual(count);
+
+      const fetchParams = { ...params };
+      delete fetchParams.addons;
+      delete fetchParams.count;
+
+      const state = reducer(prevState, fetchAddonsByAuthors(fetchParams));
+
+      expect(getCountForAuthorNames(state, ['author1'])).toEqual(null);
     });
   });
 

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -229,7 +229,6 @@ describe(__filename, () => {
       const params = getParams({
         addons: [multiAuthorAddon],
         authorUsernames,
-        count: 1,
       });
 
       const newState = reducer(undefined, loadAddonsByAuthors(params));
@@ -245,7 +244,6 @@ describe(__filename, () => {
       const params = getParams({
         addons: Object.values(addons),
         authorUsernames: ['fakeUsername'],
-        count: Object.values(addons).length,
         forAddonSlug: undefined,
       });
 
@@ -267,7 +265,6 @@ describe(__filename, () => {
       const params = getParams({
         addons: Object.values(addons),
         authorUsernames: ['test', 'test2', 'test3'],
-        count: Object.values(addons).length,
         forAddonSlug: undefined,
       });
 
@@ -293,7 +290,6 @@ describe(__filename, () => {
       const params = getParams({
         addons: [fakeAddon],
         forAddonSlug: fakeAddon.slug,
-        count: 1,
         pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
 
@@ -309,8 +305,6 @@ describe(__filename, () => {
       const firstParams = getParams({
         addons: [addons.firstAddon, addons.secondAddon],
         forAddonSlug: undefined,
-        count: 2,
-        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
 
       let state = reducer(undefined, loadAddonsByAuthors(firstParams));
@@ -318,8 +312,6 @@ describe(__filename, () => {
       const secondParams = getParams({
         addons: [addons.thirdAddon],
         forAddonSlug: undefined,
-        count: 1,
-        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
 
       state = reducer(state, loadAddonsByAuthors(secondParams));
@@ -337,8 +329,6 @@ describe(__filename, () => {
       const firstParams = getParams({
         addons: [addons.firstAddon, addons.secondAddon],
         forAddonSlug: undefined,
-        count: 2,
-        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
 
       let state = reducer(undefined, loadAddonsByAuthors(firstParams));
@@ -351,8 +341,6 @@ describe(__filename, () => {
       const secondParams = getParams({
         addons: [addons.thirdAddon],
         forAddonSlug: undefined,
-        count: 1,
-        pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       });
 
       state = reducer(state, loadAddonsByAuthors(secondParams));
@@ -674,7 +662,10 @@ describe(__filename, () => {
     });
 
     it('returns null when there is no match', () => {
-      const state = reducer(undefined, fetchAddonsByAuthors(params));
+      const state = reducer(undefined, fetchAddonsByAuthors({
+        ...params,
+        authorUsernames: ['someOtherAuthor'],
+      }));
 
       expect(getLoadingForAuthorNames(state, ['author2'])).toEqual(null);
     });

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -43,6 +43,7 @@ describe(__filename, () => {
   function _fetchAddonsByAuthors(params) {
     sagaTester.dispatch(fetchAddonsByAuthors({
       errorHandlerId: errorHandler.id,
+      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
       ...params,
     }));
   }
@@ -139,7 +140,6 @@ describe(__filename, () => {
     _fetchAddonsByAuthors({
       authorUsernames: [],
       forAddonSlug: fakeAddon.slug,
-      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
     });
 
     const expectedAction = errorHandler.createClearingAction();
@@ -159,7 +159,6 @@ describe(__filename, () => {
     _fetchAddonsByAuthors({
       authorUsernames: [],
       forAddonSlug: fakeAddon.slug,
-      pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
     });
 
     const errorAction = errorHandler.createErrorAction(error);


### PR DESCRIPTION
Fix #5353 

---

This PR:

- removes unused code (`byAuthorNamesAndAddonType`) in the `addonsByAuthors` reducer
- adds `pageSize` as a required argument to `fetchAddonsByAuthors()` in order to pass this value from the UI
- adds `page` and `sort` arguments (optional) to `fetchAddonsByAuthors()` to be able to paginate the add-ons related to a user
- adds `countFor` attribute to the state, which is designed like `loadingFor`
- passes `count` and `pageSize` to `loadAddonsByAuthors()`, `pageSize` was computed two times before, now this value is defined once in the UI and passed everywhere
- adds a `getCountForAuthorNames()` selector, similar to `getLoadingForAuthorNames()`