### PR TITLE
Remove the A/B test from the TADAr so that recommendations are 100% of traffic

### DIFF
--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -110,7 +110,6 @@ export class AddonRecommendationsBase extends React.Component<Props> {
       fetchRecommendations({
         errorHandlerId: this.props.errorHandler.id,
         guid,
-        recommended: true,
       }),
     );
   }

--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -2,7 +2,6 @@
 import makeClassName from 'classnames';
 import invariant from 'invariant';
 import * as React from 'react';
-import defaultCookie from 'react-cookie';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
@@ -29,53 +28,33 @@ import type { DispatchFunc } from 'core/types/redux';
 import './styles.scss';
 
 export const TAAR_IMPRESSION_CATEGORY = 'AMO Addon / Recommendations Shown';
-export const TAAR_COHORT_COOKIE_NAME = 'taar_cohort';
 export const TAAR_COHORT_DIMENSION = 'dimension4';
-export const TAAR_COHORT_INCLUDED: 'TAAR_COHORT_INCLUDED' =
-  'TAAR_COHORT_INCLUDED';
-export const TAAR_COHORT_EXCLUDED: 'TAAR_COHORT_EXCLUDED' =
-  'TAAR_COHORT_EXCLUDED';
+export const TAAR_COHORT_INCLUDED = 'TAAR_COHORT_INCLUDED';
 export const TAAR_EXPERIMENT_PARTICIPANT = 'TAAR-LITE-AB';
 export const TAAR_EXPERIMENT_PARTICIPANT_DIMENSION = 'dimension5';
