### PR TITLE
Saga/Reducer for flashing review related messages

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -18,6 +18,8 @@ export const FETCH_GROUPED_RATINGS: 'FETCH_GROUPED_RATINGS' =
   'FETCH_GROUPED_RATINGS';
 export const FETCH_REVIEWS: 'FETCH_REVIEWS' = 'FETCH_REVIEWS';
 export const FETCH_USER_REVIEWS: 'FETCH_USER_REVIEWS' = 'FETCH_USER_REVIEWS';
+export const FLASH_REVIEW_MESSAGE: 'FLASH_REVIEW_MESSAGE' =
+  'FLASH_REVIEW_MESSAGE';
 export const HIDE_EDIT_REVIEW_FORM: 'HIDE_EDIT_REVIEW_FORM' =
   'HIDE_EDIT_REVIEW_FORM';
 export const HIDE_REPLY_TO_REVIEW_FORM: 'HIDE_REPLY_TO_REVIEW_FORM' =
@@ -582,5 +584,32 @@ export const updateAddonReview = ({
   return {
     type: UPDATE_ADDON_REVIEW,
     payload: { body, errorHandlerId, rating, reviewId },
+  };
+};
+
+export const ABORTED: 'aborted' = 'aborted';
+export const SAVED_RATING: 'saved-rating' = 'saved-rating';
+export const SAVED_REVIEW: 'saved-review' = 'saved-review';
+export const STARTED_SAVE_RATING: 'started-save-rating' = 'started-save-rating';
+export const STARTED_SAVE_REVIEW: 'started-save-review' = 'started-save-review';
+
+export type FlashMessageType =
+  | typeof ABORTED
+  | typeof SAVED_RATING
+  | typeof SAVED_REVIEW
+  | typeof STARTED_SAVE_RATING
+  | typeof STARTED_SAVE_REVIEW;
+
+export type FlashReviewMessageAction = {|
+  type: typeof FLASH_REVIEW_MESSAGE,
+  payload: { message: FlashMessageType | void },
+|};
+
+export const flashReviewMessage = (
+  message: FlashMessageType | void,
+): FlashReviewMessageAction => {
+  return {
+    type: FLASH_REVIEW_MESSAGE,
+    payload: { message },
   };
 };

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -594,6 +594,7 @@ export const STARTED_SAVE_RATING: 'started-save-rating' = 'started-save-rating';
 export const STARTED_SAVE_REVIEW: 'started-save-review' = 'started-save-review';
 
 export type FlashMessageType =
+  | void
   | typeof ABORTED
   | typeof SAVED_RATING
   | typeof SAVED_REVIEW
@@ -602,11 +603,11 @@ export type FlashMessageType =
 
 export type FlashReviewMessageAction = {|
   type: typeof FLASH_REVIEW_MESSAGE,
-  payload: { message: FlashMessageType | void },
+  payload: { message: FlashMessageType },
 |};
 
 export const flashReviewMessage = (
-  message: FlashMessageType | void,
+  message: FlashMessageType,
 ): FlashReviewMessageAction => {
   return {
     type: FLASH_REVIEW_MESSAGE,

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -20,6 +20,8 @@ export const FETCH_REVIEWS: 'FETCH_REVIEWS' = 'FETCH_REVIEWS';
 export const FETCH_USER_REVIEWS: 'FETCH_USER_REVIEWS' = 'FETCH_USER_REVIEWS';
 export const FLASH_REVIEW_MESSAGE: 'FLASH_REVIEW_MESSAGE' =
   'FLASH_REVIEW_MESSAGE';
+export const HIDE_FLASHED_REVIEW_MESSAGE: 'HIDE_FLASHED_REVIEW_MESSAGE' =
+  'HIDE_FLASHED_REVIEW_MESSAGE';
 export const HIDE_EDIT_REVIEW_FORM: 'HIDE_EDIT_REVIEW_FORM' =
   'HIDE_EDIT_REVIEW_FORM';
 export const HIDE_REPLY_TO_REVIEW_FORM: 'HIDE_REPLY_TO_REVIEW_FORM' =
@@ -594,7 +596,6 @@ export const STARTED_SAVE_RATING: 'started-save-rating' = 'started-save-rating';
 export const STARTED_SAVE_REVIEW: 'started-save-review' = 'started-save-review';
 
 export type FlashMessageType =
-  | void
   | typeof ABORTED
   | typeof SAVED_RATING
   | typeof SAVED_REVIEW
@@ -609,8 +610,20 @@ export type FlashReviewMessageAction = {|
 export const flashReviewMessage = (
   message: FlashMessageType,
 ): FlashReviewMessageAction => {
+  invariant(message, 'message is required');
+
   return {
     type: FLASH_REVIEW_MESSAGE,
     payload: { message },
+  };
+};
+
+export type HideFlashedReviewMessageAction = {|
+  type: typeof HIDE_FLASHED_REVIEW_MESSAGE,
+|};
+
+export const hideFlashedReviewMessage = (): HideFlashedReviewMessageAction => {
+  return {
+    type: HIDE_FLASHED_REVIEW_MESSAGE,
   };
 };

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -4,6 +4,7 @@ import { oneLine } from 'common-tags';
 import {
   CLEAR_ADDON_REVIEWS,
   FLASH_REVIEW_MESSAGE,
+  HIDE_FLASHED_REVIEW_MESSAGE,
   SEND_REPLY_TO_REVIEW,
   SEND_REVIEW_FLAG,
   SET_ADDON_REVIEWS,
@@ -25,6 +26,7 @@ import type {
   FlagReviewAction,
   FlashMessageType,
   HideEditReviewFormAction,
+  HideFlashedReviewMessageAction,
   HideReplyToReviewFormAction,
   ReviewWasFlaggedAction,
   SendReplyToReviewAction,
@@ -272,6 +274,7 @@ type ReviewActionType =
   | FlagReviewAction
   | FlashReviewMessageAction
   | HideEditReviewFormAction
+  | HideFlashedReviewMessageAction
   | HideReplyToReviewFormAction
   | ReviewWasFlaggedAction
   | SendReplyToReviewAction
@@ -474,6 +477,12 @@ export default function reviewsReducer(
       return {
         ...state,
         flashMessage: payload.message,
+      };
+    }
+    case HIDE_FLASHED_REVIEW_MESSAGE: {
+      return {
+        ...state,
+        flashMessage: undefined,
       };
     }
     default:

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -3,6 +3,7 @@ import { oneLine } from 'common-tags';
 
 import {
   CLEAR_ADDON_REVIEWS,
+  FLASH_REVIEW_MESSAGE,
   SEND_REPLY_TO_REVIEW,
   SEND_REVIEW_FLAG,
   SET_ADDON_REVIEWS,
@@ -22,6 +23,7 @@ import {
 import type {
   ClearAddonReviewsAction,
   FlagReviewAction,
+  FlashMessageType,
   HideEditReviewFormAction,
   HideReplyToReviewFormAction,
   ReviewWasFlaggedAction,
@@ -30,6 +32,7 @@ import type {
   SetInternalReviewAction,
   SetLatestReviewAction,
   SetGroupedRatingsAction,
+  FlashReviewMessageAction,
   SetReviewAction,
   SetReviewReplyAction,
   SetUserReviewsAction,
@@ -91,6 +94,8 @@ export type ReviewsState = {|
   view: {
     [reviewId: number]: ViewStateByReviewId,
   },
+  // Short-lived messages about reviews.
+  flashMessage?: FlashMessageType,
 |};
 
 export const initialState: ReviewsState = {
@@ -263,8 +268,11 @@ export const addReviewToState = ({
 
 type ReviewActionType =
   | ClearAddonReviewsAction
+  | FlagReviewAction
+  | FlashReviewMessageAction
   | HideEditReviewFormAction
   | HideReplyToReviewFormAction
+  | ReviewWasFlaggedAction
   | SendReplyToReviewAction
   | SetAddonReviewsAction
   | SetGroupedRatingsAction
@@ -274,9 +282,7 @@ type ReviewActionType =
   | SetReviewReplyAction
   | SetUserReviewsAction
   | ShowEditReviewFormAction
-  | ShowReplyToReviewFormAction
-  | FlagReviewAction
-  | ReviewWasFlaggedAction;
+  | ShowReplyToReviewFormAction;
 
 export default function reviewsReducer(
   state: ReviewsState = initialState,
@@ -460,6 +466,13 @@ export default function reviewsReducer(
           ...state.groupedRatings,
           [payload.addonId]: payload.grouping,
         },
+      };
+    }
+    case FLASH_REVIEW_MESSAGE: {
+      const { payload } = action;
+      return {
+        ...state,
+        flashMessage: payload.message,
       };
     }
     default:

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -106,6 +106,7 @@ export const initialState: ReviewsState = {
   groupedRatings: {},
   // This stores review-related UI state.
   view: {},
+  flashMessage: undefined,
 };
 
 export const selectReview = (

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -57,7 +57,7 @@ import type {
 } from 'amo/actions/reviews';
 
 // Number of millesconds that a message should be flashed on screen.
-export const FLASH_MESSAGE_DURATION = 2000;
+export const FLASH_SAVED_MESSAGE_DURATION = 2000;
 
 function* fetchReviews({
   payload: { errorHandlerId, addonSlug, page },
@@ -262,7 +262,9 @@ function* manageAddonReview(
     }
 
     // Make the message disappear after some time.
-    yield new Promise((resolve) => setTimeout(resolve, FLASH_MESSAGE_DURATION));
+    yield new Promise((resolve) =>
+      setTimeout(resolve, FLASH_SAVED_MESSAGE_DURATION),
+    );
     yield put(flashReviewMessage(undefined));
   } catch (error) {
     log.warn(

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -28,6 +28,7 @@ import {
   STARTED_SAVE_REVIEW,
   UPDATE_ADDON_REVIEW,
   flashReviewMessage,
+  hideFlashedReviewMessage,
   hideReplyToReviewForm,
   setAddonReviews,
   setGroupedRatings,
@@ -268,7 +269,7 @@ function* manageAddonReview(
 
     // Make the message disappear after some time.
     yield _delay(FLASH_SAVED_MESSAGE_DURATION);
-    yield put(flashReviewMessage(undefined));
+    yield put(hideFlashedReviewMessage());
   } catch (error) {
     log.warn(
       `Failed to create/update review with action ${action.type}: ${error}`,

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -4,6 +4,7 @@ import {
   createInternalReview,
   flagReview,
   hideEditReviewForm,
+  hideFlashedReviewMessage,
   hideReplyToReviewForm,
   sendReplyToReview,
   setAddonReviews,
@@ -997,12 +998,14 @@ describe(__filename, () => {
       const state = reviewsReducer(undefined, flashReviewMessage(SAVED_RATING));
       expect(state.flashMessage).toEqual(SAVED_RATING);
     });
+  });
 
+  describe('hideFlashedReviewMessage', () => {
     it('unsets a message', () => {
       let state;
 
       state = reviewsReducer(state, flashReviewMessage(SAVED_RATING));
-      state = reviewsReducer(state, flashReviewMessage(undefined));
+      state = reviewsReducer(state, hideFlashedReviewMessage());
 
       expect(state.flashMessage).toEqual(undefined);
     });

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -1,4 +1,5 @@
 import {
+  SAVED_RATING,
   clearAddonReviews,
   createInternalReview,
   flagReview,
@@ -9,6 +10,7 @@ import {
   setGroupedRatings,
   setInternalReview,
   setLatestReview,
+  flashReviewMessage,
   setReview,
   setReviewReply,
   setReviewWasFlagged,
@@ -987,6 +989,22 @@ describe(__filename, () => {
       );
 
       expect(state.groupedRatings[firstAddonId]).toEqual(firstGrouping);
+    });
+  });
+
+  describe('flashReviewMessage', () => {
+    it('flashes a message', () => {
+      const state = reviewsReducer(undefined, flashReviewMessage(SAVED_RATING));
+      expect(state.flashMessage).toEqual(SAVED_RATING);
+    });
+
+    it('unsets a message', () => {
+      let state;
+
+      state = reviewsReducer(state, flashReviewMessage(SAVED_RATING));
+      state = reviewsReducer(state, flashReviewMessage(undefined));
+
+      expect(state.flashMessage).toEqual(undefined);
     });
   });
 });

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -29,7 +29,7 @@ import {
   REVIEW_FLAG_REASON_SPAM,
 } from 'amo/constants';
 import reviewsReducer from 'amo/reducers/reviews';
-import reviewsSaga, { FLASH_MESSAGE_DURATION } from 'amo/sagas/reviews';
+import reviewsSaga, { FLASH_SAVED_MESSAGE_DURATION } from 'amo/sagas/reviews';
 import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import apiReducer from 'core/reducers/api';
 import {
@@ -667,7 +667,7 @@ describe(__filename, () => {
         matchMessage(flashReviewMessage(SAVED_REVIEW)),
       );
 
-      clock.tick(FLASH_MESSAGE_DURATION);
+      clock.tick(FLASH_SAVED_MESSAGE_DURATION);
 
       const expectedAction = flashReviewMessage(undefined);
       await matchingSagaAction(sagaTester, matchMessage(expectedAction));

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -13,6 +13,7 @@ import {
   fetchReviews,
   fetchUserReviews,
   flagReview,
+  hideFlashedReviewMessage,
   hideReplyToReviewForm,
   sendReplyToReview,
   setAddonReviews,
@@ -657,8 +658,9 @@ describe(__filename, () => {
 
       _updateAddonReview({ body });
 
-      const expectedAction = flashReviewMessage(undefined);
-      await matchingSagaAction(sagaTester, matchMessage(expectedAction));
+      const expectedAction = hideFlashedReviewMessage();
+      const action = await sagaTester.waitFor(expectedAction.type);
+      expect(action).toEqual(expectedAction);
 
       sinon.assert.calledWith(fakeSagaDelay, FLASH_SAVED_MESSAGE_DURATION);
     });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -698,6 +698,11 @@ const globalSetTimeout = setTimeout;
 /*
  * Wait until the saga dispatches an action causing isMatch(action)
  * to return true. Throw an error if it doesn't.
+ *
+ * This is helpful for when a saga dispatches the same action
+ * but with differing payloads.
+ *
+ * For most cases you can probably just use sagaTester.waitFor() instead.
  */
 export async function matchingSagaAction(
   sagaTester,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -727,7 +727,7 @@ export async function matchingSagaAction(
 
       The saga called these action types: ${calledActions
         .map((action) => action.type)
-        .join(', ') || '[none at all]'}`,
+        .join(', ') || '(none at all)'}`,
     );
   }
 }

--- a/tests/unit/test_helpers.js
+++ b/tests/unit/test_helpers.js
@@ -2,8 +2,19 @@
 import { shallow } from 'enzyme';
 import React, { Component } from 'react';
 import { compose } from 'redux';
+import SagaTester from 'redux-saga-tester';
 
-import { shallowUntilTarget } from 'tests/unit/helpers';
+// Disabled because of
+// https://github.com/benmosher/eslint-plugin-import/issues/793
+/* eslint-disable import/order */
+import { put, takeLatest } from 'redux-saga/effects';
+/* eslint-enable import/order */
+
+import {
+  matchingSagaAction,
+  shallowUntilTarget,
+  unexpectedSuccess,
+} from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('shallowUntilTarget', () => {
@@ -129,6 +140,112 @@ describe(__filename, () => {
       root.setProps({ something: 'else' });
 
       sinon.assert.called(componentDidUpdate);
+    });
+  });
+
+  describe('matchingSagaAction', () => {
+    const START_EXAMPLE = '@@addons-frontend/start-example';
+    const EXAMPLE_ACTION = '@@addons-frontend/example-action';
+
+    function startSagaTester(handler, { startSaga = true } = {}) {
+      const sagaTester = new SagaTester({
+        initialState: {},
+        reducers: { example: (state = {}) => state },
+      });
+
+      function* exampleSaga() {
+        yield takeLatest(START_EXAMPLE, handler);
+      }
+
+      sagaTester.start(exampleSaga);
+      if (startSaga) {
+        sagaTester.dispatch({ type: START_EXAMPLE });
+      }
+
+      return sagaTester;
+    }
+
+    it('waits for a matched action', async () => {
+      function* exampleHandler() {
+        yield put({ type: EXAMPLE_ACTION, payload: { order: 'first' } });
+        yield put({ type: EXAMPLE_ACTION, payload: { order: 'second' } });
+      }
+
+      const sagaTester = startSagaTester(exampleHandler);
+
+      await matchingSagaAction(sagaTester, (action) => {
+        return (
+          action.type === EXAMPLE_ACTION && action.payload.order === 'second'
+        );
+      });
+    });
+
+    it('gives up matching the action after maxTries', async () => {
+      // eslint-disable-next-line no-empty-function
+      function* exampleHandler() {}
+
+      const sagaTester = startSagaTester(exampleHandler);
+
+      let error;
+
+      await matchingSagaAction(sagaTester, () => false, {
+        maxTries: 4,
+      }).then(unexpectedSuccess, (caughtError) => {
+        error = caughtError;
+      });
+
+      expect(error.message).toMatch(/matcher function did not return true/);
+    });
+
+    it('tells you which actions were dispatched on error', async () => {
+      const actionTypes = [
+        '@@addons-frontend/first-action',
+        '@@addons-frontend/second-action',
+        '@@addons-frontend/third-action',
+      ];
+
+      function* exampleHandler() {
+        for (const actionType of actionTypes) {
+          yield put({ type: actionType });
+        }
+      }
+
+      const sagaTester = startSagaTester(exampleHandler);
+
+      let error;
+
+      await matchingSagaAction(sagaTester, () => false, {
+        maxTries: 4,
+      }).then(unexpectedSuccess, (caughtError) => {
+        error = caughtError;
+      });
+
+      for (const actionType of actionTypes) {
+        expect(error.message).toContain(actionType);
+      }
+    });
+
+    it('tells you if no actions were dispatched at all', async () => {
+      function* exampleHandler() {
+        // No actions are dispatched in this handler.
+      }
+
+      const sagaTester = startSagaTester(exampleHandler, {
+        // Don't dispatch a start action.
+        startSaga: false,
+      });
+
+      let error;
+
+      await matchingSagaAction(sagaTester, () => false, {
+        maxTries: 4,
+      }).then(unexpectedSuccess, (caughtError) => {
+        error = caughtError;
+      });
+
+      expect(error.message).toMatch(
+        /saga called these action types.*none at all/,
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6012

Here's a visual of what I'd like to do with the data (below). The *saving* and *saved* message will flash on the screen temporarily. Also, the review form needs to be handled independently so I need a separate message to disable the submit button while it's in progress.

<details>
<summary>See a rough demo of the UI</summary>

![addons-frontend-inline-review mov](https://user-images.githubusercontent.com/55398/44478716-178d0d00-a604-11e8-9d1f-b0001cf2ed05.gif)


</details>