### PR TITLE
Fix page padding for add-on review listing

### DIFF
--- a/src/amo/components/AddonReviewList/styles.scss
+++ b/src/amo/components/AddonReviewList/styles.scss
@@ -3,11 +3,10 @@
 @import '~ui/css/vars';
 
 .AddonReviewList {
-  padding: $padding-page;
+  @include page-padding();
 
   @include respond-to(large) {
     display: flex;
-    padding: $padding-page-l;
   }
 
   .Card {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5655

Before

<img width="833" alt="screenshot 2018-07-18 14 58 28" src="https://user-images.githubusercontent.com/55398/42904765-a0f09fdc-8a9b-11e8-99e2-2a8b4c11c27f.png">


After

<img width="834" alt="screenshot 2018-07-18 14 59 51" src="https://user-images.githubusercontent.com/55398/42904775-a59bc94e-8a9b-11e8-8670-2b36473acaa7.png">
