### PR TITLE
Paginate user extensions and themes

### DIFF
--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -1,16 +1,22 @@
 /* @flow */
+/* eslint-disable react/no-unused-prop-types */
 import makeClassName from 'classnames';
 import deepEqual from 'deep-eql';
+import invariant from 'invariant';
 import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
 
 import AddonsCard from 'amo/components/AddonsCard';
+import Link from 'amo/components/Link';
 import {
   fetchAddonsByAuthors,
   getAddonsForUsernames,
+  getCountForAuthorNames,
   getLoadingForAuthorNames,
 } from 'amo/reducers/addonsByAuthors';
+import Paginate from 'core/components/Paginate';
 import {
   ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
@@ -18,24 +24,33 @@ import {
   ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
   ADDON_TYPE_THEMES,
+  SEARCH_SORT_POPULAR,
 } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
-import type { AddonsByAuthorsState } from 'amo/reducers/addonsByAuthors';
+import type {
+  AddonsByAuthorsState,
+  FetchAddonsByAuthorsParams,
+} from 'amo/reducers/addonsByAuthors';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
+import type { ReactRouterLocation } from 'core/types/router';
 
 import './styles.scss';
 
 type Props = {|
   addonType?: string,
+  addons?: Array<AddonType>,
   authorDisplayName: string,
   authorUsernames: Array<string>,
   className?: string,
   forAddonSlug?: string,
   numberOfAddons: number,
+  pageParam: string,
+  paginate: boolean,
+  pathname?: string,
   showMore?: boolean,
 
   // AddonsCard accepts these props which are drilled in.
@@ -45,28 +60,47 @@ type Props = {|
 
 type InjectedProps = {|
   addons?: Array<AddonType>,
+  count: number | null,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   loading?: boolean,
+  location: ReactRouterLocation,
 |};
 
 type InternalProps = { ...Props, ...InjectedProps };
 
+type DispatchFetchAddonsByAuthorsParams = {|
+  addonType: $PropertyType<FetchAddonsByAuthorsParams, 'addonType'>,
+  authorUsernames: $PropertyType<FetchAddonsByAuthorsParams, 'authorUsernames'>,
+  forAddonSlug: $PropertyType<FetchAddonsByAuthorsParams, 'forAddonSlug'>,
+  page: $PropertyType<FetchAddonsByAuthorsParams, 'page'>,
+|};
+
 export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
   static defaultProps = {
+    pageParam: 'page',
+    paginate: false,
+    showMore: true,
     showSummary: false,
     type: 'horizontal',
-    showMore: true,
   };
 
   componentWillMount() {
-    const { addonType, authorUsernames, forAddonSlug } = this.props;
+    const {
+      addonType,
+      authorUsernames,
+      forAddonSlug,
+      location,
+      pageParam,
+      paginate,
+    } = this.props;
 
     this.dispatchFetchAddonsByAuthors({
       addonType,
       authorUsernames,
       forAddonSlug,
+      page: this.getCurrentPage({ location, paginate, pageParam }),
     });
   }
 
@@ -74,55 +108,103 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
     addonType: newAddonType,
     authorUsernames: newAuthorNames,
     forAddonSlug: newForAddonSlug,
+    location: newLocation,
+    pageParam,
+    paginate,
   }: InternalProps) {
     const {
       addonType: oldAddonType,
       authorUsernames: oldAuthorNames,
       forAddonSlug: oldForAddonSlug,
+      location: oldLocation,
     } = this.props;
+
+    const newPage = paginate
+      ? oldLocation.query[pageParam] !== newLocation.query[pageParam]
+      : false;
 
     if (
       oldAddonType !== newAddonType ||
       oldForAddonSlug !== newForAddonSlug ||
-      !deepEqual(oldAuthorNames, newAuthorNames)
+      !deepEqual(oldAuthorNames, newAuthorNames) ||
+      newPage
     ) {
       this.dispatchFetchAddonsByAuthors({
         addonType: newAddonType,
         authorUsernames: newAuthorNames,
         forAddonSlug: newForAddonSlug,
+        page: this.getCurrentPage({
+          location: newLocation,
+          paginate,
+          pageParam,
+        }),
       });
     }
+  }
+
+  getCurrentPage({
+    location,
+    paginate,
+    pageParam,
+  }: {|
+    location: ReactRouterLocation,
+    pageParam: string,
+    paginate: boolean,
+  |}): number | void {
+    // We don't want to set a `page` when there is no pagination.
+    if (!paginate) {
+      return undefined;
+    }
+
+    const currentPage = parseInt(location.query[pageParam], 10);
+
+    return Number.isNaN(currentPage) || currentPage < 1 ? 1 : currentPage;
   }
 
   dispatchFetchAddonsByAuthors({
     addonType,
     authorUsernames,
     forAddonSlug,
-  }: Object) {
+    page,
+  }: DispatchFetchAddonsByAuthorsParams) {
+    const { errorHandler, numberOfAddons, paginate } = this.props;
+
+    const filtersForPagination = {};
+
+    if (paginate) {
+      invariant(page, 'page is required when paginate is `true`.');
+
+      filtersForPagination.page = page;
+      filtersForPagination.sort = SEARCH_SORT_POPULAR;
+    }
+
     this.props.dispatch(
       fetchAddonsByAuthors({
         addonType,
         authorUsernames,
-        errorHandlerId: this.props.errorHandler.id,
+        errorHandlerId: errorHandler.id,
         forAddonSlug,
-        pageSize: this.props.numberOfAddons,
+        page,
+        pageSize: numberOfAddons,
+        ...filtersForPagination,
       }),
     );
   }
 
   render() {
     const {
-      addons,
       addonType,
+      addons,
       authorDisplayName,
       authorUsernames,
       className,
       i18n,
       loading,
       numberOfAddons,
+      paginate,
+      showMore,
       showSummary,
       type,
-      showMore,
     } = this.props;
 
     if (!loading && (!addons || !addons.length)) {
@@ -222,10 +304,38 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       'AddonsByAuthorsCard--theme': ADDON_TYPE_THEMES.includes(addonType),
     });
 
