### PR TITLE
I5550 converting confirm btn to use setUIState

### DIFF
--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -3,7 +3,6 @@ import makeClassName from 'classnames';
 import * as React from 'react';
 import { compose } from 'redux';
 
-import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import withUIState from 'core/withUIState';
 import Button from 'ui/components/Button';
@@ -117,16 +116,11 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
   }
 }
 
-export const extractId = (ownProps: Props) => {
-  return `confirmButton-${ownProps.className || ''}`;
-};
-
 const ConfirmButton: React.ComponentType<Props> = compose(
   translate(),
-  withFixedErrorHandler({ fileName: __filename, extractId }),
   withUIState({
     fileName: __filename,
-    extractId,
+    extractId: () => '',
     initialState: initialUIState,
   }),
 )(ConfirmButtonBase);

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -118,7 +118,7 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
 }
 
 export const extractId = (ownProps: Props) => {
-  return `confirmButton-${ownProps.className}`;
+  return `confirmButton-${ownProps.className || ''}`;
 };
 
 const ConfirmButton: React.ComponentType<Props> = compose(

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -55,9 +55,11 @@ describe(__filename, () => {
     const root = render({ message, store });
 
     expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+    expect(root.instance().props.uiState.showConfirmation).toEqual(false);
 
     root.find(Button).simulate('click', createFakeEvent());
     applyUIStateChanges({ root, store });
+    expect(root.instance().props.uiState.showConfirmation).toEqual(true);
 
     expect(root).toHaveClassName('ConfirmButton--show-confirmation');
 
@@ -159,17 +161,5 @@ describe(__filename, () => {
 
     expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
     sinon.assert.calledWith(onConfirmSpy, event);
-  });
-
-  it('changes UI state when the confirm button is clicked', () => {
-    const { store } = dispatchClientMetadata();
-    const root = render({ store });
-
-    expect(root.instance().props.uiState.showConfirmation).toEqual(false);
-
-    root.find(Button).simulate('click', createFakeEvent());
-    applyUIStateChanges({ root, store });
-
-    expect(root.instance().props.uiState.showConfirmation).toEqual(true);
   });
 });

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -97,6 +97,25 @@ describe(__filename, () => {
     );
   });
 
+  it('passes props to the cancel button in the confirmation panel', () => {
+    const { store } = dispatchClientMetadata();
+    const cancelButtonText = 'neutral cancel button';
+    const cancelButtonType = 'neutral';
+    const root = render({ cancelButtonText, cancelButtonType, store });
+
+    // Show the confirmation panel.
+    root.find(Button).simulate('click', createFakeEvent());
+    applyUIStateChanges({ root, store });
+
+    expect(root.find('.ConfirmButton-cancel-button')).toHaveProp(
+      'buttonType',
+      cancelButtonType,
+    );
+    expect(root.find('.ConfirmButton-cancel-button').children()).toHaveText(
+      cancelButtonText,
+    );
+  });
+
   it('closes the confirmation panel on cancel ', () => {
     const { store } = dispatchClientMetadata();
     const onConfirmSpy = sinon.spy();


### PR DESCRIPTION
fixes #5550 

I wasn't totally clear if I need to do anything to the HOC. I saw this component in 2 places - the collections and the user profile - and it looks like it works with the changes in both places still. 

let me know what you think : )
