### PR TITLE
Allow for a review to be featured at the top of the All Reviews page

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -15,6 +15,7 @@ export const SHOW_REPLY_TO_REVIEW_FORM: 'SHOW_REPLY_TO_REVIEW_FORM' =
   'SHOW_REPLY_TO_REVIEW_FORM';
 export const FETCH_GROUPED_RATINGS: 'FETCH_GROUPED_RATINGS' =
   'FETCH_GROUPED_RATINGS';
+export const FETCH_REVIEW: 'FETCH_REVIEW' = 'FETCH_REVIEW';
 export const FETCH_REVIEWS: 'FETCH_REVIEWS' = 'FETCH_REVIEWS';
 export const FETCH_USER_REVIEWS: 'FETCH_USER_REVIEWS' = 'FETCH_USER_REVIEWS';
 export const FLASH_REVIEW_MESSAGE: 'FLASH_REVIEW_MESSAGE' =
@@ -118,6 +119,32 @@ export const setReviewReply = ({
     payload: { originalReviewId, reply },
   };
 };
+
+type FetchReviewParams = {|
+  errorHandlerId: string,
+  reviewId: number,
+|};
+
+export type FetchReviewAction = {|
+  type: typeof FETCH_REVIEW,
+  payload: {|
+    errorHandlerId: string,
+    reviewId: number,
+  |},
+|};
+
+export function fetchReview({
+  errorHandlerId,
+  reviewId,
+}: FetchReviewParams): FetchReviewAction {
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(reviewId, 'reviewId is required');
+
+  return {
+    type: FETCH_REVIEW,
+    payload: { errorHandlerId, reviewId },
+  };
+}
 
 type FetchReviewsParams = {|
   addonSlug: string,

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -291,13 +291,11 @@ export const deleteReview = ({
 
 export type GetReviewParams = {|
   apiState: ApiState,
-  errorHandler: ErrorHandlerType,
   reviewId: number,
 |};
 
 export const getReview = ({
   apiState,
-  errorHandler,
   reviewId,
 }: GetReviewParams = {}): Promise<ExternalReviewType> => {
   invariant(reviewId, 'reviewId is required');
@@ -306,7 +304,6 @@ export const getReview = ({
       callApi({
         auth: true,
         endpoint: `reviews/review/${reviewId}/`,
-        errorHandler,
         method: 'GET',
         apiState,
       }),

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -288,3 +288,32 @@ export const deleteReview = ({
     );
   });
 };
+
+type GetReviewParams = {|
+  apiState: ApiState,
+  errorHandler: ErrorHandlerType,
+  reviewId: number,
+|};
+
+export type GetReviewApiResponse = {|
+  ...PaginatedApiResponse<ExternalReviewType>,
+|};
+
+export const getReview = ({
+  apiState,
+  errorHandler,
+  reviewId,
+}: GetReviewParams = {}): Promise<GetReviewApiResponse> => {
+  invariant(reviewId, 'reviewId is required');
+  return new Promise((resolve) => {
+    resolve(
+      callApi({
+        auth: true,
+        endpoint: `reviews/review/${reviewId}/`,
+        errorHandler,
+        method: 'GET',
+        apiState,
+      }),
+    );
+  });
+};

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -289,21 +289,17 @@ export const deleteReview = ({
   });
 };
 
-type GetReviewParams = {|
+export type GetReviewParams = {|
   apiState: ApiState,
   errorHandler: ErrorHandlerType,
   reviewId: number,
-|};
-
-export type GetReviewApiResponse = {|
-  ...PaginatedApiResponse<ExternalReviewType>,
 |};
 
 export const getReview = ({
   apiState,
   errorHandler,
   reviewId,
-}: GetReviewParams = {}): Promise<GetReviewApiResponse> => {
+}: GetReviewParams = {}): Promise<ExternalReviewType> => {
   invariant(reviewId, 'reviewId is required');
   return new Promise((resolve) => {
     resolve(

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -1,6 +1,5 @@
 /* @flow */
 import makeClassName from 'classnames';
-import { oneLineTrim } from 'common-tags';
 import config from 'config';
 import invariant from 'invariant';
 import * as React from 'react';
@@ -301,17 +300,18 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     const noAuthor = shortByLine || this.isReply();
 
     if (review) {
-      const timestamp = i18n.moment(review.created).fromNow();
-      const linkStart = oneLineTrim`<a href="/${lang}/${clientApp}/addon/${
-        review.addonSlug
-      }/reviews/${review.id}/">`;
+      const timestamp = `
+        <a href="/${lang}/${clientApp}/addon/${review.addonSlug}/reviews/${
+        review.id
+      }/">
+          ${i18n.moment(review.created).fromNow()}
+        </a>
+      `;
       const byLineString = noAuthor
         ? // translators: Example in English: "posted last week"
-          i18n.gettext('posted %(linkStart)s%(timestamp)s%(linkEnd)s')
+          i18n.gettext('posted %(timestamp)s')
         : // translators: Example in English: "by UserName123, last week"
-          i18n.gettext(
-            'by %(authorName)s, %(linkStart)s%(timestamp)s%(linkEnd)s',
-          );
+          i18n.gettext('by %(authorName)s, %(timestamp)s');
 
       byLine = (
         <span
@@ -322,8 +322,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           dangerouslySetInnerHTML={sanitizeHTML(
             i18n.sprintf(byLineString, {
               authorName: review.userName,
-              linkStart,
-              linkEnd: '</a>',
               timestamp,
             }),
             ['a'],

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -318,6 +318,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           className={makeClassName('', {
             'AddonReviewCard-authorByLine': !noAuthor,
           })}
+          // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={sanitizeHTML(
             i18n.sprintf(byLineString, {
               authorName: review.userName,

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -9,6 +9,7 @@ import { compose } from 'redux';
 import AddonReview from 'amo/components/AddonReview';
 import AddonReviewManager from 'amo/components/AddonReviewManager';
 import FlagReviewMenu from 'amo/components/FlagReviewMenu';
+import Link from 'amo/components/Link';
 import { ADDONS_EDIT } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -312,6 +313,14 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           </span>
         );
       }
+      byLine = (
+        <Link
+          title={i18n.gettext('Go to this review')}
+          to={`/addon/${review.addonSlug}/reviews/${review.id}/`}
+        >
+          {byLine}
+        </Link>
+      );
     } else {
       byLine = <LoadingText />;
     }

--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -1,6 +1,8 @@
 /* @flow */
 import * as React from 'react';
+import NestedStatus from 'react-nested-status';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import { fetchReview } from 'amo/actions/reviews';
@@ -22,7 +24,6 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType | null,
-  location: ReactRouterLocationType,
   reviewId: number,
 |};
 
@@ -33,6 +34,7 @@ type InternalProps = {|
   featuredReview?: UserReviewType,
   i18n: I18nType,
   loadingReview: boolean,
+  location: ReactRouterLocationType,
 |};
 
 export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
@@ -79,9 +81,11 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
     const featuredReviewCard =
       errorHandler.hasError() &&
       errorHandler.capturedError.responseStatusCode === 404 ? (
-        <div className="FeaturedAddonReview-notfound">
-          {i18n.gettext('The review was not found.')}
-        </div>
+        <NestedStatus code={404}>
+          <div className="FeaturedAddonReview-notfound">
+            {i18n.gettext('The review was not found.')}
+          </div>
+        </NestedStatus>
       ) : (
         <AddonReviewCard
           addon={addon}
@@ -123,6 +127,7 @@ export const extractId = (ownProps: InternalProps) => {
 };
 
 const FeaturedAddonReview: React.ComponentType<Props> = compose(
+  withRouter,
   connect(mapStateToProps),
   translate(),
   withFixedErrorHandler({ fileName: __filename, extractId }),

--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -1,0 +1,131 @@
+/* @flow */
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import { fetchReview } from 'amo/actions/reviews';
+import AddonReviewCard from 'amo/components/AddonReviewCard';
+import { selectReview } from 'amo/reducers/reviews';
+import { withFixedErrorHandler } from 'core/errorHandler';
+import translate from 'core/i18n/translate';
+import log from 'core/logger';
+import Card from 'ui/components/Card';
+import type { UserReviewType } from 'amo/actions/reviews';
+import type { AppState } from 'amo/store';
+import type { ErrorHandlerType } from 'core/errorHandler';
+import type { AddonType } from 'core/types/addons';
+import type { I18nType } from 'core/types/i18n';
+import type { DispatchFunc } from 'core/types/redux';
+import type { ReactRouterLocationType } from 'core/types/router';
+
+import './styles.scss';
+
+type Props = {|
+  addon: AddonType | null,
+  location: ReactRouterLocationType,
+  reviewId: number,
+|};
+
+type InternalProps = {|
+  ...Props,
+  dispatch: DispatchFunc,
+  errorHandler: ErrorHandlerType,
+  featuredReview?: UserReviewType,
+  i18n: I18nType,
+  loadingReview: boolean,
+|};
+
+export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
+  constructor(props: InternalProps) {
+    super(props);
+    this.loadDataIfNeeded();
+  }
+
+  componentWillReceiveProps(nextProps: InternalProps) {
+    this.loadDataIfNeeded(nextProps);
+  }
+
+  loadDataIfNeeded(nextProps?: InternalProps) {
+    const {
+      dispatch,
+      errorHandler,
+      featuredReview,
+      loadingReview,
+      reviewId,
+    } = {
+      ...this.props,
+      ...nextProps,
+    };
+
+    if (errorHandler.hasError()) {
+      log.warn('Not loading data because of an error');
+      return;
+    }
+
+    if (!featuredReview && !loadingReview) {
+      dispatch(fetchReview({ reviewId, errorHandlerId: errorHandler.id }));
+    }
+  }
+
+  render() {
+    const { addon, errorHandler, featuredReview, location, i18n } = this.props;
+
+    const featuredReviewHeader = featuredReview
+      ? i18n.sprintf(i18n.gettext('Review by %(userName)s'), {
+          userName: featuredReview.userName,
+        })
+      : null;
+
+    const featuredReviewCard =
+      errorHandler.hasError() &&
+      errorHandler.capturedError.responseStatusCode === 404 ? (
+        <div className="FeaturedAddonReview-notfound">
+          {i18n.gettext('The review was not found.')}
+        </div>
+      ) : (
+        <AddonReviewCard
+          addon={addon}
+          location={location}
+          review={featuredReview}
+        />
+      );
+
+    return (
+      <div className="FeaturedAddonReview">
+        <Card
+          header={featuredReviewHeader}
+          className="FeaturedAddonReview-card"
+        >
+          {featuredReviewCard}
+        </Card>
+      </div>
+    );
+  }
+}
+
+export function mapStateToProps(state: AppState, ownProps: InternalProps) {
+  const { reviewId } = ownProps;
+  const featuredReview = reviewId
+    ? selectReview(state.reviews, reviewId)
+    : null;
+
+  return {
+    featuredReview,
+    loadingReview: reviewId
+      ? state.reviews.view[reviewId] &&
+        state.reviews.view[reviewId].loadingReview
+      : false,
+  };
+}
+
+export const extractId = (ownProps: InternalProps) => {
+  return ownProps.reviewId;
+};
+
+const FeaturedAddonReview: React.ComponentType<Props> = compose(
+  connect(mapStateToProps),
+  translate(),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
+)(FeaturedAddonReviewBase);
+
+export default FeaturedAddonReview;

--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -64,7 +64,11 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
       return;
     }
 
-    if (!featuredReview && !loadingReview) {
+    if (
+      (!featuredReview ||
+        (nextProps && this.props.reviewId !== nextProps.reviewId)) &&
+      !loadingReview
+    ) {
       dispatch(fetchReview({ reviewId, errorHandlerId: errorHandler.id }));
     }
   }

--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import NestedStatus from 'react-nested-status';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import { fetchReview } from 'amo/actions/reviews';
@@ -18,7 +17,6 @@ import type { ErrorHandlerType } from 'core/errorHandler';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
-import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
@@ -34,7 +32,6 @@ type InternalProps = {|
   featuredReview?: UserReviewType,
   i18n: I18nType,
   loadingReview: boolean,
-  location: ReactRouterLocationType,
 |};
 
 export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
@@ -74,7 +71,7 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
   }
 
   render() {
-    const { addon, errorHandler, featuredReview, location, i18n } = this.props;
+    const { addon, errorHandler, featuredReview, i18n } = this.props;
 
     const featuredReviewHeader = featuredReview
       ? i18n.sprintf(i18n.gettext('Review by %(userName)s'), {
@@ -91,11 +88,7 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
           </div>
         </NestedStatus>
       ) : (
-        <AddonReviewCard
-          addon={addon}
-          location={location}
-          review={featuredReview}
-        />
+        <AddonReviewCard addon={addon} review={featuredReview} />
       );
 
     return (
@@ -131,7 +124,6 @@ export const extractId = (ownProps: InternalProps) => {
 };
 
 const FeaturedAddonReview: React.ComponentType<Props> = compose(
-  withRouter,
   connect(mapStateToProps),
   translate(),
   withFixedErrorHandler({ fileName: __filename, extractId }),

--- a/src/amo/components/FeaturedAddonReview/styles.scss
+++ b/src/amo/components/FeaturedAddonReview/styles.scss
@@ -1,0 +1,5 @@
+@import '~amo/css/styles';
+
+.FeaturedAddonReview-notfound {
+  font-size: $font-size-default;
+}

--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -43,12 +43,12 @@ const Routes = ({ _config = config }: Props = {}) => (
     <Route exact path="/:lang/:application/addon/:slug/" component={Addon} />
     <Route
       exact
-      path="/:lang/:application/addon/:addonSlug/reviews/"
+      path="/:lang/:application/addon/:addonSlug/reviews/:reviewId"
       component={AddonReviewList}
     />
     <Route
       exact
-      path="/:lang/:application/addon/:addonSlug/reviews/:reviewId"
+      path="/:lang/:application/addon/:addonSlug/reviews/"
       component={AddonReviewList}
     />
 

--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -46,6 +46,11 @@ const Routes = ({ _config = config }: Props = {}) => (
       path="/:lang/:application/addon/:addonSlug/reviews/"
       component={AddonReviewList}
     />
+    <Route
+      exact
+      path="/:lang/:application/review/:reviewId"
+      component={AddonReviewList}
+    />
 
     <Route
       exact

--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -48,7 +48,7 @@ const Routes = ({ _config = config }: Props = {}) => (
     />
     <Route
       exact
-      path="/:lang/:application/review/:reviewId"
+      path="/:lang/:application/addon/:addonSlug/reviews/:reviewId"
       component={AddonReviewList}
     />
 

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -12,7 +12,7 @@ import RatingsByStar from 'amo/components/RatingsByStar';
 import FeaturedAddonReview from 'amo/components/FeaturedAddonReview';
 import { fetchReviews } from 'amo/actions/reviews';
 import { setViewContext } from 'amo/actions/viewContext';
-import { expandReviewObjects } from 'amo/reducers/reviews';
+import { expandReviewObjects, reviewsAreLoading } from 'amo/reducers/reviews';
 import {
   fetchAddon,
   getAddonBySlug,
@@ -68,7 +68,7 @@ type InternalProps = {|
   pageSize: number | null,
   reviewCount?: number,
   reviews?: Array<UserReviewType>,
-  reviewsAreLoading: boolean,
+  areReviewsLoading: boolean,
 |};
 
 export class AddonReviewListBase extends React.Component<InternalProps> {
@@ -94,7 +94,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
         params: { addonSlug },
       },
       reviews,
-      reviewsAreLoading,
+      areReviewsLoading,
     } = {
       ...this.props,
       ...nextProps,
@@ -127,7 +127,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       location = nextProps.location;
     }
 
-    if (!reviewsAreLoading && (!reviews || locationChanged)) {
+    if (!areReviewsLoading && (!reviews || locationChanged)) {
       dispatch(
         fetchReviews({
           addonSlug,
@@ -331,11 +331,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
 
         <div className="AddonReviewList-reviews">
           {reviewId && (
-            <FeaturedAddonReview
-              addon={addon}
-              location={location}
-              reviewId={reviewId}
-            />
+            <FeaturedAddonReview addon={addon} reviewId={reviewId} />
           )}
           <CardList
             className="AddonReviewList-reviews-listing"
@@ -378,7 +374,7 @@ export function mapStateToProps(state: AppState, ownProps: InternalProps) {
         state: state.reviews,
         reviews: reviewData.reviews,
       }),
-    reviewsAreLoading: Boolean(state.reviews.loadingForSlug[addonSlug]),
+    areReviewsLoading: reviewsAreLoading(state, addonSlug),
   };
 }
 

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -340,6 +340,8 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
           >
             <ul>
               {allReviews.map((review, index) => {
+                // TODO: Remove this and use the API to filter out the featured review once
+                // https://github.com/mozilla/addons-server/issues/9424 is fixed.
                 if (
                   !reviewId ||
                   (review && review.id.toString() !== reviewId)

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -340,7 +340,10 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
           >
             <ul>
               {allReviews.map((review, index) => {
-                if (!reviewId || (review && review.id !== reviewId)) {
+                if (
+                  !reviewId ||
+                  (review && review.id.toString() !== reviewId)
+                ) {
                   return (
                     <li key={String(index)}>
                       <AddonReviewCard addon={addon} review={review} />

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -381,11 +381,14 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
           >
             <ul>
               {allReviews.map((review, index) => {
-                return (
-                  <li key={String(index)}>
-                    <AddonReviewCard addon={addon} review={review} />
-                  </li>
-                );
+                if (!featuredReview || review.id !== featuredReview.id) {
+                  return (
+                    <li key={String(index)}>
+                      <AddonReviewCard addon={addon} review={review} />
+                    </li>
+                  );
+                }
+                return null;
               })}
             </ul>
           </CardList>

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -223,8 +223,8 @@ export class UserProfileBase extends React.Component<InternalProps> {
               <span>
                 {isDeveloperReply && i18n.gettext('Developer response')}
                 <Link
-                  title={i18n.gettext('Browse the reviews for this add-on')}
-                  to={`/addon/${review.addonSlug}/reviews/`}
+                  title={i18n.gettext('Go to this review')}
+                  to={`/review/${review.id}/`}
                 >
                   {i18n.moment(review.created).fromNow()}
                 </Link>

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -224,7 +224,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                 {isDeveloperReply && i18n.gettext('Developer response')}
                 <Link
                   title={i18n.gettext('Go to this review')}
-                  to={`/review/${review.id}/`}
+                  to={`/addon/${review.addonSlug}/reviews/${review.id}/`}
                 >
                   {i18n.moment(review.created).fromNow()}
                 </Link>

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -4,6 +4,7 @@ import { oneLine } from 'common-tags';
 import {
   DELETE_ADDON_REVIEW,
   FETCH_REVIEW,
+  FETCH_REVIEWS,
   FLASH_REVIEW_MESSAGE,
   HIDE_FLASHED_REVIEW_MESSAGE,
   UNLOAD_ADDON_REVIEWS,
@@ -26,6 +27,7 @@ import {
 import type {
   DeleteAddonReviewAction,
   FetchReviewAction,
+  FetchReviewsAction,
   FlagReviewAction,
   FlashMessageType,
   HideEditReviewFormAction,
@@ -104,6 +106,9 @@ export type ReviewsState = {|
   },
   // Short-lived messages about reviews.
   flashMessage?: FlashMessageType,
+  loadingForSlug: {
+    [slug: string]: boolean,
+  },
 |};
 
 export const initialState: ReviewsState = {
@@ -115,6 +120,7 @@ export const initialState: ReviewsState = {
   // This stores review-related UI state.
   view: {},
   flashMessage: undefined,
+  loadingForSlug: {},
 };
 
 export const selectReview = (
@@ -280,6 +286,7 @@ export const addReviewToState = ({
 type ReviewActionType =
   | DeleteAddonReviewAction
   | FetchReviewAction
+  | FetchReviewsAction
   | FlagReviewAction
   | FlashReviewMessageAction
   | UnloadAddonReviewsAction
@@ -446,6 +453,18 @@ export default function reviewsReducer(
         },
       });
     }
+    case FETCH_REVIEWS: {
+      const {
+        payload: { addonSlug },
+      } = action;
+      return {
+        ...state,
+        loadingForSlug: {
+          ...state.loadingForSlug,
+          [addonSlug]: true,
+        },
+      };
+    }
     case SET_ADDON_REVIEWS: {
       const { payload } = action;
       const reviews = payload.reviews.map((review) =>
@@ -462,6 +481,10 @@ export default function reviewsReducer(
             reviewCount: payload.reviewCount,
             reviews: reviews.map((review) => review.id),
           },
+        },
+        loadingForSlug: {
+          ...state.loadingForSlug,
+          [payload.addonSlug]: false,
         },
       };
     }

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -50,6 +50,7 @@ import type {
 } from 'amo/actions/reviews';
 import type { GroupedRatingsType } from 'amo/api/reviews';
 import type { FlagReviewReasonType } from 'amo/constants';
+import type { AppState } from 'amo/store';
 
 type ReviewsById = {
   [id: number]: UserReviewType,
@@ -281,6 +282,13 @@ export const addReviewToState = ({
       [review.addonId]: undefined,
     },
   };
+};
+
+export const reviewsAreLoading = (
+  state: AppState,
+  addonSlug: string,
+): boolean => {
+  return Boolean(state.reviews.loadingForSlug[addonSlug]);
 };
 
 type ReviewActionType =

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -330,6 +330,7 @@ function* deleteAddonReview({
 function* fetchReview({
   payload: { errorHandlerId, reviewId },
 }: FetchReviewAction): Generator<any, any, any> {
+  console.log('---- in saga, reviewId: ', reviewId);
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -339,14 +340,17 @@ function* fetchReview({
 
     const params: GetReviewParams = {
       apiState: state.api,
-      errorHandler,
       reviewId,
     };
 
+    console.log('---- in saga, params: ', params);
+
     const response: ExternalReviewType = yield call(getReview, params);
+    console.log('---- in saga, response: ', response);
 
     yield put(setReview(response));
   } catch (error) {
+    console.log('---- in saga, error: ', error);
     log.warn(`Failed to get review ID ${reviewId}: ${error}`);
     yield put(errorHandler.createErrorAction(error));
   }

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -12,6 +12,7 @@ import { delay } from 'redux-saga/lib/internal/utils';
 import {
   deleteReview,
   flagReview,
+  getReview,
   getReviews,
   replyToReview,
   submitReview,
@@ -21,6 +22,7 @@ import {
   CREATE_ADDON_REVIEW,
   DELETE_ADDON_REVIEW,
   FETCH_GROUPED_RATINGS,
+  FETCH_REVIEW,
   FETCH_REVIEWS,
   FETCH_USER_REVIEWS,
   SAVED_RATING,
@@ -48,7 +50,9 @@ import { createErrorHandler, getState } from 'core/sagas/utils';
 import type { AppState } from 'amo/store';
 import type {
   ExternalReviewReplyType,
+  GetReviewApiResponse,
   GetReviewsApiResponse,
+  GetReviewParams,
   GetReviewsParams,
   SubmitReviewParams,
   SubmitReviewResponse,
@@ -57,6 +61,7 @@ import type {
   CreateAddonReviewAction,
   DeleteAddonReviewAction,
   FetchGroupedRatingsAction,
+  FetchReviewAction,
   FetchReviewsAction,
   FetchUserReviewsAction,
   FlagReviewAction,
@@ -322,10 +327,35 @@ function* deleteAddonReview({
   }
 }
 
+function* fetchReview({
+  payload: { errorHandlerId, reviewId },
+}: FetchReviewAction): Generator<any, any, any> {
+  const errorHandler = createErrorHandler(errorHandlerId);
+
+  yield put(errorHandler.createClearingAction());
+
+  try {
+    const state = yield select(getState);
+
+    const params: GetReviewParams = {
+      apiState: state.api,
+      reviewId,
+    };
+
+    const response: GetReviewApiResponse = yield call(getReview, params);
+
+    yield put(setReview(response));
+  } catch (error) {
+    log.warn(`Failed to get review ID ${reviewId}: ${error}`);
+    yield put(errorHandler.createErrorAction(error));
+  }
+}
+
 export default function* reviewsSaga(
   options?: Options,
 ): Generator<any, any, any> {
   yield takeLatest(FETCH_GROUPED_RATINGS, fetchGroupedRatings);
+  yield takeLatest(FETCH_REVIEW, fetchReview);
   yield takeLatest(FETCH_REVIEWS, fetchReviews);
   yield takeLatest(FETCH_USER_REVIEWS, fetchUserReviews);
   yield takeLatest(SEND_REPLY_TO_REVIEW, handleReplyToReview);

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -330,7 +330,6 @@ function* deleteAddonReview({
 function* fetchReview({
   payload: { errorHandlerId, reviewId },
 }: FetchReviewAction): Generator<any, any, any> {
-  console.log('---- in saga, reviewId: ', reviewId);
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -343,14 +342,10 @@ function* fetchReview({
       reviewId,
     };
 
-    console.log('---- in saga, params: ', params);
-
     const response: ExternalReviewType = yield call(getReview, params);
-    console.log('---- in saga, response: ', response);
 
     yield put(setReview(response));
   } catch (error) {
-    console.log('---- in saga, error: ', error);
     log.warn(`Failed to get review ID ${reviewId}: ${error}`);
     yield put(errorHandler.createErrorAction(error));
   }

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -50,7 +50,7 @@ import { createErrorHandler, getState } from 'core/sagas/utils';
 import type { AppState } from 'amo/store';
 import type {
   ExternalReviewReplyType,
-  GetReviewApiResponse,
+  ExternalReviewType,
   GetReviewsApiResponse,
   GetReviewParams,
   GetReviewsParams,
@@ -339,10 +339,11 @@ function* fetchReview({
 
     const params: GetReviewParams = {
       apiState: state.api,
+      errorHandler,
       reviewId,
     };
 
-    const response: GetReviewApiResponse = yield call(getReview, params);
+    const response: ExternalReviewType = yield call(getReview, params);
 
     yield put(setReview(response));
   } catch (error) {

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -36,4 +36,19 @@
   color: $sub-text-color;
   display: flex;
   font-size: $font-size-s;
+
+  a,
+  a:link,
+  a:visited {
+    color: $grey-50;
+  }
+
+  a:active,
+  a:hover {
+    color: $link-color;
+  }
+
+  a:focus {
+    @include focus();
+  }
 }

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -40,7 +40,8 @@
   a,
   a:link,
   a:visited {
-    color: $grey-50;
+    color: $sub-text-color;
+    font-weight: normal;
   }
 
   a:active,

--- a/tests/unit/amo/api/test_reviews.js
+++ b/tests/unit/amo/api/test_reviews.js
@@ -6,6 +6,7 @@ import {
   deleteReview,
   flagReview,
   getLatestUserReview,
+  getReview,
   getReviews,
   replyToReview,
   submitReview,
@@ -429,6 +430,32 @@ describe(__filename, () => {
 
       await deleteReview(params);
       mockApi.verify();
+    });
+  });
+
+  describe('getReview', () => {
+    it('calls the API', async () => {
+      const params = {
+        apiState,
+        errorHandler: createStubErrorHandler(),
+        reviewId: fakeReview.id,
+      };
+      const fakeResponse = getReviewsResponse({ reviews: [fakeReview] });
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          auth: true,
+          endpoint: `reviews/review/${params.reviewId}/`,
+          errorHandler: params.errorHandler,
+          method: 'GET',
+          apiState: params.apiState,
+        })
+        .returns(Promise.resolve(fakeResponse));
+
+      const response = await getReview(params);
+      mockApi.verify();
+      expect(response).toEqual(fakeResponse);
     });
   });
 });

--- a/tests/unit/amo/api/test_reviews.js
+++ b/tests/unit/amo/api/test_reviews.js
@@ -437,7 +437,6 @@ describe(__filename, () => {
     it('calls the API', async () => {
       const params = {
         apiState,
-        errorHandler: createStubErrorHandler(),
         reviewId: fakeReview.id,
       };
       const fakeResponse = getReviewsResponse({ reviews: [fakeReview] });
@@ -447,7 +446,6 @@ describe(__filename, () => {
         .withArgs({
           auth: true,
           endpoint: `reviews/review/${params.reviewId}/`,
-          errorHandler: params.errorHandler,
           method: 'GET',
           apiState: params.apiState,
         })

--- a/tests/unit/amo/api/test_reviews.js
+++ b/tests/unit/amo/api/test_reviews.js
@@ -451,7 +451,7 @@ describe(__filename, () => {
           method: 'GET',
           apiState: params.apiState,
         })
-        .returns(Promise.resolve(fakeResponse));
+        .resolves(fakeResponse);
 
       const response = await getReview(params);
       mockApi.verify();

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -929,8 +929,24 @@ describe(__filename, () => {
 
   describe('byLine', () => {
     function renderByLine(root) {
-      return shallow(root.find(UserReview).prop('byLine'));
+      return shallow(root.find(UserReview).prop('byLine'), {
+        // The `Link` component needs the store.
+        context: { store },
+      });
     }
+
+    it('renders a byLine with a permalink to the review', () => {
+      const slug = 'some-slug';
+      const review = signInAndDispatchSavedReview({
+        externalReview: { ...fakeReview, addon: { ...fakeReview.addon, slug } },
+      });
+      const root = render({ review });
+
+      expect(renderByLine(root)).toHaveProp(
+        'to',
+        `/addon/${slug}/reviews/${review.id}/`,
+      );
+    });
 
     it('renders a byLine with an author by default', () => {
       const i18n = fakeI18n();
@@ -940,7 +956,7 @@ describe(__filename, () => {
       });
       const root = render({ i18n, review });
 
-      expect(renderByLine(root)).toHaveText(
+      expect(renderByLine(root).children()).toHaveText(
         `by ${name}, ${i18n.moment(review.created).fromNow()}`,
       );
     });
@@ -952,8 +968,7 @@ describe(__filename, () => {
 
       const root = renderReply({ i18n, reply });
 
-      expect(root.find(UserReview)).toHaveProp(
-        'byLine',
+      expect(renderByLine(root).children()).toHaveText(
         `posted ${i18n.moment(reply.created).fromNow()}`,
       );
     });
@@ -963,8 +978,7 @@ describe(__filename, () => {
       const review = signInAndDispatchSavedReview();
       const root = render({ i18n, shortByLine: true, review });
 
-      expect(root.find(UserReview)).toHaveProp(
-        'byLine',
+      expect(renderByLine(root).children()).toHaveText(
         `posted ${i18n.moment(review.created).fromNow()}`,
       );
     });

--- a/tests/unit/amo/components/TestFeaturedAddonReview.js
+++ b/tests/unit/amo/components/TestFeaturedAddonReview.js
@@ -52,7 +52,7 @@ describe(__filename, () => {
     );
   };
 
-  it('fetches a review if needed', () => {
+  it('fetches a review on mount', () => {
     const reviewId = 1;
     const dispatch = sinon.stub(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
@@ -66,6 +66,33 @@ describe(__filename, () => {
       dispatch,
       fetchReview({
         reviewId,
+        errorHandlerId: errorHandler.id,
+      }),
+    );
+  });
+
+  it('fetches a review when the reviewId changes', () => {
+    const firstReviewId = 1;
+    const secondReviewId = 1;
+    const dispatch = sinon.stub(store, 'dispatch');
+    const errorHandler = createStubErrorHandler();
+
+    const root = render({
+      errorHandler,
+      reviewId: firstReviewId,
+    });
+
+    dispatch.resetHistory();
+
+    // This will trigger the componentWillReceiveProps() method.
+    root.setProps({
+      reviewId: secondReviewId,
+    });
+
+    sinon.assert.calledWith(
+      dispatch,
+      fetchReview({
+        reviewId: secondReviewId,
         errorHandlerId: errorHandler.id,
       }),
     );

--- a/tests/unit/amo/components/TestFeaturedAddonReview.js
+++ b/tests/unit/amo/components/TestFeaturedAddonReview.js
@@ -1,0 +1,148 @@
+import * as React from 'react';
+
+import { fetchReview, setReview } from 'amo/actions/reviews';
+import FeaturedAddonReview, {
+  FeaturedAddonReviewBase,
+} from 'amo/components/FeaturedAddonReview';
+import AddonReviewCard from 'amo/components/AddonReviewCard';
+import { createApiError } from 'core/api';
+import { ErrorHandler } from 'core/errorHandler';
+import { dispatchClientMetadata, fakeReview } from 'tests/unit/amo/helpers';
+import {
+  createStubErrorHandler,
+  fakeI18n,
+  createFakeLocation,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  let store;
+
+  beforeEach(() => {
+    store = dispatchClientMetadata().store;
+  });
+
+  const getProps = ({
+    location = createFakeLocation(),
+    params,
+    ...customProps
+  } = {}) => {
+    return {
+      errorHandler: createStubErrorHandler(),
+      i18n: fakeI18n(),
+      location,
+      store,
+      ...customProps,
+    };
+  };
+
+  const render = ({ ...customProps } = {}) => {
+    const props = getProps(customProps);
+
+    return shallowUntilTarget(
+      <FeaturedAddonReview {...props} />,
+      FeaturedAddonReviewBase,
+    );
+  };
+
+  it('fetches a review if needed', () => {
+    const reviewId = 1;
+    const dispatch = sinon.stub(store, 'dispatch');
+    const errorHandler = createStubErrorHandler();
+
+    render({
+      errorHandler,
+      reviewId,
+    });
+
+    sinon.assert.calledWith(
+      dispatch,
+      fetchReview({
+        reviewId,
+        errorHandlerId: errorHandler.id,
+      }),
+    );
+  });
+
+  it('does not fetch a review if one is already loading', () => {
+    const reviewId = 1;
+    const errorHandler = createStubErrorHandler();
+    store.dispatch(fetchReview({ errorHandlerId: errorHandler.id, reviewId }));
+
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+
+    render({
+      errorHandler,
+      reviewId,
+    });
+
+    sinon.assert.neverCalledWith(
+      fakeDispatch,
+      fetchReview({
+        reviewId,
+        errorHandlerId: errorHandler.id,
+      }),
+    );
+  });
+
+  it('does not fetch a review if one is already loaded', () => {
+    const reviewId = 1;
+    const errorHandler = createStubErrorHandler();
+    store.dispatch(setReview({ ...fakeReview, id: reviewId }));
+
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+
+    render({
+      errorHandler,
+      reviewId,
+    });
+
+    sinon.assert.neverCalledWith(
+      fakeDispatch,
+      fetchReview({
+        reviewId,
+        errorHandlerId: errorHandler.id,
+      }),
+    );
+  });
+
+  it('displays a message if the review is not found', () => {
+    const errorHandler = new ErrorHandler({
+      id: 'some-error-handler-id',
+      dispatch: store.dispatch,
+    });
+    errorHandler.handle(
+      createApiError({
+        response: { status: 404 },
+        apiURL: 'https://some/api/endpoint',
+        jsonResponse: { message: 'not found' },
+      }),
+    );
+
+    const root = render({ errorHandler });
+    expect(root.find('.FeaturedAddonReview-notfound')).toHaveLength(1);
+  });
+
+  it('displays a featured review', () => {
+    const reviewId = 123;
+    store.dispatch(setReview({ ...fakeReview, id: reviewId }));
+
+    const root = render({ reviewId });
+
+    const card = root.find(AddonReviewCard);
+    expect(card).toHaveLength(1);
+    expect(card.prop('review').id).toEqual(reviewId);
+  });
+
+  it('displays the correct header for the review', () => {
+    const reviewId = 123;
+    store.dispatch(setReview({ ...fakeReview, id: reviewId }));
+
+    const root = render({ reviewId });
+
+    expect(root.find('.FeaturedAddonReview-card')).toHaveProp(
+      'header',
+      `Review by ${fakeReview.user.name}`,
+    );
+  });
+});

--- a/tests/unit/amo/components/TestFeaturedAddonReview.js
+++ b/tests/unit/amo/components/TestFeaturedAddonReview.js
@@ -53,7 +53,7 @@ describe(__filename, () => {
     );
   };
 
-  it('fetches a review on mount', () => {
+  it('fetches a review at construction', () => {
     const reviewId = 1;
     const dispatch = sinon.stub(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
@@ -75,8 +75,13 @@ describe(__filename, () => {
   it('fetches a review when the reviewId changes', () => {
     const firstReviewId = 1;
     const secondReviewId = 2;
-    const dispatch = sinon.stub(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
+
+    store.dispatch(
+      fetchReview({ errorHandlerId: errorHandler.id, reviewId: firstReviewId }),
+    );
+    store.dispatch(setReview({ ...fakeReview, id: firstReviewId }));
+    const dispatch = sinon.stub(store, 'dispatch');
 
     const root = render({
       errorHandler,

--- a/tests/unit/amo/components/TestFeaturedAddonReview.js
+++ b/tests/unit/amo/components/TestFeaturedAddonReview.js
@@ -1,3 +1,4 @@
+import NestedStatus from 'react-nested-status';
 import * as React from 'react';
 
 import { fetchReview, setReview } from 'amo/actions/reviews';
@@ -73,7 +74,7 @@ describe(__filename, () => {
 
   it('fetches a review when the reviewId changes', () => {
     const firstReviewId = 1;
-    const secondReviewId = 1;
+    const secondReviewId = 2;
     const dispatch = sinon.stub(store, 'dispatch');
     const errorHandler = createStubErrorHandler();
 
@@ -155,6 +156,7 @@ describe(__filename, () => {
 
     const root = render({ errorHandler });
     expect(root.find('.FeaturedAddonReview-notfound')).toHaveLength(1);
+    expect(root.find(NestedStatus)).toHaveProp('code', 404);
   });
 
   it('displays a featured review', () => {

--- a/tests/unit/amo/components/TestFeaturedAddonReview.js
+++ b/tests/unit/amo/components/TestFeaturedAddonReview.js
@@ -13,6 +13,8 @@ import {
   fakeI18n,
   createFakeLocation,
   shallowUntilTarget,
+  createContextWithFakeRouter,
+  createFakeHistory,
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -42,6 +44,11 @@ describe(__filename, () => {
     return shallowUntilTarget(
       <FeaturedAddonReview {...props} />,
       FeaturedAddonReviewBase,
+      {
+        shallowOptions: createContextWithFakeRouter({
+          history: createFakeHistory(),
+        }),
+      },
     );
   };
 

--- a/tests/unit/amo/components/TestRoutes.js
+++ b/tests/unit/amo/components/TestRoutes.js
@@ -15,7 +15,7 @@ describe(__filename, () => {
 
   it('renders the routes for the amo app', () => {
     const root = render();
-    expect(root.find(Route)).toHaveLength(26);
+    expect(root.find(Route)).toHaveLength(27);
   });
 
   describe('path = /:lang/:application/401/', () => {

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -19,6 +19,7 @@ import {
   ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
   CLIENT_APP_FIREFOX,
+  SET_VIEW_CONTEXT,
 } from 'core/constants';
 import {
   fetchAddon,
@@ -371,24 +372,9 @@ describe(__filename, () => {
       const errorHandler = createStubErrorHandler();
       render({ errorHandler });
 
-      // Note: Because we expect setViewContext NOT to be called, we don't have a specific
-      // addon.type argument to use for an assert.neverCalledWith, so instead we verify that
-      // dispatch is called twice, and that those calls are not for setViewContext.
-      // There must be a better way!
-      sinon.assert.calledTwice(dispatch);
-      sinon.assert.calledWith(
+      sinon.assert.neverCalledWithMatch(
         dispatch,
-        fetchAddon({
-          slug: fakeAddon.slug,
-          errorHandler,
-        }),
-      );
-      sinon.assert.calledWith(
-        dispatch,
-        fetchReviews({
-          addonSlug: fakeAddon.slug,
-          errorHandlerId: errorHandler.id,
-        }),
+        sinon.match({ type: SET_VIEW_CONTEXT }),
       );
     });
 

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -514,7 +514,7 @@ describe(__filename, () => {
       dispatchAddonReviews({ reviews });
 
       const root = render({
-        params: { reviewId: reviews[0].id },
+        params: { reviewId: reviews[0].id.toString() },
       });
 
       const items = root
@@ -665,13 +665,16 @@ describe(__filename, () => {
         return render(otherProps);
       };
 
+      const renderFooter = (root) => {
+        return shallow(
+          root.find('.AddonReviewList-reviews-listing').prop('footer'),
+        );
+      };
+
       it('configures a paginator with the right URL', () => {
         const root = renderWithPagination();
 
-        const footer = root
-          .find('.AddonReviewList-reviews-listing')
-          .prop('footer');
-        const paginator = shallow(footer);
+        const paginator = renderFooter(root);
 
         expect(paginator.instance()).toBeInstanceOf(Paginate);
         expect(paginator).toHaveProp('pathname', root.instance().url());
@@ -680,11 +683,7 @@ describe(__filename, () => {
       it('configures a paginator with the right Link', () => {
         const root = renderWithPagination();
 
-        const footer = root
-          .find('.AddonReviewList-reviews-listing')
-          .prop('footer');
-        // `footer` contains a paginator
-        expect(shallow(footer)).toHaveProp('LinkComponent', Link);
+        expect(renderFooter(root)).toHaveProp('LinkComponent', Link);
       });
 
       it('configures a paginator with the right review count', () => {
@@ -692,22 +691,14 @@ describe(__filename, () => {
 
         const root = renderWithPagination({ reviews });
 
-        const footer = root
-          .find('.AddonReviewList-reviews-listing')
-          .prop('footer');
-        // `footer` contains a paginator
-        expect(shallow(footer)).toHaveProp('count', reviews.length);
+        expect(renderFooter(root)).toHaveProp('count', reviews.length);
       });
 
       it('sets the paginator to page 1 without a query', () => {
         // Render with an empty query string.
         const root = renderWithPagination({ location: createFakeLocation() });
 
-        const footer = root
-          .find('.AddonReviewList-reviews-listing')
-          .prop('footer');
-        // `footer` contains a paginator
-        expect(shallow(footer)).toHaveProp('currentPage', 1);
+        expect(renderFooter(root)).toHaveProp('currentPage', 1);
       });
 
       it('sets the paginator to the query string page', () => {
@@ -717,11 +708,7 @@ describe(__filename, () => {
           location: createFakeLocation({ query: { page } }),
         });
 
-        const footer = root
-          .find('.AddonReviewList-reviews-listing')
-          .prop('footer');
-        // `footer` contains a paginator
-        expect(shallow(footer)).toHaveProp('currentPage', page);
+        expect(renderFooter(root)).toHaveProp('currentPage', page);
       });
     });
 

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -2,12 +2,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import fallbackIcon from 'amo/img/icons/default-64.png';
-import {
-  fetchReview,
-  fetchReviews,
-  setAddonReviews,
-  setReview,
-} from 'amo/actions/reviews';
+import { fetchReviews, setAddonReviews } from 'amo/actions/reviews';
 import { setViewContext } from 'amo/actions/viewContext';
 import AddonReviewList, {
   AddonReviewListBase,
@@ -33,7 +28,6 @@ import {
 import ErrorList from 'ui/components/ErrorList';
 import {
   dispatchClientMetadata,
-  dispatchSignInActions,
   fakeAddon,
   fakeReview,
 } from 'tests/unit/amo/helpers';
@@ -137,98 +131,6 @@ describe(__filename, () => {
       const root = render({ reviews: null });
 
       expect(root.find(Paginate)).toHaveLength(0);
-    });
-
-    it('fetches a review if needed', () => {
-      const reviewId = 1;
-      const dispatch = sinon.stub(store, 'dispatch');
-      const errorHandler = createStubErrorHandler();
-
-      render({
-        errorHandler,
-        params: { addonSlug: undefined, reviewId },
-      });
-
-      sinon.assert.calledWith(
-        dispatch,
-        fetchReview({
-          reviewId,
-          errorHandlerId: errorHandler.id,
-        }),
-      );
-    });
-
-    it('does not fetch a review if one is already loading', () => {
-      const reviewId = 1;
-      const errorHandler = createStubErrorHandler();
-      store.dispatch(
-        fetchReview({ errorHandlerId: errorHandler.id, reviewId }),
-      );
-
-      const fakeDispatch = sinon.stub(store, 'dispatch');
-
-      render({
-        errorHandler,
-        params: { addonSlug: undefined, reviewId },
-      });
-
-      sinon.assert.neverCalledWith(
-        fakeDispatch,
-        fetchReview({
-          reviewId,
-          errorHandlerId: errorHandler.id,
-        }),
-      );
-    });
-
-    it('does not fetch a review if one is already loaded', () => {
-      const reviewId = 1;
-      const errorHandler = createStubErrorHandler();
-      store.dispatch(setReview({ ...fakeReview, id: reviewId }));
-
-      const fakeDispatch = sinon.stub(store, 'dispatch');
-
-      render({
-        errorHandler,
-        params: { addonSlug: undefined, reviewId },
-      });
-
-      sinon.assert.neverCalledWith(
-        fakeDispatch,
-        fetchReview({
-          reviewId,
-          errorHandlerId: errorHandler.id,
-        }),
-      );
-    });
-
-    it('fetches an addon based on a reviewId', () => {
-      const addonSlug = 'some-addon-slug';
-      const reviewId = 1;
-      const errorHandler = createStubErrorHandler();
-      const review = {
-        ...fakeReview,
-        id: reviewId,
-        addon: { ...fakeReview.addon, slug: addonSlug },
-      };
-
-      store.dispatch(setReview(review));
-
-      const fakeDispatch = sinon.stub(store, 'dispatch');
-
-      render({
-        addon: null,
-        errorHandler,
-        params: { addonSlug: undefined, reviewId },
-      });
-
-      sinon.assert.calledWith(
-        fakeDispatch,
-        fetchAddon({
-          slug: addonSlug,
-          errorHandler,
-        }),
-      );
     });
 
     it('fetches an addon if requested by slug', () => {
@@ -927,76 +829,6 @@ describe(__filename, () => {
     });
   });
 
-  describe('featuredReview', () => {
-    it('displays a featured review', () => {
-      const reviewId = 1;
-      const errorHandler = createStubErrorHandler();
-      store.dispatch(setReview({ ...fakeReview, id: reviewId }));
-
-      const root = render({
-        errorHandler,
-        params: { reviewId },
-      });
-
-      expect(root.find('.AddonReviewList-featuredReview')).toHaveLength(1);
-      expect(
-        root
-          .find('.AddonReviewList-featuredReview')
-          .find(AddonReviewCard)
-          .prop('review').id,
-      ).toEqual(reviewId);
-    });
-
-    it('does not display a featured review when not requested', () => {
-      const root = render({
-        params: { reviewId: undefined },
-      });
-
-      expect(root.find('.AddonReviewList-featuredReview')).toHaveLength(0);
-    });
-
-    it('displays the correct header for a users own review', () => {
-      const reviewId = 1;
-      const userId = 1;
-      const newStore = dispatchSignInActions({ userId }).store;
-      const errorHandler = createStubErrorHandler();
-      newStore.dispatch(
-        setReview({
-          ...fakeReview,
-          id: reviewId,
-          user: { ...fakeReview.user, id: userId },
-        }),
-      );
-
-      const root = render({
-        errorHandler,
-        params: { reviewId },
-        store: newStore,
-      });
-
-      expect(root.find('.AddonReviewList-featuredReview')).toHaveProp(
-        'header',
-        `My Review`,
-      );
-    });
-
-    it('displays the correct header for another users review', () => {
-      const reviewId = 1;
-      const errorHandler = createStubErrorHandler();
-      store.dispatch(setReview({ ...fakeReview, id: reviewId }));
-
-      const root = render({
-        errorHandler,
-        params: { reviewId },
-      });
-
-      expect(root.find('.AddonReviewList-featuredReview')).toHaveProp(
-        'header',
-        `Review by ${fakeReview.user.name}`,
-      );
-    });
-  });
-
   describe('extractId', () => {
     it('returns a unique ID based on the addon slug and page', () => {
       const ownProps = getProps({
@@ -1014,16 +846,6 @@ describe(__filename, () => {
       });
 
       expect(extractId(ownProps)).toEqual(`foobar-`);
-    });
-
-    it('returns a unique ID based on reviewId', () => {
-      const reviewId = 1;
-      const ownProps = getProps({
-        params: { addonSlug: undefined, reviewId },
-        location: createFakeLocation(),
-      });
-
-      expect(extractId(ownProps)).toEqual(`${reviewId}-`);
     });
   });
 });

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -942,7 +942,7 @@ describe(__filename, () => {
       expect(
         root
           .find('.AddonReviewList-featuredReview')
-          .find(AddonReviewListItem)
+          .find(AddonReviewCard)
           .prop('review').id,
       ).toEqual(reviewId);
     });

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -506,6 +506,27 @@ describe(__filename, () => {
       });
     });
 
+    it('does not include a review in the listing if the review is also featured', () => {
+      const reviews = [
+        { ...fakeReview, id: 1, rating: 1 },
+        { ...fakeReview, id: 2, rating: 2 },
+      ];
+      dispatchAddonReviews({ reviews });
+
+      const root = render({
+        params: { reviewId: reviews[0].id },
+      });
+
+      const items = root
+        .find('.AddonReviewList-reviews-listing')
+        .find(AddonReviewCard);
+
+      expect(items).toHaveLength(1);
+      expect(items.at(0).prop('review')).toMatchObject({
+        id: reviews[1].id,
+      });
+    });
+
     it("renders the add-on's icon in the header", () => {
       const addon = { ...fakeAddon };
       const header = renderAddonHeader({ addon });

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -833,7 +833,10 @@ describe(__filename, () => {
       context: { store },
     });
 
-    expect(byLine.find(Link)).toHaveProp('to', `/review/${fakeReview.id}/`);
+    expect(byLine.find(Link)).toHaveProp(
+      'to',
+      `/addon/${fakeReview.addon.slug}/reviews/${fakeReview.id}/`,
+    );
     expect(byLine.find(Link).childAt(0)).toHaveText(
       root
         .instance()

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -833,14 +833,7 @@ describe(__filename, () => {
       context: { store },
     });
 
-    expect(byLine.find(Link)).toHaveProp(
-      'title',
-      'Browse the reviews for this add-on',
-    );
-    expect(byLine.find(Link)).toHaveProp(
-      'to',
-      `/addon/${fakeReview.addon.slug}/reviews/`,
-    );
+    expect(byLine.find(Link)).toHaveProp('to', `/review/${fakeReview.id}/`);
     expect(byLine.find(Link).childAt(0)).toHaveText(
       root
         .instance()

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -3,6 +3,8 @@ import {
   deleteAddonReview,
   unloadAddonReviews,
   createInternalReview,
+  fetchReview,
+  fetchReviews,
   flagReview,
   hideEditReviewForm,
   hideFlashedReviewMessage,
@@ -107,9 +109,33 @@ describe(__filename, () => {
     expect(storedReview.reply.body).toEqual(replyBody);
   });
 
+  describe('FETCH_REVIEW', () => {
+    it('sets a loading flag when fetching a review', () => {
+      const reviewId = 1;
+      const state = reviewsReducer(
+        undefined,
+        fetchReview({ errorHandlerId: 1, reviewId }),
+      );
+
+      expect(state.view[reviewId].loadingReview).toEqual(true);
+    });
+  });
+
+  describe('FETCH_REVIEWS', () => {
+    it('sets a loading flag when fetching reviews', () => {
+      const addonSlug = 'some-slug';
+      const state = reviewsReducer(
+        undefined,
+        fetchReviews({ errorHandlerId: 1, addonSlug }),
+      );
+
+      expect(state.loadingForSlug[addonSlug]).toEqual(true);
+    });
+  });
+
   describe('SET_REVIEW', () => {
     it('calls _addReviewToState()', () => {
-      const _addReviewToState = sinon.spy();
+      const _addReviewToState = sinon.stub().returns(initialState);
 
       const review = fakeReview;
       reviewsReducer(undefined, setReview(review), {
@@ -120,6 +146,13 @@ describe(__filename, () => {
         state: initialState,
         review: createInternalReview(review),
       });
+    });
+
+    it('sets the loading flag to false', () => {
+      const review = fakeReview;
+      const state = reviewsReducer(undefined, setReview(fakeReview));
+
+      expect(state.view[review.id].loadingReview).toEqual(false);
     });
   });
 
@@ -293,6 +326,21 @@ describe(__filename, () => {
 
       expect(newState.byAddon.slug1.reviewCount).toEqual(1);
       expect(newState.byAddon.slug2.reviewCount).toEqual(2);
+    });
+
+    it('sets the loading flag to false', () => {
+      const addonSlug = 'some-slug';
+      const state = reviewsReducer(
+        undefined,
+        setAddonReviews({
+          addonSlug,
+          pageSize: DEFAULT_API_PAGE_SIZE,
+          reviews: [fakeReview],
+          reviewCount: 1,
+        }),
+      );
+
+      expect(state.loadingForSlug[addonSlug]).toEqual(false);
     });
   });
 
@@ -761,6 +809,7 @@ describe(__filename, () => {
         editingReview: false,
         flag: {},
         replyingToReview: false,
+        loadingReview: false,
         submittingReply: false,
       });
     });


### PR DESCRIPTION
Fixes #2771 

There are (at least) a couple of issues:

1. I'm having the same problem I had with recommendations and SSR where the sagas do not finish in time and the page is broken for SSR, unless I move the processing to `componentDidMount`. This does cause a noticeable delay in all the content appearing on the page, so we may want to find another way of dealing with this. I've added a comment to the code about this as well.

2. I had trouble coming up with a good way to test that a particular action was not dispatched. I have also added a comment to the code about this and welcome any suggestions.

The new version of the All Reviews page is located at `/review/[reviewId]/`, e.g., http://localhost:3000/en-US/firefox/review/563237/, and currently looks like this:

![screenshot 2018-09-07 15 36 15](https://user-images.githubusercontent.com/142755/45239597-c8a5cf80-b2b3-11e8-84c0-e110c57f361e.png)

Here's what it looks like if it's not your own review:

![screenshot 2018-09-10 08 36 13](https://user-images.githubusercontent.com/142755/45297854-aa6aea00-b4d4-11e8-99e0-9db1ef5876b8.png)
