### PR TITLE
Add buffer mode to pino-devtools for disco

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       }
     },
     "start-dev": {
-      "command": "npm run clean && concurrently 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools'",
+      "command": "npm run clean && concurrently 'npm run webpack-dev-server' 'node bin/server.js | pino-devtools --mode buffer'",
       "env": {
         "ENABLE_PIPING": "true",
         "NODE_ENV": "development",


### PR DESCRIPTION
I forgot to add this in a previous PR. Running `yarn disco` should continue to work but we'll have the server logs in the console now :)