### PR TITLE
Remove componentWillMount() calls

### DIFF
--- a/src/amo/components/Addon/index.js
+++ b/src/amo/components/Addon/index.js
@@ -104,7 +104,9 @@ export class AddonBase extends React.Component {
     getClientCompatibility: _getClientCompatibility,
   };
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
+
     const {
       addon,
       addonIsLoading,
@@ -113,7 +115,7 @@ export class AddonBase extends React.Component {
       errorHandler,
       lang,
       match: { params },
-    } = this.props;
+    } = props;
 
     // This makes sure we do not try to dispatch any new actions in the case
     // of an error.

--- a/src/amo/components/AddonReviewList/index.js
+++ b/src/amo/components/AddonReviewList/index.js
@@ -69,7 +69,9 @@ type InternalProps = {|
 |};
 
 export class AddonReviewListBase extends React.Component<InternalProps> {
-  componentWillMount() {
+  constructor(props: InternalProps) {
+    super(props);
+
     this.loadDataIfNeeded();
   }
 

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -82,7 +82,9 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
     type: 'horizontal',
   };
 
-  componentWillMount() {
+  constructor(props: InternalProps) {
+    super(props);
+
     const {
       addonType,
       authorUsernames,
@@ -90,7 +92,7 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       location,
       pageParam,
       paginate,
-    } = this.props;
+    } = props;
 
     this.dispatchFetchAddonsByAuthors({
       addonType,

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -56,14 +56,17 @@ type InternalProps = {|
 |};
 
 export class CategoriesBase extends React.Component<InternalProps> {
-  componentWillMount() {
+  constructor(props: InternalProps) {
+    super(props);
+
     const {
       addonType,
       categoriesState,
       dispatch,
       errorHandler,
       loading,
-    } = this.props;
+    } = props;
+
     invariant(addonType, 'addonType is undefined');
 
     if (!loading && !categoriesState) {

--- a/src/amo/components/Category/index.js
+++ b/src/amo/components/Category/index.js
@@ -62,7 +62,9 @@ export class CategoryBase extends React.Component {
     _config: config,
   };
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
+
     this.loadDataIfNeeded();
   }
 
@@ -92,7 +94,7 @@ export class CategoryBase extends React.Component {
     }
 
     if (!apiAddonTypeIsValid(params.visibleAddonType)) {
-      log.warn(oneLine`Skipping componentWillMount() because visibleAddonType
+      log.warn(oneLine`Skipping loadDataIfNeeded() because visibleAddonType
         is invalid: ${params.visibleAddonType}`);
       return;
     }
@@ -112,7 +114,7 @@ export class CategoryBase extends React.Component {
       }
 
       if (!category) {
-        log.warn(oneLine`Skipping componentWillMount() because category is
+        log.warn(oneLine`Skipping loadDataIfNeeded() because category is
           invalid: ${params.slug}`);
         return;
       }

--- a/src/amo/components/Collection/index.js
+++ b/src/amo/components/Collection/index.js
@@ -123,8 +123,10 @@ export class CollectionBase extends React.Component<InternalProps> {
 
   constructor(props: InternalProps) {
     super(props);
+
     this.addonPlaceholderCount = DEFAULT_ADDON_PLACEHOLDER_COUNT;
     this.maybeResetAddonPlaceholderCount();
+    this.loadDataIfNeeded();
   }
 
   maybeResetAddonPlaceholderCount() {
@@ -134,10 +136,6 @@ export class CollectionBase extends React.Component<InternalProps> {
       // the placeholder count when loading the next set of add-ons.
       this.addonPlaceholderCount = collection.addons.length;
     }
-  }
-
-  componentWillMount() {
-    this.loadDataIfNeeded();
   }
 
   componentDidUpdate() {

--- a/src/amo/components/Home/index.js
+++ b/src/amo/components/Home/index.js
@@ -91,13 +91,15 @@ export class HomeBase extends React.Component {
     includeFeaturedThemes: false,
   };
 
-  componentWillMount() {
+  constructor(props) {
+    super(props);
+
     const {
       dispatch,
       errorHandler,
       includeFeaturedThemes,
       resultsLoaded,
-    } = this.props;
+    } = props;
 
     dispatch(setViewContext(VIEW_CONTEXT_HOME));
 

--- a/src/amo/components/LandingPage/index.js
+++ b/src/amo/components/LandingPage/index.js
@@ -66,11 +66,13 @@ export class LandingPageBase extends React.Component {
     _config: config,
   };
 
-  componentWillMount() {
-    const { params } = this.props.match;
+  constructor(props) {
+    super(props);
+
+    const { params } = props.match;
 
     if (!apiAddonTypeIsValid(params.visibleAddonType)) {
-      log.warn(oneLine`Skipping componentWillMount() because visibleAddonType
+      log.warn(oneLine`Skipping constructor() because visibleAddonType
         is invalid: ${params.visibleAddonType}`);
       return;
     }

--- a/src/amo/components/LanguageTools/index.js
+++ b/src/amo/components/LanguageTools/index.js
@@ -73,8 +73,10 @@ type Props = {|
 |};
 
 export class LanguageToolsBase extends React.Component<Props> {
-  componentWillMount() {
-    const { dispatch, errorHandler, languageTools } = this.props;
+  constructor(props: Props) {
+    super(props);
+
+    const { dispatch, errorHandler, languageTools } = props;
 
     dispatch(setViewContext(VIEW_CONTEXT_LANGUAGE_TOOLS));
 

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -32,11 +32,13 @@ type InternalProps = {|
 |};
 
 export class RatingsByStarBase extends React.Component<InternalProps> {
-  componentWillMount() {
+  constructor(props: InternalProps) {
+    super(props);
+
     // TODO: this is intended to load on the server (before mount) but it
     // does not.
     // See: https://github.com/mozilla/addons-frontend/issues/5854
-    this.loadDataIfNeeded(this.props);
+    this.loadDataIfNeeded(props);
   }
 
   componentWillReceiveProps(nextProps: InternalProps) {

--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -70,10 +70,12 @@ export class SearchBase extends React.Component<InternalProps> {
     results: [],
   };
 
-  componentWillMount() {
+  constructor(props: InternalProps) {
+    super(props);
+
     this.dispatchSearch({
-      newFilters: this.props.filters,
-      oldFilters: this.props.filtersUsedForResults,
+      newFilters: props.filters,
+      oldFilters: props.filtersUsedForResults,
     });
   }
 

--- a/src/amo/components/SearchPage/index.js
+++ b/src/amo/components/SearchPage/index.js
@@ -36,8 +36,10 @@ type InternalProps = {|
 |};
 
 export class SearchPageBase extends React.Component<InternalProps> {
-  componentWillMount() {
-    const { clientApp, filters, lang, location } = this.props;
+  constructor(props: InternalProps) {
+    super(props);
+
+    const { clientApp, filters, lang, location } = props;
 
     let shouldRedirect = false;
     const newFilters = { ...filters };
@@ -87,7 +89,7 @@ export class SearchPageBase extends React.Component<InternalProps> {
         convertFiltersToQueryParams(newFilters),
       );
 
-      this.props.dispatch(
+      props.dispatch(
         sendServerRedirect({
           status: 302,
           url: `/${lang}/${clientApp}/search/${queryString}`,

--- a/src/amo/components/UserProfile/index.js
+++ b/src/amo/components/UserProfile/index.js
@@ -79,7 +79,9 @@ type InternalProps = {|
 |};
 
 export class UserProfileBase extends React.Component<InternalProps> {
-  componentWillMount() {
+  constructor(props: InternalProps) {
+    super(props);
+
     const {
       dispatch,
       errorHandler,
@@ -88,7 +90,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
       match: { params },
       reviews,
       user,
-    } = this.props;
+    } = props;
 
     if (errorHandler.hasError()) {
       log.warn('Not loading data because of an error.');

--- a/src/amo/components/UserProfileEdit/index.js
+++ b/src/amo/components/UserProfileEdit/index.js
@@ -99,16 +99,14 @@ export class UserProfileEditBase extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
+    const { dispatch, errorHandler, username, user } = props;
+
     this.state = {
       showProfileDeletionModal: false,
       pictureData: null,
       successMessage: null,
-      ...this.getFormValues(props.user),
+      ...this.getFormValues(user),
     };
-  }
-
-  componentWillMount() {
-    const { dispatch, errorHandler, username, user } = this.props;
 
     if (errorHandler.hasError()) {
       log.warn('Not loading data because of an error.');

--- a/src/ui/components/Hero/index.js
+++ b/src/ui/components/Hero/index.js
@@ -25,8 +25,10 @@ type InternalProps = {|
 |};
 
 export class HeroBase extends React.Component<InternalProps> {
-  componentWillMount() {
-    const { dispatch, heroBanners, name, random, sections } = this.props;
+  constructor(props: InternalProps) {
+    super(props);
+
+    const { dispatch, heroBanners, name, random, sections } = props;
 
     if (!heroBanners[name]) {
       dispatch(setHeroBannerOrder({ name, random, sections }));

--- a/tests/unit/core/server/test_server.js
+++ b/tests/unit/core/server/test_server.js
@@ -351,7 +351,9 @@ describe(__filename, () => {
       const newURL = '/redirect/to/this/url';
 
       class Redirect extends React.Component {
-        componentWillMount() {
+        constructor(props) {
+          super(props);
+
           store.dispatch(
             sendServerRedirect({
               status: 301,


### PR DESCRIPTION
Fix #6186

---

This PR updates our codebase to get rid of the `componentWillMount()` calls and use the `constructor()` instead, as specified [here](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data):

> When supporting server rendering, it’s currently necessary to provide the data synchronously – componentWillMount was often used for this purpose but the constructor can be used as a replacement. The upcoming suspense APIs will make async data fetching cleanly possible for both client and server rendering.