### PR TITLE
changing the order of calls of unloadCollectionBySlug & pushLocation

### DIFF
--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -388,10 +388,10 @@ export function* deleteCollection({
 
     yield call(api.deleteCollection, params);
 
+    yield put(pushLocation(`/${lang}/${clientApp}/collections/`));
+
     // Unload the collection from state.
     yield put(unloadCollectionBySlug(slug));
-
-    yield put(pushLocation(`/${lang}/${clientApp}/collections/`));
   } catch (error) {
     log.warn(`Failed to delete collection: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -822,17 +822,18 @@ describe(__filename, () => {
 
       _deleteCollection(params);
 
-      const expectedUnloadAction = unloadCollectionBySlug(params.slug);
-
-      const unloadAction = await sagaTester.waitFor(expectedUnloadAction.type);
-      expect(unloadAction).toEqual(expectedUnloadAction);
-
       const expectedPushAction = pushLocation(
         `/${lang}/${clientApp}/collections/`,
       );
 
       const pushAction = await sagaTester.waitFor(expectedPushAction.type);
       expect(pushAction).toEqual(expectedPushAction);
+
+      const expectedUnloadAction = unloadCollectionBySlug(params.slug);
+
+      const unloadAction = await sagaTester.waitFor(expectedUnloadAction.type);
+      expect(unloadAction).toEqual(expectedUnloadAction);
+
       mockApi.verify();
     });
 


### PR DESCRIPTION
Fixes #5708 

Before: 
![screenshot from 2018-08-03 12-53-17](https://user-images.githubusercontent.com/22130317/43630599-5c5ed2f0-971e-11e8-91b4-5d7cfd7c6a01.png)


After:
![screenshot from 2018-08-03 12-54-26](https://user-images.githubusercontent.com/22130317/43630566-4738680a-971e-11e8-9990-3b58f6f98288.png)

