### PR TITLE
Use user data when the API does not return the updated data right away after a user profile update

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -328,6 +328,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       notifications,
       occupation,
       picture,
+      pictureData,
       username,
     } = this.state;
 
@@ -338,6 +339,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
         errorHandlerId: errorHandler.id,
         notifications,
         picture,
+        pictureData,
         userFields: {
           biography,
           display_name: displayName,

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -150,6 +150,7 @@ type UpdateUserAccountParams = {|
   errorHandlerId: string,
   notifications: NotificationsUpdateType,
   picture: File | null,
+  pictureData: string | null,
   userFields: UserEditableFieldsType,
   userId: UserId,
 |};
@@ -163,18 +164,31 @@ export const updateUserAccount = ({
   errorHandlerId,
   notifications,
   picture,
+  pictureData,
   userFields,
   userId,
 }: UpdateUserAccountParams): UpdateUserAccountAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(notifications, 'notifications are required');
-  invariant(picture !== undefined, 'picture is required');
   invariant(userFields, 'userFields are required');
   invariant(userId, 'userId is required');
 
+  invariant(picture !== undefined, 'picture is required');
+
+  if (picture) {
+    invariant(pictureData, 'pictureData is required when picture is present');
+  }
+
   return {
     type: UPDATE_USER_ACCOUNT,
-    payload: { errorHandlerId, notifications, picture, userFields, userId },
+    payload: {
+      errorHandlerId,
+      notifications,
+      picture,
+      pictureData,
+      userFields,
+      userId,
+    },
   };
 };
 

--- a/src/amo/sagas/users.js
+++ b/src/amo/sagas/users.js
@@ -85,6 +85,9 @@ export function* updateUserAccount({
         );
         if (index !== -1) {
           allNotifications[index].enabled = notifications.announcements;
+          log.debug(
+            'Optimistically set user value for "announcements" notification',
+          );
         }
       }
 

