### PR TITLE
I5703 adjusting styles to minimize big icon while waiting for addon

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -116,6 +116,7 @@
 .Addon-theme-header {
   border-radius: $border-radius-default;
   height: auto;
+  max-height: $theme-height-legacy;
   max-width: $theme-width-default;
   order: -1;
   overflow-y: hidden;

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -75,6 +75,7 @@
 
     .SearchResult-icon {
       border-radius: $border-radius-default;
+      max-height: $theme-height-legacy;
     }
 
     @include respond-to(extraLarge) {

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -48,3 +48,6 @@ $max-modal-width: 768px;
 // Theme image dimensions
 $theme-height-default: 92px;
 $theme-width-default: 680px;
+
+// Lightweight images are slightly different
+$theme-height-legacy: 100px;


### PR DESCRIPTION
fixes #5703 

I did not see this issue consistently and I am not sure if this will be the end all solution but it does  seem to minimize the icon size at least. I believe this icon should be appearing as a placeholder while the we are waiting for the addon to load (right?). So this just gives a max height to make it look a little nicer. Note that I am going by lwt's height since it is a little bigger and for now since it's it should I think it should work for both.