### PR TITLE
Use pino/browser in test env

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -6,4 +6,5 @@ module.exports = {
   allowErrorSimulation: true,
   enableClientConsole: true,
   isDeployed: false,
+  loggingLevel: 'debug',
 };

--- a/src/core/logger.js
+++ b/src/core/logger.js
@@ -1,5 +1,20 @@
 import config from 'config';
-import pino from 'pino';
+
+let pino = null;
+if (process.env.NODE_ENV === 'test') {
+  // We explicitely require the "browser" (client) version of Pino to write
+  // logs with `console` and not `stdout` so that Jest can handle the output.
+  // See: https://github.com/mozilla/addons-frontend/issues/5869
+  //
+  // eslint-disable-next-line global-require
+  pino = require('pino/browser');
+} else {
+  // Pino is an isomorphic logging library and works well on both the server
+  // and the client without configuration.
+  //
+  // eslint-disable-next-line global-require
+  pino = require('pino');
+}
 
 const appName = config.get('appName');
 


### PR DESCRIPTION
Fix #5869

---

The alternative option would be to use the following Jest option: `--browser`, but that would mean enabling this feature for everything.