### PR TITLE
Introduce a useFiltersFromLocation property to AutoSearchInput to support changes to CollectionManager

### DIFF
--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -59,6 +59,7 @@ type Props = {|
   // This is accessibility text for what selecting a suggestion will do.
   selectSuggestionText: string,
   showInputLabel?: boolean,
+  useFiltersFromLocation: boolean,
 |};
 
 type MappedProps = {|
@@ -193,7 +194,9 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
       return;
     }
 
-    const filters = this.createFiltersFromQuery(value);
+    const filters = this.props.useFiltersFromLocation
+      ? this.createFiltersFromQuery(value)
+      : {};
 
     this.setState({ autocompleteIsOpen: true });
 

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -61,6 +61,7 @@ export class SearchFormBase extends React.Component<Props> {
           query={query}
           selectSuggestionText={i18n.gettext('Go to the add-on page')}
           showInputLabel={false}
+          useFiltersFromLocation
         />
       </form>
     );

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -45,6 +45,7 @@ describe(__filename, () => {
       onSuggestionSelected: sinon.stub(),
       selectSuggestionText: 'Go to the extension detail page',
       store,
+      useFiltersFromLocation: true,
       ...customProps,
     };
   };
@@ -277,8 +278,9 @@ describe(__filename, () => {
       const dispatch = sinon.spy(store, 'dispatch');
       const locationQuery = { type: ADDON_TYPE_EXTENSION };
       const root = render({
-        store,
         location: fakeRouterLocation({ query: locationQuery }),
+        store,
+        useFiltersFromLocation: true,
       });
 
       const query = 'ad blocker';
@@ -293,6 +295,28 @@ describe(__filename, () => {
             operatingSystem: OS_WINDOWS,
             query,
           },
+        }),
+      );
+    });
+
+    it('ignores filters from the location', () => {
+      const { store } = dispatchClientMetadata();
+      const dispatch = sinon.spy(store, 'dispatch');
+      const locationQuery = { type: ADDON_TYPE_EXTENSION };
+      const root = render({
+        location: fakeRouterLocation({ query: locationQuery }),
+        store,
+        useFiltersFromLocation: false,
+      });
+
+      const query = 'ad blocker';
+      fetchSuggestions({ root, query });
+
+      sinon.assert.calledWith(
+        dispatch,
+        autocompleteStart({
+          errorHandlerId: root.instance().props.errorHandler.id,
+          filters: {},
         }),
       );
     });


### PR DESCRIPTION
Supports #3991 

I need to be able to prevent the AutoSearchInput component from automatically creating filters based on the location query parameters for my changes to the CollectionManager to support sorting add-ons in a collection, and this seemed like a simple way of doing that.
