### PR TITLE
Revert add-on added message timeout to 5 seconds

### DIFF
--- a/src/amo/components/CollectionAddAddon/index.js
+++ b/src/amo/components/CollectionAddAddon/index.js
@@ -25,7 +25,7 @@ import type { DispatchFunc } from 'core/types/redux';
 
 import './styles.scss';
 
-export const MESSAGE_RESET_TIME = 25000;
+export const MESSAGE_RESET_TIME = 5000;
 const MESSAGE_FADEOUT_TIME = 450;
 
 type UIStateType = {|


### PR DESCRIPTION
This change was accidentally committed.

We should cherry-pick this for this week's tag.