### PR TITLE
fixing broken text wrapping in notes

### DIFF
--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -35,6 +35,7 @@ textarea {
 *::before,
 *::after {
   box-sizing: inherit;
+  word-break: break-word;
 }
 
 body {

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -35,7 +35,7 @@ textarea {
 *::before,
 *::after {
   box-sizing: inherit;
-  word-break: break-word;
+  word-wrap: break-word;
 }
 
 body {


### PR DESCRIPTION
Fixes #5315 

Before: 
![before](https://user-images.githubusercontent.com/22130317/41817394-df57de6c-77b7-11e8-9b9a-70bb81fb6a2c.png)


After:
![after](https://user-images.githubusercontent.com/22130317/41817399-004c94a0-77b8-11e8-9bfd-cb410f85d037.png)



