### PR TITLE
Push review controls to a new line when out of space (fixes Reply to Review layout issues)

### DIFF
--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -217,60 +217,67 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
       <React.Fragment>
         {authorAndTime}
 
-        {siteUser && review && review.userId === siteUser.id ? (
-          <div>
-            {/* This will render an overlay to edit the review */}
-            {editingReview ? (
-              <AddonReview
-                onEscapeOverlay={this.onEscapeReviewOverlay}
-                onReviewSubmitted={this.onReviewSubmitted}
-                review={review}
-              />
-            ) : null}
+        <div className="AddonReviewListItem-allControls">
+          {siteUser && review && review.userId === siteUser.id ? (
+            <React.Fragment>
+              {/* This will render an overlay to edit the review */}
+              {editingReview ? (
+                <AddonReview
+                  onEscapeOverlay={this.onEscapeReviewOverlay}
+                  onReviewSubmitted={this.onReviewSubmitted}
+                  review={review}
+                />
+              ) : null}
+              <a
+                href="#edit"
+                onClick={this.onClickToEditReview}
+                className="AddonReviewListItem-edit AddonReviewListItem-control"
+              >
+                {isReply
+                  ? i18n.gettext('Edit my reply')
+                  : i18n.gettext('Edit my review')}
+              </a>
+            </React.Fragment>
+          ) : null}
+
+          {review &&
+          addon &&
+          siteUser &&
+          !replyingToReview &&
+          !review.reply &&
+          !isReply &&
+          (isAddonAuthor({ addon, userId: siteUser.id }) ||
+            siteUserHasReplyPerm) &&
+          review.userId !== siteUser.id ? (
             <a
-              href="#edit"
-              onClick={this.onClickToEditReview}
-              className="AddonReviewListItem-edit AddonReviewListItem-control"
+              href="#reply"
+              onClick={this.onClickToBeginReviewReply}
+              className="AddonReviewListItem-begin-reply AddonReviewListItem-control"
             >
-              {isReply
-                ? i18n.gettext('Edit my reply')
-                : i18n.gettext('Edit my review')}
+              <Icon name="reply-arrow" />
+              {i18n.gettext('Reply to this review')}
             </a>
-          </div>
-        ) : null}
+          ) : null}
 
