### PR TITLE
Do not run snyk on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
     - stage:
       <<: *node-prod
       env: COMMAND=snyk-ci
+      if: fork = false
     - stage:
       <<: *node-prod
       env: COMMAND=prettier-ci

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ As a member of the `add-ons-team`, you can fix an issue reported by running:
 yarn snyk-wizard
 ```
 
-The wizard allows you to decide whether you want to upgrade dependencies or ignore the issue for 30 days. See the existing reasons to ignore an issue in the [`.snyk`](.snyk) file. Snyk is a bit intrusive and changes many things (like re-adding `snyk test` to the npm `test` script): double check your changes before submitting a Pull Request. You have successfully fixed an issue when `yarn snyk-ci` does not complain.
+The wizard allows you to decide whether you want to upgrade dependencies or ignore the issue for 30 days. See the existing reasons to ignore an issue in the [`.snyk`](.snyk) file. Snyk is a bit intrusive and changes many things (like re-adding `snyk test` to the npm `test` script): double check your changes before submitting a Pull Request. You have successfully fixed an issue when `yarn snyk-ci` does not complain. Make sure you open a Pull Request with a branch pushed to this repository and not from your fork, because the `snyk-ci` job (Travis CI) does not run on forks.
 
 Note: You should authenticate yourself once by running `yarn snyk auth` (no dash). It will open a link in your favorite browser and authenticate you locally.
 


### PR DESCRIPTION
Fix #5819

---

We do not run the `snyk` job when the PR comes from a fork:

- The build for this PR does not have it: https://travis-ci.org/mozilla/addons-frontend/builds/411224682?utm_source=github_status&utm_medium=notification
- The build for the branch pushed directly on this repo has it: https://travis-ci.org/mozilla/addons-frontend/builds/411227047?utm_source=github_status&utm_medium=notification