### PR TITLE
Configure DismissibleTextForm for inline add-on reviews

### DIFF
--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -25,11 +25,12 @@ export type OnSubmitParams = {|
 type Props = {|
   className?: string,
   onDelete?: null | (() => void),
-  onDismiss: () => void,
+  onDismiss?: () => void,
   onSubmit: (params: OnSubmitParams) => void,
   isSubmitting?: boolean,
   microButtons?: boolean,
   placeholder?: string,
+  puffyButtons?: boolean,
   submitButtonClassName?: string,
   submitButtonText?: string,
   submitButtonInProgressText?: string,
@@ -59,6 +60,8 @@ export class DismissibleTextFormBase extends React.Component<
 
   static defaultProps = {
     isSubmitting: false,
+    microButtons: false,
+    puffyButtons: false,
   };
 
   constructor(props: InternalProps) {
@@ -81,9 +84,11 @@ export class DismissibleTextFormBase extends React.Component<
   };
 
   onDismiss = (event: SyntheticEvent<any>) => {
+    const { onDismiss } = this.props;
     event.preventDefault();
+    invariant(onDismiss, 'onDismiss() is required');
 
-    this.props.onDismiss();
+    onDismiss();
   };
 
   onSubmit = (event: SyntheticEvent<any>) => {
@@ -103,7 +108,9 @@ export class DismissibleTextFormBase extends React.Component<
       isSubmitting,
       microButtons,
       onDelete,
+      onDismiss,
       placeholder,
+      puffyButtons,
       submitButtonClassName,
       submitButtonText,
       submitButtonInProgressText,
@@ -122,6 +129,11 @@ export class DismissibleTextFormBase extends React.Component<
         submitButtonInProgressText || i18n.gettext('Submitting'),
     };
 
+    invariant(
+      !(microButtons && puffyButtons),
+      'microButtons and puffyButtons cannot both be true; choose one',
+    );
+
     return (
       <form className={makeClassName('DismissibleTextForm-form', className)}>
         <Textarea
@@ -139,15 +151,17 @@ export class DismissibleTextFormBase extends React.Component<
             These buttons each have an href so that they become anchor tags.
             This prevents mobile taps from triggering their hover styles.
           */}
-          <Button
-            href="#cancel"
-            onClick={this.onDismiss}
-            className="DismissibleTextForm-dismiss"
-            disabled={isSubmitting}
-            type="cancel"
-          >
-            {i18n.gettext('Cancel')}
-          </Button>
+          {onDismiss && (
+            <Button
+              href="#cancel"
+              onClick={this.onDismiss}
+              className="DismissibleTextForm-dismiss"
+              disabled={isSubmitting}
+              type="cancel"
+            >
+              {i18n.gettext('Cancel')}
+            </Button>
+          )}
           <span className="DismissibleTextForm-delete-submit-buttons">
             {onDelete && (
               <Button
@@ -157,6 +171,7 @@ export class DismissibleTextFormBase extends React.Component<
                 href="#delete"
                 onClick={this.onDelete}
                 micro={microButtons}
+                puffy={puffyButtons}
               >
                 {i18n.gettext('Delete')}
               </Button>
@@ -171,6 +186,7 @@ export class DismissibleTextFormBase extends React.Component<
               href="#submit"
               onClick={this.onSubmit}
               micro={microButtons}
+              puffy={puffyButtons}
             >
               {isSubmitting
                 ? text.submitButtonInProgressText

--- a/tests/unit/ui/components/TestDismissibleTextForm.js
+++ b/tests/unit/ui/components/TestDismissibleTextForm.js
@@ -263,11 +263,26 @@ describe(__filename, () => {
     expect(root.find('.DismissibleTextForm-submit')).toHaveProp('micro', true);
   });
 
-  it('creates non-micro buttons by default', () => {
+  it('creates puffy buttons when requested', () => {
+    const root = shallowRender({ puffyButtons: true, onDelete: sinon.stub() });
+
+    expect(root.find('.DismissibleTextForm-delete')).toHaveProp('puffy', true);
+    expect(root.find('.DismissibleTextForm-submit')).toHaveProp('puffy', true);
+  });
+
+  it('creates non-micro, non-puffy buttons by default', () => {
     const root = shallowRender({ onDelete: sinon.stub() });
 
     expect(root.find('.DismissibleTextForm-delete')).toHaveProp('micro', false);
     expect(root.find('.DismissibleTextForm-submit')).toHaveProp('micro', false);
+    expect(root.find('.DismissibleTextForm-delete')).toHaveProp('puffy', false);
+    expect(root.find('.DismissibleTextForm-submit')).toHaveProp('puffy', false);
+  });
+
+  it('cannot create conflicting button types', () => {
+    expect(() => {
+      shallowRender({ puffyButtons: true, microButtons: true });
+    }).toThrow(/microButtons and puffyButtons cannot both be true/);
   });
 
   it('disables the delete button when there is no text', () => {
@@ -309,18 +324,5 @@ describe(__filename, () => {
     const root = shallowRender({ onDismiss: undefined });
 
     expect(root.find('.DismissibleTextForm-dismiss')).toHaveLength(0);
-  });
-
-  it('can render puffy buttons', () => {
-    const root = shallowRender({ puffyButtons: true, onDelete: () => {} });
-
-    expect(root.find('.DismissibleTextForm-delete')).toHaveProp('puffy', true);
-    expect(root.find('.DismissibleTextForm-submit')).toHaveProp('puffy', true);
-  });
-
-  it('cannot render conflicting button types', () => {
-    expect(() => {
-      shallowRender({ puffyButtons: true, microButtons: true });
-    }).toThrow(/microButtons and puffyButtons cannot both be true/);
   });
 });

--- a/tests/unit/ui/components/TestDismissibleTextForm.js
+++ b/tests/unit/ui/components/TestDismissibleTextForm.js
@@ -304,4 +304,23 @@ describe(__filename, () => {
     sinon.assert.called(event.preventDefault);
     sinon.assert.called(onDelete);
   });
+
+  it('can hide the cancel/dismiss button', () => {
+    const root = shallowRender({ onDismiss: undefined });
+
+    expect(root.find('.DismissibleTextForm-dismiss')).toHaveLength(0);
+  });
+
+  it('can render puffy buttons', () => {
+    const root = shallowRender({ puffyButtons: true, onDelete: () => {} });
+
+    expect(root.find('.DismissibleTextForm-delete')).toHaveProp('puffy', true);
+    expect(root.find('.DismissibleTextForm-submit')).toHaveProp('puffy', true);
+  });
+
+  it('cannot render conflicting button types', () => {
+    expect(() => {
+      shallowRender({ puffyButtons: true, microButtons: true });
+    }).toThrow(/microButtons and puffyButtons cannot both be true/);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5976

I need to hide the cancel / dismiss button and make the submit button puffy.