### PR TITLE
Fix display issues with long displayName on UserProfile page

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -152,6 +152,7 @@
 
 .SearchResult-author {
   display: none;
+  overflow: auto;
   word-wrap: break-word;
 
   @include respond-to(medium) {

--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -68,6 +68,8 @@ $avatar-size: 64px;
   font-size: $font-size-l;
   grid-column: 1 / span 3;
   margin: 0;
+  overflow: auto;
+  word-wrap: break-word;
 
   @include respond-to(medium) {
     font-size: $font-size-xl;


### PR DESCRIPTION
Fixes #5494 

Before:

![screenshot 2018-07-04 13 38 23](https://user-images.githubusercontent.com/142755/42289802-8bed1e06-7f8f-11e8-91a6-971b33c871fe.png)

After:

![screenshot 2018-07-04 13 38 55](https://user-images.githubusercontent.com/142755/42289812-9fd63ed4-7f8f-11e8-921b-cb0fb927dc85.png)
