### PR TITLE
Fix pathname in SearchFilters

### DIFF
--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -34,10 +34,12 @@ const NO_FILTER = '';
 export class SearchFiltersBase extends React.Component {
   static propTypes = {
     _config: PropTypes.object,
+    clientApp: PropTypes.string.isRequired,
     filters: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     i18n: PropTypes.object.isRequired,
-    location: PropTypes.object.isRequired,
+    lang: PropTypes.string.isRequired,
+    pathname: PropTypes.string.isRequired,
   };
 
   static defaultProps = {
@@ -87,7 +89,7 @@ export class SearchFiltersBase extends React.Component {
   };
 
   doSearch({ newFilters }) {
-    const { location, history } = this.props;
+    const { clientApp, lang, history, pathname } = this.props;
 
     if (newFilters.page) {
       // Since it's now a new search, reset the page.
@@ -96,7 +98,7 @@ export class SearchFiltersBase extends React.Component {
     }
 
     history.push({
-      pathname: location.pathname,
+      pathname: `/${lang}/${clientApp}${pathname}`,
       query: convertFiltersToQueryParams(newFilters),
     });
   }
@@ -231,7 +233,9 @@ export class SearchFiltersBase extends React.Component {
 
 export function mapStateToProps(state) {
   return {
+    clientApp: state.api.clientApp,
     filters: state.search.filters,
+    lang: state.api.lang,
   };
 }
 

--- a/tests/unit/amo/components/TestSearchFilters.js
+++ b/tests/unit/amo/components/TestSearchFilters.js
@@ -25,18 +25,19 @@ import {
 describe(__filename, () => {
   let fakeHistory;
 
-  function render({
-    filters = {},
-    pathname = '/en-US/android/search/',
-    ...props
-  } = {}) {
+  function render({ filters = {}, pathname = '/search/', ...props } = {}) {
     const errorHandler = createStubErrorHandler();
     const { store } = dispatchClientMetadata();
 
     store.dispatch(searchStart({ errorHandlerId: errorHandler.id, filters }));
 
     return shallowUntilTarget(
-      <SearchFilters i18n={fakeI18n()} store={store} {...props} />,
+      <SearchFilters
+        i18n={fakeI18n()}
+        pathname={pathname}
+        store={store}
+        {...props}
+      />,
       SearchFiltersBase,
       {
         shallowOptions: createContextWithFakeRouter({


### PR DESCRIPTION
Fix #5822

---

I reverted some changes made in #5652 (RRv4 upgrade) because that's the
root cause of #5822. The `SearchFilters` must navigate to the search
page from the "search tools" page.