-
-export type CohortName =
-  | typeof TAAR_COHORT_INCLUDED
-  | typeof TAAR_COHORT_EXCLUDED;
 
 type Props = {|
   addon: AddonType | null,
   className?: string,
-  cookie: typeof defaultCookie,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
-  randomizer: () => number,
   recommendations: Recommendations | null,
   tracking: typeof defaultTracking,
 |};
 
 export class AddonRecommendationsBase extends React.Component<Props> {
   static defaultProps = {
-    cookie: defaultCookie,
-    randomizer: Math.random,
     recommendations: null,
     tracking: defaultTracking,
   };
 
   componentDidMount() {
-    const { addon, cookie, randomizer, recommendations, tracking } = this.props;
-
-    // Set a cohort for the experiment.
-    this.cohort = cookie.load(TAAR_COHORT_COOKIE_NAME);
-    if (this.cohort === undefined) {
-      this.cohort =
-        randomizer() >= 0.5 ? TAAR_COHORT_INCLUDED : TAAR_COHORT_EXCLUDED;
-      cookie.save(TAAR_COHORT_COOKIE_NAME, this.cohort, { path: '/' });
-    }
+    const { addon, recommendations, tracking } = this.props;
 
     tracking.setDimension({
       dimension: TAAR_COHORT_DIMENSION,
-      value: this.cohort,
+      value: TAAR_COHORT_INCLUDED,
     });
 
     tracking.setDimension({
@@ -84,10 +63,7 @@ export class AddonRecommendationsBase extends React.Component<Props> {
     });
 
     if (addon && !recommendations) {
-      this.dispatchFetchRecommendations({
-        guid: addon.guid,
-        recommended: this.cohort === TAAR_COHORT_INCLUDED,
-      });
+      this.dispatchFetchRecommendations(addon.guid);
     }
   }
 
@@ -103,10 +79,7 @@ export class AddonRecommendationsBase extends React.Component<Props> {
 
     // Fetch recommendations when the add-on changes.
     if (newAddon && oldAddon !== newAddon) {
-      this.dispatchFetchRecommendations({
-        guid: newAddon.guid,
-        recommended: this.cohort === TAAR_COHORT_INCLUDED,
-      });
+      this.dispatchFetchRecommendations(newAddon.guid);
     }
 
     // Send the GA ping when recommendations are loaded.
@@ -120,7 +93,6 @@ export class AddonRecommendationsBase extends React.Component<Props> {
       invariant(newAddon, 'newAddon is required');
       invariant(outcome, 'outcome is required');
 
-      // TODO: Determine the exact format for this output.
       let action = outcome;
       if (fallbackReason) {
         action = `${action}-${fallbackReason}`;
@@ -133,14 +105,12 @@ export class AddonRecommendationsBase extends React.Component<Props> {
     }
   }
 
-  cohort: CohortName;
-
-  dispatchFetchRecommendations({ guid, recommended }: Object) {
+  dispatchFetchRecommendations(guid: string) {
     this.props.dispatch(
       fetchRecommendations({
         errorHandlerId: this.props.errorHandler.id,
         guid,
-        recommended,
+        recommended: true,
       }),
     );
   }

--- a/src/amo/reducers/recommendations.js
+++ b/src/amo/reducers/recommendations.js
@@ -60,7 +60,7 @@ export const abortFetchRecommendations = ({
 type FetchRecommendationsParams = {|
   errorHandlerId: string,
   guid: string,
-  recommended: boolean,
+  recommended?: boolean,
 |};
 
 export type FetchRecommendationsAction = {|
@@ -71,11 +71,10 @@ export type FetchRecommendationsAction = {|
 export const fetchRecommendations = ({
   errorHandlerId,
   guid,
-  recommended,
+  recommended = true,
 }: FetchRecommendationsParams): FetchRecommendationsAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(guid, 'guid is required');
-  invariant(typeof recommended === 'boolean', 'recommended is required');
 
   return {
     type: FETCH_RECOMMENDATIONS,

--- a/src/amo/sagas/recommendations.js
+++ b/src/amo/sagas/recommendations.js
@@ -1,4 +1,6 @@
 /* @flow */
+import invariant from 'invariant';
+
 import { call, put, select, takeLatest } from 'redux-saga/effects';
 import {
   FETCH_RECOMMENDATIONS,
@@ -18,6 +20,7 @@ export function* fetchRecommendations({
   yield put(errorHandler.createClearingAction());
 
   try {
+    invariant(typeof recommended === 'boolean', 'recommended is required');
     const state = yield select(getState);
 
     const params: GetRecommendationsParams = {

--- a/tests/unit/amo/components/TestAddonRecommendations.js
+++ b/tests/unit/amo/components/TestAddonRecommendations.js
@@ -46,7 +46,6 @@ describe(__filename, () => {
     return fetchRecommendations({
       errorHandlerId: errorHandler.id,
       guid,
-      recommended: true,
     });
   }
 
@@ -156,7 +155,6 @@ describe(__filename, () => {
       fetchRecommendations({
         errorHandlerId: errorHandler.id,
         guid: addon.guid,
-        recommended: true,
       }),
     );
   });
@@ -190,7 +188,6 @@ describe(__filename, () => {
       fetchRecommendations({
         errorHandlerId: errorHandler.id,
         guid: newAddon.guid,
-        recommended: true,
       }),
     );
   });

--- a/tests/unit/amo/sagas/test_recommendations.js
+++ b/tests/unit/amo/sagas/test_recommendations.js
@@ -31,7 +31,6 @@ describe(__filename, () => {
   });
 
   const guid = 'some-guid';
-  const recommended = true;
 
   function _fetchRecommendations(params) {
     sagaTester.dispatch(
@@ -56,12 +55,12 @@ describe(__filename, () => {
       .withArgs({
         api: state.api,
         guid,
-        recommended,
+        recommended: true,
       })
       .once()
       .returns(Promise.resolve(recommendations));
 
-    _fetchRecommendations({ guid, recommended });
+    _fetchRecommendations({ guid });
 
     const expectedLoadAction = loadRecommendations({
       addons: recommendations.results,
@@ -76,7 +75,7 @@ describe(__filename, () => {
   });
 
   it('clears the error handler', async () => {
-    _fetchRecommendations({ guid, recommended });
+    _fetchRecommendations({ guid });
 
     const expectedAction = errorHandler.createClearingAction();
 
@@ -92,7 +91,7 @@ describe(__filename, () => {
       .once()
       .returns(Promise.reject(error));
 
-    _fetchRecommendations({ guid, recommended });
+    _fetchRecommendations({ guid });
 
     const expectedAction = errorHandler.createErrorAction(error);
     const action = await sagaTester.waitFor(expectedAction.type);


### PR DESCRIPTION
Fixes #5408 

This ensures that 100% of users will request actual recommendations from TADAr. As per the comment at https://github.com/mozilla/addons-frontend/issues/5408#issuecomment-400971189 we will not be making any changes to the data sent to GA at this time.

These changes are currently isolated to the `AddonRecommendations` component. Although we could potentially make these changes at a lower level, removing the `recommended` property from `FetchRecommendationsParams`, I think it's best to just leave that as is for now, as there is a suggestion we may be doing further experiments with this feature in the future. 
