### PR TITLE
Pass errorHandler from UserProfile to AddonsByAuthorsCards

### DIFF
--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -28,6 +28,7 @@ import {
 } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
+import log from 'core/logger';
 import type {
   AddonsByAuthorsState,
   FetchAddonsByAuthorsParams,
@@ -45,6 +46,7 @@ type Props = {|
   authorDisplayName: string,
   authorUsernames: Array<string>,
   className?: string,
+  errorHandler?: ErrorHandlerType,
   forAddonSlug?: string,
   numberOfAddons: number,
   pageParam: string,
@@ -62,7 +64,6 @@ type InternalProps = {|
   addons?: Array<AddonType>,
   count: number | null,
   dispatch: DispatchFunc,
-  errorHandler: ErrorHandlerType,
   i18n: I18nType,
   loading?: boolean,
   location: ReactRouterLocation,
@@ -176,6 +177,8 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       filtersForPagination.sort = SEARCH_SORT_POPULAR;
     }
 
+    invariant(errorHandler, 'errorHandler is required');
+
     this.props.dispatch(
       fetchAddonsByAuthors({
         addonType,
@@ -196,6 +199,7 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       authorDisplayName,
       authorUsernames,
       className,
+      errorHandler,
       i18n,
       loading,
       numberOfAddons,
@@ -204,6 +208,13 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       showSummary,
       type,
     } = this.props;
+
+    invariant(errorHandler, 'errorHandler is required');
+
+    if (errorHandler.hasError()) {
+      log.warn('Captured API Error:', errorHandler.capturedError);
+      return null;
+    }
 
     if (!loading && (!addons || !addons.length)) {
       return null;

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -28,7 +28,6 @@ import {
 } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
-import log from 'core/logger';
 import type {
   AddonsByAuthorsState,
   FetchAddonsByAuthorsParams,
@@ -212,8 +211,7 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
     invariant(errorHandler, 'errorHandler is required');
 
     if (errorHandler.hasError()) {
-      log.warn('Captured API Error:', errorHandler.capturedError);
-      return null;
+      return errorHandler.renderError();
     }
 
     if (!loading && (!addons || !addons.length)) {

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -146,11 +146,9 @@ export class UserProfileBase extends React.Component<InternalProps> {
   }
 
   getURL() {
-    const { user } = this.props;
+    const { params } = this.props;
 
-    invariant(user, 'user is required');
-
-    return `/user/${user.username}/`;
+    return `/user/${params.username}/`;
   }
 
   getEditURL() {
@@ -385,13 +383,14 @@ export class UserProfileBase extends React.Component<InternalProps> {
             ) : null}
           </Card>
 
-          {user &&
-            user.username && (
+          {params &&
+            params.username && (
               <div className="UserProfile-addons-and-reviews">
                 <AddonsByAuthorsCard
                   addonType={ADDON_TYPE_EXTENSION}
-                  authorDisplayName={user.name}
-                  authorUsernames={[user.username]}
+                  authorDisplayName={user ? user.name : params.username}
+                  authorUsernames={[params.username]}
+                  errorHandler={errorHandler}
                   numberOfAddons={EXTENSIONS_BY_AUTHORS_PAGE_SIZE}
                   pageParam="page_e"
                   paginate
@@ -403,8 +402,9 @@ export class UserProfileBase extends React.Component<InternalProps> {
 
                 <AddonsByAuthorsCard
                   addonType={ADDON_TYPE_THEME}
-                  authorDisplayName={user.name}
-                  authorUsernames={[user.username]}
+                  authorDisplayName={user ? user.name : params.username}
+                  authorUsernames={[params.username]}
+                  errorHandler={errorHandler}
                   numberOfAddons={THEMES_BY_AUTHORS_PAGE_SIZE}
                   pageParam="page_t"
                   paginate

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -24,6 +24,7 @@ import {
   SEARCH_SORT_POPULAR,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
+import ErrorList from 'ui/components/ErrorList';
 import {
   dispatchClientMetadata,
   fakeAddon,
@@ -971,7 +972,7 @@ describe(__filename, () => {
     });
   });
 
-  it('does not render anything when an API error is thrown', () => {
+  it('renders an error when an API error is thrown', () => {
     const { store } = dispatchClientMetadata();
     const authorUsernames = ['some', 'authors'];
 
@@ -979,7 +980,6 @@ describe(__filename, () => {
       id: 'some-id',
       dispatch: store.dispatch,
     });
-
     errorHandler.handle(
       createApiError({
         response: { status: 404 },
@@ -995,6 +995,6 @@ describe(__filename, () => {
       store,
     });
 
-    expect(root.html()).toBeNull();
+    expect(root.find(ErrorList)).toHaveLength(1);
   });
 });

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -11,8 +11,9 @@ import {
   fetchAddonsByAuthors,
   loadAddonsByAuthors,
 } from 'amo/reducers/addonsByAuthors';
+import { createApiError } from 'core/api';
+import { ErrorHandler } from 'core/errorHandler';
 import Paginate from 'core/components/Paginate';
-import { createInternalAddon } from 'core/reducers/addons';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_DICT,
@@ -22,6 +23,7 @@ import {
   ADDON_TYPE_THEME,
   SEARCH_SORT_POPULAR,
 } from 'core/constants';
+import { createInternalAddon } from 'core/reducers/addons';
 import {
   dispatchClientMetadata,
   fakeAddon,
@@ -967,5 +969,32 @@ describe(__filename, () => {
         }),
       );
     });
+  });
+
+  it('does not render anything when an API error is thrown', () => {
+    const { store } = dispatchClientMetadata();
+    const authorUsernames = ['some', 'authors'];
+
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: store.dispatch,
+    });
+
+    errorHandler.handle(
+      createApiError({
+        response: { status: 404 },
+        apiURL: 'https://some/api/endpoint',
+        jsonResponse: { message: 'not found' },
+      }),
+    );
+
+    const root = render({
+      addonType: ADDON_TYPE_EXTENSION,
+      authorUsernames,
+      errorHandler,
+      store,
+    });
+
+    expect(root.html()).toBeNull();
   });
 });

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -919,60 +919,24 @@ describe(__filename, () => {
     sinon.assert.notCalled(dispatchSpy);
   });
 
-  it('returns a 404 if an AddonsByAuthorsCard receives a 404 API error', () => {
-    const { store } = signInUserWithUsername('black-panther');
+  it('returns a 404 when the API returns a 404', () => {
+    const { store } = dispatchSignInActions();
+
     const errorHandler = new ErrorHandler({
       id: 'some-error-handler-id',
       dispatch: store.dispatch,
     });
+    errorHandler.handle(
+      createApiError({
+        response: { status: 404 },
+        apiURL: 'https://some/api/endpoint',
+        jsonResponse: { message: 'internal server error' },
+      }),
+    );
 
     const root = renderUserProfile({ errorHandler, store });
-
-    // Simulate an error thrown inside the first AddonsByAuthorsCard.
-    root
-      .find(AddonsByAuthorsCard)
-      .at(0)
-      .prop('errorHandler')
-      .handle(
-        createApiError({
-          response: { status: 404 },
-          apiURL: 'https://some/api/endpoint',
-          jsonResponse: { message: 'not found' },
-        }),
-      );
-
-    // Trigger a re-rendering.
-    root.setProps();
 
     expect(root.find(NotFound)).toHaveLength(1);
-  });
-
-  it('renders errors from an AddonsByAuthorsCard', () => {
-    const { store } = dispatchSignInActions();
-    const errorHandler = new ErrorHandler({
-      id: 'some-id',
-      dispatch: store.dispatch,
-    });
-
-    const root = renderUserProfile({ errorHandler, store });
-
-    // Simulate an error thrown inside the second AddonsByAuthorsCard.
-    root
-      .find(AddonsByAuthorsCard)
-      .at(1)
-      .prop('errorHandler')
-      .handle(
-        createApiError({
-          response: { status: 500 },
-          apiURL: 'https://some/api/endpoint',
-          jsonResponse: { message: 'internal server error' },
-        }),
-      );
-
-    // Trigger a re-rendering.
-    root.setProps();
-
-    expect(root.find(ErrorList)).toHaveLength(1);
   });
 
   describe('errorHandler - extractId', () => {

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -498,6 +498,35 @@ describe(__filename, () => {
     expect(root.find(AddonsByAuthorsCard)).toHaveLength(2);
   });
 
+  it('passes the errorHandler to the AddonsByAuthorsCard', () => {
+    const errorHandler = createStubErrorHandler();
+    const root = renderUserProfile({ errorHandler });
+
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp(
+      'errorHandler',
+      errorHandler,
+    );
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp(
+      'errorHandler',
+      errorHandler,
+    );
+  });
+
+  it('renders AddonsByAuthorsCard without a user', () => {
+    const username = 'not-loaded';
+    const root = renderUserProfile({ params: { username } });
+
+    expect(root.find(AddonsByAuthorsCard)).toHaveLength(2);
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp(
+      'authorDisplayName',
+      username,
+    );
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp(
+      'authorDisplayName',
+      username,
+    );
+  });
+
   it('renders AddonsByAuthorsCard for extensions', () => {
     const username = 'tofumatt';
     const root = renderUserProfile({ params: { username } });
@@ -534,12 +563,6 @@ describe(__filename, () => {
       'pathname',
       `/user/${username}/`,
     );
-  });
-
-  it('renders no AddonsByAuthorsCard if no user found', () => {
-    const root = renderUserProfile({ params: { username: 'not-loaded' } });
-
-    expect(root.find(AddonsByAuthorsCard)).toHaveLength(0);
   });
 
   it('renders a not found page if the API request is a 404', () => {
@@ -894,6 +917,62 @@ describe(__filename, () => {
     });
 
     sinon.assert.notCalled(dispatchSpy);
+  });
+
+  it('returns a 404 if an AddonsByAuthorsCard receives a 404 API error', () => {
+    const { store } = signInUserWithUsername('black-panther');
+    const errorHandler = new ErrorHandler({
+      id: 'some-error-handler-id',
+      dispatch: store.dispatch,
+    });
+
+    const root = renderUserProfile({ errorHandler, store });
+
+    // Simulate an error thrown inside the first AddonsByAuthorsCard.
+    root
+      .find(AddonsByAuthorsCard)
+      .at(0)
+      .prop('errorHandler')
+      .handle(
+        createApiError({
+          response: { status: 404 },
+          apiURL: 'https://some/api/endpoint',
+          jsonResponse: { message: 'not found' },
+        }),
+      );
+
+    // Trigger a re-rendering.
+    root.setProps();
+
+    expect(root.find(NotFound)).toHaveLength(1);
+  });
+
+  it('renders errors from an AddonsByAuthorsCard', () => {
+    const { store } = dispatchSignInActions();
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: store.dispatch,
+    });
+
+    const root = renderUserProfile({ errorHandler, store });
+
+    // Simulate an error thrown inside the second AddonsByAuthorsCard.
+    root
+      .find(AddonsByAuthorsCard)
+      .at(1)
+      .prop('errorHandler')
+      .handle(
+        createApiError({
+          response: { status: 500 },
+          apiURL: 'https://some/api/endpoint',
+          jsonResponse: { message: 'internal server error' },
+        }),
+      );
+
+    // Trigger a re-rendering.
+    root.setProps();
+
+    expect(root.find(ErrorList)).toHaveLength(1);
   });
 
   describe('errorHandler - extractId', () => {


### PR DESCRIPTION
Fix #5442

---

This PR allows to return a 404 when extensions and/or themes on a user
profile cannot be loaded (and the API returns a 404 when trying to fetch
these add-ons), likely due to an invalid query parameter value.

Passing the `errorHandler` from the `UserProfile` component to the
`AddonsByAuthorsCard` components is required to make sure we return a
`NotFound` component on the server, thus returning a real `404` HTTP
response.

I also decided to hide the `AddonsByAuthorsCard` when an error occurs,
because it is better than being stuck in a loading state. On an add-on
detail page, it is "secondary data" so does not matter much I guess,
and on the user profile, the `UserProfile` will display the error.

I don't know if the added tests are enough or if we could find a better
patch, but I don't really see how we could do better here.