### PR TITLE
Sort by popularity should use descending order

### DIFF
--- a/src/amo/components/CollectionSort/index.js
+++ b/src/amo/components/CollectionSort/index.js
@@ -14,7 +14,7 @@ import {
   COLLECTION_SORT_DATE_ADDED_ASCENDING,
   COLLECTION_SORT_DATE_ADDED_DESCENDING,
   COLLECTION_SORT_NAME,
-  COLLECTION_SORT_POPULARITY,
+  COLLECTION_SORT_POPULARITY_DESCENDING,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
 import Card from 'ui/components/Card';
@@ -91,7 +91,7 @@ export class CollectionSortBase extends React.Component<InternalProps> {
       },
       {
         label: i18n.gettext('Popularity'),
-        value: COLLECTION_SORT_POPULARITY,
+        value: COLLECTION_SORT_POPULARITY_DESCENDING,
       },
     ];
   }

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -140,7 +140,8 @@ export const SEARCH_SORT_UPDATED = 'updated';
 export const COLLECTION_SORT_DATE_ADDED_ASCENDING = 'added';
 export const COLLECTION_SORT_DATE_ADDED_DESCENDING = '-added';
 export const COLLECTION_SORT_NAME = 'name';
-export const COLLECTION_SORT_POPULARITY = 'popularity';
+// Note that popularity sort should be in descending order.
+export const COLLECTION_SORT_POPULARITY = '-popularity';
 
 // Operating system for add-ons and files
 export const OS_ALL = 'all';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -140,8 +140,7 @@ export const SEARCH_SORT_UPDATED = 'updated';
 export const COLLECTION_SORT_DATE_ADDED_ASCENDING = 'added';
 export const COLLECTION_SORT_DATE_ADDED_DESCENDING = '-added';
 export const COLLECTION_SORT_NAME = 'name';
-// Note that popularity sort should be in descending order.
-export const COLLECTION_SORT_POPULARITY = '-popularity';
+export const COLLECTION_SORT_POPULARITY_DESCENDING = '-popularity';
 
 // Operating system for add-ons and files
 export const OS_ALL = 'all';


### PR DESCRIPTION
Fixes #5581 

Note that I looked for an opportunity to test this change, but as all we're doing is changing the value of a constant, there isn't really anything to test. We don't generally test values of constants.