### PR TITLE
Improve contrast of survey notice box

### DIFF
--- a/src/core/components/SurveyNotice/styles.scss
+++ b/src/core/components/SurveyNotice/styles.scss
@@ -1,3 +1,5 @@
+@import '~photon-colors/photon-colors';
+
 .SurveyNotice {
   .Notice-column {
     justify-content: center;
@@ -6,6 +8,6 @@
   &.Notice-generic {
     // This strays from the Photon spec because the Photon background is the
     // same as the page background which means the notice box could not be seen.
-    background-color: #d7d7db;
+    background-color: $grey-30;
   }
 }

--- a/src/core/components/SurveyNotice/styles.scss
+++ b/src/core/components/SurveyNotice/styles.scss
@@ -1,3 +1,11 @@
-.SurveyNotice .Notice-column {
-  justify-content: center;
+.SurveyNotice {
+  .Notice-column {
+    justify-content: center;
+  }
+
+  &.Notice-generic {
+    // This strays from the Photon spec because the Photon background is the
+    // same as the page background which means the notice box could not be seen.
+    background-color: #d7d7db;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5653

Before:

<img width="942" alt="screenshot 2018-07-18 14 26 56" src="https://user-images.githubusercontent.com/55398/42903370-3df3496a-8a97-11e8-8615-e0f829f41e14.png">


After:

<img width="942" alt="screenshot 2018-07-18 14 23 43" src="https://user-images.githubusercontent.com/55398/42903375-4364b1a4-8a97-11e8-8f4b-b96240587cd6.png">
<img width="323" alt="screenshot 2018-07-18 14 32 00" src="https://user-images.githubusercontent.com/55398/42903408-5b5c3dfe-8a97-11e8-9e75-be1e71bbdd1d.png">