+    let paginator = null;
+
+    if (paginate) {
+      const { count, location, pageParam, pathname } = this.props;
+
+      invariant(pathname, 'pathname is required when paginate is `true`.');
+
+      const currentPage = this.getCurrentPage({
+        location,
+        paginate,
+        pageParam,
+      });
+
+      paginator =
+        count && count > numberOfAddons ? (
+          <Paginate
+            LinkComponent={Link}
+            count={count}
+            currentPage={currentPage}
+            pageParam={pageParam}
+            pathname={pathname}
+            perPage={numberOfAddons}
+            queryParams={location.query}
+          />
+        ) : null;
+    }
+
     return (
       <AddonsCard
         addons={addons}
         className={classnames}
+        footer={paginator}
         header={header}
         loading={loading}
         placeholderCount={numberOfAddons}
@@ -250,19 +360,31 @@ export const mapStateToProps = (
     forAddonSlug,
   );
   addons = addons ? addons.slice(0, numberOfAddons) : addons;
+
+  const count = getCountForAuthorNames(
+    state.addonsByAuthors,
+    authorUsernames,
+    addonType,
+  );
+
   const loading = getLoadingForAuthorNames(
     state.addonsByAuthors,
     authorUsernames,
     addonType,
   );
 
-  return { addons, loading };
+  return {
+    addons,
+    count,
+    loading,
+  };
 };
 
 const AddonsByAuthorsCard: React.ComponentType<Props> = compose(
-  translate(),
   connect(mapStateToProps),
+  translate(),
   withErrorHandler({ name: 'AddonsByAuthorsCard' }),
+  withRouter,
 )(AddonsByAuthorsCardBase);
 
 export default AddonsByAuthorsCard;

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -34,6 +34,13 @@
       }
     }
 
