### PR TITLE
Use pino-devtools to view the server logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       }
     },
     "start-dev": {
-      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | pino'",
+      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools'",
       "env": {
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",
@@ -108,7 +108,7 @@
       }
     },
     "start-dev-proxy": {
-      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | pino' 'node bin/proxy.js | pino'",
+      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools' 'node bin/proxy.js | pino'",
       "env": {
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",
@@ -272,6 +272,7 @@
     "node-sass": "^4.5.2",
     "object.values": "^1.0.4",
     "photon-colors": "^3.0.1",
+    "pino-devtools": "^1.0.2",
     "piping": "^1.0.0-rc.4",
     "po2json": "^0.4.5",
     "postcss-loader": "2.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,6 +4934,10 @@ is-word-character@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -6748,6 +6752,12 @@ open@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
 
+opn@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"
+  dependencies:
+    is-wsl "^1.1.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -7028,6 +7038,17 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pino-devtools@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pino-devtools/-/pino-devtools-1.0.2.tgz#3e6eeeb53c4025606572993f61ad06a585bc5969"
+  dependencies:
+    minimist "^1.2.0"
+    opn "^5.3.0"
+    pump "^3.0.0"
+    split2 "^2.2.0"
+    through2 "^2.0.3"
+    ws "^6.0.0"
 
 pino-std-serializers@^2.0.0:
   version "2.1.0"
@@ -9646,7 +9667,7 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-through2@^2.0.0, through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.2, through2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
@@ -10439,6 +10460,12 @@ ws@^4.0.0:
 ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.0.0.tgz#eaa494aded00ac4289d455bac8d84c7c651cef35"
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
Fix #4041

---

This PR uses [pino-devtools](https://github.com/willdurand/pino-devtools) to view the server logs:

![screen shot 2018-08-07 at 17 48 57](https://user-images.githubusercontent.com/217628/43786960-2e2815a0-9a6a-11e8-9632-0dd094b4d40b.png)
