### PR TITLE
Show a more appropriate tooltip for current rating

### DIFF
--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -88,6 +88,12 @@ export class RatingBase extends React.Component<InternalProps, StateType> {
     invariant(starRating, 'starRating is required when readOnly=false');
 
     if (rating) {
+      if (starRating === rating) {
+        return i18n.sprintf(i18n.gettext('Rated %(rating)s out of 5'), {
+          rating: i18n.formatNumber(parseFloat(rating).toFixed(1)),
+        });
+      }
+
       return i18n.sprintf(
         i18n.gettext(`Update your rating to %(starRating)s out of 5`),
         { starRating },

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -215,14 +215,20 @@ describe(__filename, () => {
   });
 
   it('renders an appropriate title when updating a rating', () => {
-    const root = render({ rating: 3 });
+    const userRating = 3;
+    const root = render({ rating: userRating });
 
-    [1, 2, 3, 4, 5].forEach((rating) => {
+    [1, 2, 4, 5].forEach((rating) => {
       expect(getStar({ root, rating })).toHaveProp(
         'title',
         `Update your rating to ${rating} out of 5`,
       );
     });
+
+    expect(getStar({ root, rating: userRating })).toHaveProp(
+      'title',
+      `Rated ${userRating} out of 5`,
+    );
   });
 
   it('prevents form submission when selecting a rating', () => {


### PR DESCRIPTION
Fixes #4955 - We should show a more appropriate tooltip for the respective star if a rating is present.

See below for two GIFs that showcase the updates:

![new tooltip message](https://user-images.githubusercontent.com/13009507/44621844-8aec8400-a87b-11e8-8aea-e1614285eac6.gif)

![write a review tooltip](https://user-images.githubusercontent.com/13009507/44621845-8de77480-a87b-11e8-9b4d-97842966a821.gif)
