### PR TITLE
Update profile deletion copy

### DIFF
--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -446,6 +446,8 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     const isEditingCurrentUser =
       currentUser && user ? currentUser.id === user.id : false;
 
+    const userProfileURL = `/user/${username}/`;
+
     return (
       <div className="UserProfileEdit">
         {user && (
@@ -461,7 +463,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
         <Card className="UserProfileEdit-user-links">
           <ul>
             <li>
-              <Link to={`/user/${username}/`}>
+              <Link to={userProfileURL}>
                 {isEditingCurrentUser
                   ? i18n.gettext('View My Profile')
                   : i18n.gettext(`View user's profile`)}
@@ -525,11 +527,11 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                     dangerouslySetInnerHTML={sanitizeHTML(
                       i18n.sprintf(
                         i18n.gettext(`You can change your email address on
-                            Firefox Accounts. %(startLink)sNeed help?%(endLink)s`),
+                            Firefox Accounts. %(linkStart)sNeed help?%(linkEnd)s`),
                         {
-                          startLink:
+                          linkStart:
                             '<a href="https://support.mozilla.org/kb/change-primary-email-address-firefox-accounts">',
-                          endLink: '</a>',
+                          linkEnd: '</a>',
                         },
                       ),
                       ['a'],
@@ -691,14 +693,14 @@ export class UserProfileEditBase extends React.Component<Props, State> {
               <p className="UserProfileEdit-notifications-aside">
                 {isEditingCurrentUser
                   ? i18n.gettext(
-                      `From time to time, Mozilla may send you email about upcoming
-                  releases and add-on events. Please select the topics you are
-                  interested in.`,
+                      `From time to time, Mozilla may send you email about
+                      upcoming releases and add-on events. Please select the
+                      topics you are interested in.`,
                     )
                   : i18n.gettext(
-                      `From time to time, Mozilla may send this user email about
-                  upcoming releases and add-on events. Please select the
-                  topics this user may be interested in.`,
+                      `From time to time, Mozilla may send this user email
+                      about upcoming releases and add-on events. Please select
+                      the topics this user may be interested in.`,
                     )}
               </p>
 
@@ -728,11 +730,11 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 {/* eslint-disable-next-line no-nested-ternary */}
                 {isEditingCurrentUser
                   ? isUpdating
-                    ? i18n.gettext('Updating your profile…')
-                    : i18n.gettext('Update my profile')
+                    ? i18n.gettext('Updating your account…')
+                    : i18n.gettext('Update My Account')
                   : isUpdating
-                    ? i18n.gettext("Updating user's profile…")
-                    : i18n.gettext("Update user's profile")}
+                    ? i18n.gettext('Updating this account…')
+                    : i18n.gettext('Update This Account')}
               </Button>
               <Button
                 buttonType="neutral"
@@ -743,8 +745,8 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 type="button"
               >
                 {isEditingCurrentUser
-                  ? i18n.gettext('Delete my profile')
-                  : i18n.gettext(`Delete user's profile`)}
+                  ? i18n.gettext('Delete My Account')
+                  : i18n.gettext(`Delete This Account`)}
               </Button>
             </div>
           </div>
@@ -756,42 +758,63 @@ export class UserProfileEditBase extends React.Component<Props, State> {
             header={
               isEditingCurrentUser
                 ? i18n.gettext(
-                    `Attention: You are about to delete your profile. Are you sure?`,
+                    `IMPORTANT: Deleting your account is irreversible.`,
                   )
                 : i18n.gettext(
-                    `Attention: You are about to delete a profile. Are you sure?`,
+                    `IMPORTANT: Deleting this account is irreversible.`,
                   )
             }
             onEscapeOverlay={this.onCancelProfileDeletion}
             visibleOnLoad
           >
+            <p>
+              {isEditingCurrentUser
+                ? i18n.gettext(
+                    `Your data will be permanently removed, including profile
+                    details (picture, user name, display name, location, home
+                    page, biography, occupation) and notification preferences.
+                    Your reviews and ratings will be anonymised and no longer
+                    editable.`,
+                  )
+                : i18n.gettext(
+                    `The user’s data will be permanently removed, including
+                    profile details (picture, user name, display name,
+                    location, home page, biography, occupation) and
+                    notification preferences. Reviews and ratings will be
+                    anonymised and no longer editable.`,
+                  )}
+            </p>
             <p
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={sanitizeHTML(
+                //
                 i18n.sprintf(
-                  i18n.gettext(`If you confirm this
-                    %(startStrong)sirreversible action%(endStrong)s, the
-                    following data will be removed: profile picture,
-                    profile details (including username, email, display
-                    name, location, home page, biography, occupation) and
-                    notification preferences. Other data such as ratings
-                    and reviews will be anonymized.`),
+                  isEditingCurrentUser
+                    ? i18n.gettext(
+                        `%(strongStart)sNOTE:%(strongEnd)s You cannot delete
+                        your account if you are the %(linkStart)sauthor of any
+                        add-ons%(linkEnd)s. You must %(docLinkStart)stransfer
+                        ownership%(docLinkEnd)s or delete the add-ons before
+                        you can delete your account.`,
+                      )
+                    : i18n.gettext(
+                        `%(strongStart)sNOTE:%(strongEnd)s You cannot delete a
+                        user’s account if the user is the %(linkStart)sauthor
+                        of any add-ons%(linkEnd)s.`,
+                      ),
                   {
-                    startStrong: '<strong>',
-                    endStrong: '</strong>',
+                    linkStart: `<a href="${userProfileURL}">`,
+                    linkEnd: '</a>',
+                    docLinkStart:
+                      '<a href="https://developer.mozilla.org/Add-ons/Distribution#More_information_about_AMO">',
+                    docLinkEnd: '</a>',
+                    strongStart: '<strong>',
+                    strongEnd: '</strong>',
                   },
                 ),
-                ['strong'],
+                ['a', 'strong'],
               )}
             />
-            <p>
-              {isEditingCurrentUser
-                ? i18n.gettext(`Important: if you own add-ons, you have to
-                  transfer them to other users or to delete them before you
-                  can delete your profile.`)
-                : i18n.gettext(`Important: a user profile can only be deleted if
-                  the user does not own any add-ons.`)}
-            </p>
             <div className="UserProfileEdit-buttons-wrapper">
               <Button
                 buttonType="alert"
@@ -801,8 +824,8 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 puffy
               >
                 {isEditingCurrentUser
-                  ? i18n.gettext('Yes, delete my profile')
-                  : i18n.gettext('Yes, delete this profile')}
+                  ? i18n.gettext('Delete My Account')
+                  : i18n.gettext('Delete This Account')}
               </Button>
               <Button
                 buttonType="cancel"

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -527,11 +527,11 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                     dangerouslySetInnerHTML={sanitizeHTML(
                       i18n.sprintf(
                         i18n.gettext(`You can change your email address on
-                            Firefox Accounts. %(linkStart)sNeed help?%(linkEnd)s`),
+                          Firefox Accounts. %(startLink)sNeed help?%(endLink)s`),
                         {
-                          linkStart:
+                          startLink:
                             '<a href="https://support.mozilla.org/kb/change-primary-email-address-firefox-accounts">',
-                          linkEnd: '</a>',
+                          endLink: '</a>',
                         },
                       ),
                       ['a'],
@@ -787,7 +787,6 @@ export class UserProfileEditBase extends React.Component<Props, State> {
             <p
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={sanitizeHTML(
-                //
                 i18n.sprintf(
                   isEditingCurrentUser
                     ? i18n.gettext(

--- a/src/amo/components/UserProfileEditPicture/index.js
+++ b/src/amo/components/UserProfileEditPicture/index.js
@@ -63,7 +63,7 @@ export const UserProfileEditPictureBase = ({
           onChange={onSelect}
           type="file"
         />
-        <span className={buttonClass}>{i18n.gettext('Choose photo...')}</span>
+        <span className={buttonClass}>{i18n.gettext('Choose Photo…')}</span>
       </label>
 
       {user &&
@@ -74,7 +74,7 @@ export const UserProfileEditPictureBase = ({
             message={i18n.gettext('Do you really want to delete this picture?')}
             onConfirm={onDelete}
           >
-            {i18n.gettext('Delete this picture')}
+            {i18n.gettext('Delete This Picture')}
           </ConfirmButton>
         )}
     </section>

--- a/tests/unit/amo/components/TestUserProfileEdit.js
+++ b/tests/unit/amo/components/TestUserProfileEdit.js
@@ -587,7 +587,7 @@ describe(__filename, () => {
     const button = root.find('.UserProfileEdit-submit-button');
 
     expect(button).toHaveLength(1);
-    expect(button.dive()).toHaveText('Update my profile');
+    expect(button.dive()).toHaveText('Update My Account');
     expect(button).toHaveProp('disabled', false);
   });
 
@@ -596,7 +596,7 @@ describe(__filename, () => {
     const button = root.find('.UserProfileEdit-delete-button');
 
     expect(button).toHaveLength(1);
-    expect(button.dive()).toHaveText('Delete my profile');
+    expect(button.dive()).toHaveText('Delete My Account');
     expect(button).toHaveProp('disabled', false);
   });
 
@@ -607,7 +607,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({ params, store });
 
     expect(root.find('.UserProfileEdit-submit-button').dive()).toHaveText(
-      `Update user's profile`,
+      `Update This Account`,
     );
   });
 
@@ -618,7 +618,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({ params, store });
 
     expect(root.find('.UserProfileEdit-delete-button').dive()).toHaveText(
-      `Delete user's profile`,
+      `Delete This Account`,
     );
   });
 
@@ -630,7 +630,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({ store });
 
     expect(root.find('.UserProfileEdit-submit-button').dive()).toHaveText(
-      'Updating your profile…',
+      'Updating your account…',
     );
   });
 
@@ -643,7 +643,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({ params, store });
 
     expect(root.find('.UserProfileEdit-submit-button').dive()).toHaveText(
-      `Updating user's profile…`,
+      `Updating this account…`,
     );
   });
 
