### PR TITLE
Enable deleting a review from the review listing page

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -611,6 +611,7 @@ export const hideFlashedReviewMessage = (): HideFlashedReviewMessageAction => {
 
 type DeleteAddonReviewParams = {|
   errorHandlerId: string,
+  isReplyToReviewId?: number,
   reviewId: number,
 |};
 
@@ -621,6 +622,7 @@ export type DeleteAddonReviewAction = {|
 
 export const deleteAddonReview = ({
   errorHandlerId,
+  isReplyToReviewId,
   reviewId,
 }: DeleteAddonReviewParams) => {
   invariant(errorHandlerId, 'errorHandlerId is required');
@@ -628,7 +630,7 @@ export const deleteAddonReview = ({
 
   return {
     type: DELETE_ADDON_REVIEW,
-    payload: { errorHandlerId, reviewId },
+    payload: { errorHandlerId, isReplyToReviewId, reviewId },
   };
 };
 

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -260,7 +260,7 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
                 'AddonReviewListItem-control',
                 confirmButtonClassName,
               )}
-              id={confirmButtonClassName}
+              id={`${confirmButtonClassName}-${review.id}`}
               message={
                 isReply
                   ? i18n.gettext('Do you really want to delete this reply?')

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import makeClassName from 'classnames';
 import invariant from 'invariant';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -20,10 +21,11 @@ import {
   showEditReviewForm,
   showReplyToReviewForm,
 } from 'amo/actions/reviews';
+import ConfirmButton from 'ui/components/ConfirmButton';
+import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import UserReview from 'ui/components/UserReview';
-import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { UserType } from 'amo/reducers/users';
 import type { AppState } from 'amo/store';
@@ -229,6 +231,8 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
       byLine = <LoadingText />;
     }
 
+    const confirmButtonClassName = 'AddonReviewListItem-delete';
+
     const controls = (
       <div className="AddonReviewListItem-allControls">
         {siteUser && review && review.userId === siteUser.id ? (
@@ -250,15 +254,24 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
                 ? i18n.gettext('Edit my reply')
                 : i18n.gettext('Edit my review')}
             </a>
-            <a
-              href="#delete"
-              onClick={this.onClickToDeleteReview}
-              className="AddonReviewListItem-delete AddonReviewListItem-control"
+            <ConfirmButton
+              buttonType="cancel"
+              className={makeClassName(
+                'AddonReviewListItem-control',
+                confirmButtonClassName,
+              )}
+              id={confirmButtonClassName}
+              message={
+                isReply
+                  ? i18n.gettext('Do you really want to delete this reply?')
+                  : i18n.gettext('Do you really want to delete this review?')
+              }
+              onConfirm={this.onClickToDeleteReview}
             >
               {isReply
                 ? i18n.gettext('Delete my reply')
                 : i18n.gettext('Delete my review')}
-            </a>
+            </ConfirmButton>
           </React.Fragment>
         ) : null}
 

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -256,10 +256,12 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
             </a>
             <ConfirmButton
               buttonType="cancel"
+              cancelButtonType="neutral"
               className={makeClassName(
                 'AddonReviewListItem-control',
                 confirmButtonClassName,
               )}
+              confirmButtonText={i18n.gettext('Delete')}
               id={`${confirmButtonClassName}-${review.id}`}
               message={
                 isReply

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -47,6 +47,7 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
+  deletingReview: boolean,
   dispatch: DispatchFunc,
   editingReview: boolean,
   errorHandler: ErrorHandlerType,
@@ -199,6 +200,7 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
   render() {
     const {
       addon,
+      deletingReview,
       editingReview,
       errorHandler,
       i18n,
@@ -254,26 +256,32 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
                 ? i18n.gettext('Edit my reply')
                 : i18n.gettext('Edit my review')}
             </a>
-            <ConfirmButton
-              buttonType="cancel"
-              cancelButtonType="neutral"
-              className={makeClassName(
-                'AddonReviewListItem-control',
-                confirmButtonClassName,
-              )}
-              confirmButtonText={i18n.gettext('Delete')}
-              id={`${confirmButtonClassName}-${review.id}`}
-              message={
-                isReply
-                  ? i18n.gettext('Do you really want to delete this reply?')
-                  : i18n.gettext('Do you really want to delete this review?')
-              }
-              onConfirm={this.onClickToDeleteReview}
-            >
-              {isReply
-                ? i18n.gettext('Delete my reply')
-                : i18n.gettext('Delete my review')}
-            </ConfirmButton>
+            {deletingReview ? (
+              <span className="AddonReviewListItem-control AddonReviewListItem-deleting">
+                {i18n.gettext('Deleting…')}
+              </span>
+            ) : (
+              <ConfirmButton
+                buttonType="cancel"
+                cancelButtonType="neutral"
+                className={makeClassName(
+                  'AddonReviewListItem-control',
+                  confirmButtonClassName,
+                )}
+                confirmButtonText={i18n.gettext('Delete')}
+                id={`${confirmButtonClassName}-${review.id}`}
+                message={
+                  isReply
+                    ? i18n.gettext('Do you really want to delete this reply?')
+                    : i18n.gettext('Do you really want to delete this review?')
+                }
+                onConfirm={this.onClickToDeleteReview}
+              >
+                {isReply
+                  ? i18n.gettext('Delete my reply')
+                  : i18n.gettext('Delete my review')}
+              </ConfirmButton>
+            )}
           </React.Fragment>
         ) : null}
 
@@ -323,18 +331,21 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
 }
 
 export function mapStateToProps(state: AppState, ownProps: Props) {
+  let deletingReview = false;
   let editingReview = false;
   let replyingToReview = false;
   let submittingReply = false;
   if (ownProps.review) {
     const view = state.reviews.view[ownProps.review.id];
     if (view) {
+      deletingReview = view.deletingReview;
       editingReview = view.editingReview;
       replyingToReview = view.replyingToReview;
       submittingReply = view.submittingReply;
     }
   }
   return {
+    deletingReview,
     editingReview,
     siteUserHasReplyPerm: hasPermission(state, ADDONS_EDIT),
     replyingToReview,

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import invariant from 'invariant';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -12,6 +13,7 @@ import log from 'core/logger';
 import { getCurrentUser, hasPermission } from 'amo/reducers/users';
 import { isAddonAuthor } from 'core/utils';
 import {
+  deleteAddonReview,
   hideEditReviewForm,
   hideReplyToReviewForm,
   sendReplyToReview,
@@ -54,6 +56,20 @@ type InternalProps = {|
 |};
 
 export class AddonReviewListItemBase extends React.Component<InternalProps> {
+  onClickToDeleteReview = (event: SyntheticEvent<HTMLElement>) => {
+    const { dispatch, errorHandler, isReplyToReviewId, review } = this.props;
+    event.preventDefault();
+
+    invariant(review, 'review is required');
+    dispatch(
+      deleteAddonReview({
+        errorHandlerId: errorHandler.id,
+        reviewId: review.id,
+        isReplyToReviewId,
+      }),
+    );
+  };
+
   onClickToEditReview = (event: SyntheticEvent<any>) => {
     const { dispatch, isReplyToReviewId, review } = this.props;
     event.preventDefault();
@@ -233,6 +249,15 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
               {isReply
                 ? i18n.gettext('Edit my reply')
                 : i18n.gettext('Edit my review')}
+            </a>
+            <a
+              href="#delete"
+              onClick={this.onClickToDeleteReview}
+              className="AddonReviewListItem-delete AddonReviewListItem-control"
+            >
+              {isReply
+                ? i18n.gettext('Delete my reply')
+                : i18n.gettext('Delete my review')}
             </a>
           </React.Fragment>
         ) : null}

--- a/src/amo/components/AddonReviewListItem/index.js
+++ b/src/amo/components/AddonReviewListItem/index.js
@@ -256,7 +256,7 @@ export class AddonReviewListItemBase extends React.Component<InternalProps> {
                 ? i18n.gettext('Edit my reply')
                 : i18n.gettext('Edit my review')}
             </a>
-            {deletingReview ? (
+            {deletingReview && !errorHandler.hasError() ? (
               <span className="AddonReviewListItem-control AddonReviewListItem-deleting">
                 {i18n.gettext('Deleting…')}
               </span>

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -30,6 +30,19 @@
   }
 }
 
+.AddonReviewListItem-delete {
+  .ConfirmButton-cancel-button,
+  .ConfirmButton-confirm-button,
+  .ConfirmButton-default-button {
+    font-size: 12px;
+  }
+
+  .ConfirmButton-default-button {
+    align-items: flex-start;
+    color: $blue-50;
+  }
+}
+
 .AddonReviewListItem-control {
   @include margin-start(6px);
 

--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -34,12 +34,16 @@
   .ConfirmButton-cancel-button,
   .ConfirmButton-confirm-button,
   .ConfirmButton-default-button {
-    font-size: 12px;
+    font-size: $font-size-s;
   }
 
   .ConfirmButton-default-button {
     align-items: flex-start;
     color: $blue-50;
+  }
+
+  .ConfirmButton-buttons {
+    flex-flow: row-reverse;
   }
 }
 

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -500,8 +500,6 @@ export default function reviewsReducer(
 
       if (reviewData) {
         const { addonId, addonSlug, userId } = reviewData;
-        delete newState.byId[reviewId];
-        delete newState.view[reviewId];
         return {
           ...newState,
           byAddon: {

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -490,6 +490,7 @@ export default function reviewsReducer(
       if (reviewData) {
         const { addonId, addonSlug, userId } = reviewData;
         delete newState.byId[reviewId];
+        delete newState.view[reviewId];
         return {
           ...newState,
           byAddon: {

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -2,6 +2,7 @@
 import { oneLine } from 'common-tags';
 
 import {
+  DELETE_ADDON_REVIEW,
   FLASH_REVIEW_MESSAGE,
   HIDE_FLASHED_REVIEW_MESSAGE,
   UNLOAD_ADDON_REVIEWS,
@@ -22,6 +23,7 @@ import {
   createInternalReview,
 } from 'amo/actions/reviews';
 import type {
+  DeleteAddonReviewAction,
   UnloadAddonReviewsAction,
   FlagReviewAction,
   FlashMessageType,
@@ -75,6 +77,7 @@ export type FlagState = {
 };
 
 type ViewStateByReviewId = {|
+  deletingReview: boolean,
   editingReview: boolean,
   flag: FlagState,
   replyingToReview: boolean,
@@ -175,6 +178,7 @@ export const changeViewState = ({
     view: {
       ...state.view,
       [reviewId]: {
+        deletingReview: false,
         editingReview: false,
         replyingToReview: false,
         submittingReply: false,
@@ -270,6 +274,7 @@ export const addReviewToState = ({
 };
 
 type ReviewActionType =
+  | DeleteAddonReviewAction
   | FlagReviewAction
   | FlashReviewMessageAction
   | UnloadAddonReviewsAction
@@ -296,6 +301,12 @@ export default function reviewsReducer(
   }: {| _addReviewToState: typeof addReviewToState |} = {},
 ) {
   switch (action.type) {
+    case DELETE_ADDON_REVIEW:
+      return changeViewState({
+        state,
+        reviewId: action.payload.reviewId,
+        stateChange: { deletingReview: true },
+      });
     case SEND_REPLY_TO_REVIEW:
       return changeViewState({
         state,
@@ -497,6 +508,10 @@ export default function reviewsReducer(
             ...newState.byAddon,
             [addonSlug]: undefined,
           },
+          byId: {
+            ...newState.byId,
+            [reviewId]: undefined,
+          },
           byUserId: {
             ...newState.byUserId,
             [userId]: undefined,
@@ -504,6 +519,10 @@ export default function reviewsReducer(
           groupedRatings: {
             ...newState.groupedRatings,
             [addonId]: undefined,
+          },
+          view: {
+            ...newState.view,
+            [reviewId]: undefined,
           },
         };
       }

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -297,7 +297,10 @@ function* deleteAddonReview({
       reviewId,
     });
 
-    yield put(unloadAddonReviews({ reviewId: isReplyToReviewId || reviewId }));
+    yield put(unloadAddonReviews({ reviewId }));
+    if (isReplyToReviewId) {
+      yield put(unloadAddonReviews({ reviewId: isReplyToReviewId }));
+    }
   } catch (error) {
     log.warn(`Failed to delete review ID ${reviewId}: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -284,7 +284,7 @@ function* manageAddonReview(
 }
 
 function* deleteAddonReview({
-  payload: { errorHandlerId, reviewId },
+  payload: { errorHandlerId, isReplyToReviewId, reviewId },
 }: DeleteAddonReviewAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -297,7 +297,7 @@ function* deleteAddonReview({
       reviewId,
     });
 
-    yield put(unloadAddonReviews({ reviewId }));
+    yield put(unloadAddonReviews({ reviewId: isReplyToReviewId || reviewId }));
   } catch (error) {
     log.warn(`Failed to delete review ID ${reviewId}: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -214,24 +214,22 @@ describe(__filename, () => {
     ).toHaveLength(0);
   });
 
-  it('dispatches deleteReview when a user clicks the delete link', () => {
+  it('dispatches deleteReview when a user deletes a review', () => {
     const review = signInAndDispatchSavedReview();
     const dispatchSpy = sinon.spy(store, 'dispatch');
-    const preventDefaultSpy = sinon.spy();
     const root = render({ review });
     const { errorHandler } = root.instance().props;
 
     const deleteButton = renderControls(root).find(
       '.AddonReviewListItem-delete',
     );
-    const clickEvent = createFakeEvent();
-    deleteButton.simulate('click', clickEvent);
+    const deleteEvent = createFakeEvent();
 
     // This emulates a user clicking the delete button and confirming.
     const onDelete = deleteButton.prop('onConfirm');
-    onDelete(createFakeEvent({ preventDefault: preventDefaultSpy }));
+    onDelete(deleteEvent);
 
-    sinon.assert.calledOnce(preventDefaultSpy);
+    sinon.assert.calledOnce(deleteEvent.preventDefault);
     sinon.assert.calledWith(
       dispatchSpy,
       deleteAddonReview({
@@ -780,7 +778,7 @@ describe(__filename, () => {
       );
     });
 
-    it('dispatches deleteReview when a user clicks the delete link for a developer reply', () => {
+    it('dispatches deleteReview when a user deletes a developer reply', () => {
       const originalReviewId = 543;
       const developerUserId = 321;
       const review = signInAndDispatchSavedReview({
@@ -788,19 +786,19 @@ describe(__filename, () => {
         reviewUserId: developerUserId,
       });
       const dispatchSpy = sinon.spy(store, 'dispatch');
-      const preventDefaultSpy = sinon.spy();
 
       const root = renderReply({ originalReviewId, reply: review });
       const { errorHandler } = root.instance().props;
 
+      const deleteEvent = createFakeEvent();
       const deleteButton = renderControls(root).find(
         '.AddonReviewListItem-delete',
       );
       // This emulates a user clicking the delete button and confirming.
       const onDelete = deleteButton.prop('onConfirm');
-      onDelete(createFakeEvent({ preventDefault: preventDefaultSpy }));
+      onDelete(deleteEvent);
 
-      sinon.assert.calledOnce(preventDefaultSpy);
+      sinon.assert.calledOnce(deleteEvent.preventDefault);
       sinon.assert.calledWith(
         dispatchSpy,
         deleteAddonReview({

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -27,6 +27,7 @@ import {
 } from 'tests/unit/amo/helpers';
 import {
   createFakeEvent,
+  createStubErrorHandler,
   fakeI18n,
   createFakeLocation,
   shallowUntilTarget,
@@ -237,6 +238,22 @@ describe(__filename, () => {
         reviewId: review.id,
       }),
     );
+  });
+
+  it('renders a deleting message when a user deletes a review', () => {
+    const review = signInAndDispatchSavedReview();
+    store.dispatch(
+      deleteAddonReview({
+        errorHandlerId: createStubErrorHandler().id,
+        reviewId: review.id,
+      }),
+    );
+
+    const root = render({ review });
+
+    const controls = renderControls(root);
+    expect(controls.find('.AddonReviewListItem-deleting')).toHaveLength(1);
+    expect(controls.find('.AddonReviewListItem-delete')).toHaveLength(0);
   });
 
   it('lets you begin editing your review', () => {

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -196,6 +196,10 @@ describe(__filename, () => {
     const deleteLink = renderControls(root).find('.AddonReviewListItem-delete');
     expect(deleteLink).toHaveLength(1);
     expect(deleteLink.children()).toHaveText('Delete my review');
+    expect(deleteLink).toHaveProp(
+      'message',
+      'Do you really want to delete this review?',
+    );
   });
 
   it('does not render delete link when review belongs to another user', () => {
@@ -213,6 +217,7 @@ describe(__filename, () => {
   it('dispatches deleteReview when a user clicks the delete link', () => {
     const review = signInAndDispatchSavedReview();
     const dispatchSpy = sinon.spy(store, 'dispatch');
+    const preventDefaultSpy = sinon.spy();
     const root = render({ review });
     const { errorHandler } = root.instance().props;
 
@@ -222,7 +227,11 @@ describe(__filename, () => {
     const clickEvent = createFakeEvent();
     deleteButton.simulate('click', clickEvent);
 
-    sinon.assert.called(clickEvent.preventDefault);
+    // This emulates a user clicking the delete button and confirming.
+    const onDelete = deleteButton.prop('onConfirm');
+    onDelete(createFakeEvent({ preventDefault: preventDefaultSpy }));
+
+    sinon.assert.calledOnce(preventDefaultSpy);
     sinon.assert.calledWith(
       dispatchSpy,
       deleteAddonReview({
@@ -765,6 +774,10 @@ describe(__filename, () => {
       );
       expect(deleteLink).toHaveLength(1);
       expect(deleteLink.children()).toHaveText('Delete my reply');
+      expect(deleteLink).toHaveProp(
+        'message',
+        'Do you really want to delete this reply?',
+      );
     });
 
     it('dispatches deleteReview when a user clicks the delete link for a developer reply', () => {
@@ -775,16 +788,19 @@ describe(__filename, () => {
         reviewUserId: developerUserId,
       });
       const dispatchSpy = sinon.spy(store, 'dispatch');
+      const preventDefaultSpy = sinon.spy();
+
       const root = renderReply({ originalReviewId, reply: review });
       const { errorHandler } = root.instance().props;
 
       const deleteButton = renderControls(root).find(
         '.AddonReviewListItem-delete',
       );
-      const clickEvent = createFakeEvent();
-      deleteButton.simulate('click', clickEvent);
+      // This emulates a user clicking the delete button and confirming.
+      const onDelete = deleteButton.prop('onConfirm');
+      onDelete(createFakeEvent({ preventDefault: preventDefaultSpy }));
 
-      sinon.assert.called(clickEvent.preventDefault);
+      sinon.assert.calledOnce(preventDefaultSpy);
       sinon.assert.calledWith(
         dispatchSpy,
         deleteAddonReview({

--- a/tests/unit/amo/components/TestAddonReviewListItem.js
+++ b/tests/unit/amo/components/TestAddonReviewListItem.js
@@ -256,6 +256,28 @@ describe(__filename, () => {
     expect(controls.find('.AddonReviewListItem-delete')).toHaveLength(0);
   });
 
+  it('renders a delete link when an error occurs when deleting a review', () => {
+    const review = signInAndDispatchSavedReview();
+    store.dispatch(
+      deleteAddonReview({
+        errorHandlerId: createStubErrorHandler().id,
+        reviewId: review.id,
+      }),
+    );
+
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: store.dispatch,
+    });
+    errorHandler.handle(new Error('some unexpected error'));
+
+    const root = render({ errorHandler, review });
+
+    const controls = renderControls(root);
+    expect(controls.find('.AddonReviewListItem-deleting')).toHaveLength(0);
+    expect(controls.find('.AddonReviewListItem-delete')).toHaveLength(1);
+  });
+
   it('lets you begin editing your review', () => {
     const review = signInAndDispatchSavedReview();
     const dispatchSpy = sinon.spy(store, 'dispatch');

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -347,6 +347,14 @@ describe(__filename, () => {
         }),
       );
 
+      state = changeViewState({
+        state,
+        reviewId: review.id,
+        stateChange: {
+          someFlag: true,
+        },
+      });
+
       return state;
     };
 
@@ -370,6 +378,7 @@ describe(__filename, () => {
       expect(state.byAddon[addonSlug].reviews).toEqual([reviewId]);
       expect(state.byUserId[userId].reviews).toEqual([reviewId]);
       expect(state.groupedRatings[addonId]).toEqual(grouping);
+      expect(state.view[reviewId].someFlag).toEqual(true);
 
       // Clear all data based on a reviewId.
       state = reviewsReducer(state, unloadAddonReviews({ reviewId }));
@@ -378,6 +387,7 @@ describe(__filename, () => {
       expect(state.byAddon[addonSlug]).toEqual(undefined);
       expect(state.byUserId[userId]).toEqual(undefined);
       expect(state.groupedRatings[addonId]).toEqual(undefined);
+      expect(state.view[reviewId]).toEqual(undefined);
     });
 
     it('preserves unrelated reviews data', () => {
@@ -415,6 +425,7 @@ describe(__filename, () => {
       expect(state.byAddon[addonSlug2].reviews).toEqual([reviewId2]);
       expect(state.byUserId[userId2].reviews).toEqual([reviewId2]);
       expect(state.groupedRatings[addonId2]).toEqual(grouping);
+      expect(state.view[reviewId2].someFlag).toEqual(true);
 
       state = reviewsReducer(state, unloadAddonReviews({ reviewId }));
 
@@ -423,6 +434,7 @@ describe(__filename, () => {
       expect(state.byAddon[addonSlug2].reviews).toEqual([reviewId2]);
       expect(state.byUserId[userId2].reviews).toEqual([reviewId2]);
       expect(state.groupedRatings[addonId2]).toEqual(grouping);
+      expect(state.view[reviewId2].someFlag).toEqual(true);
     });
   });
 

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -1,5 +1,6 @@
 import {
   SAVED_RATING,
+  deleteAddonReview,
   unloadAddonReviews,
   createInternalReview,
   flagReview,
@@ -734,6 +735,7 @@ describe(__filename, () => {
       });
 
       expect(state.view[review.id]).toEqual({
+        deletingReview: false,
         editingReview: false,
         flag: {},
         replyingToReview: false,
@@ -1110,6 +1112,22 @@ describe(__filename, () => {
       state = reviewsReducer(state, hideFlashedReviewMessage());
 
       expect(state.flashMessage).toEqual(undefined);
+    });
+  });
+
+  describe('deleteAddonReview', () => {
+    it('stores view state about deleting a review', () => {
+      const review = { ...fakeReview, id: 837 };
+
+      const state = reviewsReducer(
+        undefined,
+        deleteAddonReview({
+          errorHandlerId: 'some-id',
+          reviewId: review.id,
+        }),
+      );
+
+      expect(state.view[review.id].deletingReview).toEqual(true);
     });
   });
 });

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -719,6 +719,28 @@ describe(__filename, () => {
       mockApi.verify();
     });
 
+    it('clears related reviews for an add-on review reply', async () => {
+      const reviewId = 12345;
+      const isReplyToReviewId = 98765;
+
+      mockApi
+        .expects('deleteReview')
+        .once()
+        .withArgs({
+          apiState,
+          reviewId,
+        })
+        .returns(Promise.resolve());
+
+      _deleteAddonReview({ isReplyToReviewId, reviewId });
+
+      const expectedAction = unloadAddonReviews({
+        reviewId: isReplyToReviewId,
+      });
+      const action = await sagaTester.waitFor(expectedAction.type);
+      expect(action).toEqual(expectedAction);
+    });
+
     it('dispatches an error', async () => {
       const error = new Error('some API error maybe');
       mockApi.expects('deleteReview').rejects(error);

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -697,7 +697,8 @@ const globalSetTimeout = setTimeout;
 
 /*
  * Wait until the saga dispatches an action causing isMatch(action)
- * to return true. Throw an error if it doesn't.
+ * to return true, and return that action.
+ * Throw an error if the action is not dispatched.
  *
  * This is helpful for when a saga dispatches the same action
  * but with differing payloads.
@@ -710,11 +711,13 @@ export async function matchingSagaAction(
   { maxTries = 50 } = {},
 ) {
   let calledActions = [];
+  let foundAction;
   let matched = false;
 
   for (let attempt = 0; attempt < maxTries; attempt++) {
     calledActions = sagaTester.getCalledActions();
-    if (calledActions.find(isMatch) !== undefined) {
+    foundAction = calledActions.find(isMatch);
+    if (foundAction !== undefined) {
       matched = true;
       break;
     }
@@ -735,4 +738,5 @@ export async function matchingSagaAction(
         .join(', ') || '(none at all)'}`,
     );
   }
+  return foundAction;
 }

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -712,13 +712,11 @@ export async function matchingSagaAction(
 ) {
   let calledActions = [];
   let foundAction;
-  let matched = false;
 
   for (let attempt = 0; attempt < maxTries; attempt++) {
     calledActions = sagaTester.getCalledActions();
     foundAction = calledActions.find(isMatch);
     if (foundAction !== undefined) {
-      matched = true;
       break;
     }
 
@@ -726,7 +724,7 @@ export async function matchingSagaAction(
     await new Promise((resolve) => globalSetTimeout(resolve, 1));
   }
 
-  if (!matched) {
+  if (!foundAction) {
     throw new Error(
       `
       The matcher function did not return true:

--- a/tests/unit/test_helpers.js
+++ b/tests/unit/test_helpers.js
@@ -180,6 +180,32 @@ describe(__filename, () => {
       });
     });
 
+    it('returns the matched action', async () => {
+      const firstValue = 'first';
+      const secondValue = 'second';
+
+      const makeAction = (value) => {
+        return {
+          type: EXAMPLE_ACTION,
+          payload: { order: value },
+        };
+      };
+
+      function* exampleHandler() {
+        yield put(makeAction(firstValue));
+        yield put(makeAction(secondValue));
+      }
+
+      const sagaTester = startSagaTester(exampleHandler);
+
+      const returnedAction = await matchingSagaAction(sagaTester, (action) => {
+        return (
+          action.type === EXAMPLE_ACTION && action.payload.order === secondValue
+        );
+      });
+      expect(returnedAction).toEqual(makeAction(secondValue));
+    });
+
     it('gives up matching the action after maxTries', async () => {
       // eslint-disable-next-line no-empty-function
       function* exampleHandler() {}

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -87,6 +87,18 @@ describe(__filename, () => {
     expect(cancelButton.children()).toHaveText('Cancel');
   });
 
+  it('hides the default button after it is clicked', () => {
+    const { store } = dispatchClientMetadata();
+    const root = render({ store });
+
+    root
+      .find('.ConfirmButton-default-button')
+      .simulate('click', createFakeEvent());
+    applyUIStateChanges({ root, store });
+
+    expect(root.find('.ConfirmButton-default-button')).toHaveLength(0);
+  });
+
   it('passes props to the confirm button in the confirmation panel', () => {
     const { store } = dispatchClientMetadata();
     const confirmButtonText = 'neutral confirm button';


### PR DESCRIPTION
Fixes #3075 

This adds a "Delete my review" link to reviews that are deletable by the current user, and a "Delete my reply" link to replies that are deletable by the current user. Clicking the link deletes the review/reply immediately and refreshes the list of reviews.

I considered using the `ConfirmButton` as we've used for deleting a collection and a user profile, but I think that's probably unnecessary for deleting a review/reply.

A user's review:

![screenshot 2018-08-27 14 23 49](https://user-images.githubusercontent.com/142755/44677801-d8482d00-aa04-11e8-9a69-386b06f649a7.png)

A developer's response:

![screenshot 2018-08-27 14 27 45](https://user-images.githubusercontent.com/142755/44678047-6b816280-aa05-11e8-99f4-0ff47b79f908.png)
