### PR TITLE
[Fixes]#5627: Description text box should have only a vertical expansion

### DIFF
--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -17,7 +17,7 @@
   input,
   textarea {
     width: 100%;
-    resize: none;
+    resize: vertical;
 
     &:focus {
       @include focus();

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -17,6 +17,7 @@
   input,
   textarea {
     width: 100%;
+    resize: none;
 
     &:focus {
       @include focus();

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -16,8 +16,8 @@
 
   input,
   textarea {
-    width: 100%;
     resize: vertical;
+    width: 100%;
 
     &:focus {
       @include focus();


### PR DESCRIPTION
Fixes: #5627  
Bug: 
![Alt Text](https://user-images.githubusercontent.com/33448286/42804655-45a287ec-89b2-11e8-9764-55cb6e9c5408.gif)
Result:The text-area has resize vertical, so only vertical expansion can occur
![screenshot from 2018-08-17 15-19-57](https://user-images.githubusercontent.com/10033914/44260373-d4aced00-a231-11e8-8172-493482b959d0.png)