-        {review &&
-        addon &&
-        siteUser &&
-        !replyingToReview &&
-        !review.reply &&
-        !isReply &&
-        (isAddonAuthor({ addon, userId: siteUser.id }) ||
-          siteUserHasReplyPerm) &&
-        review.userId !== siteUser.id ? (
-          <a
-            href="#reply"
-            onClick={this.onClickToBeginReviewReply}
-            className="AddonReviewListItem-begin-reply AddonReviewListItem-control"
-          >
-            <Icon name="reply-arrow" />
-            {i18n.gettext('Reply to this review')}
-          </a>
-        ) : null}
-
-        {review ? (
-          <FlagReviewMenu
-            isDeveloperReply={isReply}
-            location={location}
-            openerClass="AddonReviewListItem-control"
-            review={review}
-          />
-        ) : null}
+          {review ? (
+            <FlagReviewMenu
+              isDeveloperReply={isReply}
+              location={location}
+              openerClass="AddonReviewListItem-control"
+              review={review}
+            />
+          ) : null}
+        </div>
       </React.Fragment>
     );
 
     return (
-      <UserReview review={review} byLine={byLine} showRating={!isReply}>
+      <UserReview
+        className="AddonReviewListItem"
+        review={review}
+        byLine={byLine}
+        showRating={!isReply}
+      >
         {errorHandler.renderErrorIfPresent()}
         {this.renderReply()}
       </UserReview>

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -5,7 +5,6 @@
 
 .AddonReviewListItem {
   .Rating {
-    align-self: start;
     height: $default-line-height;
   }
 

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -1,14 +1,33 @@
 @import '~photon-colors/photon-colors';
+@import '~core/css/inc/vars';
 @import '~core/css/inc/mixins';
 @import '~amo/css/inc/vars';
 
-.AddonReviewListItem-control {
-  display: flex;
-  // On small screens, reduce the width to break up words in
-  // controls like *Edit my review*.
-  max-width: 20vw;
-  width: max-content;
+.AddonReviewListItem {
+  .Rating {
+    align-self: start;
+    height: $default-line-height;
+  }
 
+  .UserReview-byLine {
+    flex-wrap: wrap;
+  }
+}
+
+.AddonReviewListItem-allControls {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+  width: 100%;
+
+  @include respond-to(extraExtraLarge) {
+    justify-content: flex-start;
+    margin-top: 0;
+    width: auto;
+  }
+}
+
+.AddonReviewListItem-control {
   @include margin-start(6px);
 
   @include respond-to(medium) {

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -14,6 +14,8 @@
 .Icon {
   content: '';
   display: inline-block;
+  // Do not let flex containers shrink icons.
+  flex-shrink: 0;
   height: $default-icon-size;
   width: $default-icon-size;
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3424 by flex-wrapping controls to a new line (this works better than the grid approach in https://github.com/mozilla/addons-frontend/pull/5951). The idea of pushing controls to a new line has come up before so it will solve a few problems.

<hr>

Here is how it looked **before**. Notice that it's not as bad as the original screenshot in the issue, thanks to https://github.com/mozilla/addons-frontend/issues/5926

<img width="321" alt="screenshot 2018-08-15 10 13 06" src="https://user-images.githubusercontent.com/55398/44156131-ccba8648-a074-11e8-9555-0070587b5173.png">

<hr>

Here's how that screen looks **after**

<img width="323" alt="screenshot 2018-08-16 09 57 54" src="https://user-images.githubusercontent.com/55398/44216667-0f802980-a13b-11e8-9677-534d6797c9f8.png">
<img width="324" alt="screenshot 2018-08-16 09 58 44" src="https://user-images.githubusercontent.com/55398/44216668-0f802980-a13b-11e8-9bc5-cc48f070015e.png">
<img width="322" alt="screenshot 2018-08-16 09 59 03" src="https://user-images.githubusercontent.com/55398/44216669-1018c000-a13b-11e8-948e-981f8c6000a6.png">

<hr>

Here are some other mobile views

<img width="323" alt="screenshot 2018-08-16 10 00 39" src="https://user-images.githubusercontent.com/55398/44216818-7a316500-a13b-11e8-8379-2573621ffdac.png">
<img width="323" alt="screenshot 2018-08-16 10 01 07" src="https://user-images.githubusercontent.com/55398/44216819-7ac9fb80-a13b-11e8-9c6b-c8ca768ddc06.png">
<img width="323" alt="screenshot 2018-08-16 10 01 27" src="https://user-images.githubusercontent.com/55398/44216820-7ac9fb80-a13b-11e8-91f1-1d32e55bdec0.png">

<hr>

Larger screens:

<img width="772" alt="screenshot 2018-08-16 10 03 19" src="https://user-images.githubusercontent.com/55398/44217044-1f4c3d80-a13c-11e8-8c43-318cca2b56d2.png">
<img width="1026" alt="screenshot 2018-08-16 10 03 49" src="https://user-images.githubusercontent.com/55398/44217045-1fe4d400-a13c-11e8-8e5d-9f3d00965de1.png">
<img width="1359" alt="screenshot 2018-08-16 10 04 30" src="https://user-images.githubusercontent.com/55398/44217046-1fe4d400-a13c-11e8-9bbc-8bbf91fda2ce.png">
<img width="1181" alt="screenshot 2018-08-16 10 05 44" src="https://user-images.githubusercontent.com/55398/44217047-1fe4d400-a13c-11e8-90af-32d07e8d9ebf.png">
<img width="861" alt="screenshot 2018-08-16 10 06 20" src="https://user-images.githubusercontent.com/55398/44217048-1fe4d400-a13c-11e8-8116-81aaff9ac819.png">
