### PR TITLE
Fix AMInstallButton alignment on addon detail page

### DIFF
--- a/src/amo/components/Addon/styles.scss
+++ b/src/amo/components/Addon/styles.scss
@@ -6,6 +6,7 @@
   @include page-padding();
 
   .Addon-summary-and-install-button-wrapper {
+    .AMInstallButton,
     .InstallButton,
     .Button--get-firefox {
       @include respond-to(medium) {
@@ -151,6 +152,7 @@
   word-wrap: break-word;
 }
 
+.Addon .AMInstallButton,
 .Addon .InstallButton {
   @include respond-to(medium) {
     @include margin-start(auto);
@@ -160,6 +162,7 @@
   }
 }
 
+.Addon .AMInstallButton-button,
 .Addon .InstallButton-button,
 .Button--get-firefox {
   width: 100%;


### PR DESCRIPTION
Fix #6092

---

Before:

![screen shot 2018-08-28 at 17 49 07](https://user-images.githubusercontent.com/217628/44734670-c5a82380-aaea-11e8-9142-74d9b6881d4c.png)

After:

![screen shot 2018-08-28 at 17 49 05](https://user-images.githubusercontent.com/217628/44734668-c50f8d00-aaea-11e8-8265-e8cf63fc2d16.png)