### PR TITLE
Use cheap-module-eval-source-map in webpack dev

### DIFF
--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -44,7 +44,7 @@ for (const app of appsBuildList) {
 }
 
 export default Object.assign({}, webpackConfig, {
-  devtool: 'heap-module-eval-source-map',
+  devtool: 'cheap-module-eval-source-map',
   context: path.resolve(__dirname),
   entry: entryPoints,
   output: Object.assign({}, webpackConfig.output, {

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -44,7 +44,7 @@ for (const app of appsBuildList) {
 }
 
 export default Object.assign({}, webpackConfig, {
-  devtool: 'inline-source-map',
+  devtool: 'heap-module-eval-source-map',
   context: path.resolve(__dirname),
   entry: entryPoints,
   output: Object.assign({}, webpackConfig.output, {


### PR DESCRIPTION
Fix #4508

---

This `devtool` value is the recommended one, and it is faster than the
previous one: https://webpack.js.org/configuration/devtool/.

From what I know, the main difference is that it does not link to the
column, only to the line (where an error has occurred for instance). I
don't think it really matters because we only have 80 columns anyway.