### PR TITLE
Redirect to the slug that is returned by the API call when creating or editing a collection

### DIFF
--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -266,11 +266,11 @@ export function* modifyCollection(
         slug,
         ...baseApiParams,
       };
-      yield call(api.updateCollection, apiParams);
+      response = yield call(api.updateCollection, apiParams);
     }
 
     const { lang, clientApp } = state.api;
-    const effectiveSlug = slug || collectionSlug;
+    const effectiveSlug = (response && response.slug) || slug || collectionSlug;
     invariant(effectiveSlug, 'Both slug and collectionSlug cannot be empty');
     const newLocation = `/${lang}/${clientApp}/collections/${username}/${effectiveSlug}/`;
 
@@ -307,7 +307,7 @@ export function* modifyCollection(
         }),
       );
 
-      const slugWasEdited = slug && slug !== collectionSlug;
+      const slugWasEdited = effectiveSlug !== collectionSlug;
       if (!slugWasEdited) {
         // Invalidate the stored collection object. This will force each
         // component to re-fetch the collection. This is only necessary

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -567,7 +567,9 @@ describe(__filename, () => {
           slug: returnedSlug,
         });
 
-        mockApi.expects('updateCollection').returns(collectionDetailResponse);
+        mockApi
+          .expects('updateCollection')
+          .returns(Promise.resolve(collectionDetailResponse));
 
         const collectionSlug = 'some-collection';
         const updateFilters = { page: 2 };

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -559,46 +559,34 @@ describe(__filename, () => {
         ).not.toContain(unloadCollectionBySlug(collectionSlug).type);
       });
 
-      it('redirects to the existing slug after update', async () => {
-        mockApi.expects('updateCollection').returns(Promise.resolve());
+      it('redirects to the resulting slug after update', async () => {
+        const submittedSlug = 'submitted-slug';
+        const returnedSlug = 'returned-slug';
+
+        const collectionDetailResponse = createFakeCollectionDetail({
+          slug: returnedSlug,
+        });
+
+        mockApi.expects('updateCollection').returns(collectionDetailResponse);
 
         const collectionSlug = 'some-collection';
         const updateFilters = { page: 2 };
-        // Update everything except the slug.
         _updateCollection({
           collectionSlug,
           filters: updateFilters,
-          slug: undefined,
+          slug: submittedSlug,
           username,
         });
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation({
-          pathname: `/${lang}/${clientApp}/collections/${username}/${collectionSlug}/`,
+          pathname: `/${lang}/${clientApp}/collections/${username}/${returnedSlug}/`,
           query: convertFiltersToQueryParams(updateFilters),
         });
 
         const action = await sagaTester.waitFor(expectedAction.type);
         expect(action).toEqual(expectedAction);
 
-        mockApi.verify();
-      });
-
-      it('redirects to the new slug after update', async () => {
-        mockApi.expects('updateCollection').returns(Promise.resolve());
-
-        const newSlug = 'new-slug';
-        const updateFilters = { page: 2 };
-        _updateCollection({ filters: updateFilters, slug: newSlug, username });
-
-        const { lang, clientApp } = clientData.state.api;
-        const expectedAction = pushLocation({
-          pathname: `/${lang}/${clientApp}/collections/${username}/${newSlug}/`,
-          query: convertFiltersToQueryParams(updateFilters),
-        });
-
-        const action = await sagaTester.waitFor(expectedAction.type);
-        expect(action).toEqual(expectedAction);
         mockApi.verify();
       });
     });
@@ -656,21 +644,26 @@ describe(__filename, () => {
       });
 
       it('redirects to the collection edit screen after create', async () => {
+        const submittedSlug = 'submitted-slug';
+        const returnedSlug = 'returned-slug';
         const state = sagaTester.getState();
-        const params = getParams({ lang: state.api.lang });
 
-        const collectionDetailResponse = createFakeCollectionDetail(params);
+        const collectionDetailResponse = createFakeCollectionDetail({
+          slug: returnedSlug,
+        });
 
         mockApi
           .expects('createCollection')
           .once()
           .returns(Promise.resolve(collectionDetailResponse));
 
-        _createCollection(params);
+        _createCollection(
+          getParams({ lang: state.api.lang, slug: submittedSlug }),
+        );
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${username}/${slug}/edit/`,
+          `/${lang}/${clientApp}/collections/${username}/${returnedSlug}/edit/`,
         );
 
         const action = await sagaTester.waitFor(expectedAction.type);


### PR DESCRIPTION
Fixes #5424 
