### PR TITLE
Express external/internal props more concisely

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ function getAllAddons({ categoryId }: GetAllAddonsParams = {}) {
   [`src/core/types/util`](https://github.com/mozilla/addons-frontend/blob/master/src/core/types/util.js)
   if you have to. This is meant as a working replacement for
   [$Exact<T>](https://flow.org/en/docs/types/utilities/#toc-exact).
-* Add a type hint for components wrapped in HOCs (higher order components) so that Flow can validate calls to the component. Here is an example:
+* Add a type hint for components wrapped in HOCs (higher order components) so that Flow can validate calls to the component. We need to add a hint because we don't yet have decent type coverage for all the HOCs we rely on. Here is an example:
 
 ```js
 // Imagine this is something like components/ConfirmButton/index.js

--- a/README.md
+++ b/README.md
@@ -160,6 +160,40 @@ function getAllAddons({ categoryId }: GetAllAddonsParams = {}) {
   [`src/core/types/util`](https://github.com/mozilla/addons-frontend/blob/master/src/core/types/util.js)
   if you have to. This is meant as a working replacement for
   [$Exact<T>](https://flow.org/en/docs/types/utilities/#toc-exact).
+* Add a type hint for components wrapped in HOCs (higher order components) so that Flow can validate calls to the component. Here is an example:
+
+```js
+// Imagine this is something like components/ConfirmButton/index.js
+import { compose } from 'redux';
+import * as React from 'react';
+
+// This expresses externally used props, i.e. to validate how the app would use <ConfirmButton />
+type Props = {|
+  prompt?: string | null,
+|};
+
+// This expresses internally used props, such as i18n which is injected by translate()
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
+|};
+
+export class ConfirmButtonBase extends React.Component<InternalProps> {
+  render() {
+    const prompt = this.props.prompt || this.props.i18n.gettext('Confirm');
+    return <button>{prompt}</button>;
+  }
+}
+
+// This provides a type hint for the final component with its external props.
+// The i18n prop is not in external props because it is injected by translate() for internal use only.
+const ConfirmButton: React.ComponentType<Props> = compose(translate())(
+  ConfirmButtonBase,
+);
+
+export default ConfirmButton;
+```
+
 * Try to avoid loose types like `Object` or `any` but feel free to use
   them if you are spending too much time declaring types that depend on other
   types that depend on other types, and so on.

--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -46,21 +46,20 @@ type DispatchMappedProps = {|
 |};
 
 type Props = {|
-  createLocalState?: typeof defaultLocalStateCreator,
-  debounce?: typeof defaultDebounce,
   onEscapeOverlay?: () => void,
   onReviewSubmitted: () => void | Promise<void>,
   review: UserReviewType,
   ...DispatchMappedProps,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   apiState: ApiStateType,
+  createLocalState: typeof defaultLocalStateCreator,
+  debounce: typeof defaultDebounce,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 type State = {|
   reviewBody: ?string,
@@ -80,7 +79,6 @@ export class AddonReviewBase extends React.Component<InternalProps, State> {
     this.state = {
       reviewBody: props.review.body,
     };
-    invariant(props.createLocalState, 'createLocalState() is undefined');
     this.localState = props.createLocalState(`AddonReview:${props.review.id}`);
     this.checkForStoredState();
   }
@@ -163,7 +161,6 @@ export class AddonReviewBase extends React.Component<InternalProps, State> {
   };
 
   onBodyInput = (event: ElementEvent<HTMLInputElement>) => {
-    invariant(this.props.debounce, 'debounce() is undefined');
     const saveState = this.props.debounce((state) => {
       // After a few keystrokes, save the text to a local store
       // so we can recover from crashes.

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -41,7 +41,8 @@ type Props = {|
   review?: UserReviewType | null,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   dispatch: DispatchFunc,
   editingReview: boolean,
   errorHandler: ErrorHandlerType,
@@ -51,8 +52,6 @@ type InjectedProps = {|
   siteUserHasReplyPerm: boolean,
   submittingReply: boolean,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class AddonReviewListItemBase extends React.Component<InternalProps> {
   onClickToEditReview = (event: SyntheticEvent<any>) => {

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -43,15 +43,14 @@ type Props = {|
   type?: 'horizontal' | 'vertical',
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   addons?: Array<AddonType>,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   loading?: boolean,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
   static defaultProps = {

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -48,7 +48,6 @@ export type SuggestionType = {|
 export type SearchFilters = Object;
 
 type Props = {|
-  debounce?: typeof defaultDebounce,
   inputLabelText?: string,
   // This is the name property of the <input> tag.
   inputName: string,
@@ -68,14 +67,14 @@ type MappedProps = {|
   userAgentInfo: UserAgentInfoType,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   ...MappedProps,
+  debounce: typeof defaultDebounce,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 type State = {|
   autocompleteIsOpen: boolean,
@@ -104,6 +103,7 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
   searchInput: React.ElementRef<'input'> | null;
 
   static defaultProps = {
+    debounce: defaultDebounce,
     showInputLabel: true,
   };
 
@@ -120,8 +120,7 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
       'The selectSuggestionText property is required',
     );
 
-    const debounce = props.debounce || defaultDebounce;
-    this.dispatchAutocompleteStart = debounce(
+    this.dispatchAutocompleteStart = this.props.debounce(
       ({ filters }) => {
         const { dispatch, errorHandler } = this.props;
 

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -40,12 +40,13 @@ type CategoriesStateType = {|
   loading: boolean,
 |};
 
-type Props = {
+type Props = {|
   addonType: string,
   className?: string,
-};
+|};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   categoriesState: $PropertyType<CategoriesStateType, 'categories'>,
   clientApp: string,
   dispatch: DispatchFunc,
@@ -53,8 +54,6 @@ type InjectedProps = {|
   i18n: I18nType,
   loading: boolean,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class CategoriesBase extends React.Component<InternalProps> {
   componentWillMount() {

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -55,13 +55,13 @@ export type AddonAddedStatusType =
 
 type Props = {|
   collection: CollectionType | null,
-  clearTimeout?: Function,
   creating: boolean,
   page: number | null,
-  setTimeout?: Function,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
+  clearTimeout: Function,
   clientApp: ?string,
   currentUsername: string,
   dispatch: DispatchFunc,
@@ -70,10 +70,9 @@ type InjectedProps = {|
   i18n: I18nType,
   isCollectionBeingModified: boolean,
   router: ReactRouterType,
+  setTimeout: Function,
   siteLang: ?string,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 type State = {|
   addonAddedStatus: AddonAddedStatusType | null,
@@ -120,7 +119,6 @@ export class CollectionManagerBase extends React.Component<
     }
 
     if (hasAddonBeenAddedNew && hasAddonBeenAddedNew !== hasAddonBeenAdded) {
-      invariant(this.props.setTimeout, 'setTimeout() is undefined');
       this.timeout = this.props.setTimeout(
         this.resetMessageStatus,
         MESSAGE_RESET_TIME,
@@ -130,7 +128,6 @@ export class CollectionManagerBase extends React.Component<
 
   componentWillUnmount() {
     if (this.timeout) {
-      invariant(this.props.clearTimeout, 'clearTimeout() is undefined');
       this.props.clearTimeout(this.timeout);
     }
   }

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -31,12 +31,11 @@ type Props = {|
   saveNote: SaveAddonNoteFunc,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 type State = {|
   editingNote: boolean,

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -19,11 +19,10 @@ type Props = {|
   errorCode?: string,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class NotFoundBase extends React.Component<InternalProps> {
   render() {

--- a/src/amo/components/FlagReview/index.js
+++ b/src/amo/components/FlagReview/index.js
@@ -19,13 +19,12 @@ type Props = {|
   wasFlaggedText: string,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   flagState: FlagState,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class FlagReviewBase extends React.Component<InternalProps> {
   onClick = (event: SyntheticEvent<any>) => {

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -27,13 +27,12 @@ type Props = {|
   review: UserReviewType,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
   siteUser: UserType | null,
   wasFlagged: boolean,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class FlagReviewMenuBase extends React.Component<InternalProps> {
   static defaultProps = {

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 /* global Node */
 /* eslint-disable react/sort-comp, react/no-unused-prop-types */
-import invariant from 'invariant';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -51,10 +50,6 @@ type LoadSavedReviewFunc = ({|
 type SubmitReviewFunc = (SubmitReviewParams) => Promise<void>;
 
 type Props = {|
-  AddonReview?: typeof DefaultAddonReview,
-  AuthenticateButton?: typeof DefaultAuthenticateButton,
-  UserRating?: typeof DefaultUserRating,
-  ReportAbuseButton?: typeof DefaultReportAbuseButton,
   addon: AddonType,
   location: ReactRouterLocation,
   onReviewSubmitted?: () => void,
@@ -66,16 +61,19 @@ type DispatchMappedProps = {|
   submitReview: SubmitReviewFunc,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   ...DispatchMappedProps,
+  AddonReview: typeof DefaultAddonReview,
+  AuthenticateButton: typeof DefaultAuthenticateButton,
+  UserRating: typeof DefaultUserRating,
+  ReportAbuseButton: typeof DefaultReportAbuseButton,
   apiState: ApiStateType,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   userId: number,
   userReview: UserReviewType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 type State = {|
   showTextEntry: boolean,
@@ -177,7 +175,6 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
 
   renderLogInToRate() {
     const { AuthenticateButton, addon, location } = this.props;
-    invariant(AuthenticateButton, 'AuthenticateButton() is undefined');
     return (
       <div className="RatingManager-log-in-to-rate">
         <AuthenticateButton
@@ -214,10 +211,6 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
       i18n.gettext('How are you enjoying your experience with %(addonName)s?'),
       { addonName: addon.name },
     );
-
-    invariant(AddonReview, 'AddonReview() is undefined');
-    invariant(UserRating, 'UserRating() is undefined');
-    invariant(ReportAbuseButton, 'ReportAbuseButton() is undefined');
 
     return (
       <div className="RatingManager">

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -30,15 +30,14 @@ type Props = {|
   addon: AddonType,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   abuseReport: AddonAbuseState,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   loading: boolean,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class ReportAbuseButtonBase extends React.Component<InternalProps> {
   textarea: React.ElementRef<typeof Textarea>;

--- a/src/amo/components/ReportUserAbuse/index.js
+++ b/src/amo/components/ReportUserAbuse/index.js
@@ -28,7 +28,8 @@ type Props = {|
   user?: UserType | null,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   hasSubmitted: boolean,
@@ -36,8 +37,6 @@ type InjectedProps = {|
   isSubmitting: boolean,
   uiVisible: boolean,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class ReportUserAbuseBase extends React.Component<InternalProps> {
   hideReportUI = () => {

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -28,11 +28,10 @@ type Props = {|
   showSummary?: boolean,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class SearchResultBase extends React.Component<InternalProps> {
   static defaultProps = {

--- a/src/amo/components/UserProfileEditNotifications/index.js
+++ b/src/amo/components/UserProfileEditNotifications/index.js
@@ -92,7 +92,8 @@ type Props = {|
   user: UserType | null,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
 
@@ -100,10 +101,7 @@ export const UserProfileEditNotificationsBase = ({
   i18n,
   onChange,
   user,
-}: {
-  ...Props,
-  ...InjectedProps,
-}) => {
+}: InternalProps) => {
   let notifications = [];
   if (!user || !user.notifications) {
     for (let i = 0; i < 2; i++) {

--- a/src/amo/components/UserProfileEditPicture/index.js
+++ b/src/amo/components/UserProfileEditPicture/index.js
@@ -19,7 +19,8 @@ type Props = {|
   user: UserType | null,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
 
@@ -30,10 +31,7 @@ export const UserProfileEditPictureBase = ({
   onSelect,
   preview,
   user,
-}: {
-  ...Props,
-  ...InjectedProps,
-}) => {
+}: InternalProps) => {
   const altText = user
     ? i18n.sprintf(i18n.gettext('Profile picture for %(name)s'), {
         name: user.name,

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -31,17 +31,16 @@ type Props = {|
   location: ReactRouterLocation,
   logInText?: string,
   logOutText?: string,
-  noIcon: boolean,
+  noIcon?: boolean,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   api: ApiStateType,
   handleLogIn: HandleLogInFunc,
   i18n: I18nType,
   siteUser: UserType | null,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class AuthenticateButtonBase extends React.Component<InternalProps> {
   static defaultProps = {

--- a/src/core/components/ErrorPage/index.js
+++ b/src/core/components/ErrorPage/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import invariant from 'invariant';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -11,15 +12,14 @@ import type { DispatchFunc } from 'core/types/redux';
 
 type Props = {|
   children: React.Node,
-  getErrorComponent: typeof getErrorComponentDefault,
+  getErrorComponent?: typeof getErrorComponentDefault,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   dispatch: DispatchFunc,
   errorPage: ErrorPageState,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class ErrorPageBase extends React.Component<InternalProps> {
   static defaultProps = {
@@ -36,6 +36,7 @@ export class ErrorPageBase extends React.Component<InternalProps> {
 
   render() {
     const { children, errorPage, getErrorComponent } = this.props;
+    invariant(getErrorComponent, 'getErrorComponent() is undefined');
 
     if (errorPage.hasError) {
       const ErrorComponent = getErrorComponent(errorPage.statusCode);

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -21,15 +21,14 @@ type Props = {|
   onConfirm: Function,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
 
 type State = {|
   showConfirmation: boolean,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class ConfirmButtonBase extends React.Component<InternalProps, State> {
   static defaultProps = {

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -36,11 +36,10 @@ type Props = {|
   text?: null | string,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 /*
  * This renders a form with an auto-resizing textarea,

--- a/src/ui/components/Hero/index.js
+++ b/src/ui/components/Hero/index.js
@@ -17,12 +17,11 @@ type Props = {|
   sections: Array<React.Element<typeof HeroSection>>,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   dispatch: DispatchFunc,
   heroBanners: Object,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class HeroBase extends React.Component<InternalProps> {
   componentWillMount() {

--- a/src/ui/components/HostPermissions/index.js
+++ b/src/ui/components/HostPermissions/index.js
@@ -12,7 +12,8 @@ type Props = {|
   permissions: Array<string>,
 |};
 
-type InjectedProps = {|
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
 
@@ -34,8 +35,6 @@ type GenerateHostPermissionsParams = {|
   // eslint-disable-next-line react/no-unused-prop-types
   messageType: HostPermissionMessageType,
 |};
-
-type InternalProps = { ...Props, ...InjectedProps };
 
 export class HostPermissionsBase extends React.Component<InternalProps> {
   getPermissionString({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5398

* When coming back after the weekend and looking at this code I realized that `InjectedProps` is unecessary. We can just use `Props` and `InternalProps`. I updated all the code so that no one copies/pastes the wrong thing for future code.
* After understanding https://github.com/facebook/flow/issues/6502 a bit more, I moved some default prop types to `InternalProps`. This is only possible for props that are solely used for testing since we don't have Flow coverage for tests. I think it's nicer this way, though, because we won't have to add a bunch of invariant checks for the default props.