### PR TITLE
Enable redux-devtools in -dev

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -19,6 +19,7 @@ module.exports = {
     'cookieMaxAge',
     'cookieSecure',
     'enableClientConsole',
+    'enableDevTools',
     'defaultLang',
     'isDeployed',
     'isDevelopment',

--- a/config/default.js
+++ b/config/default.js
@@ -36,6 +36,8 @@ module.exports = {
   cookieSecure: true,
 
   enableClientConsole: false,
+  // Enable devtools for: Redux.
+  enableDevTools: false,
 
   // If true node will serve the static files.
   enableNodeStatics: false,
@@ -95,6 +97,7 @@ module.exports = {
     'cookieSecure',
     'defaultLang',
     'enableClientConsole',
+    'enableDevTools',
     'enableNewCollectionsUI',
     'enableAddonRecommendations',
     'enableStaticThemes',

--- a/config/dev.js
+++ b/config/dev.js
@@ -8,6 +8,7 @@ module.exports = {
   staticHost: amoDevCDN,
 
   enableClientConsole: true,
+  enableDevTools: true,
 
   // Content security policy.
   CSP: {

--- a/config/development.js
+++ b/config/development.js
@@ -19,6 +19,7 @@ module.exports = {
   cookieSecure: false,
 
   enableClientConsole: true,
+  enableDevTools: true,
 
   serverPort: 3000,
   webpackServerHost,

--- a/package.json
+++ b/package.json
@@ -273,7 +273,6 @@
     "react-hot-loader": "^4.0.0",
     "react-test-renderer": "^16.4.1",
     "react-transform-hmr": "^1.0.4",
-    "redux-devtools": "^3.4.1",
     "redux-saga-tester": "^1.0.372",
     "require-uncached": "^1.0.3",
     "rimraf": "^2.6.1",

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -33,8 +33,10 @@ export function middleware({
 
   return compose(
     applyMiddleware(...callbacks),
-    isDev && _window && _window.devToolsExtension
-      ? _window.devToolsExtension()
+    _config.get('enableDevTools') &&
+    _window &&
+    _window.__REDUX_DEVTOOLS_EXTENSION__
+      ? _window.__REDUX_DEVTOOLS_EXTENSION__()
       : (createStore) => createStore,
   );
 }

--- a/tests/unit/core/test_store.js
+++ b/tests/unit/core/test_store.js
@@ -1,15 +1,14 @@
 import { middleware } from 'core/store';
+import { getFakeConfig } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  function configForDev(isDevelopment, config = {}) {
-    const finalConfig = { isDevelopment, ...config };
-
-    return {
-      get(key) {
-        return finalConfig[key];
-      },
-    };
-  }
+  const configForDev = (isDevelopment, config = {}) => {
+    return getFakeConfig({
+      isDevelopment,
+      server: false,
+      ...config,
+    });
+  };
 
   it('includes the middleware in development', () => {
     const _createLogger = sinon.stub();
@@ -19,7 +18,7 @@ describe(__filename, () => {
         _createLogger,
       }),
     ).toBe('function');
-    expect(_createLogger.called).toEqual(true);
+    sinon.assert.called(_createLogger);
   });
 
   it('does not apply middleware if not in development', () => {
@@ -30,7 +29,7 @@ describe(__filename, () => {
         _createLogger,
       }),
     ).toBe('function');
-    expect(_createLogger.called).toEqual(false);
+    sinon.assert.notCalled(_createLogger);
   });
 
   it('handles a falsey window while on the server', () => {
@@ -43,7 +42,7 @@ describe(__filename, () => {
         _window,
       }),
     ).toBe('function');
-    expect(_createLogger.called).toEqual(true);
+    sinon.assert.called(_createLogger);
   });
 
   it('does not create a logger for the server', () => {
@@ -54,12 +53,14 @@ describe(__filename, () => {
         _createLogger,
       }),
     ).toBe('function');
-    expect(_createLogger.called).toEqual(false);
+    sinon.assert.notCalled(_createLogger);
   });
 
   it('uses a placeholder store enhancer when devtools is not available', () => {
     const _window = {}; // __REDUX_DEVTOOLS_EXTENSION__() is undefined
-    const enhancer = middleware({ _config: configForDev(true), _window });
+    const _config = getFakeConfig({ enableDevTools: true });
+
+    const enhancer = middleware({ _config, _window });
 
     expect(typeof enhancer).toBe('function');
 
@@ -71,7 +72,7 @@ describe(__filename, () => {
     const _window = {
       __REDUX_DEVTOOLS_EXTENSION__: sinon.spy(),
     };
-    const _config = configForDev(true, { enableDevTools: true });
+    const _config = getFakeConfig({ enableDevTools: true });
 
     expect(typeof middleware({ _config, _window })).toBe('function');
     sinon.assert.called(_window.__REDUX_DEVTOOLS_EXTENSION__);
@@ -81,7 +82,7 @@ describe(__filename, () => {
     const _window = {
       __REDUX_DEVTOOLS_EXTENSION__: sinon.spy(),
     };
-    const _config = configForDev(true, { enableDevTools: false });
+    const _config = getFakeConfig({ enableDevTools: false });
 
     expect(typeof middleware({ _config, _window })).toBe('function');
     sinon.assert.notCalled(_window.__REDUX_DEVTOOLS_EXTENSION__);

--- a/tests/unit/core/test_store.js
+++ b/tests/unit/core/test_store.js
@@ -69,21 +69,21 @@ describe(__filename, () => {
 
   it('adds the devtools store enhancer when config enables it', () => {
     const _window = {
-      __REDUX_DEVTOOLS_EXTENSION__: sinon.spy((createStore) => createStore),
+      __REDUX_DEVTOOLS_EXTENSION__: sinon.spy(),
     };
     const _config = configForDev(true, { enableDevTools: true });
 
     expect(typeof middleware({ _config, _window })).toBe('function');
-    expect(_window.__REDUX_DEVTOOLS_EXTENSION__.called).toEqual(true);
+    sinon.assert.called(_window.__REDUX_DEVTOOLS_EXTENSION__);
   });
 
   it('does not add the devtools store enhancer when config disables it', () => {
     const _window = {
-      __REDUX_DEVTOOLS_EXTENSION__: sinon.spy((createStore) => createStore),
+      __REDUX_DEVTOOLS_EXTENSION__: sinon.spy(),
     };
     const _config = configForDev(true, { enableDevTools: false });
 
     expect(typeof middleware({ _config, _window })).toBe('function');
-    expect(_window.__REDUX_DEVTOOLS_EXTENSION__.called).toEqual(false);
+    sinon.assert.notCalled(_window.__REDUX_DEVTOOLS_EXTENSION__);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7381,7 +7381,7 @@ prop-types@15.6.2, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -7913,21 +7913,6 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
-
-redux-devtools-instrument@^1.0.1:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.3.tgz#c510d67ab4e5e4525acd6e410c25ab46b85aca7c"
-  dependencies:
-    lodash "^4.2.0"
-    symbol-observable "^1.0.2"
-
-redux-devtools@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/redux-devtools/-/redux-devtools-3.4.1.tgz#09d342ce0ab6087be679e953a1d7c530efa1138e"
-  dependencies:
-    lodash "^4.2.0"
-    prop-types "^15.5.7"
-    redux-devtools-instrument "^1.0.1"
 
 redux-logger@3.0.6:
   version "3.0.6"
@@ -9340,7 +9325,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.2, symbol-observable@^1.0.3:
+symbol-observable@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
Fix #5622

---

This PR introduces a new config paramter `enableDevTools` that can be
use to enable devtools in any environment.

I'd like to debug #5608 in -dev and I think it would be useful to have
the Redux devtools available in this environment. FWIW, Airbnb has the
Redux devtools in all envs, including -prod, which is super great.

As a first step, we can enable the devtools in -dev, and see if we need
to turn them on for -stage and/or -prod later.

I also removed a package that we are not using at all. We use the
following Redux devtools:
https://github.com/zalmoxisus/redux-devtools-extension, which does not
need any extra dependency. It is only enabled if the browser extension
is installed and opened.