### PR TITLE
Fix discopane css

### DIFF
--- a/src/disco/components/DiscoPane/styles.scss
+++ b/src/disco/components/DiscoPane/styles.scss
@@ -16,8 +16,9 @@
 
 .disco-content {
   color: $header-copy-font-color;
-  font-size: 14px;
-  line-height: 1.28;
+  font-size: 16px;
+  line-height: 1.5;
+  max-width: 620px;
   width: 100%;
 
   &:last-child {


### PR DESCRIPTION
Fix #5323 (see comments)

---

Before:

![screen shot 2018-07-17 at 14 06 05](https://user-images.githubusercontent.com/217628/42816258-906c92e6-89ca-11e8-8787-c643ec9f189d.png)


After:

![screen shot 2018-07-17 at 13 55 30](https://user-images.githubusercontent.com/217628/42816141-152e7040-89ca-11e8-9fad-110662e51a3c.png)
