### PR TITLE
Simplify how saved ratings are rendered

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -40,7 +40,6 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType | null,
-  bodyFallback?: React.Node | string,
   className?: string,
   flaggable?: boolean,
   isReplyToReviewId?: number,
@@ -180,10 +179,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       return i18n.gettext('Edit my reply');
     }
 
-    if (this.isRatingOnly()) {
-      return i18n.gettext('Edit my rating');
-    }
-
     return i18n.gettext('Edit my review');
   }
 
@@ -270,7 +265,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   render() {
     const {
       addon,
-      bodyFallback,
       className,
       deletingReview,
       editingReview,
@@ -324,13 +318,15 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
                 review={review}
               />
             ) : null}
-            <a
-              href="#edit"
-              onClick={this.onClickToEditReview}
-              className="AddonReviewCard-edit AddonReviewCard-control"
-            >
-              {this.editPrompt()}
-            </a>
+            {!this.isRatingOnly() && (
+              <a
+                href="#edit"
+                onClick={this.onClickToEditReview}
+                className="AddonReviewCard-edit AddonReviewCard-control"
+              >
+                {this.editPrompt()}
+              </a>
+            )}
             {deletingReview && !errorHandler.hasError() ? (
               <span className="AddonReviewCard-control AddonReviewCard-deleting">
                 {i18n.gettext('Deleting…')}
@@ -386,11 +382,12 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
     return (
       <UserReview
-        bodyFallback={bodyFallback}
-        className={makeClassName('AddonReviewCard', className)}
+        className={makeClassName('AddonReviewCard', className, {
+          'AddonReviewCard-ratingOnly': this.isRatingOnly(),
+        })}
         controls={controls}
         review={review}
-        byLine={byLine}
+        byLine={!this.isRatingOnly() && byLine}
         showRating={!this.isReply() && showRating}
       >
         {errorHandler.renderErrorIfPresent()}

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -277,33 +277,32 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
       );
     }
 
-    const bodyFallback = (
-      <div className="RatingManager-emptyReviewBody">
-        <Button
-          onClick={this.showTextEntry}
-          href="#writeReview"
-          buttonType="action"
-          puffy
-        >
-          {i18n.gettext('Write a review')}
-        </Button>
-      </div>
-    );
-
     return (
       <React.Fragment>
         {this.renderUserRatingForm()}
         {userReview && (
-          <AddonReviewCard
-            addon={addon}
-            bodyFallback={bodyFallback}
-            className="RatingManager-AddonReviewCard"
-            flaggable={false}
-            location={location}
-            review={userReview}
-            shortByLine
-            showRating={false}
-          />
+          <React.Fragment>
+            <AddonReviewCard
+              addon={addon}
+              className="RatingManager-AddonReviewCard"
+              flaggable={false}
+              location={location}
+              review={userReview}
+              shortByLine
+              showRating={false}
+            />
+            {!userReview.body && (
+              <Button
+                className="RatingManager-writeReviewButton"
+                onClick={this.showTextEntry}
+                href="#writeReview"
+                buttonType="action"
+                puffy
+              >
+                {i18n.gettext('Write a review')}
+              </Button>
+            )}
+          </React.Fragment>
         )}
       </React.Fragment>
     );

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -36,16 +36,19 @@
   .AddonReviewCard-allControls {
     justify-content: space-between;
   }
+
+  .AddonReviewCard-ratingOnly .AddonReviewCard-allControls {
+    justify-content: center;
+  }
 }
 
-.RatingManager-AddonReviewCard {
+.RatingManager-AddonReviewCard:not(.AddonReviewCard-ratingOnly) {
   background-color: transparentize($blue-50, 0.95);
   border-radius: $border-radius-default;
   padding: 12px;
 
   @include respond-to(medium) {
-    padding: 24px;
-    padding-bottom: 12px;
+    padding: 12px 24px 12px 24px;
   }
 }
 
@@ -53,8 +56,7 @@
   margin: 12px;
 }
 
