### PR TITLE
Do not add br between html tags

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -86,7 +86,7 @@ export function sanitizeHTML(text, allowTags = [], _purify = purify) {
 
 // Convert new lines to HTML breaks.
 export function nl2br(text) {
-  return (text || '').replace(/(?:\r\n|\r|\n)/g, '<br />');
+  return (text || '').replace(/(\r\n|\r|\n)(?!\s*<.+?>)/g, '<br />');
 }
 
 /*

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -86,7 +86,7 @@ export function sanitizeHTML(text, allowTags = [], _purify = purify) {
 
 // Convert new lines to HTML breaks.
 export function nl2br(text) {
-  return (text || '').replace(/(\r\n|\r|\n)(?!\s*<.+?>)/g, '<br />');
+  return (text || '').replace(/(\r\n|\r|\n)(?!<.+?>)/g, '<br />');
 }
 
 /*

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -406,12 +406,18 @@ describe(__filename, () => {
       expect(nl2br(null)).toEqual('');
     });
 
+    it('returns mixed content with <br/>', () => {
+      expect(nl2br('foo\nbar\n\n<b>bold</b>')).toEqual(
+        'foo<br />bar<br />\n<b>bold</b>',
+      );
+    });
+
     it('returns valid HTML', () => {
       const htmlValue =
-        '<ul>\n\n\n<li>ul\nli<strong>foo\nbar</strong>\n</li>\r\n</ul>';
+        '<ul>\n<li>ul\nli<strong>foo\nbar</strong>\n</li>\n</ul>';
 
       expect(nl2br(htmlValue)).toEqual(
-        '<ul>\n\n\n<li>ul<br />li<strong>foo<br />bar</strong>\n</li>\r\n</ul>',
+        '<ul>\n<li>ul<br />li<strong>foo<br />bar</strong>\n</li>\n</ul>',
       );
     });
   });

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -405,6 +405,15 @@ describe(__filename, () => {
     it('handles null text', () => {
       expect(nl2br(null)).toEqual('');
     });
+
+    it('returns valid HTML', () => {
+      const htmlValue =
+        '<ul>\n\n\n<li>ul\nli<strong>foo\nbar</strong>\n</li>\r\n</ul>';
+
+      expect(nl2br(htmlValue)).toEqual(
+        '<ul>\n\n\n<li>ul<br />li<strong>foo<br />bar</strong>\n</li>\r\n</ul>',
+      );
+    });
   });
 
   describe('isAllowedOrigin', () => {

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -412,12 +412,25 @@ describe(__filename, () => {
       );
     });
 
-    it('returns valid HTML', () => {
-      const htmlValue =
-        '<ul>\n<li>ul\nli<strong>foo\nbar</strong>\n</li>\n</ul>';
+    it('preserves line breaks between tags', () => {
+      const htmlValue = '<ul>\n<li><strong></strong>\n</li>\n</ul>';
 
       expect(nl2br(htmlValue)).toEqual(
-        '<ul>\n<li>ul<br />li<strong>foo<br />bar</strong>\n</li>\n</ul>',
+        '<ul>\n<li><strong></strong>\n</li>\n</ul>',
+      );
+    });
+
+    it('converts line breaks in tag content', () => {
+      const htmlValue = '<strong>foo\nbar</strong>';
+
+      expect(nl2br(htmlValue)).toEqual('<strong>foo<br />bar</strong>');
+    });
+
+    it('returns valid HTML', () => {
+      const htmlValue = 'ul\nli<strong>foo\nbar</strong>';
+
+      expect(nl2br(htmlValue)).toEqual(
+        'ul<br />li<strong>foo<br />bar</strong>',
       );
     });
   });


### PR DESCRIPTION
Fix #5473

---

This PR removes `<br />` occurences between HTML tags.