### PR TITLE
Fix top-level describe block descriptions

### DIFF
--- a/tests/unit/TestCSPConfig.js
+++ b/tests/unit/TestCSPConfig.js
@@ -14,7 +14,7 @@ const apiHosts = {
   production: 'https://addons.mozilla.org',
 };
 
-describe('CSP Config Defaults', () => {
+describe(__filename, () => {
   const existingNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {

--- a/tests/unit/TestConfig.js
+++ b/tests/unit/TestConfig.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 
-describe('Config Environment Variables', () => {
+describe(__filename, () => {
   beforeEach(() => {
     jest.resetModules();
   });

--- a/tests/unit/TestFrameGuardConfig.js
+++ b/tests/unit/TestFrameGuardConfig.js
@@ -3,7 +3,7 @@ import config from 'config';
 
 const appsList = config.get('validAppNames');
 
-describe('App Specific Frameguard Config', () => {
+describe(__filename, () => {
   const existingNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {

--- a/tests/unit/TestLocalesConfig.js
+++ b/tests/unit/TestLocalesConfig.js
@@ -29,19 +29,19 @@ describe(__filename, () => {
     it(`should have a "${lang}" entry for locale dir in config.langs`, () =>
       expect(langs).toContain(lang));
   }
-});
 
-describe('Check Locale JS for entities', () => {
-  for (const localeJSFile of glob.sync('src/locale/*/*.js')) {
-    it(`${localeJSFile} should not have html entities`, (done) => {
-      fs.readFile(localeJSFile, 'utf8', (err, data) => {
-        if (!err) {
-          expect(/&[^\s]+;/.test(data)).toBeFalsy();
-        } else {
-          throw new Error(err);
-        }
-        done();
+  describe('Check Locale JS for entities', () => {
+    for (const localeJSFile of glob.sync('src/locale/*/*.js')) {
+      it(`${localeJSFile} should not have html entities`, (done) => {
+        fs.readFile(localeJSFile, 'utf8', (err, data) => {
+          if (!err) {
+            expect(/&[^\s]+;/.test(data)).toBeFalsy();
+          } else {
+            throw new Error(err);
+          }
+          done();
+        });
       });
-    });
-  }
+    }
+  });
 });

--- a/tests/unit/TestPackageJson.js
+++ b/tests/unit/TestPackageJson.js
@@ -15,7 +15,7 @@ const packageJson = JSON.parse(
                               with the exact same version */
 const skipDevDeps = ['postcss-loader', 'prettier', 'pretty-quick'];
 
-describe('Package JSON', () => {
+describe(__filename, () => {
   Object.keys(packageJson.devDependencies).forEach((key) => {
     it(`should have devDependencies[${key}] version prefixed with "^"`, () => {
       if (!skipDevDeps.includes(key)) {

--- a/tests/unit/TestPrefixConfig.js
+++ b/tests/unit/TestPrefixConfig.js
@@ -1,4 +1,4 @@
-describe('AMO Prefix config', () => {
+describe(__filename, () => {
   const existingNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {

--- a/tests/unit/TestSriDataPlugin.js
+++ b/tests/unit/TestSriDataPlugin.js
@@ -7,7 +7,7 @@ import tmp from 'tmp';
 
 import SriDataPlugin from 'core/server/sriDataPlugin';
 
-describe('SriDataPlugin', () => {
+describe(__filename, () => {
   let distDir;
   let srcDir;
   let tempDir;

--- a/tests/unit/amo/actions/testViewContext.js
+++ b/tests/unit/amo/actions/testViewContext.js
@@ -1,6 +1,6 @@
 import { setViewContext } from 'amo/actions/viewContext';
 
-describe('amo/actions/setViewContext', () => {
+describe(__filename, () => {
   it('requires a context', () => {
     expect(() => setViewContext()).toThrow(/context parameter is required/);
   });

--- a/tests/unit/amo/actions/test_featured.js
+++ b/tests/unit/amo/actions/test_featured.js
@@ -2,50 +2,54 @@ import { getFeatured, loadFeatured } from 'amo/actions/featured';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 
-describe('amo/actions/featured/getFeatured', () => {
-  function getActionArgs(args = {}) {
-    const errorHandler = createStubErrorHandler();
-    return {
-      addonType: ADDON_TYPE_EXTENSION,
-      errorHandlerId: errorHandler.id,
-      ...args,
-    };
-  }
+describe(__filename, () => {
+  describe('amo/actions/featured/getFeatured', () => {
+    function getActionArgs(args = {}) {
+      const errorHandler = createStubErrorHandler();
+      return {
+        addonType: ADDON_TYPE_EXTENSION,
+        errorHandlerId: errorHandler.id,
+        ...args,
+      };
+    }
 
-  it('sets the filters', () => {
-    const action = getFeatured(
-      getActionArgs({
-        errorHandlerId: 'some-id',
+    it('sets the filters', () => {
+      const action = getFeatured(
+        getActionArgs({
+          errorHandlerId: 'some-id',
+          addonType: ADDON_TYPE_THEME,
+        }),
+      );
+      expect(action.payload).toEqual({
         addonType: ADDON_TYPE_THEME,
-      }),
-    );
-    expect(action.payload).toEqual({
-      addonType: ADDON_TYPE_THEME,
-      errorHandlerId: 'some-id',
+        errorHandlerId: 'some-id',
+      });
+    });
+
+    it('throws if no addonType is set', () => {
+      const args = getActionArgs();
+      delete args.addonType;
+      expect(() => getFeatured(args)).toThrowError('addonType must be set');
+    });
+
+    it('throws if no errorHandler is set', () => {
+      const args = getActionArgs();
+      delete args.errorHandlerId;
+      expect(() => getFeatured(args)).toThrowError(
+        'errorHandlerId must be set',
+      );
     });
   });
 
-  it('throws if no addonType is set', () => {
-    const args = getActionArgs();
-    delete args.addonType;
-    expect(() => getFeatured(args)).toThrowError('addonType must be set');
-  });
+  describe('amo/actions/featured/loadFeatured', () => {
+    const response = {
+      entities: sinon.stub(),
+      result: sinon.stub(),
+    };
+    const action = loadFeatured({ addonType: 'theme', ...response });
 
-  it('throws if no errorHandler is set', () => {
-    const args = getActionArgs();
-    delete args.errorHandlerId;
-    expect(() => getFeatured(args)).toThrowError('errorHandlerId must be set');
-  });
-});
-
-describe('amo/actions/featured/loadFeatured', () => {
-  const response = {
-    entities: sinon.stub(),
-    result: sinon.stub(),
-  };
-  const action = loadFeatured({ addonType: 'theme', ...response });
-
-  it('sets the payload', () => {
-    expect(action.payload).toEqual({ addonType: 'theme', ...response });
+    it('sets the payload', () => {
+      expect(action.payload).toEqual({ addonType: 'theme', ...response });
+    });
   });
 });

--- a/tests/unit/amo/components/TestAboutPage.js
+++ b/tests/unit/amo/components/TestAboutPage.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import About, { AboutBase } from 'amo/components/StaticPages/About';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
-describe('About', () => {
+describe(__filename, () => {
   function render() {
     return shallowUntilTarget(<About i18n={fakeI18n()} />, AboutBase);
   }

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -1421,104 +1421,104 @@ describe(__filename, () => {
       expect(extractId(props)).toEqual('some-slug');
     });
   });
-});
 
-describe('mapStateToProps', () => {
-  let store;
+  describe('mapStateToProps', () => {
+    let store;
 
-  beforeEach(() => {
-    store = createStore().store;
-  });
+    beforeEach(() => {
+      store = createStore().store;
+    });
 
-  function signIn(params) {
-    dispatchSignInActions({ store, ...params });
-  }
+    function signIn(params) {
+      dispatchSignInActions({ store, ...params });
+    }
 
-  function fetchAddon({ addon = fakeAddon } = {}) {
-    store.dispatch(loadAddons(createFetchAddonResult(addon).entities));
-  }
+    function fetchAddon({ addon = fakeAddon } = {}) {
+      store.dispatch(loadAddons(createFetchAddonResult(addon).entities));
+    }
 
-  function _mapStateToProps(
-    state = store.getState(),
-    ownProps = { params: { slug: fakeAddon.slug } },
-  ) {
-    return mapStateToProps(state, ownProps);
-  }
+    function _mapStateToProps(
+      state = store.getState(),
+      ownProps = { params: { slug: fakeAddon.slug } },
+    ) {
+      return mapStateToProps(state, ownProps);
+    }
 
-  it('can handle a missing addon', () => {
-    signIn();
-    const { addon, platformFiles } = _mapStateToProps();
-    expect(addon).toBeFalsy();
-    // Make sure this isn't undefined since it gets read from `addon`.
-    expect(platformFiles).toEqual({});
-  });
+    it('can handle a missing addon', () => {
+      signIn();
+      const { addon, platformFiles } = _mapStateToProps();
+      expect(addon).toBeFalsy();
+      // Make sure this isn't undefined since it gets read from `addon`.
+      expect(platformFiles).toEqual({});
+    });
 
-  it('sets the clientApp and userAgent', () => {
-    const clientAppFromAgent = 'firefox';
-    signIn({ clientApp: clientAppFromAgent });
-    fetchAddon();
-    const { clientApp, userAgentInfo } = _mapStateToProps();
+    it('sets the clientApp and userAgent', () => {
+      const clientAppFromAgent = 'firefox';
+      signIn({ clientApp: clientAppFromAgent });
+      fetchAddon();
+      const { clientApp, userAgentInfo } = _mapStateToProps();
 
-    expect(clientApp).toEqual(clientAppFromAgent);
-    const { browser, os } = sampleUserAgentParsed;
-    expect(userAgentInfo).toEqual({ browser, os });
-  });
+      expect(clientApp).toEqual(clientAppFromAgent);
+      const { browser, os } = sampleUserAgentParsed;
+      expect(userAgentInfo).toEqual({ browser, os });
+    });
 
-  it('sets installStatus to INSTALLED when add-on is installed', () => {
-    signIn();
-    fetchAddon();
-    store.dispatch(
-      setInstallState({
-        ...fakeInstalledAddon,
-        guid: fakeAddon.guid,
-        status: INSTALLED,
-      }),
-    );
-    const { installStatus } = _mapStateToProps();
+    it('sets installStatus to INSTALLED when add-on is installed', () => {
+      signIn();
+      fetchAddon();
+      store.dispatch(
+        setInstallState({
+          ...fakeInstalledAddon,
+          guid: fakeAddon.guid,
+          status: INSTALLED,
+        }),
+      );
+      const { installStatus } = _mapStateToProps();
 
-    expect(installStatus).toEqual(INSTALLED);
-  });
+      expect(installStatus).toEqual(INSTALLED);
+    });
 
-  it('sets installStatus to UNKNOWN when add-on is not installed', () => {
-    signIn();
-    fetchAddon();
-    const { installStatus } = _mapStateToProps();
+    it('sets installStatus to UNKNOWN when add-on is not installed', () => {
+      signIn();
+      fetchAddon();
+      const { installStatus } = _mapStateToProps();
 
-    expect(installStatus).toEqual(UNKNOWN);
-  });
+      expect(installStatus).toEqual(UNKNOWN);
+    });
 
-  it('must convert all addon props to component props', () => {
-    signIn();
-    const description = 'whatever';
-    fetchAddon({ addon: { ...fakeAddon, description } });
-    const props = _mapStateToProps();
+    it('must convert all addon props to component props', () => {
+      signIn();
+      const description = 'whatever';
+      fetchAddon({ addon: { ...fakeAddon, description } });
+      const props = _mapStateToProps();
 
-    // Make sure a random addon prop gets passed as a component prop
-    // so that the withInstallHelpers HOC works.
-    expect(props.description).toEqual(description);
-  });
+      // Make sure a random addon prop gets passed as a component prop
+      // so that the withInstallHelpers HOC works.
+      expect(props.description).toEqual(description);
+    });
 
-  it('must convert all installed addon props to component props', () => {
-    signIn();
-    fetchAddon();
-    store.dispatch(
-      setInstallState({
-        ...fakeInstalledAddon,
-        guid: fakeAddon.guid,
-        status: INSTALLED,
-      }),
-    );
-    const { needsRestart } = _mapStateToProps();
+    it('must convert all installed addon props to component props', () => {
+      signIn();
+      fetchAddon();
+      store.dispatch(
+        setInstallState({
+          ...fakeInstalledAddon,
+          guid: fakeAddon.guid,
+          status: INSTALLED,
+        }),
+      );
+      const { needsRestart } = _mapStateToProps();
 
-    // Make sure a random installedAddon prop gets passed as a component prop
-    // so that the withInstallHelpers HOC works.
-    expect(needsRestart).toEqual(false);
-  });
+      // Make sure a random installedAddon prop gets passed as a component prop
+      // so that the withInstallHelpers HOC works.
+      expect(needsRestart).toEqual(false);
+    });
 
-  it('handles a non-existant add-on', () => {
-    signIn();
-    const { addon } = _mapStateToProps();
+    it('handles a non-existant add-on', () => {
+      signIn();
+      const { addon } = _mapStateToProps();
 
-    expect(addon).toEqual(null);
+      expect(addon).toEqual(null);
+    });
   });
 });

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -15,7 +15,7 @@ import { dispatchClientMetadata, fakeCategory } from 'tests/unit/amo/helpers';
 import { createStubErrorHandler, fakeI18n } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
 
-describe('<Categories />', () => {
+describe(__filename, () => {
   let store;
 
   beforeEach(() => {

--- a/tests/unit/amo/components/TestCategoriesPage.js
+++ b/tests/unit/amo/components/TestCategoriesPage.js
@@ -6,7 +6,7 @@ import { CategoriesPageBase } from 'amo/components/CategoriesPage';
 import { ADDON_TYPE_EXTENSION } from 'core/constants';
 import { visibleAddonType } from 'core/utils';
 
-describe('amo/components/CategoriesPage', () => {
+describe(__filename, () => {
   it('renders Categories', () => {
     const params = {
       visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),

--- a/tests/unit/amo/components/TestFooter.js
+++ b/tests/unit/amo/components/TestFooter.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Footer, { FooterBase } from 'amo/components/Footer';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
-describe('Footer', () => {
+describe(__filename, () => {
   function renderFooter({ ...props }) {
     return shallowUntilTarget(
       <Footer i18n={fakeI18n()} {...props} />,

--- a/tests/unit/amo/components/TestLanguagePicker.js
+++ b/tests/unit/amo/components/TestLanguagePicker.js
@@ -14,86 +14,88 @@ import {
 } from 'amo/components/LanguagePicker';
 import { fakeI18n, fakeRouterLocation } from 'tests/unit/helpers';
 
-describe('LanguagePicker', () => {
-  function renderLanguagePicker({ ...props }) {
-    const initialState = { api: { clientApp: 'android', lang: 'fr' } };
-    const { store } = createStore({ initialState });
+describe(__filename, () => {
+  describe('LanguagePicker', () => {
+    function renderLanguagePicker({ ...props }) {
+      const initialState = { api: { clientApp: 'android', lang: 'fr' } };
+      const { store } = createStore({ initialState });
 
-    return findRenderedComponentWithType(
-      renderIntoDocument(
-        <Provider store={store}>
-          <LanguagePickerBase i18n={fakeI18n()} {...props} />
-        </Provider>,
-      ),
-      LanguagePickerBase,
-    );
-  }
+      return findRenderedComponentWithType(
+        renderIntoDocument(
+          <Provider store={store}>
+            <LanguagePickerBase i18n={fakeI18n()} {...props} />
+          </Provider>,
+        ),
+        LanguagePickerBase,
+      );
+    }
 
-  it('renders a LanguagePicker', () => {
-    const root = renderLanguagePicker();
+    it('renders a LanguagePicker', () => {
+      const root = renderLanguagePicker();
 
-    expect(root.selector.tagName).toEqual('SELECT');
-  });
-
-  it('selects the current locale', () => {
-    const root = renderLanguagePicker({ currentLocale: 'fr' });
-
-    expect(findDOMNode(root).querySelector('option:checked').value).toEqual(
-      'fr',
-    );
-  });
-
-  it('changes the language on change', () => {
-    const _window = { location: '/fr/firefox/' };
-    const root = renderLanguagePicker({
-      currentLocale: 'fr',
-      location: fakeRouterLocation({ pathname: _window.location }),
-      _window,
-    });
-    const fakeEvent = {
-      preventDefault: sinon.stub(),
-      target: { value: 'es' },
-    };
-    Simulate.change(root.selector, fakeEvent);
-
-    expect(_window.location).toEqual('/es/firefox/');
-  });
-});
-
-describe('changeLocaleURL', () => {
-  it('changes the URL', () => {
-    const newURL = changeLocaleURL({
-      currentLocale: 'en-US',
-      location: fakeRouterLocation({
-        pathname: '/en-US/firefox/nowhere/',
-        query: { page: 1, q: 'search' },
-      }),
-      newLocale: 'en-GB',
+      expect(root.selector.tagName).toEqual('SELECT');
     });
 
-    expect(newURL).toEqual('/en-GB/firefox/nowhere/?page=1&q=search');
-  });
+    it('selects the current locale', () => {
+      const root = renderLanguagePicker({ currentLocale: 'fr' });
 
-  it('handles URLs without query params', () => {
-    const newURL = changeLocaleURL({
-      currentLocale: 'en-US',
-      location: fakeRouterLocation({ pathname: '/en-US/firefox/nowhere/' }),
-      newLocale: 'ar',
+      expect(findDOMNode(root).querySelector('option:checked').value).toEqual(
+        'fr',
+      );
     });
 
-    expect(newURL).toEqual('/ar/firefox/nowhere/');
+    it('changes the language on change', () => {
+      const _window = { location: '/fr/firefox/' };
+      const root = renderLanguagePicker({
+        currentLocale: 'fr',
+        location: fakeRouterLocation({ pathname: _window.location }),
+        _window,
+      });
+      const fakeEvent = {
+        preventDefault: sinon.stub(),
+        target: { value: 'es' },
+      };
+      Simulate.change(root.selector, fakeEvent);
+
+      expect(_window.location).toEqual('/es/firefox/');
+    });
   });
 
-  it('only changes the locale section of the URL', () => {
-    const newURL = changeLocaleURL({
-      currentLocale: 'en-US',
-      location: fakeRouterLocation({
-        pathname: '/en-US/firefox/en-US-to-en-GB-guide/',
-        query: { foo: 'en-US' },
-      }),
-      newLocale: 'ar',
+  describe('changeLocaleURL', () => {
+    it('changes the URL', () => {
+      const newURL = changeLocaleURL({
+        currentLocale: 'en-US',
+        location: fakeRouterLocation({
+          pathname: '/en-US/firefox/nowhere/',
+          query: { page: 1, q: 'search' },
+        }),
+        newLocale: 'en-GB',
+      });
+
+      expect(newURL).toEqual('/en-GB/firefox/nowhere/?page=1&q=search');
     });
 
-    expect(newURL).toEqual('/ar/firefox/en-US-to-en-GB-guide/?foo=en-US');
+    it('handles URLs without query params', () => {
+      const newURL = changeLocaleURL({
+        currentLocale: 'en-US',
+        location: fakeRouterLocation({ pathname: '/en-US/firefox/nowhere/' }),
+        newLocale: 'ar',
+      });
+
+      expect(newURL).toEqual('/ar/firefox/nowhere/');
+    });
+
+    it('only changes the locale section of the URL', () => {
+      const newURL = changeLocaleURL({
+        currentLocale: 'en-US',
+        location: fakeRouterLocation({
+          pathname: '/en-US/firefox/en-US-to-en-GB-guide/',
+          query: { foo: 'en-US' },
+        }),
+        newLocale: 'ar',
+      });
+
+      expect(newURL).toEqual('/ar/firefox/en-US-to-en-GB-guide/?foo=en-US');
+    });
   });
 });

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -39,7 +39,7 @@ import {
   userAuthToken,
 } from 'tests/unit/helpers';
 
-describe('RatingManager', () => {
+describe(__filename, () => {
   let store;
 
   beforeEach(() => {

--- a/tests/unit/amo/components/TestReviewGuide.js
+++ b/tests/unit/amo/components/TestReviewGuide.js
@@ -5,7 +5,7 @@ import ReviewGuide, {
 } from 'amo/components/StaticPages/ReviewGuide';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
-describe('ReviewGuide', () => {
+describe(__filename, () => {
   function render() {
     return shallowUntilTarget(
       <ReviewGuide i18n={fakeI18n()} />,

--- a/tests/unit/amo/reducers/testViewContext.js
+++ b/tests/unit/amo/reducers/testViewContext.js
@@ -1,7 +1,7 @@
 import viewContext, { initialState } from 'amo/reducers/viewContext';
 import { VIEW_CONTEXT_EXPLORE } from 'core/constants';
 
-describe('viewContext reducer', () => {
+describe(__filename, () => {
   it('defaults to explore', () => {
     const state = viewContext(initialState, {});
 

--- a/tests/unit/amo/sagas/testCategories.js
+++ b/tests/unit/amo/sagas/testCategories.js
@@ -10,7 +10,7 @@ import apiReducer from 'core/reducers/api';
 import categoriesReducer from 'core/reducers/categories';
 import { createStubErrorHandler } from 'tests/unit/helpers';
 
-describe('categoriesSaga', () => {
+describe(__filename, () => {
   let errorHandler;
   let initialState;
   let sagaTester;

--- a/tests/unit/amo/sagas/testIndex.js
+++ b/tests/unit/amo/sagas/testIndex.js
@@ -1,6 +1,6 @@
 import rootSagas from 'amo/sagas';
 
-describe('amo rootSagas', () => {
+describe(__filename, () => {
   it('should run all sagas without an error', () => {
     expect(() => {
       rootSagas().next();

--- a/tests/unit/amo/test_utils.js
+++ b/tests/unit/amo/test_utils.js
@@ -3,7 +3,7 @@ import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
 import { getErrorComponent } from 'amo/utils';
 
-describe('amo/utils', () => {
+describe(__filename, () => {
   describe('getErrorComponent', () => {
     it('returns a NotAuthorized component for 401 errors', () => {
       expect(getErrorComponent(401)).toEqual(NotAuthorized);

--- a/tests/unit/core/TestAddonManager.js
+++ b/tests/unit/core/TestAddonManager.js
@@ -7,7 +7,7 @@ import {
 } from 'core/constants';
 import { unexpectedSuccess } from 'tests/unit/helpers';
 
-describe('addonManager', () => {
+describe(__filename, () => {
   let fakeAddon;
   let fakeCallback;
   let fakeInstallObj;

--- a/tests/unit/core/TestInstallAddon.js
+++ b/tests/unit/core/TestInstallAddon.js
@@ -570,998 +570,1009 @@ describe(__filename, () => {
       expect(url).toMatch(/lang=he/);
     });
   });
-});
 
-describe(`${__filename}: withInstallHelpers`, () => {
-  const defaultInstallSource = 'some-install-source';
-  const WrappedComponent = sinon.stub();
-  let configStub;
-  let mapDispatchToProps;
+  describe('withInstallHelpers', () => {
+    const defaultInstallSource = 'some-install-source';
+    const WrappedComponent = sinon.stub();
+    let configStub;
+    let mapDispatchToProps;
 
-  function getMapStateToProps({
-    _tracking,
-    installations = {},
-    state = {},
-  } = {}) {
-    return mapStateToProps({ installations, addons: {} }, state, { _tracking });
-  }
-
-  beforeAll(() => {
-    mapDispatchToProps = makeMapDispatchToProps({
-      WrappedComponent,
-      defaultInstallSource,
-    });
-  });
-
-  beforeEach(() => {
-    configStub = sinon
-      .stub(config, 'get')
-      .withArgs('server')
-      .returns(false);
-  });
-
-  describe('setCurrentStatus', () => {
-    it('sets the status to ENABLED when an enabled add-on found', () => {
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        defaultInstallSource: null,
+    function getMapStateToProps({
+      _tracking,
+      installations = {},
+      state = {},
+    } = {}) {
+      return mapStateToProps({ installations, addons: {} }, state, {
+        _tracking,
       });
-      const { setCurrentStatus } = root.instance().props;
+    }
 
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ENABLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('lets you pass custom props to setCurrentStatus', () => {
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        defaultInstallSource: null,
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      dispatch.resetHistory();
-      return setCurrentStatus(addon).then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ENABLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('sets the status to DISABLED when a disabled add-on found', () => {
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        defaultInstallSource: null,
-        _addonManager: getFakeAddonManagerWrapper({
-          getAddon: Promise.resolve({
-            isActive: false,
-            isEnabled: false,
-            type: ADDON_TYPE_EXTENSION,
-          }),
-        }),
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: DISABLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('sets the status to DISABLED when an inactive add-on found', () => {
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        defaultInstallSource: null,
-        _addonManager: getFakeAddonManagerWrapper({
-          getAddon: Promise.resolve({
-            isActive: false,
-            isEnabled: true,
-            type: ADDON_TYPE_EXTENSION,
-          }),
-        }),
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: DISABLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('sets the status to ENABLED when an enabled theme is found', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper({
-        getAddon: Promise.resolve({
-          type: ADDON_TYPE_THEME,
-          isActive: true,
-          isEnabled: true,
-        }),
-      });
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        defaultInstallSource: null,
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ENABLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('sets the status to DISABLED when an inactive theme is found', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper({
-        getAddon: Promise.resolve({
-          isActive: false,
-          isEnabled: true,
-          type: ADDON_TYPE_THEME,
-        }),
-      });
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        defaultInstallSource: null,
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: DISABLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('sets the status to DISABLED when a disabled theme is found', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper({
-        getAddon: Promise.resolve({
-          isActive: true,
-          isEnabled: false,
-          type: ADDON_TYPE_THEME,
-        }),
-      });
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        defaultInstallSource: null,
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: DISABLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('sets the status to UNINSTALLED when not found', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper({
-        getAddon: Promise.reject(),
-      });
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        defaultInstallSource: null,
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: UNINSTALLED,
-            url: installURL,
-          }),
-        );
-      });
-    });
-
-    it('dispatches error when setCurrentStatus gets exception', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper({
-        // Resolve a null addon which will trigger an exception.
-        getAddon: Promise.resolve(null),
-      });
-      const addon = createInternalAddon(fakeAddon);
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-      });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ERROR,
-            error: FATAL_ERROR,
-          }),
-        );
-      });
-    });
-
-    it('adds defaultInstallSource to the URL', () => {
-      const installURL = 'http://the.url/';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
+    beforeAll(() => {
+      mapDispatchToProps = makeMapDispatchToProps({
+        WrappedComponent,
         defaultInstallSource,
       });
-      const { setCurrentStatus } = root.instance().props;
-
-      return setCurrentStatus().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ENABLED,
-            url: `${installURL}?src=${defaultInstallSource}`,
-          }),
-        );
-      });
     });
-  });
-
-  describe('makeProgressHandler', () => {
-    it('sets the download progress on STATE_DOWNLOADING', () => {
-      const dispatch = sinon.spy();
-      const guid = 'foo@addon';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({ state: 'STATE_DOWNLOADING', progress: 300, maxProgress: 990 });
-      sinon.assert.calledWith(dispatch, {
-        type: DOWNLOAD_PROGRESS,
-        payload: { downloadProgress: 30, guid },
-      });
-    });
-
-    it('sets status to error on onDownloadFailed', () => {
-      const dispatch = sinon.spy();
-      const guid = '{my-addon}';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({ state: 'STATE_SOMETHING' }, { type: 'onDownloadFailed' });
-      sinon.assert.calledWith(dispatch, {
-        type: 'INSTALL_ERROR',
-        payload: { guid, error: DOWNLOAD_FAILED },
-      });
-    });
-
-    it('sets status to installing onDownloadEnded', () => {
-      const dispatch = sinon.spy();
-      const guid = '{my-addon}';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({ state: 'STATE_SOMETHING' }, { type: 'onDownloadEnded' });
-      sinon.assert.calledWith(
-        dispatch,
-        setInstallState({
-          guid,
-          status: INSTALLING,
-        }),
-      );
-    });
-
-    it('resets status to uninstalled on onInstallCancelled', () => {
-      const dispatch = sinon.spy();
-      const guid = '{my-addon}';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallCancelled' });
-      sinon.assert.calledWith(dispatch, {
-        type: INSTALL_CANCELLED,
-        payload: { guid },
-      });
-    });
-
-    it('sets status to error on onInstallFailed', () => {
-      const dispatch = sinon.spy();
-      const guid = '{my-addon}';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallFailed' });
-      sinon.assert.calledWith(dispatch, {
-        type: 'INSTALL_ERROR',
-        payload: { guid, error: INSTALL_FAILED },
-      });
-    });
-
-    it('does nothing on unknown events', () => {
-      const dispatch = sinon.spy();
-      const guid = 'foo@addon';
-      const handler = makeProgressHandler(dispatch, guid);
-      handler({ state: 'WAT' }, { type: 'onNothingPerformed' });
-      sinon.assert.notCalled(dispatch);
-    });
-  });
-
-  describe('enable', () => {
-    it('calls addonManager.enable() and content notification', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper({
-        permissionPromptsEnabled: false,
-      });
-      const name = 'the-name';
-      const iconUrl = 'https://a.m.o/some-icon.png';
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        name,
-        icon_url: iconUrl,
-      });
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-      });
-      const { enable } = root.instance().props;
-
-      const fakeShowInfo = sinon.stub();
-      return enable({ _showInfo: fakeShowInfo }).then(() => {
-        sinon.assert.calledWith(fakeAddonManager.enable, addon.guid);
-        sinon.assert.calledWith(fakeShowInfo, { name, iconUrl });
-      });
-    });
-
-    it('calls addonManager.enable() without content notification', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper({
-        permissionPromptsEnabled: true,
-      });
-      const name = 'the-name';
-      const iconUrl = 'https://a.m.o/some-icon.png';
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        name,
-        icon_url: iconUrl,
-      });
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-      });
-      const { enable } = root.instance().props;
-
-      const fakeShowInfo = sinon.stub();
-      return enable({ _showInfo: fakeShowInfo }).then(() => {
-        sinon.assert.calledWith(fakeAddonManager.enable, addon.guid);
-        sinon.assert.neverCalledWith(fakeShowInfo, { name, iconUrl });
-      });
-    });
-
-    it('dispatches a FATAL_ERROR', () => {
-      const fakeAddonManager = {
-        enable: sinon.stub().returns(Promise.reject(new Error('hai'))),
-      };
-      const addon = createInternalAddon(fakeAddon);
-      const { dispatch, root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-      });
-      const { enable } = root.instance().props;
-
-      return enable().then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ERROR,
-            error: FATAL_ERROR,
-          }),
-        );
-      });
-    });
-
-    it('does not dispatch a FATAL_ERROR when setEnabled is missing', () => {
-      const fakeAddonManager = {
-        enable: sinon
-          .stub()
-          .returns(Promise.reject(new Error(SET_ENABLE_NOT_AVAILABLE))),
-      };
-      const { root, dispatch } = renderWithInstallHelpers({
-        _addonManager: fakeAddonManager,
-      });
-      const { enable } = root.instance().props;
-
-      return enable().then(() => {
-        sinon.assert.notCalled(dispatch);
-      });
-    });
-  });
-
-  describe('install', () => {
-    const installURL = 'https://mysite.com/download.xpi';
-
-    it('calls addonManager.install()', () => {
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url: installURL }],
-        }),
-      );
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        defaultInstallSource,
-      });
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.calledWith(
-          fakeAddonManager.install,
-          `${installURL}?src=${defaultInstallSource}`,
-          sinon.match.func,
-          { src: defaultInstallSource },
-        );
-      });
-    });
-
-    it('tracks the start of an addon install', () => {
-      const addon = createInternalAddon(fakeAddon);
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: getFakeAddonManagerWrapper({
-          // Make the install fail so that we can be sure only
-          // the 'start' event gets tracked.
-          install: sinon
-            .stub()
-            .returns(Promise.reject(new Error('install error'))),
-        }),
-        _tracking: fakeTracking,
-      });
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        // Even though the install() promise fails, it gets caught
-        // and resolved successfully.
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
-          category: getAddonEventCategory(
-            ADDON_TYPE_EXTENSION,
-            INSTALL_STARTED_ACTION,
-          ),
-          label: addon.name,
-        });
-        sinon.assert.calledOnce(fakeTracking.sendEvent);
-      });
-    });
-
-    it('tracks an addon install', () => {
-      const addon = createInternalAddon(fakeAddon);
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _tracking: fakeTracking,
-      });
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
-          category: getAddonEventCategory(ADDON_TYPE_EXTENSION, INSTALL_ACTION),
-          label: addon.name,
-        });
-      });
-    });
-
-    it('tracks the start of a static theme install', () => {
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-      });
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _tracking: fakeTracking,
-      });
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
-          category: getAddonEventCategory(
-            ADDON_TYPE_STATIC_THEME,
-            INSTALL_STARTED_ACTION,
-          ),
-          label: addon.name,
-        });
-      });
-    });
-
-    it('tracks a static theme addon install', () => {
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-      });
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _tracking: fakeTracking,
-      });
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
-          category: getAddonEventCategory(
-            ADDON_TYPE_STATIC_THEME,
-            INSTALL_ACTION,
-          ),
-          label: addon.name,
-        });
-      });
-    });
-
-    it('should dispatch START_DOWNLOAD', () => {
-      const addon = createInternalAddon(fakeAddon);
-      const { root, dispatch } = renderWithInstallHelpers(addon);
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.calledWith(dispatch, {
-          type: START_DOWNLOAD,
-          payload: { guid: addon.guid },
-        });
-      });
-    });
-
-    it('should dispatch SHOW_INFO if permissionPromptsEnabled is false', () => {
-      const iconUrl = 'some-icon-url';
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        icon_url: iconUrl,
-      });
-      const props = {
-        ...addon,
-        _addonManager: getFakeAddonManagerWrapper({
-          permissionPromptsEnabled: false,
-        }),
-      };
-      const { root, dispatch } = renderWithInstallHelpers(props);
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.calledWith(dispatch, {
-          type: SHOW_INFO,
-          payload: {
-            addonName: addon.name,
-            imageURL: iconUrl,
-            closeAction: sinon.match.func,
-          },
-        });
-
-        const arg = dispatch.secondCall.args[0];
-        // Prove we're looking at the SHOW_INFO dispatch.
-        expect(arg.type).toEqual(SHOW_INFO);
-
-        // Test that close action dispatches.
-        dispatch.resetHistory();
-        arg.payload.closeAction();
-        sinon.assert.calledWith(dispatch, {
-          type: CLOSE_INFO,
-        });
-      });
-    });
-
-    it('should not dispatch SHOW_INFO if permissionPromptsEnabled is true', () => {
-      const iconUrl = 'some-icon-url';
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        icon_url: iconUrl,
-      });
-      const props = {
-        ...addon,
-        _addonManager: getFakeAddonManagerWrapper({
-          permissionPromptsEnabled: true,
-        }),
-      };
-      const { root, dispatch } = renderWithInstallHelpers(props);
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.neverCalledWith(dispatch, {
-          type: SHOW_INFO,
-          payload: {
-            addonName: addon.name,
-            imageURL: iconUrl,
-            closeAction: sinon.match.func,
-          },
-        });
-      });
-    });
-
-    it('dispatches error when addonManager.install throws', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      fakeAddonManager.install = sinon.stub().returns(Promise.reject());
-
-      const addon = createInternalAddon(fakeAddon);
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-      });
-      const { install } = root.instance().props;
-
-      return install(addon).then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ERROR,
-            error: FATAL_INSTALL_ERROR,
-          }),
-        );
-      });
-    });
-  });
-
-  describe('uninstall', () => {
-    it('calls addonManager.uninstall()', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      const addon = createInternalAddon(fakeAddon);
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-      });
-      const { uninstall } = root.instance().props;
-
-      return uninstall(addon).then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({ guid: addon.guid, status: UNINSTALLING }),
-        );
-        sinon.assert.calledWith(fakeAddonManager.uninstall, addon.guid);
-      });
-    });
-
-    it('dispatches error when addonManager.uninstall throws', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      fakeAddonManager.uninstall = sinon
-        .stub()
-        .returns(Promise.reject(new Error('Add-on Manager uninstall error')));
-      const addon = createInternalAddon(fakeAddon);
-      const { root, dispatch } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-      });
-      const { uninstall } = root.instance().props;
-
-      return uninstall(addon).then(() => {
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({ guid: addon.guid, status: UNINSTALLING }),
-        );
-        sinon.assert.calledWith(
-          dispatch,
-          setInstallState({
-            guid: addon.guid,
-            status: ERROR,
-            error: FATAL_UNINSTALL_ERROR,
-          }),
-        );
-      });
-    });
-
-    it('tracks an addon uninstall', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const addon = createInternalAddon(fakeAddon);
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        _tracking: fakeTracking,
-      });
-      const { uninstall } = root.instance().props;
-
-      return uninstall(addon).then(() => {
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
-          category: getAddonEventCategory(
-            ADDON_TYPE_EXTENSION,
-            UNINSTALL_ACTION,
-          ),
-          label: addon.name,
-        });
-      });
-    });
-
-    it('tracks a static theme addon uninstall', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_STATIC_THEME,
-      });
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        _tracking: fakeTracking,
-      });
-      const { uninstall } = root.instance().props;
-
-      return uninstall(addon).then(() => {
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
-          category: getAddonEventCategory(
-            ADDON_TYPE_STATIC_THEME,
-            UNINSTALL_ACTION,
-          ),
-          label: addon.name,
-        });
-      });
-    });
-
-    it('tracks a theme uninstall', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const addon = createInternalAddon(fakeTheme);
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        _tracking: fakeTracking,
-      });
-      const { uninstall } = root.instance().props;
-
-      return uninstall(addon).then(() => {
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: getAddonTypeForTracking(ADDON_TYPE_THEME),
-          category: getAddonEventCategory(ADDON_TYPE_THEME, UNINSTALL_ACTION),
-          label: addon.name,
-        });
-      });
-    });
-
-    it('tracks a unknown type uninstall', () => {
-      const fakeAddonManager = getFakeAddonManagerWrapper();
-      const fakeTracking = {
-        sendEvent: sinon.spy(),
-      };
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        type: INVALID_TYPE,
-      });
-      const { root } = renderWithInstallHelpers({
-        ...addon,
-        _addonManager: fakeAddonManager,
-        _tracking: fakeTracking,
-      });
-      const { uninstall } = root.instance().props;
-
-      return uninstall(addon).then(() => {
-        sinon.assert.calledWith(fakeTracking.sendEvent, {
-          action: TRACKING_TYPE_INVALID,
-          category: getAddonEventCategory(INVALID_TYPE, UNINSTALL_ACTION),
-          label: addon.name,
-        });
-      });
-    });
-  });
-
-  describe('mapDispatchToProps', () => {
-    let fakeDispatch;
 
     beforeEach(() => {
-      fakeDispatch = sinon.stub();
-    });
-
-    it('still maps props on the server', () => {
-      sinon.restore();
       configStub = sinon
         .stub(config, 'get')
         .withArgs('server')
-        .returns(true);
-      expect(mapDispatchToProps(fakeDispatch)).toEqual({
-        dispatch: fakeDispatch,
-        defaultInstallSource,
-        WrappedComponent,
+        .returns(false);
+    });
+
+    describe('setCurrentStatus', () => {
+      it('sets the status to ENABLED when an enabled add-on found', () => {
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          defaultInstallSource: null,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ENABLED,
+              url: installURL,
+            }),
+          );
+        });
       });
-      sinon.assert.calledWith(configStub, 'server');
+
+      it('lets you pass custom props to setCurrentStatus', () => {
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          defaultInstallSource: null,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        dispatch.resetHistory();
+        return setCurrentStatus(addon).then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ENABLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('sets the status to DISABLED when a disabled add-on found', () => {
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          defaultInstallSource: null,
+          _addonManager: getFakeAddonManagerWrapper({
+            getAddon: Promise.resolve({
+              isActive: false,
+              isEnabled: false,
+              type: ADDON_TYPE_EXTENSION,
+            }),
+          }),
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: DISABLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('sets the status to DISABLED when an inactive add-on found', () => {
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          defaultInstallSource: null,
+          _addonManager: getFakeAddonManagerWrapper({
+            getAddon: Promise.resolve({
+              isActive: false,
+              isEnabled: true,
+              type: ADDON_TYPE_EXTENSION,
+            }),
+          }),
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: DISABLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('sets the status to ENABLED when an enabled theme is found', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper({
+          getAddon: Promise.resolve({
+            type: ADDON_TYPE_THEME,
+            isActive: true,
+            isEnabled: true,
+          }),
+        });
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          defaultInstallSource: null,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ENABLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('sets the status to DISABLED when an inactive theme is found', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper({
+          getAddon: Promise.resolve({
+            isActive: false,
+            isEnabled: true,
+            type: ADDON_TYPE_THEME,
+          }),
+        });
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          defaultInstallSource: null,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: DISABLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('sets the status to DISABLED when a disabled theme is found', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper({
+          getAddon: Promise.resolve({
+            isActive: true,
+            isEnabled: false,
+            type: ADDON_TYPE_THEME,
+          }),
+        });
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          defaultInstallSource: null,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: DISABLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('sets the status to UNINSTALLED when not found', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper({
+          getAddon: Promise.reject(),
+        });
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          defaultInstallSource: null,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: UNINSTALLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('dispatches error when setCurrentStatus gets exception', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper({
+          // Resolve a null addon which will trigger an exception.
+          getAddon: Promise.resolve(null),
+        });
+        const addon = createInternalAddon(fakeAddon);
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ERROR,
+              error: FATAL_ERROR,
+            }),
+          );
+        });
+      });
+
+      it('adds defaultInstallSource to the URL', () => {
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          defaultInstallSource,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ENABLED,
+              url: `${installURL}?src=${defaultInstallSource}`,
+            }),
+          );
+        });
+      });
     });
 
-    it('requires platformFiles', () => {
-      const props = defaultProps();
-      delete props.platformFiles;
-      expect(() => {
-        makeMapDispatchToProps({})(fakeDispatch, props);
-      }).toThrowError(/platformFiles prop is required/);
+    describe('makeProgressHandler', () => {
+      it('sets the download progress on STATE_DOWNLOADING', () => {
+        const dispatch = sinon.spy();
+        const guid = 'foo@addon';
+        const handler = makeProgressHandler(dispatch, guid);
+        handler({
+          state: 'STATE_DOWNLOADING',
+          progress: 300,
+          maxProgress: 990,
+        });
+        sinon.assert.calledWith(dispatch, {
+          type: DOWNLOAD_PROGRESS,
+          payload: { downloadProgress: 30, guid },
+        });
+      });
+
+      it('sets status to error on onDownloadFailed', () => {
+        const dispatch = sinon.spy();
+        const guid = '{my-addon}';
+        const handler = makeProgressHandler(dispatch, guid);
+        handler({ state: 'STATE_SOMETHING' }, { type: 'onDownloadFailed' });
+        sinon.assert.calledWith(dispatch, {
+          type: 'INSTALL_ERROR',
+          payload: { guid, error: DOWNLOAD_FAILED },
+        });
+      });
+
+      it('sets status to installing onDownloadEnded', () => {
+        const dispatch = sinon.spy();
+        const guid = '{my-addon}';
+        const handler = makeProgressHandler(dispatch, guid);
+        handler({ state: 'STATE_SOMETHING' }, { type: 'onDownloadEnded' });
+        sinon.assert.calledWith(
+          dispatch,
+          setInstallState({
+            guid,
+            status: INSTALLING,
+          }),
+        );
+      });
+
+      it('resets status to uninstalled on onInstallCancelled', () => {
+        const dispatch = sinon.spy();
+        const guid = '{my-addon}';
+        const handler = makeProgressHandler(dispatch, guid);
+        handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallCancelled' });
+        sinon.assert.calledWith(dispatch, {
+          type: INSTALL_CANCELLED,
+          payload: { guid },
+        });
+      });
+
+      it('sets status to error on onInstallFailed', () => {
+        const dispatch = sinon.spy();
+        const guid = '{my-addon}';
+        const handler = makeProgressHandler(dispatch, guid);
+        handler({ state: 'STATE_SOMETHING' }, { type: 'onInstallFailed' });
+        sinon.assert.calledWith(dispatch, {
+          type: 'INSTALL_ERROR',
+          payload: { guid, error: INSTALL_FAILED },
+        });
+      });
+
+      it('does nothing on unknown events', () => {
+        const dispatch = sinon.spy();
+        const guid = 'foo@addon';
+        const handler = makeProgressHandler(dispatch, guid);
+        handler({ state: 'WAT' }, { type: 'onNothingPerformed' });
+        sinon.assert.notCalled(dispatch);
+      });
     });
 
-    it('requires userAgentInfo', () => {
-      const props = defaultProps();
-      delete props.userAgentInfo;
-      expect(() => {
-        makeMapDispatchToProps({})(fakeDispatch, props);
-      }).toThrowError(/userAgentInfo prop is required/);
+    describe('enable', () => {
+      it('calls addonManager.enable() and content notification', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper({
+          permissionPromptsEnabled: false,
+        });
+        const name = 'the-name';
+        const iconUrl = 'https://a.m.o/some-icon.png';
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          name,
+          icon_url: iconUrl,
+        });
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+        });
+        const { enable } = root.instance().props;
+
+        const fakeShowInfo = sinon.stub();
+        return enable({ _showInfo: fakeShowInfo }).then(() => {
+          sinon.assert.calledWith(fakeAddonManager.enable, addon.guid);
+          sinon.assert.calledWith(fakeShowInfo, { name, iconUrl });
+        });
+      });
+
+      it('calls addonManager.enable() without content notification', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper({
+          permissionPromptsEnabled: true,
+        });
+        const name = 'the-name';
+        const iconUrl = 'https://a.m.o/some-icon.png';
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          name,
+          icon_url: iconUrl,
+        });
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+        });
+        const { enable } = root.instance().props;
+
+        const fakeShowInfo = sinon.stub();
+        return enable({ _showInfo: fakeShowInfo }).then(() => {
+          sinon.assert.calledWith(fakeAddonManager.enable, addon.guid);
+          sinon.assert.neverCalledWith(fakeShowInfo, { name, iconUrl });
+        });
+      });
+
+      it('dispatches a FATAL_ERROR', () => {
+        const fakeAddonManager = {
+          enable: sinon.stub().returns(Promise.reject(new Error('hai'))),
+        };
+        const addon = createInternalAddon(fakeAddon);
+        const { dispatch, root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+        });
+        const { enable } = root.instance().props;
+
+        return enable().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ERROR,
+              error: FATAL_ERROR,
+            }),
+          );
+        });
+      });
+
+      it('does not dispatch a FATAL_ERROR when setEnabled is missing', () => {
+        const fakeAddonManager = {
+          enable: sinon
+            .stub()
+            .returns(Promise.reject(new Error(SET_ENABLE_NOT_AVAILABLE))),
+        };
+        const { root, dispatch } = renderWithInstallHelpers({
+          _addonManager: fakeAddonManager,
+        });
+        const { enable } = root.instance().props;
+
+        return enable().then(() => {
+          sinon.assert.notCalled(dispatch);
+        });
+      });
     });
 
