### PR TITLE
Refactor Overlay CSS to allow click everywhere

### DIFF
--- a/src/ui/components/Overlay/styles.scss
+++ b/src/ui/components/Overlay/styles.scss
@@ -5,7 +5,14 @@
 }
 
 .Overlay--visible {
-  display: block;
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100%;
 }
 
 .Overlay-background {
@@ -23,13 +30,6 @@
 }
 
 .Overlay-contents {
-  align-items: center;
   display: flex;
-  justify-content: center;
-  left: 0;
-  position: fixed;
-  top: 50%;
-  transform: translate(0, -50%);
-  width: 100%;
   z-index: 1001;
 }


### PR DESCRIPTION
Fix #5851

---

I refactored the CSS to reduce the `.Overlay-contents` area so that we
can click anywhere around the modal to close it.