### PR TITLE
Do not run tests twice after editing a file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -38,5 +38,9 @@ module.exports = {
     'jest-watch-typeahead/filename',
     'jest-watch-typeahead/testname',
   ],
+  watchPathIgnorePatterns: [
+    '<rootDir>/bin/server.js',
+    '<rootDir>/webpack-assets.json',
+  ],
   verbose: false,
 };


### PR DESCRIPTION
Fix #2639

---

I find this behavior annoying and found the GH issue last night, so here is a patch.
I hooked into the Jest process to see which files were triggering a re-run.