### PR TITLE
Fix button colors according to Photon spec

### DIFF
--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -141,8 +141,8 @@ $puffy-font-size: 15px;
 
 .Button--action {
   @include button(
-    $background: $blue-50,
-    $background-active: $blue-60,
+    $background: $blue-60,
+    $background-active: $blue-80,
     $background-hover: $blue-70
   );
 }
@@ -165,8 +165,8 @@ $puffy-font-size: 15px;
 
 .Button--alert {
   @include button(
-    $background: $red-50,
-    $background-active: $red-60,
+    $background: $red-60,
+    $background-active: $red-80,
     $background-hover: $red-70
   );
 }


### PR DESCRIPTION
Fix #5789

---

According to the spec, the primary buttons (called "action" in our code
base) should have such colors:

- blue 60
- blue 70 for hover
- blue 80 for active

See: https://design.firefox.com/photon/components/buttons.html#behaviours

I also updated the error colors according to this section: https://design.firefox.com/photon/patterns/errors.html#colors