+    &:not(.Card--no-footer) {
+      .Card-contents {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+    }
+
     .Card-contents .AddonsCard-list {
       background-color: $white;
       display: grid;

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -8,12 +8,16 @@
 
     .Card-contents {
       background: $white;
-      border-bottom-left-radius: $border-radius-default;
-      border-bottom-right-radius: $border-radius-default;
       padding: 12px 6px;
+
+      .Card-footer-text ~ &,
+      .Card-footer-link ~ & {
+        border-bottom-left-radius: $border-radius-default;
+        border-bottom-right-radius: $border-radius-default;
+      }
     }
 
-    .Card-footer,
+    .Card-footer-text,
     .Card-footer-link {
       @include end(0);
       @include text-align-end();

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -8,13 +8,9 @@
 
     .Card-contents {
       background: $white;
+      border-bottom-left-radius: $border-radius-default;
+      border-bottom-right-radius: $border-radius-default;
       padding: 12px 6px;
-
-      .Card-footer-text ~ &,
-      .Card-footer-link ~ & {
-        border-bottom-left-radius: $border-radius-default;
-        border-bottom-right-radius: $border-radius-default;
-      }
     }
 
     .Card-footer-text,

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -85,6 +85,14 @@ export class UserProfileBase extends React.Component<Props> {
     }
   }
 
+  getURL() {
+    const { user } = this.props;
+
+    invariant(user, 'user is required');
+
+    return `/user/${user.username}/`;
+  }
+
   getEditURL() {
     const { currentUser, user } = this.props;
 
@@ -260,9 +268,12 @@ export class UserProfileBase extends React.Component<Props> {
                   authorDisplayName={user.name}
                   authorUsernames={[user.username]}
                   numberOfAddons={EXTENSIONS_BY_AUTHORS_PAGE_SIZE}
+                  pageParam="page_e"
+                  paginate
+                  pathname={this.getURL()}
+                  showMore={false}
                   showSummary
                   type="vertical"
-                  showMore={false}
                 />
 
                 <AddonsByAuthorsCard
@@ -270,6 +281,9 @@ export class UserProfileBase extends React.Component<Props> {
                   authorDisplayName={user.name}
                   authorUsernames={[user.username]}
                   numberOfAddons={THEMES_BY_AUTHORS_PAGE_SIZE}
+                  pageParam="page_t"
+                  paginate
+                  pathname={this.getURL()}
                   showMore={false}
                 />
               </div>

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -44,7 +44,7 @@ export const FETCH_ADDONS_BY_AUTHORS: 'FETCH_ADDONS_BY_AUTHORS' =
 export const LOAD_ADDONS_BY_AUTHORS: 'LOAD_ADDONS_BY_AUTHORS' =
   'LOAD_ADDONS_BY_AUTHORS';
 
-type FetchAddonsByAuthorsParams = {|
+export type FetchAddonsByAuthorsParams = {|
   addonType?: string,
   authorUsernames: Array<string>,
   errorHandlerId: string,
@@ -228,6 +228,35 @@ const reducer = (
           ...newState.byAddonSlug,
           [forAddonSlug]: undefined,
         };
+      } else if (authorUsernames.length) {
+        // Potentially remove add-ons loaded for these authors with this add-on
+        // type, so that we can load new add-ons in the UI (pagination). We do
+        // not do it when `forAddonSlug` is defined to avoid re-fetching the
+        // add-ons by authors on an add-on detail page.
+
+        const addonsToRemove = getAddonsForUsernames(
+          newState,
+          authorUsernames,
+          addonType,
+        );
+
+        if (addonsToRemove) {
+          for (const addonToRemove of addonsToRemove) {
+            newState.byAddonId[addonToRemove.id] = undefined;
+
+            if (addonToRemove.authors) {
+              for (const author of addonToRemove.authors) {
+                newState.byUsername[author.username] = newState.byUsername[
+                  author.username
+                ].filter((id) => id !== addonToRemove.id);
+
+                newState.byUserId[author.id] = newState.byUserId[
+                  author.id
+                ].filter((id) => id !== addonToRemove.id);
+              }
+            }
+          }
+        }
       }
 
       const authorNamesWithAddonType = joinAuthorNamesAndAddonType(

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -228,11 +228,11 @@ const reducer = (
           ...newState.byAddonSlug,
           [forAddonSlug]: undefined,
         };
-      } else if (authorUsernames.length) {
+      }
+
+      if (authorUsernames.length) {
         // Potentially remove add-ons loaded for these authors with this add-on
-        // type, so that we can load new add-ons in the UI (pagination). We do
-        // not do it when `forAddonSlug` is defined to avoid re-fetching the
-        // add-ons by authors on an add-on detail page.
+        // type, so that we can load new add-ons in the UI (pagination).
 
         const addonsToRemove = getAddonsForUsernames(
           newState,

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -242,8 +242,6 @@ const reducer = (
 
         if (addonsToRemove) {
           for (const addonToRemove of addonsToRemove) {
-            newState.byAddonId[addonToRemove.id] = undefined;
-
             if (addonToRemove.authors) {
               for (const author of addonToRemove.authors) {
                 newState.byUsername[author.username] = newState.byUsername[

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -22,6 +22,7 @@ export class PaginateBase extends React.Component {
     count: PropTypes.number.isRequired,
     currentPage: PropTypes.number,
     i18n: PropTypes.object.isRequired,
+    pageParam: PropTypes.string,
     pathname: PropTypes.string.isRequired,
     perPage: PropTypes.number,
     queryParams: PropTypes.object,
@@ -29,6 +30,7 @@ export class PaginateBase extends React.Component {
   };
 
   static defaultProps = {
+    pageParam: 'page',
     perPage: DEFAULT_API_PAGE_SIZE,
     showPages: 7,
   };
@@ -77,7 +79,14 @@ export class PaginateBase extends React.Component {
   }
 
   render() {
-    const { LinkComponent, count, i18n, pathname, queryParams } = this.props;
+    const {
+      LinkComponent,
+      count,
+      i18n,
+      pageParam,
+      pathname,
+      queryParams,
+    } = this.props;
 
     const pageCount = this.pageCount();
     const currentPage = this.getCurrentPage();
@@ -95,8 +104,8 @@ export class PaginateBase extends React.Component {
     const linkParams = {
       LinkComponent,
       currentPage,
-      pathname,
       pageCount,
+      pathname,
       queryParams,
     };
 
@@ -108,15 +117,22 @@ export class PaginateBase extends React.Component {
             {...linkParams}
             className="Paginate-item--previous"
             page={currentPage - 1}
+            pageParam={pageParam}
             text={i18n.gettext('Previous')}
           />
           {this.visiblePages({ pageCount }).map((page) => (
-            <PaginatorLink {...linkParams} key={`page-${page}`} page={page} />
+            <PaginatorLink
+              {...linkParams}
+              key={`page-${page}`}
+              page={page}
+              pageParam={pageParam}
+            />
           ))}
           <PaginatorLink
             {...linkParams}
             className="Paginate-item--next"
             page={currentPage + 1}
+            pageParam={pageParam}
             text={i18n.gettext('Next')}
           />
         </div>

--- a/src/core/components/PaginatorLink/index.js
+++ b/src/core/components/PaginatorLink/index.js
@@ -8,11 +8,16 @@ export default class PaginatorLink extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     currentPage: PropTypes.number.isRequired,
-    pathname: PropTypes.string.isRequired,
     page: PropTypes.number.isRequired,
     pageCount: PropTypes.number.isRequired,
+    pageParam: PropTypes.string,
+    pathname: PropTypes.string.isRequired,
     queryParams: PropTypes.object,
     text: PropTypes.string,
+  };
+
+  static defaultProps = {
+    pageParam: 'page',
   };
 
   render() {
@@ -21,6 +26,7 @@ export default class PaginatorLink extends React.Component {
       currentPage,
       page,
       pageCount,
+      pageParam,
       pathname,
       queryParams,
       text,
@@ -55,7 +61,7 @@ export default class PaginatorLink extends React.Component {
       <Button
         buttonType="cancel"
         className={makeClassName('Paginate-item', className)}
-        to={{ pathname, query: { ...queryParams, page } }}
+        to={{ pathname, query: { ...queryParams, [pageParam]: page } }}
       >
         {text || page}
       </Button>

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -182,6 +182,6 @@ export type CollectionAddonType = {|
 
 export type SearchResultAddonType = {|
   ...AddonType,
-  authors?: PartialAddonAuthorType,
+  authors?: Array<PartialAddonAuthorType>,
   current_version?: PartialAddonVersionType,
 |};

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -96,9 +96,9 @@ describe(__filename, () => {
         : EXTENSIONS_BY_AUTHORS_PAGE_SIZE;
 
     const addons = [];
-    const nbAddons = count || pageSize;
+    const totalAddons = typeof count === 'number' ? count : pageSize;
 
-    for (let i = 0; i < nbAddons; i++) {
+    for (let i = 0; i < totalAddons; i++) {
       addons.push({
         ...fakeAddon,
         id: i + 1,

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -464,20 +464,40 @@ describe(__filename, () => {
   });
 
   it('renders AddonsByAuthorsCard for extensions', () => {
-    const root = renderUserProfile();
+    const username = 'tofumatt';
+    const root = renderUserProfile({ params: { username } });
 
     expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp(
       'addonType',
       ADDON_TYPE_EXTENSION,
     );
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp(
+      'pageParam',
+      'page_e',
+    );
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp('paginate', true);
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp(
+      'pathname',
+      `/user/${username}/`,
+    );
   });
 
   it('renders AddonsByAuthorsCard for themes', () => {
-    const root = renderUserProfile();
+    const username = 'tofumatt';
+    const root = renderUserProfile({ params: { username } });
 
     expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp(
       'addonType',
       ADDON_TYPE_THEME,
+    );
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp(
+      'pageParam',
+      'page_t',
+    );
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp('paginate', true);
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp(
+      'pathname',
+      `/user/${username}/`,
     );
   });
 

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -307,6 +307,12 @@ describe(__filename, () => {
       expect(prevState.byAddonId).toEqual({
         [fakeAddon.id]: createInternalAddon(fakeAddon),
       });
+      expect(prevState.byUserId).toEqual({
+        [userId]: [fakeAddon.id],
+      });
+      expect(prevState.byUsername).toEqual({
+        [username]: [fakeAddon.id],
+      });
 
       const state = reducer(
         prevState,
@@ -318,7 +324,9 @@ describe(__filename, () => {
         }),
       );
 
-      expect(state.byAddonId).toEqual({});
+      expect(prevState.byAddonId).toEqual({
+        [fakeAddon.id]: createInternalAddon(fakeAddon),
+      });
       expect(state.byUserId).toEqual({
         [userId]: [],
       });

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -248,48 +248,6 @@ describe(__filename, () => {
       });
     });
 
-    it('does not remove the previously loaded add-ons for authorUsernames when forAddonSlug is specified', () => {
-      const { slug: forAddonSlug } = fakeAddon;
-      const { id: userId, username } = fakeAddon.authors[0];
-
-      const prevState = reducer(
-        undefined,
-        loadAddonsByAuthors({
-          addonType: ADDON_TYPE_EXTENSION,
-          addons: [fakeAddon],
-          authorUsernames: [username],
-          count: 1,
-          forAddonSlug,
-          pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
-        }),
-      );
-
-      expect(prevState.byAddonId).toEqual({
-        [fakeAddon.id]: createInternalAddon(fakeAddon),
-      });
-
-      const state = reducer(
-        prevState,
-        fetchAddonsByAuthors({
-          addonType: ADDON_TYPE_EXTENSION,
-          authorUsernames: [username],
-          errorHandlerId: 'error-handler-id',
-          forAddonSlug,
-          pageSize: EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
-        }),
-      );
-
-      expect(state.byAddonId).toEqual({
-        [fakeAddon.id]: createInternalAddon(fakeAddon),
-      });
-      expect(state.byUsername).toEqual({
-        [username]: [fakeAddon.id],
-      });
-      expect(state.byUserId).toEqual({
-        [userId]: [fakeAddon.id],
-      });
-    });
-
     it('removes the previously loaded add-ons for authorUsernames', () => {
       const { id: userId, username } = fakeAddon.authors[0];
 

--- a/tests/unit/core/components/TestPaginate.js
+++ b/tests/unit/core/components/TestPaginate.js
@@ -218,10 +218,11 @@ describe(__filename, () => {
 
     const firstLink = root.find(PaginatorLink).first();
     // Just do a quick sanity check on the first link.
-    expect(firstLink).toHaveProp('queryParams', queryParams);
     expect(firstLink).toHaveProp('currentPage', currentPage);
-    expect(firstLink).toHaveProp('pathname', pathname);
     expect(firstLink).toHaveProp('pageCount', pageCount);
+    expect(firstLink).toHaveProp('pageParam', 'page');
+    expect(firstLink).toHaveProp('pathname', pathname);
+    expect(firstLink).toHaveProp('queryParams', queryParams);
   });
 
   it('defaults currentPage to 1', () => {
@@ -250,5 +251,13 @@ describe(__filename, () => {
 
     const firstLink = root.find(PaginatorLink).first();
     expect(firstLink).toHaveProp('currentPage', 1);
+  });
+
+  it('passes `pageParam` to paginator links if supplied', () => {
+    const pageParam = 'my-page-filter';
+    const root = renderPaginate({ count: 50, pageParam });
+
+    const firstLink = root.find(PaginatorLink).first();
+    expect(firstLink).toHaveProp('pageParam', pageParam);
   });
 });

--- a/tests/unit/core/components/TestPaginatorLink.js
+++ b/tests/unit/core/components/TestPaginatorLink.js
@@ -53,6 +53,21 @@ describe(__filename, () => {
     expect(link.find('.my-cool-class')).toHaveLength(1);
   });
 
+  it('uses the `pageParam` to configure the `page` query parameter', () => {
+    const page = 3;
+    const pathname = '/some/link';
+
+    const link = render({
+      page,
+      pageParam: 'p',
+      pathname,
+    });
+
+    expect(link.find(Button).prop('to')).toHaveProperty('query', {
+      p: page,
+    });
+  });
+
   describe('when the link is to the current page', () => {
     it('does not contain a link and is disabled', () => {
       const item = render({ currentPage: 3, page: 3 });


### PR DESCRIPTION
Fix #4809 

~~⚠️ Depends on #5352~~

---

This PR allows to paginate extensions and/or themes of a given user, on their profile page. Pagination is per card, so that we can paginate extensions and themes independently (two different query parameters).

A good user to try this PR: https://addons-dev.allizom.org/en-US/firefox/user/l4/

~~TODO: more tests~~

## Gif

![2018-06-21 19 23 09](https://user-images.githubusercontent.com/217628/41734924-a3bd1d58-7588-11e8-83f8-4606e975498f.gif)
