### PR TITLE
Introduce a `AppState` type for redux

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,8 @@
     "document": true,
     "webpackIsomorphicTools": true,
     "ga": true,
+    // https://flow.org/en/docs/types/utilities/#toc-objmap
+    "$ObjMap": true,
     // https://flow.org/en/docs/types/utilities/#toc-propertytype
     "$PropertyType": true,
     // These are undocumented utilities that ship with Flow

--- a/src/amo/actions/viewContext.js
+++ b/src/amo/actions/viewContext.js
@@ -1,9 +1,9 @@
 /* @flow */
-import type { ViewContextType } from 'amo/reducers/viewContext';
+import type { ViewContextState } from 'amo/reducers/viewContext';
 import { SET_VIEW_CONTEXT } from 'core/constants';
 
 export function setViewContext(
-  context: $PropertyType<ViewContextType, 'context'>,
+  context: $PropertyType<ViewContextState, 'context'>,
 ) {
   if (!context) {
     throw new Error('context parameter is required');

--- a/src/amo/api/collections.js
+++ b/src/amo/api/collections.js
@@ -7,11 +7,11 @@ import type {
   ExternalCollectionAddon,
   ExternalCollectionDetail,
 } from 'amo/reducers/collections';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 import type { LocalizedString, PaginatedApiResponse } from 'core/types/api';
 
 export type GetCollectionParams = {|
-  api: ApiStateType,
+  api: ApiState,
   slug: string,
   username: string,
 |};
@@ -94,7 +94,7 @@ export const getAllCollectionAddons = async ({
 };
 
 type ListCollectionsParams = {|
-  api: ApiStateType,
+  api: ApiState,
   nextURL?: string,
   username: string,
 |};
@@ -133,7 +133,7 @@ export const getAllUserCollections = async ({
 };
 
 type ModifyCollectionParams = {|
-  api: ApiStateType,
+  api: ApiState,
   defaultLocale: ?string,
   description: ?LocalizedString,
   // Even though the API accepts string|number, we need to always use
@@ -267,7 +267,7 @@ export const createCollection = ({
 
 type ModifyCollectionAddonBaseParams = {|
   addonId: number,
-  api: ApiStateType,
+  api: ApiState,
   slug: string,
   username: string,
   _modifyCollectionAddon?: (any) => Promise<void>,
@@ -354,7 +354,7 @@ export const updateCollectionAddon = ({
 
 export type RemoveAddonFromCollectionParams = {|
   addonId: number,
-  api: ApiStateType,
+  api: ApiState,
   slug: string,
   username: string,
 |};
@@ -379,7 +379,7 @@ export const removeAddonFromCollection = ({
 };
 
 export type DeleteCollectionParams = {|
-  api: ApiStateType,
+  api: ApiState,
   slug: string,
   username: string,
 |};

--- a/src/amo/api/recommendations.js
+++ b/src/amo/api/recommendations.js
@@ -2,12 +2,12 @@
 import invariant from 'invariant';
 
 import { callApi } from 'core/api';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 import type { PaginatedApiResponse } from 'core/types/api';
 import type { ExternalAddonType } from 'core/types/addons';
 
 export type GetRecommendationsParams = {|
-  api: ApiStateType,
+  api: ApiState,
   guid: string,
   recommended: boolean,
 |};

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -4,7 +4,7 @@ import { oneLine } from 'common-tags';
 import { REVIEW_FLAG_REASON_OTHER } from 'amo/constants';
 import { callApi } from 'core/api';
 import type { FlagReviewReasonType } from 'amo/constants';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { PaginatedApiResponse } from 'core/types/api';
 
@@ -43,7 +43,7 @@ export type ExternalReviewType = {|
 // can type check each one independently.
 export type SubmitReviewParams = {|
   addonId?: number,
-  apiState?: ApiStateType,
+  apiState?: ApiState,
   body?: string,
   errorHandler?: ErrorHandlerType,
   rating?: number | null,
@@ -102,7 +102,7 @@ export function submitReview({
 }
 
 type ReplyToReviewParams = {|
-  apiState?: ApiStateType,
+  apiState?: ApiState,
   body: string,
   errorHandler?: ErrorHandlerType,
   originalReviewId: number,
@@ -138,7 +138,7 @@ export const replyToReview = ({
 export type GetReviewsParams = {|
   // This is the addon ID, slug, or guid.
   addon?: number | string,
-  apiState?: ApiStateType,
+  apiState?: ApiState,
   filter?: string,
   page?: number,
   page_size?: number,
@@ -172,7 +172,7 @@ export function getReviews({
 
 export type GetLatestReviewParams = {|
   addon: number,
-  apiState?: ApiStateType,
+  apiState?: ApiState,
   user: number,
   version: number,
 |};
@@ -203,7 +203,7 @@ export function getLatestUserReview({
 }
 
 type FlagReviewParams = {|
-  apiState?: ApiStateType,
+  apiState?: ApiState,
   errorHandler?: ErrorHandlerType,
   note?: string,
   reason: FlagReviewReasonType,

--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -9,12 +9,12 @@ import type {
   ExternalUserType,
   NotificationsType,
 } from 'amo/reducers/users';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 
 export function currentUserAccount({
   api,
 }: {|
-  api: ApiStateType,
+  api: ApiState,
 |}): Promise<ExternalUserType> {
   invariant(api, 'api state is required.');
 
@@ -31,7 +31,7 @@ export function updateUserAccount({
   userId,
   ...editableFields
 }: {|
-  api: ApiStateType,
+  api: ApiState,
   editableFields: UserEditableFieldsType,
   picture?: File | null,
   userId: UserId,
@@ -65,7 +65,7 @@ export function updateUserAccount({
 }
 
 type UserApiParams = {|
-  api: ApiStateType,
+  api: ApiState,
   username: string,
 |};
 
@@ -102,7 +102,7 @@ export function updateUserNotifications({
   notifications,
   userId,
 }: {|
-  api: ApiStateType,
+  api: ApiState,
   notifications: NotificationsUpdateType,
   userId: UserId,
 |}): Promise<NotificationsType> {
@@ -123,7 +123,7 @@ export function deleteUserPicture({
   api,
   userId,
 }: {|
-  api: ApiStateType,
+  api: ApiState,
   userId: UserId,
 |}): Promise<ExternalUserType> {
   invariant(api, 'api state is required.');
@@ -141,7 +141,7 @@ export function deleteUserAccount({
   api,
   userId,
 }: {|
-  api: ApiStateType,
+  api: ApiState,
   userId: UserId,
 |}): Promise<UserId> {
   invariant(api, 'api state is required.');

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -21,11 +21,8 @@ import type { AddonType } from 'core/types/addons';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
-import type {
-  CollectionsState,
-  CollectionType,
-} from 'amo/reducers/collections';
-import type { UsersStateType } from 'amo/reducers/users';
+import type { CollectionType } from 'amo/reducers/collections';
+import type { AppState } from 'amo/store';
 import type { ElementEvent } from 'core/types/dom';
 
 import './styles.scss';
@@ -278,10 +275,7 @@ export class AddAddonToCollectionBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (
-  state: {| collections: CollectionsState, users: UsersStateType |},
-  ownProps: Props,
-) => {
+export const mapStateToProps = (state: AppState, ownProps: Props) => {
   const { collections, users } = state;
   const currentUser = getCurrentUser(users);
   const currentUsername = currentUser && currentUser.username;

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -17,7 +17,7 @@ import Card from 'ui/components/Card';
 import DefinitionList, { Definition } from 'ui/components/DefinitionList';
 import LoadingText from 'ui/components/LoadingText';
 import type { I18nType } from 'core/types/i18n';
-import type { UsersStateType } from 'amo/reducers/users';
+import type { AppState } from 'amo/store';
 
 type Props = {|
   addon: AddonType | null,
@@ -254,7 +254,7 @@ export class AddonMoreInfoBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (state: {| users: UsersStateType |}) => {
+export const mapStateToProps = (state: AppState) => {
   return {
     userId: state.users.currentUserID,
     hasStatsPermission: hasPermission(state, STATS_VIEW),

--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -16,10 +16,8 @@ import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import defaultTracking from 'core/tracking';
 import LoadingText from 'ui/components/LoadingText';
-import type {
-  Recommendations,
-  RecommendationsState,
-} from 'amo/reducers/recommendations';
+import type { Recommendations } from 'amo/reducers/recommendations';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
 import type { AddonType } from 'core/types/addons';
@@ -151,10 +149,7 @@ export class AddonRecommendationsBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (
-  state: {| recommendations: RecommendationsState |},
-  ownProps: Props,
-) => {
+const mapStateToProps = (state: AppState, ownProps: Props) => {
   const { addon } = ownProps;
   const recommendations = addon
     ? getRecommendationsByGuid({

--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -20,7 +20,8 @@ import OverlayCard from 'ui/components/OverlayCard';
 import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { SubmitReviewParams } from 'amo/api/reviews';
-import type { ApiStateType } from 'core/reducers/api';
+import type { AppState } from 'amo/store';
+import type { ApiState } from 'core/reducers/api';
 import type { ErrorHandler as ErrorHandlerType } from 'core/errorHandler';
 import type { ElementEvent } from 'core/types/dom';
 import type { DispatchFunc } from 'core/types/redux';
@@ -32,7 +33,7 @@ type SetDenormalizedReviewFunction = (review: $Shape<UserReviewType>) => void;
 
 type RefreshAddonFunction = (params: {|
   addonSlug: string,
-  apiState: ApiStateType,
+  apiState: ApiState,
 |}) => Promise<void>;
 
 type UpdateReviewTextFunction = (
@@ -54,7 +55,7 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
-  apiState: ApiStateType,
+  apiState: ApiState,
   createLocalState: typeof defaultLocalStateCreator,
   debounce: typeof defaultDebounce,
   errorHandler: ErrorHandlerType,
@@ -266,7 +267,7 @@ export class AddonReviewBase extends React.Component<InternalProps, State> {
   }
 }
 
-export const mapStateToProps = (state: {| api: ApiStateType |}) => ({
+export const mapStateToProps = (state: AppState) => ({
   apiState: state.api,
 });
 

--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -24,12 +24,9 @@ import NotFound from 'amo/components/ErrorPage/NotFound';
 import Card from 'ui/components/Card';
 import CardList from 'ui/components/CardList';
 import LoadingText from 'ui/components/LoadingText';
-import type { ErrorHandlerType } from 'core/errorHandler';
+import type { AppState } from 'amo/store';
 import type { UserReviewType } from 'amo/actions/reviews';
-import type { ReviewState } from 'amo/reducers/reviews';
-import type { AddonState } from 'core/reducers/addons';
-import type { ApiStateType } from 'core/reducers/api';
-import type { UsersStateType } from 'amo/reducers/users';
+import type { ErrorHandlerType } from 'core/errorHandler';
 import type { AddonType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocation, ReactRouterType } from 'core/types/router';
@@ -308,13 +305,6 @@ export class AddonReviewListBase extends React.Component<Props> {
     );
   }
 }
-
-type AppState = {|
-  addons: AddonState,
-  api: ApiStateType,
-  users: UsersStateType,
-  reviews: ReviewState,
-|};
 
 export function mapStateToProps(state: AppState, ownProps: Props) {
   if (!ownProps || !ownProps.params || !ownProps.params.addonSlug) {

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -23,9 +23,9 @@ import LoadingText from 'ui/components/LoadingText';
 import UserRating from 'ui/components/UserRating';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import type { UserReviewType } from 'amo/actions/reviews';
-import type { ReviewState } from 'amo/reducers/reviews';
+import type { UserType } from 'amo/reducers/users';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
-import type { UsersStateType, UserType } from 'amo/reducers/users';
 import type { AddonType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
 import type { OnSubmitParams } from 'ui/components/DismissibleTextForm';
@@ -293,10 +293,7 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
   }
 }
 
-export function mapStateToProps(
-  state: {| users: UsersStateType, reviews: ReviewState |},
-  ownProps: Props,
-) {
+export function mapStateToProps(state: AppState, ownProps: Props) {
   let editingReview = false;
   let replyingToReview = false;
   let submittingReply = false;

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -28,10 +28,8 @@ import {
 } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
-import type {
-  AddonsByAuthorsState,
-  FetchAddonsByAuthorsParams,
-} from 'amo/reducers/addonsByAuthors';
+import type { FetchAddonsByAuthorsParams } from 'amo/reducers/addonsByAuthors';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
@@ -354,10 +352,7 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (
-  state: {| addonsByAuthors: AddonsByAuthorsState |},
-  ownProps: Props,
-) => {
+export const mapStateToProps = (state: AppState, ownProps: Props) => {
   const { addonType, authorUsernames, forAddonSlug, numberOfAddons } = ownProps;
 
   let addons = getAddonsForUsernames(

--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -14,7 +14,6 @@ import { getDjangoBase62, getErrorComponent } from 'amo/utils';
 import Footer from 'amo/components/Footer';
 import Header from 'amo/components/Header';
 import { logOutUser as logOutUserAction } from 'amo/reducers/users';
-import type { ViewContextType } from 'amo/reducers/viewContext';
 import { addChangeListeners } from 'core/addonManager';
 import { setUserAgent as setUserAgentAction } from 'core/actions';
 import { setInstallState } from 'core/actions/installations';
@@ -27,7 +26,7 @@ import DefaultErrorPage from 'core/components/ErrorPage';
 import InfoDialog from 'core/containers/InfoDialog';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
-import type { ApiStateType } from 'core/reducers/api';
+import type { AppState } from 'amo/store';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocation } from 'core/types/router';
 import type { InstalledAddon } from 'core/reducers/installations';
@@ -243,10 +242,7 @@ export class AppBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (state: {
-  api: ApiStateType,
-  viewContext: ViewContextType,
-}) => ({
+export const mapStateToProps = (state: AppState) => ({
   authToken: state.api && state.api.token,
   clientApp: state.api.clientApp,
   isHomePage: state.viewContext.context === VIEW_CONTEXT_HOME,

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -23,7 +23,8 @@ import {
   autocompleteStart,
 } from 'core/reducers/autocomplete';
 import Icon from 'ui/components/Icon';
-import type { ApiStateType, UserAgentInfoType } from 'core/reducers/api';
+import type { AppState } from 'amo/store';
+import type { UserAgentInfoType } from 'core/reducers/api';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocation } from 'core/types/router';
@@ -360,13 +361,7 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
   }
 }
 
-// TODO: port reducers/autocomplete.js to Flow
-type AutocompleteState = Object;
-
-const mapStateToProps = (state: {|
-  api: ApiStateType,
-  autocomplete: AutocompleteState,
-|}): MappedProps => {
+const mapStateToProps = (state: AppState): MappedProps => {
   return {
     suggestions: state.autocomplete.suggestions,
     loadingSuggestions: state.autocomplete.loading,

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -8,14 +8,14 @@ import { compose } from 'redux';
 import { setViewContext } from 'amo/actions/viewContext';
 import { categoriesFetch } from 'core/actions/categories';
 import { withErrorHandler } from 'core/errorHandler';
-import type { ErrorHandlerType } from 'core/errorHandler';
-import type { ApiStateType } from 'core/reducers/api';
 import translate from 'core/i18n/translate';
-import type { DispatchFunc } from 'core/types/redux';
 import { getCategoryColor, visibleAddonType } from 'core/utils';
 import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
+import type { AppState } from 'amo/store';
+import type { ErrorHandlerType } from 'core/errorHandler';
+import type { DispatchFunc } from 'core/types/redux';
 import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
@@ -161,10 +161,7 @@ export class CategoriesBase extends React.Component<InternalProps> {
   }
 }
 
-export function mapStateToProps(state: {|
-  api: ApiStateType,
-  categories: CategoriesStateType,
-|}) {
+export function mapStateToProps(state: AppState) {
   return {
     categoriesState: state.categories.categories,
     clientApp: state.api.clientApp,

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -49,12 +49,10 @@ import MetadataCard from 'ui/components/MetadataCard';
 import Select from 'ui/components/Select';
 import type {
   CollectionFilters,
-  CollectionsState,
   CollectionType,
 } from 'amo/reducers/collections';
-import type { UsersStateType } from 'amo/reducers/users';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
-import type { ApiStateType } from 'core/reducers/api';
 import type { CollectionAddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
@@ -574,14 +572,7 @@ export class CollectionBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (
-  state: {|
-    api: ApiStateType,
-    collections: CollectionsState,
-    users: UsersStateType,
-  |},
-  ownProps: InternalProps,
-) => {
+export const mapStateToProps = (state: AppState, ownProps: InternalProps) => {
   const { loading } = state.collections.current;
   const { creating, location } = ownProps;
 

--- a/src/amo/components/CollectionList/index.js
+++ b/src/amo/components/CollectionList/index.js
@@ -15,11 +15,8 @@ import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
 import CardList from 'ui/components/CardList';
 import UserCollection from 'ui/components/UserCollection';
-import type {
-  CollectionsState,
-  CollectionType,
-} from 'amo/reducers/collections';
-import type { UsersStateType } from 'amo/reducers/users';
+import type { CollectionType } from 'amo/reducers/collections';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
@@ -146,10 +143,7 @@ export class CollectionListBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (state: {|
-  collections: CollectionsState,
-  users: UsersStateType,
-|}) => {
+export const mapStateToProps = (state: AppState) => {
   const { collections, users } = state;
 
   const currentUser = getCurrentUser(users);

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -30,11 +30,9 @@ import type {
 } from 'amo/components/AutoSearchInput';
 import type {
   CollectionFilters,
-  CollectionsState,
   CollectionType,
 } from 'amo/reducers/collections';
-import type { UsersStateType } from 'amo/reducers/users';
-import type { ApiStateType } from 'core/reducers/api';
+import type { AppState } from 'amo/store';
 import type { I18nType } from 'core/types/i18n';
 import type { ElementEvent } from 'core/types/dom';
 import type { ErrorHandlerType } from 'core/errorHandler';
@@ -454,12 +452,9 @@ export const extractId = (ownProps: Props) => {
   return `collection-${collection ? collection.slug : ''}`;
 };
 
-export const mapStateToProps = (state: {|
-  api: ApiStateType,
-  collections: CollectionsState,
-  users: UsersStateType,
-|}) => {
+export const mapStateToProps = (state: AppState) => {
   const currentUser = getCurrentUser(state.users);
+
   return {
     hasAddonBeenAdded: state.collections.hasAddonBeenAdded,
     clientApp: state.api.clientApp,

--- a/src/amo/components/DownloadFirefoxButton/index.js
+++ b/src/amo/components/DownloadFirefoxButton/index.js
@@ -6,8 +6,9 @@ import { compose } from 'redux';
 
 import { makeQueryStringWithUTM } from 'amo/utils';
 import translate from 'core/i18n/translate';
-import type { ApiStateType, UserAgentInfoType } from 'core/reducers/api';
 import Button from 'ui/components/Button';
+import type { AppState } from 'amo/store';
+import type { UserAgentInfoType } from 'core/reducers/api';
 import type { I18nType } from 'core/types/i18n';
 
 type Props = {|
@@ -41,11 +42,7 @@ export const DownloadFirefoxButtonBase = ({
   );
 };
 
-type StateType = {|
-  api: ApiStateType,
-|};
-
-export function mapStateToProps(state: StateType) {
+export function mapStateToProps(state: AppState) {
   return {
     userAgentInfo: state.api.userAgentInfo,
   };

--- a/src/amo/components/FlagReview/index.js
+++ b/src/amo/components/FlagReview/index.js
@@ -6,9 +6,10 @@ import { compose } from 'redux';
 import { flagReview } from 'amo/actions/reviews';
 import { withErrorHandler } from 'core/errorHandler';
 import LoadingText from 'ui/components/LoadingText';
+import type { AppState } from 'amo/store';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { FlagReviewReasonType } from 'amo/constants';
-import type { FlagState, ReviewState } from 'amo/reducers/reviews';
+import type { FlagState } from 'amo/reducers/reviews';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { DispatchFunc } from 'core/types/redux';
 
@@ -70,17 +71,16 @@ export class FlagReviewBase extends React.Component<InternalProps> {
   }
 }
 
-const mapStateToProps = (
-  state: {| reviews: ReviewState |},
-  ownProps: Props,
-) => {
+const mapStateToProps = (state: AppState, ownProps: Props) => {
   let flagState = {};
+
   if (ownProps.review) {
     const view = state.reviews.view[ownProps.review.id];
     if (view && view.flag && view.flag.reason === ownProps.reason) {
       flagState = view.flag;
     }
   }
+
   return {
     flagState,
   };

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -14,9 +14,9 @@ import { getCurrentUser } from 'amo/reducers/users';
 import translate from 'core/i18n/translate';
 import ListItem from 'ui/components/ListItem';
 import TooltipMenu from 'ui/components/TooltipMenu';
-import type { ReviewState } from 'amo/reducers/reviews';
+import type { AppState } from 'amo/store';
 import type { I18nType } from 'core/types/i18n';
-import type { UsersStateType, UserType } from 'amo/reducers/users';
+import type { UserType } from 'amo/reducers/users';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { ReactRouterLocation } from 'core/types/router';
 
@@ -132,17 +132,16 @@ export class FlagReviewMenuBase extends React.Component<InternalProps> {
   }
 }
 
-const mapStateToProps = (
-  state: {| users: UsersStateType, reviews: ReviewState |},
-  ownProps: Props,
-) => {
+const mapStateToProps = (state: AppState, ownProps: Props) => {
   let wasFlagged = false;
+
   if (ownProps.review) {
     const view = state.reviews.view[ownProps.review.id];
     if (view && view.flag && view.flag.wasFlagged) {
       wasFlagged = true;
     }
   }
+
   return {
     wasFlagged,
     siteUser: getCurrentUser(state.users),

--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -23,9 +23,8 @@ import {
 } from 'core/reducers/languageTools';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
-import type { ApiStateType } from 'core/reducers/api';
-import type { LanguageToolsState } from 'core/reducers/languageTools';
 import type { LanguageToolType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
 import type { I18nType } from 'core/types/i18n';
@@ -255,10 +254,7 @@ export class LanguageToolsBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (state: {|
-  languageTools: LanguageToolsState,
-  api: ApiStateType,
-|}) => {
+export const mapStateToProps = (state: AppState) => {
   return {
     languageTools: getAllLanguageTools(state),
     lang: state.api.lang,

--- a/src/amo/components/PermissionsCard/index.js
+++ b/src/amo/components/PermissionsCard/index.js
@@ -4,11 +4,12 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';
-import type { AddonType } from 'core/types/addons';
-import type { ApiStateType, UserAgentInfoType } from 'core/reducers/api';
-import type { I18nType } from 'core/types/i18n';
 import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
+import type { AppState } from 'amo/store';
+import type { AddonType } from 'core/types/addons';
+import type { UserAgentInfoType } from 'core/reducers/api';
+import type { I18nType } from 'core/types/i18n';
 
 import { PermissionUtils } from './permissions';
 
@@ -65,7 +66,7 @@ export class PermissionsCardBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (state: {| api: ApiStateType |}) => {
+export const mapStateToProps = (state: AppState) => {
   return {
     userAgentInfo: state.api.userAgentInfo,
   };

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -24,16 +24,15 @@ import {
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import DefaultUserRating from 'ui/components/UserRating';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type {
   GetLatestReviewParams,
   SubmitReviewParams,
 } from 'amo/api/reviews';
-import type { ReviewState } from 'amo/reducers/reviews';
-import type { ApiStateType } from 'core/reducers/api';
-import type { UsersStateType } from 'amo/reducers/users';
 import type { DispatchFunc } from 'core/types/redux';
+import type { ApiState } from 'core/reducers/api';
 import type { AddonType, AddonVersionType } from 'core/types/addons';
 import type { ReactRouterLocation } from 'core/types/router';
 import type { I18nType } from 'core/types/i18n';
@@ -42,7 +41,7 @@ import './styles.scss';
 
 type LoadSavedReviewFunc = ({|
   addonId: $PropertyType<GetLatestReviewParams, 'addon'>,
-  apiState: ApiStateType,
+  apiState: ApiState,
   userId: $PropertyType<GetLatestReviewParams, 'user'>,
   versionId: $PropertyType<GetLatestReviewParams, 'version'>,
 |}) => Promise<any>;
@@ -68,7 +67,7 @@ type InternalProps = {|
   AuthenticateButton: typeof DefaultAuthenticateButton,
   UserRating: typeof DefaultUserRating,
   ReportAbuseButton: typeof DefaultReportAbuseButton,
-  apiState: ApiStateType,
+  apiState: ApiState,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   userId: number,
@@ -243,10 +242,7 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
   }
 }
 
-export const mapStateToProps = (
-  state: {| api: ApiStateType, reviews: ReviewState, users: UsersStateType |},
-  ownProps: Props,
-) => {
+export const mapStateToProps = (state: AppState, ownProps: Props) => {
   const userId = state.users.currentUserID;
   let userReview;
 

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -19,7 +19,8 @@ import {
 } from 'core/reducers/abuse';
 import { sanitizeHTML } from 'core/utils';
 import Button from 'ui/components/Button';
-import type { AddonAbuseState, AbuseState } from 'core/reducers/abuse';
+import type { AppState } from 'amo/store';
+import type { AddonAbuseState } from 'core/reducers/abuse';
 import type { DispatchFunc } from 'core/types/redux';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
@@ -230,10 +231,7 @@ export class ReportAbuseButtonBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (
-  state: {| abuse: AbuseState |},
-  ownProps: Props,
-) => {
+export const mapStateToProps = (state: AppState, ownProps: Props) => {
   const { addon } = ownProps;
 
   return {

--- a/src/amo/components/ReportUserAbuse/index.js
+++ b/src/amo/components/ReportUserAbuse/index.js
@@ -14,7 +14,7 @@ import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
 import Button from 'ui/components/Button';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
-import type { UserAbuseReportsState } from 'amo/reducers/userAbuseReports';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { DispatchFunc } from 'core/types/redux';
 import type { I18nType } from 'core/types/i18n';
@@ -173,10 +173,7 @@ export class ReportUserAbuseBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (
-  state: {| userAbuseReports: UserAbuseReportsState |},
-  ownProps: Props,
-) => {
+export const mapStateToProps = (state: AppState, ownProps: Props) => {
   const abuseReport =
     ownProps.user && state.userAbuseReports.byUserId[ownProps.user.id]
       ? state.userAbuseReports.byUserId[ownProps.user.id]

--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -28,9 +28,9 @@ import {
   convertFiltersToQueryParams,
   hasSearchFilters,
 } from 'core/searchUtils';
-import type { ViewContextType } from 'amo/reducers/viewContext';
+import type { AppState } from 'amo/store';
 import type { ErrorHandler as ErrorHandlerType } from 'core/errorHandler';
-import type { SearchType, FiltersType } from 'core/reducers/search';
+import type { FiltersType } from 'core/reducers/search';
 import type { AddonType, CollectionAddonType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
 import type { I18nType } from 'core/types/i18n';
@@ -252,10 +252,7 @@ export class SearchBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (state: {|
-  search: SearchType,
-  viewContext: ViewContextType,
-|}) => {
+export const mapStateToProps = (state: AppState) => {
   return {
     context: state.viewContext.context,
     count: state.search.count,

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -12,7 +12,7 @@ import type {
   SearchFilters,
   SuggestionType,
 } from 'amo/components/AutoSearchInput';
-import type { ApiStateType } from 'core/reducers/api';
+import type { AppState } from 'amo/store';
 import type { I18nType } from 'core/types/i18n';
 import type { ReactRouterType } from 'core/types/router';
 
@@ -67,7 +67,7 @@ export class SearchFormBase extends React.Component<Props> {
   }
 }
 
-export function mapStateToProps(state: {| api: ApiStateType |}): $Shape<Props> {
+export function mapStateToProps(state: AppState): $Shape<Props> {
   const { api } = state;
 
   return { apiLang: api.lang, clientApp: api.clientApp };

--- a/src/amo/components/SearchPage/index.js
+++ b/src/amo/components/SearchPage/index.js
@@ -18,6 +18,7 @@ import {
   convertFiltersToQueryParams,
   convertQueryParamsToFilters,
 } from 'core/searchUtils';
+import type { AppState } from 'amo/store';
 import type { FiltersType } from 'core/reducers/search';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocation } from 'core/types/router';
@@ -110,7 +111,7 @@ export class SearchPageBase extends React.Component<InternalProps> {
   }
 }
 
-export function mapStateToProps(state: any, ownProps: InternalProps) {
+export function mapStateToProps(state: AppState, ownProps: InternalProps) {
   const { location } = ownProps;
 
   const filtersFromLocation = convertQueryParamsToFilters(location.query);

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -20,8 +20,8 @@ import translate from 'core/i18n/translate';
 import { visibleAddonType } from 'core/utils';
 import DropdownMenu from 'ui/components/DropdownMenu';
 import DropdownMenuItem from 'ui/components/DropdownMenuItem';
+import type { AppState } from 'amo/store';
 import type { ViewContextType } from 'amo/reducers/viewContext';
-import type { ApiStateType } from 'core/reducers/api';
 import type { DispatchFunc } from 'core/types/redux';
 import type { I18nType } from 'core/types/i18n';
 
@@ -160,10 +160,7 @@ export class SectionLinksBase extends React.Component<Props> {
   }
 }
 
-export function mapStateToProps(state: {
-  api: ApiStateType,
-  viewContext: ViewContextType,
-}) {
+export function mapStateToProps(state: AppState) {
   return {
     clientApp: state.api.clientApp,
     viewContext: state.viewContext.context,

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -46,9 +46,9 @@ import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
 import UserAvatar from 'ui/components/UserAvatar';
 import UserRating from 'ui/components/UserRating';
+import type { AppState } from 'amo/store';
 import type { UserReviewType } from 'amo/actions/reviews';
-import type { ReviewState } from 'amo/reducers/reviews';
-import type { UsersStateType, UserType } from 'amo/reducers/users';
+import type { UserType } from 'amo/reducers/users';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocation } from 'core/types/router';
 import type { ErrorHandlerType } from 'core/errorHandler';
@@ -429,10 +429,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
   }
 }
 
-export function mapStateToProps(
-  state: {| reviews: ReviewState, users: UsersStateType |},
-  ownProps: Props,
-) {
+export function mapStateToProps(state: AppState, ownProps: Props) {
   const currentUser = getCurrentUser(state.users);
   const user = getUserByUsername(state.users, ownProps.params.username);
   const isOwner = currentUser && user && currentUser.id === user.id;

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -34,12 +34,8 @@ import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
 import Notice from 'ui/components/Notice';
 import OverlayCard from 'ui/components/OverlayCard';
-import type {
-  NotificationsUpdateType,
-  UsersStateType,
-  UserType,
-} from 'amo/reducers/users';
-import type { ApiStateType } from 'core/reducers/api';
+import type { NotificationsUpdateType, UserType } from 'amo/reducers/users';
+import type { AppState } from 'amo/store';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
@@ -843,13 +839,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
   }
 }
 
-export function mapStateToProps(
-  state: {
-    api: ApiStateType,
-    users: UsersStateType,
-  },
-  ownProps: Props,
-) {
+export function mapStateToProps(state: AppState, ownProps: Props) {
   const { clientApp, lang } = state.api;
 
   const currentUser = getCurrentUser(state.users);

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -138,42 +138,40 @@ export const joinAuthorNamesAndAddonType = (
 };
 
 export const getLoadingForAuthorNames = (
-  state: AddonsByAuthorsState,
+  addonsByAuthorsState: AddonsByAuthorsState,
   authorUsernames: Array<string>,
   addonType?: string,
 ): boolean | null => {
   return (
-    state.loadingFor[joinAuthorNamesAndAddonType(authorUsernames, addonType)] ||
-    null
+    addonsByAuthorsState.loadingFor[
+      joinAuthorNamesAndAddonType(authorUsernames, addonType)
+    ] || null
   );
 };
 
 export const getCountForAuthorNames = (
-  state: AddonsByAuthorsState,
+  addonsByAuthorsState: AddonsByAuthorsState,
   authorUsernames: Array<string>,
   addonType?: string,
 ) => {
   return (
-    state.countFor[joinAuthorNamesAndAddonType(authorUsernames, addonType)] ||
-    null
+    addonsByAuthorsState.countFor[
+      joinAuthorNamesAndAddonType(authorUsernames, addonType)
+    ] || null
   );
 };
 
 export const getAddonsForSlug = (
-  state: AddonsByAuthorsState,
+  addonsByAuthorsState: AddonsByAuthorsState,
   slug: string,
 ): Array<SearchResultAddonType> | null => {
-  const ids = state.byAddonSlug[slug];
+  const ids = addonsByAuthorsState.byAddonSlug[slug];
 
-  return ids
-    ? ids.map((id) => {
-        return state.byAddonId[id];
-      })
-    : null;
+  return ids ? ids.map((id) => addonsByAuthorsState.byAddonId[id]) : null;
 };
 
 export const getAddonsForUsernames = (
-  state: AddonsByAuthorsState,
+  addonsByAuthorsState: AddonsByAuthorsState,
   usernames: Array<string>,
   addonType?: string,
   excludeSlug?: string,
@@ -182,7 +180,7 @@ export const getAddonsForUsernames = (
 
   const ids = usernames
     .map((username) => {
-      return state.byUsername[username];
+      return addonsByAuthorsState.byUsername[username];
     })
     .reduce((array, addonIds) => {
       if (addonIds) {
@@ -199,7 +197,7 @@ export const getAddonsForUsernames = (
   return ids.length
     ? ids
         .map((id) => {
-          return state.byAddonId[id];
+          return addonsByAuthorsState.byAddonId[id];
         })
         .filter((addon) => {
           const addonTypeFilter = getAddonTypeFilter(addonType);

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -801,16 +801,19 @@ export const getCollectionById = ({
 };
 
 export const getCurrentCollection = (
-  state: CollectionsState,
+  collectionsState: CollectionsState,
 ): CollectionType | null => {
-  if (!state) {
-    throw new Error('The state parameter is required');
+  if (!collectionsState) {
+    throw new Error('The collectionsState parameter is required');
   }
-  if (!state.current.id) {
+  if (!collectionsState.current.id) {
     return null;
   }
 
-  return getCollectionById({ id: state.current.id, state });
+  return getCollectionById({
+    id: collectionsState.current.id,
+    state: collectionsState,
+  });
 };
 
 type CreateInternalCollectionParams = {|

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -167,7 +167,7 @@ export const changeViewState = ({
   state,
   reviewId,
   stateChange,
-}: ChangeViewStateParams = {}): $Shape<ReviewsState> => {
+}: ChangeViewStateParams = {}): ReviewsState => {
   const change = { ...stateChange };
 
   const existingFlag = state.view[reviewId] ? state.view[reviewId].flag : {};

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -68,7 +68,7 @@ type ViewStateByReviewId = {|
   submittingReply: boolean,
 |};
 
-export type ReviewState = {|
+export type ReviewsState = {|
   byAddon: ReviewsByAddon,
   byId: ReviewsById,
   byUserId: ReviewsByUserId,
@@ -92,7 +92,7 @@ export type ReviewState = {|
   //
 |};
 
-export const initialState: ReviewState = {
+export const initialState: ReviewsState = {
   byAddon: {},
   byId: {},
   byUserId: {},
@@ -101,7 +101,7 @@ export const initialState: ReviewState = {
 };
 
 type ExpandReviewObjectsParams = {|
-  state: ReviewState,
+  state: ReviewsState,
   reviews: Array<number>,
 |};
 
@@ -137,7 +137,7 @@ function mergeInNewReview(
 }
 
 type StoreReviewObjectsParams = {|
-  state: ReviewState,
+  state: ReviewsState,
   reviews: Array<UserReviewType>,
 |};
 
@@ -158,7 +158,7 @@ export const storeReviewObjects = ({
 };
 
 type ChangeViewStateParams = {|
-  state: ReviewState,
+  state: ReviewsState,
   reviewId: number,
   stateChange: $Shape<ViewStateByReviewId>,
 |};
@@ -167,7 +167,7 @@ export const changeViewState = ({
   state,
   reviewId,
   stateChange,
-}: ChangeViewStateParams = {}): $Shape<ReviewState> => {
+}: ChangeViewStateParams = {}): $Shape<ReviewsState> => {
   const change = { ...stateChange };
 
   const existingFlag = state.view[reviewId] ? state.view[reviewId].flag : {};
@@ -192,7 +192,7 @@ export const changeViewState = ({
 };
 
 export const getReviewsByUserId = (
-  state: ReviewState,
+  state: ReviewsState,
   userId: number,
 ): ReviewsData | null => {
   const storedReviewsData = state.byUserId[userId];
@@ -223,7 +223,7 @@ type ReviewActionType =
   | ReviewWasFlaggedAction;
 
 export default function reviewsReducer(
-  state: ReviewState = initialState,
+  state: ReviewsState = initialState,
   action: ReviewActionType,
 ) {
   switch (action.type) {

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -192,18 +192,18 @@ export const changeViewState = ({
 };
 
 export const getReviewsByUserId = (
-  state: ReviewsState,
+  reviewsState: ReviewsState,
   userId: number,
 ): ReviewsData | null => {
-  const storedReviewsData = state.byUserId[userId];
+  const storedReviewsData = reviewsState.byUserId[userId];
 
   return storedReviewsData
     ? {
         pageSize: storedReviewsData.pageSize,
         reviewCount: storedReviewsData.reviewCount,
         reviews: expandReviewObjects({
-          state,
           reviews: storedReviewsData.reviews,
+          state: reviewsState,
         }),
       }
     : null;

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -75,7 +75,7 @@ export type UserType = {|
   notifications: NotificationsType | null,
 |};
 
-export type UsersStateType = {
+export type UsersState = {
   currentUserID: UserId | null,
   byID: { [userId: UserId]: UserType },
   byUsername: { [username: string]: UserId },
@@ -95,7 +95,7 @@ export type UserEditableFieldsType = {|
   username?: string | null,
 |};
 
-export const initialState: UsersStateType = {
+export const initialState: UsersState = {
   currentUserID: null,
   byID: {},
   byUsername: {},
@@ -359,17 +359,17 @@ export const loadUserNotifications = ({
   };
 };
 
-export const getUserById = (users: UsersStateType, userId: number) => {
+export const getUserById = (users: UsersState, userId: number) => {
   invariant(userId, 'userId is required');
   return users.byID[userId];
 };
 
-export const getUserByUsername = (users: UsersStateType, username: string) => {
+export const getUserByUsername = (users: UsersState, username: string) => {
   invariant(username, 'username is required');
   return users.byID[users.byUsername[username.toLowerCase()]];
 };
 
-export const getCurrentUser = (users: UsersStateType) => {
+export const getCurrentUser = (users: UsersState) => {
   if (!users.currentUserID) {
     return null;
   }
@@ -393,7 +393,7 @@ export const isDeveloper = (user: UserType | null): boolean => {
 };
 
 export const hasPermission = (
-  state: { users: UsersStateType },
+  state: { users: UsersState },
   permission: string,
 ): boolean => {
   const currentUser = getCurrentUser(state.users);
@@ -417,7 +417,7 @@ export const hasPermission = (
 };
 
 export const hasAnyReviewerRelatedPermission = (state: {
-  users: UsersStateType,
+  users: UsersState,
 }): boolean => {
   const currentUser = getCurrentUser(state.users);
 
@@ -452,7 +452,7 @@ export const addUserToState = ({
   user,
 }: {
   user: ExternalUserType,
-  state: UsersStateType,
+  state: UsersState,
 }): {|
   byID: { [userId: UserId]: UserType },
   byUsername: { [username: string]: UserId },
@@ -489,9 +489,9 @@ type Action =
   | LogOutUserAction;
 
 const reducer = (
-  state: UsersStateType = initialState,
+  state: UsersState = initialState,
   action: Action,
-): UsersStateType => {
+): UsersState => {
   switch (action.type) {
     case UPDATE_USER_ACCOUNT:
       return {

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -11,6 +11,7 @@ import {
   RATINGS_MODERATE,
   THEMES_REVIEW,
 } from 'core/constants';
+import type { AppState } from 'amo/store';
 
 export const FINISH_UPDATE_USER_ACCOUNT: 'FINISH_UPDATE_USER_ACCOUNT' =
   'FINISH_UPDATE_USER_ACCOUNT';
@@ -392,10 +393,7 @@ export const isDeveloper = (user: UserType | null): boolean => {
   return user.is_addon_developer || user.is_artist;
 };
 
-export const hasPermission = (
-  state: { users: UsersState },
-  permission: string,
-): boolean => {
+export const hasPermission = (state: AppState, permission: string): boolean => {
   const currentUser = getCurrentUser(state.users);
 
   // If the user isn't authenticated, they have no permissions.
@@ -416,9 +414,7 @@ export const hasPermission = (
   return permissions.includes(permission);
 };
 
-export const hasAnyReviewerRelatedPermission = (state: {
-  users: UsersState,
-}): boolean => {
+export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {
   const currentUser = getCurrentUser(state.users);
 
   // If the user isn't authenticated, they have no permissions.

--- a/src/amo/reducers/viewContext.js
+++ b/src/amo/reducers/viewContext.js
@@ -8,24 +8,26 @@ import {
   SET_VIEW_CONTEXT,
 } from 'core/constants';
 
-export type ViewContextType = {|
-  context:
-    | typeof ADDON_TYPE_EXTENSION
-    | typeof ADDON_TYPE_THEME
-    | typeof VIEW_CONTEXT_EXPLORE
-    | typeof VIEW_CONTEXT_HOME
-    | typeof VIEW_CONTEXT_LANGUAGE_TOOLS,
+export type ViewContextType =
+  | typeof ADDON_TYPE_EXTENSION
+  | typeof ADDON_TYPE_THEME
+  | typeof VIEW_CONTEXT_EXPLORE
+  | typeof VIEW_CONTEXT_HOME
+  | typeof VIEW_CONTEXT_LANGUAGE_TOOLS;
+
+export type ViewContextState = {|
+  context: ViewContextType,
 |};
 
 export type ViewContextActionType = {|
   type: typeof SET_VIEW_CONTEXT,
-  payload: ViewContextType,
+  payload: ViewContextState,
 |};
 
 export const initialState = { context: VIEW_CONTEXT_EXPLORE };
 
 export default function viewContext(
-  state: ViewContextType = initialState,
+  state: ViewContextState = initialState,
   action: ViewContextActionType,
 ) {
   switch (action.type) {

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -76,6 +76,18 @@ export type AppState = {|
   viewContext: ViewContextState,
 |};
 
+// This is a type function that takes a state type and returns a reducer
+// type, i.e. a function that accepts and returns the same state type.
+/* eslint-disable no-undef */
+type CreateReducerType = <AnyState>(
+  AnyState,
+) => (AnyState, action: Object) => AnyState;
+/* eslint-enable no-undef */
+
+// Given AppState, create a type for all possible application reducers.
+// See https://flow.org/en/docs/types/utilities/#toc-objmap
+type AppReducersType = $ObjMap<AppState, CreateReducerType>;
+
 type CreateStoreParams = {|
   history: Object,
   initialState: Object,
@@ -86,34 +98,35 @@ export default function createStore({
   initialState = {},
 }: CreateStoreParams = {}) {
   const sagaMiddleware = createSagaMiddleware();
+  const reducers: AppReducersType = {
+    abuse,
+    addons,
+    addonsByAuthors,
+    api,
+    autocomplete,
+    categories,
+    collections,
+    errors,
+    errorPage,
+    formOverlay,
+    heroBanners,
+    home,
+    infoDialog,
+    installations,
+    landing,
+    languageTools,
+    recommendations,
+    redirectTo,
+    reviews,
+    routing,
+    search,
+    uiState,
+    userAbuseReports,
+    users,
+    viewContext,
+  };
   const store = _createStore(
-    combineReducers({
-      abuse,
-      addons,
-      addonsByAuthors,
-      api,
-      autocomplete,
-      categories,
-      collections,
-      errors,
-      errorPage,
-      formOverlay,
-      heroBanners,
-      home,
-      infoDialog,
-      installations,
-      landing,
-      languageTools,
-      recommendations,
-      redirectTo,
-      reviews,
-      routing,
-      search,
-      uiState,
-      userAbuseReports,
-      users,
-      viewContext,
-    }),
+    combineReducers(reducers),
     initialState,
     middleware({
       routerMiddleware: routerMiddleware(history),

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -1,3 +1,4 @@
+/* @flow */
 import { createStore as _createStore, combineReducers } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import { browserHistory } from 'react-router';
@@ -28,11 +29,62 @@ import redirectTo from 'core/reducers/redirectTo';
 import search from 'core/reducers/search';
 import uiState from 'core/reducers/uiState';
 import { middleware } from 'core/store';
+import type { AddonsByAuthorsState } from 'amo/reducers/addonsByAuthors';
+import type { CollectionsState } from 'amo/reducers/collections';
+import type { HomeState } from 'amo/reducers/home';
+import type { RecommendationsState } from 'amo/reducers/recommendations';
+import type { ReviewsState } from 'amo/reducers/reviews';
+import type { UserAbuseReportsState } from 'amo/reducers/userAbuseReports';
+import type { UsersState } from 'amo/reducers/users';
+import type { ViewContextState } from 'amo/reducers/viewContext';
+import type { AbuseState } from 'core/reducers/abuse';
+import type { AddonsState } from 'core/reducers/addons';
+import type { ApiState } from 'core/reducers/api';
+import type { ErrorPageState } from 'core/reducers/errorPage';
+import type { FormOverlayState } from 'core/reducers/formOverlay';
+import type { LanguageToolsState } from 'core/reducers/languageTools';
+import type { InstallationsState } from 'core/reducers/installations';
+import type { RedirectToState } from 'core/reducers/redirectTo';
+import type { SearchState } from 'core/reducers/search';
+import type { UIStateState } from 'core/reducers/uiState';
+
+export type AppState = {|
+  abuse: AbuseState,
+  addons: AddonsState,
+  addonsByAuthors: AddonsByAuthorsState,
+  api: ApiState,
+  autocomplete: Object,
+  categories: Object,
+  collections: CollectionsState,
+  errorPage: ErrorPageState,
+  errors: Object,
+  formOverlay: FormOverlayState,
+  heroBanners: Object,
+  home: HomeState,
+  infoDialog: Object,
+  installations: InstallationsState,
+  landing: Object,
+  languageTools: LanguageToolsState,
+  recommendations: RecommendationsState,
+  redirectTo: RedirectToState,
+  reviews: ReviewsState,
+  routing: Object,
+  search: SearchState,
+  uiState: UIStateState,
+  userAbuseReports: UserAbuseReportsState,
+  users: UsersState,
+  viewContext: ViewContextState,
+|};
+
+type CreateStoreParams = {|
+  history: Object,
+  initialState: Object,
+|};
 
 export default function createStore({
   history = browserHistory,
   initialState = {},
-} = {}) {
+}: CreateStoreParams = {}) {
   const sagaMiddleware = createSagaMiddleware();
   const store = _createStore(
     combineReducers({

--- a/src/core/api/abuse.js
+++ b/src/core/api/abuse.js
@@ -1,6 +1,6 @@
 /* @flow */
 import { callApi } from 'core/api';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 
 /*
  * A reporter object, returned by Abuse Report APIs
@@ -21,7 +21,7 @@ export type AbuseReporter = {|
 
 export type ReportAddonParams = {|
   addonSlug: string,
-  api: ApiStateType,
+  api: ApiState,
   message: string,
 |};
 
@@ -36,7 +36,7 @@ export function reportAddon({ addonSlug, api, message }: ReportAddonParams) {
 }
 
 export type ReportUserParams = {|
-  api: ApiStateType,
+  api: ApiState,
   message: string,
   userId: number,
 |};

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -16,7 +16,7 @@ import {
   convertFiltersToQueryParams,
 } from 'core/searchUtils';
 import type { ErrorHandlerType } from 'core/errorHandler';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 import type { LocalizedString, PaginatedApiResponse } from 'core/types/api';
 import type { ReactRouterLocation } from 'core/types/router';
 
@@ -80,7 +80,7 @@ type CallApiParams = {|
   method?: 'GET' | 'POST' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'PUT' | 'PATCH',
   params?: Object,
   schema?: Object,
-  state?: ApiStateType,
+  state?: ApiState,
   _config?: typeof config,
 |};
 
@@ -220,7 +220,7 @@ export function callApi({
 }
 
 type FetchAddonParams = {|
-  api: ApiStateType,
+  api: ApiState,
   slug: string,
 |};
 
@@ -250,7 +250,7 @@ export function startLoginUrl({
   return `${API_BASE}/accounts/login/start/${query}`;
 }
 
-export function categories({ api }: {| api: ApiStateType |}) {
+export function categories({ api }: {| api: ApiState |}) {
   return callApi({
     endpoint: 'addons/categories',
     schema: { results: [category] },
@@ -258,7 +258,7 @@ export function categories({ api }: {| api: ApiStateType |}) {
   });
 }
 
-export function logOutFromServer({ api }: {| api: ApiStateType |}) {
+export function logOutFromServer({ api }: {| api: ApiState |}) {
   return callApi({
     auth: true,
     credentials: true,
@@ -269,7 +269,7 @@ export function logOutFromServer({ api }: {| api: ApiStateType |}) {
 }
 
 type AutocompleteParams = {|
-  api: ApiStateType,
+  api: ApiState,
   filters: {|
     query: string,
     addonType?: string,

--- a/src/core/api/languageTools.js
+++ b/src/core/api/languageTools.js
@@ -1,9 +1,9 @@
 /* @flow */
 import { callApi } from 'core/api';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 
 export type LanguageToolsParams = {|
-  api: ApiStateType,
+  api: ApiState,
 |};
 
 export function languageTools({ api }: LanguageToolsParams) {

--- a/src/core/api/search.js
+++ b/src/core/api/search.js
@@ -5,10 +5,10 @@ import {
   convertFiltersToQueryParams,
   fixFiltersForAndroidThemes,
 } from 'core/searchUtils';
-import type { ApiStateType } from 'core/reducers/api';
+import type { ApiState } from 'core/reducers/api';
 
 export type SearchParams = {|
-  api: ApiStateType,
+  api: ApiState,
   auth?: boolean,
   // TODO: Make a "searchFilters" type because these are the same args
   // for convertFiltersToQueryParams.

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -11,8 +11,9 @@ import { getCurrentUser, logOutUser } from 'amo/reducers/users';
 import translate from 'core/i18n/translate';
 import Button from 'ui/components/Button';
 import Icon from 'ui/components/Icon';
-import type { ApiStateType } from 'core/reducers/api';
-import type { UsersStateType, UserType } from 'amo/reducers/users';
+import type { AppState } from 'amo/store';
+import type { ApiState } from 'core/reducers/api';
+import type { UserType } from 'amo/reducers/users';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocation } from 'core/types/router';
 import type { I18nType } from 'core/types/i18n';
@@ -22,7 +23,7 @@ type HandleLogInFunc = (
   options?: {| _window: typeof window |},
 ) => void;
 
-type HandleLogOutFunction = ({| api: ApiStateType |}) => Promise<void>;
+type HandleLogOutFunction = ({| api: ApiState |}) => Promise<void>;
 
 type Props = {|
   buttonType?: string,
@@ -36,7 +37,7 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
-  api: ApiStateType,
+  api: ApiState,
   handleLogIn: HandleLogInFunc,
   i18n: I18nType,
   siteUser: UserType | null,
@@ -98,15 +99,12 @@ export class AuthenticateButtonBase extends React.Component<InternalProps> {
 }
 
 type StateMappedProps = {|
-  api: ApiStateType,
+  api: ApiState,
   handleLogIn: HandleLogInFunc,
   siteUser: UserType | null,
 |};
 
-export const mapStateToProps = (state: {|
-  api: ApiStateType,
-  users: UsersStateType,
-|}): StateMappedProps => ({
+export const mapStateToProps = (state: AppState): StateMappedProps => ({
   api: state.api,
   handleLogIn(location, { _window = window } = {}) {
     // eslint-disable-next-line no-param-reassign

--- a/src/core/components/ErrorPage/index.js
+++ b/src/core/components/ErrorPage/index.js
@@ -7,6 +7,7 @@ import { compose } from 'redux';
 import log from 'core/logger';
 import { getErrorComponent as getErrorComponentDefault } from 'core/utils';
 import { loadErrorPage } from 'core/reducers/errorPage';
+import type { AppState } from 'amo/store';
 import type { ErrorPageState } from 'core/reducers/errorPage';
 import type { DispatchFunc } from 'core/types/redux';
 
@@ -49,7 +50,7 @@ export class ErrorPageBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (state: {| errorPage: ErrorPageState |}) => ({
+export const mapStateToProps = (state: AppState) => ({
   errorPage: state.errorPage,
 });
 

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -263,7 +263,7 @@ export function createInternalAddon(apiAddon: ExternalAddonType): AddonType {
 
 type AddonID = number;
 
-export type AddonState = {|
+export type AddonsState = {|
   // Flow wants hash maps with string keys.
   // See: https://zhenyong.github.io/flowtype/docs/objects.html#objects-as-maps
   byID: { [addonId: string]: AddonType },
@@ -271,21 +271,21 @@ export type AddonState = {|
   bySlug: { [addonSlug: string]: AddonID },
 |};
 
-export const initialState: AddonState = {
+export const initialState: AddonsState = {
   byID: {},
   byGUID: {},
   bySlug: {},
 };
 
 export const getAddonByID = (
-  state: { addons: AddonState },
+  state: { addons: AddonsState },
   id: AddonID,
 ): AddonType | null => {
   return state.addons.byID[`${id}`] || null;
 };
 
 export const getAddonBySlug = (
-  state: { addons: AddonState },
+  state: { addons: AddonsState },
   slug: string,
 ): AddonType | null => {
   const addonId = state.addons.bySlug[slug];
@@ -294,7 +294,7 @@ export const getAddonBySlug = (
 };
 
 export const getAddonByGUID = (
-  state: { addons: AddonState },
+  state: { addons: AddonsState },
   guid: string,
 ): AddonType | null => {
   const addonId = state.addons.byGUID[guid];
@@ -303,7 +303,7 @@ export const getAddonByGUID = (
 };
 
 export const getAllAddons = (state: {
-  addons: AddonState,
+  addons: AddonsState,
 }): Array<AddonType> => {
   const addons = state.addons.byID;
 
@@ -312,7 +312,7 @@ export const getAllAddons = (state: {
 };
 
 export default function addonsReducer(
-  state: AddonState = initialState,
+  state: AddonsState = initialState,
   action: LoadAddonsAction,
 ) {
   switch (action.type) {

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -2,6 +2,7 @@
 import { oneLine } from 'common-tags';
 
 import { ADDON_TYPE_THEME } from 'core/constants';
+import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import log from 'core/logger';
 import type {
@@ -278,14 +279,14 @@ export const initialState: AddonsState = {
 };
 
 export const getAddonByID = (
-  state: { addons: AddonsState },
+  state: AppState,
   id: AddonID,
 ): AddonType | null => {
   return state.addons.byID[`${id}`] || null;
 };
 
 export const getAddonBySlug = (
-  state: { addons: AddonsState },
+  state: AppState,
   slug: string,
 ): AddonType | null => {
   const addonId = state.addons.bySlug[slug];
@@ -294,7 +295,7 @@ export const getAddonBySlug = (
 };
 
 export const getAddonByGUID = (
-  state: { addons: AddonsState },
+  state: AppState,
   guid: string,
 ): AddonType | null => {
   const addonId = state.addons.byGUID[guid];
@@ -302,9 +303,7 @@ export const getAddonByGUID = (
   return getAddonByID(state, addonId);
 };
 
-export const getAllAddons = (state: {
-  addons: AddonsState,
-}): Array<AddonType> => {
+export const getAllAddons = (state: AppState): Array<AddonType> => {
   const addons = state.addons.byID;
 
   // $FLOW_FIXME: see https://github.com/facebook/flow/issues/2221.

--- a/src/core/reducers/api.js
+++ b/src/core/reducers/api.js
@@ -62,7 +62,7 @@ export type UserAgentInfoType = {|
   },
 |};
 
-export type ApiStateType = {
+export type ApiState = {
   clientApp: ?string,
   lang: ?string,
   token: ?string,
@@ -70,7 +70,7 @@ export type ApiStateType = {
   userAgentInfo: UserAgentInfoType,
 };
 
-export const initialApiState: ApiStateType = {
+export const initialApiState: ApiState = {
   clientApp: null,
   lang: null,
   token: null,
@@ -86,9 +86,9 @@ type Action =
   | LogOutUserAction;
 
 export default function api(
-  state: Exact<ApiStateType> = initialApiState,
+  state: Exact<ApiState> = initialApiState,
   action: Action,
-): Exact<ApiStateType> {
+): Exact<ApiState> {
   switch (action.type) {
     case SET_AUTH_TOKEN:
       return {

--- a/src/core/reducers/installations.js
+++ b/src/core/reducers/installations.js
@@ -47,12 +47,12 @@ export type InstallationAction = {|
   type: string,
 |};
 
-type InstallationState = {
+export type InstallationsState = {
   [guid: $PropertyType<AddonType, 'guid'>]: InstalledAddon,
 };
 
 export default function installations(
-  state: InstallationState = {},
+  state: InstallationsState = {},
   { type, payload }: InstallationAction,
 ) {
   function updateAddon(newProps: Object): InstalledAddon {

--- a/src/core/reducers/languageTools.js
+++ b/src/core/reducers/languageTools.js
@@ -1,4 +1,5 @@
 /* @flow */
+import type { AppState } from 'amo/store';
 import type { LanguageToolType } from 'core/types/addons';
 
 export const FETCH_LANGUAGE_TOOLS: 'FETCH_LANGUAGE_TOOLS' =
@@ -57,9 +58,9 @@ export const loadLanguageTools = ({
   };
 };
 
-export const getAllLanguageTools = (state: {
-  languageTools: LanguageToolsState,
-}): Array<LanguageToolType> => {
+export const getAllLanguageTools = (
+  state: AppState,
+): Array<LanguageToolType> => {
   const { byID } = state.languageTools;
 
   // TODO: one day, Flow will get `Object.values()` right but for now... we

--- a/src/core/reducers/redirectTo.js
+++ b/src/core/reducers/redirectTo.js
@@ -5,7 +5,7 @@ import log from 'core/logger';
 
 const SEND_SERVER_REDIRECT: 'SEND_SERVER_REDIRECT' = 'SEND_SERVER_REDIRECT';
 
-type State = {|
+export type RedirectToState = {|
   url: null | string,
   status: null | 301 | 302 | 303 | 305 | 307 | 308,
 |};
@@ -16,14 +16,14 @@ export const initialState = {
 };
 
 type SendServerRedirectParams = {|
-  ...State,
+  ...RedirectToState,
   _config?: Object,
 |};
 
 type SendServerRedirectAction = {|
   type: typeof SEND_SERVER_REDIRECT,
   payload: {|
-    ...State,
+    ...RedirectToState,
   |},
 |};
 
@@ -54,7 +54,7 @@ export const sendServerRedirect = ({
 
 type Action = SendServerRedirectAction;
 
-const reducer = (state: State = initialState, action: Action) => {
+const reducer = (state: RedirectToState = initialState, action: Action) => {
   switch (action.type) {
     case SEND_SERVER_REDIRECT: {
       const { payload } = action;

--- a/src/core/reducers/search.js
+++ b/src/core/reducers/search.js
@@ -23,7 +23,7 @@ export type FiltersType = {|
   sort?: string,
 |};
 
-export type SearchType = {|
+export type SearchState = {|
   count: number,
   filters: FiltersType | {},
   loading: boolean,
@@ -31,7 +31,7 @@ export type SearchType = {|
   results: Array<AddonType | CollectionAddonType>,
 |};
 
-export const initialState: SearchType = {
+export const initialState: SearchState = {
   count: 0,
   filters: {},
   loading: false,
@@ -114,9 +114,9 @@ type Action =
   | SearchLoadAction;
 
 export default function search(
-  state: SearchType = initialState,
+  state: SearchState = initialState,
   action: Action,
-): SearchType {
+): SearchState {
   switch (action.type) {
     case SEARCH_STARTED: {
       const { payload } = action;

--- a/src/core/reducers/uiState.js
+++ b/src/core/reducers/uiState.js
@@ -3,7 +3,7 @@ import invariant from 'invariant';
 
 export const SET_UI_STATE = 'SET_UI_STATE';
 
-export type UIStateType = {
+export type UIStateState = {
   [id: string]: Object,
 };
 
@@ -32,7 +32,7 @@ export const setUIState = ({
 type UIStateActions = SetUIStateAction;
 
 export default function uiStateReducer(
-  state: UIStateType = initialState,
+  state: UIStateState = initialState,
   action: UIStateActions,
 ) {
   switch (action.type) {

--- a/src/core/sagas/utils.js
+++ b/src/core/sagas/utils.js
@@ -1,10 +1,9 @@
 /* @flow */
 import { ErrorHandler } from 'core/errorHandler';
 import defaultLog from 'core/logger';
-import type { ApiStateType } from 'core/reducers/api';
+import type { AppState } from 'amo/store';
 
 type CreateErrorHandlerType = {| log: typeof defaultLog |};
-type StateType = {| api: ApiStateType, auth: Object |};
 
 export function createErrorHandler(
   id: string,
@@ -19,6 +18,6 @@ export function createErrorHandler(
 }
 
 // Convenience function to extract state info.
-export function getState(state: StateType): StateType {
+export function getState(state: AppState): AppState {
   return state;
 }

--- a/src/core/withUIState.js
+++ b/src/core/withUIState.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import { normalizeFileNameId } from 'core/utils';
 import { setUIState } from 'core/reducers/uiState';
-import type { UIStateType } from 'core/reducers/uiState';
+import type { AppState } from 'amo/store';
 
 type ExtractIdFunc = (props: Object) => string;
 
@@ -33,10 +33,7 @@ export const createUIStateMapper = ({
   fileName?: string,
   uiStateID?: string,
 |}) => {
-  const mapStateToProps = (
-    state: {| uiState: UIStateType |},
-    props: Object,
-  ) => {
+  const mapStateToProps = (state: AppState, props: Object) => {
     let computedUIStateID;
     if (uiStateID) {
       computedUIStateID = uiStateID;

--- a/src/ui/components/FormOverlay/index.js
+++ b/src/ui/components/FormOverlay/index.js
@@ -8,9 +8,9 @@ import { closeFormOverlay } from 'core/reducers/formOverlay';
 import translate from 'core/i18n/translate';
 import Button from 'ui/components/Button';
 import Icon from 'ui/components/Icon';
+import type { AppState } from 'amo/store';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
-import type { FormOverlayState } from 'core/reducers/formOverlay';
 
 import './styles.scss';
 
@@ -152,10 +152,7 @@ export class FormOverlayBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (
-  state: {| formOverlay: FormOverlayState |},
-  ownProps: Props,
-): $Shape<Props> => {
+const mapStateToProps = (state: AppState, ownProps: Props): $Shape<Props> => {
   const overlayState = state.formOverlay[ownProps.id];
 
   if (!overlayState) {

--- a/src/ui/components/FormOverlay/index.js
+++ b/src/ui/components/FormOverlay/index.js
@@ -32,6 +32,7 @@ type Props = {|
 export class FormOverlayBase extends React.Component<Props> {
   static defaultProps = {
     isOpen: false,
+    isSubmitting: false,
   };
 
   closeOverlay(event: SyntheticEvent<any>) {
@@ -152,7 +153,7 @@ export class FormOverlayBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: AppState, ownProps: Props): $Shape<Props> => {
+const mapStateToProps = (state: AppState, ownProps: Props) => {
   const overlayState = state.formOverlay[ownProps.id];
 
   if (!overlayState) {

--- a/src/ui/components/Hero/index.js
+++ b/src/ui/components/Hero/index.js
@@ -7,6 +7,7 @@ import { compose } from 'redux';
 import { setHeroBannerOrder } from 'core/reducers/heroBanners';
 import Card from 'ui/components/Card';
 import HeroSection from 'ui/components/HeroSection';
+import type { AppState } from 'amo/store';
 import type { DispatchFunc } from 'core/types/redux';
 
 import './styles.scss';
@@ -52,7 +53,7 @@ export class HeroBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (state: Object) => {
+export const mapStateToProps = (state: AppState) => {
   return { heroBanners: state.heroBanners };
 };
 

--- a/src/ui/components/UserRating/index.js
+++ b/src/ui/components/UserRating/index.js
@@ -6,8 +6,8 @@ import { compose } from 'redux';
 import { getCurrentUser } from 'amo/reducers/users';
 import Rating, { RATING_STYLE_SIZE_TYPES } from 'ui/components/Rating';
 import translate from 'core/i18n/translate';
+import type { AppState } from 'amo/store';
 import type { UserReviewType } from 'amo/actions/reviews';
-import type { UsersStateType } from 'amo/reducers/users';
 
 type Props = {|
   className?: string,
@@ -41,12 +41,10 @@ export const UserRatingBase = (props: Props) => {
   );
 };
 
-const mapStateToProps = (
-  state: {| users: UsersStateType |},
-  ownProps: Props,
-) => {
+const mapStateToProps = (state: AppState, ownProps: Props) => {
   const { review } = ownProps;
   const siteUser = getCurrentUser(state.users);
+
   return { isOwner: !!(siteUser && review && review.userId === siteUser.id) };
 };
 

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -962,7 +962,7 @@ describe(__filename, () => {
   describe('getCurrentCollection', () => {
     it('requires the state parameter', () => {
       expect(() => getCurrentCollection()).toThrow(
-        /state parameter is required/,
+        /collectionsState parameter is required/,
       );
     });
 


### PR DESCRIPTION
Fix #4058

---

Other changes:

- All sub-state (or "small" state) have a type that is the name of the reducer + the `State` suffix:

```
reducers/abuse  => AbuseState
reducers/fooBar => FooBarState
```