### PR TITLE
Add privacy link to Get Firefox, update download link

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -495,7 +495,7 @@ export class AddonBase extends React.Component {
       ? addonsByAuthors.length
       : 0;
 
-    const downloadUrl = `https://www.mozilla.org/firefox/new/${makeQueryStringWithUTM(
+    const downloadUrl = `https://www.mozilla.org/firefox/download/thanks/${makeQueryStringWithUTM(
       {
         utm_content: 'install-addon-button',
       },
@@ -561,14 +561,22 @@ export class AddonBase extends React.Component {
                   )}
                 {addon &&
                   !isFireFox && (
-                    <Button
-                      buttonType="confirm"
-                      href={downloadUrl}
-                      puffy
-                      className="Button--get-firefox"
-                    >
-                      {i18n.gettext('Only with Firefox—Get Firefox Now')}
-                    </Button>
+                    <div className="Addon-get-firefox">
+                      <Button
+                        buttonType="confirm"
+                        href={downloadUrl}
+                        puffy
+                        className="Addon-get-firefox-button"
+                      >
+                        {i18n.gettext('Only with Firefox—Get Firefox Now')}
+                      </Button>
+                      <a
+                        className="Addon-get-firefox-privacy-link"
+                        href="https://www.mozilla.org/privacy/firefox/"
+                      >
+                        {i18n.gettext('Firefox Privacy Notice')}
+                      </a>
+                    </div>
                   )}
               </div>
 

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -255,22 +255,24 @@
   flex-direction: column;
   width: max-content;
 
-  .Addon-get-firefox-privacy-link,
-  .Addon-get-firefox-privacy-link:active,
-  .Addon-get-firefox-privacy-link:focus,
-  .Addon-get-firefox-privacy-link:link,
-  .Addon-get-firefox-privacy-link:visited,
-  .Addon-get-firefox-privacy-link:hover {
-    @include font-bold();
+  .Addon-get-firefox-privacy-link {
+    &,
+    &:active,
+    &:focus,
+    &:link,
+    &:visited,
+    &:hover {
+      @include font-bold();
 
-    color: $ink-90;
-    font-size: $font-size-caption10;
-    text-decoration: none;
-  }
+      color: $ink-90;
+      font-size: $font-size-caption10;
+      text-decoration: none;
+    }
 
-  .Addon-get-firefox-privacy-link:active,
-  .Addon-get-firefox-privacy-link:focus,
-  .Addon-get-firefox-privacy-link:hover {
-    text-decoration: underline;
+    &:active,
+    &:focus,
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -16,9 +16,15 @@
     }
 
     .InstallButton,
-    .Addon-get-firefox-button {
+    .Addon-get-firefox {
       @include respond-to(medium) {
         align-self: flex-end;
+      }
+    }
+
+    .InstallButton,
+    .Addon-get-firefox-button {
+      @include respond-to(medium) {
         margin-bottom: 12px;
       }
     }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -254,10 +254,14 @@
   .Addon-get-firefox-privacy-link:link,
   .Addon-get-firefox-privacy-link:visited,
   .Addon-get-firefox-privacy-link:hover {
-    @include font-medium();
+    @include font-bold();
 
     color: $ink-90;
-    font-size: $font-size-s;
+    font-size: $font-size-caption10;
     text-decoration: none;
+  }
+
+  .Addon-get-firefox-privacy-link:hover {
+    text-decoration: underline;
   }
 }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -253,7 +253,6 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  width: max-content;
 
   .Addon-get-firefox-privacy-link {
     &,

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -251,6 +251,7 @@
 
   .Addon-get-firefox-privacy-link,
   .Addon-get-firefox-privacy-link:active,
+  .Addon-get-firefox-privacy-link:focus,
   .Addon-get-firefox-privacy-link:link,
   .Addon-get-firefox-privacy-link:visited,
   .Addon-get-firefox-privacy-link:hover {
@@ -261,6 +262,8 @@
     text-decoration: none;
   }
 
+  .Addon-get-firefox-privacy-link:active,
+  .Addon-get-firefox-privacy-link:focus,
   .Addon-get-firefox-privacy-link:hover {
     text-decoration: underline;
   }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -1,6 +1,7 @@
 @import "~core/css/inc/mixins";
 @import "~amo/css/inc/vars";
 @import "~ui/css/vars";
+@import "~photon-colors/photon-colors";
 
 .Addon {
   padding: $padding-page;
@@ -11,7 +12,7 @@
 
   .Addon-summary-and-install-button-wrapper {
     .InstallButton,
-    .Button--get-firefox {
+    .Addon-get-firefox-button {
       @include respond-to(medium) {
         align-self: flex-end;
         margin-bottom: 12px;
@@ -191,7 +192,7 @@
 }
 
 .Addon .InstallButton-button,
-.Button--get-firefox {
+.Addon-get-firefox-button {
   width: 100%;
 
   @include respond-to(medium) {
@@ -236,4 +237,23 @@
   // .Addon-overall-rating .Card-footer-link {
   //   display: none;
   // }
+}
+
+.Addon-get-firefox {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  width: max-content;
+
+  .Addon-get-firefox-privacy-link,
+  .Addon-get-firefox-privacy-link:active,
+  .Addon-get-firefox-privacy-link:link,
+  .Addon-get-firefox-privacy-link:visited,
+  .Addon-get-firefox-privacy-link:hover {
+    @include font-medium();
+
+    color: $ink-90;
+    font-size: $font-size-s;
+    text-decoration: none;
+  }
 }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -11,6 +11,10 @@
   }
 
   .Addon-summary-and-install-button-wrapper {
+    .Addon-get-firefox-button {
+      margin-bottom: 6px;
+    }
+
     .InstallButton,
     .Addon-get-firefox-button {
       @include respond-to(medium) {

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -19,6 +19,8 @@ $default-font-family: "Clear Sans", Helvetica, Arial, sans-serif;
 
 // Font-Size Variables
 $font-size-default: 14px;
+// https://design.firefox.com/photon/visuals/typography.html#scale
+$font-size-caption10: 11px;
 $font-size-s: 12px;
 $font-size-m: 16px;
 $font-size-l: 28px;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5245

<img width="281" alt="screenshot 2018-06-25 16 36 29" src="https://user-images.githubusercontent.com/55398/41877202-077eaa5e-7896-11e8-9cd3-44fef4c353f1.png">

<img width="623" alt="screenshot 2018-06-25 16 19 11" src="https://user-images.githubusercontent.com/55398/41876711-52ff2334-7894-11e8-9a89-49558d332ef7.png">
<img width="813" alt="screenshot 2018-06-25 16 19 52" src="https://user-images.githubusercontent.com/55398/41876713-548b7392-7894-11e8-9a95-7cddc9e4977e.png">
<img width="990" alt="screenshot 2018-06-25 16 20 25" src="https://user-images.githubusercontent.com/55398/41876716-56eadab0-7894-11e8-96ec-d3459dea8fcc.png">
