### PR TITLE
Put existing visited collection in collections

### DIFF
--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -907,6 +907,7 @@ export const loadCollectionIntoState = ({
   // make sure we don't overwrite any existing addons.
   if (!internalCollection.addons && existingCollection) {
     internalCollection.addons = existingCollection.addons;
+    internalCollection.pageSize = existingCollection.pageSize;
   }
 
   return {

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -702,6 +702,7 @@ describe(__filename, () => {
 
   describe('loadCollectionIntoState', () => {
     it('preserves existing collection addons', () => {
+      const fakePageSize = 5;
       const fakeCollectionAddon = createFakeCollectionAddon({
         addon: { ...fakeAddon, id: 1 },
       });
@@ -717,6 +718,7 @@ describe(__filename, () => {
         state: initialState,
         collection,
         addons,
+        pageSize: fakePageSize,
       });
 
       // Simulate loading it a second time but without addons.
@@ -724,6 +726,7 @@ describe(__filename, () => {
 
       const collectionInState = state.byId[collection.id];
       expect(collectionInState.addons).toEqual(createInternalAddons(addons));
+      expect(collectionInState.pageSize).toEqual(fakePageSize);
     });
 
     it('loads notes for collection add-ons', () => {


### PR DESCRIPTION
Fixes #5930 

#### Description
When users go from collection A page(after refresh) to collections and back to collection A page, if addons number over 25, the pagination is disappeared.
The initial pageSize send from `LOAD_USER_COLLECTIONS` to `loadCollectionIntoState` is always null. So if the `existingCollection` is stored to collections, it can have all the existing data, including `pageSize`.

![fixed](https://user-images.githubusercontent.com/6767433/44992469-db758700-afc9-11e8-9860-2218254f3a53.gif)

