### PR TITLE
Display nothing when there is no addon description

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -278,9 +278,8 @@ export class AddonBase extends React.Component {
       // For any theme type, we want to hide the summary text here since that is
       // already displayed in the header.
       showAbout =
-        ((description === addon.summary &&
-          addon.type === ADDON_TYPE_STATIC_THEME) ||
-          addon.type === ADDON_TYPE_THEME) === false;
+        (description === addon.summary || addon.type === ADDON_TYPE_THEME) ===
+        false;
 
       if (!description || !description.length) {
         return null;

--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -187,6 +187,10 @@
       // Fixes screenshot overflow in FF 52 ESR.
       max-width: 100%;
       overflow-x: hidden;
+
+      .Card:first-child {
+        margin-top: 0;
+      }
     }
 
     .AddonDescription-contents {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -784,6 +784,76 @@ describe(__filename, () => {
     expect(root.find('.AddonDescription')).toHaveLength(0);
   });
 
+  it('does not display anything when the lightweight theme has no description', () => {
+    const summary = 'my theme is very cool';
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        summary,
+        description: null,
+      }),
+    });
+
+    expect(root.find('.AddonDescription')).toHaveLength(0);
+  });
+
+  it('does not display anything when the generic add-on has no description', () => {
+    const summary = 'my theme is very cool';
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_COMPLETE_THEME,
+        summary,
+        description: null,
+      }),
+    });
+
+    expect(root.find('.AddonDescription')).toHaveLength(0);
+  });
+
+  it('does not display anything when the search plugin has no description', () => {
+    const summary = 'my theme is very cool';
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_OPENSEARCH,
+        summary,
+        description: null,
+      }),
+    });
+
+    expect(root.find('.AddonDescription')).toHaveLength(0);
+  });
+
+  it('does not display anything when the language pack has no description', () => {
+    const summary = 'my theme is very cool';
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_LANG,
+        summary,
+        description: null,
+      }),
+    });
+
+    expect(root.find('.AddonDescription')).toHaveLength(0);
+  });
+
+  it('does not display anything when the dictionary has no description', () => {
+    const summary = 'my theme is very cool';
+    const root = shallowRender({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_DICT,
+        summary,
+        description: null,
+      }),
+    });
+
+    expect(root.find('.AddonDescription')).toHaveLength(0);
+  });
+
   it("displays the extension's description when both description and summary are supplied", () => {
     const description = 'some cool description';
     const root = shallowRender({

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -781,11 +781,8 @@ describe(__filename, () => {
       }),
     });
 
-    expect(root.find('.AddonDescription')).toHaveLength(1);
-
-    expect(root.find('.AddonDescription-contents')).toHaveHTML(
-      `<div class="AddonDescription-contents">${summary}</div>`,
-    );
+    expect(root.find('.AddonDescription')).toHaveLength(0);
+    expect(root.find('.AddonDescription-contents')).toHaveLength(0);
   });
 
   it("displays the extension's description when both description and summary are supplied", () => {

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -798,7 +798,7 @@ describe(__filename, () => {
     expect(root.find('.AddonDescription')).toHaveLength(0);
   });
 
-  it('does not display anything when the generic add-on has no description', () => {
+  it('does not display anything when the complete theme has no description', () => {
     const summary = 'my theme is very cool';
     const root = shallowRender({
       addon: createInternalAddon({

--- a/tests/unit/amo/components/TestAddon.js
+++ b/tests/unit/amo/components/TestAddon.js
@@ -770,7 +770,7 @@ describe(__filename, () => {
     expect(root.find('.AddonDescription')).toHaveLength(0);
   });
 
-  it("displays the extension's summary when there is no description", () => {
+  it('does not display anything when the extension has no description', () => {
     const summary = 'my theme is very cool';
     const root = shallowRender({
       addon: createInternalAddon({
@@ -782,7 +782,6 @@ describe(__filename, () => {
     });
 
     expect(root.find('.AddonDescription')).toHaveLength(0);
-    expect(root.find('.AddonDescription-contents')).toHaveLength(0);
   });
 
   it("displays the extension's description when both description and summary are supplied", () => {


### PR DESCRIPTION
Fixes #6058 - When there is no description present for an add-on, show nothing instead of showing an exact duplicate of the add-ons summary.