--- a/src/amo/sagas/users.js
+++ b/src/amo/sagas/users.js
@@ -35,7 +35,14 @@ export function* fetchCurrentUserAccount({ payload }) {
 }
 
 export function* updateUserAccount({
-  payload: { errorHandlerId, notifications, picture, userFields, userId },
+  payload: {
+    errorHandlerId,
+    notifications,
+    picture,
+    pictureData,
+    userFields,
+    userId,
+  },
 }) {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -50,6 +57,14 @@ export function* updateUserAccount({
       userId,
       ...userFields,
     });
+
+    if (picture) {
+      // The post-upload task (resize, etc.) is asynchronous so we set the
+      // uploaded file before loading the user account in order to display the
+      // latest picture.
+      // See: https://github.com/mozilla/addons-frontend/issues/5252
+      user.picture_url = pictureData;
+    }
 
     yield put(loadUserAccount({ user }));
 

--- a/src/amo/sagas/users.js
+++ b/src/amo/sagas/users.js
@@ -75,6 +75,19 @@ export function* updateUserAccount({
         userId,
       });
 
+      if (typeof notifications.announcements !== 'undefined') {
+        // The Salesforce integration is asynchronous and takes a lot of time
+        // so we set the notification to whatever the user has chosen,
+        // otherwise we would display the wrong notification value.
+        // See: https://github.com/mozilla/addons-frontend/issues/5219
+        const index = allNotifications.findIndex(
+          (notification) => notification.name === 'announcements',
+        );
+        if (index !== -1) {
+          allNotifications[index].enabled = notifications.announcements;
+        }
+      }
+
       yield put(
         loadUserNotifications({
           notifications: allNotifications,

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -569,6 +569,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         notifications: {},
         picture: null,
+        pictureData: null,
         userFields: {
           biography: user.biography,
           display_name: user.display_name,
@@ -690,6 +691,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         notifications: {},
         picture: null,
+        pictureData: null,
         userFields: {
           biography: user.biography,
           display_name: user.display_name,
@@ -736,6 +738,7 @@ describe(__filename, () => {
           reply: false,
         },
         picture: null,
+        pictureData: null,
         userFields: {
           biography: user.biography,
           display_name: user.display_name,

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -307,6 +307,87 @@ describe(__filename, () => {
       const calledAction = await sagaTester.waitFor(errorAction.type);
       expect(calledAction).toEqual(errorAction);
     });
+
+    // See: https://github.com/mozilla/addons-frontend/issues/5219
+    it('overrides the "announcements" notification if updated', async () => {
+      const ANNOUNCEMENTS_NOTIFICATION = 'announcements';
+
+      const state = sagaTester.getState();
+
+      const username = 'babar';
+      const user = createUserAccountResponse({ id: 5001, username });
+
+      // Set the "announcements" notification to false by default.
+      const currentNotifications = createUserNotificationsResponse().map(
+        (notification) => {
+          if (notification.name !== ANNOUNCEMENTS_NOTIFICATION) {
+            return notification;
+          }
+
+          return {
+            ...notification,
+            enabled: false,
+          };
+        },
+      );
+
+      const updatedNotifications = {
+        [ANNOUNCEMENTS_NOTIFICATION]: false,
+      };
+
+      mockApi
+        .expects('updateUserAccount')
+        .withArgs({
+          api: state.api,
+          picture: null,
+          userId: user.id,
+        })
+        .once()
+        .returns(Promise.resolve(user));
+
+      mockApi
+        .expects('updateUserNotifications')
+        .withArgs({
+          api: state.api,
+          notifications: updatedNotifications,
+          userId: user.id,
+        })
+        .once()
+        // The API returns the currentNotifications because the Basket
+        // synchronization takes time.
+        .returns(Promise.resolve(currentNotifications));
+
+      sagaTester.dispatch(
+        updateUserAccount({
+          errorHandlerId: errorHandler.id,
+          notifications: updatedNotifications,
+          picture: null,
+          userFields: {},
+          userId: user.id,
+        }),
+      );
+
+      const newNotifications = currentNotifications.map((notification) => {
+        if (notification.name !== ANNOUNCEMENTS_NOTIFICATION) {
+          return notification;
+        }
+
+        return {
+          ...notification,
+          enabled: updatedNotifications[ANNOUNCEMENTS_NOTIFICATION],
+        };
+      });
+
+      const expectedCalledAction = loadUserNotifications({
+        notifications: newNotifications,
+        username,
+      });
+
+      const calledAction = await sagaTester.waitFor(expectedCalledAction.type);
+
+      expect(calledAction).toEqual(expectedCalledAction);
+      mockApi.verify();
+    });
   });
 
   describe('deleteUserPicture', () => {

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -171,11 +171,13 @@ describe(__filename, () => {
       expect(calledFinishAction.payload).toEqual({});
     });
 
-    it('can receive a picture file in payload', async () => {
+    it('can receive a picture file and picture data in payload', async () => {
       const state = sagaTester.getState();
       const user = createUserAccountResponse({ id: 5001 });
 
       const picture = new File([], 'some-image.png');
+      const pictureData = 'image';
+
       const userFields = {
         biography: 'I fell into a burning ring of fire.',
         location: 'Folsom Prison',
@@ -197,13 +199,18 @@ describe(__filename, () => {
           errorHandlerId: errorHandler.id,
           notifications: {},
           picture,
+          pictureData,
           userFields,
           userId: user.id,
         }),
       );
 
       const expectedCalledAction = loadUserAccount({
-        user: { ...user, ...userFields },
+        user: {
+          ...user,
+          ...userFields,
+          picture_url: pictureData,
+        },
       });
 
       const calledAction = await sagaTester.waitFor(expectedCalledAction.type);


### PR DESCRIPTION
Fix #5252
Fix #5219

---

The idea is: because we have the uploaded file and we are able to display this picture in the edit page, why not using it after having successfully submitted the form?

Same for the Basket integration issue: we now what the user has chosen, so let's use it. Because it is only overridden in the `edit` saga, I believe it is quite safe.

---

TODO:

- [x] add tests for the notification