### PR TITLE
Add INACTIVE status for extensions

### DIFF
--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -15,6 +15,7 @@ import {
   DOWNLOADING,
   ENABLED,
   ENABLING,
+  INACTIVE,
   INSTALLED,
   INSTALLING,
   INSTALL_ACTION,
@@ -212,6 +213,7 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
         return i18n.gettext('Installing');
       case UNINSTALLING:
         return i18n.gettext('Uninstalling');
+      case INACTIVE:
       default:
         return isTheme(addon.type)
           ? i18n.gettext('Install Theme')

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -7,6 +7,7 @@ export const DOWNLOADING = 'DOWNLOADING';
 export const ENABLED = 'ENABLED';
 export const ENABLING = 'ENABLING';
 export const ERROR = 'ERROR';
+export const INACTIVE = 'INACTIVE';
 export const INSTALLED = 'INSTALLED';
 export const INSTALLING = 'INSTALLING';
 export const UNINSTALLED = 'UNINSTALLED';
@@ -15,11 +16,12 @@ export const UNKNOWN = 'UNKNOWN';
 export const validInstallStates = [
   DISABLED,
   DISABLING,
-  ENABLED,
-  ENABLING,
   DOWNLOADING,
   ENABLED,
+  ENABLED,
+  ENABLING,
   ERROR,
+  INACTIVE,
   INSTALLED,
   INSTALLING,
   UNINSTALLED,

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -12,6 +12,7 @@ import {
   DOWNLOADING,
   ENABLED,
   ENABLING,
+  INACTIVE,
   INSTALLED,
   INSTALLING,
   INSTALL_STARTED_ACTION,
@@ -476,6 +477,14 @@ describe(__filename, () => {
     expect(icon).toHaveProp('name', 'plus-dark');
 
     expect(root.find(AnimatedIcon)).toHaveLength(0);
+  });
+
+  it('renders a "Add to Firefox" button when add-on is INACTIVE', () => {
+    const root = render({ status: INACTIVE });
+
+    const button = root.find(Button);
+    expect(button).toHaveLength(1);
+    expect(button.childAt(1)).toHaveText('Add to Firefox');
   });
 
   it.each([DOWNLOADING, ENABLING, INSTALLING, UNINSTALLING])(

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -18,6 +18,7 @@ import {
   FATAL_ERROR,
   FATAL_INSTALL_ERROR,
   FATAL_UNINSTALL_ERROR,
+  INACTIVE,
   INSTALL_ACTION,
   INSTALL_CANCELLED,
   INSTALL_STARTED_ACTION,
@@ -181,7 +182,6 @@ describe(__filename, () => {
       getAddon: Promise.resolve({
         isActive: true,
         isEnabled: true,
-        type: ADDON_TYPE_EXTENSION,
       }),
     });
 
@@ -205,7 +205,6 @@ describe(__filename, () => {
       getAddon: Promise.resolve({
         isActive: true,
         isEnabled: true,
-        type: ADDON_TYPE_EXTENSION,
       }),
     });
 
@@ -238,7 +237,6 @@ describe(__filename, () => {
       getAddon: Promise.resolve({
         isActive: true,
         isEnabled: true,
-        type: ADDON_TYPE_EXTENSION,
       }),
     });
 
@@ -704,7 +702,6 @@ describe(__filename, () => {
             getAddon: Promise.resolve({
               isActive: false,
               isEnabled: false,
-              type: ADDON_TYPE_EXTENSION,
             }),
           }),
         });
@@ -722,11 +719,45 @@ describe(__filename, () => {
         });
       });
 
-      it('sets the status to DISABLED when an inactive add-on found', () => {
+      it('sets the status to DISABLED when the extension is inactive and disabled', () => {
         const installURL = 'http://the.url/';
         const addon = createInternalAddon(
           createFakeAddon({
             files: [{ platform: OS_ALL, url: installURL }],
+            type: ADDON_TYPE_EXTENSION,
+          }),
+        );
+
+        const { root, dispatch } = renderWithInstallHelpers({
+          ...addon,
+          defaultInstallSource: null,
+          _addonManager: getFakeAddonManagerWrapper({
+            getAddon: Promise.resolve({
+              isActive: false,
+              isEnabled: false,
+            }),
+          }),
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              guid: addon.guid,
+              status: DISABLED,
+              url: installURL,
+            }),
+          );
+        });
+      });
+
+      it('sets the status to INACTIVE when an inactive extension is found', () => {
+        const installURL = 'http://the.url/';
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [{ platform: OS_ALL, url: installURL }],
+            type: ADDON_TYPE_EXTENSION,
           }),
         );
 
@@ -737,7 +768,6 @@ describe(__filename, () => {
             getAddon: Promise.resolve({
               isActive: false,
               isEnabled: true,
-              type: ADDON_TYPE_EXTENSION,
             }),
           }),
         });
@@ -748,7 +778,7 @@ describe(__filename, () => {
             dispatch,
             setInstallState({
               guid: addon.guid,
-              status: DISABLED,
+              status: INACTIVE,
               url: installURL,
             }),
           );
@@ -758,7 +788,6 @@ describe(__filename, () => {
       it('sets the status to ENABLED when an enabled theme is found', () => {
         const fakeAddonManager = getFakeAddonManagerWrapper({
           getAddon: Promise.resolve({
-            type: ADDON_TYPE_THEME,
             isActive: true,
             isEnabled: true,
           }),
@@ -767,6 +796,7 @@ describe(__filename, () => {
         const addon = createInternalAddon(
           createFakeAddon({
             files: [{ platform: OS_ALL, url: installURL }],
+            type: ADDON_TYPE_THEME,
           }),
         );
 
@@ -794,13 +824,13 @@ describe(__filename, () => {
           getAddon: Promise.resolve({
             isActive: false,
             isEnabled: true,
-            type: ADDON_TYPE_THEME,
           }),
         });
         const installURL = 'http://the.url/';
         const addon = createInternalAddon(
           createFakeAddon({
             files: [{ platform: OS_ALL, url: installURL }],
+            type: ADDON_TYPE_THEME,
           }),
         );
 
@@ -828,13 +858,13 @@ describe(__filename, () => {
           getAddon: Promise.resolve({
             isActive: true,
             isEnabled: false,
-            type: ADDON_TYPE_THEME,
           }),
         });
         const installURL = 'http://the.url/';
         const addon = createInternalAddon(
           createFakeAddon({
             files: [{ platform: OS_ALL, url: installURL }],
+            type: ADDON_TYPE_THEME,
           }),
         );
 


### PR DESCRIPTION
Partially fix #5929

---

I said "partially" because there is some work to do on the browser side. See: https://bugzilla.mozilla.org/show_bug.cgi?id=1477155#c1.

This allows to get a "Add to Firefox" button when an **extension** has been removed from "about:addons". It does not work for themes, though. 

I also fixed the test cases because `getAddonById` clearly does not return `type` as we are used to use: it is either `extension` or `theme`, not `persona`, `statictheme`, etc.