### PR TITLE
I5578-updating static theme tracking info

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -103,7 +103,7 @@ export const INCOMPATIBLE_UNSUPPORTED_PLATFORM =
 
 // Tracking add-on types
 export const TRACKING_TYPE_EXTENSION = 'addon';
-export const TRACKING_TYPE_STATIC_THEME = 'addon:statictheme';
+export const TRACKING_TYPE_STATIC_THEME = ADDON_TYPE_STATIC_THEME;
 export const TRACKING_TYPE_THEME = 'theme';
 export const TRACKING_TYPE_INVALID = 'invalid';
 


### PR DESCRIPTION
fixes #5578 

notice eventAction is now just `statictheme`

## Before
![Alt text](https://monosnap.com/image/vmUcfDcKBoAI6KilN8SoxcAmuoqrE6.png)

## After
![Alt text](https://monosnap.com/image/9haB0sW9RyafiGCBqbQttzQlMap1km.png)
