### PR TITLE
I5417 static theme badge

### DIFF
--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -2,7 +2,11 @@
 import * as React from 'react';
 import { compose } from 'redux';
 
-import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_STATIC_THEME,
+  ADDON_TYPE_THEME,
+} from 'core/constants';
 import translate from 'core/i18n/translate';
 import { isQuantumCompatible } from 'core/utils/compatibility';
 import Badge from 'ui/components/Badge';
@@ -27,6 +31,7 @@ export const AddonBadgesBase = (props: Props) => {
     switch (addonType) {
       case ADDON_TYPE_EXTENSION:
         return i18n.gettext('Featured Extension');
+      case ADDON_TYPE_STATIC_THEME:
       case ADDON_TYPE_THEME:
         return i18n.gettext('Featured Theme');
       default:

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -8,6 +8,11 @@
   @include respond-to(large) {
     grid-column: 2;
     grid-row: 1;
+
+    .Addon-theme & {
+      grid-column: auto;
+      grid-row: auto;
+    }
   }
 }
 
@@ -17,5 +22,15 @@
   @include respond-to(large) {
     @include margin-start(12px);
     @include text-align-end();
+
+    .Addon-theme & {
+      margin: 0;
+    }
+
+    .Icon {
+      .Addon-theme & {
+        margin: 0;
+      }
+    }
   }
 }

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -24,7 +24,7 @@
     @include text-align-end();
 
     .Addon-theme & {
-      margin: 0;
+      @include margin-start(0);
     }
 
     .Icon {

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -15,7 +15,7 @@
 
     .Addon-theme & {
       flex-direction: row;
-      margin: 0;
+      margin-left: 0;
     }
   }
 

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -12,6 +12,11 @@
     display: flex;
     flex-direction: row-reverse;
     margin: 0 0 12px;
+
+    .Addon-theme & {
+      flex-direction: row;
+      margin: 0;
+    }
   }
 
   .Icon {

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -15,7 +15,6 @@
 
     .Addon-theme & {
       flex-direction: row;
-      margin-left: 0;
     }
   }
 

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -4,6 +4,7 @@ import AddonBadges, { AddonBadgesBase } from 'amo/components/AddonBadges';
 import {
   ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
   CLIENT_APP_FIREFOX,
 } from 'core/constants';
@@ -54,6 +55,18 @@ describe(__filename, () => {
       ...fakeAddon,
       is_featured: true,
       type: ADDON_TYPE_THEME,
+    });
+    const root = shallowRender({ addon });
+
+    expect(root.find(Badge)).toHaveProp('type', 'featured');
+    expect(root.find(Badge)).toHaveProp('label', 'Featured Theme');
+  });
+
+  it('adds a different badge label when a "static theme" addon is featured', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_featured: true,
+      type: ADDON_TYPE_STATIC_THEME,
     });
     const root = shallowRender({ addon });
 


### PR DESCRIPTION
fixes #5417 

## BEFORE:
![Alt text](https://monosnap.com/image/MurxJJpz4cl29AyXVkjpRdCk1GxMeJ.png)

## AFTER:
![Alt text](https://monosnap.com/image/vuxpoAUlofR8UxSAl0QqrNSiDtEMbZ.png)

this PR addresses the text (from `Featured Add-on` -> to `Featured Theme`) and addresses styles noted in the issue...

Regarding the style updates, do you prefer to override these in 1 place or is how I have it here okay?