### PR TITLE
I5703 fixing scaled icon flash

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -164,13 +164,10 @@ export class AddonBase extends React.Component {
         previewURL = addon.previewURL;
       }
 
-      const themeClassName = 'Addon-theme-header';
-
       return (
         <div
+          className="Addon-theme-header"
           key="Addon-theme-image"
-          className={themeClassName}
-          id={themeClassName}
           role="presentation"
         >
           <img
@@ -183,7 +180,7 @@ export class AddonBase extends React.Component {
     }
 
     return (
-      <div className="Addon-icon">
+      <div className="Addon-icon" key="Addon-icon-header">
         <img
           alt={label}
           className="Addon-icon-image"

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -150,7 +150,7 @@ export class AddonBase extends React.Component {
       ? i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
           title: addon.name,
         })
-      : '';
+      : null;
 
     if (addon && isTheme(addon.type)) {
       const previewHeader = addon.previews.length && addon.previews[0];
@@ -167,7 +167,12 @@ export class AddonBase extends React.Component {
       const themeClassName = 'Addon-theme-header';
 
       return (
-        <div className={themeClassName} id={themeClassName} role="presentation">
+        <div
+          key="Addon-theme-image"
+          className={themeClassName}
+          id={themeClassName}
+          role="presentation"
+        >
           <img
             alt={label}
             className="Addon-theme-header-image"
@@ -178,13 +183,13 @@ export class AddonBase extends React.Component {
     }
 
     return (
-      <span className="Addon-icon">
+      <div className="Addon-icon">
         <img
           alt={label}
           className="Addon-icon-image"
           src={getAddonIconUrl(addon)}
         />
-      </span>
+      </div>
     );
   }
 

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -146,6 +146,12 @@ export class AddonBase extends React.Component {
   headerImage() {
     const { addon, i18n } = this.props;
 
+    const label = addon
+      ? i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
+          title: addon.name,
+        })
+      : '';
+
     if (addon && isTheme(addon.type)) {
       const previewHeader = addon.previews.length && addon.previews[0];
 
@@ -154,43 +160,31 @@ export class AddonBase extends React.Component {
           ? previewHeader.image_url
           : null;
 
-      const label = addon
-        ? i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
-            title: addon.name,
-          })
-        : '';
-
-      const type = addon ? addon.type : ADDON_TYPE_EXTENSION;
-
-      if (!previewURL && type === ADDON_TYPE_THEME) {
+      if (!previewURL && addon.type === ADDON_TYPE_THEME) {
         previewURL = addon.previewURL;
       }
 
-      const headerImage = (
-        <img
-          alt={label}
-          className="Addon-theme-header-image"
-          src={previewURL}
-        />
-      );
+      const themeClassName = 'Addon-theme-header';
 
       return (
-        <div
-          className="Addon-theme-header"
-          id="Addon-theme-header"
-          role="presentation"
-        >
-          {headerImage}
+        <div className={themeClassName} id={themeClassName} role="presentation">
+          <img
+            alt={label}
+            className="Addon-theme-header-image"
+            src={previewURL}
+          />
         </div>
       );
     }
 
-    const iconUrl = getAddonIconUrl(addon);
-
     return (
-      <div className="Addon-icon">
-        <img className="Addon-icon-image" alt="" src={iconUrl} />
-      </div>
+      <span className="Addon-icon">
+        <img
+          alt={label}
+          className="Addon-icon-image"
+          src={getAddonIconUrl(addon)}
+        />
+      </span>
     );
   }
 

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -116,7 +116,9 @@ export class SearchResultBase extends React.Component<InternalProps> {
         <div className={iconWrapperClassnames}>
           {imageURL ? (
             <img
-              className="SearchResult-icon"
+              className={makeClassName('SearchResult-icon', {
+                'SearchResult-icon--loading': !addon,
+              })}
               src={imageURL}
               alt={addon ? `${addon.name}` : ''}
             />

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -2,6 +2,8 @@
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 
+$icon-default-size: 32px;
+
 .SearchResult {
   list-style-type: none;
   margin: 0 0 1px;
@@ -49,8 +51,8 @@
 
 .SearchResult-icon {
   display: inline-block;
-  height: 32px;
-  width: 32px;
+  height: $icon-default-size;
+  width: $icon-default-size;
 
   .SearchResult--theme & {
     border-radius: $border-radius-default;
@@ -59,6 +61,13 @@
     object-fit: cover;
     object-position: top left;
     width: 100%;
+  }
+
+  &.SearchResult-icon--loading {
+    .SearchResult--theme & {
+      height: $icon-default-size;
+      width: $icon-default-size;
+    }
   }
 }
 

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -299,7 +299,7 @@ describe(__filename, () => {
     // Since withInstallHelpers relies on this, make sure it's initialized.
     expect(root.instance().props.platformFiles).toEqual({});
 
-    expect(root.find('.Addon-icon img').prop('alt')).toEqual('');
+    expect(root.find('.Addon-icon img').prop('alt')).toEqual(null);
   });
 
   it('does not dispatch fetchAddon action when slug is the same', () => {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -298,6 +298,8 @@ describe(__filename, () => {
 
     // Since withInstallHelpers relies on this, make sure it's initialized.
     expect(root.instance().props.platformFiles).toEqual({});
+
+    expect(root.find('.Addon-icon img').prop('alt')).toEqual('');
   });
 
   it('does not dispatch fetchAddon action when slug is the same', () => {
@@ -878,14 +880,17 @@ describe(__filename, () => {
 
   it('renders an amo CDN icon image', () => {
     const iconURL = 'https://addons.cdn.mozilla.net/foo.jpg';
+    const addonName = 'some-addon-name';
     const root = shallowRender({
       addon: createInternalAddon({
         ...fakeAddon,
         icon_url: iconURL,
+        name: addonName,
       }),
     });
-    const src = root.find('.Addon-icon img').prop('src');
-    expect(src).toEqual(iconURL);
+    const image = root.find('.Addon-icon img');
+    expect(image.prop('src')).toEqual(iconURL);
+    expect(image.prop('alt')).toEqual(`Preview of ${addonName}`);
   });
 
   it('renders a fall-back asset', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -178,9 +178,7 @@ describe(__filename, () => {
   });
 
   it('renders a loading class name while there is no addon', () => {
-    const root = render({
-      addon: null,
-    });
+    const root = render({ addon: null });
 
     expect(root.find('.SearchResult-icon')).toHaveClassName(
       '.SearchResult-icon--loading',

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -177,6 +177,16 @@ describe(__filename, () => {
     expect(root.find('.SearchResult-icon')).not.toHaveProp('alt', '');
   });
 
+  it('renders a loading class name while there is no addon', () => {
+    const root = render({
+      addon: null,
+    });
+
+    expect(root.find('.SearchResult-icon')).toHaveClassName(
+      '.SearchResult-icon--loading',
+    );
+  });
+
   it('displays the thumbnail image as the default src for static theme', () => {
     const headerImageFull = 'https://addons.cdn.mozilla.net/full/12345.png';
 


### PR DESCRIPTION
fixes #5703 

From what I could tell the url was changed in the src *after* the classname was updated and for a split second you see the icon large b/c it takes on the new classname styles:

![Alt text](https://monosnap.com/image/dcCkZmvEUm78sGjbirOsJTihjGtARi.png)

In the header, the only way that I found that fixes this is to change the html structure or to use a key on the image/wrapping div. This might be another reconciliation issue (?). I decided to go the html approach - changing out a div for a span. let me know what you think..

note: i did a little bit of clean up too : )


