### PR TITLE
Don't break words in review control links

### DIFF
--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -4,6 +4,9 @@
 
 .AddonReviewListItem-control {
   display: flex;
+  // On small screens, reduce the width to break up words in
+  // controls like *Edit my review*.
+  max-width: 20vw;
   width: max-content;
 
   @include margin-start(6px);

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -4,6 +4,8 @@
 
 .AddonReviewListItem-control {
   display: flex;
+  width: max-content;
+
   @include margin-start(6px);
 
   @include respond-to(medium) {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5926

**Before**

<img width="324" alt="screenshot 2018-08-13 17 28 37" src="https://user-images.githubusercontent.com/55398/44061597-ac8b80b8-9f1e-11e8-8027-9633379c4d3c.png">


**After**

<img width="323" alt="screenshot 2018-08-13 21 32 23" src="https://user-images.githubusercontent.com/55398/44068694-0af3a91a-9f41-11e8-80ee-965626695e31.png">
<img width="323" alt="screenshot 2018-08-13 21 33 09" src="https://user-images.githubusercontent.com/55398/44068695-0b0e9720-9f41-11e8-8f3f-96a679879f2e.png">
<img width="322" alt="screenshot 2018-08-13 21 35 07" src="https://user-images.githubusercontent.com/55398/44068696-0b236042-9f41-11e8-81b6-1c5477fff626.png">
