### PR TITLE
Add missing id to input file

### DIFF
--- a/src/amo/components/UserProfileEditPicture/index.js
+++ b/src/amo/components/UserProfileEditPicture/index.js
@@ -80,6 +80,7 @@ export class UserProfileEditPictureBase extends React.Component<InternalProps> {
             accept="image/png, image/jpeg"
             className="UserProfileEditPicture-file-input"
             disabled={!user}
+            id={name}
             name={name}
             onBlur={this.onBlur}
             onChange={onSelect}


### PR DESCRIPTION
Fix #6006

---

To get rid of ESLint errors, I added `htmlFor` but `id` was missing on
the `input`, causing a mismatch leading to the (fake) button never
calling the underlying input file anymore.