### PR TITLE
Handle zero-prefixed usernames in UserProfile

### DIFF
--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -448,7 +448,7 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
   // `getUserByUsername()` requires a string as second argument.
   let user = getUserByUsername(state.users, `${username}`);
 
-  if (!user) {
+  if (!user && /^[0-9]+$/.test(username)) {
     const userId = parseInt(username, 10);
     user = !Number.isNaN(userId) ? getUserById(state.users, userId) : undefined;
   }

--- a/tests/unit/amo/components/TestUserProfile.js
+++ b/tests/unit/amo/components/TestUserProfile.js
@@ -189,6 +189,23 @@ describe(__filename, () => {
     expect(header.find('.UserProfile-name')).toHaveText('Matt MacTofu');
   });
 
+  // See https://github.com/mozilla/addons-frontend/issues/6007
+  it('handles loading zero-prefixed usernames', () => {
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    const username = '0foxgiven';
+    const root = renderUserProfile({ params: { username }, store });
+
+    sinon.assert.calledWith(
+      dispatchSpy,
+      fetchUserAccount({
+        errorHandlerId: root.instance().props.errorHandler.id,
+        username,
+      }),
+    );
+  });
+
   it('does not render any tag if user is not a developer or artist', () => {
     const { store } = dispatchSignInActions({
       userProps: defaultUserProps({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6007

I checked all other usage of `parseInt()` and I don't think we need to fix anything else. It's surprising that `parseInt('0something', 10)` returns `0` 🤡 👯 