### PR TITLE
Upgrade to pino-devtools 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       }
     },
     "start-dev-proxy": {
-      "command": "npm run clean && concurrently 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools' 'node bin/proxy.js | pino-pretty'",
+      "command": "npm run clean && concurrently 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools --mode buffer' 'node bin/proxy.js | pino-pretty'",
       "env": {
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",
@@ -274,7 +274,7 @@
     "node-sass": "^4.5.2",
     "object.values": "^1.0.4",
     "photon-colors": "^3.0.1",
-    "pino-devtools": "^1.0.2",
+    "pino-devtools": "^2.0.0",
     "pino-pretty": "^2.0.1",
     "piping": "^1.0.0-rc.4",
     "po2json": "^0.4.5",

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -17,6 +17,12 @@ export default async function createClient(
   createStore,
   { _FastClick = FastClick, sagas = null } = {},
 ) {
+  if (config.get('isDevelopment')) {
+    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+    const { fetchBufferedLogs } = require('pino-devtools/src/client');
+    await fetchBufferedLogs();
+  }
+
   // This code needs to come before anything else so we get logs/errors if
   // anything else in this function goes wrong.
   const publicSentryDsn = config.get('publicSentryDsn');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7254,9 +7254,9 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-pino-devtools@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pino-devtools/-/pino-devtools-1.0.2.tgz#3e6eeeb53c4025606572993f61ad06a585bc5969"
+pino-devtools@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pino-devtools/-/pino-devtools-2.0.0.tgz#709b35988df1c724d6c68afa23bcb427616b2bc5"
   dependencies:
     minimist "^1.2.0"
     opn "^5.3.0"


### PR DESCRIPTION
`pino-devtools` 2.0 introduces a new mode to output the logs in the same console as the application (buffer mode), which is now used here.

![screen shot 2018-08-23 at 10 34 27](https://user-images.githubusercontent.com/217628/44514356-26d19080-a6c0-11e8-8cc0-a06744f8b798.png)