-.RatingManager-emptyReviewBody {
-  display: flex;
-  justify-content: center;
-  margin: 24px 0 24px;
+.RatingManager-writeReviewButton {
+  margin-top: 12px;
+  width: 100%;
 }

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -38,8 +38,16 @@ function reviewBody({
   } else {
     bodyAttr.dangerouslySetInnerHTML = html;
   }
-  // eslint-disable-next-line react/no-danger-with-children
-  return <div className="UserReview-body" {...bodyAttr} />;
+
+  return (
+    <div
+      className={makeClassName('UserReview-body', {
+        // Add an extra class if the content is an empty string.
+        'UserReview-emptyBody': !content && !html,
+      })}
+      {...bodyAttr}
+    />
+  );
 }
 
 const UserReview: React.ComponentType<Props> = ({

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -11,7 +11,6 @@ import type { UserReviewType } from 'amo/actions/reviews';
 import './styles.scss';
 
 type Props = {|
-  bodyFallback?: React.Node | string,
   byLine: React.Node | null,
   children?: React.Node,
   className?: string,
@@ -44,7 +43,6 @@ function reviewBody({
 }
 
 const UserReview: React.ComponentType<Props> = ({
-  bodyFallback,
   byLine,
   children,
   className,
@@ -59,8 +57,6 @@ const UserReview: React.ComponentType<Props> = ({
       body = reviewBody({
         html: sanitizeHTML(nl2br(review.body), ['br']),
       });
-    } else if (bodyFallback) {
-      body = reviewBody({ content: bodyFallback });
     } else {
       body = reviewBody({ content: '' });
     }

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -25,8 +25,11 @@
 
 .UserReview-body {
   font-size: $font-size-default;
-  margin: 4px 0 6px;
   word-wrap: break-word;
+
+  &:not(.UserReview-emptyBody) {
+    margin: 4px 0 6px;
+  }
 }
 
 .UserReview-byLine {

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -170,14 +170,6 @@ describe(__filename, () => {
     expect(root).toHaveClassName(className);
   });
 
-  it('passes bodyFallback to UserReview', () => {
-    const bodyFallback = 'placeholder for empty reviews';
-    const root = render({ bodyFallback });
-
-    const rating = root.find(UserReview);
-    expect(rating).toHaveProp('bodyFallback', bodyFallback);
-  });
-
   it('can hide a rating explicitly', () => {
     const root = render({ showRating: false, review: _setReview(fakeReview) });
 
@@ -341,14 +333,35 @@ describe(__filename, () => {
     );
   });
 
-  it('lets you edit your rating', () => {
+  it('does not provide an edit link for ratings', () => {
     const review = signInAndDispatchSavedReview({
       externalReview: fakeRatingOnly,
     });
     const root = render({ review });
 
     const editButton = renderControls(root).find('.AddonReviewCard-edit');
-    expect(editButton.text()).toContain('Edit my rating');
+    expect(editButton).toHaveLength(0);
+  });
+
+  it('adds AddonReviewCard-ratingOnly to rating-only reviews', () => {
+    const review = signInAndDispatchSavedReview({
+      externalReview: fakeRatingOnly,
+    });
+    const root = render({ review });
+
+    expect(root).toHaveClassName('.AddonReviewCard-ratingOnly');
+  });
+
+  it('does not add AddonReviewCard-ratingOnly to reviews with a body', () => {
+    const review = signInAndDispatchSavedReview({
+      externalReview: {
+        ...fakeReview,
+        body: 'This is a written review',
+      },
+    });
+    const root = render({ review });
+
+    expect(root).not.toHaveClassName('.AddonReviewCard-ratingOnly');
   });
 
   it('configures the edit-review form', () => {
@@ -833,6 +846,15 @@ describe(__filename, () => {
         'byLine',
         `posted ${i18n.moment(review.created).fromNow()}`,
       );
+    });
+
+    it('does not render a byLine for ratings', () => {
+      const review = signInAndDispatchSavedReview({
+        externalReview: fakeRatingOnly,
+      });
+      const root = render({ review });
+
+      expect(root).toHaveProp('byLine', false);
     });
   });
 

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -594,18 +594,15 @@ describe(__filename, () => {
       expect(reviewCard).toHaveProp('location', location);
     });
 
-    it('configures AddonReviewCard with a write review button for ratings', () => {
+    it('provides a write review button for ratings', () => {
       const review = { ...fakeReview, body: undefined };
       const root = renderInline({
         store: createStoreWithLatestReview({ review }),
       });
 
-      const reviewCard = root.find(AddonReviewCard);
-      expect(reviewCard).toHaveProp('bodyFallback');
-
-      const bodyFallback = shallow(reviewCard.prop('bodyFallback'));
-      bodyFallback.find(Button).simulate('click', createFakeEvent());
-      root.update();
+      const writeReview = root.find('.RatingManager-writeReviewButton');
+      expect(writeReview).toHaveLength(1);
+      writeReview.simulate('click', createFakeEvent());
 
       expect(root.find(AddonReviewCard)).toHaveLength(0);
       expect(root.find(AddonReviewManager)).toHaveLength(1);

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -1,4 +1,3 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { createInternalAddon } from 'core/reducers/addons';
@@ -24,7 +23,6 @@ import RatingManager, {
 } from 'amo/components/RatingManager';
 import ReportAbuseButton from 'amo/components/ReportAbuseButton';
 import AuthenticateButton from 'core/components/AuthenticateButton';
-import Button from 'ui/components/Button';
 import UserRating from 'ui/components/UserRating';
 import {
   dispatchClientMetadata,

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -76,48 +76,6 @@ describe(__filename, () => {
     expect(root.find('.UserReview-body')).toHaveText('');
   });
 
-  it('can render a fallback for reviews without a body', () => {
-    const bodyFallback = 'some kind of placeholder';
-    const root = render({
-      bodyFallback,
-      review: _setReview({ ...fakeReview, body: undefined }),
-    });
-
-    expect(root.find('.UserReview-body')).toHaveText(bodyFallback);
-  });
-
-  it('only renders a fallback when the review body is empty', () => {
-    const body = 'This is an actual review';
-    const bodyFallback = 'some kind of placeholder';
-    const root = render({
-      bodyFallback,
-      review: _setReview({ ...fakeReview, body }),
-    });
-
-    expect(root.find('.UserReview-body')).not.toHaveText(bodyFallback);
-    expect(
-      root
-        .find('.UserReview-body')
-        .render()
-        .text(),
-    ).toEqual(body);
-  });
-
-  it('renders without a review body and without a fallback', () => {
-    const root = render({
-      bodyFallback: undefined,
-      review: _setReview({ ...fakeReview, body: undefined }),
-    });
-
-    expect(
-      root
-        .find('.UserReview-body')
-        .render()
-        .text(),
-    ).toEqual('');
-    expect(root.find(LoadingText)).toHaveLength(0);
-  });
-
   it('can hide ratings', () => {
     const root = render({ showRating: false });
 

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -76,6 +76,27 @@ describe(__filename, () => {
     expect(root.find('.UserReview-body')).toHaveText('');
   });
 
+  it('adds UserReview-emptyBody for an empty body', () => {
+    const root = render({
+      review: _setReview({ ...fakeReview, body: undefined }),
+    });
+
+    const body = root.find('.UserReview-body');
+    expect(body).toHaveClassName('UserReview-emptyBody');
+  });
+
+  it('does not add UserReview-emptyBody when there is a body', () => {
+    const root = render({
+      review: _setReview({
+        ...fakeReview,
+        body: 'This add-on is fantastic',
+      }),
+    });
+
+    const body = root.find('.UserReview-body');
+    expect(body).not.toHaveClassName('UserReview-emptyBody');
+  });
+
   it('can hide ratings', () => {
     const root = render({ showRating: false });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6178

**Before**

<img width="402" alt="screenshot 2018-09-06 22 14 40" src="https://user-images.githubusercontent.com/55398/45238920-12d58380-b2a9-11e8-80e1-139a2e83daee.png">


**After**

<img width="402" alt="screenshot 2018-09-07 14 48 58" src="https://user-images.githubusercontent.com/55398/45240201-6518a380-b2ad-11e8-830a-c542279a5315.png">
<img width="402" alt="screenshot 2018-09-07 14 49 14" src="https://user-images.githubusercontent.com/55398/45240202-6518a380-b2ad-11e8-9b15-44cbde606bb6.png">

