### PR TITLE
Greenkeeper/monorepo.enzyme 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "cookie": "^0.3.1",
     "css-loader": "^0.28.3",
     "enzyme": "^3.5.0",
-    "enzyme-adapter-react-16": "^1.1.0",
+    "enzyme-adapter-react-16": "^1.3.0",
     "eslint": "^5.3.0",
     "eslint-config-amo": "^1.8.3",
     "eslint-plugin-amo": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "content-security-policy-parser": "^0.1.0",
     "cookie": "^0.3.1",
     "css-loader": "^0.28.3",
-    "enzyme": "^3.2.0",
+    "enzyme": "^3.5.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^5.3.0",
     "eslint-config-amo": "^1.8.3",


### PR DESCRIPTION
Looks like it fails, see: https://github.com/airbnb/enzyme/issues/1795