@@ -1251,25 +1251,27 @@ describe(__filename, () => {
     expect(modal).toHaveLength(1);
     expect(modal).toHaveProp(
       'header',
-      'Attention: You are about to delete your profile. Are you sure?',
+      'IMPORTANT: Deleting your account is irreversible.',
     );
     expect(modal).toHaveProp('visibleOnLoad', true);
 
-    expect(modal.find('p').at(0)).toHaveProp('dangerouslySetInnerHTML', {
-      __html: oneLine`If you confirm this <strong>irreversible action</strong>,
-        the following data will be removed: profile picture, profile details
-        (including username, email, display name, location, home page,
-        biography, occupation) and notification preferences. Other data such as
-        ratings and reviews will be anonymized.`,
-    });
+    expect(modal.find('p').at(0)).toHaveText(
+      oneLine`Your data will be permanently removed, including profile details
+      (picture, user name, display name, location, home page, biography,
+      occupation) and notification preferences. Your reviews and ratings will
+      be anonymised and no longer editable.`,
+    );
 
-    expect(modal.find('p').at(1)).toHaveText(oneLine`Important: if you own
-      add-ons, you have to transfer them to other users or to delete them
-      before you can delete your profile.`);
+    expect(modal.find('p').at(1)).toHaveHTML(
+      oneLine`<p><strong>NOTE:</strong> You cannot delete your account if you
+      are the <a href="/user/tofumatt/">author of any add-ons</a>. You must
+      <a href="https://developer.mozilla.org/Add-ons/Distribution#More_information_about_AMO">transfer ownership</a>
+      or delete the add-ons before you can delete your account.</p>`,
+    );
 
     expect(root.find('.UserProfileEdit-confirm-button')).toHaveLength(1);
     expect(root.find('.UserProfileEdit-confirm-button').children()).toHaveText(
-      'Yes, delete my profile',
+      'Delete My Account',
     );
     expect(root.find('.UserProfileEdit-confirm-button')).toHaveProp(
       'disabled',
@@ -1311,7 +1313,7 @@ describe(__filename, () => {
 
     expect(root.find('.UserProfileEdit-deletion-modal')).toHaveProp(
       'header',
-      'Attention: You are about to delete a profile. Are you sure?',
+      'IMPORTANT: Deleting this account is irreversible.',
     );
 
     expect(
@@ -1319,11 +1321,12 @@ describe(__filename, () => {
         .find('.UserProfileEdit-deletion-modal')
         .find('p')
         .at(1),
-    ).toHaveText(oneLine`Important: a user profile can only be deleted if the
-        user does not own any add-ons.`);
+    ).toHaveHTML(oneLine`<p><strong>NOTE:</strong> You cannot delete a user’s
+    account if the user is the <a href="/user/another-user/">author of any
+    add-ons</a>.</p>`);
 
     expect(root.find('.UserProfileEdit-confirm-button').children()).toHaveText(
-      'Yes, delete this profile',
+      'Delete This Account',
     );
   });
 

--- a/tests/unit/amo/components/TestUserProfileEditPicture.js
+++ b/tests/unit/amo/components/TestUserProfileEditPicture.js
@@ -126,7 +126,7 @@ describe(__filename, () => {
     );
     expect(root.find(ConfirmButton)).toHaveProp('onConfirm', onDelete);
     expect(root.find(ConfirmButton).children()).toHaveText(
-      'Delete this picture',
+      'Delete This Picture',
     );
   });
 


### PR DESCRIPTION
Fix #5184 

---

Google doc: https://docs.google.com/document/d/1nnv1gwiQe5K3tvYXdsA2QmtWKO6XD75aD31V0hoyI_k/edit?ts=5b3679d3

This PR updates the copy for the user ~~profile~~ account deletion according to the Google doc above. It also slightly improves some other texts on this edit page thanks to the comments in the Google doc.

**Why WIP?** We still need a final decision about some red color on the "important" and "notes" words (again, please see the Google doc).

## Screenshots

Regular user:

<img width="519" alt="screen shot 2018-06-30 at 00 24 49" src="https://user-images.githubusercontent.com/217628/42117312-1d54e942-7bfc-11e8-9ee1-e2d6f6d1ef31.png">

Admin:

<img width="510" alt="screen shot 2018-06-30 at 00 24 55" src="https://user-images.githubusercontent.com/217628/42117292-0c4b8048-7bfc-11e8-9389-7585d80f6d5c.png">

Other fixes: buttons at the bottom

<img width="751" alt="screen shot 2018-06-30 at 00 25 51" src="https://user-images.githubusercontent.com/217628/42117347-442c6b1c-7bfc-11e8-9862-6c326ff21787.png">

Other fixes: upload buttons

<img width="305" alt="screen shot 2018-06-30 at 00 25 56" src="https://user-images.githubusercontent.com/217628/42117339-4031f8e2-7bfc-11e8-9d46-a41799c96bfd.png">

