### PR TITLE
Fix style of the "Delete my review" link

### DIFF
--- a/src/amo/components/AddonReviewListItem/styles.scss
+++ b/src/amo/components/AddonReviewListItem/styles.scss
@@ -37,6 +37,7 @@
   .ConfirmButton-default-button {
     align-items: flex-start;
     color: $blue-50;
+    display: contents;
   }
 
   .ConfirmButton-buttons {


### PR DESCRIPTION
Fixes #6112 

This fixes it for me on Chrome.

Before:

<img width="744" alt="screenshot 2018-09-04 08 19 58" src="https://user-images.githubusercontent.com/142755/45030937-79de0880-b01b-11e8-9f7b-318661ebb7e4.png">

After:

<img width="752" alt="screenshot 2018-09-04 08 19 39" src="https://user-images.githubusercontent.com/142755/45030947-81051680-b01b-11e8-9aff-7ceb35a2e04a.png">
