### PR TITLE
Add version param to callApi

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -14,6 +14,7 @@ module.exports = {
     'amoCDN',
     'apiHost',
     'apiPath',
+    'apiVersion',
     'appName',
     'cookieMaxAge',
     'cookieName',

--- a/config/default.js
+++ b/config/default.js
@@ -73,7 +73,8 @@ module.exports = {
   amoCDN: amoProdCDN,
   staticHost: amoProdCDN,
   apiHost: apiProdHost,
-  apiPath: '/api/v3',
+  apiPath: '/api/',
+  apiVersion: 'v3',
 
   // The version for the favicon.
   // This should be changed when a new favicon is pushed to the CDN to prevent
@@ -92,6 +93,7 @@ module.exports = {
     'amoCDN',
     'apiHost',
     'apiPath',
+    'apiVersion',
     'appName',
     'authTokenValidFor',
     'cookieMaxAge',

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -82,6 +82,7 @@ type CallApiParams = {|
   params?: Object,
   schema?: Object,
   _config?: typeof config,
+  version?: string,
 |};
 
 export function callApi({
@@ -95,6 +96,7 @@ export function callApi({
   credentials,
   errorHandler,
   _config = config,
+  version = _config.get('apiVersion'),
 }: CallApiParams): Promise<any> {
   if (!endpoint) {
     return Promise.reject(
@@ -105,13 +107,15 @@ export function callApi({
     errorHandler.clear();
   }
 
+  const apiPath = `${config.get('apiPath')}${version}`;
+
   const parsedUrl = url.parse(endpoint, true);
   let adjustedEndpoint = parsedUrl.pathname || '';
   if (!parsedUrl.host) {
     // If it's a relative URL, add the API prefix.
     const slash = !adjustedEndpoint.startsWith('/') ? '/' : '';
-    adjustedEndpoint = `${config.get('apiPath')}${slash}${adjustedEndpoint}`;
-  } else if (!adjustedEndpoint.startsWith(config.get('apiPath'))) {
+    adjustedEndpoint = `${apiPath}${slash}${adjustedEndpoint}`;
+  } else if (!adjustedEndpoint.startsWith(apiPath)) {
     // If it's an absolute URL, it must have the correct prefix.
     return Promise.reject(
       new Error(`Absolute URL "${endpoint}" has an unexpected prefix.`),
@@ -234,11 +238,15 @@ export function fetchAddon({ api, slug }: FetchAddonParams) {
 }
 
 export function startLoginUrl({
+  _config = config,
   location,
 }: {|
+  _config?: typeof config,
   location: ReactRouterLocationType,
 |}) {
-  const configName = config.get('fxaConfig');
+  const apiVersion = _config.get('apiVersion');
+  const configName = _config.get('fxaConfig');
+
   const params = {
     config: undefined,
     to: url.format({ ...location }),
@@ -247,7 +255,8 @@ export function startLoginUrl({
     params.config = configName;
   }
   const query = makeQueryString(params);
-  return `${API_BASE}/accounts/login/start/${query}`;
+
+  return `${API_BASE}${apiVersion}/accounts/login/start/${query}`;
 }
 
 export function categories({ api }: {| api: ApiState |}) {

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -459,6 +459,7 @@ export function runServer({
                 `[isDeployed:${config.get('isDeployed')}]`,
                 `[apiHost:${config.get('apiHost')}]`,
                 `[apiPath:${config.get('apiPath')}]`,
+                `[apiVersion:${config.get('apiVersion')}]`,
               ].join(' '),
             );
             if (proxyEnabled) {

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -414,12 +414,13 @@ describe(__filename, () => {
     });
 
     it('uses the config version as default value', async () => {
-      const _config = getFakeConfig({ apiVersion: '456' });
+      const apiVersion = '456';
+      const _config = getFakeConfig({ apiVersion });
       const endpoint = '/some-endpoint/';
 
       mockWindow
         .expects('fetch')
-        .withArgs(sinon.match('/api/456/some-endpoint/'))
+        .withArgs(sinon.match(`/api/${apiVersion}/some-endpoint/`))
         .returns(createApiResponse());
 
       await api.callApi({ _config, endpoint });
@@ -587,21 +588,23 @@ describe(__filename, () => {
     });
 
     it('includes the next path the config if set', () => {
-      const _config = getFakeConfig({ fxaConfig: 'my-config' });
+      const fxaConfig = 'my-config';
+      const _config = getFakeConfig({ fxaConfig });
       const location = createFakeLocation({ pathname: '/foo' });
 
       expect(getStartLoginQs({ _config, location })).toEqual({
         to: '/foo',
-        config: 'my-config',
+        config: fxaConfig,
       });
     });
 
     it('uses the API version from config', () => {
-      const _config = getFakeConfig({ apiVersion: 'v789' });
+      const apiVersion = 'v789';
+      const _config = getFakeConfig({ apiVersion });
       const location = createFakeLocation();
 
       expect(api.startLoginUrl({ _config, location })).toContain(
-        '/api/v789/accounts/login/start/',
+        `/api/${apiVersion}/accounts/login/start/`,
       );
     });
   });

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -399,6 +399,32 @@ describe(__filename, () => {
       await api.callApi({ endpoint, body });
       mockWindow.verify();
     });
+
+    it('sets a custom API version', async () => {
+      const endpoint = '/some-endpoint/';
+      const version = 'v123';
+
+      mockWindow
+        .expects('fetch')
+        .withArgs(sinon.match(`/api/${version}/some-endpoint/`))
+        .returns(createApiResponse());
+
+      await api.callApi({ endpoint, version });
+      mockWindow.verify();
+    });
+
+    it('uses the config version as default value', async () => {
+      const _config = getFakeConfig({ apiVersion: '456' });
+      const endpoint = '/some-endpoint/';
+
+      mockWindow
+        .expects('fetch')
+        .withArgs(sinon.match('/api/456/some-endpoint/'))
+        .returns(createApiResponse());
+
+      await api.callApi({ _config, endpoint });
+      mockWindow.verify();
+    });
   });
 
   describe('makeQueryString', () => {
@@ -546,27 +572,37 @@ describe(__filename, () => {
   });
 
   describe('startLoginUrl', () => {
-    const getStartLoginQs = (location) =>
-      querystring.parse(api.startLoginUrl({ location }).split('?')[1]);
+    const getStartLoginQs = ({ _config, location }) => {
+      return querystring.parse(
+        api.startLoginUrl({ _config, location }).split('?')[1],
+      );
+    };
 
     it('includes the next path', () => {
       const location = createFakeLocation({
         pathname: '/foo',
         query: { bar: 'BAR' },
       });
-      expect(getStartLoginQs(location)).toEqual({ to: '/foo?bar=BAR' });
+      expect(getStartLoginQs({ location })).toEqual({ to: '/foo?bar=BAR' });
     });
 
     it('includes the next path the config if set', () => {
-      sinon
-        .stub(config, 'get')
-        .withArgs('fxaConfig')
-        .returns('my-config');
+      const _config = getFakeConfig({ fxaConfig: 'my-config' });
       const location = createFakeLocation({ pathname: '/foo' });
-      expect(getStartLoginQs(location)).toEqual({
+
+      expect(getStartLoginQs({ _config, location })).toEqual({
         to: '/foo',
         config: 'my-config',
       });
+    });
+
+    it('uses the API version from config', () => {
+      const _config = getFakeConfig({ apiVersion: 'v789' });
+      const location = createFakeLocation();
+
+      expect(api.startLoginUrl({ _config, location })).toContain(
+        '/api/v789/accounts/login/start/',
+      );
     });
   });
 


### PR DESCRIPTION
Refs #5527 

---

This PR adds a `version` parameter to the `callApi` function, used by most higher-level API calls, along with a `apiVersion` config parameter. This will ease the API version upgrade described in #5527.