### PR TITLE
Fixes #5388 resolves addon custom icon squashing

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -185,9 +185,9 @@ export class AddonBase extends React.Component {
       <div className="Addon-icon" key="Addon-icon-header">
         <div className="Addon-img-wrapper">
           <img
-          alt={label}
-          className="Addon-icon-image"
-          src={getAddonIconUrl(addon)}
+            alt={label}
+            className="Addon-icon-image"
+            src={getAddonIconUrl(addon)}
           />
         </div>
       </div>

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -183,7 +183,7 @@ export class AddonBase extends React.Component {
 
     return (
       <div className="Addon-icon" key="Addon-icon-header">
-        <div className="Addon-img-wrapper">
+        <div className="Addon-icon-wrapper">
           <img
             alt={label}
             className="Addon-icon-image"

--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -183,11 +183,13 @@ export class AddonBase extends React.Component {
 
     return (
       <div className="Addon-icon" key="Addon-icon-header">
-        <img
+        <div className="Addon-img-wrapper">
+          <img
           alt={label}
           className="Addon-icon-image"
           src={getAddonIconUrl(addon)}
-        />
+          />
+        </div>
       </div>
     );
   }

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -32,7 +32,7 @@
   }
 }
 
-.Addon-img-wrapper {
+.Addon-icon-wrapper {
   height: 48px;
   overflow: hidden;
   width: 48px;

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -34,19 +34,19 @@
 
 .Addon-img-wrapper {
   height: 48px;
-  width: 48px;
   overflow: hidden;
+  width: 48px;
 
   @include respond-to(medium) {
     height: 64px;
-    width: 64px;
     overflow: hidden;
+    width: 64px;
   }
 }
 
 .Addon-icon-image {
   height: auto;
-  width: 100%; 
+  width: 100%;
 }
 
 .Addon-header-wrapper {

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -32,14 +32,21 @@
   }
 }
 
-.Addon-icon-image {
+.Addon-img-wrapper {
   height: 48px;
   width: 48px;
+  overflow: hidden;
 
   @include respond-to(medium) {
     height: 64px;
     width: 64px;
+    overflow: hidden;
   }
+}
+
+.Addon-icon-image {
+  height: auto;
+  width: 100%; 
 }
 
 .Addon-header-wrapper {


### PR DESCRIPTION
Fixes #5388 

Image used - size: 1.96 MB (JPEG), dimensions: 1980 × 1289


### BEFORE
<img width="1368" alt="screen shot 2018-08-17 at 2 27 43 am" src="https://user-images.githubusercontent.com/35342019/44236530-ea3afc00-a1ca-11e8-8a85-8a977345e573.png">

### AFTER
<img width="1369" alt="screen shot 2018-08-17 at 3 09 46 am" src="https://user-images.githubusercontent.com/35342019/44236576-10f93280-a1cb-11e8-97ee-8630df07b54f.png">

### Description
- Wrapped the custom icon image inside a div `Addon-img-wrapper` and imposed the restriction of `height` and `width` acc to screen size. And, changed styles for class `Addon-icon-image` to `height:auto;` and `width:100%` thus resolving the squashing problem. 
- By the following changes, horizontal images do not squash anymore but if the height of image is greater than 64px(potrait images) its cropped from bottom (not squashed), which should be the desired behaviour as read in the #4629. Please confirm this? 
- Do I need to write tests for the same?

Thank you for all the help, please review this @willdurand  @ioanarusiczki 


