### PR TITLE
Clear error handler when unmounting UserProfileEdit component

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -196,6 +196,10 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     }
   }
 
+  componentWillUnmount() {
+    this.props.errorHandler.clear();
+  }
+
   onDeleteProfile = (e: SyntheticEvent<HTMLButtonElement>) => {
     e.preventDefault();
 

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -1507,4 +1507,18 @@ describe(__filename, () => {
 
     expect(root.find(Notice)).toHaveLength(0);
   });
+
+  it('clears the error handler when unmounting', () => {
+    const { store } = signInUserWithUsername('babar');
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const errorHandler = createStubErrorHandler();
+
+    const root = renderUserProfileEdit({ errorHandler, store });
+
+    dispatchSpy.resetHistory();
+
+    root.unmount();
+
+    sinon.assert.calledWith(dispatchSpy, errorHandler.createClearingAction());
+  });
 });


### PR DESCRIPTION
Fix #5327

---

When we navigate to another page, the component is unmounted, hence it
seems like a good idea to clear the error handler in this lifecycle
method.