### PR TITLE
Add new amo:dev-https command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Here are some commands you can run:
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | yarn amo                    | Start the dev server/proxy (for amo) using data from Docker                                                                   |
 | yarn amo:dev                | Start the dev server/proxy (for amo) using data from the dev server (https://addons-dev.allizom.org/)                         |
+| yarn amo:dev-https          | Same as `amo:dev` but with HTTPS                                                                                              |
 | yarn amo:no-proxy           | Start the dev server without a proxy (for amo) using data from Docker                                                         |
 | yarn amo:stage              | Start the dev server/proxy (for amo) using data from the staging server (https://addons.allizom.org/)                         |
 | yarn build                  | Build an app specified with the `NODE_APP_INSTANCE` environment variable.                                                     |

--- a/README.md
+++ b/README.md
@@ -33,38 +33,38 @@ The easiest way to manage multiple node versions in development is to use [nvm](
 
 Here are some commands you can run:
 
-| Command                     | Description                                                                                                                   |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| yarn amo                    | Start the dev server/proxy (for amo) using data from Docker                                                                   |
-| yarn amo:dev                | Start the dev server/proxy (for amo) using data from the dev server (https://addons-dev.allizom.org/)                         |
-| yarn amo:dev-https          | Same as `amo:dev` but with HTTPS                                                                                              |
-| yarn amo:no-proxy           | Start the dev server without a proxy (for amo) using data from Docker                                                         |
-| yarn amo:stage              | Start the dev server/proxy (for amo) using data from the staging server (https://addons.allizom.org/)                         |
-| yarn build                  | Build an app specified with the `NODE_APP_INSTANCE` environment variable.                                                     |
-| yarn build-all              | Build all the applications.                                                                                                   |
-| yarn build-ci               | Run the `build-all` and `bundlesize` npm scripts.                                                                             |
-| yarn bundlesize             | Run [bundlesize][] to check the generated AMO bundle sizes. [Building AMO is required first](#building-and-running-services). |
-| yarn disco                  | Start the dev server (for Discovery Pane) using data from the dev server (https://addons-dev.allizom.org/)                    |
-| yarn flow                   | Run Flow. By default this checks for errors and exits                                                                         |
-| yarn flow:check             | Explicitly check for Flow errors and exit                                                                                     |
-| yarn flow:dev               | Continuously check for Flow errors                                                                                            |
-| yarn eslint                 | Lint the JS                                                                                                                   |
-| yarn snyk                   | Run [snyk](#snyk) (without a command)                                                                                         |
-| yarn snyk-ci                | Run [snyk](#snyk) `test` and `monitor`                                                                                        |
-| yarn snyk-wizard            | Run [snyk](#snyk) `wizard` to fix an issue reported by snyk                                                                   |
-| yarn start-func-test-server | Start a Docker container for functional tests                                                                                 |
-| yarn stylelint              | Lint the SCSS                                                                                                                 |
-| yarn storybook              | Run [storybook](https://storybook.js.org/)                                                                                    |
-| yarn lint                   | Run all the JS + SCSS linters                                                                                                 |
-| yarn prettier               | Run [Prettier][] to automatically format the entire codebase                                                                  |
-| yarn prettier-dev           | Run [Pretty-Quick][] to automatically compare and format modified source files against the master branch                      |
-| yarn prettier-ci            | Run [Prettier][] and fail if some code has been changed without being formatted                                               |
-| yarn version-check          | Check you have the required dependencies                                                                                      |
-| yarn test                   | Run all tests (Enters [jest][] in `--watch` mode)                                                                             |
-| yarn test-coverage          | Run all tests and generate code coverage report (Enters [jest][] in `--watch` mode)                                           |
-| yarn test-coverage-once     | Run all tests, generate code coverage report, then exit                                                                       |
-| yarn test-once              | Run all tests, run all JS + SCSS linters, then exit                                                                           |
-| yarn test-ci                | Run all continuous integration checks. This is only meant to run on TravisCI.                                                 |
+| Command                     | Description                                                                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| yarn amo                    | Start the dev server/proxy (for amo) using data from Docker                                                                                                                                     |
+| yarn amo:dev                | Start the dev server/proxy (for amo) using data from the dev server (https://addons-dev.allizom.org/)                                                                                           |
+| yarn amo:dev-https          | Same as `amo:dev` but with HTTPS, available at: https://example.com:3000/. [Read about setting up this environment](docs/moz-addon-manager.md#developing-with-a-local-https-server-recommended) |
+| yarn amo:no-proxy           | Start the dev server without a proxy (for amo) using data from Docker                                                                                                                           |
+| yarn amo:stage              | Start the dev server/proxy (for amo) using data from the staging server (https://addons.allizom.org/)                                                                                           |
+| yarn build                  | Build an app specified with the `NODE_APP_INSTANCE` environment variable.                                                                                                                       |
+| yarn build-all              | Build all the applications.                                                                                                                                                                     |
+| yarn build-ci               | Run the `build-all` and `bundlesize` npm scripts.                                                                                                                                               |
+| yarn bundlesize             | Run [bundlesize][] to check the generated AMO bundle sizes. [Building AMO is required first](#building-and-running-services).                                                                   |
+| yarn disco                  | Start the dev server (for Discovery Pane) using data from the dev server (https://addons-dev.allizom.org/)                                                                                      |
+| yarn flow                   | Run Flow. By default this checks for errors and exits                                                                                                                                           |
+| yarn flow:check             | Explicitly check for Flow errors and exit                                                                                                                                                       |
+| yarn flow:dev               | Continuously check for Flow errors                                                                                                                                                              |
+| yarn eslint                 | Lint the JS                                                                                                                                                                                     |
+| yarn snyk                   | Run [snyk](#snyk) (without a command)                                                                                                                                                           |
+| yarn snyk-ci                | Run [snyk](#snyk) `test` and `monitor`                                                                                                                                                          |
+| yarn snyk-wizard            | Run [snyk](#snyk) `wizard` to fix an issue reported by snyk                                                                                                                                     |
+| yarn start-func-test-server | Start a Docker container for functional tests                                                                                                                                                   |
+| yarn stylelint              | Lint the SCSS                                                                                                                                                                                   |
+| yarn storybook              | Run [storybook](https://storybook.js.org/)                                                                                                                                                      |
+| yarn lint                   | Run all the JS + SCSS linters                                                                                                                                                                   |
+| yarn prettier               | Run [Prettier][] to automatically format the entire codebase                                                                                                                                    |
+| yarn prettier-dev           | Run [Pretty-Quick][] to automatically compare and format modified source files against the master branch                                                                                        |
+| yarn prettier-ci            | Run [Prettier][] and fail if some code has been changed without being formatted                                                                                                                 |
+| yarn version-check          | Check you have the required dependencies                                                                                                                                                        |
+| yarn test                   | Run all tests (Enters [jest][] in `--watch` mode)                                                                                                                                               |
+| yarn test-coverage          | Run all tests and generate code coverage report (Enters [jest][] in `--watch` mode)                                                                                                             |
+| yarn test-coverage-once     | Run all tests, generate code coverage report, then exit                                                                                                                                         |
+| yarn test-once              | Run all tests, run all JS + SCSS linters, then exit                                                                                                                                             |
+| yarn test-ci                | Run all continuous integration checks. This is only meant to run on TravisCI.                                                                                                                   |
 
 ### Running tests
 

--- a/bin/local-dev-server-certs/index.js
+++ b/bin/local-dev-server-certs/index.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const key = fs.readFileSync(path.join(__dirname, 'example.com.key.pem'), 'utf8');
+const cert = fs.readFileSync(path.join(__dirname, 'example.com.crt.pem'), 'utf8');
+const ca = fs.readFileSync(path.join(__dirname, 'example.com.ca.crt.pem'), 'utf8');
+
+module.exports = {
+  ca,
+  cert,
+  key,
+};

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -2,6 +2,7 @@ require('babel-register');
 
 const fs = require('fs');
 const http = require('http');
+const https = require('https');
 const path = require('path');
 
 const config = require('config');
@@ -14,9 +15,11 @@ const log = pino({
   name: `${config.get('appName')}.proxy`,
 });
 
-const proxy = httpProxy.createProxyServer();
+const useHttpsForDev = process.env.USE_HTTPS_FOR_DEV;
+const protocol = useHttpsForDev ? 'https' : 'http';
+
 const apiHost = config.get('proxyApiHost', null) || config.get('apiHost');
-const frontendHost = `http://${config.get('serverHost')}:${config.get('serverPort')}`;
+const frontendHost = `${protocol}://${config.get('serverHost')}:${config.get('serverPort')}`;
 
 log.info(`apiHost: ${apiHost}`);
 log.info(`frontendHost: ${frontendHost}`);
@@ -52,16 +55,30 @@ function getHost(req) {
   return frontendHost;
 }
 
-const server = http.createServer((req, res) => {
+// Skip SSL check to avoid the 'self signed certificate in certificate chain' error.
+const proxy = httpProxy.createProxyServer({ secure: false });
+
+const handler = (req, res) => {
   const host = getHost(req);
   return proxy.web(req, res, {
     target: host,
     changeOrigin: true,
     autoRewrite: true,
-    protocolRewrite: 'http',
+    protocolRewrite: protocol,
     cookieDomainRewrite: '',
   });
-});
+};
+
+let server;
+
+if (useHttpsForDev) {
+  // eslint-disable-next-line global-require
+  const { key, cert, ca } = require('./local-dev-server-certs');
+
+  server = https.createServer({ key, cert, ca }, handler);
+} else {
+  server = http.createServer(handler);
+}
 
 proxy.on('proxyRes', (proxyRes, req, res) => {
   log.debug(`${proxyRes.statusCode} ~> ${getHost(req)}${req.url}`);
@@ -69,14 +86,15 @@ proxy.on('proxyRes', (proxyRes, req, res) => {
 });
 
 proxy.on('error', (error, req, res) => {
-  const htmlFile = fs.readFileSync(
-    path.join(__dirname, 'loading-page.html'), 'utf8');
+  const htmlFile = fs.readFileSync(path.join(__dirname, 'loading-page.html'), 'utf8');
 
   log.error(`ERR ~> ${getHost(req)}${req.url} ${error}`);
   res.writeHead(500, { 'Content-type': 'text/html' });
   res.end(htmlFile);
 });
 
+const host = useHttpsForDev ? process.env.SERVER_HOST : 'localhost';
 const port = parseInt(config.get('proxyPort', '3333'), 10);
-log.info(`🚦 Proxy running at http://localhost:${port}`);
+
+log.info(`🚦 Proxy running at ${protocol}://${host}:${port}`);
 server.listen(port);

--- a/bin/server.js
+++ b/bin/server.js
@@ -16,12 +16,18 @@ if (!appName) {
   process.exit(1);
 }
 
-if (config.util.getEnv('NODE_ENV') === 'development') {
+if (process.env.NODE_ENV === 'development') {
   if (!require('piping')({
     hook: true,
     ignore: /(\/\.|~$|\.json|\.scss$)/i,
   })) {
     return;
+  }
+
+  if (process.env.USE_HTTPS_FOR_DEV) {
+    // Skip SSL check to avoid the 'self signed certificate in certificate
+    // chain' error.
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   }
 }
 

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -3,6 +3,8 @@
 /* eslint-disable strict, no-console */
 
 require('babel-register');
+const https = require('https');
+
 const Express = require('express');
 const config = require('config');
 const webpack = require('webpack');
@@ -34,7 +36,17 @@ const app = new Express();
 app.use(webpackDevMiddleware(compiler, serverOptions));
 app.use(webpackHotMiddleware(compiler));
 
-app.listen(port, (err) => {
+let server;
+
+if (process.env.USE_HTTPS_FOR_DEV) {
+  // eslint-disable-next-line global-require
+  const { key, cert, ca } = require('./local-dev-server-certs');
+  server = https.createServer({ key, cert, ca }, app);
+} else {
+  server = app;
+}
+
+server.listen(port, (err) => {
   if (err) {
     console.error(err);
   } else {

--- a/config/development.js
+++ b/config/development.js
@@ -1,10 +1,9 @@
 // Config specific to local development
 import { amoDevCDN, apiDevHost, sentryHost } from './lib/shared';
 
-const webpackServerHost = '127.0.0.1';
+const webpackServerHost = process.env.WEBPACK_SERVER_HOST || '127.0.0.1';
 const webpackServerPort = 3001;
 const webpackHost = `${webpackServerHost}:${webpackServerPort}`;
-
 
 module.exports = {
   apiHost: apiDevHost,

--- a/docs/moz-addon-manager.md
+++ b/docs/moz-addon-manager.md
@@ -1,8 +1,8 @@
 # Develop features for mozAddonManager
 
-The AMO and Discovery Pane apps use the [`mozAddonManager`](https://bugzilla.mozilla.org/show_bug.cgi?id=1310752) web API to achieve a more seamless add-on installation user experience. However, this API is only available to a limited list of domains. If you go to https://addons.mozilla.org (production) in Firefox then `mozAddonManager` is available on the page. If you go to a development site then it's not.
+The AMO and Discovery Pane apps use the [`mozAddonManager`](https://bugzilla.mozilla.org/show_bug.cgi?id=1310752) web API to achieve a more seamless add-on installation user experience. However, this API is only available to a limited list of domains. If you go to https://addons.mozilla.org (production) in Firefox then `mozAddonManager` is available on the page. If you go to a non-production site (local, development or staging) then it's not by default.
 
-## Turning on mozAddonManager for development
+## Turning on mozAddonManager in -dev and -stage environments
 
 To access `mozAddonManager` on a development site like https://addons-dev.allizom.org or https://addons.allizom.org go to `about:config` in Firefox and set this property to `true`:
 
@@ -12,7 +12,7 @@ extensions.webapi.testing
 
 Refresh the page, open the JavaScript console, and you should see a global `mozAddonManager` object.
 
-## Install add-ons for development
+## Install add-ons in -dev and -stage environments
 
 To fully install add-ons from a development site like https://addons-dev.allizom.org or https://addons.allizom.org you will need to tell Firefox to honor their signing certificates. Go to `about:config` in Firefox and set this property to `true`:
 
@@ -34,7 +34,39 @@ To activate access to this API on a development site, first make sure you set th
 
 If you're testing on desktop Firefox to emulate Android (for development), you need to make sure your user agent looks like Firefox for Android. You can [save a custom device](https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode#Saving_custom_devices) in [Responsive Design Mode](https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode) with a [Firefox for Android user agent string](<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox#Android_(version_41_and_above)>). Make sure it is touch enabled. This will let you see the add-on installation switch on desktop.
 
-## Developing with a local server
+## Developing with a local HTTPS server (recommended)
+
+It is possible to serve the local development version of this project with HTTPS enabled. By doing this, you can have access to `mozAddonManager` locally and install add-ons with a regular [Firefox Nightly build](https://www.mozilla.org/en-US/firefox/channel/desktop/#nightly) (no need to build Firefox yourself). All you need is to configure your environment as follows:
+
+1. Add a new entry to your `/etc/hosts` file (or equivalent on Windows systems):
+
+   ```
+   127.0.0.1   example.com
+   ```
+
+2. Install a self-signed CA certificate for `example.com`:
+
+   - Download [this file](https://raw.githubusercontent.com/mozilla/addons-frontend/master/bin/local-dev-server-certs/example.com.ca.crt.pem)
+   - Go to `about:preferences#privacy`
+   - Click the _View Certificates..._ button (at the bottom of the page)
+   - Click the _Import..._ button
+   - Choose the file you have downloaded before (`example.com.ca.crt.pem`)
+   - Accept this CA certificate to trust websites
+
+3. Start this project with the command below:
+
+   ```
+   yarn amo:dev-https
+   ```
+
+This allows you to browse the project at https://example.com:3000/ (and not `localhost`). In order to get access to the `mozAddonManager` and be able to install add-ons, you still need to set two prefs:
+
+- `extensions.webapi.testing` set to `true` [to turn on `mozAddonManager`](#turning-on-mozaddonmanager-in--dev-and--stage-environments)
+- `xpinstall.signatures.dev-root` set to `true` [to install add-ons](#install-add-ons-in--dev-and--stage-environments)
+
+You are all set!
+
+## Developing with a local server and a patched Firefox
 
 When you're running a server locally for development, you need to grant `mozAddonManager` access to your `localhost` domain in addition to setting the `extensions.webapi.testing` preference to `true`.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean": "rimraf './dist/*!(.gitkeep)' './webpack-assets.json' './src/locale/**(!.gitkeep)'",
     "amo": "better-npm-run amo",
     "amo:dev": "better-npm-run amo:dev",
+    "amo:dev-https": "better-npm-run amo:dev-https",
     "amo:ui-tests": "better-npm-run amo:ui-tests",
     "amo:no-proxy": "better-npm-run amo:no-proxy",
     "amo:stage": "better-npm-run amo:stage",
@@ -65,6 +66,15 @@
         "AMO_CDN": "https://addons-dev-cdn.allizom.org",
         "PROXY_API_HOST": "https://addons-dev.allizom.org",
         "NODE_APP_INSTANCE": "amo"
+      }
+    },
+    "amo:dev-https": {
+      "command": "better-npm-run amo:dev",
+      "env": {
+        "API_HOST": "https://example.com:3000",
+        "SERVER_HOST": "example.com",
+        "USE_HTTPS_FOR_DEV": "true",
+        "WEBPACK_SERVER_HOST": "example.com"
       }
     },
     "amo:ui-tests": {


### PR DESCRIPTION
Fix #6143

---

~~This setup works at 99%. I am not able to install extensions though~~ (edit: it works with Nightly), but the rest looks good. CSP complains about sha1 signatures too, but this is not related.

All you need to get started is to import [the CA certificate](https://github.com/mozilla/addons-frontend/blob/14624803fc0d8db424cb2da471f68911163c6253/bin/local-dev-server-certs/example.com.ca.crt.pem) in Firefox:

![screen shot 2018-09-11 at 16 07 46](https://user-images.githubusercontent.com/217628/45365762-8941f080-b5dd-11e8-921b-c21dd9a47243.png)

