### PR TITLE
apiState should not be optional in api/reviews.js - 6055

### DIFF
--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -43,7 +43,7 @@ export type ExternalReviewType = {|
 // can type check each one independently.
 export type SubmitReviewParams = {|
   addonId?: number,
-  apiState?: ApiState,
+  apiState: ApiState,
   body?: string,
   errorHandler?: ErrorHandlerType,
   rating?: number | null,
@@ -102,7 +102,7 @@ export function submitReview({
 }
 
 type ReplyToReviewParams = {|
-  apiState?: ApiState,
+  apiState: ApiState,
   body: string,
   errorHandler?: ErrorHandlerType,
   originalReviewId: number,
@@ -138,7 +138,7 @@ export const replyToReview = ({
 export type GetReviewsParams = {|
   // This is the addon ID, slug, or guid.
   addon?: number | string,
-  apiState?: ApiState,
+  apiState: ApiState,
   filter?: string,
   page?: number,
   page_size?: number,
@@ -186,7 +186,7 @@ export function getReviews({
 
 export type GetLatestReviewParams = {|
   addon: number,
-  apiState?: ApiState,
+  apiState: ApiState,
   user: number,
   version: number,
 |};
@@ -217,7 +217,7 @@ export function getLatestUserReview({
 }
 
 type FlagReviewParams = {|
-  apiState?: ApiState,
+  apiState: ApiState,
   errorHandler?: ErrorHandlerType,
   note?: string,
   reason: FlagReviewReasonType,


### PR DESCRIPTION
`Fixes #6055`
- Initial fix for apiState should not be optional in api/reviews.js
- All tests are successful.
