### PR TITLE
use sinon.assert everywhere

### DIFF
--- a/tests/unit/amo/components/TestApp.js
+++ b/tests/unit/amo/components/TestApp.js
@@ -132,16 +132,18 @@ describe(__filename, () => {
       _window: fakeWindow,
       _cookie,
     });
-    expect(fakeEvent.preventDefault.called).toBeTruthy();
+    sinon.assert.called(fakeEvent.preventDefault);
     sinon.assert.calledWith(_cookie.save, 'mamo', 'off', { path: '/' });
-    expect(fakeWindow.location.reload.called).toBeTruthy();
+    sinon.assert.called(fakeWindow.location.reload);
   });
 
   it('sets up a callback for setting add-on status', () => {
     const dispatch = sinon.spy();
     const { handleGlobalEvent } = mapDispatchToProps(dispatch);
     const payload = { guid: '@my-addon', status: 'some-status' };
+
     handleGlobalEvent(payload);
+
     sinon.assert.calledWith(dispatch, { type: INSTALL_STATE, payload });
   });
 
@@ -151,6 +153,7 @@ describe(__filename, () => {
     const userAgent = 'tofubrowser';
 
     setUserAgent(userAgent);
+
     sinon.assert.calledWith(dispatch, setUserAgentAction(userAgent));
   });
 
