### PR TITLE
Fix CSP for disco and amo locally

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -34,18 +34,26 @@ module.exports = {
         sentryHost,
         webpackHost,
       ],
+      fontSrc: [
+        webpackHost,
+      ],
       imgSrc: [
         "'self'",
+        'data:',
+        amoDevCDN,
         webpackHost,
       ],
       scriptSrc: [
         "'self'",
+        // webpack injects inline JS
+        "'unsafe-inline'",
         amoDevCDN,
         webpackHost,
       ],
       styleSrc: [
         "'self'",
-        'blob:',
+        // webpack injects inline CSS
+        "'unsafe-inline'",
       ],
     },
     reportOnly: true,

--- a/package.json
+++ b/package.json
@@ -62,8 +62,6 @@
       "env": {
         "AMO_CDN": "https://addons-dev-cdn.allizom.org",
         "PROXY_API_HOST": "https://addons-dev.allizom.org",
-        "FXA_CONFIG": "local",
-        "CSP": false,
         "NODE_APP_INSTANCE": "amo"
       }
     },

--- a/src/core/middleware/security.js
+++ b/src/core/middleware/security.js
@@ -37,7 +37,7 @@ export function csp({ _config = config, noScriptStyles, _log = log } = {}) {
     _config.get('CSP') !== 'false' ? deepcopy(_config.get('CSP')) : false;
 
   if (cspConfig) {
-    if (noScriptStyles) {
+    if (noScriptStyles && !_config.get('isDevelopment')) {
       const hash = crypto
         .createHash('sha256')
         .update(noScriptStyles)

--- a/src/core/middleware/security.js
+++ b/src/core/middleware/security.js
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
+import { oneLine } from 'common-tags';
 import helmet from 'helmet';
 import config from 'config';
 import deepcopy from 'deepcopy';
@@ -37,18 +38,23 @@ export function csp({ _config = config, noScriptStyles, _log = log } = {}) {
     _config.get('CSP') !== 'false' ? deepcopy(_config.get('CSP')) : false;
 
   if (cspConfig) {
-    if (noScriptStyles && !_config.get('isDevelopment')) {
-      const hash = crypto
-        .createHash('sha256')
-        .update(noScriptStyles)
-        .digest('base64');
+    if (noScriptStyles) {
+      if (!_config.get('isDevelopment')) {
+        const hash = crypto
+          .createHash('sha256')
+          .update(noScriptStyles)
+          .digest('base64');
 
-      const cspValue = `'sha256-${hash}'`;
-      if (
-        cspConfig.directives &&
-        !cspConfig.directives.styleSrc.includes(cspValue)
-      ) {
-        cspConfig.directives.styleSrc.push(cspValue);
+        const cspValue = `'sha256-${hash}'`;
+        if (
+          cspConfig.directives &&
+          !cspConfig.directives.styleSrc.includes(cspValue)
+        ) {
+          cspConfig.directives.styleSrc.push(cspValue);
+        }
+      } else {
+        _log.debug(oneLine`CSP style-src hash has been omitted to allow
+          "unsafe-inline" in development`);
       }
     }
 

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -44,7 +44,7 @@ for (const app of appsBuildList) {
 }
 
 export default Object.assign({}, webpackConfig, {
-  devtool: 'cheap-module-eval-source-map',
+  devtool: 'cheap-module-source-map',
   context: path.resolve(__dirname),
   entry: entryPoints,
   output: Object.assign({}, webpackConfig.output, {


### PR DESCRIPTION
Fix #2984

---

Explanations in comments.

I got a lot of CSP issues in the disco app locally, so I investigated a bit. It turned out that amo had CSP disabled locally but not disco. I tried to fix the CSP errors for disco and tried to enable CSP on amo, which actually worked.