-    it('requires location', () => {
-      const props = defaultProps();
-      delete props.location;
-      expect(() => {
-        makeMapDispatchToProps({})(fakeDispatch, props);
-      }).toThrowError(/location prop is required/);
-    });
+    describe('install', () => {
+      const installURL = 'https://mysite.com/download.xpi';
 
-    it('can wrap an extension with the right props', () => {
-      const props = defaultProps();
-      expect(() => {
-        makeMapDispatchToProps({})(fakeDispatch, props);
-      }).not.toThrowError();
-    });
-  });
+      it('calls addonManager.install()', () => {
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+          }),
+        );
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          defaultInstallSource,
+        });
+        const { install } = root.instance().props;
 
-  describe('installTheme', () => {
-    const baseAddon = {
-      name: 'hai-theme',
-      guid: '{install-theme}',
-      status: UNINSTALLED,
-      type: ADDON_TYPE_THEME,
-    };
+        return install(addon).then(() => {
+          sinon.assert.calledWith(
+            fakeAddonManager.install,
+            `${installURL}?src=${defaultInstallSource}`,
+            sinon.match.func,
+            { src: defaultInstallSource },
+          );
+        });
+      });
 
-    function installThemeStubs() {
-      return {
-        _themeInstall: sinon.spy(),
-        _tracking: {
+      it('tracks the start of an addon install', () => {
+        const addon = createInternalAddon(fakeAddon);
+        const fakeTracking = {
           sendEvent: sinon.spy(),
-        },
+        };
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: getFakeAddonManagerWrapper({
+            // Make the install fail so that we can be sure only
+            // the 'start' event gets tracked.
+            install: sinon
+              .stub()
+              .returns(Promise.reject(new Error('install error'))),
+          }),
+          _tracking: fakeTracking,
+        });
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          // Even though the install() promise fails, it gets caught
+          // and resolved successfully.
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
+            category: getAddonEventCategory(
+              ADDON_TYPE_EXTENSION,
+              INSTALL_STARTED_ACTION,
+            ),
+            label: addon.name,
+          });
+          sinon.assert.calledOnce(fakeTracking.sendEvent);
+        });
+      });
+
+      it('tracks an addon install', () => {
+        const addon = createInternalAddon(fakeAddon);
+        const fakeTracking = {
+          sendEvent: sinon.spy(),
+        };
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _tracking: fakeTracking,
+        });
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
+            category: getAddonEventCategory(
+              ADDON_TYPE_EXTENSION,
+              INSTALL_ACTION,
+            ),
+            label: addon.name,
+          });
+        });
+      });
+
+      it('tracks the start of a static theme install', () => {
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_STATIC_THEME,
+        });
+        const fakeTracking = {
+          sendEvent: sinon.spy(),
+        };
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _tracking: fakeTracking,
+        });
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
+            category: getAddonEventCategory(
+              ADDON_TYPE_STATIC_THEME,
+              INSTALL_STARTED_ACTION,
+            ),
+            label: addon.name,
+          });
+        });
+      });
+
+      it('tracks a static theme addon install', () => {
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_STATIC_THEME,
+        });
+        const fakeTracking = {
+          sendEvent: sinon.spy(),
+        };
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _tracking: fakeTracking,
+        });
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
+            category: getAddonEventCategory(
+              ADDON_TYPE_STATIC_THEME,
+              INSTALL_ACTION,
+            ),
+            label: addon.name,
+          });
+        });
+      });
+
+      it('should dispatch START_DOWNLOAD', () => {
+        const addon = createInternalAddon(fakeAddon);
+        const { root, dispatch } = renderWithInstallHelpers(addon);
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.calledWith(dispatch, {
+            type: START_DOWNLOAD,
+            payload: { guid: addon.guid },
+          });
+        });
+      });
+
+      it('should dispatch SHOW_INFO if permissionPromptsEnabled is false', () => {
+        const iconUrl = 'some-icon-url';
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          icon_url: iconUrl,
+        });
+        const props = {
+          ...addon,
+          _addonManager: getFakeAddonManagerWrapper({
+            permissionPromptsEnabled: false,
+          }),
+        };
+        const { root, dispatch } = renderWithInstallHelpers(props);
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.calledWith(dispatch, {
+            type: SHOW_INFO,
+            payload: {
+              addonName: addon.name,
+              imageURL: iconUrl,
+              closeAction: sinon.match.func,
+            },
+          });
+
+          const arg = dispatch.secondCall.args[0];
+          // Prove we're looking at the SHOW_INFO dispatch.
+          expect(arg.type).toEqual(SHOW_INFO);
+
+          // Test that close action dispatches.
+          dispatch.resetHistory();
+          arg.payload.closeAction();
+          sinon.assert.calledWith(dispatch, {
+            type: CLOSE_INFO,
+          });
+        });
+      });
+
+      it('should not dispatch SHOW_INFO if permissionPromptsEnabled is true', () => {
+        const iconUrl = 'some-icon-url';
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          icon_url: iconUrl,
+        });
+        const props = {
+          ...addon,
+          _addonManager: getFakeAddonManagerWrapper({
+            permissionPromptsEnabled: true,
+          }),
+        };
+        const { root, dispatch } = renderWithInstallHelpers(props);
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.neverCalledWith(dispatch, {
+            type: SHOW_INFO,
+            payload: {
+              addonName: addon.name,
+              imageURL: iconUrl,
+              closeAction: sinon.match.func,
+            },
+          });
+        });
+      });
+
+      it('dispatches error when addonManager.install throws', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        fakeAddonManager.install = sinon.stub().returns(Promise.reject());
+
+        const addon = createInternalAddon(fakeAddon);
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+        });
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ERROR,
+              error: FATAL_INSTALL_ERROR,
+            }),
+          );
+        });
+      });
+    });
+
+    describe('uninstall', () => {
+      it('calls addonManager.uninstall()', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        const addon = createInternalAddon(fakeAddon);
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+        });
+        const { uninstall } = root.instance().props;
+
+        return uninstall(addon).then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({ guid: addon.guid, status: UNINSTALLING }),
+          );
+          sinon.assert.calledWith(fakeAddonManager.uninstall, addon.guid);
+        });
+      });
+
+      it('dispatches error when addonManager.uninstall throws', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        fakeAddonManager.uninstall = sinon
+          .stub()
+          .returns(Promise.reject(new Error('Add-on Manager uninstall error')));
+        const addon = createInternalAddon(fakeAddon);
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+        });
+        const { uninstall } = root.instance().props;
+
+        return uninstall(addon).then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({ guid: addon.guid, status: UNINSTALLING }),
+          );
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: ERROR,
+              error: FATAL_UNINSTALL_ERROR,
+            }),
+          );
+        });
+      });
+
+      it('tracks an addon uninstall', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        const fakeTracking = {
+          sendEvent: sinon.spy(),
+        };
+        const addon = createInternalAddon(fakeAddon);
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          _tracking: fakeTracking,
+        });
+        const { uninstall } = root.instance().props;
+
+        return uninstall(addon).then(() => {
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
+            category: getAddonEventCategory(
+              ADDON_TYPE_EXTENSION,
+              UNINSTALL_ACTION,
+            ),
+            label: addon.name,
+          });
+        });
+      });
+
+      it('tracks a static theme addon uninstall', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        const fakeTracking = {
+          sendEvent: sinon.spy(),
+        };
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          type: ADDON_TYPE_STATIC_THEME,
+        });
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          _tracking: fakeTracking,
+        });
+        const { uninstall } = root.instance().props;
+
+        return uninstall(addon).then(() => {
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
+            category: getAddonEventCategory(
+              ADDON_TYPE_STATIC_THEME,
+              UNINSTALL_ACTION,
+            ),
+            label: addon.name,
+          });
+        });
+      });
+
+      it('tracks a theme uninstall', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        const fakeTracking = {
+          sendEvent: sinon.spy(),
+        };
+        const addon = createInternalAddon(fakeTheme);
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          _tracking: fakeTracking,
+        });
+        const { uninstall } = root.instance().props;
+
+        return uninstall(addon).then(() => {
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: getAddonTypeForTracking(ADDON_TYPE_THEME),
+            category: getAddonEventCategory(ADDON_TYPE_THEME, UNINSTALL_ACTION),
+            label: addon.name,
+          });
+        });
+      });
+
+      it('tracks a unknown type uninstall', () => {
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        const fakeTracking = {
+          sendEvent: sinon.spy(),
+        };
+        const addon = createInternalAddon({
+          ...fakeAddon,
+          type: INVALID_TYPE,
+        });
+        const { root } = renderWithInstallHelpers({
+          ...addon,
+          _addonManager: fakeAddonManager,
+          _tracking: fakeTracking,
+        });
+        const { uninstall } = root.instance().props;
+
+        return uninstall(addon).then(() => {
+          sinon.assert.calledWith(fakeTracking.sendEvent, {
+            action: TRACKING_TYPE_INVALID,
+            category: getAddonEventCategory(INVALID_TYPE, UNINSTALL_ACTION),
+            label: addon.name,
+          });
+        });
+      });
+    });
+
+    describe('mapDispatchToProps', () => {
+      let fakeDispatch;
+
+      beforeEach(() => {
+        fakeDispatch = sinon.stub();
+      });
+
+      it('still maps props on the server', () => {
+        sinon.restore();
+        configStub = sinon
+          .stub(config, 'get')
+          .withArgs('server')
+          .returns(true);
+        expect(mapDispatchToProps(fakeDispatch)).toEqual({
+          dispatch: fakeDispatch,
+          defaultInstallSource,
+          WrappedComponent,
+        });
+        sinon.assert.calledWith(configStub, 'server');
+      });
+
+      it('requires platformFiles', () => {
+        const props = defaultProps();
+        delete props.platformFiles;
+        expect(() => {
+          makeMapDispatchToProps({})(fakeDispatch, props);
+        }).toThrowError(/platformFiles prop is required/);
+      });
+
+      it('requires userAgentInfo', () => {
+        const props = defaultProps();
+        delete props.userAgentInfo;
+        expect(() => {
+          makeMapDispatchToProps({})(fakeDispatch, props);
+        }).toThrowError(/userAgentInfo prop is required/);
+      });
+
+      it('requires location', () => {
+        const props = defaultProps();
+        delete props.location;
+        expect(() => {
+          makeMapDispatchToProps({})(fakeDispatch, props);
+        }).toThrowError(/location prop is required/);
+      });
+
+      it('can wrap an extension with the right props', () => {
+        const props = defaultProps();
+        expect(() => {
+          makeMapDispatchToProps({})(fakeDispatch, props);
+        }).not.toThrowError();
+      });
+    });
+
+    describe('installTheme', () => {
+      const baseAddon = {
+        name: 'hai-theme',
+        guid: '{install-theme}',
+        status: UNINSTALLED,
+        type: ADDON_TYPE_THEME,
       };
-    }
 
-    it('installs the theme when it is not installed', () => {
-      const addon = { ...baseAddon };
-      const node = sinon.stub();
-      const stubs = installThemeStubs();
-      installTheme(node, addon, stubs);
-      expect(stubs._themeInstall.calledWith(node)).toBeTruthy();
-    });
+      function installThemeStubs() {
+        return {
+          _themeInstall: sinon.spy(),
+          _tracking: {
+            sendEvent: sinon.spy(),
+          },
+        };
+      }
 
-    it('tracks a theme install', () => {
-      const addon = { ...baseAddon };
-      const node = sinon.stub();
-      const stubs = installThemeStubs();
-      installTheme(node, addon, stubs);
-      sinon.assert.calledWith(stubs._tracking.sendEvent, {
-        action: TRACKING_TYPE_THEME,
-        category: INSTALL_THEME_STARTED_CATEGORY,
-        label: 'hai-theme',
+      it('installs the theme when it is not installed', () => {
+        const addon = { ...baseAddon };
+        const node = sinon.stub();
+        const stubs = installThemeStubs();
+        installTheme(node, addon, stubs);
+        expect(stubs._themeInstall.calledWith(node)).toBeTruthy();
       });
-      sinon.assert.calledWith(stubs._tracking.sendEvent, {
-        action: TRACKING_TYPE_THEME,
-        category: INSTALL_THEME_CATEGORY,
-        label: 'hai-theme',
+
+      it('tracks a theme install', () => {
+        const addon = { ...baseAddon };
+        const node = sinon.stub();
+        const stubs = installThemeStubs();
+        installTheme(node, addon, stubs);
+        sinon.assert.calledWith(stubs._tracking.sendEvent, {
+          action: TRACKING_TYPE_THEME,
+          category: INSTALL_THEME_STARTED_CATEGORY,
+          label: 'hai-theme',
+        });
+        sinon.assert.calledWith(stubs._tracking.sendEvent, {
+          action: TRACKING_TYPE_THEME,
+          category: INSTALL_THEME_CATEGORY,
+          label: 'hai-theme',
+        });
+        sinon.assert.calledTwice(stubs._tracking.sendEvent);
       });
-      sinon.assert.calledTwice(stubs._tracking.sendEvent);
-    });
 
-    it('does not try to install theme if INSTALLED', () => {
-      const addon = { ...baseAddon, status: INSTALLED };
-      const node = sinon.stub();
-      const stubs = installThemeStubs();
-      installTheme(node, addon, stubs);
-      expect(stubs._tracking.sendEvent.called).toBeFalsy();
-      expect(stubs._themeInstall.called).toBeFalsy();
-    });
+      it('does not try to install theme if INSTALLED', () => {
+        const addon = { ...baseAddon, status: INSTALLED };
+        const node = sinon.stub();
+        const stubs = installThemeStubs();
+        installTheme(node, addon, stubs);
+        expect(stubs._tracking.sendEvent.called).toBeFalsy();
+        expect(stubs._themeInstall.called).toBeFalsy();
+      });
 
-    it('does not try to install theme if it is an extension', () => {
-      const addon = { ...baseAddon, type: ADDON_TYPE_EXTENSION };
-      const node = sinon.stub();
-      const stubs = installThemeStubs();
-      installTheme(node, addon, stubs);
-      expect(stubs._tracking.sendEvent.called).toBeFalsy();
-      expect(stubs._themeInstall.called).toBeFalsy();
-    });
+      it('does not try to install theme if it is an extension', () => {
+        const addon = { ...baseAddon, type: ADDON_TYPE_EXTENSION };
+        const node = sinon.stub();
+        const stubs = installThemeStubs();
+        installTheme(node, addon, stubs);
+        expect(stubs._tracking.sendEvent.called).toBeFalsy();
+        expect(stubs._themeInstall.called).toBeFalsy();
+      });
 
-    describe('getBrowserThemeData', () => {
-      it('formats the browser theme data', () => {
-        const { getBrowserThemeData } = getMapStateToProps();
-        sinon.stub(themeInstall, 'getThemeData').returns({ foo: 'wat' });
-        expect(getBrowserThemeData({ some: 'data' })).toEqual('{"foo":"wat"}');
+      describe('getBrowserThemeData', () => {
+        it('formats the browser theme data', () => {
+          const { getBrowserThemeData } = getMapStateToProps();
+          sinon.stub(themeInstall, 'getThemeData').returns({ foo: 'wat' });
+          expect(getBrowserThemeData({ some: 'data' })).toEqual(
+            '{"foo":"wat"}',
+          );
+        });
       });
     });
   });

--- a/tests/unit/core/TestLocalState.js
+++ b/tests/unit/core/TestLocalState.js
@@ -12,7 +12,7 @@ function fakeLocalForage(overrides = {}) {
   };
 }
 
-describe('LocalState', () => {
+describe(__filename, () => {
   let localState;
 
   beforeAll(() => {

--- a/tests/unit/core/actions/test_categories.js
+++ b/tests/unit/core/actions/test_categories.js
@@ -1,41 +1,43 @@
 import * as actions from 'core/actions/categories';
 import { CATEGORIES_FETCH, CATEGORIES_LOAD } from 'core/constants';
 
-describe('CATEGORIES_FETCH', () => {
-  function _categoriesFetch({ errorHandlerId = 'some-handler-id' } = {}) {
-    return actions.categoriesFetch({ errorHandlerId });
-  }
+describe(__filename, () => {
+  describe('CATEGORIES_FETCH', () => {
+    function _categoriesFetch({ errorHandlerId = 'some-handler-id' } = {}) {
+      return actions.categoriesFetch({ errorHandlerId });
+    }
 
-  it('sets the type', () => {
-    expect(_categoriesFetch().type).toEqual(CATEGORIES_FETCH);
+    it('sets the type', () => {
+      expect(_categoriesFetch().type).toEqual(CATEGORIES_FETCH);
+    });
+
+    it('requires an error handler ID', () => {
+      expect(() => actions.categoriesFetch()).toThrow(
+        /errorHandlerId is required/,
+      );
+    });
+
+    it('puts the error handler ID in the payload', () => {
+      const errorHandlerId = 'some-custom-id';
+      expect(
+        _categoriesFetch({ errorHandlerId }).payload.errorHandlerId,
+      ).toEqual(errorHandlerId);
+    });
   });
 
-  it('requires an error handler ID', () => {
-    expect(() => actions.categoriesFetch()).toThrow(
-      /errorHandlerId is required/,
-    );
-  });
+  describe('CATEGORIES_LOAD', () => {
+    const response = {
+      entities: {},
+      result: ['foo', 'bar'],
+    };
+    const action = actions.categoriesLoad(response);
 
-  it('puts the error handler ID in the payload', () => {
-    const errorHandlerId = 'some-custom-id';
-    expect(_categoriesFetch({ errorHandlerId }).payload.errorHandlerId).toEqual(
-      errorHandlerId,
-    );
-  });
-});
+    it('sets the type', () => {
+      expect(action.type).toEqual(CATEGORIES_LOAD);
+    });
 
-describe('CATEGORIES_LOAD', () => {
-  const response = {
-    entities: {},
-    result: ['foo', 'bar'],
-  };
-  const action = actions.categoriesLoad(response);
-
-  it('sets the type', () => {
-    expect(action.type).toEqual(CATEGORIES_LOAD);
-  });
-
-  it('sets the payload', () => {
-    expect(action.payload.result).toEqual(['foo', 'bar']);
+    it('sets the payload', () => {
+      expect(action.payload.result).toEqual(['foo', 'bar']);
+    });
   });
 });

--- a/tests/unit/core/actions/test_errors.js
+++ b/tests/unit/core/actions/test_errors.js
@@ -1,7 +1,7 @@
 import { clearError, setError, setErrorMessage } from 'core/actions/errors';
 import { CLEAR_ERROR, SET_ERROR } from 'core/constants';
 
-describe('core/actions/errors', () => {
+describe(__filename, () => {
   describe('setError', () => {
     it('creates an error action', () => {
       const id = 'some-id';

--- a/tests/unit/core/actions/test_index.js
+++ b/tests/unit/core/actions/test_index.js
@@ -1,41 +1,45 @@
 import * as actions from 'core/actions';
 import { userAgents } from 'tests/unit/helpers';
 
-describe('core actions setAuthToken', () => {
-  it('requires a token', () => {
-    expect(() => actions.setAuthToken()).toThrowError(/token cannot be falsey/);
-  });
-});
-
-describe('core actions setLang', () => {
-  it('creates the SET_LANG action', () => {
-    expect(actions.setLang('fr')).toEqual({
-      type: 'SET_LANG',
-      payload: { lang: 'fr' },
-    });
-  });
-});
-
-describe('core actions setClientApp', () => {
-  it('creates the SET_CLIENT_APP action', () => {
-    expect(actions.setClientApp('firefox')).toEqual({
-      type: 'SET_CLIENT_APP',
-      payload: { clientApp: 'firefox' },
+describe(__filename, () => {
+  describe('core actions setAuthToken', () => {
+    it('requires a token', () => {
+      expect(() => actions.setAuthToken()).toThrowError(
+        /token cannot be falsey/,
+      );
     });
   });
 
-  it('requires a clientApp value', () => {
-    expect(() => actions.setClientApp('')).toThrowError(/cannot be falsey/);
+  describe('core actions setLang', () => {
+    it('creates the SET_LANG action', () => {
+      expect(actions.setLang('fr')).toEqual({
+        type: 'SET_LANG',
+        payload: { lang: 'fr' },
+      });
+    });
   });
-});
 
-describe('core actions setUserAgent', () => {
-  it('creates the SET_USER_AGENT action', () => {
-    const userAgent = userAgents.chrome[0];
+  describe('core actions setClientApp', () => {
+    it('creates the SET_CLIENT_APP action', () => {
+      expect(actions.setClientApp('firefox')).toEqual({
+        type: 'SET_CLIENT_APP',
+        payload: { clientApp: 'firefox' },
+      });
+    });
 
-    expect(actions.setUserAgent(userAgent)).toEqual({
-      type: 'SET_USER_AGENT',
-      payload: { userAgent },
+    it('requires a clientApp value', () => {
+      expect(() => actions.setClientApp('')).toThrowError(/cannot be falsey/);
+    });
+  });
+
+  describe('core actions setUserAgent', () => {
+    it('creates the SET_USER_AGENT action', () => {
+      const userAgent = userAgents.chrome[0];
+
+      expect(actions.setUserAgent(userAgent)).toEqual({
+        type: 'SET_USER_AGENT',
+        payload: { userAgent },
+      });
     });
   });
 });

--- a/tests/unit/core/client/test_client_config.js
+++ b/tests/unit/core/client/test_client_config.js
@@ -1,6 +1,6 @@
 import { ClientConfig } from 'core/client/config';
 
-describe('client-config module', () => {
+describe(__filename, () => {
   let config;
 
   beforeEach(() => {

--- a/tests/unit/core/client/test_logger.js
+++ b/tests/unit/core/client/test_logger.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/named
 import { bindConsoleMethod } from 'core/logger';
 
-describe('logger.bindConsoleMethod()', () => {
+describe(__filename, () => {
   let fakeConsole;
   let fakeConfig;
 

--- a/tests/unit/core/i18n/TestI18nProvider.js
+++ b/tests/unit/core/i18n/TestI18nProvider.js
@@ -5,7 +5,7 @@ import { renderIntoDocument } from 'react-dom/test-utils';
 import I18nProvider from 'core/i18n/Provider';
 import { fakeI18n } from 'tests/unit/helpers';
 
-describe('I18nProvider', () => {
+describe(__filename, () => {
   class MyComponent extends React.Component {
     static contextTypes = {
       i18n: PropTypes.object.isRequired,

--- a/tests/unit/core/i18n/test_translate.js
+++ b/tests/unit/core/i18n/test_translate.js
@@ -30,7 +30,7 @@ class InnerComponent extends React.Component {
   }
 }
 
-describe('translate()', () => {
+describe(__filename, () => {
   function render({
     Component = translate()(InnerComponent),
     i18n = fakeI18n(),

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -6,7 +6,7 @@ import * as utils from 'core/i18n/utils';
 
 const defaultLang = config.get('defaultLang');
 
-describe('i18n utils', () => {
+describe(__filename, () => {
   describe('normalizeLang()', () => {
     it('should normalize standard languages', () => {
       expect(utils.normalizeLang('en-us')).toEqual('en-US');

--- a/tests/unit/core/middleware/test_HstsMiddleware.js
+++ b/tests/unit/core/middleware/test_HstsMiddleware.js
@@ -3,7 +3,7 @@ import MockExpressResponse from 'mock-express-response';
 
 import { hsts } from 'core/middleware';
 
-describe('HSTS Middleware', () => {
+describe(__filename, () => {
   it('provides the expected HSTS headers', () => {
     const middleware = hsts();
     const nextSpy = sinon.stub();

--- a/tests/unit/core/middleware/test_cspMiddleware.js
+++ b/tests/unit/core/middleware/test_cspMiddleware.js
@@ -7,211 +7,213 @@ import parse from 'content-security-policy-parser';
 import log from 'core/logger';
 import { csp, getNoScriptStyles } from 'core/middleware';
 
-describe('CSP Middleware', () => {
-  const existingNodeEnv = process.env.NODE_ENV;
+describe(__filename, () => {
+  describe('CSP Middleware', () => {
+    const existingNodeEnv = process.env.NODE_ENV;
 
-  afterEach(() => {
-    process.env.NODE_ENV = existingNodeEnv;
-    delete process.env.NODE_APP_INSTANCE;
-  });
-
-  it('provides the expected csp output for amo with noScriptStyles', () => {
-    process.env.NODE_ENV = 'production';
-    process.env.NODE_APP_INSTANCE = 'amo';
-    jest.resetModules();
-    // eslint-disable-next-line global-require
-    const config = require('config');
-    const middleware = csp({
-      _config: config,
-      appName: 'amo',
-      noScriptStyles: getNoScriptStyles('amo'),
+    afterEach(() => {
+      process.env.NODE_ENV = existingNodeEnv;
+      delete process.env.NODE_APP_INSTANCE;
     });
-    const nextSpy = sinon.stub();
-    const req = new MockExpressRequest();
-    const res = new MockExpressResponse();
-    middleware(req, res, nextSpy);
-    const cspHeader = res.get('content-security-policy');
-    const policy = parse(cspHeader);
-    const cdnHost = 'https://addons-amo.cdn.mozilla.net';
-    expect(policy['default-src']).toEqual(["'none'"]);
-    expect(policy['object-src']).toEqual(["'none'"]);
-    expect(policy['frame-src']).toEqual(["'none'"]);
-    expect(policy['media-src']).toEqual(["'none'"]);
-    expect(policy['form-action']).toEqual(["'self'"]);
-    expect(policy['base-uri']).toEqual(["'self'"]);
-    expect(policy['img-src']).toEqual(
-      expect.arrayContaining([
-        "'self'",
-        'data:',
+
+    it('provides the expected csp output for amo with noScriptStyles', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.NODE_APP_INSTANCE = 'amo';
+      jest.resetModules();
+      // eslint-disable-next-line global-require
+      const config = require('config');
+      const middleware = csp({
+        _config: config,
+        appName: 'amo',
+        noScriptStyles: getNoScriptStyles('amo'),
+      });
+      const nextSpy = sinon.stub();
+      const req = new MockExpressRequest();
+      const res = new MockExpressResponse();
+      middleware(req, res, nextSpy);
+      const cspHeader = res.get('content-security-policy');
+      const policy = parse(cspHeader);
+      const cdnHost = 'https://addons-amo.cdn.mozilla.net';
+      expect(policy['default-src']).toEqual(["'none'"]);
+      expect(policy['object-src']).toEqual(["'none'"]);
+      expect(policy['frame-src']).toEqual(["'none'"]);
+      expect(policy['media-src']).toEqual(["'none'"]);
+      expect(policy['form-action']).toEqual(["'self'"]);
+      expect(policy['base-uri']).toEqual(["'self'"]);
+      expect(policy['img-src']).toEqual(
+        expect.arrayContaining([
+          "'self'",
+          'data:',
+          cdnHost,
+          'https://addons.cdn.mozilla.net',
+          'https://www.google-analytics.com',
+        ]),
+      );
+      expect(policy['script-src']).toEqual([
         cdnHost,
-        'https://addons.cdn.mozilla.net',
-        'https://www.google-analytics.com',
-      ]),
-    );
-    expect(policy['script-src']).toEqual([
-      cdnHost,
-      'https://www.google-analytics.com/analytics.js',
-    ]);
-    expect(policy['script-src']).not.toContain("'self'");
-    expect(policy['connect-src']).not.toContain("'self'");
-    expect(policy['connect-src']).toEqual([
-      'https://addons.mozilla.org',
-      'https://sentry.prod.mozaws.net',
-    ]);
-    expect(policy['style-src']).toEqual([
-      cdnHost,
-      "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='",
-    ]);
-    expect(nextSpy.calledOnce).toEqual(true);
-  });
-
-  it('provides the expected style-src directive when noScriptStyles is false', () => {
-    process.env.NODE_ENV = 'production';
-    process.env.NODE_APP_INSTANCE = 'amo';
-    jest.resetModules();
-    // eslint-disable-next-line global-require
-    const config = require('config');
-    const middleware = csp({
-      _config: config,
-      appName: 'amo',
-      noScriptStyles: false,
-    });
-    const nextSpy = sinon.stub();
-    const req = new MockExpressRequest();
-    const res = new MockExpressResponse();
-    middleware(req, res, nextSpy);
-    const cspHeader = res.get('content-security-policy');
-    const policy = parse(cspHeader);
-    const cdnHost = 'https://addons-amo.cdn.mozilla.net';
-    expect(policy['style-src']).toEqual([cdnHost]);
-    expect(nextSpy.calledOnce).toEqual(true);
-  });
-
-  it('provides the expected csp output for the disco app', () => {
-    process.env.NODE_ENV = 'production';
-    process.env.NODE_APP_INSTANCE = 'disco';
-    jest.resetModules();
-    // eslint-disable-next-line global-require
-    const config = require('config');
-    const middleware = csp({
-      _config: config,
-      appName: 'amo',
-      noScriptStyles: getNoScriptStyles('disco'),
-    });
-    const nextSpy = sinon.stub();
-    const req = new MockExpressRequest();
-    const res = new MockExpressResponse();
-    middleware(req, res, nextSpy);
-    const cspHeader = res.get('content-security-policy');
-    const policy = parse(cspHeader);
-    const cdnHost = 'https://addons-discovery.cdn.mozilla.net';
-    expect(policy['default-src']).toEqual(["'none'"]);
-    expect(policy['object-src']).toEqual(["'none'"]);
-    expect(policy['base-uri']).toEqual(["'self'"]);
-    expect(policy['frame-src']).toEqual(["'none'"]);
-    expect(policy['form-action']).toEqual(["'none'"]);
-    expect(policy['img-src']).toEqual(
-      expect.arrayContaining([
-        "'self'",
-        'data:',
+        'https://www.google-analytics.com/analytics.js',
+      ]);
+      expect(policy['script-src']).not.toContain("'self'");
+      expect(policy['connect-src']).not.toContain("'self'");
+      expect(policy['connect-src']).toEqual([
+        'https://addons.mozilla.org',
+        'https://sentry.prod.mozaws.net',
+      ]);
+      expect(policy['style-src']).toEqual([
         cdnHost,
-        'https://addons.cdn.mozilla.net',
-        'https://www.google-analytics.com',
-      ]),
-    );
-    expect(policy['script-src']).toEqual([
-      cdnHost,
-      'https://www.google-analytics.com/analytics.js',
-    ]);
-    expect(policy['script-src']).not.toContain("'self'");
-    expect(policy['connect-src']).not.toContain("'self'");
-    expect(policy['connect-src']).toEqual([
-      'https://addons.mozilla.org',
-      'https://sentry.prod.mozaws.net',
-    ]);
-    expect(policy['style-src']).toEqual([
-      cdnHost,
-      "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='",
-    ]);
-    expect(policy['media-src']).toEqual([cdnHost]);
-    expect(nextSpy.calledOnce).toEqual(true);
-  });
-
-  it('converts false string to false boolean', () => {
-    // This is so we can have environment config vars (`CSP=false`) for
-    // `better-npm-run` that allow us to disable CSP when using dev/stage
-    // data on a local dev server.
-    const warnStub = sinon.stub();
-    const middleware = csp({
-      _config: {
-        get: sinon
-          .stub()
-          .withArgs('CSP')
-          .returns('false'),
-      },
-      _log: {
-        warn: warnStub,
-      },
+        "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='",
+      ]);
+      expect(nextSpy.calledOnce).toEqual(true);
     });
-    const nextSpy = sinon.stub();
-    const req = new MockExpressRequest();
-    const res = new MockExpressResponse();
-    middleware(req, res, nextSpy);
-    expect(warnStub.calledWith('CSP has been disabled from the config')).toBe(
-      true,
-    );
-    expect(nextSpy.calledOnce).toEqual(true);
-  });
 
-  it('logs if the csp config is false', () => {
-    const warnStub = sinon.stub();
-    const middleware = csp({
-      _config: {
-        get: sinon
-          .stub()
-          .withArgs('CSP')
-          .returns(false),
-      },
-      _log: {
-        warn: warnStub,
-      },
+    it('provides the expected style-src directive when noScriptStyles is false', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.NODE_APP_INSTANCE = 'amo';
+      jest.resetModules();
+      // eslint-disable-next-line global-require
+      const config = require('config');
+      const middleware = csp({
+        _config: config,
+        appName: 'amo',
+        noScriptStyles: false,
+      });
+      const nextSpy = sinon.stub();
+      const req = new MockExpressRequest();
+      const res = new MockExpressResponse();
+      middleware(req, res, nextSpy);
+      const cspHeader = res.get('content-security-policy');
+      const policy = parse(cspHeader);
+      const cdnHost = 'https://addons-amo.cdn.mozilla.net';
+      expect(policy['style-src']).toEqual([cdnHost]);
+      expect(nextSpy.calledOnce).toEqual(true);
     });
-    const nextSpy = sinon.stub();
-    const req = new MockExpressRequest();
-    const res = new MockExpressResponse();
-    middleware(req, res, nextSpy);
-    expect(warnStub.calledWith('CSP has been disabled from the config')).toBe(
-      true,
-    );
-    expect(nextSpy.calledOnce).toEqual(true);
-  });
 
-  it('does not blow up if optional args missing', () => {
-    csp();
-  });
-});
-
-describe('noScriptStyles', () => {
-  it('should log on ENOENT', () => {
-    const logStub = sinon.stub(log, 'debug');
-    sinon.stub(fs, 'readFileSync').throws({
-      code: 'ENOENT',
-      message: 'soz',
+    it('provides the expected csp output for the disco app', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.NODE_APP_INSTANCE = 'disco';
+      jest.resetModules();
+      // eslint-disable-next-line global-require
+      const config = require('config');
+      const middleware = csp({
+        _config: config,
+        appName: 'amo',
+        noScriptStyles: getNoScriptStyles('disco'),
+      });
+      const nextSpy = sinon.stub();
+      const req = new MockExpressRequest();
+      const res = new MockExpressResponse();
+      middleware(req, res, nextSpy);
+      const cspHeader = res.get('content-security-policy');
+      const policy = parse(cspHeader);
+      const cdnHost = 'https://addons-discovery.cdn.mozilla.net';
+      expect(policy['default-src']).toEqual(["'none'"]);
+      expect(policy['object-src']).toEqual(["'none'"]);
+      expect(policy['base-uri']).toEqual(["'self'"]);
+      expect(policy['frame-src']).toEqual(["'none'"]);
+      expect(policy['form-action']).toEqual(["'none'"]);
+      expect(policy['img-src']).toEqual(
+        expect.arrayContaining([
+          "'self'",
+          'data:',
+          cdnHost,
+          'https://addons.cdn.mozilla.net',
+          'https://www.google-analytics.com',
+        ]),
+      );
+      expect(policy['script-src']).toEqual([
+        cdnHost,
+        'https://www.google-analytics.com/analytics.js',
+      ]);
+      expect(policy['script-src']).not.toContain("'self'");
+      expect(policy['connect-src']).not.toContain("'self'");
+      expect(policy['connect-src']).toEqual([
+        'https://addons.mozilla.org',
+        'https://sentry.prod.mozaws.net',
+      ]);
+      expect(policy['style-src']).toEqual([
+        cdnHost,
+        "'sha256-DiZjxuHvKi7pvUQCxCVyk1kAFJEUWe+jf6HWMI5agj4='",
+      ]);
+      expect(policy['media-src']).toEqual([cdnHost]);
+      expect(nextSpy.calledOnce).toEqual(true);
     });
-    getNoScriptStyles('disco');
-    sinon.assert.calledWithMatch(logStub, /noscript styles not found at/);
+
+    it('converts false string to false boolean', () => {
+      // This is so we can have environment config vars (`CSP=false`) for
+      // `better-npm-run` that allow us to disable CSP when using dev/stage
+      // data on a local dev server.
+      const warnStub = sinon.stub();
+      const middleware = csp({
+        _config: {
+          get: sinon
+            .stub()
+            .withArgs('CSP')
+            .returns('false'),
+        },
+        _log: {
+          warn: warnStub,
+        },
+      });
+      const nextSpy = sinon.stub();
+      const req = new MockExpressRequest();
+      const res = new MockExpressResponse();
+      middleware(req, res, nextSpy);
+      expect(warnStub.calledWith('CSP has been disabled from the config')).toBe(
+        true,
+      );
+      expect(nextSpy.calledOnce).toEqual(true);
+    });
+
+    it('logs if the csp config is false', () => {
+      const warnStub = sinon.stub();
+      const middleware = csp({
+        _config: {
+          get: sinon
+            .stub()
+            .withArgs('CSP')
+            .returns(false),
+        },
+        _log: {
+          warn: warnStub,
+        },
+      });
+      const nextSpy = sinon.stub();
+      const req = new MockExpressRequest();
+      const res = new MockExpressResponse();
+      middleware(req, res, nextSpy);
+      expect(warnStub.calledWith('CSP has been disabled from the config')).toBe(
+        true,
+      );
+      expect(nextSpy.calledOnce).toEqual(true);
+    });
+
+    it('does not blow up if optional args missing', () => {
+      csp();
+    });
   });
 
-  it('should log on unknown exception', () => {
-    const logStub = sinon.stub(log, 'info');
-    sinon.stub(fs, 'readFileSync').throws({
-      code: 'WHATEVER',
-      message: 'soz',
+  describe('noScriptStyles', () => {
+    it('should log on ENOENT', () => {
+      const logStub = sinon.stub(log, 'debug');
+      sinon.stub(fs, 'readFileSync').throws({
+        code: 'ENOENT',
+        message: 'soz',
+      });
+      getNoScriptStyles('disco');
+      sinon.assert.calledWithMatch(logStub, /noscript styles not found at/);
     });
-    getNoScriptStyles('disco');
-    sinon.assert.calledWithMatch(
-      logStub,
-      /noscript styles could not be parsed from/,
-    );
+
+    it('should log on unknown exception', () => {
+      const logStub = sinon.stub(log, 'info');
+      sinon.stub(fs, 'readFileSync').throws({
+        code: 'WHATEVER',
+        message: 'soz',
+      });
+      getNoScriptStyles('disco');
+      sinon.assert.calledWithMatch(
+        logStub,
+        /noscript styles could not be parsed from/,
+      );
+    });
   });
 });

--- a/tests/unit/core/middleware/test_frameguardMiddleware.js
+++ b/tests/unit/core/middleware/test_frameguardMiddleware.js
@@ -6,7 +6,7 @@ import { frameguard } from 'core/middleware';
 
 const appsList = config.get('validAppNames');
 
-describe('Frameguard Middleware', () => {
+describe(__filename, () => {
   const existingNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {

--- a/tests/unit/core/middleware/test_logRequests.js
+++ b/tests/unit/core/middleware/test_logRequests.js
@@ -4,7 +4,7 @@ import MockExpressResponse from 'mock-express-response';
 import log from 'core/logger';
 import { logRequests } from 'core/middleware';
 
-describe('logRequest Middleware', () => {
+describe(__filename, () => {
   it('logs requests', () => {
     const middleware = logRequests;
     const req = new MockExpressRequest();

--- a/tests/unit/core/middleware/test_prefixMiddleware.js
+++ b/tests/unit/core/middleware/test_prefixMiddleware.js
@@ -1,6 +1,6 @@
 import { prefixMiddleware } from 'core/middleware';
 
-describe('Prefix Middleware', () => {
+describe(__filename, () => {
   let fakeRes;
   let fakeNext;
   let fakeConfig;

--- a/tests/unit/core/middleware/test_staticAssets.js
+++ b/tests/unit/core/middleware/test_staticAssets.js
@@ -3,7 +3,7 @@ import config from 'config';
 
 import { serveAssetsLocally } from 'core/middleware';
 
-describe('Static Assets Middleware', () => {
+describe(__filename, () => {
   it('calls Express.static', () => {
     const expressStub = sinon.stub(Express, 'static');
     sinon

--- a/tests/unit/core/middleware/test_trailingSlashMiddleware.js
+++ b/tests/unit/core/middleware/test_trailingSlashMiddleware.js
@@ -1,6 +1,6 @@
 import { trailingSlashesMiddleware } from 'core/middleware';
 
-describe('Trailing Slashes Middleware', () => {
+describe(__filename, () => {
   let fakeRes;
   let fakeNext;
   let fakeConfig;

--- a/tests/unit/core/reducers/testInfoDialog.js
+++ b/tests/unit/core/reducers/testInfoDialog.js
@@ -1,7 +1,7 @@
 import infoDialog from 'core/reducers/infoDialog';
 import { SHOW_INFO, CLOSE_INFO } from 'core/constants';
 
-describe('infoDialog reducer', () => {
+describe(__filename, () => {
   it('defaults to an empty object', () => {
     expect(infoDialog(undefined, { type: 'UNRELATED' })).toEqual({});
   });

--- a/tests/unit/core/reducers/test_api.js
+++ b/tests/unit/core/reducers/test_api.js
@@ -9,7 +9,7 @@ import {
   userAuthToken,
 } from 'tests/unit/helpers';
 
-describe('api reducer', () => {
+describe(__filename, () => {
   it('maintains the old state', () => {
     const state = { some: 'state' };
     expect(api(state, { type: 'UNRELATED' })).toBe(state);

--- a/tests/unit/core/reducers/test_categories.js
+++ b/tests/unit/core/reducers/test_categories.js
@@ -13,7 +13,7 @@ import { categoriesFetch, categoriesLoad } from 'core/actions/categories';
 import categories, { initialState } from 'core/reducers/categories';
 import { fakeCategory } from 'tests/unit/amo/helpers';
 
-describe('categories reducer', () => {
+describe(__filename, () => {
   it('defaults to an empty set of categories', () => {
     const state = categories(undefined, { type: 'unrelated' });
     expect(state.categories).toEqual(null);

--- a/tests/unit/core/reducers/test_errorPage.js
+++ b/tests/unit/core/reducers/test_errorPage.js
@@ -11,7 +11,7 @@ function getErrorPageState(store) {
   return store.getState().errorPage;
 }
 
-describe('errorPage reducer', () => {
+describe(__filename, () => {
   let store;
 
   beforeEach(() => {

--- a/tests/unit/core/reducers/test_installations.js
+++ b/tests/unit/core/reducers/test_installations.js
@@ -18,7 +18,7 @@ import {
 import installations from 'core/reducers/installations';
 import { fakeInstalledAddon } from 'tests/unit/amo/helpers';
 
-describe('installations reducer', () => {
+describe(__filename, () => {
   it('is an empty object by default', () => {
     expect(installations(undefined, { type: 'whatever' })).toEqual({});
   });

--- a/tests/unit/core/sagas/testAddons.js
+++ b/tests/unit/core/sagas/testAddons.js
@@ -10,7 +10,7 @@ import {
   createStubErrorHandler,
 } from 'tests/unit/helpers';
 
-describe('core/sagas/addons', () => {
+describe(__filename, () => {
   let apiState;
   let errorHandler;
   let mockApi;

--- a/tests/unit/core/sagas/testUtils.js
+++ b/tests/unit/core/sagas/testUtils.js
@@ -10,7 +10,7 @@ import apiReducer from 'core/reducers/api';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 import { dispatchSignInActions } from 'tests/unit/amo/helpers';
 
-describe('Saga utils', () => {
+describe(__filename, () => {
   it('does not allow usage of dispatch from a saga', () => {
     const fakeLog = { error: sinon.stub() };
     const errorHandler = createErrorHandler('some-error-handler', {

--- a/tests/unit/core/test_imageUtils.js
+++ b/tests/unit/core/test_imageUtils.js
@@ -2,7 +2,7 @@ import { getAddonIconUrl } from 'core/imageUtils';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 import fallbackIcon from 'amo/img/icons/default-64.png';
 
-describe('getAddonIconUrl', () => {
+describe(__filename, () => {
   const allowedIcon = 'https://addons.cdn.mozilla.net/webdev-64.png';
 
   it('return icon url as in fake addon', () => {

--- a/tests/unit/core/test_store.js
+++ b/tests/unit/core/test_store.js
@@ -1,6 +1,6 @@
 import { middleware } from 'core/store';
 
-describe('core store middleware', () => {
+describe(__filename, () => {
   function configForDev(isDevelopment, config = {}) {
     const finalConfig = { isDevelopment, ...config };
     return {

--- a/tests/unit/core/test_tracking.js
+++ b/tests/unit/core/test_tracking.js
@@ -25,304 +25,318 @@ import {
   UNINSTALL_THEME_CATEGORY,
 } from 'core/constants';
 
-describe('Tracking', () => {
-  function stubConfig(overrides = {}) {
-    const config = {
-      trackingEnabled: true,
-      trackingId: 'sample-tracking-id',
-      ...overrides,
-    };
-    return { get: sinon.spy((key) => config[key]) };
-  }
-
-  function createTracking(overrides = {}) {
-    return new Tracking({
-      _isDoNotTrackEnabled: () => false,
-      _config: stubConfig(),
-      ...overrides,
-    });
-  }
-
-  beforeEach(() => {
-    window.ga = sinon.stub();
-  });
-
-  it('should not enable GA when configured off', () => {
-    createTracking({
-      _config: stubConfig({ trackingEnabled: false }),
-    });
-    sinon.assert.notCalled(window.ga);
-  });
-
-  it('should not send events when tracking is configured off', () => {
-    const tracking = createTracking({
-      _config: stubConfig({ trackingEnabled: false }),
-    });
-    tracking.sendEvent({
-      category: 'whatever',
-      action: 'some-action',
-    });
-    sinon.assert.notCalled(window.ga);
-  });
-
-  it('should disable GA due to missing id', () => {
-    createTracking({
-      _isDoNotTrackEnabled: () => false,
-      _config: stubConfig({
+describe(__filename, () => {
+  describe('Tracking', () => {
+    function stubConfig(overrides = {}) {
+      const config = {
         trackingEnabled: true,
-        trackingId: null,
-      }),
+        trackingId: 'sample-tracking-id',
+        ...overrides,
+      };
+      return { get: sinon.spy((key) => config[key]) };
+    }
+
+    function createTracking(overrides = {}) {
+      return new Tracking({
+        _isDoNotTrackEnabled: () => false,
+        _config: stubConfig(),
+        ...overrides,
+      });
+    }
+
+    beforeEach(() => {
+      window.ga = sinon.stub();
     });
-    sinon.assert.notCalled(window.ga);
-  });
 
-  it('should disable GA due to Do Not Track', () => {
-    createTracking({
-      _isDoNotTrackEnabled: () => true,
-      _config: stubConfig({ trackingEnabled: true }),
-      trackingEnabled: true,
+    it('should not enable GA when configured off', () => {
+      createTracking({
+        _config: stubConfig({ trackingEnabled: false }),
+      });
+      sinon.assert.notCalled(window.ga);
     });
-    sinon.assert.notCalled(window.ga);
-  });
 
-  it('should send initial page view when enabled', () => {
-    createTracking({
-      _config: stubConfig({ trackingSendInitPageView: true }),
-    });
-    sinon.assert.calledWith(window.ga, 'send', 'pageview');
-  });
-
-  it('should set dimension3', () => {
-    createTracking();
-    sinon.assert.calledWith(window.ga, 'set', 'dimension3', 'addons-frontend');
-  });
-
-  it('should not send initial page view when disabled', () => {
-    createTracking({ trackingSendInitPageView: false });
-    // Make sure only 'create' and 'set' were called, not 'send'.
-    sinon.assert.calledWith(window.ga, 'create');
-    sinon.assert.calledWith(window.ga, 'set', 'dimension3', 'addons-frontend');
-    sinon.assert.callCount(window.ga, 2);
-  });
-
-  it('should throw if page not set', () => {
-    const tracking = createTracking();
-    expect(() => {
-      tracking.setPage();
-    }).toThrowError(/page is required/);
-  });
-
-  it('should call ga with setPage', () => {
-    const tracking = createTracking();
-    const page = 'some/page/';
-    tracking.setPage(page);
-    sinon.assert.calledWith(window.ga, 'set', 'page', page);
-  });
-
-  it('should throw if category not set', () => {
-    const tracking = createTracking();
-    expect(() => {
-      tracking.sendEvent();
-    }).toThrowError(/category is required/);
-  });
-
-  it('should throw if action not set', () => {
-    const tracking = createTracking();
-    expect(() => {
+    it('should not send events when tracking is configured off', () => {
+      const tracking = createTracking({
+        _config: stubConfig({ trackingEnabled: false }),
+      });
       tracking.sendEvent({
         category: 'whatever',
+        action: 'some-action',
       });
-    }).toThrowError(/action is required/);
-  });
-
-  it('should call _ga with sendEvent', () => {
-    const tracking = createTracking();
-    const category = 'some-category';
-    const action = 'some-action';
-    tracking.sendEvent({
-      category,
-      action,
+      sinon.assert.notCalled(window.ga);
     });
-    sinon.assert.calledWithMatch(window.ga, 'send', {
-      eventCategory: category,
-      eventAction: action,
+
+    it('should disable GA due to missing id', () => {
+      createTracking({
+        _isDoNotTrackEnabled: () => false,
+        _config: stubConfig({
+          trackingEnabled: true,
+          trackingId: null,
+        }),
+      });
+      sinon.assert.notCalled(window.ga);
+    });
+
+    it('should disable GA due to Do Not Track', () => {
+      createTracking({
+        _isDoNotTrackEnabled: () => true,
+        _config: stubConfig({ trackingEnabled: true }),
+        trackingEnabled: true,
+      });
+      sinon.assert.notCalled(window.ga);
+    });
+
+    it('should send initial page view when enabled', () => {
+      createTracking({
+        _config: stubConfig({ trackingSendInitPageView: true }),
+      });
+      sinon.assert.calledWith(window.ga, 'send', 'pageview');
+    });
+
+    it('should set dimension3', () => {
+      createTracking();
+      sinon.assert.calledWith(
+        window.ga,
+        'set',
+        'dimension3',
+        'addons-frontend',
+      );
+    });
+
+    it('should not send initial page view when disabled', () => {
+      createTracking({ trackingSendInitPageView: false });
+      // Make sure only 'create' and 'set' were called, not 'send'.
+      sinon.assert.calledWith(window.ga, 'create');
+      sinon.assert.calledWith(
+        window.ga,
+        'set',
+        'dimension3',
+        'addons-frontend',
+      );
+      sinon.assert.callCount(window.ga, 2);
+    });
+
+    it('should throw if page not set', () => {
+      const tracking = createTracking();
+      expect(() => {
+        tracking.setPage();
+      }).toThrowError(/page is required/);
+    });
+
+    it('should call ga with setPage', () => {
+      const tracking = createTracking();
+      const page = 'some/page/';
+      tracking.setPage(page);
+      sinon.assert.calledWith(window.ga, 'set', 'page', page);
+    });
+
+    it('should throw if category not set', () => {
+      const tracking = createTracking();
+      expect(() => {
+        tracking.sendEvent();
+      }).toThrowError(/category is required/);
+    });
+
+    it('should throw if action not set', () => {
+      const tracking = createTracking();
+      expect(() => {
+        tracking.sendEvent({
+          category: 'whatever',
+        });
+      }).toThrowError(/action is required/);
+    });
+
+    it('should call _ga with sendEvent', () => {
+      const tracking = createTracking();
+      const category = 'some-category';
+      const action = 'some-action';
+      tracking.sendEvent({
+        category,
+        action,
+      });
+      sinon.assert.calledWithMatch(window.ga, 'send', {
+        eventCategory: category,
+        eventAction: action,
+      });
+    });
+
+    it('should call _ga when pageView is called', () => {
+      const tracking = createTracking();
+      const data = {
+        dimension1: 'whatever',
+        dimension2: 'whatever2',
+      };
+      tracking.pageView(data);
+      sinon.assert.calledWith(window.ga, 'send', 'pageview', data);
+    });
+
+    it('should set a custom dimension when requested', () => {
+      const tracking = createTracking();
+      const dimension = 'dimension1';
+      const value = 'a value';
+      tracking.setDimension({ dimension, value });
+      sinon.assert.calledWith(window.ga, 'set', dimension, value);
     });
   });
 
-  it('should call _ga when pageView is called', () => {
-    const tracking = createTracking();
-    const data = {
-      dimension1: 'whatever',
-      dimension2: 'whatever2',
-    };
-    tracking.pageView(data);
-    sinon.assert.calledWith(window.ga, 'send', 'pageview', data);
+  describe('getAddonTypeForTracking', () => {
+    it('returns addon for TYPE_EXTENSION', () => {
+      expect(getAddonTypeForTracking(ADDON_TYPE_EXTENSION)).toEqual(
+        TRACKING_TYPE_EXTENSION,
+      );
+    });
+
+    it('returns addon for TYPE_OPENSEARCH', () => {
+      expect(getAddonTypeForTracking(ADDON_TYPE_OPENSEARCH)).toEqual(
+        TRACKING_TYPE_EXTENSION,
+      );
+    });
+
+    it('returns theme for TYPE_THEME', () => {
+      expect(getAddonTypeForTracking(ADDON_TYPE_THEME)).toEqual(
+        TRACKING_TYPE_THEME,
+      );
+    });
+
+    it('returns addon:statictheme for TYPE_STATIC_THEME', () => {
+      expect(getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME)).toEqual(
+        TRACKING_TYPE_STATIC_THEME,
+      );
+    });
+
+    it('returns invalid for unknown type', () => {
+      expect(getAddonTypeForTracking('whatever')).toEqual(
+        TRACKING_TYPE_INVALID,
+      );
+    });
   });
 
-  it('should set a custom dimension when requested', () => {
-    const tracking = createTracking();
-    const dimension = 'dimension1';
-    const value = 'a value';
-    tracking.setDimension({ dimension, value });
-    sinon.assert.calledWith(window.ga, 'set', dimension, value);
-  });
-});
+  describe('getAddonEventCategory', () => {
+    it('returns the expected category when type is extension and installAction is install started', () => {
+      expect(
+        getAddonEventCategory(ADDON_TYPE_EXTENSION, INSTALL_STARTED_ACTION),
+      ).toEqual(INSTALL_EXTENSION_STARTED_CATEGORY);
+    });
 
-describe('getAddonTypeForTracking', () => {
-  it('returns addon for TYPE_EXTENSION', () => {
-    expect(getAddonTypeForTracking(ADDON_TYPE_EXTENSION)).toEqual(
-      TRACKING_TYPE_EXTENSION,
-    );
-  });
+    it('returns the expected category when type is lightweight theme and installAction is install started', () => {
+      expect(
+        getAddonEventCategory(ADDON_TYPE_THEME, INSTALL_STARTED_ACTION),
+      ).toEqual(INSTALL_THEME_STARTED_CATEGORY);
+    });
 
-  it('returns addon for TYPE_OPENSEARCH', () => {
-    expect(getAddonTypeForTracking(ADDON_TYPE_OPENSEARCH)).toEqual(
-      TRACKING_TYPE_EXTENSION,
-    );
-  });
+    it('returns the expected category when type is static theme and installAction is install started', () => {
+      expect(
+        getAddonEventCategory(ADDON_TYPE_STATIC_THEME, INSTALL_STARTED_ACTION),
+      ).toEqual(INSTALL_THEME_STARTED_CATEGORY);
+    });
 
-  it('returns theme for TYPE_THEME', () => {
-    expect(getAddonTypeForTracking(ADDON_TYPE_THEME)).toEqual(
-      TRACKING_TYPE_THEME,
-    );
-  });
+    it('returns the expected category when type is extension and installAction is uninstall', () => {
+      expect(
+        getAddonEventCategory(ADDON_TYPE_EXTENSION, UNINSTALL_ACTION),
+      ).toEqual(UNINSTALL_EXTENSION_CATEGORY);
+    });
 
-  it('returns addon:statictheme for TYPE_STATIC_THEME', () => {
-    expect(getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME)).toEqual(
-      TRACKING_TYPE_STATIC_THEME,
-    );
-  });
+    it('returns the expected category when type is lightweight theme and installAction is uninstall started', () => {
+      expect(getAddonEventCategory(ADDON_TYPE_THEME, UNINSTALL_ACTION)).toEqual(
+        UNINSTALL_THEME_CATEGORY,
+      );
+    });
 
-  it('returns invalid for unknown type', () => {
-    expect(getAddonTypeForTracking('whatever')).toEqual(TRACKING_TYPE_INVALID);
-  });
-});
+    it('returns the expected category when type is static theme and installAction is uninstall started', () => {
+      expect(
+        getAddonEventCategory(ADDON_TYPE_STATIC_THEME, UNINSTALL_ACTION),
+      ).toEqual(UNINSTALL_THEME_CATEGORY);
+    });
 
-describe('getAddonEventCategory', () => {
-  it('returns the expected category when type is extension and installAction is install started', () => {
-    expect(
-      getAddonEventCategory(ADDON_TYPE_EXTENSION, INSTALL_STARTED_ACTION),
-    ).toEqual(INSTALL_EXTENSION_STARTED_CATEGORY);
-  });
+    it('returns the expected category when type is extension and installAction is install', () => {
+      expect(
+        getAddonEventCategory(ADDON_TYPE_EXTENSION, INSTALL_ACTION),
+      ).toEqual(INSTALL_EXTENSION_CATEGORY);
+    });
 
-  it('returns the expected category when type is lightweight theme and installAction is install started', () => {
-    expect(
-      getAddonEventCategory(ADDON_TYPE_THEME, INSTALL_STARTED_ACTION),
-    ).toEqual(INSTALL_THEME_STARTED_CATEGORY);
-  });
+    it('returns the expected category when type is lightweight theme and installAction is install', () => {
+      expect(getAddonEventCategory(ADDON_TYPE_THEME, INSTALL_ACTION)).toEqual(
+        INSTALL_THEME_CATEGORY,
+      );
+    });
 
-  it('returns the expected category when type is static theme and installAction is install started', () => {
-    expect(
-      getAddonEventCategory(ADDON_TYPE_STATIC_THEME, INSTALL_STARTED_ACTION),
-    ).toEqual(INSTALL_THEME_STARTED_CATEGORY);
+    it('returns the expected category when type is static theme and installAction is install', () => {
+      expect(
+        getAddonEventCategory(ADDON_TYPE_STATIC_THEME, INSTALL_ACTION),
+      ).toEqual(INSTALL_THEME_CATEGORY);
+    });
   });
 
-  it('returns the expected category when type is extension and installAction is uninstall', () => {
-    expect(
-      getAddonEventCategory(ADDON_TYPE_EXTENSION, UNINSTALL_ACTION),
-    ).toEqual(UNINSTALL_EXTENSION_CATEGORY);
-  });
+  describe('Do Not Track', () => {
+    it('should respect DNT when enabled', () => {
+      expect(
+        isDoNotTrackEnabled({
+          _navigator: { doNotTrack: '1' },
+          _window: {},
+        }),
+      ).toBe(true);
+      expect(
+        isDoNotTrackEnabled({
+          _navigator: {},
+          _window: { doNotTrack: '1' },
+        }),
+      ).toBe(true);
+    });
 
-  it('returns the expected category when type is lightweight theme and installAction is uninstall started', () => {
-    expect(getAddonEventCategory(ADDON_TYPE_THEME, UNINSTALL_ACTION)).toEqual(
-      UNINSTALL_THEME_CATEGORY,
-    );
-  });
+    it('should respect not enabled DNT', () => {
+      expect(
+        isDoNotTrackEnabled({
+          _navigator: { doNotTrack: '0' },
+          _window: {},
+        }),
+      ).toBe(false);
+      expect(
+        isDoNotTrackEnabled({
+          _navigator: {},
+          _window: { doNotTrack: '0' },
+        }),
+      ).toBe(false);
+    });
 
-  it('returns the expected category when type is static theme and installAction is uninstall started', () => {
-    expect(
-      getAddonEventCategory(ADDON_TYPE_STATIC_THEME, UNINSTALL_ACTION),
-    ).toEqual(UNINSTALL_THEME_CATEGORY);
-  });
+    it('should treat unknown values as no DNT', () => {
+      expect(
+        isDoNotTrackEnabled({
+          _navigator: { doNotTrack: 'leave me alone' },
+          _window: {},
+        }),
+      ).toBe(false);
+      expect(
+        isDoNotTrackEnabled({
+          _navigator: {},
+          _window: { doNotTrack: 'leave me alone' },
+        }),
+      ).toBe(false);
+    });
 
-  it('returns the expected category when type is extension and installAction is install', () => {
-    expect(getAddonEventCategory(ADDON_TYPE_EXTENSION, INSTALL_ACTION)).toEqual(
-      INSTALL_EXTENSION_CATEGORY,
-    );
-  });
+    it('should handle missing navigator and window', () => {
+      expect(isDoNotTrackEnabled({ _navigator: null })).toBe(false);
+      expect(isDoNotTrackEnabled({ _window: null })).toBe(false);
+    });
 
-  it('returns the expected category when type is lightweight theme and installAction is install', () => {
-    expect(getAddonEventCategory(ADDON_TYPE_THEME, INSTALL_ACTION)).toEqual(
-      INSTALL_THEME_CATEGORY,
-    );
-  });
-
-  it('returns the expected category when type is static theme and installAction is install', () => {
-    expect(
-      getAddonEventCategory(ADDON_TYPE_STATIC_THEME, INSTALL_ACTION),
-    ).toEqual(INSTALL_THEME_CATEGORY);
-  });
-});
-
-describe('Do Not Track', () => {
-  it('should respect DNT when enabled', () => {
-    expect(
+    it('should log that DNT disabled tracking', () => {
+      const fakeLog = { log: sinon.stub() };
       isDoNotTrackEnabled({
+        _log: fakeLog,
         _navigator: { doNotTrack: '1' },
         _window: {},
-      }),
-    ).toBe(true);
-    expect(
+      });
+
+      sinon.assert.calledWith(fakeLog.log, 'Do Not Track is enabled');
+
+      // Check with `window.doNotTrack` as well, just for completeness.
+      fakeLog.log.resetHistory();
       isDoNotTrackEnabled({
+        _log: fakeLog,
         _navigator: {},
         _window: { doNotTrack: '1' },
-      }),
-    ).toBe(true);
-  });
+      });
 
-  it('should respect not enabled DNT', () => {
-    expect(
-      isDoNotTrackEnabled({
-        _navigator: { doNotTrack: '0' },
-        _window: {},
-      }),
-    ).toBe(false);
-    expect(
-      isDoNotTrackEnabled({
-        _navigator: {},
-        _window: { doNotTrack: '0' },
-      }),
-    ).toBe(false);
-  });
-
-  it('should treat unknown values as no DNT', () => {
-    expect(
-      isDoNotTrackEnabled({
-        _navigator: { doNotTrack: 'leave me alone' },
-        _window: {},
-      }),
-    ).toBe(false);
-    expect(
-      isDoNotTrackEnabled({
-        _navigator: {},
-        _window: { doNotTrack: 'leave me alone' },
-      }),
-    ).toBe(false);
-  });
-
-  it('should handle missing navigator and window', () => {
-    expect(isDoNotTrackEnabled({ _navigator: null })).toBe(false);
-    expect(isDoNotTrackEnabled({ _window: null })).toBe(false);
-  });
-
-  it('should log that DNT disabled tracking', () => {
-    const fakeLog = { log: sinon.stub() };
-    isDoNotTrackEnabled({
-      _log: fakeLog,
-      _navigator: { doNotTrack: '1' },
-      _window: {},
+      sinon.assert.calledWith(fakeLog.log, 'Do Not Track is enabled');
     });
-
-    sinon.assert.calledWith(fakeLog.log, 'Do Not Track is enabled');
-
-    // Check with `window.doNotTrack` as well, just for completeness.
-    fakeLog.log.resetHistory();
-    isDoNotTrackEnabled({
-      _log: fakeLog,
-      _navigator: {},
-      _window: { doNotTrack: '1' },
-    });
-
-    sinon.assert.calledWith(fakeLog.log, 'Do Not Track is enabled');
   });
 });

--- a/tests/unit/disco/components/TestAddonCompatibilityError.js
+++ b/tests/unit/disco/components/TestAddonCompatibilityError.js
@@ -11,7 +11,7 @@ import {
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
-describe('AddonCompatibilityError', () => {
+describe(__filename, () => {
   function render({ ...props }) {
     const { store } = dispatchClientMetadata();
 

--- a/tests/unit/disco/components/TestApp.js
+++ b/tests/unit/disco/components/TestApp.js
@@ -47,82 +47,84 @@ function renderApp(customProps = {}) {
   return findDOMNode(root);
 }
 
-describe('App', () => {
-  it('renders its children', () => {
-    const rootNode = renderApp();
-    expect(rootNode.tagName.toLowerCase()).toEqual('div');
-    expect(rootNode.querySelector('p').textContent).toEqual('The component');
-  });
-
-  it('renders padding compensation class for FF < 50', () => {
-    const rootNode = renderApp({ browserVersion: '49.0' });
-    expect(rootNode.className).toContain('padding-compensation');
-  });
-
-  it('does not render padding compensation class for a bogus value', () => {
-    const rootNode = renderApp({ browserVersion: 'whatever' });
-    expect(rootNode.className).not.toContain('padding-compensation');
-  });
-
-  it('does not render padding compensation class for a undefined value', () => {
-    const rootNode = renderApp({ browserVersion: undefined });
-    expect(rootNode.className).not.toContain('padding-compensation');
-  });
-
-  it('does not render padding compensation class for FF == 50', () => {
-    const rootNode = renderApp({ browserVersion: '50.0' });
-    expect(rootNode.className).not.toContain('padding-compensation');
-  });
-
-  it('does not render padding compensation class for FF > 50', () => {
-    const rootNode = renderApp({ browserVersion: '52.0a1' });
-    expect(rootNode.className).not.toContain('padding-compensation');
-  });
-
-  it('renders a response with a 200 status', () => {
-    const root = shallow(<AppBase {...renderProps()} />);
-    expect(root.find(NestedStatus)).toHaveProp('code', 200);
-  });
-});
-
-describe('App errors', () => {
-  it('renders a 404', () => {
-    const { store } = createStore();
-    const error = createApiError({
-      apiURL: 'http://test.com',
-      response: { status: 404 },
+describe(__filename, () => {
+  describe('App', () => {
+    it('renders its children', () => {
+      const rootNode = renderApp();
+      expect(rootNode.tagName.toLowerCase()).toEqual('div');
+      expect(rootNode.querySelector('p').textContent).toEqual('The component');
     });
-    store.dispatch(loadErrorPage({ error }));
 
-    const rootNode = renderApp({ store });
-    expect(rootNode.textContent).not.toContain('The component');
-    expect(rootNode.textContent).toContain('Page not found');
-  });
-
-  it('renders a generic error', () => {
-    const { store } = createStore();
-    const error = createApiError({
-      apiURL: 'http://test.com',
-      response: { status: 500 },
+    it('renders padding compensation class for FF < 50', () => {
+      const rootNode = renderApp({ browserVersion: '49.0' });
+      expect(rootNode.className).toContain('padding-compensation');
     });
-    store.dispatch(loadErrorPage({ error }));
 
-    const rootNode = renderApp({ store });
-    expect(rootNode.textContent).not.toContain('The component');
-    expect(rootNode.textContent).toContain('Server Error');
+    it('does not render padding compensation class for a bogus value', () => {
+      const rootNode = renderApp({ browserVersion: 'whatever' });
+      expect(rootNode.className).not.toContain('padding-compensation');
+    });
+
+    it('does not render padding compensation class for a undefined value', () => {
+      const rootNode = renderApp({ browserVersion: undefined });
+      expect(rootNode.className).not.toContain('padding-compensation');
+    });
+
+    it('does not render padding compensation class for FF == 50', () => {
+      const rootNode = renderApp({ browserVersion: '50.0' });
+      expect(rootNode.className).not.toContain('padding-compensation');
+    });
+
+    it('does not render padding compensation class for FF > 50', () => {
+      const rootNode = renderApp({ browserVersion: '52.0a1' });
+      expect(rootNode.className).not.toContain('padding-compensation');
+    });
+
+    it('renders a response with a 200 status', () => {
+      const root = shallow(<AppBase {...renderProps()} />);
+      expect(root.find(NestedStatus)).toHaveProp('code', 200);
+    });
   });
-});
 
-describe('mapStateToProps', () => {
-  const fakeRouterParams = {
-    params: {
-      version: '49.0',
-    },
-  };
+  describe('App errors', () => {
+    it('renders a 404', () => {
+      const { store } = createStore();
+      const error = createApiError({
+        apiURL: 'http://test.com',
+        response: { status: 404 },
+      });
+      store.dispatch(loadErrorPage({ error }));
 
-  it('returns browserVersion', () => {
-    expect(mapStateToProps(null, fakeRouterParams).browserVersion).toEqual(
-      '49.0',
-    );
+      const rootNode = renderApp({ store });
+      expect(rootNode.textContent).not.toContain('The component');
+      expect(rootNode.textContent).toContain('Page not found');
+    });
+
+    it('renders a generic error', () => {
+      const { store } = createStore();
+      const error = createApiError({
+        apiURL: 'http://test.com',
+        response: { status: 500 },
+      });
+      store.dispatch(loadErrorPage({ error }));
+
+      const rootNode = renderApp({ store });
+      expect(rootNode.textContent).not.toContain('The component');
+      expect(rootNode.textContent).toContain('Server Error');
+    });
+  });
+
+  describe('mapStateToProps', () => {
+    const fakeRouterParams = {
+      params: {
+        version: '49.0',
+      },
+    };
+
+    it('returns browserVersion', () => {
+      expect(mapStateToProps(null, fakeRouterParams).browserVersion).toEqual(
+        '49.0',
+      );
+    });
   });
 });

--- a/tests/unit/disco/components/TestFooter.js
+++ b/tests/unit/disco/components/TestFooter.js
@@ -10,7 +10,7 @@ function render(props = {}) {
   );
 }
 
-describe('Footer', () => {
+describe(__filename, () => {
   it('renders a footer', () => {
     const root = render();
 

--- a/tests/unit/disco/reducers/testDiscoResults.js
+++ b/tests/unit/disco/reducers/testDiscoResults.js
@@ -5,7 +5,7 @@ import {
   fakeDiscoAddon,
 } from 'tests/unit/disco/helpers';
 
-describe('discoResults reducer', () => {
+describe(__filename, () => {
   it('defaults to an empty array', () => {
     expect(discoResults(undefined, { type: 'UNRELATED' })).toEqual([]);
   });

--- a/tests/unit/disco/test_actions.js
+++ b/tests/unit/disco/test_actions.js
@@ -4,64 +4,66 @@ import {
   fakeDiscoAddon,
 } from 'tests/unit/disco/helpers';
 
-describe('disco/actions/loadDiscoResults', () => {
-  function defaultParams() {
-    const addon = {
-      heading: 'Discovery Addon',
-      description: 'editorial text',
-      addon: fakeDiscoAddon,
-    };
-    const { entities, result } = createFetchDiscoveryResult([addon]);
-    return { entities, result };
-  }
+describe(__filename, () => {
+  describe('disco/actions/loadDiscoResults', () => {
+    function defaultParams() {
+      const addon = {
+        heading: 'Discovery Addon',
+        description: 'editorial text',
+        addon: fakeDiscoAddon,
+      };
+      const { entities, result } = createFetchDiscoveryResult([addon]);
+      return { entities, result };
+    }
 
-  it('requires an entities param', () => {
-    const params = defaultParams();
-    delete params.entities;
-    expect(() => loadDiscoResults(params)).toThrow(
-      /entities parameter is required/,
-    );
+    it('requires an entities param', () => {
+      const params = defaultParams();
+      delete params.entities;
+      expect(() => loadDiscoResults(params)).toThrow(
+        /entities parameter is required/,
+      );
+    });
+
+    it('requires a result param', () => {
+      const params = defaultParams();
+      delete params.result;
+      expect(() => loadDiscoResults(params)).toThrow(
+        /result parameter is required/,
+      );
+    });
   });
 
-  it('requires a result param', () => {
-    const params = defaultParams();
-    delete params.result;
-    expect(() => loadDiscoResults(params)).toThrow(
-      /result parameter is required/,
-    );
-  });
-});
+  describe('disco/actions/getDiscoResults', () => {
+    function defaultParams() {
+      return {
+        errorHandlerId: 'some-id',
+        taarParams: {
+          platform: 'Darwin',
+          'telemetry-client-id': 'client-id',
+        },
+      };
+    }
 
-describe('disco/actions/getDiscoResults', () => {
-  function defaultParams() {
-    return {
-      errorHandlerId: 'some-id',
-      taarParams: {
-        platform: 'Darwin',
-        'telemetry-client-id': 'client-id',
-      },
-    };
-  }
+    it('requires errorHandlerId', () => {
+      const params = defaultParams();
+      delete params.errorHandlerId;
+      expect(() => {
+        getDiscoResults(params);
+      }).toThrow(/errorHandlerId is required/);
+    });
 
-  it('requires errorHandlerId', () => {
-    const params = defaultParams();
-    delete params.errorHandlerId;
-    expect(() => {
-      getDiscoResults(params);
-    }).toThrow(/errorHandlerId is required/);
-  });
+    it('requires taarParams.platform', () => {
+      const params = defaultParams();
+      delete params.taarParams.platform;
+      expect(() => {
+        getDiscoResults(params);
+      }).toThrow(/taarParams\.platform is required/);
+    });
 
-  it('requires taarParams.platform', () => {
-    const params = defaultParams();
-    delete params.taarParams.platform;
-    expect(() => {
-      getDiscoResults(params);
-    }).toThrow(/taarParams\.platform is required/);
-  });
-
-  it('adds errorHandlerId to the payload', () => {
-    const params = defaultParams();
-    const action = getDiscoResults(params);
-    expect(action.payload.errorHandlerId).toEqual(params.errorHandlerId);
+    it('adds errorHandlerId to the payload', () => {
+      const params = defaultParams();
+      const action = getDiscoResults(params);
+      expect(action.payload.errorHandlerId).toEqual(params.errorHandlerId);
+    });
   });
 });

--- a/tests/unit/disco/test_tracking.js
+++ b/tests/unit/disco/test_tracking.js
@@ -3,7 +3,7 @@
 import getInstallData from 'disco/tracking';
 import { DISCO_DATA_UNKNOWN } from 'disco/constants';
 
-describe('disco pane install tracking data', () => {
+describe(__filename, () => {
   function getFakeWindow(hash) {
     return {
       decodeURIComponent: window.decodeURIComponent,

--- a/tests/unit/disco/test_utils.js
+++ b/tests/unit/disco/test_utils.js
@@ -1,6 +1,6 @@
 import { sanitizeHTMLWithExternalLinks } from 'disco/utils';
 
-describe('sanitizeHTMLWithExternalLinks', () => {
+describe(__filename, () => {
   it('adds `target` and `rel` attributes to HTML "targetable" elements', () => {
     const html = '<a href="http://example.org">link</a>';
     expect(sanitizeHTMLWithExternalLinks(html, ['a'])).toEqual({

--- a/tests/unit/testHelpers.js
+++ b/tests/unit/testHelpers.js
@@ -5,7 +5,7 @@ import { compose } from 'redux';
 
 import { shallowUntilTarget } from 'tests/unit/helpers';
 
-describe('helpers', () => {
+describe(__filename, () => {
   describe('shallowUntilTarget', () => {
     function ExampleBase() {
       return <div>Example component</div>;

--- a/tests/unit/ui/components/TestCardList.js
+++ b/tests/unit/ui/components/TestCardList.js
@@ -8,7 +8,7 @@ function renderToDOM(props) {
   return findDOMNode(renderIntoDocument(<CardList {...props} />));
 }
 
-describe('ui/components/CardList', () => {
+describe(__filename, () => {
   it('adds a CardList class', () => {
     const root = renderToDOM();
     expect(root.className).toContain('CardList');

--- a/tests/unit/ui/components/TestLoadingText.js
+++ b/tests/unit/ui/components/TestLoadingText.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import LoadingText from 'ui/components/LoadingText';
 
-describe('<LoadingText />', () => {
+describe(__filename, () => {
   const render = (props = {}) => shallow(<LoadingText {...props} />);
 
   it('renders LoadingText element with className', () => {

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -3,7 +3,7 @@ import { renderIntoDocument, Simulate } from 'react-dom/test-utils';
 
 import Overlay from 'ui/components/Overlay';
 
-describe('<Overlay />', () => {
+describe(__filename, () => {
   function render(props = {}) {
     return renderIntoDocument(<Overlay {...props} />);
   }

--- a/tests/unit/ui/components/TestOverlayCard.js
+++ b/tests/unit/ui/components/TestOverlayCard.js
@@ -8,7 +8,7 @@ import { findDOMNode } from 'react-dom';
 import Overlay from 'ui/components/Overlay';
 import OverlayCard from 'ui/components/OverlayCard';
 
-describe('<OverlayCard />', () => {
+describe(__filename, () => {
   function render(props = {}) {
     return renderIntoDocument(<OverlayCard {...props} />);
   }

--- a/tests/unit/ui/components/TestSwitch.js
+++ b/tests/unit/ui/components/TestSwitch.js
@@ -4,7 +4,7 @@ import { findDOMNode } from 'react-dom';
 
 import Switch from 'ui/components/Switch';
 
-describe('<Switch />', () => {
+describe(__filename, () => {
   function renderButton(props = {}) {
     const renderProps = {
       dispatch: sinon.spy(),


### PR DESCRIPTION
Fix #2928 

---

This PR makes sure we always have a top-level `describe` block with `__filename` as a description.

Note: the diff is large because I added a few top-level `describe` blocks in test files where there were multiple `describe` top-level blocks (hence re-indenting almost all the code in the files).