@@ -244,7 +247,8 @@ describe(__filename, () => {
 
       const fuzz = 3; // account for the rounded offset calculation.
       clock.tick((authTokenValidFor + fuzz) * 1000);
-      expect(logOutUser.called).toBeTruthy();
+
+      sinon.assert.called(logOutUser);
     });
 
     it('only sets one timer when receiving new props', () => {
@@ -258,8 +262,8 @@ describe(__filename, () => {
 
       const fuzz = 3; // account for the rounded offset calculation.
       clock.tick((authTokenValidFor + fuzz) * 1000);
-      expect(logOutUser.called).toBeTruthy();
-      expect(logOutUser.calledOnce).toBeTruthy();
+
+      sinon.assert.calledOnce(logOutUser);
     });
 
     it('does not set a timer when receiving an empty auth token', () => {
@@ -283,7 +287,8 @@ describe(__filename, () => {
       renderAppWithAuth({ authTokenValidFor, logOutUser });
 
       clock.tick(5 * 1000); // 5 seconds
-      expect(logOutUser.called).toBeFalsy();
+
+      sinon.assert.notCalled(logOutUser);
     });
 
     it('only starts a timer when authTokenValidFor is configured', () => {
@@ -292,7 +297,8 @@ describe(__filename, () => {
       renderAppWithAuth({ authTokenValidFor: null, logOutUser });
 
       clock.tick(100 * 1000);
-      expect(logOutUser.called).toBeFalsy();
+
+      sinon.assert.notCalled(logOutUser);
     });
 
     it('ignores malformed timestamps', () => {
@@ -308,7 +314,8 @@ describe(__filename, () => {
       render({ authToken, authTokenValidFor, logOutUser });
 
       clock.tick(authTokenValidFor * 1000);
-      expect(logOutUser.called).toBeFalsy();
+
+      sinon.assert.notCalled(logOutUser);
     });
 
     it('ignores empty timestamps', () => {
@@ -319,7 +326,8 @@ describe(__filename, () => {
       render({ authToken, authTokenValidFor, logOutUser });
 
       clock.tick(authTokenValidFor * 1000);
-      expect(logOutUser.called).toBeFalsy();
+
+      sinon.assert.notCalled(logOutUser);
     });
 
     it('ignores malformed tokens', () => {
@@ -330,7 +338,8 @@ describe(__filename, () => {
       render({ authToken, authTokenValidFor, logOutUser });
 
       clock.tick(authTokenValidFor * 1000);
-      expect(logOutUser.called).toBeFalsy();
+
+      sinon.assert.notCalled(logOutUser);
     });
 
     it('does not set a timeout for expirations too far in the future', () => {
@@ -341,7 +350,8 @@ describe(__filename, () => {
 
       const fuzz = 3; // account for the rounded offset calculation.
       clock.tick((authTokenValidFor + fuzz) * 1000);
-      expect(logOutUser.called).toBeFalsy();
+
+      sinon.assert.notCalled(logOutUser);
     });
 
     it('maps a logOutUser action', () => {

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -101,7 +101,6 @@ describe(__filename, () => {
       loadSavedReview,
     });
 
-    sinon.assert.called(loadSavedReview);
     sinon.assert.calledWith(loadSavedReview, {
       apiState: signedInApiState,
       userId,
@@ -391,7 +390,6 @@ describe(__filename, () => {
           .returns(Promise.resolve({ ...fakeReview, ...params }));
 
         return actions.submitReview(params).then(() => {
-          sinon.assert.called(dispatch);
           sinon.assert.calledWith(dispatch, setReview(fakeReview));
           mockApi.verify();
         });
@@ -422,7 +420,6 @@ describe(__filename, () => {
           })
           .then(() => {
             mockApi.verify();
-            sinon.assert.called(dispatch);
             sinon.assert.calledWith(dispatch, setReview(fakeReview));
           });
       });

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -101,9 +101,8 @@ describe(__filename, () => {
       loadSavedReview,
     });
 
-    expect(loadSavedReview.called).toEqual(true);
-    const args = loadSavedReview.firstCall.args[0];
-    expect(args).toEqual({
+    sinon.assert.called(loadSavedReview);
+    sinon.assert.calledWith(loadSavedReview, {
       apiState: signedInApiState,
       userId,
       addonId: addon.id,
@@ -126,7 +125,7 @@ describe(__filename, () => {
       }),
     });
     return root.onSelectRating(5).then(() => {
-      expect(submitReview.called).toEqual(true);
+      sinon.assert.called(submitReview);
 
       const call = submitReview.firstCall.args[0];
       expect(call.versionId).toEqual(321);
@@ -147,7 +146,7 @@ describe(__filename, () => {
       userReview: setReview(fakeReview).payload,
     });
     return root.onSelectRating(5).then(() => {
-      expect(submitReview.called).toBeTruthy();
+      sinon.assert.called(submitReview);
 
       const call = submitReview.firstCall.args[0];
       expect(call.reviewId).toBeTruthy();
@@ -183,7 +182,7 @@ describe(__filename, () => {
       addon,
     });
     return root.onSelectRating(newReview.rating).then(() => {
-      expect(submitReview.called).toBeTruthy();
+      sinon.assert.called(submitReview);
 
       // Make sure the review is submitted in a way where it will be
       // newly created against the current version.
@@ -200,7 +199,7 @@ describe(__filename, () => {
     const FakeAddonReview = sinon.spy(() => <div />);
     const root = render({ AddonReview: FakeAddonReview, userReview });
 
-    expect(FakeAddonReview.called).toEqual(false);
+    sinon.assert.notCalled(FakeAddonReview);
 
     return root.onSelectRating(5).then(() => {
       sinon.assert.called(FakeAddonReview);
@@ -246,10 +245,10 @@ describe(__filename, () => {
     const userId = null; // logged out
     const root = render({ AddonReview: FakeAddonReview, userReview, userId });
 
-    expect(FakeAddonReview.called).toEqual(false);
+    sinon.assert.notCalled(FakeAddonReview);
 
     return root.onSelectRating(5).then(() => {
-      expect(FakeAddonReview.called).toBeFalsy();
+      sinon.assert.notCalled(FakeAddonReview);
     });
   });
 
@@ -259,7 +258,7 @@ describe(__filename, () => {
 
     const root = render({ UserRating: UserRatingStub, userReview });
 
-    expect(UserRatingStub.called).toEqual(true);
+    sinon.assert.called(UserRatingStub);
     const props = UserRatingStub.firstCall.args[0];
     expect(props.onSelectRating).toEqual(root.onSelectRating);
     expect(props.review).toEqual(userReview);
@@ -270,7 +269,7 @@ describe(__filename, () => {
 
     render({ UserRating: UserRatingStub, userReview: null });
 
-    expect(UserRatingStub.called).toEqual(true);
+    sinon.assert.called(UserRatingStub);
     const props = UserRatingStub.firstCall.args[0];
     expect(props.rating).toBe(undefined);
   });
@@ -294,7 +293,7 @@ describe(__filename, () => {
         AuthenticateButton,
         addon: createInternalAddon({ ...fakeAddon, type: addonType }),
       });
-      expect(AuthenticateButton.called).toBeTruthy();
+      sinon.assert.called(AuthenticateButton);
       const props = AuthenticateButton.firstCall.args[0];
       return props.logInText;
     }
@@ -302,7 +301,7 @@ describe(__filename, () => {
     it('does not load saved ratings', () => {
       const loadSavedReview = sinon.spy();
       renderWithoutUser({ loadSavedReview });
-      expect(loadSavedReview.called).toEqual(false);
+      sinon.assert.notCalled(loadSavedReview);
     });
 
     it('renders an AuthenticateButton', () => {
@@ -310,7 +309,7 @@ describe(__filename, () => {
       const location = fakeRouterLocation();
       renderWithoutUser({ AuthenticateButton, location });
 
-      expect(AuthenticateButton.called).toBeTruthy();
+      sinon.assert.called(AuthenticateButton);
       const props = AuthenticateButton.firstCall.args[0];
       expect(props.location).toEqual(location);
     });
@@ -392,9 +391,8 @@ describe(__filename, () => {
           .returns(Promise.resolve({ ...fakeReview, ...params }));
 
         return actions.submitReview(params).then(() => {
-          expect(dispatch.called).toEqual(true);
-          const action = dispatch.firstCall.args[0];
-          expect(action).toEqual(setReview(fakeReview));
+          sinon.assert.called(dispatch);
+          sinon.assert.calledWith(dispatch, setReview(fakeReview));
           mockApi.verify();
         });
       });
@@ -424,8 +422,8 @@ describe(__filename, () => {
           })
           .then(() => {
             mockApi.verify();
-            expect(dispatch.called).toEqual(true);
-            expect(dispatch.firstCall.args[0]).toEqual(setReview(fakeReview));
+            sinon.assert.called(dispatch);
+            sinon.assert.calledWith(dispatch, setReview(fakeReview));
           });
       });
 
@@ -440,7 +438,7 @@ describe(__filename, () => {
             addonId,
           })
           .then(() => {
-            expect(dispatch.called).toEqual(false);
+            sinon.assert.notCalled(dispatch);
           });
       });
     });

--- a/tests/unit/core/TestAddonManager.js
+++ b/tests/unit/core/TestAddonManager.js
@@ -94,15 +94,14 @@ describe(__filename, () => {
   });
 
   describe('getAddon()', () => {
-    it('should call mozAddonManager.getAddonByID() with id', () => {
+    it('should call mozAddonManager.getAddonByID() with id', async () => {
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
-      return addonManager
-        .getAddon('test-id', { _mozAddonManager: fakeMozAddonManager })
-        .then(() => {
-          expect(
-            fakeMozAddonManager.getAddonByID.calledWith('test-id'),
-          ).toBeTruthy();
-        });
+
+      await addonManager.getAddon('test-id', {
+        _mozAddonManager: fakeMozAddonManager,
+      });
+
+      sinon.assert.calledWith(fakeMozAddonManager.getAddonByID, 'test-id');
     });
 
     it('should reject if mozAddonManager.getAddonByID() resolves with falsey addon', () => {
@@ -125,70 +124,68 @@ describe(__filename, () => {
   });
 
   describe('install()', () => {
-    it('should call mozAddonManager.createInstall() with url', () =>
-      addonManager
-        .install(fakeInstallUrl, fakeCallback, {
-          _mozAddonManager: fakeMozAddonManager,
-          src: 'home',
-        })
-        .then(() => {
-          expect(
-            fakeMozAddonManager.createInstall.calledWith({
-              url: `${fakeInstallUrl}?src=home`,
-            }),
-          ).toBeTruthy();
-        }));
+    it('should call mozAddonManager.createInstall() with url', async () => {
+      await addonManager.install(fakeInstallUrl, fakeCallback, {
+        _mozAddonManager: fakeMozAddonManager,
+        src: 'home',
+      });
 
-    it('should call installObj.addEventListener to setup events', () =>
-      addonManager
-        .install(fakeInstallUrl, fakeCallback, {
-          _mozAddonManager: fakeMozAddonManager,
-          src: 'home',
-        })
-        .then(() => {
-          // It registers an extra onInstallFailed and onInstallEnded listener.
-          expect(fakeInstallObj.addEventListener.callCount).toEqual(
-            INSTALL_EVENT_LIST.length + 2,
-          );
-        }));
+      sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
+        url: `${fakeInstallUrl}?src=home`,
+      });
+    });
 
-    it('should call installObj.install()', () =>
-      addonManager
-        .install(fakeInstallUrl, fakeCallback, {
-          _mozAddonManager: fakeMozAddonManager,
-          src: 'home',
-        })
-        .then(() => {
-          expect(fakeInstallObj.install.called).toBeTruthy();
-        }));
+    it('should call installObj.addEventListener to setup events', async () => {
+      await addonManager.install(fakeInstallUrl, fakeCallback, {
+        _mozAddonManager: fakeMozAddonManager,
+        src: 'home',
+      });
 
-    it('rejects if the install fails', () => {
+      // It registers an extra onInstallFailed and onInstallEnded listener.
+      sinon.assert.callCount(
+        fakeInstallObj.addEventListener,
+        INSTALL_EVENT_LIST.length + 2,
+      );
+    });
+
+    it('should call installObj.install()', async () => {
+      await addonManager.install(fakeInstallUrl, fakeCallback, {
+        _mozAddonManager: fakeMozAddonManager,
+        src: 'home',
+      });
+
+      sinon.assert.called(fakeInstallObj.install);
+    });
+
+    it('rejects if the install fails', async (done) => {
       fakeInstallObj.install = sinon.spy(function install() {
         this.onInstallFailedListener();
       });
-      return addonManager
-        .install(fakeInstallUrl, fakeCallback, {
+
+      try {
+        await addonManager.install(fakeInstallUrl, fakeCallback, {
           _mozAddonManager: fakeMozAddonManager,
           src: 'home',
-        })
-        .then(unexpectedSuccess, () =>
-          expect(fakeInstallObj.install.called).toBeTruthy(),
-        );
+        });
+
+        done.fail(new Error('this should not be called'));
+      } catch (e) {
+        sinon.assert.calledOnce(fakeInstallObj.install);
+        done();
+      }
     });
 
-    it('passes the installObj, the event and the id to the callback', () => {
+    it('passes the installObj, the event and the id to the callback', async () => {
       const fakeEvent = { type: 'fakeEvent' };
-      return addonManager
-        .install(fakeInstallUrl, fakeCallback, {
-          _mozAddonManager: fakeMozAddonManager,
-          src: 'home',
-        })
-        .then(() => {
-          fakeInstallObj.onDownloadProgressListener(fakeEvent);
-          expect(
-            fakeCallback.calledWith(fakeInstallObj, fakeEvent),
-          ).toBeTruthy();
-        });
+
+      await addonManager.install(fakeInstallUrl, fakeCallback, {
+        _mozAddonManager: fakeMozAddonManager,
+        src: 'home',
+      });
+
+      fakeInstallObj.onDownloadProgressListener(fakeEvent);
+
+      sinon.assert.calledWith(fakeCallback, fakeInstallObj, fakeEvent);
     });
 
     it('requires a src', () =>
@@ -254,13 +251,18 @@ describe(__filename, () => {
 
     GLOBAL_EVENTS.forEach((event) => {
       const status = GLOBAL_EVENT_STATUS_MAP[event];
+
       it(`calls callback with status ${status}`, () => {
         const id = 'foo@whatever';
         const needsRestart = false;
+
         handleChangeEvent({ id, needsRestart, type: event });
-        expect(
-          fakeEventCallback.calledWith({ guid: id, needsRestart, status }),
-        ).toBeTruthy();
+
+        sinon.assert.calledWith(fakeEventCallback, {
+          guid: id,
+          needsRestart,
+          status,
+        });
       });
     });
 
@@ -272,16 +274,18 @@ describe(__filename, () => {
   });
 
   describe('enable()', () => {
-    it('should call addon.setEnable()', () => {
+    it('should call addon.setEnable()', async () => {
       fakeAddon = {
         setEnabled: sinon.stub(),
       };
+
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
-      return addonManager
-        .enable('whatever', { _mozAddonManager: fakeMozAddonManager })
-        .then(() => {
-          expect(fakeAddon.setEnabled.calledWith(true)).toBeTruthy();
-        });
+
+      await addonManager.enable('whatever', {
+        _mozAddonManager: fakeMozAddonManager,
+      });
+
+      sinon.assert.calledWith(fakeAddon.setEnabled, true);
     });
 
     it('should throw if addon.setEnable does not exist', () => {

--- a/tests/unit/core/TestAddonManager.js
+++ b/tests/unit/core/TestAddonManager.js
@@ -157,22 +157,22 @@ describe(__filename, () => {
       sinon.assert.called(fakeInstallObj.install);
     });
 
-    it('rejects if the install fails', async (done) => {
+    it('rejects if the install fails', () => {
       fakeInstallObj.install = sinon.spy(function install() {
         this.onInstallFailedListener();
       });
 
-      try {
-        await addonManager.install(fakeInstallUrl, fakeCallback, {
-          _mozAddonManager: fakeMozAddonManager,
-          src: 'home',
-        });
-
-        done.fail(new Error('this should not be called'));
-      } catch (e) {
-        sinon.assert.calledOnce(fakeInstallObj.install);
-        done();
-      }
+      return (
+        addonManager
+          .install(fakeInstallUrl, fakeCallback, {
+            _mozAddonManager: fakeMozAddonManager,
+            src: 'home',
+          })
+          // The second argument is the reject function.
+          .then(unexpectedSuccess, () => {
+            sinon.assert.calledOnce(fakeInstallObj.install);
+          })
+      );
     });
 
     it('passes the installObj, the event and the id to the callback', async () => {

--- a/tests/unit/core/TestInstallAddon.js
+++ b/tests/unit/core/TestInstallAddon.js
@@ -1526,7 +1526,7 @@ describe(__filename, () => {
         const node = sinon.stub();
         const stubs = installThemeStubs();
         installTheme(node, addon, stubs);
-        expect(stubs._themeInstall.calledWith(node)).toBeTruthy();
+        sinon.assert.calledWith(stubs._themeInstall, node);
       });
 
       it('tracks a theme install', () => {
@@ -1552,8 +1552,8 @@ describe(__filename, () => {
         const node = sinon.stub();
         const stubs = installThemeStubs();
         installTheme(node, addon, stubs);
-        expect(stubs._tracking.sendEvent.called).toBeFalsy();
-        expect(stubs._themeInstall.called).toBeFalsy();
+        sinon.assert.notCalled(stubs._tracking.sendEvent);
+        sinon.assert.notCalled(stubs._themeInstall);
       });
 
       it('does not try to install theme if it is an extension', () => {
@@ -1561,8 +1561,8 @@ describe(__filename, () => {
         const node = sinon.stub();
         const stubs = installThemeStubs();
         installTheme(node, addon, stubs);
-        expect(stubs._tracking.sendEvent.called).toBeFalsy();
-        expect(stubs._themeInstall.called).toBeFalsy();
+        sinon.assert.notCalled(stubs._tracking.sendEvent);
+        sinon.assert.notCalled(stubs._themeInstall);
       });
 
       describe('getBrowserThemeData', () => {

--- a/tests/unit/core/TestThemeInstall.js
+++ b/tests/unit/core/TestThemeInstall.js
@@ -19,11 +19,9 @@ describe(__filename, () => {
 
     themeInstall(fakeNode, fakeDoc);
 
-    expect(fakeDoc.createEvent.calledWith('Events')).toBeTruthy();
-    expect(
-      fakeEvent.initEvent.calledWith(THEME_INSTALL, true, false),
-    ).toBeTruthy();
-    expect(fakeNode.dispatchEvent.calledWith(fakeEvent)).toBeTruthy();
+    sinon.assert.calledWith(fakeDoc.createEvent, 'Events');
+    sinon.assert.calledWith(fakeEvent.initEvent, THEME_INSTALL, true, false);
+    sinon.assert.calledWith(fakeNode.dispatchEvent, fakeEvent);
   });
 
   it('returns themeData from getThemeData', () => {

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -108,7 +108,7 @@ describe(__filename, () => {
       sinon.stub(errorHandler, 'clear');
 
       await api.callApi({ endpoint: 'resource', errorHandler });
-      expect(errorHandler.clear.called).toBeTruthy();
+      sinon.assert.called(errorHandler.clear);
     });
 
     it('passes errors to the error handler', async () => {
@@ -126,7 +126,7 @@ describe(__filename, () => {
       await api
         .callApi({ endpoint: 'resource', errorHandler })
         .then(unexpectedSuccess, () => {
-          expect(errorHandler.handle.called).toBeTruthy();
+          sinon.assert.called(errorHandler.handle);
           const { args } = errorHandler.handle.firstCall;
           expect(args[0].response.data.non_field_errors).toEqual(
             nonFieldErrors,
@@ -198,7 +198,7 @@ describe(__filename, () => {
       await api
         .callApi({ endpoint: 'resource', errorHandler })
         .then(unexpectedSuccess, () => {
-          expect(errorHandler.handle.called).toBeTruthy();
+          sinon.assert.called(errorHandler.handle);
           const { args } = errorHandler.handle.firstCall;
           expect(args[0].message).toEqual('this could be any error');
         });

--- a/tests/unit/core/client/test_logger.js
+++ b/tests/unit/core/client/test_logger.js
@@ -28,7 +28,7 @@ describe(__filename, () => {
   it('aliases as expected', () => {
     const logAlias = getAlias('log');
     logAlias('whatever');
-    expect(fakeConsole.log.called).toBeTruthy();
+    sinon.assert.called(fakeConsole.log);
   });
 
   it('throws if the method does not exist on the object', () => {
@@ -46,7 +46,7 @@ describe(__filename, () => {
     };
     const infoAlias = getAlias('info', { _function: fakeFunc });
     infoAlias('hello');
-    expect(fakeFunc.prototype.apply.called).toBeTruthy();
+    sinon.assert.called(fakeFunc.prototype.apply);
   });
 
   it('uses a noop function if the client console loggin is off', () => {
@@ -54,7 +54,7 @@ describe(__filename, () => {
     const fakeNoopFunc = sinon.stub();
     const infoAlias = getAlias('info', { _noop: fakeNoopFunc });
     infoAlias('hello');
-    expect(fakeNoopFunc.called).toBeTruthy();
+    sinon.assert.called(fakeNoopFunc);
   });
 
   it('still throws if invalid method despite being noop', () => {

--- a/tests/unit/core/components/TestInfoDialog.js
+++ b/tests/unit/core/components/TestInfoDialog.js
@@ -63,7 +63,7 @@ describe(__filename, () => {
       const dialog = renderInfoDialog();
       const root = findDOMNode(dialog);
       Simulate.click(root.querySelector('button'));
-      expect(closeAction.called).toBeTruthy();
+      sinon.assert.called(closeAction);
     });
   });
 
@@ -105,7 +105,7 @@ describe(__filename, () => {
       ReactDOM.render(<FakeContainer />, mountNode);
       const outsideNode = document.getElementById('outside-component');
       simulateClick(outsideNode);
-      expect(closeAction.called).toBeTruthy();
+      sinon.assert.called(closeAction);
     });
   });
 

--- a/tests/unit/core/components/TestInstallSwitch.js
+++ b/tests/unit/core/components/TestInstallSwitch.js
@@ -107,9 +107,11 @@ describe(__filename, () => {
     const uninstall = sinon.stub();
     const button = renderButton({ status: DOWNLOADING, install, uninstall });
     const root = findDOMNode(button);
+
     Simulate.click(root);
-    expect(!install.called).toBeTruthy();
-    expect(!uninstall.called).toBeTruthy();
+
+    sinon.assert.notCalled(install);
+    sinon.assert.notCalled(uninstall);
   });
 
   it('should associate the label and input with id and for attributes', () => {
@@ -174,9 +176,12 @@ describe(__filename, () => {
       name,
       status: UNINSTALLED,
     });
+
     const root = findDOMNode(button.switchEl);
+
     Simulate.click(root);
-    expect(install.calledWith()).toBeTruthy();
+
+    sinon.assert.called(install);
   });
 
   it('should call enable function on click when uninstalled', () => {
@@ -194,8 +199,10 @@ describe(__filename, () => {
       status: DISABLED,
     });
     const root = findDOMNode(button.switchEl);
+
     Simulate.click(root);
-    expect(enable.calledWith()).toBeTruthy();
+
+    sinon.assert.called(enable);
   });
 
   it('should call uninstall function on click when installed', () => {
@@ -212,9 +219,12 @@ describe(__filename, () => {
       type,
       uninstall,
     });
+
     const root = findDOMNode(button.switchEl);
+
     Simulate.click(root);
-    expect(uninstall.calledWith({ guid, installURL, name, type })).toBeTruthy();
+
+    sinon.assert.calledWith(uninstall, { guid, installURL, name, type });
   });
 
   it('returns early when button is clicked on disabled switch', () => {
@@ -241,9 +251,9 @@ describe(__filename, () => {
     const root = findDOMNode(button.switchEl);
     Simulate.click(root);
 
-    expect(enable.notCalled).toBeTruthy();
-    expect(install.notCalled).toBeTruthy();
-    expect(installTheme.notCalled).toBeTruthy();
-    expect(uninstall.notCalled).toBeTruthy();
+    sinon.assert.notCalled(enable);
+    sinon.assert.notCalled(install);
+    sinon.assert.notCalled(installTheme);
+    sinon.assert.notCalled(uninstall);
   });
 });

--- a/tests/unit/core/i18n/TestI18nProvider.js
+++ b/tests/unit/core/i18n/TestI18nProvider.js
@@ -1,6 +1,6 @@
+import { mount } from 'enzyme';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { renderIntoDocument } from 'react-dom/test-utils';
 
 import I18nProvider from 'core/i18n/Provider';
 import { fakeI18n } from 'tests/unit/helpers';
@@ -17,7 +17,7 @@ describe(__filename, () => {
   }
 
   function render({ i18n }) {
-    return renderIntoDocument(
+    return mount(
       <I18nProvider i18n={i18n}>
         <MyComponent />
       </I18nProvider>,
@@ -26,7 +26,9 @@ describe(__filename, () => {
 
   it('sets the i18n as context', () => {
     const i18n = fakeI18n();
+
     render({ i18n });
-    expect(i18n.gettext.calledWith('Howdy')).toBeTruthy();
+
+    sinon.assert.calledWith(i18n.gettext, 'Howdy');
   });
 });

--- a/tests/unit/core/i18n/test_translate.js
+++ b/tests/unit/core/i18n/test_translate.js
@@ -48,15 +48,15 @@ describe(__filename, () => {
   it('pulls i18n from context', () => {
     const i18n = fakeI18n();
     render({ i18n });
-    expect(i18n.gettext.called).toBeTruthy();
+    sinon.assert.called(i18n.gettext);
   });
 
   it('overrides the i18n from props', () => {
     const contextI18n = fakeI18n();
     const propsI18n = fakeI18n();
     render({ i18n: contextI18n, componentProps: { i18n: propsI18n } });
-    expect(contextI18n.gettext.called).toBeFalsy();
-    expect(propsI18n.gettext.called).toBeTruthy();
+    sinon.assert.notCalled(contextI18n.gettext);
+    sinon.assert.called(propsI18n.gettext);
   });
 
   it('throws an exception calling getWrappedInstance without withRef', () => {

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -65,7 +65,7 @@ describe(__filename, () => {
         error: sinon.stub(),
       };
       utils.langToLocale('whatevs-this-is-really-odd', fakeLog);
-      expect(fakeLog.error.called).toBeTruthy();
+      sinon.assert.called(fakeLog.error);
     });
 
     it('should return undefined for invalid input', () => {
@@ -92,7 +92,7 @@ describe(__filename, () => {
         error: sinon.stub(),
       };
       utils.localeToLang('what_the_heck_is_this', fakeLog);
-      expect(fakeLog.error.called).toBeTruthy();
+      sinon.assert.called(fakeLog.error);
     });
 
     it('should return undefined for invalid input', () => {

--- a/tests/unit/core/middleware/test_HstsMiddleware.js
+++ b/tests/unit/core/middleware/test_HstsMiddleware.js
@@ -9,8 +9,10 @@ describe(__filename, () => {
     const nextSpy = sinon.stub();
     const req = new MockExpressRequest();
     const res = new MockExpressResponse();
+
     middleware(req, res, nextSpy);
+
     expect(res.get('strict-transport-security')).toEqual('max-age=31536000');
-    expect(nextSpy.calledOnce).toEqual(true);
+    sinon.assert.calledOnce(nextSpy);
   });
 });

--- a/tests/unit/core/middleware/test_cspMiddleware.js
+++ b/tests/unit/core/middleware/test_cspMiddleware.js
@@ -63,7 +63,7 @@ describe(__filename, () => {
         cdnHost,
         "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='",
       ]);
-      expect(nextSpy.calledOnce).toEqual(true);
+      sinon.assert.calledOnce(nextSpy);
     });
 
     it('provides the expected style-src directive when noScriptStyles is false', () => {
@@ -85,7 +85,7 @@ describe(__filename, () => {
       const policy = parse(cspHeader);
       const cdnHost = 'https://addons-amo.cdn.mozilla.net';
       expect(policy['style-src']).toEqual([cdnHost]);
-      expect(nextSpy.calledOnce).toEqual(true);
+      sinon.assert.calledOnce(nextSpy);
     });
 
     it('provides the expected csp output for the disco app', () => {
@@ -135,7 +135,7 @@ describe(__filename, () => {
         "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='",
       ]);
       expect(policy['media-src']).toEqual([cdnHost]);
-      expect(nextSpy.calledOnce).toEqual(true);
+      sinon.assert.calledOnce(nextSpy);
     });
 
     it('converts false string to false boolean', () => {
@@ -158,10 +158,11 @@ describe(__filename, () => {
       const req = new MockExpressRequest();
       const res = new MockExpressResponse();
       middleware(req, res, nextSpy);
-      expect(warnStub.calledWith('CSP has been disabled from the config')).toBe(
-        true,
+      sinon.assert.calledWith(
+        warnStub,
+        'CSP has been disabled from the config',
       );
-      expect(nextSpy.calledOnce).toEqual(true);
+      sinon.assert.calledOnce(nextSpy);
     });
 
     it('logs if the csp config is false', () => {
@@ -181,10 +182,11 @@ describe(__filename, () => {
       const req = new MockExpressRequest();
       const res = new MockExpressResponse();
       middleware(req, res, nextSpy);
-      expect(warnStub.calledWith('CSP has been disabled from the config')).toBe(
-        true,
+      sinon.assert.calledWith(
+        warnStub,
+        'CSP has been disabled from the config',
       );
-      expect(nextSpy.calledOnce).toEqual(true);
+      sinon.assert.calledOnce(nextSpy);
     });
 
     it('does not blow up if optional args missing', () => {

--- a/tests/unit/core/middleware/test_frameguardMiddleware.js
+++ b/tests/unit/core/middleware/test_frameguardMiddleware.js
@@ -28,7 +28,7 @@ describe(__filename, () => {
       const res = new MockExpressResponse();
       middleware(req, res, nextSpy);
       expect(res.get('x-frame-options')).toEqual('DENY');
-      expect(nextSpy.calledOnce).toEqual(true);
+      sinon.assert.calledOnce(nextSpy);
     });
   }
 

--- a/tests/unit/core/middleware/test_logRequests.js
+++ b/tests/unit/core/middleware/test_logRequests.js
@@ -11,8 +11,10 @@ describe(__filename, () => {
     const res = new MockExpressResponse();
     const nextSpy = sinon.stub();
     const logInfoStub = sinon.stub(log, 'info');
+
     middleware(req, res, nextSpy);
-    expect(logInfoStub.called).toBe(true);
-    expect(nextSpy.calledOnce).toBe(true);
+
+    sinon.assert.called(logInfoStub);
+    sinon.assert.calledOnce(nextSpy);
   });
 });

--- a/tests/unit/core/middleware/test_trailingSlashMiddleware.js
+++ b/tests/unit/core/middleware/test_trailingSlashMiddleware.js
@@ -31,7 +31,7 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeNext.called).toBeTruthy();
+    sinon.assert.called(fakeNext);
   });
 
   it('should add trailing slashes to a URL if one is not found', () => {
@@ -42,8 +42,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([301, '/foo/bar/']);
-    expect(fakeNext.called).toBeFalsy();
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/foo/bar/');
+    sinon.assert.notCalled(fakeNext);
   });
 
   it('should not add trailing slashes if the URL has an exception', () => {
@@ -54,8 +54,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.called).toBeFalsy();
-    expect(fakeNext.called).toBeTruthy();
+    sinon.assert.notCalled(fakeRes.redirect);
+    sinon.assert.called(fakeNext);
   });
 
   it('should handle trailing slash exceptions with $lang', () => {
@@ -66,8 +66,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.called).toBeFalsy();
-    expect(fakeNext.called).toBeTruthy();
+    sinon.assert.notCalled(fakeRes.redirect);
+    sinon.assert.called(fakeNext);
   });
 
   it('should handle trailing slash exceptions with $clientApp', () => {
@@ -78,8 +78,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.called).toBeFalsy();
-    expect(fakeNext.called).toBeTruthy();
+    sinon.assert.notCalled(fakeRes.redirect);
+    sinon.assert.called(fakeNext);
   });
 
   it('should handle trailing slash exceptions with $lang/$clientApp', () => {
@@ -90,8 +90,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.called).toBeFalsy();
-    expect(fakeNext.called).toBeTruthy();
+    sinon.assert.notCalled(fakeRes.redirect);
+    sinon.assert.called(fakeNext);
   });
 
   it('should not be an exception without $lang/$clientApp', () => {
@@ -102,8 +102,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([301, '/slash/trailing/']);
-    expect(fakeNext.called).toBeFalsy();
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/slash/trailing/');
+    sinon.assert.notCalled(fakeNext);
   });
 
   it('should not be an exception without both $lang/$clientApp', () => {
@@ -114,11 +114,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([
-      301,
-      '/en-US/slash/trailing/',
-    ]);
-    expect(fakeNext.called).toBeFalsy();
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/en-US/slash/trailing/');
+    sinon.assert.notCalled(fakeNext);
   });
 
   it('redirects a URL with $lang and $clientApp without an exception', () => {
@@ -129,11 +126,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([
-      301,
-      '/en-US/firefox/trailing/',
-    ]);
-    expect(fakeNext.called).toBeFalsy();
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/en-US/firefox/trailing/');
+    sinon.assert.notCalled(fakeNext);
   });
 
   it('detects an exception that has a query string', () => {
@@ -144,8 +138,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.called).toBeFalsy();
-    expect(fakeNext.called).toBeTruthy();
+    sinon.assert.notCalled(fakeRes.redirect);
+    sinon.assert.called(fakeNext);
   });
 
   it('does not remove query string', () => {
@@ -156,11 +150,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([
-      301,
-      '/hello/?query=test',
-    ]);
-    expect(fakeNext.called).toBeFalsy();
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/hello/?query=test');
+    sinon.assert.notCalled(fakeNext);
   });
 
   it('should not be an exception with missing $lang', () => {
@@ -171,11 +162,8 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([
-      301,
-      '/firefox/slash/trailing/',
-    ]);
-    expect(fakeNext.called).toBeFalsy();
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/firefox/slash/trailing/');
+    sinon.assert.notCalled(fakeNext);
   });
 
   it('should include query params in the redirect', () => {
@@ -186,11 +174,12 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([
+    sinon.assert.calledWith(
+      fakeRes.redirect,
       301,
       '/foo/search/?q=foo&category=bar',
-    ]);
-    expect(fakeNext.called).toBeFalsy();
+    );
+    sinon.assert.notCalled(fakeNext);
   });
 
   it('should handle several ? in URL (though that should never happen)', () => {
@@ -201,10 +190,11 @@ describe(__filename, () => {
     trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
       _config: fakeConfig,
     });
-    expect(fakeRes.redirect.firstCall.args).toEqual([
+    sinon.assert.calledWith(
+      fakeRes.redirect,
       301,
       '/foo/search/?q=foo&category=bar?test=bad',
-    ]);
-    expect(fakeNext.called).toBeFalsy();
+    );
+    sinon.assert.notCalled(fakeNext);
   });
 });

--- a/tests/unit/core/testErrorHandler.js
+++ b/tests/unit/core/testErrorHandler.js
@@ -174,8 +174,9 @@ describe(__filename, () => {
       const error = new Error();
       errorHandler.handle(error);
 
-      expect(store.dispatch.called).toBeTruthy();
-      expect(store.dispatch.firstCall.args[0]).toEqual(
+      sinon.assert.called(store.dispatch);
+      sinon.assert.calledWith(
+        store.dispatch,
         setError({ id: errorHandler.id, error }),
       );
     });
@@ -357,8 +358,9 @@ describe(__filename, () => {
     it('dispatches an error', () => {
       const error = new Error();
       errorHandler.handle(error);
-      expect(errorHandler.dispatch.called).toBeTruthy();
-      expect(errorHandler.dispatch.firstCall.args[0]).toEqual(
+      sinon.assert.called(errorHandler.dispatch);
+      sinon.assert.calledWith(
+        errorHandler.dispatch,
         setError({ id: errorHandler.id, error }),
       );
     });
@@ -396,8 +398,9 @@ describe(__filename, () => {
 
     it('clears an error', () => {
       errorHandler.clear();
-      expect(errorHandler.dispatch.called).toBeTruthy();
-      expect(errorHandler.dispatch.firstCall.args[0]).toEqual(
+      sinon.assert.called(errorHandler.dispatch);
+      sinon.assert.calledWith(
+        errorHandler.dispatch,
         clearError(errorHandler.id),
       );
     });

--- a/tests/unit/core/testErrorHandler.js
+++ b/tests/unit/core/testErrorHandler.js
@@ -174,7 +174,6 @@ describe(__filename, () => {
       const error = new Error();
       errorHandler.handle(error);
 
-      sinon.assert.called(store.dispatch);
       sinon.assert.calledWith(
         store.dispatch,
         setError({ id: errorHandler.id, error }),
@@ -358,7 +357,6 @@ describe(__filename, () => {
     it('dispatches an error', () => {
       const error = new Error();
       errorHandler.handle(error);
-      sinon.assert.called(errorHandler.dispatch);
       sinon.assert.calledWith(
         errorHandler.dispatch,
         setError({ id: errorHandler.id, error }),
@@ -398,7 +396,6 @@ describe(__filename, () => {
 
     it('clears an error', () => {
       errorHandler.clear();
-      sinon.assert.called(errorHandler.dispatch);
       sinon.assert.calledWith(
         errorHandler.dispatch,
         clearError(errorHandler.id),

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -358,8 +358,7 @@ describe(__filename, () => {
         .returns(Promise.resolve({ entities }));
 
       return refreshAddon({ addonSlug, apiState, dispatch }).then(() => {
-        expect(dispatch.called).toBeTruthy();
-        expect(dispatch.firstCall.args[0]).toEqual(loadAddons(entities));
+        sinon.assert.calledWith(dispatch, loadAddons(entities));
         mockApi.verify();
       });
     });
@@ -373,7 +372,7 @@ describe(__filename, () => {
       return refreshAddon({ addonSlug, apiState, dispatch }).then(
         unexpectedSuccess,
         () => {
-          expect(dispatch.called).toEqual(false);
+          sinon.assert.notCalled(dispatch);
         },
       );
     });
@@ -543,8 +542,7 @@ describe(__filename, () => {
       const callback = sinon.spy(() => Promise.resolve());
       const asPromised = safePromise(callback);
       return asPromised('one', 'two', 'three').then(() => {
-        expect(callback.called).toBeTruthy();
-        expect(callback.firstCall.args).toEqual(['one', 'two', 'three']);
+        sinon.assert.calledWith(callback, 'one', 'two', 'three');
       });
     });
 
@@ -610,8 +608,7 @@ describe(__filename, () => {
       const node = findRenderedComponentWithType(root, NotFound);
 
       expect(node).toBeTruthy();
-      expect(_config.get.called).toBeTruthy();
-      expect(_config.get.firstCall.args[0]).toEqual(configKey);
+      sinon.assert.calledWith(_config.get, configKey);
     });
 
     it('passes through component and props when enabled', () => {
@@ -619,7 +616,7 @@ describe(__filename, () => {
       const SomeComponent = sinon.spy(() => <div />);
       render({ color: 'orange', size: 'large' }, { SomeComponent, _config });
 
-      expect(SomeComponent.called).toBeTruthy();
+      sinon.assert.called(SomeComponent);
       const props = SomeComponent.firstCall.args[0];
       expect(props.color).toEqual('orange');
       expect(props.size).toEqual('large');

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -614,12 +614,11 @@ describe(__filename, () => {
     it('passes through component and props when enabled', () => {
       const _config = { get: () => true };
       const SomeComponent = sinon.spy(() => <div />);
-      render({ color: 'orange', size: 'large' }, { SomeComponent, _config });
+      const props = { color: 'orange', size: 'large' };
 
-      sinon.assert.called(SomeComponent);
-      const props = SomeComponent.firstCall.args[0];
-      expect(props.color).toEqual('orange');
-      expect(props.size).toEqual('large');
+      render(props, { SomeComponent, _config });
+
+      sinon.assert.calledWith(SomeComponent, props);
     });
   });
 

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -65,40 +65,40 @@ describe(__filename, () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 1);
-    expect(onSelectRating.called).toEqual(true);
-    expect(onSelectRating.firstCall.args[0]).toEqual(1);
+    sinon.assert.called(onSelectRating);
+    sinon.assert.calledWith(onSelectRating, 1);
   });
 
   it('lets you select a two star rating', () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 2);
-    expect(onSelectRating.called).toEqual(true);
-    expect(onSelectRating.firstCall.args[0]).toEqual(2);
+    sinon.assert.called(onSelectRating);
+    sinon.assert.calledWith(onSelectRating, 2);
   });
 
   it('lets you select a three star rating', () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 3);
-    expect(onSelectRating.called).toEqual(true);
-    expect(onSelectRating.firstCall.args[0]).toEqual(3);
+    sinon.assert.called(onSelectRating);
+    sinon.assert.calledWith(onSelectRating, 3);
   });
 
   it('lets you select a four star rating', () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 4);
-    expect(onSelectRating.called).toEqual(true);
-    expect(onSelectRating.firstCall.args[0]).toEqual(4);
+    sinon.assert.called(onSelectRating);
+    sinon.assert.calledWith(onSelectRating, 4);
   });
 
   it('lets you select a five star rating', () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 5);
-    expect(onSelectRating.called).toEqual(true);
-    expect(onSelectRating.firstCall.args[0]).toEqual(5);
+    sinon.assert.called(onSelectRating);
+    sinon.assert.calledWith(onSelectRating, 5);
   });
 
   it('renders correct full stars for a rating', () => {
@@ -214,8 +214,8 @@ describe(__filename, () => {
     const button = root.ratingElements[4];
     Simulate.click(button, fakeEvent);
 
-    expect(fakeEvent.preventDefault.called).toEqual(true);
-    expect(fakeEvent.stopPropagation.called).toEqual(true);
+    sinon.assert.called(fakeEvent.preventDefault);
+    sinon.assert.called(fakeEvent.stopPropagation);
   });
 
   it('requires a valid onSelectRating callback', () => {
@@ -235,7 +235,7 @@ describe(__filename, () => {
         readOnly: true,
       });
       selectRating(root, 5);
-      expect(onSelectRating.called).toEqual(false);
+      sinon.assert.notCalled(onSelectRating);
     });
 
     it('does not classify as editable when read-only', () => {

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -65,7 +65,6 @@ describe(__filename, () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 1);
-    sinon.assert.called(onSelectRating);
     sinon.assert.calledWith(onSelectRating, 1);
   });
 
@@ -73,7 +72,6 @@ describe(__filename, () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 2);
-    sinon.assert.called(onSelectRating);
     sinon.assert.calledWith(onSelectRating, 2);
   });
 
@@ -81,7 +79,6 @@ describe(__filename, () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 3);
-    sinon.assert.called(onSelectRating);
     sinon.assert.calledWith(onSelectRating, 3);
   });
 
@@ -89,7 +86,6 @@ describe(__filename, () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 4);
-    sinon.assert.called(onSelectRating);
     sinon.assert.calledWith(onSelectRating, 4);
   });
 
@@ -97,7 +93,6 @@ describe(__filename, () => {
     const onSelectRating = sinon.stub();
     const root = render({ onSelectRating });
     selectRating(root, 5);
-    sinon.assert.called(onSelectRating);
     sinon.assert.calledWith(onSelectRating, 5);
   });
 

--- a/tests/unit/ui/components/TestSwitch.js
+++ b/tests/unit/ui/components/TestSwitch.js
@@ -89,8 +89,10 @@ describe(__filename, () => {
     const onChange = sinon.spy();
     const root = findDOMNode(renderButton({ onChange }));
     const checkbox = root.querySelector('input[type=checkbox]');
+
     Simulate.change(checkbox);
-    expect(onChange.calledWith()).toBeTruthy();
+
+    sinon.assert.called(onChange);
   });
 
   it('associates the label and input with id and for attributes', () => {


### PR DESCRIPTION
Fix #2437 

---

- use `sinon.assert` everywhere
- remove more unused code