### PR TITLE
Show compatible langpacks based on app version when possible

### DIFF
--- a/src/amo/components/AddonReview/index.js
+++ b/src/amo/components/AddonReview/index.js
@@ -11,7 +11,8 @@ import {
   setInternalReview as _setInternalReview,
   setReview,
 } from 'amo/actions/reviews';
-import { refreshAddon as _refreshAddon, sanitizeHTML } from 'core/utils';
+import { fetchAddon } from 'core/api';
+import { sanitizeHTML } from 'core/utils';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import defaultLocalStateCreator, { LocalState } from 'core/localState';
@@ -21,6 +22,7 @@ import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { SubmitReviewParams } from 'amo/api/reviews';
 import type { AppState } from 'amo/store';
+import { loadAddons } from 'core/reducers/addons';
 import type { ApiState } from 'core/reducers/api';
 import type { ErrorHandler as ErrorHandlerType } from 'core/errorHandler';
 import type { ElementEvent } from 'core/types/dom';
@@ -281,7 +283,9 @@ export const mapDispatchToProps = (
     refreshAddon:
       ownProps.refreshAddon ||
       (({ addonSlug, apiState }) => {
-        return _refreshAddon({ addonSlug, apiState, dispatch });
+        return fetchAddon({ slug: addonSlug, api: apiState }).then(
+          ({ entities }) => dispatch(loadAddons(entities)),
+        );
       }),
     setInternalReview: (review) => {
       dispatch(_setInternalReview(review));

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -3,7 +3,6 @@
 import url from 'url';
 
 import utf8 from 'utf8';
-import 'isomorphic-fetch';
 import { schema as normalizrSchema, normalize } from 'normalizr';
 import { oneLine } from 'common-tags';
 import config from 'config';

--- a/src/core/polyfill.js
+++ b/src/core/polyfill.js
@@ -1,2 +1,3 @@
 import 'babel-polyfill';
 import 'raf/polyfill';
+import 'isomorphic-fetch';

--- a/src/core/sagas/addons.js
+++ b/src/core/sagas/addons.js
@@ -9,6 +9,7 @@ import { call, put, select, takeEvery } from 'redux-saga/effects';
 import { fetchAddon as fetchAddonFromApi } from 'core/api';
 import { FETCH_ADDON, loadAddons } from 'core/reducers/addons';
 import log from 'core/logger';
+import type { FetchAddonParams } from 'core/api';
 import type { FetchAddonAction } from 'core/reducers/addons';
 
 import { createErrorHandler, getState } from './utils';
@@ -20,7 +21,10 @@ export function* fetchAddon({
   yield put(errorHandler.createClearingAction());
   try {
     const state = yield select(getState);
-    const response = yield call(fetchAddonFromApi, { api: state.api, slug });
+
+    const params: FetchAddonParams = { api: state.api, slug };
+    const response = yield call(fetchAddonFromApi, params);
+
     yield put(loadAddons(response.entities));
   } catch (error) {
     log.warn(`Failed to load add-on with slug ${slug}: ${error}`);

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -7,8 +7,6 @@ import invariant from 'invariant';
 import qhistory from 'qhistory';
 import { stringify, parse } from 'qs';
 
-import { loadAddons } from 'core/reducers/addons';
-import { fetchAddon } from 'core/api';
 import {
   ADDON_TYPE_COMPLETE_THEME,
   ADDON_TYPE_OPENSEARCH,
@@ -104,12 +102,6 @@ export function sanitizeUserHTML(text) {
     'strong',
     'ul',
   ]);
-}
-
-export function refreshAddon({ addonSlug, apiState, dispatch } = {}) {
-  return fetchAddon({ slug: addonSlug, api: apiState }).then(({ entities }) =>
-    dispatch(loadAddons(entities)),
-  );
 }
 
 export function isAddonAuthor({ addon, userId }) {

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -11,6 +11,8 @@ import Adapter from 'enzyme-adapter-react-16';
 // See: github.com/mozilla/addons-frontend/pull/2540#discussion_r120926107
 import 'jest-enzyme';
 
+import 'core/polyfill';
+
 Enzyme.configure({ adapter: new Adapter() });
 
 if (!Object.values) {

--- a/tests/unit/amo/components/TestAddonReview.js
+++ b/tests/unit/amo/components/TestAddonReview.js
@@ -459,12 +459,11 @@ describe(__filename, () => {
           .expects('fetchAddon')
           .rejects(new Error('Error accessing API'));
 
-        return actions.refreshAddon({ addonSlug, apiState }).then(
-          unexpectedSuccess,
-          () => {
+        return actions
+          .refreshAddon({ addonSlug, apiState })
+          .then(unexpectedSuccess, () => {
             sinon.assert.notCalled(dispatch);
-          },
-        );
+          });
       });
     });
 

--- a/tests/unit/amo/components/TestAddonReview.js
+++ b/tests/unit/amo/components/TestAddonReview.js
@@ -5,7 +5,8 @@ import { mount } from 'enzyme';
 import I18nProvider from 'core/i18n/Provider';
 import { setInternalReview, setReview } from 'amo/actions/reviews';
 import * as reviewsApi from 'amo/api/reviews';
-import * as coreUtils from 'core/utils';
+import * as coreApi from 'core/api';
+import { loadAddons } from 'core/reducers/addons';
 import AddonReview, {
   mapDispatchToProps,
   mapStateToProps,
@@ -19,9 +20,11 @@ import {
 } from 'tests/unit/amo/helpers';
 import {
   createFakeEvent,
+  createFetchAddonResult,
   createStubErrorHandler,
   fakeI18n,
   shallowUntilTarget,
+  unexpectedSuccess,
 } from 'tests/unit/helpers';
 import OverlayCard from 'ui/components/OverlayCard';
 import UserRating from 'ui/components/UserRating';
@@ -398,16 +401,16 @@ describe(__filename, () => {
   });
 
   describe('mapDispatchToProps', () => {
-    let mockUtils;
-    let mockApi;
+    let mockReviewsApi;
+    let mockCoreApi;
     let dispatch;
     let actions;
 
     const { api } = dispatchSignInActions().state;
 
     beforeEach(() => {
-      mockUtils = sinon.mock(coreUtils);
-      mockApi = sinon.mock(reviewsApi);
+      mockReviewsApi = sinon.mock(reviewsApi);
+      mockCoreApi = sinon.mock(coreApi);
       dispatch = sinon.stub();
       actions = mapDispatchToProps(dispatch, {});
     });
@@ -421,31 +424,47 @@ describe(__filename, () => {
           apiState: api,
         };
 
-        mockApi
+        mockReviewsApi
           .expects('submitReview')
           .withArgs(params)
           .returns(Promise.resolve(fakeReview));
 
         return actions.updateReviewText({ ...params }).then(() => {
-          mockApi.verify();
+          mockReviewsApi.verify();
           sinon.assert.calledWith(dispatch, setReview(fakeReview));
         });
       });
     });
 
     describe('refreshAddon', () => {
-      it('binds dispatch and calls utils.refreshAddon()', () => {
-        const apiState = api;
+      const addonSlug = fakeAddon.slug;
+      const apiState = dispatchSignInActions().state.api;
 
-        mockUtils
-          .expects('refreshAddon')
+      it('fetches and dispatches an add-on', async () => {
+        const { entities } = createFetchAddonResult(fakeAddon);
+        mockCoreApi
+          .expects('fetchAddon')
           .once()
-          .withArgs({ addonSlug: 'some-slug', apiState, dispatch })
-          .returns(Promise.resolve());
+          .withArgs({ slug: addonSlug, api: apiState })
+          .resolves({ entities });
 
-        return actions
-          .refreshAddon({ addonSlug: 'some-slug', apiState })
-          .then(() => mockUtils.verify());
+        await actions.refreshAddon({ addonSlug, apiState });
+
+        sinon.assert.calledWith(dispatch, loadAddons(entities));
+        mockCoreApi.verify();
+      });
+
+      it('handles 404s when loading the add-on', () => {
+        mockCoreApi
+          .expects('fetchAddon')
+          .rejects(new Error('Error accessing API'));
+
+        return actions.refreshAddon({ addonSlug, apiState }).then(
+          unexpectedSuccess,
+          () => {
+            sinon.assert.notCalled(dispatch);
+          },
+        );
       });
     });
 

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -2,7 +2,6 @@ import url from 'url';
 
 import config from 'config';
 
-import * as api from 'core/api';
 import {
   ADDON_TYPE_COMPLETE_THEME,
   ADDON_TYPE_DICT,
@@ -34,7 +33,6 @@ import {
   isValidClientApp,
   nl2br,
   normalizeFileNameId,
-  refreshAddon,
   removeProtocolFromURL,
   safePromise,
   sanitizeHTML,
@@ -43,12 +41,11 @@ import {
   visibleAddonType,
   trimAndAddProtocolToUrl,
 } from 'core/utils';
-import { createInternalAddon, loadAddons } from 'core/reducers/addons';
-import { dispatchSignInActions, fakeAddon } from 'tests/unit/amo/helpers';
+import { createInternalAddon } from 'core/reducers/addons';
+import { fakeAddon } from 'tests/unit/amo/helpers';
 import {
   createFakeHistory,
   createFakeLocation,
-  createFetchAddonResult,
   getFakeConfig,
   unexpectedSuccess,
   userAgents,
@@ -329,46 +326,6 @@ describe(__filename, () => {
 
     it('should be invalid if passed "whatever"', () => {
       expect(isValidClientApp('whatever', { _config })).toEqual(false);
-    });
-  });
-
-  describe('refreshAddon', () => {
-    const addonSlug = fakeAddon.slug;
-    const apiState = dispatchSignInActions().state.api;
-    let dispatch;
-    let mockApi;
-
-    beforeEach(() => {
-      dispatch = sinon.spy();
-      mockApi = sinon.mock(api);
-    });
-
-    it('fetches and dispatches an add-on', () => {
-      const { entities } = createFetchAddonResult(fakeAddon);
-      mockApi
-        .expects('fetchAddon')
-        .once()
-        .withArgs({ slug: addonSlug, api: apiState })
-        .returns(Promise.resolve({ entities }));
-
-      return refreshAddon({ addonSlug, apiState, dispatch }).then(() => {
-        sinon.assert.calledWith(dispatch, loadAddons(entities));
-        mockApi.verify();
-      });
-    });
-
-    it('handles 404s when loading the add-on', () => {
-      mockApi
-        .expects('fetchAddon')
-        .once()
-        .withArgs({ slug: addonSlug, api: apiState })
-        .returns(Promise.reject(new Error('Error accessing API')));
-      return refreshAddon({ addonSlug, apiState, dispatch }).then(
-        unexpectedSuccess,
-        () => {
-          sinon.assert.notCalled(dispatch);
-        },
-      );
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/4935

~~In the interest of time and simplicity, I did not actually test this by setting up multiple versions of language packs.~~ I was able to test this with http://localhost:3000/en-US/firefox/addon/finn-language-pack/ (see https://github.com/mozilla/addons-server/issues/8180#issuecomment-418687835)

Also, I opened up a can of worms here. The moving of `refreshAddon` was to fix a circular dependency and the new polyfill code was probably always a bug but I think moving `refreshAddon` made it worse.