### PR TITLE
Refresh user collections when a collection is saved, and don't use the current collection when editing

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -583,7 +583,7 @@ export const mapStateToProps = (
   ownProps: InternalProps,
 ) => {
   const { loading } = state.collections.current;
-  const { location } = ownProps;
+  const { creating, location } = ownProps;
 
   const filters = {
     page: location.query.page || 1,
@@ -592,7 +592,7 @@ export const mapStateToProps = (
   };
 
   const currentUser = getCurrentUser(state.users);
-  const collection = getCurrentCollection(state.collections);
+  const collection = creating ? null : getCurrentCollection(state.collections);
 
   const isOwner =
     collection && currentUser && collection.authorId === currentUser.id;

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -45,6 +45,8 @@ export const UPDATE_COLLECTION_ADDON: 'UPDATE_COLLECTION_ADDON' =
   'UPDATE_COLLECTION_ADDON';
 export const DELETE_COLLECTION_ADDON_NOTES: 'DELETE_COLLECTION_ADDON_NOTES' =
   'DELETE_COLLECTION_ADDON_NOTES';
+export const UNLOAD_USER_COLLECTIONS: 'UNLOAD_USER_COLLECTIONS' =
+  'UNLOAD_USER_COLLECTIONS';
 
 export type CollectionFilters = {|
   page: number,
@@ -769,6 +771,26 @@ export const deleteCollectionAddonNotes = ({
   };
 };
 
+type UnloadUserCollectionsParams = {|
+  username: string,
+|};
+
+export type UnloadUserCollectionsAction = {|
+  type: typeof UNLOAD_USER_COLLECTIONS,
+  payload: UnloadUserCollectionsParams,
+|};
+
+export const unloadUserCollections = ({
+  username,
+}: UnloadUserCollectionsParams): UnloadUserCollectionsAction => {
+  invariant(username, 'username is required');
+
+  return {
+    type: UNLOAD_USER_COLLECTIONS,
+    payload: { username },
+  };
+};
+
 export const createInternalAddons = (
   items: ExternalCollectionAddons,
 ): Array<CollectionAddonType> => {
@@ -974,7 +996,8 @@ type Action =
   | LoadCurrentCollectionPageAction
   | LoadUserCollectionsAction
   | BeginCollectionModificationAction
-  | FinishCollectionModificationAction;
+  | FinishCollectionModificationAction
+  | UnloadUserCollectionsAction;
 
 const reducer = (
   state: CollectionsState = initialState,
@@ -1231,6 +1254,20 @@ const reducer = (
         return { ...state, byId: newIdMap };
       }
       return state;
+    }
+
+    case UNLOAD_USER_COLLECTIONS: {
+      const { username } = action.payload;
+      return {
+        ...state,
+        userCollections: {
+          ...state.userCollections,
+          [username]: {
+            collections: null,
+            loading: false,
+          },
+        },
+      };
     }
 
     default:

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -31,7 +31,6 @@ import {
   loadUserCollections,
   localizeCollectionDetail,
   unloadCollectionBySlug,
-  unloadUserCollections,
 } from 'amo/reducers/collections';
 import * as api from 'amo/api/collections';
 import log from 'core/logger';
@@ -275,13 +274,6 @@ export function* modifyCollection(
     invariant(effectiveSlug, 'Both slug and collectionSlug cannot be empty');
     const newLocation = `/${lang}/${clientApp}/collections/${username}/${effectiveSlug}/`;
 
-    // Unload the user's collections, which will force a re-fetch.
-    yield put(
-      unloadUserCollections({
-        username,
-      }),
-    );
-
     if (creating) {
       invariant(response, 'response is required when creating');
       // If a new collection was just created, load it so that it will
@@ -383,12 +375,6 @@ export function* deleteCollection({
     // Unload the collection from state.
     yield put(unloadCollectionBySlug(slug));
 
-    // Unload the user's collections, which will force a re-fetch.
-    yield put(
-      unloadUserCollections({
-        username,
-      }),
-    );
     yield put(pushLocation(`/${lang}/${clientApp}/collections/`));
   } catch (error) {
     log.warn(`Failed to delete collection: ${error}`);

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -26,12 +26,12 @@ import {
   convertFiltersToQueryParams,
   finishCollectionModification,
   fetchCurrentCollectionPage as fetchCurrentCollectionPageAction,
-  fetchUserCollections as fetchUserCollectionsAction,
   loadCurrentCollection,
   loadCurrentCollectionPage,
   loadUserCollections,
   localizeCollectionDetail,
   unloadCollectionBySlug,
+  unloadUserCollections,
 } from 'amo/reducers/collections';
 import * as api from 'amo/api/collections';
 import log from 'core/logger';
@@ -275,10 +275,9 @@ export function* modifyCollection(
     invariant(effectiveSlug, 'Both slug and collectionSlug cannot be empty');
     const newLocation = `/${lang}/${clientApp}/collections/${username}/${effectiveSlug}/`;
 
-    // Refresh the user's list of collections.
+    // Unload the user's collections, which will force a re-fetch.
     yield put(
-      fetchUserCollectionsAction({
-        errorHandlerId: errorHandler.id,
+      unloadUserCollections({
         username,
       }),
     );
@@ -384,9 +383,9 @@ export function* deleteCollection({
     // Unload the collection from state.
     yield put(unloadCollectionBySlug(slug));
 
+    // Unload the user's collections, which will force a re-fetch.
     yield put(
-      fetchUserCollectionsAction({
-        errorHandlerId: errorHandler.id,
+      unloadUserCollections({
         username,
       }),
     );

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -275,6 +275,14 @@ export function* modifyCollection(
     invariant(effectiveSlug, 'Both slug and collectionSlug cannot be empty');
     const newLocation = `/${lang}/${clientApp}/collections/${username}/${effectiveSlug}/`;
 
+    // Refresh the user's list of collections.
+    yield put(
+      fetchUserCollectionsAction({
+        errorHandlerId: errorHandler.id,
+        username,
+      }),
+    );
+
     if (creating) {
       invariant(response, 'response is required when creating');
       // If a new collection was just created, load it so that it will

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -790,6 +790,7 @@ describe(__filename, () => {
     expect(wrapper.find(AddonsCard)).toHaveLength(0);
     expect(wrapper.find(CollectionManager)).toHaveLength(1);
     expect(wrapper.find(CollectionManager)).toHaveProp('creating', true);
+    expect(wrapper.find(CollectionManager)).toHaveProp('collection', null);
 
     // Make sure these were not rendered.
     expect(wrapper.find('.Collection-title')).toHaveLength(0);

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -23,6 +23,7 @@ import reducer, {
   loadUserCollections,
   localizeCollectionDetail,
   unloadCollectionBySlug,
+  unloadUserCollections,
 } from 'amo/reducers/collections';
 import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import { COLLECTION_SORT_NAME } from 'core/constants';
@@ -371,6 +372,30 @@ describe(__filename, () => {
       expect(userState.collections).toEqual([1]);
 
       expect(state.bySlug[collection.slug]).toEqual(collection.id);
+    });
+
+    it('unloads user collections', () => {
+      const username = 'some-user';
+      const collection = createFakeCollectionDetail({ id: 1 });
+
+      let state = reducer(
+        undefined,
+        loadUserCollections({
+          username,
+          collections: [collection],
+        }),
+      );
+
+      expect(state.userCollections[username].collections).toEqual([1]);
+
+      state = reducer(
+        state,
+        unloadUserCollections({
+          username,
+        }),
+      );
+
+      expect(state.userCollections[username].collections).toEqual(null);
     });
 
     it('sets a loading flag when begining to add add-on to collection', () => {

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -6,8 +6,10 @@ import reducer, {
   addonAddedToCollection,
   beginCollectionModification,
   convertFiltersToQueryParams,
+  createCollection,
   createInternalAddons,
   createInternalCollection,
+  deleteCollection,
   expandCollections,
   fetchCurrentCollection,
   fetchCurrentCollectionPage,
@@ -23,7 +25,7 @@ import reducer, {
   loadUserCollections,
   localizeCollectionDetail,
   unloadCollectionBySlug,
-  unloadUserCollections,
+  updateCollection,
 } from 'amo/reducers/collections';
 import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import { COLLECTION_SORT_NAME } from 'core/constants';
@@ -374,7 +376,7 @@ describe(__filename, () => {
       expect(state.bySlug[collection.slug]).toEqual(collection.id);
     });
 
-    it('unloads user collections', () => {
+    it('unloads user collections after creating', () => {
       const username = 'some-user';
       const collection = createFakeCollectionDetail({ id: 1 });
 
@@ -390,7 +392,64 @@ describe(__filename, () => {
 
       state = reducer(
         state,
-        unloadUserCollections({
+        createCollection({
+          errorHandlerId: createStubErrorHandler().id,
+          name: 'some-collection',
+          slug: 'some-slug',
+          username,
+        }),
+      );
+
+      expect(state.userCollections[username].collections).toEqual(null);
+    });
+
+    it('unloads user collections after updating', () => {
+      const username = 'some-user';
+      const collection = createFakeCollectionDetail({ id: 1 });
+
+      let state = reducer(
+        undefined,
+        loadUserCollections({
+          username,
+          collections: [collection],
+        }),
+      );
+
+      expect(state.userCollections[username].collections).toEqual([1]);
+
+      state = reducer(
+        state,
+        updateCollection({
+          collectionSlug: 'some-slug',
+          errorHandlerId: createStubErrorHandler().id,
+          filters: {},
+          name: 'some-collection',
+          username,
+        }),
+      );
+
+      expect(state.userCollections[username].collections).toEqual(null);
+    });
+
+    it('unloads user collections after deleting', () => {
+      const username = 'some-user';
+      const collection = createFakeCollectionDetail({ id: 1 });
+
+      let state = reducer(
+        undefined,
+        loadUserCollections({
+          username,
+          collections: [collection],
+        }),
+      );
+
+      expect(state.userCollections[username].collections).toEqual([1]);
+
+      state = reducer(
+        state,
+        deleteCollection({
+          errorHandlerId: createStubErrorHandler().id,
+          slug: 'some-slug',
           username,
         }),
       );

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -22,6 +22,7 @@ import collectionsReducer, {
   localizeCollectionDetail,
   removeAddonFromCollection,
   unloadCollectionBySlug,
+  unloadUserCollections,
   updateCollection,
   updateCollectionAddon,
 } from 'amo/reducers/collections';
@@ -497,8 +498,7 @@ describe(__filename, () => {
 
         _updateCollection({ username: testUsername });
 
-        const expectedAction = fetchUserCollections({
-          errorHandlerId: errorHandler.id,
+        const expectedAction = unloadUserCollections({
           username: testUsername,
         });
 
@@ -801,18 +801,25 @@ describe(__filename, () => {
 
       _deleteCollection(params);
 
-      const expectedUnloadAction = unloadCollectionBySlug(params.slug);
+      const expectedUnloadCollectionAction = unloadCollectionBySlug(
+        params.slug,
+      );
 
-      const unloadAction = await sagaTester.waitFor(expectedUnloadAction.type);
-      expect(unloadAction).toEqual(expectedUnloadAction);
+      const unloadCollectionAction = await sagaTester.waitFor(
+        expectedUnloadCollectionAction.type,
+      );
+      expect(unloadCollectionAction).toEqual(expectedUnloadCollectionAction);
 
-      const expectedFetchAction = fetchUserCollections({
-        errorHandlerId: errorHandler.id,
+      const expectedUnloadUserCollectionsAction = unloadUserCollections({
         username: params.username,
       });
 
-      const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);
-      expect(fetchAction).toEqual(expectedFetchAction);
+      const unloadUserCollectionsAction = await sagaTester.waitFor(
+        expectedUnloadUserCollectionsAction.type,
+      );
+      expect(unloadUserCollectionsAction).toEqual(
+        expectedUnloadUserCollectionsAction,
+      );
 
       const expectedPushAction = pushLocation(
         `/${lang}/${clientApp}/collections/`,

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -490,6 +490,22 @@ describe(__filename, () => {
         expect(action).toEqual(expectedAction);
         mockApi.verify();
       });
+
+      it('refreshes user collections', async () => {
+        const testUsername = 'some-username';
+        mockApi.expects('updateCollection').returns(Promise.resolve());
+
+        _updateCollection({ username: testUsername });
+
+        const expectedAction = fetchUserCollections({
+          errorHandlerId: errorHandler.id,
+          username: testUsername,
+        });
+
+        const action = await sagaTester.waitFor(expectedAction.type);
+        expect(action).toEqual(expectedAction);
+        mockApi.verify();
+      });
     });
 
     describe('update logic', () => {

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -22,7 +22,6 @@ import collectionsReducer, {
   localizeCollectionDetail,
   removeAddonFromCollection,
   unloadCollectionBySlug,
-  unloadUserCollections,
   updateCollection,
   updateCollectionAddon,
 } from 'amo/reducers/collections';
@@ -491,21 +490,6 @@ describe(__filename, () => {
         expect(action).toEqual(expectedAction);
         mockApi.verify();
       });
-
-      it('refreshes user collections', async () => {
-        const testUsername = 'some-username';
-        mockApi.expects('updateCollection').returns(Promise.resolve());
-
-        _updateCollection({ username: testUsername });
-
-        const expectedAction = unloadUserCollections({
-          username: testUsername,
-        });
-
-        const action = await sagaTester.waitFor(expectedAction.type);
-        expect(action).toEqual(expectedAction);
-        mockApi.verify();
-      });
     });
 
     describe('update logic', () => {
@@ -801,25 +785,10 @@ describe(__filename, () => {
 
       _deleteCollection(params);
 
-      const expectedUnloadCollectionAction = unloadCollectionBySlug(
-        params.slug,
-      );
+      const expectedUnloadAction = unloadCollectionBySlug(params.slug);
 
-      const unloadCollectionAction = await sagaTester.waitFor(
-        expectedUnloadCollectionAction.type,
-      );
-      expect(unloadCollectionAction).toEqual(expectedUnloadCollectionAction);
-
-      const expectedUnloadUserCollectionsAction = unloadUserCollections({
-        username: params.username,
-      });
-
-      const unloadUserCollectionsAction = await sagaTester.waitFor(
-        expectedUnloadUserCollectionsAction.type,
-      );
-      expect(unloadUserCollectionsAction).toEqual(
-        expectedUnloadUserCollectionsAction,
-      );
+      const unloadAction = await sagaTester.waitFor(expectedUnloadAction.type);
+      expect(unloadAction).toEqual(expectedUnloadAction);
 
       const expectedPushAction = pushLocation(
         `/${lang}/${clientApp}/collections/`,


### PR DESCRIPTION
Fixes #5425 

This fixes both issues as reported at #5425.

It updates the list of user collections after one is saved, which will then allow it to appear immediately on the My Collections screen, and it also doesn't use the currently loaded collection when rendering the Create Collection form, so we don't end up with pre-populated fields.