### PR TITLE
Show empty reviews in user profile

### DIFF
--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -69,8 +69,6 @@ function* fetchUserReviews({
 
     const params: GetReviewsParams = {
       apiState: state.api,
-      // Hide star-only ratings (reviews that do not have a body).
-      filter: 'without_empty_body',
       page,
       user: userId,
     };

--- a/tests/unit/amo/sagas/testReviews.js
+++ b/tests/unit/amo/sagas/testReviews.js
@@ -311,7 +311,6 @@ describe(__filename, () => {
         .once()
         .withArgs({
           apiState,
-          filter: 'without_empty_body',
           page: 1,
           user: userId,
         })


### PR DESCRIPTION
Fix #5474

---

This PR removes the filter to retrieve ALL reviews of a user.