### PR TITLE
Remove withRef params

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -646,7 +646,7 @@ export const extractId = (ownProps) => {
 
 export default compose(
   withRouter,
-  translate({ withRef: true }),
+  translate(),
   connect(mapStateToProps),
   withInstallHelpers({ defaultInstallSource: INSTALL_SOURCE_DETAIL_PAGE }),
   withFixedErrorHandler({ fileName: __filename, extractId }),

--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -117,5 +117,5 @@ export function mapStateToProps(state) {
 
 export default compose(
   connect(mapStateToProps),
-  translate({ withRef: true }),
+  translate(),
 )(AddonCompatibilityErrorBase);

--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -301,7 +301,7 @@ const AddonReview: React.ComponentType<Props> = compose(
     mapStateToProps,
     mapDispatchToProps,
   ),
-  translate({ withRef: true }),
+  translate(),
 )(AddonReviewBase);
 
 export default AddonReview;

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -172,7 +172,7 @@ export function mapStateToProps(state: AppState) {
 const Categories: React.ComponentType<Props> = compose(
   withErrorHandler({ name: 'Categories' }),
   connect(mapStateToProps),
-  translate({ withRef: true }),
+  translate(),
 )(CategoriesBase);
 
 export default Categories;

--- a/src/amo/components/CategoriesPage/index.js
+++ b/src/amo/components/CategoriesPage/index.js
@@ -19,8 +19,8 @@ export class CategoriesPageBase extends React.Component<Props> {
   }
 }
 
-const CategoriesPage: React.ComponentType<Props> = compose(
-  translate({ withRef: true }),
-)(CategoriesPageBase);
+const CategoriesPage: React.ComponentType<Props> = compose(translate())(
+  CategoriesPageBase,
+);
 
 export default CategoriesPage;

--- a/src/amo/components/ErrorPage/NotAuthorized/index.js
+++ b/src/amo/components/ErrorPage/NotAuthorized/index.js
@@ -53,8 +53,8 @@ export class NotAuthorizedBase extends React.Component<Props> {
   }
 }
 
-const NotAuthorized: React.ComponentType<Props> = compose(
-  translate({ withRef: true }),
-)(NotAuthorizedBase);
+const NotAuthorized: React.ComponentType<Props> = compose(translate())(
+  NotAuthorizedBase,
+);
 
 export default NotAuthorized;

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -71,8 +71,6 @@ export class NotFoundBase extends React.Component<InternalProps> {
   }
 }
 
-const NotFound: React.ComponentType<Props> = compose(
-  translate({ withRef: true }),
-)(NotFoundBase);
+const NotFound: React.ComponentType<Props> = compose(translate())(NotFoundBase);
 
 export default NotFound;

--- a/src/amo/components/ErrorPage/ServerError/index.js
+++ b/src/amo/components/ErrorPage/ServerError/index.js
@@ -48,4 +48,4 @@ export class ServerErrorBase extends React.Component {
   }
 }
 
-export default compose(translate({ withRef: true }))(ServerErrorBase);
+export default compose(translate())(ServerErrorBase);

--- a/src/amo/components/Footer/index.js
+++ b/src/amo/components/Footer/index.js
@@ -221,4 +221,4 @@ export class FooterBase extends React.Component {
   }
 }
 
-export default compose(translate({ withRef: true }))(FooterBase);
+export default compose(translate())(FooterBase);

--- a/src/amo/components/LanguagePicker/index.js
+++ b/src/amo/components/LanguagePicker/index.js
@@ -76,5 +76,5 @@ export function mapStateToProps(state) {
 
 export default compose(
   connect(mapStateToProps),
-  translate({ withRef: true }),
+  translate(),
 )(LanguagePickerBase);

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -298,9 +298,7 @@ export const mapDispatchToProps = (
   },
 });
 
