### PR TITLE
 Move the select which is used to add an add-on to a collection out of the edit form

### DIFF
--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -8,9 +8,9 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import AddonsCard from 'amo/components/AddonsCard';
+import CollectionControls from 'amo/components/CollectionControls';
 import CollectionDetails from 'amo/components/CollectionDetails';
 import CollectionManager from 'amo/components/CollectionManager';
-import CollectionSort from 'amo/components/CollectionSort';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Link from 'amo/components/Link';
 import { isFeaturedCollection } from 'amo/components/Home';
@@ -418,13 +418,11 @@ export class CollectionBase extends React.Component<InternalProps> {
             {this.renderCardContents()}
             {this.renderDeleteButton()}
           </Card>
-          {!creating && (
-            <CollectionSort
-              collection={collection}
-              editing={editing}
-              filters={filters}
-            />
-          )}
+          <CollectionControls
+            collection={collection}
+            editing={editing}
+            filters={filters}
+          />
         </div>
         <div className="Collection-items">
           {!creating && (

--- a/src/amo/components/CollectionAddAddon/styles.scss
+++ b/src/amo/components/CollectionAddAddon/styles.scss
@@ -4,8 +4,7 @@
 .CollectionAddAddon {
   .ErrorList,
   .CollectionAddAddon-noticePlaceholder {
-    margin-top: 16px;
-    min-height: 32px;
+    margin: 0;
   }
 
   .AutoSearchInput-label {

--- a/src/amo/components/CollectionAddAddon/styles.scss
+++ b/src/amo/components/CollectionAddAddon/styles.scss
@@ -2,18 +2,33 @@
 @import '~amo/css/inc/vars';
 
 .CollectionAddAddon {
+  margin-bottom: 24px;
+
   .ErrorList,
   .CollectionAddAddon-noticePlaceholder {
-    margin: 0;
+    margin-bottom: 6px;
   }
 
   .AutoSearchInput-label {
-    padding-top: 4px;
+    padding-bottom: 6px;
+  }
+
+  .AutoSearchInput-search-box {
+    padding-top: 6px;
   }
 
   .AutoSearchInput-query {
     border: 1px solid $grey-50;
     border-radius: $border-radius-xs;
+  }
+
+  .AutoSearchInput-icon-magnifying-glass {
+    top: 12px;
+  }
+
+  .AutoSearchInput-submit-button,
+  .SearchSuggestion-icon-arrow {
+    display: none;
   }
 
   .AutoSearchInput--autocompleteIsOpen .AutoSearchInput-query {

--- a/src/amo/components/CollectionControls/index.js
+++ b/src/amo/components/CollectionControls/index.js
@@ -1,0 +1,37 @@
+/* @flow */
+import * as React from 'react';
+
+import CollectionAddAddon from 'amo/components/CollectionAddAddon';
+import CollectionSort from 'amo/components/CollectionSort';
+import Card from 'ui/components/Card';
+import type {
+  CollectionFilters,
+  CollectionType,
+} from 'amo/reducers/collections';
+
+import './styles.scss';
+
+export type Props = {|
+  collection: CollectionType | null,
+  editing: boolean,
+  filters: CollectionFilters,
+|};
+
+export default class CollectionControls extends React.Component<Props> {
+  render() {
+    const { collection, editing, filters } = this.props;
+
+    return (
+      <Card className="CollectionControls">
+        {editing && (
+          <CollectionAddAddon collection={collection} filters={filters} />
+        )}
+        <CollectionSort
+          collection={collection}
+          editing={editing}
+          filters={filters}
+        />
+      </Card>
+    );
+  }
+}

--- a/src/amo/components/CollectionControls/styles.scss
+++ b/src/amo/components/CollectionControls/styles.scss
@@ -1,3 +1,13 @@
+@import '~core/css/inc/mixins';
+
 .CollectionControls {
-  margin-top: 12px;
+  margin-top: $padding-page;
+
+  @include respond-to(large) {
+    margin-top: $padding-page-l;
+  }
+
+  .Card-contents {
+    overflow: visible;
+  }
 }

--- a/src/amo/components/CollectionControls/styles.scss
+++ b/src/amo/components/CollectionControls/styles.scss
@@ -1,0 +1,3 @@
+.CollectionControls {
+  margin-top: 12px;
+}

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -7,7 +7,6 @@ import { withRouter } from 'react-router';
 import { compose } from 'redux';
 import config from 'config';
 
-import CollectionAddAddon from 'amo/components/CollectionAddAddon';
 import {
   convertFiltersToQueryParams,
   createCollection,
@@ -212,7 +211,6 @@ export class CollectionManagerBase extends React.Component<
       creating,
       currentUsername,
       errorHandler,
-      filters,
       i18n,
       isCollectionBeingModified,
       siteLang,
@@ -296,11 +294,6 @@ export class CollectionManagerBase extends React.Component<
             value={this.state.slug}
           />
         </div>
-
-        {!creating && (
-          <CollectionAddAddon collection={collection} filters={filters} />
-        )}
-
         <footer className="CollectionManager-footer">
           {/*
             type=button is necessary to override the default

--- a/src/amo/components/CollectionSort/index.js
+++ b/src/amo/components/CollectionSort/index.js
@@ -17,7 +17,6 @@ import {
   COLLECTION_SORT_POPULARITY_DESCENDING,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
-import Card from 'ui/components/Card';
 import Select from 'ui/components/Select';
 import type {
   CollectionFilters,
@@ -100,31 +99,26 @@ export class CollectionSortBase extends React.Component<InternalProps> {
     const { filters, i18n } = this.props;
 
     return (
-      <Card className="CollectionSort">
-        <form>
-          <label
-            className="CollectionSort-label"
-            htmlFor="CollectionSort-select"
-          >
-            {i18n.gettext('Sort add-ons by')}
-          </label>
-          <Select
-            className="CollectionSort-select"
-            defaultValue={filters.collectionSort}
-            id="CollectionSort-select"
-            name="sort"
-            onChange={this.onSortSelect}
-          >
-            {this.sortOptions().map((option) => {
-              return (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              );
-            })}
-          </Select>
-        </form>
-      </Card>
+      <form className="CollectionSort">
+        <label className="CollectionSort-label" htmlFor="CollectionSort-select">
+          {i18n.gettext('Sort add-ons by')}
+        </label>
+        <Select
+          className="CollectionSort-select"
+          defaultValue={filters.collectionSort}
+          id="CollectionSort-select"
+          name="sort"
+          onChange={this.onSortSelect}
+        >
+          {this.sortOptions().map((option) => {
+            return (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            );
+          })}
+        </Select>
+      </form>
     );
   }
 }

--- a/src/amo/components/CollectionSort/styles.scss
+++ b/src/amo/components/CollectionSort/styles.scss
@@ -5,7 +5,3 @@
   display: block;
   padding-bottom: 6px;
 }
-
-.CollectionSort-select {
-  margin: 0 0 6px;
-}

--- a/src/amo/components/CollectionSort/styles.scss
+++ b/src/amo/components/CollectionSort/styles.scss
@@ -1,12 +1,9 @@
 @import '~photon-colors/photon-colors';
 
-.CollectionSort {
-  margin-top: 12px;
-}
-
 .CollectionSort-label {
   color: $grey-50;
   display: block;
+  padding-bottom: 6px;
 }
 
 .CollectionSort-select {

--- a/tests/unit/amo/components/TestCollection.js
+++ b/tests/unit/amo/components/TestCollection.js
@@ -10,7 +10,7 @@ import Collection, {
 import AddonsCard from 'amo/components/AddonsCard';
 import CollectionDetails from 'amo/components/CollectionDetails';
 import CollectionManager from 'amo/components/CollectionManager';
-import CollectionSort from 'amo/components/CollectionSort';
+import CollectionControls from 'amo/components/CollectionControls';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import Paginate from 'core/components/Paginate';
@@ -760,7 +760,7 @@ describe(__filename, () => {
     sinon.assert.called(_isFeaturedCollection);
   });
 
-  it('renders a CollectionSort component', () => {
+  it('renders a CollectionControls component', () => {
     const editing = false;
     const page = 2;
     const pageSize = 10;
@@ -794,22 +794,14 @@ describe(__filename, () => {
       store,
     });
 
-    const sortComponent = wrapper.find(CollectionSort);
+    const controls = wrapper.find(CollectionControls);
 
-    expect(sortComponent).toHaveLength(1);
-    expect(sortComponent).toHaveProp('editing', editing);
-    expect(sortComponent).toHaveProp('collection', collection);
-    expect(sortComponent).toHaveProp('filters', {
+    expect(controls).toHaveProp('collection', collection);
+    expect(controls).toHaveProp('editing', editing);
+    expect(controls).toHaveProp('filters', {
       page,
       collectionSort: sort,
     });
-  });
-
-  it('does not render a CollectionSort component when creating', () => {
-    const { store } = dispatchSignInActions();
-    const wrapper = renderComponent({ creating: true, store });
-
-    expect(wrapper.find(CollectionSort)).toHaveLength(0);
   });
 
   it('renders a collection for editing', () => {

--- a/tests/unit/amo/components/TestCollectionControls.js
+++ b/tests/unit/amo/components/TestCollectionControls.js
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import CollectionAddAddon from 'amo/components/CollectionAddAddon';
+import CollectionControls from 'amo/components/CollectionControls';
+import CollectionSort from 'amo/components/CollectionSort';
+import { createInternalCollection } from 'amo/reducers/collections';
+import { COLLECTION_SORT_NAME } from 'core/constants';
+import { createFakeCollectionDetail } from 'tests/unit/amo/helpers';
+
+describe(__filename, () => {
+  const render = ({ ...otherProps } = {}) => {
+    const props = {
+      collection: createInternalCollection({
+        detail: createFakeCollectionDetail(),
+      }),
+      editing: true,
+      filters: {},
+      ...otherProps,
+    };
+
+    return shallow(<CollectionControls {...props} />);
+  };
+
+  it('renders a CollectionSort component', () => {
+    const collection = createInternalCollection({
+      detail: createFakeCollectionDetail(),
+    });
+    const editing = true;
+    const filters = { collectionSort: COLLECTION_SORT_NAME };
+
+    const root = render({ collection, editing, filters });
+
+    expect(root.find(CollectionSort)).toHaveProp('collection', collection);
+    expect(root.find(CollectionSort)).toHaveProp('editing', editing);
+    expect(root.find(CollectionSort)).toHaveProp('filters', filters);
+  });
+
+  it('renders a CollectionAddAddon component when editing', () => {
+    const collection = createInternalCollection({
+      detail: createFakeCollectionDetail(),
+    });
+    const editing = true;
+    const filters = { collectionSort: COLLECTION_SORT_NAME };
+
+    const root = render({ collection, editing, filters });
+
+    expect(root.find(CollectionAddAddon)).toHaveProp('collection', collection);
+    expect(root.find(CollectionAddAddon)).toHaveProp('filters', filters);
+  });
+
+  it('does not render a CollectionAddAddon component when not editing', () => {
+    const root = render({ editing: false });
+
+    expect(root.find(CollectionAddAddon)).toHaveLength(0);
+  });
+});

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -1,8 +1,6 @@
 import config from 'config';
 import * as React from 'react';
 
-import AutoSearchInput from 'amo/components/AutoSearchInput';
-import CollectionAddAddon from 'amo/components/CollectionAddAddon';
 import CollectionManager, {
   CollectionManagerBase,
   extractId,
@@ -284,12 +282,6 @@ describe(__filename, () => {
       'New description',
     );
     expect(root.find('#collectionSlug')).toHaveProp('value', 'new-slug');
-  });
-
-  it('hides search add-on select when creating a collection', () => {
-    const root = render({ collection: null, creating: true });
-
-    expect(root.find(AutoSearchInput)).toHaveLength(0);
   });
 
   it('creates a collection on submit', () => {
@@ -763,23 +755,6 @@ describe(__filename, () => {
     const state = root.state();
     expect(state.name).toEqual(secondCollection.name);
     expect(state.description).toEqual(secondCollection.description);
-  });
-
-  it('displays a CollectionAddAddon component when not creating', () => {
-    const collection = createInternalCollection({
-      detail: createFakeCollectionDetail(),
-    });
-    const filters = {};
-    const root = render({ collection, creating: false, filters });
-
-    expect(root.find(CollectionAddAddon)).toHaveProp('collection', collection);
-    expect(root.find(CollectionAddAddon)).toHaveProp('filters', filters);
-  });
-
-  it('does not display a CollectionAddAddon component when creating', () => {
-    const root = render({ creating: true });
-
-    expect(root.find(CollectionAddAddon)).toHaveLength(0);
   });
 
   describe('extractId', () => {


### PR DESCRIPTION
Fixes #5675 
Fixes #5286
Fixes #4617
Depends on #5669 

There is one UX quirk that may be an issue. When you add an add-on to a collection, the card increases in size to show the "Added to collection" notice, and then, when the notice fades away, the card reduces in size. The fact that it changes its size to show the notice is consistent with what we do when there's an error, but it's a bit odd because of the notice disappearing and the card shrinking. See the screenshot as an example:

![jul-20-2018 09-47-13](https://user-images.githubusercontent.com/142755/43005842-06451c8e-8c02-11e8-8749-58883cd9a80a.gif)

The only option I can think of to mitigate this is to reserve enough blank space at the top of the card for the message, but then that looks bad whenever the message is not visible, which is why I wrote it the way it currently is. Do you have an opinion @pwalm?

Before:

![screenshot 2018-07-20 09 51 12](https://user-images.githubusercontent.com/142755/43005992-76d25804-8c02-11e8-8e30-e8ca05f478aa.png)
After:

![screenshot 2018-07-20 09 49 27](https://user-images.githubusercontent.com/142755/43005896-36b5ec40-8c02-11e8-9630-75ece95eb382.png)

 
