### PR TITLE
I5707 adding all addon types to action list for GA

### DIFF
--- a/src/core/tracking.js
+++ b/src/core/tracking.js
@@ -170,18 +170,12 @@ export class Tracking {
 }
 
 export function getAddonTypeForTracking(type) {
-  const extensionTrackingTypes = [
-    ADDON_TYPE_DICT,
-    ADDON_TYPE_EXTENSION,
-    ADDON_TYPE_LANG,
-    ADDON_TYPE_OPENSEARCH,
-  ];
-
-  const index = extensionTrackingTypes.indexOf(type);
-
   return (
     {
-      [extensionTrackingTypes[index]]: TRACKING_TYPE_EXTENSION,
+      [ADDON_TYPE_DICT]: TRACKING_TYPE_EXTENSION,
+      [ADDON_TYPE_EXTENSION]: TRACKING_TYPE_EXTENSION,
+      [ADDON_TYPE_LANG]: TRACKING_TYPE_EXTENSION,
+      [ADDON_TYPE_OPENSEARCH]: TRACKING_TYPE_EXTENSION,
       [ADDON_TYPE_STATIC_THEME]: TRACKING_TYPE_STATIC_THEME,
       [ADDON_TYPE_THEME]: TRACKING_TYPE_THEME,
     }[type] || TRACKING_TYPE_INVALID

--- a/src/core/tracking.js
+++ b/src/core/tracking.js
@@ -7,7 +7,9 @@ import invariant from 'invariant';
 import { convertBoolean } from 'core/utils';
 import log from 'core/logger';
 import {
+  ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
@@ -168,10 +170,18 @@ export class Tracking {
 }
 
 export function getAddonTypeForTracking(type) {
+  const extensionTrackingTypes = [
+    ADDON_TYPE_DICT,
+    ADDON_TYPE_EXTENSION,
+    ADDON_TYPE_LANG,
+    ADDON_TYPE_OPENSEARCH,
+  ];
+
+  const index = extensionTrackingTypes.indexOf(type);
+
   return (
     {
-      [ADDON_TYPE_EXTENSION]: TRACKING_TYPE_EXTENSION,
-      [ADDON_TYPE_OPENSEARCH]: TRACKING_TYPE_EXTENSION,
+      [extensionTrackingTypes[index]]: TRACKING_TYPE_EXTENSION,
       [ADDON_TYPE_STATIC_THEME]: TRACKING_TYPE_STATIC_THEME,
       [ADDON_TYPE_THEME]: TRACKING_TYPE_THEME,
     }[type] || TRACKING_TYPE_INVALID

--- a/tests/unit/core/test_tracking.js
+++ b/tests/unit/core/test_tracking.js
@@ -6,7 +6,9 @@ import {
   getAddonTypeForTracking,
 } from 'core/tracking';
 import {
+  ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
@@ -188,6 +190,18 @@ describe(__filename, () => {
 
     it('returns addon for TYPE_OPENSEARCH', () => {
       expect(getAddonTypeForTracking(ADDON_TYPE_OPENSEARCH)).toEqual(
+        TRACKING_TYPE_EXTENSION,
+      );
+    });
+
+    it('returns addon for TYPE_DICT', () => {
+      expect(getAddonTypeForTracking(ADDON_TYPE_DICT)).toEqual(
+        TRACKING_TYPE_EXTENSION,
+      );
+    });
+
+    it('returns addon for TYPE_LANG', () => {
+      expect(getAddonTypeForTracking(ADDON_TYPE_LANG)).toEqual(
         TRACKING_TYPE_EXTENSION,
       );
     });


### PR DESCRIPTION
fixes #5707 

So it looks like we using extension tracking for install as a catchall if it wasn’t a lightweight theme or open search type.  

Earlier we were not using `getAddonTypeForTracking` (previously called `getAction`) for install, only uninstalls it seems. So on a side but related note I think you should probably see invalid coming up on uninstalls..

Anyway, I’ve added all the missing types so in theory we shouldn’t see invalid anymore if it’s one of these types. Just a note, I am still tracking these with the extension tracking type - is that what we want? Or should each addon type have their very own tracking type?

These are currently the tracking types that are set up:
```javascript
// Tracking add-on types
export const TRACKING_TYPE_EXTENSION = 'addon';
export const TRACKING_TYPE_STATIC_THEME = ADDON_TYPE_STATIC_THEME;
export const TRACKING_TYPE_THEME = 'theme';
export const TRACKING_TYPE_INVALID = 'invalid';
```


Here are some example screenshots for a dictionary type (notice the GA info in console at the bottom of each screenshot)
BEFORE: 
![Alt text](https://monosnap.com/image/2KTSdvrMAkUGa04KGnxDbq43ywRrdx.png)

AFTER:
![Alt text](https://monosnap.com/image/eFGj06F6trruMsSuJ6OC5ZwGUWs8Rk.png)

// cc @muffinresearch @willdurand 