### PR TITLE
Accept numeric IDs to browse a user profile page

### DIFF
--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -18,6 +18,7 @@ import { getReviewsByUserId } from 'amo/reducers/reviews';
 import {
   fetchUserAccount,
   getCurrentUser,
+  getUserById,
   getUserByUsername,
   hasPermission,
   isDeveloper,
@@ -141,9 +142,9 @@ export class UserProfileBase extends React.Component<InternalProps> {
   }
 
   getURL() {
-    const { params } = this.props;
+    const { params, user } = this.props;
 
-    return `/user/${params.username}/`;
+    return `/user/${user ? user.username : params.username}/`;
   }
 
   getEditURL() {
@@ -382,7 +383,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                 <AddonsByAuthorsCard
                   addonType={ADDON_TYPE_EXTENSION}
                   authorDisplayName={user ? user.name : params.username}
-                  authorUsernames={[params.username]}
+                  authorUsernames={[user ? user.username : params.username]}
                   errorHandler={errorHandler}
                   numberOfAddons={EXTENSIONS_BY_AUTHORS_PAGE_SIZE}
                   pageParam="page_e"
@@ -396,7 +397,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                 <AddonsByAuthorsCard
                   addonType={ADDON_TYPE_THEME}
                   authorDisplayName={user ? user.name : params.username}
-                  authorUsernames={[params.username]}
+                  authorUsernames={[user ? user.username : params.username]}
                   errorHandler={errorHandler}
                   numberOfAddons={THEMES_BY_AUTHORS_PAGE_SIZE}
                   pageParam="page_t"
@@ -415,8 +416,18 @@ export class UserProfileBase extends React.Component<InternalProps> {
 }
 
 export function mapStateToProps(state: AppState, ownProps: Props) {
+  const { username } = ownProps.params;
+
   const currentUser = getCurrentUser(state.users);
-  const user = getUserByUsername(state.users, ownProps.params.username);
+
+  // `getUserByUsername()` requires a string as second argument.
+  let user = getUserByUsername(state.users, `${username}`);
+
+  if (!user) {
+    const userId = parseInt(username, 10);
+    user = !Number.isNaN(userId) ? getUserById(state.users, userId) : undefined;
+  }
+
   const isOwner = currentUser && user && currentUser.id === user.id;
 
   const canEditProfile =

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -141,10 +141,14 @@ export class UserProfileBase extends React.Component<InternalProps> {
     }
   }
 
-  getURL() {
+  getUsername() {
     const { params, user } = this.props;
 
-    return `/user/${user ? user.username : params.username}/`;
+    return user ? user.username : params.username;
+  }
+
+  getURL() {
+    return `/user/${this.getUsername()}/`;
   }
 
   getEditURL() {
@@ -383,7 +387,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                 <AddonsByAuthorsCard
                   addonType={ADDON_TYPE_EXTENSION}
                   authorDisplayName={user ? user.name : params.username}
-                  authorUsernames={[user ? user.username : params.username]}
+                  authorUsernames={[this.getUsername()]}
                   errorHandler={errorHandler}
                   numberOfAddons={EXTENSIONS_BY_AUTHORS_PAGE_SIZE}
                   pageParam="page_e"
@@ -397,7 +401,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                 <AddonsByAuthorsCard
                   addonType={ADDON_TYPE_THEME}
                   authorDisplayName={user ? user.name : params.username}
-                  authorUsernames={[user ? user.username : params.username]}
+                  authorUsernames={[this.getUsername()]}
                   errorHandler={errorHandler}
                   numberOfAddons={THEMES_BY_AUTHORS_PAGE_SIZE}
                   pageParam="page_t"

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -926,6 +926,15 @@ describe(__filename, () => {
     expect(root.find(NotFound)).toHaveLength(1);
   });
 
+  it('renders a user profile when URL contains a user ID', () => {
+    const { store } = signInUserWithUsername('black-panther');
+    const user = getCurrentUser(store.getState().users);
+
+    const root = renderUserProfile({ params: { username: user.id }, store });
+
+    expect(root.find('.UserProfile')).toHaveLength(1);
+  });
+
   describe('errorHandler - extractId', () => {
     it('returns a unique ID based on params', () => {
       const username = 'foo';

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -930,9 +930,37 @@ describe(__filename, () => {
     const { store } = signInUserWithUsername('black-panther');
     const user = getCurrentUser(store.getState().users);
 
+    const reviews = Array(DEFAULT_API_PAGE_SIZE).fill(fakeReview);
+    _setUserReviews({
+      store,
+      userId: user.id,
+      reviews,
+      count: DEFAULT_API_PAGE_SIZE + 2,
+    });
+
     const root = renderUserProfile({ params: { username: user.id }, store });
+    const header = getHeaderPropComponent(root);
 
     expect(root.find('.UserProfile')).toHaveLength(1);
+    expect(header.find('.UserProfile-name')).toHaveText(user.name);
+
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp('authorUsernames', [
+      user.username,
+    ]);
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp(
+      'pathname',
+      `/user/${user.username}/`,
+    );
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp('authorUsernames', [
+      user.username,
+    ]);
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp(
+      'pathname',
+      `/user/${user.username}/`,
+    );
+
+    const paginator = shallow(root.find('.UserProfile-reviews').prop('footer'));
+    expect(paginator).toHaveProp('pathname', `/user/${user.username}/`);
   });
 
   describe('errorHandler - extractId', () => {


### PR DESCRIPTION
Fix #5594 

---

I had this fix in one of my local branches... This PR allows a user profile page to be shown when using a user ID in the URL (for backward compatibility purpose).