### PR TITLE
Fix Download Firefox button text on mobile screens

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -106,8 +106,8 @@
 
 .Header-button {
   margin-bottom: 12px;
-  white-space: nowrap;
   vertical-align: top;
+  white-space: nowrap;
 }
 
 .Header-developer-hub-link {

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -106,6 +106,7 @@
 
 .Header-button {
   margin-bottom: 12px;
+  white-space: nowrap;
   vertical-align: top;
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5371

Before

<img width="326" alt="screenshot 2018-06-22 13 57 17" src="https://user-images.githubusercontent.com/55398/41794821-47fd9b98-7626-11e8-8f74-a7e244676e26.png">


After

<img width="326" alt="screenshot 2018-06-22 14 00 50" src="https://user-images.githubusercontent.com/55398/41794827-4d9b6850-7626-11e8-90de-8f55f3651be8.png">
