### PR TITLE
Push review controls to a new line on small screens (fixes Reply to Review layout issues)

### DIFF
--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -215,7 +215,9 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
 
     const byLine = (
       <React.Fragment>
-        {authorAndTime}
+        <div className="AddonReviewListItem-author">
+          {authorAndTime}
+        </div>
 
         {siteUser && review && review.userId === siteUser.id ? (
           <div>

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -215,64 +215,68 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
 
     const byLine = (
       <React.Fragment>
-        <div className="AddonReviewListItem-author">
-          {authorAndTime}
-        </div>
+        {authorAndTime}
+        <div className="AddonReviewListItem-allControls">
+          {siteUser && review && review.userId === siteUser.id ? (
+            <React.Fragment>
+              {/* This will render an overlay to edit the review */}
+              {editingReview ? (
+                <AddonReview
+                  onEscapeOverlay={this.onEscapeReviewOverlay}
+                  onReviewSubmitted={this.onReviewSubmitted}
+                  review={review}
+                />
+              ) : null}
+              <a
+                href="#edit"
+                onClick={this.onClickToEditReview}
+                className="AddonReviewListItem-edit AddonReviewListItem-control"
+              >
+                {isReply
+                  ? i18n.gettext('Edit my reply')
+                  : i18n.gettext('Edit my review')}
+              </a>
+            </React.Fragment>
+          ) : null}
 
-        {siteUser && review && review.userId === siteUser.id ? (
-          <div>
-            {/* This will render an overlay to edit the review */}
-            {editingReview ? (
-              <AddonReview
-                onEscapeOverlay={this.onEscapeReviewOverlay}
-                onReviewSubmitted={this.onReviewSubmitted}
-                review={review}
-              />
-            ) : null}
+          {review &&
+          addon &&
+          siteUser &&
+          !replyingToReview &&
+          !review.reply &&
+          !isReply &&
+          (isAddonAuthor({ addon, userId: siteUser.id }) ||
+            siteUserHasReplyPerm) &&
+          review.userId !== siteUser.id ? (
             <a
-              href="#edit"
-              onClick={this.onClickToEditReview}
-              className="AddonReviewListItem-edit AddonReviewListItem-control"
+              href="#reply"
+              onClick={this.onClickToBeginReviewReply}
+              className="AddonReviewListItem-begin-reply AddonReviewListItem-control"
             >
-              {isReply
-                ? i18n.gettext('Edit my reply')
-                : i18n.gettext('Edit my review')}
+              <Icon name="reply-arrow" />
+              {i18n.gettext('Reply to this review')}
             </a>
-          </div>
-        ) : null}
+          ) : null}
 
-        {review &&
-        addon &&
-        siteUser &&
-        !replyingToReview &&
-        !review.reply &&
-        !isReply &&
-        (isAddonAuthor({ addon, userId: siteUser.id }) ||
-          siteUserHasReplyPerm) &&
-        review.userId !== siteUser.id ? (
-          <a
-            href="#reply"
-            onClick={this.onClickToBeginReviewReply}
-            className="AddonReviewListItem-begin-reply AddonReviewListItem-control"
-          >
-            <Icon name="reply-arrow" />
-            {i18n.gettext('Reply to this review')}
-          </a>
-        ) : null}
-
-        {review ? (
-          <FlagReviewMenu
-            isDeveloperReply={isReply}
-            location={location}
-            openerClass="AddonReviewListItem-control"
-            review={review}
-          />
-        ) : null}
+          {review ? (
+            <FlagReviewMenu
+              isDeveloperReply={isReply}
+              location={location}
+              openerClass="AddonReviewListItem-control"
+              review={review}
+            />
+          ) : null}
+        </div>
       </React.Fragment>
     );
 
     return (
-      <UserReview review={review} byLine={byLine} showRating={!isReply}>
+      <UserReview
+        className="AddonReviewListItem"
+        review={review}
+        byLine={byLine}
+        showRating={!isReply}
+      >
         {errorHandler.renderErrorIfPresent()}
         {this.renderReply()}
       </UserReview>

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -215,7 +215,7 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
 
     const byLine = (
       <React.Fragment>
-        {authorAndTime}
+        <div className="AddonReviewListItem-author">{authorAndTime}</div>
         <div className="AddonReviewListItem-allControls">
           {siteUser && review && review.userId === siteUser.id ? (
             <React.Fragment>

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -31,10 +31,10 @@
 
 .AddonReviewListItem-allControls {
   display: flex;
-  justify-content: end;
   // Push all controls down to a new row on small screens.
   grid-column-end: span 2;
   grid-column-start: 1;
+  justify-content: end;
   margin-top: 6px;
 
   @include respond-to(medium) {

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -5,7 +5,6 @@
 
 .AddonReviewListItem {
   .Rating {
-    align-self: start;
     height: $default-line-height;
   }
 

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -1,12 +1,27 @@
 @import '~photon-colors/photon-colors';
+@import '~core/css/inc/vars';
 @import '~core/css/inc/mixins';
 @import '~amo/css/inc/vars';
 
+.AddonReviewListItem {
+  .Rating {
+    align-self: start;
+    height: $default-line-height;
+  }
+
+  .UserReview-byLine {
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+
+    @include respond-to(medium) {
+      grid-template-columns: repeat(3, auto);
+      justify-content: start;
+    }
+  }
+}
+
 .AddonReviewListItem-control {
   display: flex;
-  // On small screens, reduce the width to break up words in
-  // controls like *Edit my review*.
-  max-width: 40vw;
   width: max-content;
 
   @include margin-start(12px);
@@ -20,13 +35,9 @@
   }
 }
 
-.AddonReviewListItem .UserReview-byLine {
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-
-  @include respond-to(medium) {
-    grid-template-columns: repeat(3, max-content);
-  }
+.AddonReviewListItem-author {
+  // Make sure AddonReviewListItem-control elements don't squeeze this out.
+  min-width: 5vw;
 }
 
 .AddonReviewListItem-allControls {
@@ -40,7 +51,6 @@
   @include respond-to(medium) {
     grid-column-end: auto;
     grid-column-start: auto;
-    justify-content: start;
     margin-top: 0;
   }
 }

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -6,10 +6,10 @@
   display: flex;
   // On small screens, reduce the width to break up words in
   // controls like *Edit my review*.
-  max-width: 20vw;
+  max-width: 40vw;
   width: max-content;
 
-  @include margin-start(6px);
+  @include margin-start(12px);
 
   @include respond-to(medium) {
     @include margin-start(24px);
@@ -20,9 +20,29 @@
   }
 }
 
-.AddonReviewListItem-author {
-  // Account for long display names on small screens.
-  max-width: 30vw;
+.AddonReviewListItem .UserReview-byLine {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+
+  @include respond-to(medium) {
+    grid-template-columns: repeat(3, max-content);
+  }
+}
+
+.AddonReviewListItem-allControls {
+  display: flex;
+  justify-content: end;
+  // Push all controls down to a new row on small screens.
+  grid-column-end: span 2;
+  grid-column-start: 1;
+  margin-top: 6px;
+
+  @include respond-to(medium) {
+    grid-column-end: auto;
+    grid-column-start: auto;
+    justify-content: start;
+    margin-top: 0;
+  }
 }
 
 .AddonReviewListItem-reply {

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -42,6 +42,7 @@
 
 .AddonReviewListItem-allControls {
   display: flex;
+  flex-wrap: wrap;
   // Push all controls down to a new row on small screens.
   grid-column-end: span 2;
   grid-column-start: 1;

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -20,6 +20,11 @@
   }
 }
 
+.AddonReviewListItem-author {
+  // Account for long display names on small screens.
+  max-width: 30vw;
+}
+
 .AddonReviewListItem-reply {
   background-color: transparentize($blue-50, 0.95);
   border-radius: $border-radius-default;

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -180,6 +180,8 @@
   @include icon($name: 'reply-arrow');
 
   height: 11.68px;
+  // Make sure a flex layout doesn't reduce the width.
+  min-width: 14px;
   width: 14px;
 
   [dir='rtl'] & {

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -180,6 +180,8 @@
   @include icon($name: 'reply-arrow');
 
   height: 11.68px;
+  // Make sure flex layouts don't squeeze this.
+  min-width: 14px;
   width: 14px;
 
   [dir='rtl'] & {

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -180,8 +180,6 @@
   @include icon($name: 'reply-arrow');
 
   height: 11.68px;
-  // Make sure a flex layout doesn't reduce the width.
-  min-width: 14px;
   width: 14px;
 
   [dir='rtl'] & {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3424 by moving review controls to a new row on small screens. This has come up before so it will solve a few problems.

<hr>

Here is how it looked **before**. Notice that it's not as bad as the original screenshot in the issue, thanks to https://github.com/mozilla/addons-frontend/issues/5926

<img width="321" alt="screenshot 2018-08-15 10 13 06" src="https://user-images.githubusercontent.com/55398/44156131-ccba8648-a074-11e8-9555-0070587b5173.png">

<hr>

Here's how it looks **after** the patch:

<img width="323" alt="screenshot 2018-08-15 12 55 47" src="https://user-images.githubusercontent.com/55398/44164176-ee600000-a08a-11e8-9021-0e51b34fde42.png">
<img width="324" alt="screenshot 2018-08-15 12 55 59" src="https://user-images.githubusercontent.com/55398/44164177-ee600000-a08a-11e8-8591-66fa5c62372e.png">
<img width="324" alt="screenshot 2018-08-15 12 56 23" src="https://user-images.githubusercontent.com/55398/44164178-ee600000-a08a-11e8-8fa6-2f1ea4b502e2.png">
<img width="323" alt="screenshot 2018-08-15 12 57 03" src="https://user-images.githubusercontent.com/55398/44164179-ee600000-a08a-11e8-8fa4-b3db7a77ac39.png">
<img width="322" alt="screenshot 2018-08-15 12 57 41" src="https://user-images.githubusercontent.com/55398/44164181-ee600000-a08a-11e8-86d5-ef4f048e20ae.png">
<img width="323" alt="screenshot 2018-08-15 12 58 05" src="https://user-images.githubusercontent.com/55398/44164182-eef89680-a08a-11e8-9721-ca0bff3184e1.png">

<hr>

Large screens:

<img width="720" alt="screenshot 2018-08-15 12 57 30" src="https://user-images.githubusercontent.com/55398/44164180-ee600000-a08a-11e8-99a2-43513b37fe05.png">
<img width="548" alt="screenshot 2018-08-15 14 30 37" src="https://user-images.githubusercontent.com/55398/44168759-e0fd4280-a097-11e8-93a2-2f1bf2140ffb.png">
