### PR TITLE
Fix tooltip for email field

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -506,15 +506,16 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 value={this.state.username}
               />
 
-              <div title={i18n.gettext('Email address cannot be changed here')}>
+              <div>
                 <label className="UserProfileEdit--label" htmlFor="email">
                   {i18n.gettext('Email Address')}
                 </label>
                 <input
                   className="UserProfileEdit-email"
-                  disabled
                   defaultValue={user && user.email}
+                  disabled
                   onChange={this.onFieldChange}
+                  title={i18n.gettext('Email address cannot be changed here')}
                   type="email"
                 />
                 {isEditingCurrentUser && (

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -370,6 +370,10 @@ describe(__filename, () => {
 
     expect(root.find('.UserProfileEdit-email')).toHaveLength(1);
     expect(root.find('.UserProfileEdit-email')).toHaveProp('disabled', true);
+    expect(root.find('.UserProfileEdit-email')).toHaveProp(
+      'title',
+      'Email address cannot be changed here',
+    );
   });
 
   it('renders help sections for some fields', () => {


### PR DESCRIPTION
Fix #5391 

---

This PR moves the title to the field (instead of the parent div).