### PR TITLE
Add an underline to the links to "all reviews" from the AddonMeta component

### DIFF
--- a/src/amo/components/AddonMeta/styles.scss
+++ b/src/amo/components/AddonMeta/styles.scss
@@ -51,7 +51,6 @@
   a:visited {
     color: $grey-50;
     font-weight: normal;
-    text-decoration: none;
   }
 
   a.AddonMeta-reviews-content-link {
@@ -59,6 +58,11 @@
     &:link,
     &:visited {
       color: $black;
+    }
+
+    &:active,
+    &:hover {
+      color: $link-color;
     }
   }
 


### PR DESCRIPTION
Fixes #5952 

Before:

![screenshot 2018-08-15 15 10 05](https://user-images.githubusercontent.com/142755/44167917-7d761380-a09d-11e8-8583-3355081f8cb1.png)

Note that hovering over the number "153" in the *before* version does not change the color of the number to blue.

After:

![screenshot 2018-08-15 15 12 29](https://user-images.githubusercontent.com/142755/44167971-a5657700-a09d-11e8-97d2-37089ee7c322.png)

After, while hovering over the number of reviews:

![screenshot 2018-08-15 15 08 19](https://user-images.githubusercontent.com/142755/44167988-b44c2980-a09d-11e8-9740-0c209714f188.png)

Note also that hovering over the text "Reviews" changes the color to blue in both the before and after versions.