### PR TITLE
Switch to firefox dev edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ config/local*
 .tox
 tests/ui/.cache
 tests/ui/__pycache__
+tests/ui/.pytest_cache/
 *.pyc
 
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,27 @@ jobs:
     - stage:
       <<: *tox
       addons:
-        firefox: latest-nightly
+        firefox: latest-dev
         hosts: example.com
       env: TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
+      install:
+        - yarn
+        - yarn start-func-test-server &
+      before_script:
+        - wget -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER/geckodriver-v$GECKODRIVER-linux64.tar.gz
+        - mkdir $HOME/geckodriver && tar xvf /tmp/geckodriver.tar.gz -C $HOME/geckodriver
+        - export PATH=$HOME/geckodriver:$PATH
+        - firefox --version
+        - geckodriver --version
+        - pip install tox
+        # Wait for server to be available
+        - until $(curl --output /dev/null --silent --head --fail -k https://example.com:4000); do printf '.'; sleep 5; done
+    - stage:
+      <<: *tox
+      addons:
+        firefox: latest-nightly
+        hosts: example.com
+      env: ALLOWED_TO_FAIL=1 TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
       install:
         - yarn
         - yarn start-func-test-server &
@@ -76,3 +94,8 @@ jobs:
     - stage:
       <<: *tox
       env: TOXENV=dennis-lint
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: ALLOWED_TO_FAIL=1 TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,15 @@ jobs:
     # Run the functional tests.
     - stage:
       <<: *tox
+      # TODO: remove this stage when we switch back to `firefox-nightly`
+      # See: https://github.com/mozilla/addons-frontend/issues/5781
       addons:
         firefox: latest-dev
         hosts: example.com
-      env: TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
+      # We need to specify `IS_TEMPORARY=1` so that the `env` value is
+      # different than the stage right after (which is currently allowed to
+      # fail until we fix the issue with FF Nightly)
+      env: IS_TEMPORARY=1 TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
       install:
         - yarn
         - yarn start-func-test-server &
@@ -75,7 +80,7 @@ jobs:
       addons:
         firefox: latest-nightly
         hosts: example.com
-      env: ALLOWED_TO_FAIL=1 TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
+      env: TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
       install:
         - yarn
         - yarn start-func-test-server &
@@ -95,7 +100,9 @@ jobs:
       <<: *tox
       env: TOXENV=dennis-lint
 
+# TODO: remove this configuration when we switch back to `firefox-nightly`
+# See: https://github.com/mozilla/addons-frontend/issues/5781
 matrix:
   fast_finish: true
   allow_failures:
-    - env: ALLOWED_TO_FAIL=1 TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH
+    - env: TOXENV=discopane-ui-tests GECKODRIVER=0.20.1 MOZ_HEADLESS=1 PATH=./node_modules/.bin:$PATH


### PR DESCRIPTION
Refs #5781 

---

This PR changes the Firefox version from nightly to dev edition in order
to get a green feedback again. The issue is related to a "menu" button
not being found anymore. All FF versions < 63 are not affected.

I added a job for nightly so that we can keep an eye on it, but this job
won't fail the build at least.