-export const RatingManagerWithI18n = compose(translate({ withRef: true }))(
-  RatingManagerBase,
-);
+export const RatingManagerWithI18n = translate()(RatingManagerBase);
 
 const RatingManager: React.ComponentType<Props> = compose(
   withRenderedErrorHandler({ name: 'RatingManager' }),

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -202,8 +202,8 @@ export class SearchResultBase extends React.Component<InternalProps> {
   }
 }
 
-const SearchResult: React.ComponentType<Props> = compose(
-  translate({ withRef: true }),
-)(SearchResultBase);
+const SearchResult: React.ComponentType<Props> = compose(translate())(
+  SearchResultBase,
+);
 
 export default SearchResult;

--- a/src/core/components/ErrorPage/GenericError/index.js
+++ b/src/core/components/ErrorPage/GenericError/index.js
@@ -38,4 +38,4 @@ export class GenericErrorBase extends React.Component {
   }
 }
 
-export default compose(translate({ withRef: true }))(GenericErrorBase);
+export default compose(translate())(GenericErrorBase);

--- a/src/core/components/ErrorPage/NotFound/index.js
+++ b/src/core/components/ErrorPage/NotFound/index.js
@@ -40,4 +40,4 @@ export class NotFoundBase extends React.Component {
   }
 }
 
-export default compose(translate({ withRef: true }))(NotFoundBase);
+export default compose(translate())(NotFoundBase);

--- a/src/core/components/ErrorPage/index.js
+++ b/src/core/components/ErrorPage/index.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import log from 'core/logger';
-import { getErrorComponent as getErrorComponentDefault } from 'core/utils';
+import { getErrorComponent as getErrorComponentDefault } from 'core/utils/errors';
 import { loadErrorPage } from 'core/reducers/errorPage';
 import type { AppState } from 'amo/store';
 import type { ErrorPageState } from 'core/reducers/errorPage';

--- a/src/core/components/Paginate/index.js
+++ b/src/core/components/Paginate/index.js
@@ -164,8 +164,6 @@ export class PaginateBase extends React.Component<InternalProps> {
   }
 }
 
-const Paginate: React.ComponentType<Props> = compose(
-  translate({ withRef: true }),
-)(PaginateBase);
+const Paginate: React.ComponentType<Props> = compose(translate())(PaginateBase);
 
 export default Paginate;

--- a/src/core/components/error-simulation/SimulateAsyncError/index.js
+++ b/src/core/components/error-simulation/SimulateAsyncError/index.js
@@ -2,7 +2,7 @@ import { compose } from 'redux';
 import * as React from 'react';
 
 import log from 'core/logger';
