### PR TITLE
fixing title of textbox in edit collection

### DIFF
--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -130,7 +130,7 @@ export class EditableCollectionAddonBase extends React.Component<
           <div className="EditableCollectionAddon-notes">
             <h4 className="EditableCollectionAddon-notes-header">
               <Icon name="comments-blue" />
-              {i18n.gettext('User comment')}
+              {i18n.gettext('Add-on note')}
             </h4>
 
             {this.state.editingNote ? (


### PR DESCRIPTION
Fixes #5395 

Before: 
![before](https://user-images.githubusercontent.com/22130317/41861880-092e9718-78c0-11e8-9ec0-cd265c66b562.png)

After: 
![after](https://user-images.githubusercontent.com/22130317/41861885-0cfa37c6-78c0-11e8-838a-0d18d693911c.png)


