### PR TITLE
Avoid scrollbar in user profile name

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -152,8 +152,7 @@
 
 .SearchResult-author {
   display: none;
-  overflow: auto;
-  word-wrap: break-word;
+  word-break: break-all;
 
   @include respond-to(medium) {
     display: block;

--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -67,8 +67,7 @@ $avatar-size: 64px;
   font-size: $font-size-l;
   grid-column: 1 / span 3;
   margin: 0;
-  overflow: auto;
-  word-wrap: break-word;
+  word-break: break-all;
 
   @include respond-to(medium) {
     font-size: $font-size-xl;


### PR DESCRIPTION
This is a slightly better fix for #5494 that avoids a scroll bar to be displayed.