### PR TITLE
Correction for Thunderbird  SeaMonkey - Fixes #5859

### DIFF
--- a/src/amo/components/StaticPages/About/index.js
+++ b/src/amo/components/StaticPages/About/index.js
@@ -39,8 +39,8 @@ export class AboutBase extends React.Component {
               // eslint-disable-next-line react/no-danger
               dangerouslySetInnerHTML={sanitizeHTML(
                 i18n.sprintf(
-                  i18n.gettext(`You can also use AMO to find add-ons for Mozilla
-                      %(startTBLink)sThunderbird%(endTBLink)s and
+                  i18n.gettext(`If you are looking for add-ons for Thunderbird or SeaMonkey, please visit
+                      %(startTBLink)sThunderbird%(endTBLink)s or
                       %(startSMLink)sSeaMonkey%(endSMLink)s.`),
                   {
                     startTBLink:


### PR DESCRIPTION
`Fixes #5859`

Remove info about Thunderbird & SeaMonkey add-ons from AMO About page #5859
