### PR TITLE
Do not kill everyone in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       }
     },
     "start-dev": {
-      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools'",
+      "command": "npm run clean && concurrently 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools'",
       "env": {
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",
@@ -108,7 +108,7 @@
       }
     },
     "start-dev-proxy": {
-      "command": "npm run clean && concurrently --kill-others 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools' 'node bin/proxy.js | pino-pretty'",
+      "command": "npm run clean && concurrently 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools' 'node bin/proxy.js | pino-pretty'",
       "env": {
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",


### PR DESCRIPTION
Fix #5886

---

We don't need to kill all processes when an error occurs.

The issue was that the server code could not be reloaded because of a
syntax error, thus exiting with a non-zero code. `concurrently` then
killed the proxy. Once you fix the syntax error, the server code
restarts correctly, but proxy is not available anymore...