### PR TITLE
A less jarring loading screen while editing a collection

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -94,6 +94,8 @@ export type SaveAddonNoteFunc = (
 ) => void;
 
 export class CollectionBase extends React.Component<InternalProps> {
+  addonPlaceholderCount: number;
+
   static defaultProps = {
     _config: config,
     _isFeaturedCollection: isFeaturedCollection,
@@ -101,8 +103,25 @@ export class CollectionBase extends React.Component<InternalProps> {
     editing: false,
   };
 
+  constructor(props: InternalProps) {
+    super(props);
+    this.addonPlaceholderCount = 5;
+    this.maybeResetAddonPlaceholderCount();
+  }
+
+  maybeResetAddonPlaceholderCount() {
+    const { collection } = this.props;
+    if (collection && collection.addons && collection.addons.length) {
+      this.addonPlaceholderCount = collection.addons.length;
+    }
+  }
+
   componentWillMount() {
     this.loadDataIfNeeded();
+  }
+
+  componentDidUpdate() {
+    this.maybeResetAddonPlaceholderCount();
   }
 
   componentWillReceiveProps(nextProps: InternalProps) {
@@ -412,6 +431,7 @@ export class CollectionBase extends React.Component<InternalProps> {
               editing={editing}
               footer={paginator}
               loading={!collection || loading}
+              placeholderCount={this.addonPlaceholderCount}
               removeAddon={this.removeAddon}
               saveNote={this.saveNote}
             />

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -56,6 +56,8 @@ import type { ReactRouterLocation } from 'core/types/router';
 
 import './styles.scss';
 
+export const DEFAULT_ADDON_PLACEHOLDER_COUNT = 3;
+
 export type Props = {|
   collection: CollectionType | null,
   creating: boolean,
@@ -105,7 +107,7 @@ export class CollectionBase extends React.Component<InternalProps> {
 
   constructor(props: InternalProps) {
     super(props);
-    this.addonPlaceholderCount = 5;
+    this.addonPlaceholderCount = DEFAULT_ADDON_PLACEHOLDER_COUNT;
     this.maybeResetAddonPlaceholderCount();
   }
 

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -114,6 +114,8 @@ export class CollectionBase extends React.Component<InternalProps> {
   maybeResetAddonPlaceholderCount() {
     const { collection } = this.props;
     if (collection && collection.addons && collection.addons.length) {
+      // Store the previous count of collection add-ons for use as
+      // the placeholder count when loading the next set of add-ons.
       this.addonPlaceholderCount = collection.addons.length;
     }
   }

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import Collection, {
   CollectionBase,
+  DEFAULT_ADDON_PLACEHOLDER_COUNT,
   extractId,
   mapStateToProps,
 } from 'amo/components/Collection';
@@ -596,7 +597,10 @@ describe(__filename, () => {
 
   it('sets a default placeholder count', () => {
     const wrapper = renderComponent();
-    expect(wrapper.find(AddonsCard)).toHaveProp('placeholderCount', 5);
+    expect(wrapper.find(AddonsCard)).toHaveProp(
+      'placeholderCount',
+      DEFAULT_ADDON_PLACEHOLDER_COUNT,
+    );
   });
 
   it('initializes add-on placeholder count with collection add-ons', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5672

I noticed this while testing out the spiffy new collections and it bugged me. I thought it was easy to fix and it totally wasn't! But I started it towards the end of the day anyway. Sigh.

<details>
<summary>Before</summary>

![addons-frontend-collection-before mov](https://user-images.githubusercontent.com/55398/42973485-e8a0b546-8b78-11e8-88d7-a2d6a4e5c58d.gif)


</details>

<details>
<summary>After</summary>

![addons-frontend-collection-after mov](https://user-images.githubusercontent.com/55398/42973496-ee7d4650-8b78-11e8-861f-35d19a019109.gif)


</details>