### PR TITLE
Set dangerouslySetInnerHTML on a div

### DIFF
--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -364,7 +364,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                   className="UserProfile-biography"
                   term={i18n.gettext('Biography')}
                 >
-                  <p
+                  <div
                     // eslint-disable-next-line react/no-danger
                     dangerouslySetInnerHTML={sanitizeUserHTML(user.biography)}
                   />

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -411,9 +411,11 @@ describe(__filename, () => {
   });
 
   it("renders the user's biography", () => {
+    const biography = '<blockquote><b>Not even vegan!</b></blockquote>';
+
     const { store } = dispatchSignInActions({
       userProps: {
-        biography: 'Not even vegan!',
+        biography,
         username: 'tofumatt',
       },
     });
@@ -424,9 +426,9 @@ describe(__filename, () => {
     expect(
       root
         .find('.UserProfile-biography')
-        .find('p')
+        .find('div')
         .html(),
-    ).toContain('Not even vegan!');
+    ).toContain(biography);
   });
 
   it('omits a null biography', () => {


### PR DESCRIPTION
Fix #5587

---

I believe the browser changes the HTML in the DOM to be valid. React
does not find what the server has sent in the `dangerouslySetInnerHTML`
when introspecting the DOM, hence the warning (locally) about the
`dangerouslySetInnerHTML` mismatch (see issue).

React 16 is weird when a difference between server and client occurs.