### PR TITLE
Listen to onOperationCancelled to fix the install status

### DIFF
--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -163,11 +163,12 @@ export function addChangeListeners(
     needsRestart: boolean,
   |}) => void,
   mozAddonManager: MozAddonManagerType,
+  { _log = log }: {| _log: typeof log |} = {},
 ) {
   function handleChangeEvent(e: AddonChangeEvent) {
     const { id: guid, type, needsRestart } = e;
 
-    log.info('Event received', { type, id: guid, needsRestart });
+    _log.info('Event received', { type, id: guid, needsRestart });
 
     if (type === ON_OPERATION_CANCELLED_EVENT) {
       // We need to retrieve the correct status for this add-on.
@@ -182,7 +183,7 @@ export function addChangeListeners(
           });
         })
         .catch((error) => {
-          log.error(
+          _log.error(
             'Unexpected error after having received onOperationCancelled event',
             error,
           );
@@ -203,7 +204,7 @@ export function addChangeListeners(
 
   if (mozAddonManager && mozAddonManager.addEventListener) {
     for (const event of GLOBAL_EVENTS) {
-      log.info(`adding event listener for "${event}"`);
+      _log.info(`adding event listener for "${event}"`);
       mozAddonManager.addEventListener(event, handleChangeEvent);
     }
 
@@ -212,9 +213,9 @@ export function addChangeListeners(
       handleChangeEvent,
     );
 
-    log.info('Global change event listeners have been initialized');
+    _log.info('Global change event listeners have been initialized');
   } else {
-    log.info('mozAddonManager.addEventListener not available');
+    _log.info('mozAddonManager.addEventListener not available');
   }
 
   return handleChangeEvent;

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -8,6 +8,7 @@ import {
   GLOBAL_EVENT_STATUS_MAP,
   INACTIVE,
   INSTALL_EVENT_LIST,
+  ON_OPERATION_CANCELLED_EVENT,
   SET_ENABLE_NOT_AVAILABLE,
 } from 'core/constants';
 import { addQueryParams, isTheme } from 'core/utils';
@@ -43,7 +44,7 @@ type OptionalParams = {|
 
 type GetAddonStatusParams = {|
   addon: FirefoxAddon,
-  type: string,
+  type?: string,
 |};
 
 export function getAddonStatus({ addon, type }: GetAddonStatusParams) {
@@ -164,18 +165,39 @@ export function addChangeListeners(
   mozAddonManager: MozAddonManagerType,
 ) {
   function handleChangeEvent(e: AddonChangeEvent) {
-    const { id, type, needsRestart } = e;
+    const { id: guid, type, needsRestart } = e;
 
-    log.info('Event received', { type, id, needsRestart });
+    log.info('Event received', { type, id: guid, needsRestart });
+
+    if (type === ON_OPERATION_CANCELLED_EVENT) {
+      // We need to retrieve the correct status for this add-on.
+      return getAddon(guid, { _mozAddonManager: mozAddonManager })
+        .then((addon) => {
+          const status = getAddonStatus({ addon });
+
+          return callback({
+            guid,
+            status,
+            needsRestart,
+          });
+        })
+        .catch((error) => {
+          log.error(
+            'Unexpected error after having received onOperationCancelled event',
+            error,
+          );
+        });
+    }
 
     // eslint-disable-next-line no-prototype-builtins
     if (GLOBAL_EVENT_STATUS_MAP.hasOwnProperty(type)) {
       return callback({
-        guid: id,
+        guid,
         status: GLOBAL_EVENT_STATUS_MAP[type],
         needsRestart,
       });
     }
+
     throw new Error(`Unknown global event: ${type}`);
   }
 
@@ -185,10 +207,16 @@ export function addChangeListeners(
       mozAddonManager.addEventListener(event, handleChangeEvent);
     }
 
+    mozAddonManager.addEventListener(
+      ON_OPERATION_CANCELLED_EVENT,
+      handleChangeEvent,
+    );
+
     log.info('Global change event listeners have been initialized');
   } else {
     log.info('mozAddonManager.addEventListener not available');
   }
+
   return handleChangeEvent;
 }
 

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -246,6 +246,8 @@ export const GLOBAL_EVENT_STATUS_MAP = {
   onEnabling: ENABLING,
   onDisabling: DISABLING,
 };
+// This mozAddonManager event has no one-to-one mapping.
+export const ON_OPERATION_CANCELLED_EVENT = 'onOperationCancelled';
 
 // The events here are set directly on mozAddonManager
 // they will be fired by addons and themes.

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -252,13 +252,9 @@ describe(__filename, () => {
 
   describe('addChangeListener', () => {
     const fakeEventCallback = sinon.stub();
-    fakeMozAddonManager = {
-      addEventListener: sinon.stub(),
-    };
 
     beforeEach(() => {
       fakeEventCallback.resetHistory();
-      fakeMozAddonManager.addEventListener.resetHistory();
     });
 
     describe('global events', () => {

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -1,14 +1,28 @@
 import * as addonManager from 'core/addonManager';
 import {
-  GLOBAL_EVENT_STATUS_MAP,
   GLOBAL_EVENTS,
+  GLOBAL_EVENT_STATUS_MAP,
   INSTALL_EVENT_LIST,
+  ON_OPERATION_CANCELLED_EVENT,
   SET_ENABLE_NOT_AVAILABLE,
 } from 'core/constants';
 import { unexpectedSuccess } from 'tests/unit/helpers';
 
+const fakeClientAddon = (overrides = {}) => ({
+  canUninstall: false,
+  description: 'some desc',
+  id: 'some@guid',
+  isActive: true,
+  isEnabled: true,
+  name: 'addon name',
+  setEnabled: sinon.stub(),
+  type: 'extension',
+  uninstall: sinon.stub(),
+  version: '1.2.3',
+  ...overrides,
+});
+
 describe(__filename, () => {
-  let fakeAddon;
   let fakeCallback;
   let fakeInstallObj;
   let fakeInstallUrl;
@@ -17,9 +31,6 @@ describe(__filename, () => {
   beforeEach(() => {
     fakeCallback = sinon.stub();
     fakeInstallUrl = 'https://fake-install-url/foo.xpi';
-    fakeAddon = {
-      uninstall: sinon.stub(),
-    };
     fakeInstallObj = {
       addEventListener: sinon.spy(function addEventListener(eventName, cb) {
         this[`${eventName}Listener`] = cb;
@@ -89,6 +100,7 @@ describe(__filename, () => {
 
   describe('getAddon()', () => {
     it('should call mozAddonManager.getAddonByID() with id', async () => {
+      const fakeAddon = { ...fakeClientAddon };
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
 
       await addonManager.getAddon('test-id', {
@@ -204,7 +216,9 @@ describe(__filename, () => {
     });
 
     it('should reject if addon.uninstall resolves with false', () => {
-      fakeAddon.uninstall.returns(Promise.resolve(false));
+      const fakeAddon = fakeClientAddon({
+        uninstall: sinon.stub().resolves(false),
+      });
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
       return addonManager
         .uninstall('test-id', { _mozAddonManager: fakeMozAddonManager })
@@ -214,7 +228,9 @@ describe(__filename, () => {
     });
 
     it('should resolve if addon.uninstall resolves with true', () => {
-      fakeAddon.uninstall.returns(Promise.resolve(true));
+      const fakeAddon = fakeClientAddon({
+        uninstall: sinon.stub().resolves(true),
+      });
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
       // If the code doesn't resolve this will blow up.
       return addonManager.uninstall('test-id', {
@@ -223,7 +239,9 @@ describe(__filename, () => {
     });
 
     it('should resolve if addon.uninstall just resolves', () => {
-      fakeAddon.uninstall.returns(Promise.resolve());
+      const fakeAddon = fakeClientAddon({
+        uninstall: sinon.stub().resolves(),
+      });
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
       // If the code doesn't resolve this will blow up.
       return addonManager.uninstall('test-id', {
@@ -238,41 +256,79 @@ describe(__filename, () => {
       addEventListener: sinon.stub(),
     };
 
-    const handleChangeEvent = addonManager.addChangeListeners(
-      fakeEventCallback,
-      fakeMozAddonManager,
-    );
+    describe('global events', () => {
+      const handleChangeEvent = addonManager.addChangeListeners(
+        fakeEventCallback,
+        fakeMozAddonManager,
+      );
 
-    GLOBAL_EVENTS.forEach((event) => {
-      const status = GLOBAL_EVENT_STATUS_MAP[event];
+      GLOBAL_EVENTS.forEach((event) => {
+        const status = GLOBAL_EVENT_STATUS_MAP[event];
 
-      it(`calls callback with status ${status}`, () => {
-        const id = 'foo@whatever';
-        const needsRestart = false;
+        it(`calls callback with status ${status}`, async () => {
+          const id = 'foo@whatever';
+          const needsRestart = false;
 
-        handleChangeEvent({ id, needsRestart, type: event });
+          await handleChangeEvent({ id, needsRestart, type: event });
 
-        sinon.assert.calledWith(fakeEventCallback, {
-          guid: id,
-          needsRestart,
-          status,
+          sinon.assert.calledWith(fakeEventCallback, {
+            guid: id,
+            needsRestart,
+            status,
+          });
         });
       });
     });
 
     it('throws on unknown event', () => {
+      const handleChangeEvent = addonManager.addChangeListeners(
+        fakeEventCallback,
+        fakeMozAddonManager,
+      );
+
       expect(() => {
         handleChangeEvent({ type: 'whatevs' });
       }).toThrowError(/Unknown global event/);
+    });
+
+    it('listens to onOperationCancelled', () => {
+      addonManager.addChangeListeners(fakeEventCallback, fakeMozAddonManager);
+
+      sinon.assert.calledWith(
+        fakeMozAddonManager.addEventListener,
+        ON_OPERATION_CANCELLED_EVENT,
+      );
+    });
+
+    it('calls the callback when onOperationCancelled is received', async () => {
+      const fakeAddon = fakeClientAddon();
+      fakeMozAddonManager.getAddonByID.resolves(fakeAddon);
+
+      const handleChangeEvent = addonManager.addChangeListeners(
+        fakeEventCallback,
+        fakeMozAddonManager,
+      );
+
+      const guid = 'foo@whatever';
+      const needsRestart = false;
+
+      await handleChangeEvent({
+        id: guid,
+        needsRestart,
+        type: ON_OPERATION_CANCELLED_EVENT,
+      });
+
+      sinon.assert.calledWith(fakeEventCallback, {
+        guid,
+        needsRestart,
+        status: addonManager.getAddonStatus({ addon: fakeAddon }),
+      });
     });
   });
 
   describe('enable()', () => {
     it('should call addon.setEnable()', async () => {
-      fakeAddon = {
-        setEnabled: sinon.stub(),
-      };
-
+      const fakeAddon = fakeClientAddon();
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
 
       await addonManager.enable('whatever', {
@@ -282,9 +338,12 @@ describe(__filename, () => {
       sinon.assert.calledWith(fakeAddon.setEnabled, true);
     });
 
-    it('should throw if addon.setEnable does not exist', () => {
-      fakeAddon = {};
+    it('should throw if addon.setEnabled does not exist', () => {
+      const fakeAddon = fakeClientAddon({
+        setEnabled: undefined,
+      });
       fakeMozAddonManager.getAddonByID.returns(Promise.resolve(fakeAddon));
+
       return addonManager
         .enable('whatevs', { _mozAddonManager: fakeMozAddonManager })
         .then(unexpectedSuccess, (err) => {

--- a/tests/unit/disco/pages/TestDiscoPane.js
+++ b/tests/unit/disco/pages/TestDiscoPane.js
@@ -325,7 +325,8 @@ describe(__filename, () => {
       renderAndMount({ mozAddonManager: fakeMozAddonManager });
       sinon.assert.callCount(
         fakeMozAddonManager.addEventListener,
-        GLOBAL_EVENTS.length,
+        // + 1 because of onOperationCancelled that is registered separately.
+        GLOBAL_EVENTS.length + 1,
       );
     });
   });


### PR DESCRIPTION
Fix #6164
Fix #562
Fix #6227

~~⚠️ depends on #6237~~

---

The `onOperationCancelled` event is fired when a user clicks the "undo"
button in `about:addons` (after having removed an add-on from this
panel). This fixes a bug where the install button state was still
"pending" on the AMO side.

Update: this `onOperationCancelled` event seems to be only sent for extensions.