### PR TITLE
Add jest summary reporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,10 @@ module.exports = {
     // Replaces the following formats with an empty module.
     '^.+\\.(scss|css|svg|woff|woff2|mp4|webm)$': '<rootDir>/tests/emptyModule',
   },
-  reporters: ['<rootDir>/tests/jest-reporters/fingers-crossed.js'],
+  reporters: [
+    '<rootDir>/tests/jest-reporters/fingers-crossed.js',
+    '<rootDir>/tests/jest-reporters/summary.js',
+  ],
   setupTestFrameworkScriptFile: '<rootDir>/tests/setup.js',
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',

--- a/tests/jest-reporters/summary.js
+++ b/tests/jest-reporters/summary.js
@@ -1,0 +1,5 @@
+/* eslint import/no-extraneous-dependencies: 0 */
+const SummaryReporter = require('jest-cli/build/reporters/summary_reporter')
+  .default;
+
+module.exports = SummaryReporter;


### PR DESCRIPTION
Fix #5956 

---

We cannot specify `summary` only, we have to import this reporter in our code to use it. I decided to do this because it works, and it is simple. Maybe we should look into writing a better reporter, but that works now so...