### PR TITLE
Prevent the test suite from ever calling a real API

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -73,6 +73,11 @@ global.sinon = sinon.createSandbox();
 // Stub the magic constant webpack normally supplies.
 global.CLIENT_CONFIG = require('core/utils').getClientConfig(config);
 
+// See: https://github.com/mozilla/addons-frontend/issues/1138
+global.fetch = () => {
+  throw new Error('API calls MUST be mocked.');
+};
+
 afterEach(() => {
   global.sinon.restore();
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -74,8 +74,10 @@ global.sinon = sinon.createSandbox();
 global.CLIENT_CONFIG = require('core/utils').getClientConfig(config);
 
 // See: https://github.com/mozilla/addons-frontend/issues/1138
-global.fetch = () => {
-  throw new Error('API calls MUST be mocked.');
+global.fetch = (input) => {
+  throw new Error(
+    `API calls MUST be mocked. URL fetched: ${input.url || input}`,
+  );
 };
 
 afterEach(() => {

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -127,6 +127,11 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
+      mockApi
+        .expects('getCollectionAddons')
+        .once()
+        .returns(Promise.reject(error));
+
       _fetchCurrentCollection({ slug, username });
 
       const expectedAction = errorHandler.createErrorAction(error);

--- a/tests/unit/testSetup.js
+++ b/tests/unit/testSetup.js
@@ -1,3 +1,5 @@
+/* global fetch, Request */
+
 describe(__filename, () => {
   describe('fetch()', () => {
     const url = 'https://addons.mozilla.org';

--- a/tests/unit/testSetup.js
+++ b/tests/unit/testSetup.js
@@ -1,0 +1,17 @@
+describe(__filename, () => {
+  describe('fetch()', () => {
+    const url = 'https://addons.mozilla.org';
+
+    it('should throw an error', () => {
+      expect(() => {
+        fetch(url);
+      }).toThrowError(`API calls MUST be mocked. URL fetched: ${url}`);
+    });
+
+    it('should throw an error when using a Request', () => {
+      expect(() => {
+        fetch(new Request(url));
+      }).toThrowError(`API calls MUST be mocked. URL fetched: ${url}`);
+    });
+  });
+});


### PR DESCRIPTION
Fix #1138

---

I tested by removing all the "mock" code of a saga test suite and in
some API test cases in the disco test suite.