### PR TITLE
Cache-Control=no-store to make auth tokens really go away

### DIFF
--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -249,6 +249,15 @@ function baseServer(
       webpackIsomorphicTools.refresh();
     }
 
+    // Make sure the initial page does not get stored. Specifically, we
+    // don't want the auth token in Redux state to hang around.
+    //
+    // The site operates as a single page app so this should really
+    // only affect how the browser loads the page when clicking
+    // the back button.
+    //
+    const cacheControl = ['no-store'];
+
     const cacheAllResponsesFor = config.get('cacheAllResponsesFor');
     if (cacheAllResponsesFor) {
       if (!isDevelopment) {
@@ -259,8 +268,11 @@ function baseServer(
       }
       log.warn(oneLine`Sending a Cache-Control header so that the client caches
         all requests for ${cacheAllResponsesFor} seconds`);
-      res.set('Cache-Control', `public, max-age=${cacheAllResponsesFor}`);
+      cacheControl.push('public');
+      cacheControl.push(`max-age=${cacheAllResponsesFor}`);
     }
+
+    res.set('Cache-Control', cacheControl.join(', '));
 
     // Vary the cache on Do Not Track headers.
     res.vary('DNT');

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -251,6 +251,7 @@ function baseServer(
 
     // Make sure the initial page does not get stored. Specifically, we
     // don't want the auth token in Redux state to hang around.
+    // See https://github.com/mozilla/addons-frontend/issues/6217
     //
     // The site operates as a single page app so this should really
     // only affect how the browser loads the page when clicking

--- a/tests/unit/core/server/test_server.js
+++ b/tests/unit/core/server/test_server.js
@@ -157,6 +157,16 @@ describe(__filename, () => {
       expect(response.statusCode).toEqual(404);
     });
 
+    it('sets a Cache-Control header', async () => {
+      const { store, sagaMiddleware } = createStoreAndSagas();
+
+      const response = await testClient({ store, sagaMiddleware })
+        .get('/en-US/firefox/')
+        .end();
+
+      expect(response.headers['cache-control']).toEqual('no-store');
+    });
+
     it('does not dispatch setAuthToken() if cookie is not found', async () => {
       const { store, sagaMiddleware } = createStoreAndSagas();
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6217

It looks like there are other headers we need for older browsers but I'm not sure it's worth it.