-import { render404IfConfigKeyIsFalse } from 'core/utils';
+import { render404IfConfigKeyIsFalse } from 'core/utils/errors';
 
 export class SimulateAsyncErrorBase extends React.Component {
   render() {

--- a/src/core/components/error-simulation/SimulateClientError/index.js
+++ b/src/core/components/error-simulation/SimulateClientError/index.js
@@ -1,7 +1,7 @@
 import { compose } from 'redux';
 import * as React from 'react';
 
-import { render404IfConfigKeyIsFalse } from 'core/utils';
+import { render404IfConfigKeyIsFalse } from 'core/utils/errors';
 import Button from 'ui/components/Button';
 
 import './styles.scss';

--- a/src/core/components/error-simulation/SimulateSyncError/index.js
+++ b/src/core/components/error-simulation/SimulateSyncError/index.js
@@ -3,7 +3,7 @@ import { compose } from 'redux';
 import * as React from 'react';
 
 import log from 'core/logger';
-import { render404IfConfigKeyIsFalse } from 'core/utils';
+import { render404IfConfigKeyIsFalse } from 'core/utils/errors';
 
 export class SimulateSyncErrorBase extends React.Component {
   render() {

--- a/src/core/i18n/translate.js
+++ b/src/core/i18n/translate.js
@@ -1,50 +1,40 @@
-import React, { Component } from 'react';
+/* @flow */
+import * as React from 'react';
 import PropTypes from 'prop-types';
-import { oneLine } from 'common-tags';
 
-function getDisplayName(component) {
-  return component.displayName || component.name || 'Component';
-}
+import { getDisplayName } from 'core/utils';
+import type { I18nType } from 'core/types/i18n';
 
-export default function translate(options = {}) {
-  const { withRef = false } = options;
+type Context = {|
+  i18n: I18nType,
+|};
 
-  return function Wrapper(WrappedComponent) {
-    class Translate extends Component {
-      constructor(props, context) {
+const translate = (): ((
+  React.ComponentType<any>,
+) => React.ComponentType<any>) => {
+  return (WrappedComponent) => {
+    class Translate extends React.Component<any> {
+      i18n: I18nType;
+
+      static contextTypes: Context = {
+        i18n: PropTypes.object,
+      };
+
+      static displayName = `Translate(${getDisplayName(WrappedComponent)})`;
+
+      constructor(props: Object, context: Context) {
         super(props, context);
+
         this.i18n = context.i18n;
       }
 
-      getWrappedInstance() {
-        if (!withRef) {
-          throw new Error(oneLine`To access the wrapped instance, you need to specify
-            { withRef: true } as the second argument of the translate() call.`);
-        }
-        return this.wrappedInstance;
-      }
-
       render() {
-        const extraProps = { i18n: this.i18n };
-
-        if (withRef) {
-          extraProps.ref = (ref) => {
-            this.wrappedInstance = ref;
-          };
-        }
-
-        return <WrappedComponent {...extraProps} {...this.props} />;
+        return <WrappedComponent i18n={this.i18n} {...this.props} />;
       }
     }
 
-    Translate.WrappedComponent = WrappedComponent;
-
-    Translate.contextTypes = {
-      i18n: PropTypes.object.isRequired,
-    };
-
-    Translate.displayName = `Translate[${getDisplayName(WrappedComponent)}]`;
-
     return Translate;
   };
-}
+};
+
+export default translate;

--- a/src/core/types/config.js
+++ b/src/core/types/config.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+export type ConfigType = {|
+  get: (key: string) => any,
+  set: (key: string, value: any) => void,
+|};

--- a/src/core/utils/errors.js
+++ b/src/core/utils/errors.js
@@ -1,0 +1,59 @@
+/* @flow */
+import * as React from 'react';
+import config from 'config';
+
+import GenericError from 'core/components/ErrorPage/GenericError';
+import NotFound from 'core/components/ErrorPage/NotFound';
+import log from 'core/logger';
+import { getDisplayName } from 'core/utils';
+import type { ConfigType } from 'core/types/config';
+
+export const getErrorComponent = (status: number | null) => {
+  switch (status) {
+    case 404:
+      return NotFound;
+    default:
+      return GenericError;
+  }
+};
+
+/*
+ * A decorator to render a 404 when a config key is false.
+ *
+ * For example, if you had a config key like this:
+ *
+ * module.exports = {
+ *   allowMyComponent: false,
+ * };
+ *
+ * then you could make your component appear as a 404 like this:
+ *
+ * class MyComponent extends React.Component {
+ *   render() { ... }
+ * }
+ *
+ * export default compose(
+ *   render404IfConfigKeyIsFalse('allowMyComponent'),
+ * )(MyComponent);
+ */
+export function render404IfConfigKeyIsFalse(
+  configKey: string,
+  { _config = config }: {| _config: ConfigType |} = {},
+) {
+  if (!configKey) {
+    throw new TypeError('configKey cannot be empty');
+  }
+
+  return (Component: React.ComponentType<any>) => (props: any) => {
+    if (!_config.get(configKey)) {
+      log.debug(
+        `config.${configKey} was false; not rendering ${getDisplayName(
+          Component,
+        )}`,
+      );
+      return <NotFound />;
+    }
+
+    return <Component {...props} />;
+  };
+}

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -4,12 +4,9 @@ import url from 'url';
 import config from 'config';
 import { AllHtmlEntities } from 'html-entities';
 import invariant from 'invariant';
-import * as React from 'react';
 
 import { loadAddons } from 'core/reducers/addons';
 import { fetchAddon } from 'core/api';
-import GenericError from 'core/components/ErrorPage/GenericError';
-import NotFound from 'core/components/ErrorPage/NotFound';
 import {
   ADDON_TYPE_COMPLETE_THEME,
   ADDON_TYPE_OPENSEARCH,
@@ -182,15 +179,6 @@ export function visibleAddonType(addonType) {
   return VISIBLE_ADDON_TYPES_MAPPING[addonType];
 }
 
-export function getErrorComponent(status) {
-  switch (status) {
-    case 404:
-      return NotFound;
-    default:
-      return GenericError;
-  }
-}
-
 export function removeProtocolFromURL(urlWithProtocol) {
   invariant(urlWithProtocol, 'urlWithProtocol is required');
 
@@ -234,41 +222,6 @@ export function trimAndAddProtocolToUrl(urlToCheck) {
     urlToReturn = `http://${urlToReturn}`;
   }
   return urlToReturn;
-}
-
-/*
- * A decorator to render a 404 when a config key is false.
- *
- * For example, if you had a config key like this:
- *
- * module.exports = {
- *   allowMyComponent: false,
- * };
- *
- * then you could make your component appear as a 404 like this:
- *
- * class MyComponent extends React.Component {
- *   render() { ... }
- * }
- *
- * export default compose(
- *   render404IfConfigKeyIsFalse('allowMyComponent'),
- * )(MyComponent);
- */
-export function render404IfConfigKeyIsFalse(
-  configKey,
-  { _config = config } = {},
-) {
-  if (!configKey) {
-    throw new TypeError('configKey cannot be empty');
-  }
-  return (Component) => (props) => {
-    if (!_config.get(configKey)) {
-      log.debug(`config.${configKey} was false; not rendering ${Component}`);
-      return <NotFound />;
-    }
-    return <Component {...props} />;
-  };
 }
 
 export function getCategoryColor(category) {
@@ -343,4 +296,8 @@ export const normalizeFileNameId = (filename) => {
   }
 
   return fileId;
+};
+
+export const getDisplayName = (component) => {
+  return component.displayName || component.name || 'Component';
 };

--- a/src/core/withUIState.js
+++ b/src/core/withUIState.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import invariant from 'invariant';
 import { connect } from 'react-redux';
 
-import { normalizeFileNameId } from 'core/utils';
+import { getDisplayName, normalizeFileNameId } from 'core/utils';
 import { setUIState } from 'core/reducers/uiState';
 import type { AppState } from 'amo/store';
 
@@ -107,9 +107,9 @@ const withUIState = ({
       }
     }
 
-    const wrappedName =
-      WrappedComponent.displayName || WrappedComponent.name || 'Component';
-    WithUIState.displayName = `WithUIState(${wrappedName})`;
+    WithUIState.displayName = `WithUIState(${getDisplayName(
+      WrappedComponent,
+    )})`;
 
     return connect(
       mapStateToProps,

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -315,12 +315,7 @@ export function mapStateToProps(state, ownProps) {
 
 export default compose(
   withRouter,
-  translate({ withRef: true }),
-  connect(
-    mapStateToProps,
-    undefined,
-    undefined,
-    { withRef: true },
-  ),
+  translate(),
+  connect(mapStateToProps),
   withInstallHelpers({ defaultInstallSource: INSTALL_SOURCE_DISCOVERY }),
 )(AddonBase);

--- a/src/disco/components/AddonCompatibilityError/index.js
+++ b/src/disco/components/AddonCompatibilityError/index.js
@@ -62,5 +62,5 @@ export function mapStateToProps(state) {
 
 export default compose(
   connect(mapStateToProps),
-  translate({ withRef: true }),
+  translate(),
 )(AddonCompatibilityErrorBase);

--- a/src/disco/components/App/index.js
+++ b/src/disco/components/App/index.js
@@ -52,5 +52,5 @@ export function mapStateToProps(state, ownProps) {
 
 export default compose(
   connect(mapStateToProps),
-  translate({ withRef: true }),
+  translate(),
 )(AppBase);

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -150,4 +150,4 @@ export class RatingBase extends React.Component {
   }
 }
 
-export default compose(translate({ withRef: true }))(RatingBase);
+export default compose(translate())(RatingBase);

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -89,4 +89,4 @@ export class ShowMoreCardBase extends React.Component {
   }
 }
 
-export default compose(translate({ withRef: true }))(ShowMoreCardBase);
+export default compose(translate())(ShowMoreCardBase);

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -5,7 +5,6 @@ import {
   renderIntoDocument,
 } from 'react-dom/test-utils';
 
-import translate from 'core/i18n/translate';
 import { setAuthToken } from 'core/actions';
 import { createInternalAddon } from 'core/reducers/addons';
 import { loadCurrentUserAccount } from 'amo/reducers/users';
@@ -23,9 +22,10 @@ import * as reviewsApi from 'amo/api/reviews';
 import createStore from 'amo/store';
 import { setReview } from 'amo/actions/reviews';
 import {
+  RatingManagerBase,
+  RatingManagerWithI18n,
   mapDispatchToProps,
   mapStateToProps,
-  RatingManagerBase,
 } from 'amo/components/RatingManager';
 import {
   fakeAddon,
@@ -33,6 +33,7 @@ import {
   signedInApiState,
 } from 'tests/unit/amo/helpers';
 import {
+  createStubErrorHandler,
   createUserAccountResponse,
   fakeI18n,
   fakeRouterLocation,
@@ -53,7 +54,7 @@ describe(__filename, () => {
       ReportAbuseButton: () => <div />,
       addon: createInternalAddon(fakeAddon),
       apiState: signedInApiState,
-      errorHandler: sinon.stub(),
+      errorHandler: createStubErrorHandler(),
       location: fakeRouterLocation({ pathname: '/some/location/' }),
       version: fakeAddon.current_version,
       userId: 91234,
@@ -62,19 +63,19 @@ describe(__filename, () => {
       store,
       ...customProps,
     };
-    const RatingManager = translate({ withRef: true })(RatingManagerBase);
+
     const root = findRenderedComponentWithType(
       renderIntoDocument(
         <I18nProvider i18n={fakeI18n()}>
           <Provider store={props.store}>
-            <RatingManager {...props} />
+            <RatingManagerWithI18n {...props} />
           </Provider>
         </I18nProvider>,
       ),
-      RatingManager,
+      RatingManagerBase,
     );
 
-    return root.getWrappedInstance();
+    return root;
   }
 
   it('prompts you to rate the add-on by name', () => {

--- a/tests/unit/core/components/TestErrorPage.js
+++ b/tests/unit/core/components/TestErrorPage.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import ErrorPage, { ErrorPageBase } from 'core/components/ErrorPage';
 import { createApiError } from 'core/api';
 import { loadErrorPage } from 'core/reducers/errorPage';
-import { getErrorComponent } from 'core/utils';
+import { getErrorComponent } from 'core/utils/errors';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 import I18nProvider from 'core/i18n/Provider';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';

--- a/tests/unit/core/i18n/test_translate.js
+++ b/tests/unit/core/i18n/test_translate.js
@@ -1,10 +1,7 @@
 /* eslint-disable react/no-multi-comp */
+import { mount } from 'enzyme';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import {
-  renderIntoDocument,
-  findRenderedComponentWithType,
-} from 'react-dom/test-utils';
 
 import I18nProvider from 'core/i18n/Provider';
 import translate from 'core/i18n/translate';
@@ -31,19 +28,20 @@ class InnerComponent extends React.Component {
 }
 
 describe(__filename, () => {
-  function render({
+  const render = ({
     Component = translate()(InnerComponent),
     i18n = fakeI18n(),
     componentProps = {},
-  } = {}) {
-    return renderIntoDocument(
+  } = {}) => {
+    return mount(
       <I18nProvider i18n={i18n}>
         <OuterComponent>
           <Component {...componentProps} />
         </OuterComponent>
       </I18nProvider>,
+      InnerComponent,
     );
-  }
+  };
 
   it('pulls i18n from context', () => {
     const i18n = fakeI18n();
@@ -57,22 +55,5 @@ describe(__filename, () => {
     render({ i18n: contextI18n, componentProps: { i18n: propsI18n } });
     sinon.assert.notCalled(contextI18n.gettext);
     sinon.assert.called(propsI18n.gettext);
-  });
-
-  it('throws an exception calling getWrappedInstance without withRef', () => {
-    const Component = translate()(InnerComponent);
-    const root = render({ Component });
-    const wrappedComponent = findRenderedComponentWithType(root, Component);
-    expect(() => {
-      wrappedComponent.getWrappedInstance();
-    }).toThrowError('To access the wrapped instance');
-  });
-
-  it('returns the wrapped instance when using withRef', () => {
-    const Component = translate({ withRef: true })(InnerComponent);
-    const root = render({ Component });
-    const wrappedComponent = findRenderedComponentWithType(root, Component);
-    const component = wrappedComponent.getWrappedInstance();
-    expect(component).toBeInstanceOf(InnerComponent);
   });
 });

--- a/tests/unit/core/utils/test_errors.js
+++ b/tests/unit/core/utils/test_errors.js
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import {
+  renderIntoDocument,
+  findRenderedComponentWithType,
+} from 'react-dom/test-utils';
+import { compose } from 'redux';
+
+import GenericError from 'core/components/ErrorPage/GenericError';
+import NotFound from 'core/components/ErrorPage/NotFound';
+import I18nProvider from 'core/i18n/Provider';
+import {
+  getErrorComponent,
+  render404IfConfigKeyIsFalse,
+} from 'core/utils/errors';
+import { fakeI18n } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  describe('getErrorComponent', () => {
+    it('returns the NotFound component when status is 404', () => {
+      expect(getErrorComponent(404)).toEqual(NotFound);
+    });
+
+    it('returns the GenericError component when status is not 404', () => {
+      expect(getErrorComponent(400)).toEqual(GenericError);
+      expect(getErrorComponent(null)).toEqual(GenericError);
+      expect(getErrorComponent(undefined)).toEqual(GenericError);
+    });
+  });
+
+  describe('render404IfConfigKeyIsFalse', () => {
+    const render = (
+      props = {},
+      {
+        configKey = 'someConfigKey',
+        _config = { get: () => true },
+        SomeComponent = () => <div />,
+      } = {},
+    ) => {
+      const WrappedComponent = compose(
+        render404IfConfigKeyIsFalse(configKey, { _config }),
+      )(SomeComponent);
+
+      return renderIntoDocument(
+        <I18nProvider i18n={fakeI18n()}>
+          <WrappedComponent {...props} />
+        </I18nProvider>,
+      );
+    };
+
+    it('requires a config key', () => {
+      expect(() => render404IfConfigKeyIsFalse()).toThrowError(
+        /configKey cannot be empty/,
+      );
+    });
+
+    it('returns a 404 when disabled by the config', () => {
+      const configKey = 'customConfigKey';
+      const _config = {
+        get: sinon.spy(() => false),
+      };
+      const root = render({}, { _config, configKey });
+      const node = findRenderedComponentWithType(root, NotFound);
+
+      expect(node).toBeTruthy();
+      sinon.assert.calledWith(_config.get, configKey);
+    });
+
+    it('passes through component and props when enabled', () => {
+      const _config = { get: () => true };
+      const SomeComponent = sinon.spy(() => <div />);
+      render({ color: 'orange', size: 'large' }, { SomeComponent, _config });
+
+      sinon.assert.called(SomeComponent);
+      const props = SomeComponent.firstCall.args[0];
+      expect(props.color).toEqual('orange');
+      expect(props.size).toEqual('large');
+    });
+  });
+});

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -1,12 +1,6 @@
 import url from 'url';
 
-import * as React from 'react';
 import config from 'config';
-import {
-  renderIntoDocument,
-  findRenderedComponentWithType,
-} from 'react-dom/test-utils';
-import { compose } from 'redux';
 
 import * as api from 'core/api';
 import {
@@ -40,7 +34,6 @@ import {
   normalizeFileNameId,
   refreshAddon,
   removeProtocolFromURL,
-  render404IfConfigKeyIsFalse,
   safePromise,
   sanitizeHTML,
   sanitizeUserHTML,
@@ -48,13 +41,10 @@ import {
   visibleAddonType,
   trimAndAddProtocolToUrl,
 } from 'core/utils';
-import NotFound from 'core/components/ErrorPage/NotFound';
-import I18nProvider from 'core/i18n/Provider';
 import { createInternalAddon, loadAddons } from 'core/reducers/addons';
 import { fakeAddon, signedInApiState } from 'tests/unit/amo/helpers';
 import {
   createFetchAddonResult,
-  fakeI18n,
   getFakeConfig,
   unexpectedSuccess,
   userAgents,
@@ -570,55 +560,6 @@ describe(__filename, () => {
       expect(trimAndAddProtocolToUrl('https://test.com')).toEqual(
         'https://test.com',
       );
-    });
-  });
-
-  describe('render404IfConfigKeyIsFalse', () => {
-    function render(
-      props = {},
-      {
-        configKey = 'someConfigKey',
-        _config = { get: () => true },
-        SomeComponent = () => <div />,
-      } = {},
-    ) {
-      const WrappedComponent = compose(
-        render404IfConfigKeyIsFalse(configKey, { _config }),
-      )(SomeComponent);
-
-      return renderIntoDocument(
-        <I18nProvider i18n={fakeI18n()}>
-          <WrappedComponent {...props} />
-        </I18nProvider>,
-      );
-    }
-
-    it('requires a config key', () => {
-      expect(() => render404IfConfigKeyIsFalse()).toThrowError(
-        /configKey cannot be empty/,
-      );
-    });
-
-    it('returns a 404 when disabled by the config', () => {
-      const configKey = 'customConfigKey';
-      const _config = {
-        get: sinon.spy(() => false),
-      };
-      const root = render({}, { _config, configKey });
-      const node = findRenderedComponentWithType(root, NotFound);
-
-      expect(node).toBeTruthy();
-      sinon.assert.calledWith(_config.get, configKey);
-    });
-
-    it('passes through component and props when enabled', () => {
-      const _config = { get: () => true };
-      const SomeComponent = sinon.spy(() => <div />);
-      const props = { color: 'orange', size: 'large' };
-
-      render(props, { SomeComponent, _config });
-
-      sinon.assert.calledWith(SomeComponent, props);
     });
   });
 


### PR DESCRIPTION
Fix #1427

---

- remove all `withRef: true` and `getWrappedInstance()` calls
- move `getErrorComponent` to `core/utils/errors`
- move `render404IfConfigKeyIsFalse` to `core/utils/errors`
- refactor `translate()` HOC (Flow + remove `withRef` logic)
- add Flow `ConfigType`
- export `getDisplayName()` function (useful for HOCs)


Note: The two functions have been moved to `core/utils/errors` because
of a circular import error (if I remember correctly).