### PR TITLE
Better pagination buttons on small screens

### DIFF
--- a/src/core/components/Paginate/styles.scss
+++ b/src/core/components/Paginate/styles.scss
@@ -4,12 +4,12 @@
 @import "~ui/css/vars";
 
 .Paginate {
-  display: inline-block;
   padding: $padding-page;
 
   @include respond-to(large) {
     background-color: $grey-10;
     border-radius: $border-radius-default;
+    display: inline-block;
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
In #5350, I fixed a CSS bug and thought that it would be OK on small
screens but I tested in real life today and we can do better.


Before:

![screen shot 2018-06-22 at 15 23 52](https://user-images.githubusercontent.com/217628/41778946-84090fdc-7630-11e8-8a47-2bd4f1429925.png)

After:

![screen shot 2018-06-22 at 15 23 33](https://user-images.githubusercontent.com/217628/41778945-83edf3fa-7630-11e8-933f-9147eeb9f80c.png)