### PR TITLE
Increase bundlesize JS threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
   "bundlesize": [
     {
       "path": "./dist/@(amo|disco)-!(i18n-)*.js",
-      "maxSize": "400 kB"
+      "maxSize": "410 kB"
     },
     {
       "path": "./dist/@(amo|disco)-i18n-*.js",


### PR DESCRIPTION
I don't have a better solution right now.

~~I'll file an issue to explore ways to reduce the bundlesize of `amo` JS.~~ See: https://github.com/mozilla/addons-frontend/issues/6192