### PR TITLE
Remove disco react warnings

### DIFF
--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -8,14 +8,11 @@ import {
 } from 'core/constants';
 import { addQueryParams } from 'core/utils';
 
-const testHasWindow = () => typeof window !== 'undefined';
-
-export function hasAddonManager({ hasWindow = testHasWindow, navigator } = {}) {
-  // Returns undefined if it cannot be determined if mozAddonManager is supported (likely server
-  // rendering with no window). Otherwise returns true/false based on mozAddonManager in navigator.
-  if (!navigator && !hasWindow()) {
-    return undefined;
+export function hasAddonManager({ navigator } = {}) {
+  if (typeof window === 'undefined') {
+    return false;
   }
+
   return 'mozAddonManager' in (navigator || window.navigator);
 }
 

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -79,7 +79,7 @@ export class InstallButtonBase extends React.Component {
     getClientCompatibility: PropTypes.func,
     guid: PropTypes.string.isRequired,
     handleChange: PropTypes.func,
-    hasAddonManager: PropTypes.bool,
+    hasAddonManager: PropTypes.bool.isRequired,
     header: PropTypes.string,
     headerURL: PropTypes.string,
     i18n: PropTypes.object.isRequired,
@@ -215,10 +215,11 @@ export class InstallButtonBase extends React.Component {
       return null;
     }
 
-    // OpenSearch plugins display their own prompt so using the "Add to
-    // Firefox" button regardless on mozAddonManager support is a better UX.
     const useButton =
-      (hasAddonManager !== undefined && !hasAddonManager) ||
+      // mozAddonManager may only be available on the client.
+      (_config.get('client') && !hasAddonManager) ||
+      // OpenSearch plugins display their own prompt so using the "Add to
+      // Firefox" button regardless on mozAddonManager support is a better UX.
       addon.type === ADDON_TYPE_OPENSEARCH ||
       this.props.useButton;
     let button;

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -45,7 +45,7 @@ export class AddonBase extends React.Component {
   static propTypes = {
     _config: PropTypes.object,
     _tracking: PropTypes.object,
-    addon: PropTypes.object.isRequired,
+    addon: PropTypes.object,
     clientApp: PropTypes.string.isRequired,
     // This is added by withInstallHelpers()
     defaultInstallSource: PropTypes.string.isRequired,
@@ -326,13 +326,14 @@ export class AddonBase extends React.Component {
 export function mapStateToProps(state, ownProps) {
   // `ownProps.guid` is already "normalized" with `getGuid()` in the
   // `DiscoPane` container component.
-  const installation = state.installations[ownProps.guid];
+  const installation = state.installations[ownProps.guid] || {};
   const addon = getAddonByGUID(state, ownProps.guid);
 
   return {
     addon,
     ...addon,
     ...installation,
+    status: installation.status || UNKNOWN,
     clientApp: state.api.clientApp,
     // This is required by the `withInstallHelpers()` HOC, apparently...
     platformFiles: addon ? addon.platformFiles : {},

--- a/src/disco/components/DiscoPane/index.js
+++ b/src/disco/components/DiscoPane/index.js
@@ -38,6 +38,7 @@ export class DiscoPaneBase extends React.Component {
     }).isRequired,
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     _addChangeListeners: PropTypes.func,
+    _config: PropTypes.object,
     _tracking: PropTypes.object,
   };
 
@@ -45,6 +46,7 @@ export class DiscoPaneBase extends React.Component {
     AddonComponent: Addon,
     mozAddonManager: config.get('server') ? {} : navigator.mozAddonManager,
     _addChangeListeners: addChangeListeners,
+    _config: config,
     _tracking: tracking,
   };
 
@@ -81,9 +83,15 @@ export class DiscoPaneBase extends React.Component {
   componentDidMount() {
     const {
       _addChangeListeners,
+      _config,
       handleGlobalEvent,
       mozAddonManager,
     } = this.props;
+
+    if (_config.get('server')) {
+      return;
+    }
+
     // Use addonManager.addChangeListener to setup and filter events.
     _addChangeListeners(handleGlobalEvent, mozAddonManager);
   }
@@ -188,14 +196,10 @@ export function mapStateToProps(state) {
   };
 }
 
-export function mapDispatchToProps(dispatch, { _config = config } = {}) {
-  const props = { dispatch };
-  if (_config.get('server')) {
-    return props;
-  }
+export function mapDispatchToProps(dispatch) {
   return {
-    ...props,
-    handleGlobalEvent(payload) {
+    dispatch,
+    handleGlobalEvent: (payload) => {
       dispatch({ type: INSTALL_STATE, payload });
     },
   };

--- a/src/disco/components/DiscoPane/index.js
+++ b/src/disco/components/DiscoPane/index.js
@@ -83,14 +83,9 @@ export class DiscoPaneBase extends React.Component {
   componentDidMount() {
     const {
       _addChangeListeners,
-      _config,
       handleGlobalEvent,
       mozAddonManager,
     } = this.props;
-
-    if (_config.get('server')) {
-      return;
-    }
 
     // Use addonManager.addChangeListener to setup and filter events.
     _addChangeListeners(handleGlobalEvent, mozAddonManager);

--- a/src/disco/components/DiscoPane/index.js
+++ b/src/disco/components/DiscoPane/index.js
@@ -38,7 +38,6 @@ export class DiscoPaneBase extends React.Component {
     }).isRequired,
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     _addChangeListeners: PropTypes.func,
-    _config: PropTypes.object,
     _tracking: PropTypes.object,
   };
 
@@ -46,7 +45,6 @@ export class DiscoPaneBase extends React.Component {
     AddonComponent: Addon,
     mozAddonManager: config.get('server') ? {} : navigator.mozAddonManager,
     _addChangeListeners: addChangeListeners,
-    _config: config,
     _tracking: tracking,
   };
 

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -55,6 +55,7 @@ describe(__filename, () => {
   });
 
   const renderProps = (customProps = {}) => ({
+    _config: getFakeConfig({ client: true }),
     addon: createInternalAddon(fakeAddon),
     getClientCompatibility: () => ({ compatible: true }),
     hasAddonManager: true,

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -43,13 +43,7 @@ describe(__filename, () => {
     });
 
     it('is false if mozAddonManager is not in navigator', () => {
-      expect(addonManager.hasAddonManager()).toBeFalsy();
-    });
-
-    it('is undefined if there is no window', () => {
-      expect(addonManager.hasAddonManager({ hasWindow: () => false })).toEqual(
-        undefined,
-      );
+      expect(addonManager.hasAddonManager()).toEqual(false);
     });
   });
 

--- a/tests/unit/disco/components/TestDiscoPane.js
+++ b/tests/unit/disco/components/TestDiscoPane.js
@@ -31,7 +31,6 @@ import {
   createFakeTracking,
   createStubErrorHandler,
   fakeI18n,
-  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import {
@@ -319,23 +318,12 @@ describe(__filename, () => {
   });
 
   describe('componentDidMount', () => {
-    it('does not set events on the server', () => {
-      const _config = getFakeConfig({ server: true });
-      const fakeMozAddonManager = {
-        addEventListener: sinon.stub(),
-      };
-
-      renderAndMount({ _config, mozAddonManager: fakeMozAddonManager });
-      sinon.assert.notCalled(fakeMozAddonManager.addEventListener);
-    });
-
     it('sets events on the client', () => {
-      const _config = getFakeConfig({ server: false });
       const fakeMozAddonManager = {
         addEventListener: sinon.stub(),
       };
 
-      renderAndMount({ _config, mozAddonManager: fakeMozAddonManager });
+      renderAndMount({ mozAddonManager: fakeMozAddonManager });
       sinon.assert.callCount(
         fakeMozAddonManager.addEventListener,
         GLOBAL_EVENTS.length,

--- a/tests/unit/disco/components/TestDiscoPane.js
+++ b/tests/unit/disco/components/TestDiscoPane.js
@@ -318,7 +318,7 @@ describe(__filename, () => {
   });
 
   describe('componentDidMount', () => {
-    it('sets events on the client', () => {
+    it('sets events', () => {
       const fakeMozAddonManager = {
         addEventListener: sinon.stub(),
       };


### PR DESCRIPTION
Fix #6059

---

This PR removes react warnings in the disco app, mostly by fixing invalid prop types.