### PR TITLE
 Add transition on AMInstallButton 

### DIFF
--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import {
   ADDON_TYPE_OPENSEARCH,
@@ -78,6 +79,8 @@ type ButtonProps = {|
   onClick: Function | null,
   puffy: boolean,
 |};
+
+const TRANSITION_TIMEOUT = 150;
 
 export class AMInstallButtonBase extends React.Component<InternalProps> {
   static defaultProps = {
@@ -304,25 +307,34 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
       }
     }
 
+    const transitionProps = {
+      classNames: 'AMInstallButton-transition',
+      timeout: TRANSITION_TIMEOUT,
+    };
+
     return (
-      <div className={makeClassName('AMInstallButton', className)}>
+      <TransitionGroup className={makeClassName('AMInstallButton', className)}>
         {this.showLoadingAnimation() ? (
-          <div
-            className={makeClassName('AMInstallButton-loading', {
-              'AMInstallButton-loading--puffy': this.props.puffy,
-            })}
-          >
-            <span className="AMInstallButton-loading-icon">
-              <Icon alt={this.getButtonText()} name="loading" />
-            </span>
-          </div>
+          <CSSTransition key="loading" {...transitionProps}>
+            <div
+              className={makeClassName('AMInstallButton-loading', {
+                'AMInstallButton-loading--puffy': this.props.puffy,
+              })}
+            >
+              <span className="AMInstallButton-loading-icon">
+                <Icon alt={this.getButtonText()} name="loading" />
+              </span>
+            </div>
+          </CSSTransition>
         ) : (
-          <Button {...buttonProps}>
-            <Icon name={this.getIconName()} />
-            {this.getButtonText()}
-          </Button>
+          <CSSTransition key="button" {...transitionProps}>
+            <Button {...buttonProps}>
+              <Icon name={this.getIconName()} />
+              {this.getButtonText()}
+            </Button>
+          </CSSTransition>
         )}
-      </div>
+      </TransitionGroup>
     );
   }
 }

--- a/src/core/components/AMInstallButton/styles.scss
+++ b/src/core/components/AMInstallButton/styles.scss
@@ -35,6 +35,19 @@
   }
 }
 
+.AMInstallButton-transition-enter {
+  opacity: 0.01;
+}
+
+.AMInstallButton-transition-exit {
+  display: none;
+}
+
+.AMInstallButton-transition-enter-active {
+  opacity: 1;
+  transition: opacity $transition-short ease;
+}
+
 .AMInstallButton {
   .AMInstallButton-button {
     white-space: nowrap;

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { TransitionGroup } from 'react-transition-group';
 
 import createStore from 'amo/store';
 import AMInstallButton, {
@@ -119,7 +120,8 @@ describe(__filename, () => {
 
     const root = render({ addon });
 
-    expect(root.type()).toEqual('div');
+    expect(root.type()).toEqual(TransitionGroup);
+    expect(root.find(TransitionGroup).prop('component')).toEqual('div');
     expect(root).toHaveClassName('AMInstallButton');
 
     const button = root.find(Button);
@@ -149,7 +151,8 @@ describe(__filename, () => {
 
     const root = render({ addon });
 
-    expect(root.type()).toEqual('div');
+    expect(root.type()).toEqual(TransitionGroup);
+    expect(root.find(TransitionGroup).prop('component')).toEqual('div');
     expect(root).toHaveClassName('AMInstallButton');
 
     const button = root.find(Button);


### PR DESCRIPTION
Fix #6165  – ~~⚠️ depends on #6170~~

---

This PR adds a short CSS transition on the `AMInstallButton`.