### PR TITLE
Add missing Manage FireFox Account link and aside description

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -535,6 +535,14 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                     )}
                   />
                 )}
+                {isEditingCurrentUser && (
+                  <a
+                    href="https://accounts.firefox.com/settings"
+                    className="UserProfileEdit-manage-account-link"
+                  >
+                    {i18n.gettext('Manage Firefox Accounts...')}
+                  </a>
+                )}
               </div>
             </Card>
 

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -133,6 +133,11 @@ describe(__filename, () => {
     );
     expect(root.find(UserProfileEditPicture)).toHaveLength(1);
 
+    expect(root.find('.UserProfileEdit-manage-account-link')).toHaveLength(1);
+    expect(root.find('.UserProfileEdit-manage-account-link')).toHaveText(
+      'Manage Firefox Accounts...',
+    );
+
     expect(root.find('.UserProfileEdit-notifications-aside'))
       .toHaveText(oneLine`From time to time, Mozilla may send you email about
         upcoming releases and add-on events. Please select the topics you are
@@ -963,6 +968,8 @@ describe(__filename, () => {
     expect(root.find('.UserProfileEdit-profile-aside')).toHaveText(oneLine`Tell
       users a bit more information about this user. These fields are optional,
       but they'll help other users get to know willdurand better.`);
+
+    expect(root.find('.UserProfileEdit-manage-account-link')).toHaveLength(0);
 
     expect(root.find({ htmlFor: 'biography' })).toHaveText(
       'Introduce willdurand to the community',


### PR DESCRIPTION
fixes #5146 

Added manage firefox account link and aside description as detailed in the mockup by @willdurand.

![peek 2018-06-23 11-34](https://user-images.githubusercontent.com/34794189/41809012-5bf57c98-76de-11e8-972b-5a3bf2253f1e.gif)

