### PR TITLE
I5555 overlay convert setstate to set ui state

### DIFF
--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -220,7 +220,7 @@ export class AddonReviewBase extends React.Component<InternalProps, State> {
       linkEnd: '</a>',
     });
 
-    const overlayClassName = 'AddonReview';
+    const overlayClassName = 'AddonReview-overlay';
 
     return (
       <OverlayCard

--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -220,11 +220,14 @@ export class AddonReviewBase extends React.Component<InternalProps, State> {
       linkEnd: '</a>',
     });
 
+    const overlayClassName = 'AddonReview';
+
     return (
       <OverlayCard
         visibleOnLoad
         onEscapeOverlay={this.props.onEscapeOverlay}
-        className="AddonReview"
+        className={overlayClassName}
+        id={overlayClassName}
       >
         <h2 className="AddonReview-header">{i18n.gettext('Write a review')}</h2>
         {/* eslint-disable react/no-danger */}

--- a/src/amo/components/AddonReview/styles.scss
+++ b/src/amo/components/AddonReview/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 
-.Overlay-contents .AddonReview {
+.Overlay-contents .AddonReview-overlay {
   .Card-contents {
     background: $base-color;
     max-height: 80vh;

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -452,6 +452,8 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
     const userProfileURL = `/user/${username}/`;
 
+    const overlayClassName = 'UserProfileEdit-deletion-modal';
+
     return (
       <div className="UserProfileEdit">
         {user && (
@@ -758,7 +760,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
         {this.state.showProfileDeletionModal && (
           <OverlayCard
-            className="UserProfileEdit-deletion-modal"
+            className={overlayClassName}
             header={
               isEditingCurrentUser
                 ? i18n.gettext(
@@ -768,6 +770,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                     `IMPORTANT: Deleting this Firefox Add-ons profile is irreversible.`,
                   )
             }
+            id={overlayClassName}
             onEscapeOverlay={this.onCancelProfileDeletion}
             visibleOnLoad
           >

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -221,8 +221,10 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     this.setState({ showProfileDeletionModal: true });
   };
 
-  onCancelProfileDeletion = (e: SyntheticEvent<HTMLButtonElement>) => {
-    e.preventDefault();
+  onCancelProfileDeletion = (event?: SyntheticEvent<any>) => {
+    if (event) {
+      event.preventDefault();
+    }
 
     this.setState({ showProfileDeletionModal: false });
   };

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -221,10 +221,8 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     this.setState({ showProfileDeletionModal: true });
   };
 
-  onCancelProfileDeletion = (event?: SyntheticEvent<any>) => {
-    if (event) {
-      event.preventDefault();
-    }
+  onCancelProfileDeletion = (e: SyntheticEvent<HTMLButtonElement>) => {
+    e.preventDefault();
 
     this.setState({ showProfileDeletionModal: false });
   };
@@ -773,7 +771,6 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                   )
             }
             id={overlayClassName}
-            onEscapeOverlay={this.onCancelProfileDeletion}
             visibleOnLoad
           >
             <p>

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -8,26 +8,12 @@ import withUIState from 'core/withUIState';
 
 import './styles.scss';
 
-// TODO: look into this as I don't see this working on the frontend
-// even in other envs.
-export const onClickBackground = (
-  event: SyntheticEvent<HTMLButtonElement>,
-  // eslint-disable-next-line no-use-before-define
-  _this: OverlayBase,
-) => {
-  if (_this.props.onEscapeOverlay) {
-    _this.props.onEscapeOverlay();
-  }
-  _this.hide();
-};
-
 type Props = {|
   className?: string,
   children: React.Element<any>,
   id: string,
-  onEscapeOverlay?: Function,
+  onEscapeOverlay?: () => void,
   visibleOnLoad?: boolean,
-  _onClickBackground: Function,
 |};
 
 type UIStateType = {|
@@ -45,7 +31,6 @@ type InternalProps = {|
 export class OverlayBase extends React.Component<InternalProps> {
   static defaultProps = {
     visibleOnLoad: false,
-    _onClickBackground: onClickBackground,
   };
 
   componentWillReceiveProps(nextProps: InternalProps) {
@@ -64,13 +49,14 @@ export class OverlayBase extends React.Component<InternalProps> {
     this.props.setUIState({ visible: false });
   }
 
-  show() {
-    this.props.setUIState({ visible: true });
-  }
-
-  toggle() {
-    this.props.setUIState({ visible: !this.props.uiState.visible });
-  }
+  // TODO: look into this as I don't see this working on the frontend
+  // even in other envs.
+  onClickBackground = () => {
+    if (this.props.onEscapeOverlay) {
+      this.props.onEscapeOverlay();
+    }
+    this.hide();
+  };
 
   render() {
     const { children, className, id, uiState } = this.props;
@@ -86,7 +72,7 @@ export class OverlayBase extends React.Component<InternalProps> {
       >
         <div
           className="Overlay-background"
-          onClick={(e) => this.props._onClickBackground(e, this)}
+          onClick={this.onClickBackground}
           role="presentation"
         />
         <div className="Overlay-contents">{children}</div>

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -81,11 +81,11 @@ export class OverlayBase extends React.Component<InternalProps> {
   }
 }
 
-export const extractId = (ownProps: InternalProps) => {
+export const extractId = (ownProps: Props) => {
   return ownProps.id;
 };
 
-const Overlay: React.ComponentType<InternalProps> = compose(
+const Overlay: React.ComponentType<Props> = compose(
   withUIState({
     fileName: __filename,
     extractId,

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -34,10 +34,8 @@ export class OverlayBase extends React.Component<InternalProps> {
   };
 
   componentDidMount() {
-    const { uiState, visibleOnLoad } = this.props;
-    if (visibleOnLoad !== uiState.visible) {
-      this.props.setUIState({ visible: visibleOnLoad });
-    }
+    const { visibleOnLoad } = this.props;
+    this.props.setUIState({ visible: visibleOnLoad });
   }
 
   componentWillReceiveProps(nextProps: InternalProps) {
@@ -50,10 +48,6 @@ export class OverlayBase extends React.Component<InternalProps> {
     ) {
       this.props.setUIState({ visible: visibleOnLoadNew });
     }
-  }
-
-  componentWillUnmount() {
-    this.hide();
   }
 
   onClickBackground = (event: SyntheticEvent<any>) => {

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -1,35 +1,47 @@
+/* @flow */
 import invariant from 'invariant';
 import makeClassName from 'classnames';
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { compose } from 'redux';
 
 import withUIState from 'core/withUIState';
 
 import './styles.scss';
 
-const initialUIState = { visible: false };
-
-// TODO: I don't see this working on the frontend
+// TODO: look into this as I don't see this working on the frontend
 // even in other envs.
-export const onClickBackground = (event, _this) => {
+export const onClickBackground = (
+  event: SyntheticEvent<HTMLButtonElement>,
+  _this: OverlayBase,
+) => {
   if (_this.props.onEscapeOverlay) {
     _this.props.onEscapeOverlay();
   }
   _this.hide();
 };
 
-export class OverlayBase extends React.Component {
-  static propTypes = {
-    children: PropTypes.node,
-    className: PropTypes.string,
-    id: PropTypes.string.isRequired,
-    visibleOnLoad: PropTypes.bool,
-    uiState: PropTypes.object,
-    setUIState: PropTypes.func,
-    _onClickBackground: PropTypes.func,
-  };
+type Props = {|
+  className?: string,
+  children: React.Element<any> | string,
+  id: string,
+  onEscapeOverlay: Function,
+  visibleOnLoad?: boolean,
+  _onClickBackground: Function,
+|};
 
+type UIStateType = {|
+  visible: boolean,
+|};
+
+const initialUIState: UIStateType = { visible: false };
+
+type InternalProps = {|
+  ...Props,
+  setUIState: ($Shape<UIStateType>) => void,
+  uiState: UIStateType,
+|};
+
+export class OverlayBase extends React.Component<InternalProps> {
   static defaultProps = {
     visibleOnLoad: false,
     uiState: initialUIState,
@@ -37,7 +49,7 @@ export class OverlayBase extends React.Component {
     _onClickBackground: onClickBackground,
   };
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: InternalProps) {
     const { uiState: uiStateOld } = this.props;
 
     if (
@@ -76,20 +88,13 @@ export class OverlayBase extends React.Component {
           onClick={(e) => this.props._onClickBackground(e, this)}
           role="presentation"
         />
-        <div
-          className="Overlay-contents"
-          ref={(ref) => {
-            this.overlayContents = ref;
-          }}
-        >
-          {children}
-        </div>
+        <div className="Overlay-contents">{children}</div>
       </div>
     );
   }
 }
 
-export const extractId = (ownProps) => {
+export const extractId = (ownProps: InternalProps) => {
   return ownProps.id;
 };
 

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -33,29 +33,40 @@ export class OverlayBase extends React.Component<InternalProps> {
     visibleOnLoad: false,
   };
 
+  componentDidMount() {
+    const { uiState, visibleOnLoad } = this.props;
+    if (visibleOnLoad !== uiState.visible) {
+      this.props.setUIState({ visible: visibleOnLoad });
+    }
+  }
+
   componentWillReceiveProps(nextProps: InternalProps) {
-    const { uiState: uiStateOld } = this.props;
+    const { uiState } = this.props;
     const { visibleOnLoad: visibleOnLoadNew } = nextProps;
 
     if (
-      (visibleOnLoadNew && !uiStateOld.visible) ||
-      uiStateOld.visible !== nextProps.uiState.visible
+      visibleOnLoadNew !== undefined &&
+      visibleOnLoadNew !== uiState.visible
     ) {
       this.props.setUIState({ visible: visibleOnLoadNew });
     }
   }
 
-  hide() {
-    this.props.setUIState({ visible: false });
+  componentWillUnmount() {
+    this.hide();
   }
 
-  // TODO: look into this as I don't see this working on the frontend
-  // even in other envs.
-  onClickBackground = () => {
+  onClickBackground = (event: SyntheticEvent<any>) => {
+    event.preventDefault();
     if (this.props.onEscapeOverlay) {
       this.props.onEscapeOverlay();
     }
+
     this.hide();
+  };
+
+  hide = () => {
+    this.props.setUIState({ visible: false });
   };
 
   render() {

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -12,6 +12,7 @@ import './styles.scss';
 // even in other envs.
 export const onClickBackground = (
   event: SyntheticEvent<HTMLButtonElement>,
+  // eslint-disable-next-line no-use-before-define
   _this: OverlayBase,
 ) => {
   if (_this.props.onEscapeOverlay) {
@@ -22,9 +23,9 @@ export const onClickBackground = (
 
 type Props = {|
   className?: string,
-  children: React.Element<any> | string,
+  children: React.Element<any>,
   id: string,
-  onEscapeOverlay: Function,
+  onEscapeOverlay?: Function,
   visibleOnLoad?: boolean,
   _onClickBackground: Function,
 |};
@@ -44,19 +45,18 @@ type InternalProps = {|
 export class OverlayBase extends React.Component<InternalProps> {
   static defaultProps = {
     visibleOnLoad: false,
-    uiState: initialUIState,
-    setUIState: () => {},
     _onClickBackground: onClickBackground,
   };
 
   componentWillReceiveProps(nextProps: InternalProps) {
     const { uiState: uiStateOld } = this.props;
+    const { visibleOnLoad: visibleOnLoadNew } = nextProps;
 
     if (
-      (nextProps.visibleOnLoad && !uiStateOld.visible) ||
+      (visibleOnLoadNew && !uiStateOld.visible) ||
       uiStateOld.visible !== nextProps.uiState.visible
     ) {
-      this.props.setUIState({ visible: nextProps.visibleOnLoad });
+      this.props.setUIState({ visible: visibleOnLoadNew });
     }
   }
 
@@ -75,6 +75,7 @@ export class OverlayBase extends React.Component<InternalProps> {
   render() {
     const { children, className, id, uiState } = this.props;
 
+    invariant(children, 'The children property is required');
     invariant(id, 'The id property is required');
 
     return (

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -10,24 +10,31 @@ import './styles.scss';
 
 const initialUIState = { visible: false };
 
+// TODO: I don't see this working on the frontend
+// even in other envs.
+export const onClickBackground = (event, _this) => {
+  if (_this.props.onEscapeOverlay) {
+    _this.props.onEscapeOverlay();
+  }
+  _this.hide();
+};
+
 export class OverlayBase extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     id: PropTypes.string.isRequired,
-    onEscapeOverlay: PropTypes.func,
     visibleOnLoad: PropTypes.bool,
     uiState: PropTypes.object,
     setUIState: PropTypes.func,
-    onClickBackground: PropTypes.func,
+    _onClickBackground: PropTypes.func,
   };
 
   static defaultProps = {
     visibleOnLoad: false,
     uiState: initialUIState,
     setUIState: () => {},
-    onClickBackground: () => {},
-    onEscapeOverlay: () => {},
+    _onClickBackground: onClickBackground,
   };
 
   componentWillReceiveProps(nextProps) {
@@ -40,15 +47,6 @@ export class OverlayBase extends React.Component {
       this.props.setUIState({ visible: nextProps.visibleOnLoad });
     }
   }
-
-  // TODO: I don't see this working on the frontend..?
-  // find out if this is expected
-  onClickBackground = () => {
-    if (this.props.onEscapeOverlay) {
-      this.props.onEscapeOverlay();
-    }
-    this.hide();
-  };
 
   hide() {
     this.props.setUIState({ visible: false });
@@ -72,16 +70,10 @@ export class OverlayBase extends React.Component {
         className={makeClassName('Overlay', className, {
           'Overlay--visible': uiState.visible,
         })}
-        ref={(ref) => {
-          this.overlayContainer = ref;
-        }}
       >
         <div
-          onClick={this.props.onClickBackground}
-          ref={(ref) => {
-            this.overlayBackground = ref;
-          }}
           className="Overlay-background"
+          onClick={(e) => this.props._onClickBackground(e, this)}
           role="presentation"
         />
         <div

--- a/src/ui/components/Overlay/index.js
+++ b/src/ui/components/Overlay/index.js
@@ -98,10 +98,12 @@ export const extractId = (ownProps: InternalProps) => {
   return ownProps.id;
 };
 
-export default compose(
+const Overlay: React.ComponentType<InternalProps> = compose(
   withUIState({
     fileName: __filename,
     extractId,
     initialState: initialUIState,
   }),
 )(OverlayBase);
+
+export default Overlay;

--- a/src/ui/components/OverlayCard/index.js
+++ b/src/ui/components/OverlayCard/index.js
@@ -1,15 +1,13 @@
 import makeClassName from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'redux';
 
-import withUIState from 'core/withUIState';
 import Card from 'ui/components/Card';
 import Overlay from 'ui/components/Overlay';
 
 import './styles.scss';
 
-export class OverlayCardBase extends React.Component {
+export default class OverlayCard extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -41,18 +39,12 @@ export class OverlayCardBase extends React.Component {
         onEscapeOverlay={this.props.onEscapeOverlay}
         id={id}
         visibleOnLoad={visibleOnLoad}
-        ref={(ref) => {
-          this.overlay = ref;
-        }}
       >
         <Card
           className={makeClassName('OverlayCard', className)}
           header={header}
           footerLink={footerLink}
           footerText={footerText}
-          ref={(ref) => {
-            this.overlayCard = ref;
-          }}
         >
           {children}
         </Card>
@@ -60,17 +52,3 @@ export class OverlayCardBase extends React.Component {
     );
   }
 }
-
-export const extractId = (ownProps) => {
-  return ownProps.id;
-};
-
-const OverlayCard = compose(
-  withUIState({
-    fileName: __filename,
-    extractId,
-    initialState: {},
-  }),
-)(OverlayCardBase);
-
-export default OverlayCard;

--- a/src/ui/components/OverlayCard/index.js
+++ b/src/ui/components/OverlayCard/index.js
@@ -1,13 +1,15 @@
 import makeClassName from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { compose } from 'redux';
 
+import withUIState from 'core/withUIState';
 import Card from 'ui/components/Card';
 import Overlay from 'ui/components/Overlay';
 
 import './styles.scss';
 
-export default class OverlayCard extends React.Component {
+export class OverlayCardBase extends React.Component {
   static propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
@@ -22,18 +24,6 @@ export default class OverlayCard extends React.Component {
   static defaultProps = {
     visibleOnLoad: false,
   };
-
-  hide() {
-    this.overlay.hide();
-  }
-
-  show() {
-    this.overlay.show();
-  }
-
-  toggle() {
-    this.overlay.toggle();
-  }
 
   render() {
     const {
@@ -70,3 +60,17 @@ export default class OverlayCard extends React.Component {
     );
   }
 }
+
+export const extractId = (ownProps) => {
+  return ownProps.id;
+};
+
+const OverlayCard = compose(
+  withUIState({
+    fileName: __filename,
+    extractId,
+    initialState: {},
+  }),
+)(OverlayCardBase);
+
+export default OverlayCard;

--- a/src/ui/components/OverlayCard/index.js
+++ b/src/ui/components/OverlayCard/index.js
@@ -12,6 +12,7 @@ export default class OverlayCard extends React.Component {
     children: PropTypes.node,
     className: PropTypes.string,
     header: PropTypes.node,
+    id: PropTypes.string.isRequired,
     footerLink: PropTypes.node,
     footerText: PropTypes.node,
     onEscapeOverlay: PropTypes.func,
@@ -39,6 +40,7 @@ export default class OverlayCard extends React.Component {
       children,
       className,
       header,
+      id,
       footerLink,
       footerText,
       visibleOnLoad,
@@ -47,6 +49,7 @@ export default class OverlayCard extends React.Component {
     return (
       <Overlay
         onEscapeOverlay={this.props.onEscapeOverlay}
+        id={id}
         visibleOnLoad={visibleOnLoad}
         ref={(ref) => {
           this.overlay = ref;

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -83,6 +83,17 @@ describe(__filename, () => {
     expect(root).toHaveClassName('Overlay--visible');
   });
 
+  it('calls onEscapeOverlay when clicking the background', () => {
+    const onEscapeOverlay = sinon.stub();
+    const root = render({
+      visibleOnLoad: true,
+      onEscapeOverlay,
+    });
+    const btn = root.find('.Overlay-background');
+    btn.simulate('click', createFakeEvent());
+    sinon.assert.called(onEscapeOverlay);
+  });
+
   it('hides when you click the background', () => {
     const { store } = dispatchClientMetadata();
     const root = render({

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -42,12 +42,7 @@ describe(__filename, () => {
   it('renders children', () => {
     const html = '<div>overriding child div</div>';
     const root = render({ children: html });
-    expect(
-      root
-        .children()
-        .at(1)
-        .props().children,
-    ).toEqual(html);
+    expect(root.find('.Overlay-contents').children()).toHaveText(html);
   });
 
   it('is hidden by default', () => {
@@ -65,11 +60,7 @@ describe(__filename, () => {
 
     expect(root).not.toHaveClassName('Overlay--visible');
 
-    const newProps = {
-      visibleOnLoad: true,
-    };
-
-    root.setProps(newProps);
+    root.setProps({ visibleOnLoad: true });
 
     applyUIStateChanges({ root, store });
 

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -60,17 +60,17 @@ describe(__filename, () => {
 
     const root = render({
       store,
-      visibleOnLoad: true,
-      uiState: { visible: false },
+      visibleOnLoad: false,
     });
 
     expect(root).not.toHaveClassName('Overlay--visible');
 
-    applyUIStateChanges({ root, store });
+    const newProps = {
+      visibleOnLoad: true,
+    };
 
-    // Applying this 2 times here to mimic how uiState works in componentWillReceiveProps:
-    // The first time through, the visible state gets changed but these changes
-    // aren't shown in uiState till the 2 time through
+    root.setProps(newProps);
+
     applyUIStateChanges({ root, store });
 
     expect(root).toHaveClassName('Overlay--visible');
@@ -86,47 +86,14 @@ describe(__filename, () => {
   });
 
   it('calls onEscapeOverlay when clicking the background', () => {
-    const clickEvent = createFakeEvent();
     const onEscapeOverlay = sinon.stub();
     const root = render({
       visibleOnLoad: true,
       onEscapeOverlay,
     });
     const btn = root.find('.Overlay-background');
-    btn.simulate('click', clickEvent);
-    const rootInstance = root.instance();
-    rootInstance.props._onClickBackground(clickEvent, rootInstance);
+    btn.simulate('click', createFakeEvent());
     sinon.assert.called(onEscapeOverlay);
-  });
-
-  it('is shown and hidden when `hide()` and `show()` are called', () => {
-    const { store } = dispatchClientMetadata();
-    const root = render({ store });
-
-    expect(root).not.toHaveClassName('Overlay--visible');
-
-    root.instance().show();
-    applyUIStateChanges({ root, store });
-    expect(root).toHaveClassName('Overlay--visible');
-
-    root.instance().hide();
-    applyUIStateChanges({ root, store });
-    expect(root).not.toHaveClassName('Overlay--visible');
-  });
-
-  it('is toggled', () => {
-    const { store } = dispatchClientMetadata();
-    const root = render({ store });
-
-    expect(root).not.toHaveClassName('Overlay--visible');
-
-    root.instance().toggle();
-    applyUIStateChanges({ root, store });
-    expect(root).toHaveClassName('Overlay--visible');
-
-    root.instance().toggle();
-    applyUIStateChanges({ root, store });
-    expect(root).not.toHaveClassName('Overlay--visible');
   });
 
   describe('extractId', () => {

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -26,20 +26,37 @@ describe(__filename, () => {
       OverlayBase,
     );
 
-    // return root;
-
     // Apply initial UI state.
     applyUIStateChanges({ root, store: props.store });
     return root;
   };
 
-  it('renders an Overlay when visibleOnLoad is true', () => {
+  it('is hidden by default', () => {
+    const root = render();
+    expect(root).not.toHaveClassName('Overlay--visible');
+  });
+
+  it('becomes visible when its mounted with visibleOnLoad prop as true', () => {
     const root = render({ visibleOnLoad: true });
 
     expect(root).toHaveClassName('Overlay');
     expect(root).toHaveClassName('Overlay--visible');
     expect(root.find('.Overlay-background')).toHaveLength(1);
     expect(root.find('.Overlay-contents')).toHaveLength(1);
+  });
+
+  it('becomes visible once the visibleOnLoad prop of true is passed', () => {
+    const { store } = dispatchClientMetadata();
+
+    const root = render({ store });
+
+    expect(root).not.toHaveClassName('Overlay--visible');
+
+    root.setProps({ visibleOnLoad: true });
+
+    applyUIStateChanges({ root, store });
+
+    expect(root).toHaveClassName('Overlay--visible');
   });
 
   it('renders extra className if provided', () => {
@@ -61,28 +78,6 @@ describe(__filename, () => {
     ).toContain(text);
   });
 
-  it('is hidden by default', () => {
-    const root = render();
-    expect(root).not.toHaveClassName('Overlay--visible');
-  });
-
-  it('becomes visible once the `visibleOnLoad` prop is passed', () => {
-    const { store } = dispatchClientMetadata();
-
-    const root = render({
-      store,
-      visibleOnLoad: false,
-    });
-
-    expect(root).not.toHaveClassName('Overlay--visible');
-
-    root.setProps({ visibleOnLoad: true });
-
-    applyUIStateChanges({ root, store });
-
-    expect(root).toHaveClassName('Overlay--visible');
-  });
-
   it('calls onEscapeOverlay when clicking the background', () => {
     const onEscapeOverlay = sinon.stub();
     const root = render({
@@ -96,10 +91,7 @@ describe(__filename, () => {
 
   it('hides when you click the background', () => {
     const { store } = dispatchClientMetadata();
-    const root = render({
-      visibleOnLoad: true,
-      store,
-    });
+    const root = render({ visibleOnLoad: true, store });
     const btn = root.find('.Overlay-background');
     btn.simulate('click', createFakeEvent());
     applyUIStateChanges({ root, store });

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -67,15 +67,8 @@ describe(__filename, () => {
 
   it('renders children', () => {
     const text = 'overriding div text..';
-    const html = <div>{text}</div>;
-    const root = render({ visibleOnLoad: true, children: html });
-
-    expect(
-      root
-        .find('.Overlay-contents')
-        .children()
-        .html(),
-    ).toContain(text);
+    const root = render({ visibleOnLoad: true, children: text });
+    expect(root.find('.Overlay-contents')).toHaveText(text);
   });
 
   it('calls onEscapeOverlay when clicking the background', () => {

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -19,8 +19,9 @@ describe(__filename, () => {
   };
 
   const render = ({ children, ...otherProps } = {}) => {
+    const html = '<div>a child div</div>';
     return shallowUntilTarget(
-      <Overlay {...getProps(otherProps)}>{children}</Overlay>,
+      <Overlay {...getProps(otherProps)}>{children || html}</Overlay>,
       OverlayBase,
     );
   };
@@ -39,7 +40,7 @@ describe(__filename, () => {
   });
 
   it('renders children', () => {
-    const html = '<div>a child div</div>';
+    const html = '<div>overriding child div</div>';
     const root = render({ children: html });
     expect(
       root

--- a/tests/unit/ui/components/TestOverlay.js
+++ b/tests/unit/ui/components/TestOverlay.js
@@ -77,14 +77,11 @@ describe(__filename, () => {
   });
 
   it('hides when you click the background', () => {
-    const onClickBackgroundSpy = sinon.stub();
     const root = render({
       visibleOnLoad: true,
-      _onClickBackground: onClickBackgroundSpy,
     });
     const btn = root.find('.Overlay-background');
     btn.simulate('click', createFakeEvent());
-    sinon.assert.called(onClickBackgroundSpy);
     expect(root).not.toHaveClassName('Overlay--visible');
   });
 

--- a/tests/unit/ui/components/TestOverlayCard.js
+++ b/tests/unit/ui/components/TestOverlayCard.js
@@ -4,13 +4,33 @@ import {
   renderIntoDocument,
 } from 'react-dom/test-utils';
 import { findDOMNode } from 'react-dom';
+import { Provider } from 'react-redux';
 
+import createStore from 'amo/store';
 import Overlay from 'ui/components/Overlay';
-import OverlayCard from 'ui/components/OverlayCard';
+import OverlayCard, { OverlayCardBase } from 'ui/components/OverlayCard';
 
 describe(__filename, () => {
+  const { store } = createStore();
+
+  const getProps = ({ ...props } = {}) => {
+    return {
+      className: 'OverlayCard',
+      id: 'OverlayCard',
+      store,
+      ...props,
+    };
+  };
+
   function render(props = {}) {
-    return renderIntoDocument(<OverlayCard {...props} />);
+    return findRenderedComponentWithType(
+      renderIntoDocument(
+        <Provider store={store}>
+          <OverlayCard {...getProps(props)} />
+        </Provider>,
+      ),
+      OverlayCardBase,
+    );
   }
 
   it('renders an OverlayCard', () => {
@@ -57,47 +77,5 @@ describe(__filename, () => {
     const rootNode = findDOMNode(root);
 
     expect(rootNode.querySelector('.kids').textContent).toContain('hi');
-  });
-
-  it('is hidden by default', () => {
-    const root = render();
-    expect(root.overlay.overlayContainer.className).not.toContain(
-      'Overlay--visible',
-    );
-  });
-
-  it('is visible when the `visibleOnLoad` prop is passed', () => {
-    const root = render({ visibleOnLoad: true });
-    expect(root.overlay.overlayContainer.className).toContain(
-      'Overlay--visible',
-    );
-  });
-
-  it('is shown and hidden when `hide()` and `show()` are called', () => {
-    const root = render();
-
-    root.show();
-    expect(root.overlay.overlayContainer.className).toContain(
-      'Overlay--visible',
-    );
-
-    root.hide();
-    expect(root.overlay.overlayContainer.className).not.toContain(
-      'Overlay--visible',
-    );
-  });
-
-  it('is toggled', () => {
-    const root = render();
-
-    root.toggle();
-    expect(root.overlay.overlayContainer.className).toContain(
-      'Overlay--visible',
-    );
-
-    root.toggle();
-    expect(root.overlay.overlayContainer.className).not.toContain(
-      'Overlay--visible',
-    );
   });
 });

--- a/tests/unit/ui/components/TestOverlayCard.js
+++ b/tests/unit/ui/components/TestOverlayCard.js
@@ -33,11 +33,6 @@ describe(__filename, () => {
     );
   }
 
-  it('renders an OverlayCard', () => {
-    const root = render();
-    expect(root.props.className).toEqual('OverlayCard');
-  });
-
   it('passes onEscapeOverlay to Overlay', () => {
     const onEscapeOverlay = sinon.stub();
     const root = render({ onEscapeOverlay });

--- a/tests/unit/ui/components/TestOverlayCard.js
+++ b/tests/unit/ui/components/TestOverlayCard.js
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 
 import createStore from 'amo/store';
 import Overlay from 'ui/components/Overlay';
-import OverlayCard, { OverlayCardBase } from 'ui/components/OverlayCard';
+import OverlayCard from 'ui/components/OverlayCard';
 
 describe(__filename, () => {
   const { store } = createStore();
@@ -29,13 +29,13 @@ describe(__filename, () => {
           <OverlayCard {...getProps(props)} />
         </Provider>,
       ),
-      OverlayCardBase,
+      OverlayCard,
     );
   }
 
   it('renders an OverlayCard', () => {
     const root = render();
-    expect(root.overlayCard).toBeTruthy();
+    expect(root.props.className).toEqual('OverlayCard');
   });
 
   it('passes onEscapeOverlay to Overlay', () => {


### PR DESCRIPTION
fixes #5555 (wip)

I had few follow up questions maybe before the official review:

Should I use update `Overlay` to use flow or is this okay how I have it?

I’ve updated the tests in the `TestOverlay` to use enzyme - that’s ideally what we want, right?  

I see that `TestOverlayCard` is using `renderIntoDocument` too and since updating `TestOverlay` actually took a bit of time for me to change I wanted to make sure before I did any more work that this is something we want.

Clicking the background in the overlay, as far as I can tell, doesn’t work :/ 
Should it? I checked dev and it didn't work for me either. On stage, it seems to work if I click in the header..? :/

