### PR TITLE
Make withUIState() components use persistent state

### DIFF
--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -49,6 +49,10 @@ type InternalProps = {|
 export class EditableCollectionAddonBase extends React.Component<
   InternalProps,
 > {
+  componentWillUnmount() {
+    this.props.setUIState(initialUIState);
+  }
+
   onEditNote = (event: SyntheticEvent<HTMLElement>) => {
     event.preventDefault();
     this.props.setUIState({ editingNote: true });
@@ -202,7 +206,6 @@ const EditableCollectionAddon: React.ComponentType<Props> = compose(
     fileName: __filename,
     extractId,
     initialState: initialUIState,
-    newStatePerInstance: true,
   }),
 )(EditableCollectionAddonBase);
 

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -202,6 +202,7 @@ const EditableCollectionAddon: React.ComponentType<Props> = compose(
     fileName: __filename,
     extractId,
     initialState: initialUIState,
+    newStatePerInstance: true,
   }),
 )(EditableCollectionAddonBase);
 

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -49,10 +49,6 @@ type InternalProps = {|
 export class EditableCollectionAddonBase extends React.Component<
   InternalProps,
 > {
-  componentWillUnmount() {
-    this.props.setUIState(initialUIState);
-  }
-
   onEditNote = (event: SyntheticEvent<HTMLElement>) => {
     event.preventDefault();
     this.props.setUIState({ editingNote: true });
@@ -206,6 +202,7 @@ const EditableCollectionAddon: React.ComponentType<Props> = compose(
     fileName: __filename,
     extractId,
     initialState: initialUIState,
+    resetOnUnmount: true,
   }),
 )(EditableCollectionAddonBase);
 

--- a/src/core/reducers/uiState.js
+++ b/src/core/reducers/uiState.js
@@ -9,6 +9,16 @@ export type UIStateState = {
 
 const initialState = {};
 
+export const selectUIState = ({
+  uiState,
+  uiStateID,
+}: {|
+  uiState: UIStateState,
+  uiStateID: string,
+|}) => {
+  return uiState[uiStateID];
+};
+
 type SetUIStateParams = {|
   id: string,
   change: Object,

--- a/src/core/withUIState.js
+++ b/src/core/withUIState.js
@@ -74,31 +74,34 @@ export const mergeUIStateProps = (
 
 /*
  * This HOC can be used to somewhat mimic the behavior of this.setState()
- * but with Redux reducers/actions instead.
+ * with Redux reducers/actions.
  *
- * It provides your component props.setUIState() which can be used just
- * like this.setState() to dispatch actions that change the internal
+ * It renders your component with a setUIState() prop that can be used
+ * just like this.setState() to dispatch actions that change the internal
  * state of the component.
  *
- * It provides props.uiState which can be used to read internal state
+ * It provides a uiState prop which can be used to read internal state
  * like you would read this.state.
  *
- * One key difference from this.setState() is that by default your
- * component will not reset its state when mounted. Instead, it uses
+ * One key difference from this.setState() is that your component will
+ * not reset its state when mounted. Instead, it uses
  * the ID returned from extractID(props) to get its state from the
  * Redux store.
  *
- * You can make the component always reset its state by configuring it
- * with newStatePerInstance: true. This will behave more like
- * this.setState() but you will lose some features of Redux persistence
- * such as predictable time travel, predictable hot reloading, and
+ * You can make the component always reset its state by adding:
+ *
+ * componentWillUnmount() {
+ *   this.props.setUIState(initialUIState);
+ * }
+ *
+ * This will behave more like this.setState() but you will lose some
+ * features of Redux persistence such as predictable hot reloading and
  * possibly other state replay features.
  */
 const withUIState = ({
   fileName,
   extractId,
   initialState,
-  newStatePerInstance = false,
 }: {|
   // This should always be set to __filename for ID purposes.
   fileName: string,
@@ -106,11 +109,6 @@ const withUIState = ({
   extractId: ExtractIdFunc,
   // An Object that defines the initial state.
   initialState: Object,
-  // When true, new component instances will be reset to initialState.
-  // Setting this to true will closely mimic how React's this.setState()
-  // works but the component will then no longer be able to initialize
-  // itself from pure Redux state. Try to avoid setting this to true if you can.
-  newStatePerInstance?: boolean,
 |}): ((React.ComponentType<any>) => React.ComponentType<any>) => {
   invariant(fileName, 'fileName is required');
   invariant(extractId, 'extractId is required');
@@ -124,20 +122,6 @@ const withUIState = ({
 
   return (WrappedComponent) => {
     class WithUIState extends React.Component<any> {
-      componentDidMount() {
-        if (newStatePerInstance) {
-          // Every time the component mounts, reset the state regardless
-          // of what is saved in the Redux store. This makes the
-          // implementation behave more like this.setState() whereby
-          // the component constructor() would always initialize
-          // like this.state = {...}.
-          //
-          // TODO: Optimize this by only dispatching if
-          // props.uiState doesn't match initialState?
-          this.props.setUIState(initialState);
-        }
-      }
-
       render() {
         return <WrappedComponent {...this.props} />;
       }

--- a/src/core/withUIState.js
+++ b/src/core/withUIState.js
@@ -72,7 +72,34 @@ export const mergeUIStateProps = (
   };
 };
 
-type withUIStateParams = {|
+/*
+ * This HOC can be used to somewhat mimic the behavior of this.setState()
+ * but with Redux reducers/actions instead.
+ *
+ * It provides your component props.setUIState() which can be used just
+ * like this.setState() to dispatch actions that change the internal
+ * state of the component.
+ *
+ * It provides props.uiState which can be used to read internal state
+ * like you would read this.state.
+ *
+ * One key difference from this.setState() is that by default your
+ * component will not reset its state when mounted. Instead, it uses
+ * the ID returned from extractID(props) to get its state from the
+ * Redux store.
+ *
+ * You can make the component always reset its state by configuring it
+ * with newStatePerInstance: true. This will behave more like
+ * this.setState() but you will lose some features of Redux persistence
+ * such as predictable time travel, predictable hot reloading, and
+ * possibly other state replay features.
+ */
+const withUIState = ({
+  fileName,
+  extractId,
+  initialState,
+  newStatePerInstance = false,
+}: {|
   // This should always be set to __filename for ID purposes.
   fileName: string,
   // A function that takes component props and returns a string to identify this state.
@@ -84,16 +111,7 @@ type withUIStateParams = {|
   // works but the component will then no longer be able to initialize
   // itself from pure Redux state. Try to avoid setting this to true if you can.
   newStatePerInstance?: boolean,
-|};
-
-const withUIState = ({
-  fileName,
-  extractId,
-  initialState,
-  newStatePerInstance = false,
-}: withUIStateParams): ((
-  React.ComponentType<any>,
-) => React.ComponentType<any>) => {
+|}): ((React.ComponentType<any>) => React.ComponentType<any>) => {
   invariant(fileName, 'fileName is required');
   invariant(extractId, 'extractId is required');
   invariant(initialState, 'initialState is required');

--- a/src/core/withUIState.js
+++ b/src/core/withUIState.js
@@ -88,11 +88,8 @@ export const mergeUIStateProps = (
  * the ID returned from extractID(props) to get its state from the
  * Redux store.
  *
- * You can make the component always reset its state by adding:
- *
- * componentWillUnmount() {
- *   this.props.setUIState(initialUIState);
- * }
+ * You can make the component always reset its state by configuring
+ * withUIState({ ..., resetOnUnmount: true }).
  *
  * This will behave more like this.setState() but you will lose some
  * features of Redux persistence such as predictable hot reloading and
@@ -102,6 +99,7 @@ const withUIState = ({
   fileName,
   extractId,
   initialState,
+  resetOnUnmount = false,
 }: {|
   // This should always be set to __filename for ID purposes.
   fileName: string,
@@ -109,6 +107,11 @@ const withUIState = ({
   extractId: ExtractIdFunc,
   // An Object that defines the initial state.
   initialState: Object,
+  // When false (the default), every component instance will always
+  // render using persistent Redux state. When true, component state will
+  // be reset when it is unmounted. Set this to true to more closely
+  // mimic this.setState() behavior.
+  resetOnUnmount?: boolean,
 |}): ((React.ComponentType<any>) => React.ComponentType<any>) => {
   invariant(fileName, 'fileName is required');
   invariant(extractId, 'extractId is required');
@@ -122,6 +125,12 @@ const withUIState = ({
 
   return (WrappedComponent) => {
     class WithUIState extends React.Component<any> {
+      componentWillUnmount() {
+        if (resetOnUnmount) {
+          this.props.setUIState(initialState);
+        }
+      }
+
       render() {
         return <WrappedComponent {...this.props} />;
       }

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -46,6 +46,10 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
     confirmButtonType: 'alert',
   };
 
+  componentWillUnmount() {
+    this.props.setUIState({ showConfirmation: false });
+  }
+
   onConfirm = (e: SyntheticEvent<HTMLButtonElement>) => {
     this.props.setUIState({ showConfirmation: false });
     this.props.onConfirm(e);

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -47,7 +47,7 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
   };
 
   componentWillUnmount() {
-    this.props.setUIState({ showConfirmation: false });
+    this.props.setUIState(initialUIState);
   }
 
   onConfirm = (e: SyntheticEvent<HTMLButtonElement>) => {

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -46,10 +46,6 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
     confirmButtonType: 'alert',
   };
 
-  componentWillUnmount() {
-    this.props.setUIState(initialUIState);
-  }
-
   onConfirm = (e: SyntheticEvent<HTMLButtonElement>) => {
     this.props.setUIState({ showConfirmation: false });
     this.props.onConfirm(e);
@@ -139,6 +135,7 @@ const ConfirmButton: React.ComponentType<Props> = compose(
     fileName: __filename,
     extractId,
     initialState: initialUIState,
+    resetOnUnmount: true,
   }),
 )(ConfirmButtonBase);
 

--- a/tests/unit/amo/components/TestEditableCollectionAddon.js
+++ b/tests/unit/amo/components/TestEditableCollectionAddon.js
@@ -317,22 +317,6 @@ describe(__filename, () => {
     });
   });
 
-  it('hides the notes form when unmounting', () => {
-    const { store } = dispatchClientMetadata();
-    const root = render({ store });
-
-    // Show the notes form.
-    root
-      .find('.EditableCollectionAddon-leaveNote-button')
-      .simulate('click', createFakeEvent());
-
-    const rootProps = root.instance().props;
-    root.unmount();
-    applyUIStateChanges({ root, rootProps, store });
-
-    expect(root.find('.EditableCollectionAddon-notes')).toHaveLength(0);
-  });
-
   describe('errorHandler - extractId', () => {
     it('returns a unique ID with an add-on', () => {
       const addon = fakeAddon;

--- a/tests/unit/amo/components/TestEditableCollectionAddon.js
+++ b/tests/unit/amo/components/TestEditableCollectionAddon.js
@@ -224,7 +224,6 @@ describe(__filename, () => {
     it('changes UI state when the leave a note button is clicked', () => {
       const { store } = dispatchClientMetadata();
       const root = render({ store });
-      applyUIStateChanges({ root, store });
 
       expect(root.instance().props.uiState.editingNote).toEqual(false);
 
@@ -316,6 +315,22 @@ describe(__filename, () => {
       sinon.assert.callCount(saveNote, 1);
       sinon.assert.calledWith(saveNote, addon.id, errorHandler, notes);
     });
+  });
+
+  it('hides the notes form when unmounting', () => {
+    const { store } = dispatchClientMetadata();
+    const root = render({ store });
+
+    // Show the notes form.
+    root
+      .find('.EditableCollectionAddon-leaveNote-button')
+      .simulate('click', createFakeEvent());
+
+    const rootProps = root.instance().props;
+    root.unmount();
+    applyUIStateChanges({ root, rootProps, store });
+
+    expect(root.find('.EditableCollectionAddon-notes')).toHaveLength(0);
   });
 
   describe('errorHandler - extractId', () => {

--- a/tests/unit/core/testWithUIState.js
+++ b/tests/unit/core/testWithUIState.js
@@ -65,37 +65,6 @@ describe(__filename, () => {
       expect(root.find('.overlay')).toHaveLength(0);
     });
 
-    it('separates state by instance', () => {
-      const AutoResettingOverlay = withUIState({
-        fileName: __filename,
-        extractId: (props) => props.id,
-        initialState: { isOpen: true },
-        newStatePerInstance: true,
-      })(OverlayBase);
-
-      const autoResettingOverlay = (props = {}) => {
-        return shallowUntilTarget(
-          <AutoResettingOverlay store={store} {...props} />,
-          OverlayBase,
-        );
-      };
-
-      const root1 = autoResettingOverlay({ id: 'one' });
-      const root2 = autoResettingOverlay({ id: 'two' });
-
-      // The first overlay should be open.
-      expect(root1.find('.overlay')).toHaveLength(1);
-
-      // Close the second overlay.
-      root2.find('.close-button').simulate('click');
-
-      applyUIStateChanges({ root: root1, store });
-      applyUIStateChanges({ root: root2, store });
-
-      // The first overlay should still be open.
-      expect(root1.find('.overlay')).toHaveLength(1);
-    });
-
     it('begins with an initial state', () => {
       class ThingBase extends React.Component {
         render() {
@@ -113,34 +82,6 @@ describe(__filename, () => {
       const root = shallowUntilTarget(<Thing store={store} />, ThingBase);
 
       expect(root.instance().props.uiState).toEqual(initialState);
-    });
-
-    it('can reset initial state per component instance', () => {
-      class ThingBase extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      const initialState = { visible: true };
-
-      const Thing = withUIState({
-        fileName: __filename,
-        // Each instance will share this same ID.
-        extractId: () => 'shared-ID',
-        initialState,
-        newStatePerInstance: true,
-      })(ThingBase);
-
-      // Create an instance and change its state.
-      const root1 = shallowUntilTarget(<Thing store={store} />, ThingBase);
-      root1.instance().props.setUIState({ visible: false });
-      applyUIStateChanges({ root: root1, store });
-      expect(root1.instance().props.uiState.visible).toEqual(false);
-
-      // Create a second instance and make sure the state was reset.
-      const root2 = shallowUntilTarget(<Thing store={store} />, ThingBase);
-      applyUIStateChanges({ root: root2, store });
-      expect(root2.instance().props.uiState).toEqual(initialState);
     });
 
     it('shares state across instances by default', () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -645,11 +645,8 @@ export const createUserNotificationsResponse = () => {
  * It's necessary because shallow Enzyme wrapper updates do not
  * propagate to all HOCs.
  */
-export function applyUIStateChanges({
-  root,
-  rootProps = root.instance().props,
-  store,
-}) {
+export function applyUIStateChanges({ root, store }) {
+  const rootProps = root.instance().props;
   const { uiStateID } = rootProps;
   invariant(
     uiStateID,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -18,6 +18,7 @@ import { ADDON_TYPE_EXTENSION, ADDON_TYPE_LANG } from 'core/constants';
 import { makeI18n } from 'core/i18n/utils';
 import { initialApiState } from 'core/reducers/api';
 import { createUIStateMapper, mergeUIStateProps } from 'core/withUIState';
+import { selectUIState } from 'core/reducers/uiState';
 import { ErrorHandler } from 'core/errorHandler';
 import { fakeAddon } from 'tests/unit/amo/helpers';
 
@@ -646,15 +647,27 @@ export const createUserNotificationsResponse = () => {
  */
 export function applyUIStateChanges({ root, store }) {
   const ownProps = root.instance().props;
+  const { uiStateID } = ownProps;
   invariant(
-    ownProps.uiStateID,
+    uiStateID,
     'uiStateID cannot be undefined; was the component wrapped in withUIState()?',
   );
 
+  const state = store.getState();
+
+  if (selectUIState({ uiState: state.uiState, uiStateID }) === undefined) {
+    throw new Error(
+      'Cannot apply UI state changes because the component has not dispatched any setUIState() actions yet',
+    );
+  }
+
   const mapStateToProps = createUIStateMapper({
-    uiStateID: ownProps.uiStateID,
+    // This value is never used. The state is always selected from the
+    // Redux store.
+    initialState: {},
+    uiStateID,
   });
-  const stateProps = mapStateToProps(store.getState(), ownProps);
+  const stateProps = mapStateToProps(state, ownProps);
   const mappedProps = mergeUIStateProps(
     stateProps,
     { dispatch: store.dispatch },

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -645,9 +645,12 @@ export const createUserNotificationsResponse = () => {
  * It's necessary because shallow Enzyme wrapper updates do not
  * propagate to all HOCs.
  */
-export function applyUIStateChanges({ root, store }) {
-  const ownProps = root.instance().props;
-  const { uiStateID } = ownProps;
+export function applyUIStateChanges({
+  root,
+  rootProps = root.instance().props,
+  store,
+}) {
+  const { uiStateID } = rootProps;
   invariant(
     uiStateID,
     'uiStateID cannot be undefined; was the component wrapped in withUIState()?',
@@ -667,11 +670,11 @@ export function applyUIStateChanges({ root, store }) {
     initialState: {},
     uiStateID,
   });
-  const stateProps = mapStateToProps(state, ownProps);
+  const stateProps = mapStateToProps(state, rootProps);
   const mappedProps = mergeUIStateProps(
     stateProps,
     { dispatch: store.dispatch },
-    ownProps,
+    rootProps,
   );
 
   root.setProps(mappedProps);

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -171,6 +171,22 @@ describe(__filename, () => {
     sinon.assert.calledWith(onConfirmSpy, event);
   });
 
+  it('hides the confirmation when unmounting', () => {
+    const { store } = dispatchClientMetadata();
+    const root = render({ store });
+
+    // Enter the confirmation state.
+    root
+      .find('.ConfirmButton-default-button')
+      .simulate('click', createFakeEvent());
+
+    const rootProps = root.instance().props;
+    root.unmount();
+    applyUIStateChanges({ root, rootProps, store });
+
+    expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
+  });
+
   describe('extractId', () => {
     it('returns a unique ID provided by the ID prop', () => {
       const id = 'special-button';

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -171,22 +171,6 @@ describe(__filename, () => {
     sinon.assert.calledWith(onConfirmSpy, event);
   });
 
-  it('hides the confirmation when unmounting', () => {
-    const { store } = dispatchClientMetadata();
-    const root = render({ store });
-
-    // Enter the confirmation state.
-    root
-      .find('.ConfirmButton-default-button')
-      .simulate('click', createFakeEvent());
-
-    const rootProps = root.instance().props;
-    root.unmount();
-    applyUIStateChanges({ root, rootProps, store });
-
-    expect(root).not.toHaveClassName('ConfirmButton--show-confirmation');
-  });
-
   describe('extractId', () => {
     it('returns a unique ID provided by the ID prop', () => {
       const id = 'special-button';


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5764

After thinking more about the problem (see https://github.com/mozilla/addons-frontend/issues/5764), I'm convinced that `withUIState()` components should be persistent by default. If--and only if--we run into problems, we can fall back to the `setState()` behavior which is to reset state for new component instances.