### PR TITLE
DEMO of picture el / I5691 (for Preview in Search and Header)

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -159,17 +159,32 @@ export class AddonBase extends React.Component {
         previewURL = addon.previewURL;
       }
 
+      const previewURLThumb = getPreviewImage(addon, { full: false });
+
+      const previewImage = previewURLThumb ? (
+        <picture>
+          <source srcSet={previewURL} media="(min-width: 500px)" />
+          <img
+            alt={label}
+            className="Addon-theme-header-image"
+            src={previewURLThumb}
+          />
+        </picture>
+      ) : (
+        <img
+          alt={label}
+          className="Addon-theme-header-image"
+          src={previewURL}
+        />
+      );
+
       return (
         <div
           className="Addon-theme-header"
           key="Addon-theme-image"
           role="presentation"
         >
-          <img
-            alt={label}
-            className="Addon-theme-header-image"
-            src={previewURL}
-          />
+          {previewImage}
         </div>
       );
     }

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -53,10 +53,15 @@ export class SearchResultBase extends React.Component<InternalProps> {
 
     const averageDailyUsers = addon ? addon.average_daily_users : null;
 
-    // Fall-back to default icon if invalid icon url.
-    const iconURL = getAddonIconUrl(addon);
+    let imageProps = {
+      alt: addon ? addon.name : null,
+      className: makeClassName('SearchResult-icon', {
+        'SearchResult-icon--loading': !addon,
+      }),
+      src: getAddonIconUrl(addon),
+    };
 
-    let imageURL = iconURL;
+    let imagehtml = <img {...imageProps} />;
 
     if (addon && isTheme(addon.type)) {
       // Since only newly created static themes will have more than one preview
@@ -71,12 +76,32 @@ export class SearchResultBase extends React.Component<InternalProps> {
             : null;
       }
 
-      imageURL = themeURL;
+      const themeURLThumb = getPreviewImage(addon, { full: false });
+
+      imageProps = themeURLThumb
+        ? {
+            ...imageProps,
+            src: themeURLThumb,
+          }
+        : {
+            ...imageProps,
+            src: themeURL,
+          };
+
+      imagehtml = themeURLThumb ? (
+        <picture>
+          <source srcSet={themeURL} media="(min-width: 500px)" />
+          <img {...imageProps} />
+        </picture>
+      ) : (
+        <img {...imageProps} />
+      );
     }
 
     // Sets classes to handle fallback if theme preview is not available.
     const iconWrapperClassnames = makeClassName('SearchResult-icon-wrapper', {
-      'SearchResult-icon-wrapper--no-theme-image': isTheme && imageURL === null,
+      'SearchResult-icon-wrapper--no-theme-image':
+        isTheme && imagehtml.src === null,
     });
 
     let addonAuthors = null;
@@ -108,14 +133,8 @@ export class SearchResultBase extends React.Component<InternalProps> {
     return (
       <div className="SearchResult-result">
         <div className={iconWrapperClassnames}>
-          {imageURL ? (
-            <img
-              className={makeClassName('SearchResult-icon', {
-                'SearchResult-icon--loading': !addon,
-              })}
-              src={imageURL}
-              alt={addon ? `${addon.name}` : ''}
-            />
+          {imageProps.src ? (
+            imagehtml
           ) : (
             <p className="SearchResult-notheme">
               {i18n.gettext('No theme preview available')}


### PR DESCRIPTION
Here is a demo using picture el for the Addon detail header image and in the Search results. It seemed safe to use given [caniuse/#feat-picture](https://caniuse.com/#feat=picture). 

I *think* generally speaking, in these cases it's still a little better to use srcset (since the images are the same - just different sizes) but right now we need more sizes (and take into consideration resolution) to see it kick in. Right now with srcset, I only really see this happening it on smaller non-retina devices. Until we get more sizes, I think the pic el is good alternate solution as it loads the smaller (thumbs) version of the images for mobile. In search esp this can be good since it's a list view of results. We might have to eventually address resolution issues here too but at least we can control this and make this change happen if we want to. For now everything I looked at looked okay... 
I arbitrarily picked 500 as the breakpoint but we can obviously adjust that..

I am personally a fan of the picture el since we have a little bit more control with the breakpoints. Let me know what you guys think : )

note: I skipped updating tests for now 

this might be a good static theme to view since it has updated preview sizes:
http://localhost:3000/en-US/firefox/addon/eco-theme/


@willdurand @kumar303 @bobsilverberg @muffinresearch 

you can compare this to PR #5693 


Also, let me know if it is more helpful to discuss/see this in another way..
