### PR TITLE
Tidy/simplify SCSS imports

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .Addon {
   @include page-padding();

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .AddonBadges {
   width: 100%;

--- a/src/amo/components/AddonCompatibilityError/style.scss
+++ b/src/amo/components/AddonCompatibilityError/style.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .AddonCompatibilityError {
   margin-top: 12px;

--- a/src/amo/components/AddonMeta/styles.scss
+++ b/src/amo/components/AddonMeta/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .AddonMeta-item {
   display: flex;

--- a/src/amo/components/AddonRecommendations/styles.scss
+++ b/src/amo/components/AddonRecommendations/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .AddonRecommendations {
   // stylelint-disable max-nesting-depth

--- a/src/amo/components/AddonReview/styles.scss
+++ b/src/amo/components/AddonReview/styles.scss
@@ -1,5 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .Overlay-contents .AddonReview-overlay {
   .Card-contents {

--- a/src/amo/components/AddonReviewList/styles.scss
+++ b/src/amo/components/AddonReviewList/styles.scss
@@ -1,7 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .AddonReviewList {
   @include page-padding();
@@ -19,7 +16,7 @@
   }
 
   .CardList {
-    margin: 0 0 $vertical-space-xs;
+    margin: 0 0 8px;
     // https://stackoverflow.com/questions/36150458
     min-width: 50%;
   }

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -1,7 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
+@import '~amo/css/styles';
 
 .AddonReviewListItem {
   .Rating {

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .AddonsByAuthorsCard {
   margin-top: 0;

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -1,6 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .AddonsCard--horizontal {
   @include respond-to(large) {

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -1,4 +1,5 @@
 @import '~normalize.css';
+@import '~core/css/inc/lib';
 @import '~amo/css/styles';
 
 html,

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -1,4 +1,4 @@
-@import '~normalize.css';
+@import '~normalize';
 @import '~core/css/inc/lib';
 @import '~amo/css/styles';
 

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -1,10 +1,5 @@
 @import '~normalize.css';
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/vars';
-@import '~core/css/inc/lib';
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 html,
 body {

--- a/src/amo/components/AutoSearchInput/styles.scss
+++ b/src/amo/components/AutoSearchInput/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .AutoSearchInput-search-box {
   position: relative;

--- a/src/amo/components/Categories/styles.scss
+++ b/src/amo/components/Categories/styles.scss
@@ -1,6 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .Categories .Card-contents {
   @include respond-to(large) {

--- a/src/amo/components/CategoriesPage/styles.scss
+++ b/src/amo/components/CategoriesPage/styles.scss
@@ -1,5 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .CategoriesPage {
   @include page-padding();

--- a/src/amo/components/Category/styles.scss
+++ b/src/amo/components/Category/styles.scss
@@ -1,5 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .Category {
   @include page-padding();

--- a/src/amo/components/CategoryHeader/styles.scss
+++ b/src/amo/components/CategoryHeader/styles.scss
@@ -1,6 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .CategoryHeader {
   border-radius: $border-radius-default;

--- a/src/amo/components/CategoryIcon/styles.scss
+++ b/src/amo/components/CategoryIcon/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 $default-icon-size: 64px;
 

--- a/src/amo/components/Collection/styles.scss
+++ b/src/amo/components/Collection/styles.scss
@@ -1,7 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~photon-colors/photon-colors';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .Collection {
   @include page-padding();

--- a/src/amo/components/CollectionAddAddon/styles.scss
+++ b/src/amo/components/CollectionAddAddon/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .CollectionAddAddon {
   margin: $padding-page 0;

--- a/src/amo/components/CollectionControls/styles.scss
+++ b/src/amo/components/CollectionControls/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .CollectionControls {
   margin-top: $padding-page;

--- a/src/amo/components/CollectionDetails/styles.scss
+++ b/src/amo/components/CollectionDetails/styles.scss
@@ -1,6 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .CollectionDetails {
   .MetadataCard {

--- a/src/amo/components/CollectionList/styles.scss
+++ b/src/amo/components/CollectionList/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~photon-colors/photon-colors';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .CollectionList {
   @include page-padding();

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -1,7 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~core/css/inc/vars.scss';
-@import '~amo/css/inc/vars';
+@import '~amo/css/styles';
 
 .CollectionManager {
   label {

--- a/src/amo/components/CollectionSort/styles.scss
+++ b/src/amo/components/CollectionSort/styles.scss
@@ -1,4 +1,4 @@
-@import '~photon-colors/photon-colors';
+@import '~amo/css/styles';
 
 .CollectionSort-label {
   color: $grey-50;

--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -1,8 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~core/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 $icon-size: 32px;
 

--- a/src/amo/components/ErrorPage/styles.scss
+++ b/src/amo/components/ErrorPage/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
+@import '~amo/css/styles';
 
 .ErrorPage {
   @include page-padding();

--- a/src/amo/components/Footer/styles.scss
+++ b/src/amo/components/Footer/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .Footer {
   @include font-opensans-regular();

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -1,8 +1,4 @@
-@import '~photon-colors/photon-colors';
-
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .Header {
   background: $ink-90;

--- a/src/amo/components/Home/styles.scss
+++ b/src/amo/components/Home/styles.scss
@@ -1,8 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~core/css/inc/vars';
-@import '~photon-colors/photon-colors';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .Home {
   @include page-padding();

--- a/src/amo/components/HomeHeroBanner/styles.scss
+++ b/src/amo/components/HomeHeroBanner/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/vars';
+@import '~amo/css/styles';
 
 /* stylelint-disable indentation */
 $colors-first-item: ('violet', #7950f2, #6741d9) ('grape', #be4bdb, #ae3ec9);

--- a/src/amo/components/LandingPage/styles.scss
+++ b/src/amo/components/LandingPage/styles.scss
@@ -1,6 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .LandingPage {
   @include page-padding();

--- a/src/amo/components/LanguageTools/styles.scss
+++ b/src/amo/components/LanguageTools/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 $cell-padding: 6px;
 

--- a/src/amo/components/PermissionsCard/styles.scss
+++ b/src/amo/components/PermissionsCard/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~photon-colors/photon-colors';
+@import '~amo/css/styles';
 
 .PermissionCard-learn-more {
   margin: 16px auto 0;

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .RatingManager-ratingControl {
   align-items: center;

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/vars';
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .RatingsByStar-graph {
   color: $grey-50;

--- a/src/amo/components/ReportAbuseButton/styles.scss
+++ b/src/amo/components/ReportAbuseButton/styles.scss
@@ -1,4 +1,4 @@
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .ReportAbuseButton {
   margin: 12px auto 0;

--- a/src/amo/components/ScreenShots/styles.scss
+++ b/src/amo/components/ScreenShots/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
+@import '~amo/css/styles';
 
 // image-height has to be 20px smaller to prevent screenshot overflow.
 // See: https://github.com/mozilla/addons-frontend/issues/4887

--- a/src/amo/components/Search/styles.scss
+++ b/src/amo/components/Search/styles.scss
@@ -1,5 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .Search {
   @include respond-to(large) {

--- a/src/amo/components/SearchContextCard/styles.scss
+++ b/src/amo/components/SearchContextCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .SearchContextCard-header {
   font-size: $font-size-l;

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -1,7 +1,4 @@
-@import '~photon-colors/photon-colors';
-
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .SearchFilters-label {
   color: $grey-50;

--- a/src/amo/components/SearchSuggestion/styles.scss
+++ b/src/amo/components/SearchSuggestion/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/mixins';
+@import '~amo/css/styles';
 
 .SearchSuggestion {
   display: flex;

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 .SectionLinks {
   display: flex;

--- a/src/amo/components/StaticPages/styles.scss
+++ b/src/amo/components/StaticPages/styles.scss
@@ -1,7 +1,4 @@
-@import '~core/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~photon-colors/photon-colors';
+@import '~amo/css/styles';
 
 .StaticPage {
   @include page-padding();

--- a/src/amo/components/UserProfile/styles.scss
+++ b/src/amo/components/UserProfile/styles.scss
@@ -1,7 +1,4 @@
-@import '~core/css/inc/vars';
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 $avatar-size: 64px;
 

--- a/src/amo/components/UserProfileEdit/styles.scss
+++ b/src/amo/components/UserProfileEdit/styles.scss
@@ -1,6 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 $font-size-aside: 10px;
 

--- a/src/amo/components/UserProfileEditNotifications/styles.scss
+++ b/src/amo/components/UserProfileEditNotifications/styles.scss
@@ -1,8 +1,4 @@
-@import '~photon-colors/photon-colors';
-
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 $input-height: 16px;
 

--- a/src/amo/components/UserProfileEditPicture/styles.scss
+++ b/src/amo/components/UserProfileEditPicture/styles.scss
@@ -1,6 +1,4 @@
-@import '~amo/css/inc/vars';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~amo/css/styles';
 
 $picture-size: 128px;
 

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -1,57 +1,5 @@
 @import '~core/css/inc/vars';
 
-$body-font-color: #000;
-
-// This is the color used for the Header and Footer background and the
-// basis of the SearchForm and Footer background colors.
-$masthead-color: #343a40;
-$masthead-light-color: #495057;
-$footer-color: #212529;
-$accent-color: #ebebeb;
-
-// No "small" breakpoint is defined here because we are mobile-first.
-// Instead of adding a rule for only mobile, add a mobile rule and override
-// it with `@include respond-to(medium) { [...] }`.
-$breakpoints: (
-  // This breakpoint exists for tweaking of very small screens.
-    extraSmall: only screen and
-    (
-      max-width: 349px,
-    ),
-  mediumOnly: only screen and
-    (
-      min-width: 500px,
-    )
-    and
-    (
-      max-width: 719px,
-    ),
-  medium: only screen and
-    (
-      min-width: 500px,
-    ),
-  large: only screen and
-    (
-      min-width: 720px,
-    ),
-  extraLarge: only screen and
-    (
-      min-width: 900px,
-    ),
-  extraExtraLarge: only screen and
-    (
-      min-width: 1150px,
-    )
-);
-
-// Vertical spacing
-$vertical-space-xxs: 4px;
-$vertical-space-xs: 8px;
-$vertical-space-s: 16px;
-$vertical-space-m: 32px;
-$vertical-space-l: 64px;
-$vertical-space-xl: 128px;
-
 // Restrict content to this width on large screens.
 $max-content-width: 1366px;
 

--- a/src/amo/css/styles.scss
+++ b/src/amo/css/styles.scss
@@ -1,0 +1,4 @@
+@import '~core/css/inc/lib';
+@import '~core/css/inc/mixins';
+@import '~ui/css/vars';
+@import './inc/vars';

--- a/src/amo/css/styles.scss
+++ b/src/amo/css/styles.scss
@@ -1,4 +1,3 @@
-@import '~core/css/inc/lib';
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 @import './inc/vars';

--- a/src/core/components/AMInstallButton/styles.scss
+++ b/src/core/components/AMInstallButton/styles.scss
@@ -1,5 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
+@import '~core/css/styles';
 
 .AMInstallButton {
   .AMInstallButton-AnimatedIcon-preloader {

--- a/src/core/components/AMInstallButton/styles.scss
+++ b/src/core/components/AMInstallButton/styles.scss
@@ -1,5 +1,4 @@
 @import '~photon-colors/photon-colors';
-@import '~core/css/inc/vars';
 @import '~core/css/inc/mixins';
 
 .AMInstallButton {

--- a/src/core/components/InfoDialog/styles.scss
+++ b/src/core/components/InfoDialog/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~ui/css/vars';
-@import '~core/css/inc/mixins';
+@import '~core/css/styles';
 
 // From Firefox source code: `toolkit/themes/shared/popupnotification.inc.css`
 $popup-notification-button-active: #0568ba;

--- a/src/core/components/InfoDialog/styles.scss
+++ b/src/core/components/InfoDialog/styles.scss
@@ -1,6 +1,5 @@
 @import '~photon-colors/photon-colors';
 @import '~ui/css/vars';
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 
 // From Firefox source code: `toolkit/themes/shared/popupnotification.inc.css`

--- a/src/core/components/InstallButton/styles.scss
+++ b/src/core/components/InstallButton/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/mixins';
+@import '~core/css/styles';
 
 .InstallButton {
   .InstallButton-button {

--- a/src/core/components/InstallButton/styles.scss
+++ b/src/core/components/InstallButton/styles.scss
@@ -1,4 +1,3 @@
-@import '~core/css/inc/vars';
 @import '~core/css/inc/mixins';
 
 .InstallButton {

--- a/src/core/components/Paginate/styles.scss
+++ b/src/core/components/Paginate/styles.scss
@@ -1,7 +1,4 @@
-@import '~photon-colors/photon-colors';
-
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~core/css/styles';
 
 .Paginate {
   padding: $padding-page;

--- a/src/core/components/SurveyNotice/styles.scss
+++ b/src/core/components/SurveyNotice/styles.scss
@@ -1,4 +1,4 @@
-@import '~photon-colors/photon-colors';
+@import '~core/css/styles';
 
 .SurveyNotice {
   .Notice-column {

--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -1,6 +1,5 @@
-@import './vars';
-@import '~amo/css/inc/vars';
 @import '~photon-colors/photon-colors';
+@import './vars';
 
 @mixin page-padding() {
   // This adds consistent padding to any top-level page component.

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -52,3 +52,33 @@ $theme-width-default: 680px;
 
 // Lightweight images are slightly different
 $theme-height-legacy: 100px;
+
+// No "small" breakpoint is defined here because we are mobile-first.
+// Instead of adding a rule for only mobile, add a mobile rule and override
+// it with `@include respond-to(medium) { [...] }`.
+$breakpoints: (
+  mediumOnly: only screen and
+    (
+      min-width: 500px,
+    )
+    and
+    (
+      max-width: 719px,
+    ),
+  medium: only screen and
+    (
+      min-width: 500px,
+    ),
+  large: only screen and
+    (
+      min-width: 720px,
+    ),
+  extraLarge: only screen and
+    (
+      min-width: 900px,
+    ),
+  extraExtraLarge: only screen and
+    (
+      min-width: 1150px,
+    ),
+);

--- a/src/core/css/styles.scss
+++ b/src/core/css/styles.scss
@@ -1,0 +1,2 @@
+@import './inc/mixins';
+@import '~ui/css/vars';

--- a/src/disco/components/Addon/styles.scss
+++ b/src/disco/components/Addon/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~disco/css/inc/vars';
+@import '~disco/css/styles';
 
 $addon-padding: 20px;
 

--- a/src/disco/components/Addon/styles.scss
+++ b/src/disco/components/Addon/styles.scss
@@ -1,5 +1,5 @@
-@import '~disco/css/inc/vars';
 @import '~core/css/inc/mixins';
+@import '~disco/css/inc/vars';
 
 $addon-padding: 20px;
 

--- a/src/disco/components/AddonCompatibilityError/style.scss
+++ b/src/disco/components/AddonCompatibilityError/style.scss
@@ -1,4 +1,4 @@
-@import '~ui/css/vars';
+@import '~disco/css/styles';
 
 .AddonCompatibilityError {
   background: $report-base-color;

--- a/src/disco/components/App/styles.scss
+++ b/src/disco/components/App/styles.scss
@@ -1,7 +1,5 @@
 @import '~normalize.css';
-@import '~core/css/inc/lib';
-@import '~core/css/inc/mixins';
-@import '~disco/css/inc/vars';
+@import '~disco/css/styles';
 
 html,
 body {

--- a/src/disco/components/App/styles.scss
+++ b/src/disco/components/App/styles.scss
@@ -1,4 +1,4 @@
-@import '~normalize.css';
+@import '~normalize';
 @import '~core/css/inc/lib';
 @import '~disco/css/styles';
 

--- a/src/disco/components/App/styles.scss
+++ b/src/disco/components/App/styles.scss
@@ -1,4 +1,5 @@
 @import '~normalize.css';
+@import '~core/css/inc/lib';
 @import '~disco/css/styles';
 
 html,

--- a/src/disco/components/DiscoPane/styles.scss
+++ b/src/disco/components/DiscoPane/styles.scss
@@ -1,4 +1,3 @@
-@import '~core/css/inc/lib';
 @import '~core/css/inc/mixins';
 @import '~disco/css/inc/vars';
 

--- a/src/disco/components/DiscoPane/styles.scss
+++ b/src/disco/components/DiscoPane/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~disco/css/inc/vars';
+@import '~disco/css/styles';
 
 .disco-pane {
   box-sizing: content-box;

--- a/src/disco/components/Footer/styles.scss
+++ b/src/disco/components/Footer/styles.scss
@@ -1,4 +1,4 @@
-@import '~disco/css/inc/vars';
+@import '~disco/css/styles';
 
 .Footer {
   text-align: center;

--- a/src/disco/css/inc/vars.scss
+++ b/src/disco/css/inc/vars.scss
@@ -7,8 +7,3 @@ $secondary-font-color: #6a6a6a;
 $header-copy-font-color: #444;
 $header-border-color: #b1b1b1;
 $link-hover-color: #0996f8;
-
-$breakpoints: (
-  small: '(max-width: 719px)',
-  large: '(min-width: 720px)',
-);

--- a/src/disco/css/styles.scss
+++ b/src/disco/css/styles.scss
@@ -1,0 +1,4 @@
+@import '~core/css/inc/lib';
+@import '~core/css/inc/mixins';
+@import '~ui/css/vars';
+@import './inc/vars';

--- a/src/disco/css/styles.scss
+++ b/src/disco/css/styles.scss
@@ -1,4 +1,3 @@
-@import '~core/css/inc/lib';
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 @import './inc/vars';

--- a/src/ui/components/Badge/styles.scss
+++ b/src/ui/components/Badge/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~photon-colors/photon-colors';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .Badge {
   color: $grey-90;

--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 $micro-font-size: 11px;
 $default-font-size: 13px;

--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -1,6 +1,4 @@
 @import '~photon-colors/photon-colors';
-
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 

--- a/src/ui/components/Card/styles.scss
+++ b/src/ui/components/Card/styles.scss
@@ -1,5 +1,4 @@
 @import '~core/css/inc/mixins';
-@import '~core/css/inc/vars';
 @import '~ui/css/vars';
 
 $footer-padding: 10px;

--- a/src/ui/components/Card/styles.scss
+++ b/src/ui/components/Card/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 $footer-padding: 10px;
 

--- a/src/ui/components/CardList/styles.scss
+++ b/src/ui/components/CardList/styles.scss
@@ -1,4 +1,3 @@
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 

--- a/src/ui/components/CardList/styles.scss
+++ b/src/ui/components/CardList/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .CardList {
   margin: $padding-page 0;

--- a/src/ui/components/ConfirmButton/styles.scss
+++ b/src/ui/components/ConfirmButton/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .ConfirmButton-buttons {
   align-items: center;

--- a/src/ui/components/DefinitionList/styles.scss
+++ b/src/ui/components/DefinitionList/styles.scss
@@ -1,5 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
+@import '~ui/css/styles';
 
 .DefinitionList {
   margin: 0;

--- a/src/ui/components/DefinitionList/styles.scss
+++ b/src/ui/components/DefinitionList/styles.scss
@@ -1,6 +1,5 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
 @import '~photon-colors/photon-colors';
+@import '~core/css/inc/mixins';
 
 .DefinitionList {
   margin: 0;

--- a/src/ui/components/DismissibleTextForm/styles.scss
+++ b/src/ui/components/DismissibleTextForm/styles.scss
@@ -1,7 +1,5 @@
 @import '~photon-colors/photon-colors';
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
-@import '~core/css/inc/vars';
 @import '~ui/css/vars';
 
 .DismissibleTextForm-form {

--- a/src/ui/components/DismissibleTextForm/styles.scss
+++ b/src/ui/components/DismissibleTextForm/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .DismissibleTextForm-form {
   margin: 6px 0;

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .DropdownMenu {
   @include text-align-start();

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -1,5 +1,4 @@
 @import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
 @import '~ui/css/vars';
 
 .DropdownMenu {

--- a/src/ui/components/DropdownMenuItem/styles.scss
+++ b/src/ui/components/DropdownMenuItem/styles.scss
@@ -1,6 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
-@import '~photon-colors/photon-colors';
+@import '~ui/css/styles';
 
 .DropdownMenuItem-section {
   color: $grey-50;

--- a/src/ui/components/ErrorList/styles.scss
+++ b/src/ui/components/ErrorList/styles.scss
@@ -1,6 +1,3 @@
-@import '~core/css/inc/vars';
-@import '~ui/css/vars';
-
 .ErrorList {
   margin: 0;
   margin-bottom: 10px;

--- a/src/ui/components/ExpandableCard/styles.scss
+++ b/src/ui/components/ExpandableCard/styles.scss
@@ -1,5 +1,4 @@
 @import '~photon-colors/photon-colors';
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 
 .ExpandableCard-ToggleLink {

--- a/src/ui/components/ExpandableCard/styles.scss
+++ b/src/ui/components/ExpandableCard/styles.scss
@@ -1,5 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
+@import '~ui/css/styles';
 
 .ExpandableCard-ToggleLink {
   display: flex;

--- a/src/ui/components/FormOverlay/styles.scss
+++ b/src/ui/components/FormOverlay/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .FormOverlay {
   align-items: center;

--- a/src/ui/components/FormOverlay/styles.scss
+++ b/src/ui/components/FormOverlay/styles.scss
@@ -1,7 +1,6 @@
-@import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
-@import '~ui/css/vars';
 @import '~photon-colors/photon-colors';
+@import '~core/css/inc/mixins';
+@import '~ui/css/vars';
 
 .FormOverlay {
   align-items: center;

--- a/src/ui/components/Hero/styles.scss
+++ b/src/ui/components/Hero/styles.scss
@@ -1,4 +1,3 @@
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 

--- a/src/ui/components/Hero/styles.scss
+++ b/src/ui/components/Hero/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .Hero {
   margin: 0 0 $padding-page;

--- a/src/ui/components/HeroSection/styles.scss
+++ b/src/ui/components/HeroSection/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .HeroSection {
   border-radius: $border-radius-default;

--- a/src/ui/components/HeroSection/styles.scss
+++ b/src/ui/components/HeroSection/styles.scss
@@ -1,5 +1,4 @@
 @import '~photon-colors/photon-colors';
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 

--- a/src/ui/components/Icon/styles.scss
+++ b/src/ui/components/Icon/styles.scss
@@ -1,6 +1,5 @@
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 @import './vars';
-@import '~core/css/inc/mixins';
 
 @mixin icon($name) {
   background: url('./img/#{$name}.svg') center no-repeat;

--- a/src/ui/components/IconXMark/styles.scss
+++ b/src/ui/components/IconXMark/styles.scss
@@ -1,4 +1,4 @@
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 @import '~ui/components/Icon/vars';
 
 .IconXMark-svg {

--- a/src/ui/components/LoadingText/styles.scss
+++ b/src/ui/components/LoadingText/styles.scss
@@ -1,4 +1,4 @@
-@import '~photon-colors/photon-colors';
+@import '~ui/css/styles';
 
 @keyframes placeHolderShimmer {
   0% {

--- a/src/ui/components/LoadingText/styles.scss
+++ b/src/ui/components/LoadingText/styles.scss
@@ -1,4 +1,3 @@
-@import '~amo/css/inc/vars';
 @import '~photon-colors/photon-colors';
 
 @keyframes placeHolderShimmer {

--- a/src/ui/components/MetadataCard/styles.scss
+++ b/src/ui/components/MetadataCard/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .MetadataCard {
   background-color: $grey-10;

--- a/src/ui/components/MetadataCard/styles.scss
+++ b/src/ui/components/MetadataCard/styles.scss
@@ -1,6 +1,5 @@
 @import '~photon-colors/photon-colors';
 @import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
 @import '~ui/css/vars';
 
 .MetadataCard {

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 @import '~ui/components/Button/styles';
 
 .Notice {

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -1,8 +1,7 @@
+@import '~photon-colors/photon-colors';
 @import '~core/css/inc/mixins';
-@import '~core/css/inc/vars';
 @import '~ui/css/vars';
 @import '~ui/components/Button/styles';
-@import '~photon-colors/photon-colors';
 
 .Notice {
   border-radius: $border-radius-s;

--- a/src/ui/components/Overlay/styles.scss
+++ b/src/ui/components/Overlay/styles.scss
@@ -1,4 +1,4 @@
-@import '~photon-colors/photon-colors';
+@import '~ui/css/styles';
 
 .Overlay {
   display: none;

--- a/src/ui/components/OverlayCard/styles.scss
+++ b/src/ui/components/OverlayCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/vars';
+@import '~ui/css/styles';
 
 .OverlayCard {
   margin: 0 20px;

--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/mixins';
+@import '~ui/css/styles';
 
 .Rating {
   align-content: center;

--- a/src/ui/components/Select/styles.scss
+++ b/src/ui/components/Select/styles.scss
@@ -1,7 +1,4 @@
-@import '~photon-colors/photon-colors';
-
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .Select {
   @include padding-end(24px);

--- a/src/ui/components/ShowMoreCard/styles.scss
+++ b/src/ui/components/ShowMoreCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~core/css/inc/mixins';
+@import '~ui/css/styles';
 
 .ShowMoreCard-contents {
   &::after {

--- a/src/ui/components/ShowMoreCard/styles.scss
+++ b/src/ui/components/ShowMoreCard/styles.scss
@@ -1,4 +1,3 @@
-@import '~core/css/inc/vars';
 @import '~core/css/inc/mixins';
 
 .ShowMoreCard-contents {

--- a/src/ui/components/Switch/styles.scss
+++ b/src/ui/components/Switch/styles.scss
@@ -1,5 +1,6 @@
 @import '~disco/css/inc/vars';
 @import '~core/css/inc/mixins';
+
 $size: 26px;
 $borderSize: 1px;
 $transition: 0.3s;

--- a/src/ui/components/Switch/styles.scss
+++ b/src/ui/components/Switch/styles.scss
@@ -1,5 +1,5 @@
+@import '~ui/css/styles';
 @import '~disco/css/inc/vars';
-@import '~core/css/inc/mixins';
 
 $size: 26px;
 $borderSize: 1px;

--- a/src/ui/components/ThemeImage/styles.scss
+++ b/src/ui/components/ThemeImage/styles.scss
@@ -1,5 +1,4 @@
 @import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
 @import '~ui/css/vars';
 
 .ThemeImage {

--- a/src/ui/components/ThemeImage/styles.scss
+++ b/src/ui/components/ThemeImage/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .ThemeImage {
   height: auto;

--- a/src/ui/components/TooltipMenu/styles.scss
+++ b/src/ui/components/TooltipMenu/styles.scss
@@ -1,4 +1,3 @@
-@import '~amo/css/inc/vars';
 @import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 

--- a/src/ui/components/TooltipMenu/styles.scss
+++ b/src/ui/components/TooltipMenu/styles.scss
@@ -1,5 +1,4 @@
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .TooltipMenu {
   border: 0;

--- a/src/ui/components/UserCollection/styles.scss
+++ b/src/ui/components/UserCollection/styles.scss
@@ -1,5 +1,5 @@
-@import '~core/css/inc/mixins';
 @import '~photon-colors/photon-colors';
+@import '~core/css/inc/mixins';
 @import '~ui/css/vars';
 
 .CardList ul > li.UserCollection {

--- a/src/ui/components/UserCollection/styles.scss
+++ b/src/ui/components/UserCollection/styles.scss
@@ -1,6 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
-@import '~ui/css/vars';
+@import '~ui/css/styles';
 
 .CardList ul > li.UserCollection {
   padding: 4px $padding-page-l;

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -1,5 +1,4 @@
-@import '~photon-colors/photon-colors';
-@import '~core/css/inc/mixins';
+@import '~ui/css/styles';
 
 .UserReview {
   word-wrap: break-word;

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -1,6 +1,5 @@
 @import '~photon-colors/photon-colors';
 @import '~core/css/inc/mixins';
-@import '~amo/css/inc/vars';
 
 .UserReview {
   word-wrap: break-word;

--- a/src/ui/css/styles.scss
+++ b/src/ui/css/styles.scss
@@ -1,0 +1,2 @@
+@import '~core/css/inc/mixins';
+@import './vars';

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -1,5 +1,5 @@
-@import '~core/css/inc/vars';
 @import '~photon-colors/photon-colors';
+@import '~core/css/inc/vars';
 
 // Desktop variables (from specs)
 $black: #343a40;

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -78,7 +78,7 @@ export default {
   ],
   resolve: {
     alias: {
-      'normalize.css': 'normalize.css/normalize.css',
+      normalize: 'normalize.css/normalize.css',
       tests: path.resolve('./tests'),
     },
     modules: [path.resolve('./src'), 'node_modules'],


### PR DESCRIPTION
Fix #6097

---

This PR cleans the different SCSS imports to avoid "amo" SCSS to leak in
`src/ui` or `src/core` so that "disco" can also use the components in
those directories. Also remove a few unused variables.

In addition, I created one file to import for each app, instead of having
different imports, not always sorted correctly. (I did not create a unique
file for the "core" components yet, though).

Why? It is super difficult to find the right imports all the time, so we
end copy/pasting imports from another file and tweak them if that does not
work. This leads to weird import statements in some files. By having only
one file to import, it makes things easier.

Why (2)? I reviewed a PR and saw some code in disco that was coming from
amo, so I decided to clean up our SCSS a bit.

I built the amo app with `master` and this PR and did not notice any size
difference. I did not see any visual regression either.