### PR TITLE
Allow AutoSearchInput to be called without a location property

### DIFF
--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -7,7 +7,6 @@ import defaultDebounce from 'lodash.debounce';
 import * as React from 'react';
 import Autosuggest from 'react-autosuggest';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 import { compose } from 'redux';
 
 import SearchSuggestion from 'amo/components/SearchSuggestion';
@@ -52,7 +51,7 @@ type Props = {|
   // This is the name property of the <input> tag.
   inputName: string,
   inputPlaceholder?: string,
-  location: ReactRouterLocation,
+  location?: ReactRouterLocation,
   onSearch: (SearchFilters) => void,
   onSuggestionSelected: (SuggestionType) => void,
   query?: string,
@@ -152,9 +151,12 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
   createFiltersFromQuery(query: string) {
     const { location, userAgentInfo } = this.props;
     // Preserve any existing search filters.
-    const filtersFromLocation = convertQueryParamsToFilters(location.query);
-    // Do not preserve page. New searches should always start on page 1.
-    delete filtersFromLocation.page;
+    let filtersFromLocation = {};
+    if (location) {
+      filtersFromLocation = convertQueryParamsToFilters(location.query);
+      // Do not preserve page. New searches should always start on page 1.
+      delete filtersFromLocation.page;
+    }
 
     return {
       operatingSystem: convertOSToFilterValue(userAgentInfo.os.name),
@@ -375,7 +377,6 @@ const mapStateToProps = (state: {|
 export const extractId = (ownProps: Props): string => ownProps.inputName;
 
 const AutoSearchInput: React.ComponentType<Props> = compose(
-  withRouter,
   withFixedErrorHandler({ fileName: __filename, extractId }),
   connect(mapStateToProps),
   translate(),

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -297,6 +297,28 @@ describe(__filename, () => {
       );
     });
 
+    it('can be used without a location', () => {
+      const { store } = dispatchClientMetadata();
+      const dispatch = sinon.spy(store, 'dispatch');
+      const root = render({
+        store,
+      });
+
+      const query = 'ad blocker';
+      fetchSuggestions({ root, query });
+
+      sinon.assert.calledWith(
+        dispatch,
+        autocompleteStart({
+          errorHandlerId: root.instance().props.errorHandler.id,
+          filters: {
+            operatingSystem: OS_WINDOWS,
+            query,
+          },
+        }),
+      );
+    });
+
     it('lets you override the default operating system', () => {
       const { store } = dispatchClientMetadata();
       const dispatch = sinon.spy(store, 'dispatch');

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -23,6 +23,7 @@ import {
 } from 'tests/unit/amo/helpers';
 import {
   createFakeEvent,
+  createStubErrorHandler,
   fakeI18n,
   fakeRouterLocation,
   shallowUntilTarget,
@@ -300,7 +301,9 @@ describe(__filename, () => {
     it('can be used without a location', () => {
       const { store } = dispatchClientMetadata();
       const dispatch = sinon.spy(store, 'dispatch');
+      const errorHandler = createStubErrorHandler();
       const root = render({
+        errorHandler,
         store,
       });
 
@@ -310,7 +313,7 @@ describe(__filename, () => {
       sinon.assert.calledWith(
         dispatch,
         autocompleteStart({
-          errorHandlerId: root.instance().props.errorHandler.id,
+          errorHandlerId: errorHandler.id,
           filters: {
             operatingSystem: OS_WINDOWS,
             query,


### PR DESCRIPTION
Supports #3991

I need to be able to prevent the AutoSearchInput component from automatically creating filters based on the location query parameters for my changes to the CollectionManager to support sorting add-ons in a collection, and this seems like a simple way of doing that.