### PR TITLE
Hook up edit button for inline reviews

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -23,6 +23,7 @@ import {
   showEditReviewForm,
   showReplyToReviewForm,
 } from 'amo/actions/reviews';
+import Button from 'ui/components/Button';
 import ConfirmButton from 'ui/components/ConfirmButton';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import Icon from 'ui/components/Icon';
@@ -49,6 +50,7 @@ type Props = {|
   review?: UserReviewType | null,
   shortByLine?: boolean,
   showRating?: boolean,
+  verticalButtons?: boolean,
 |};
 
 type InternalProps = {|
@@ -69,7 +71,9 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   static defaultProps = {
     _config: config,
     flaggable: true,
+    shortByLine: false,
     showRating: true,
+    verticalButtons: false,
   };
 
   onClickToDeleteReview = (event: SyntheticEvent<HTMLElement>) => {
@@ -290,6 +294,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       shortByLine,
       showRating,
       siteUser,
+      verticalButtons,
     } = this.props;
 
     let byLine;
@@ -393,24 +398,48 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       </div>
     );
 
+    let cancelButtonText;
+    if (verticalButtons) {
+      cancelButtonText = this.isRatingOnly()
+        ? i18n.gettext("Nevermind, I don't want to write a review")
+        : i18n.gettext("Nevermind, I don't want to edit my review");
+    }
+
     return (
       <div
         className={makeClassName('AddonReviewCard', className, {
           'AddonReviewCard-ratingOnly': this.isRatingOnly(),
+          'AddonReviewCard-viewOnly': !editingReview,
+          'AddonReviewCard-verticalButtons': verticalButtons,
         })}
       >
         {review && editingReview && _config.get('enableInlineAddonReview') ? (
           <AddonReviewManager
             onCancel={this.onCancelEditReview}
+            cancelButtonText={cancelButtonText}
+            puffyButtons={Boolean(verticalButtons)}
             review={review}
           />
         ) : (
-          <UserReview
-            controls={controls}
-            review={review}
-            byLine={!this.isRatingOnly() && byLine}
-            showRating={!this.isReply() && showRating}
-          />
+          <React.Fragment>
+            <UserReview
+              controls={controls}
+              review={review}
+              byLine={!this.isRatingOnly() && byLine}
+              showRating={!this.isReply() && showRating}
+            />
+            {this.isRatingOnly() && (
+              <Button
+                className="AddonReviewCard-writeReviewButton"
+                onClick={this.onClickToEditReview}
+                href="#writeReview"
+                buttonType="action"
+                puffy
+              >
+                {i18n.gettext('Write a review')}
+              </Button>
+            )}
+          </React.Fragment>
         )}
         {errorHandler.renderErrorIfPresent()}
         {this.renderReply()}

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -14,6 +14,20 @@
   }
 }
 
+.AddonReviewCard-verticalButtons {
+  .DismissibleTextForm-buttons {
+    display: flex;
+    flex-direction: column-reverse;
+    margin-top: 24px;
+  }
+
+  .DismissibleTextForm-dismiss {
+    margin-top: 12px;
+    text-align: center;
+    width: 100%;
+  }
+}
+
 .AddonReviewCard-authorByLine {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -89,4 +103,9 @@
   .Icon-reply-arrow {
     @include margin-end(12px);
   }
+}
+
+.AddonReviewCard-writeReviewButton {
+  margin-top: 12px;
+  width: 100%;
 }

--- a/src/amo/components/AddonReviewManager/index.js
+++ b/src/amo/components/AddonReviewManager/index.js
@@ -25,7 +25,9 @@ import type { OnSubmitParams } from 'ui/components/DismissibleTextForm';
 import './styles.scss';
 
 type Props = {|
+  cancelButtonText?: string,
   onCancel?: () => void,
+  puffyButtons?: boolean,
   review: UserReviewType,
 |};
 
@@ -38,6 +40,10 @@ type InternalProps = {|
 |};
 
 export class AddonReviewManagerBase extends React.Component<InternalProps> {
+  static defaultProps = {
+    puffyButtons: false,
+  };
+
   onSubmitRating = (rating: number) => {
     const { errorHandler, dispatch, review } = this.props;
 
@@ -63,7 +69,15 @@ export class AddonReviewManagerBase extends React.Component<InternalProps> {
   };
 
   render() {
-    const { errorHandler, i18n, onCancel, review, flashMessage } = this.props;
+    const {
+      cancelButtonText,
+      errorHandler,
+      i18n,
+      onCancel,
+      review,
+      flashMessage,
+      puffyButtons,
+    } = this.props;
 
     const reviewGuideLink = i18n.sprintf(
       i18n.gettext(
@@ -112,12 +126,13 @@ export class AddonReviewManagerBase extends React.Component<InternalProps> {
           </span>
         </div>
         <DismissibleTextForm
+          dismissButtonText={cancelButtonText}
           formFooter={formFooter}
           isSubmitting={flashMessage === STARTED_SAVE_REVIEW}
           onDismiss={onCancel}
           onSubmit={this.onSubmitReview}
           placeholder={placeholder}
-          puffyButtons
+          puffyButtons={puffyButtons}
           submitButtonText={
             review.body
               ? i18n.gettext('Update review')

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -7,11 +7,6 @@
   position: relative;
 }
 
-.RatingManager-cancelTextEntryButton {
-  text-align: center;
-  width: 100%;
-}
-
 .RatingManager-log-in-to-rate-button {
   font-size: $font-size-s;
   padding: 0;
@@ -47,7 +42,7 @@
   }
 }
 
-.RatingManager-AddonReviewCard:not(.AddonReviewCard-ratingOnly) {
+.RatingManager-AddonReviewCard.AddonReviewCard-viewOnly:not(.AddonReviewCard-ratingOnly) {
   background-color: transparentize($blue-50, 0.95);
   border-radius: $border-radius-default;
   padding: 12px;
@@ -59,9 +54,4 @@
 
 .RatingManager-UserRating {
   margin: 12px;
-}
-
-.RatingManager-writeReviewButton {
-  margin-top: 12px;
-  width: 100%;
 }

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -24,6 +24,7 @@ export type OnSubmitParams = {|
 
 type Props = {|
   className?: string,
+  dismissButtonText?: string,
   formFooter?: React.Element<any>,
   onDelete?: null | (() => void),
   onDismiss?: () => void,
@@ -105,6 +106,7 @@ export class DismissibleTextFormBase extends React.Component<
   render() {
     const {
       className,
+      dismissButtonText,
       formFooter,
       i18n,
       isSubmitting,
@@ -158,13 +160,16 @@ export class DismissibleTextFormBase extends React.Component<
           */}
           {onDismiss && (
             <Button
-              href="#cancel"
-              onClick={this.onDismiss}
+              buttonType="neutral"
               className="DismissibleTextForm-dismiss"
               disabled={isSubmitting}
+              href="#cancel"
+              micro={microButtons}
+              onClick={this.onDismiss}
+              puffy={puffyButtons}
               type="cancel"
             >
-              {i18n.gettext('Cancel')}
+              {dismissButtonText || i18n.gettext('Cancel')}
             </Button>
           )}
           <span className="DismissibleTextForm-delete-submit-buttons">

--- a/tests/unit/amo/components/TestAddonReviewManager.js
+++ b/tests/unit/amo/components/TestAddonReviewManager.js
@@ -88,6 +88,28 @@ describe(__filename, () => {
     sinon.assert.called(onCancel);
   });
 
+  it('passes cancelButtonText to DismissibleTextForm', () => {
+    const cancelButtonText = 'Nevermind, cancel it';
+    const root = render({ onCancel: sinon.stub(), cancelButtonText });
+
+    expect(root.find(DismissibleTextForm)).toHaveProp(
+      'dismissButtonText',
+      cancelButtonText,
+    );
+  });
+
+  it('configures DismissibleTextForm without puffyButtons by default', () => {
+    const root = render();
+
+    expect(root.find(DismissibleTextForm)).toHaveProp('puffyButtons', false);
+  });
+
+  it('passes puffyButtons to DismissibleTextForm', () => {
+    const root = render({ puffyButtons: true });
+
+    expect(root.find(DismissibleTextForm)).toHaveProp('puffyButtons', true);
+  });
+
   it('updates the rating when you select a star', () => {
     const { store } = dispatchClientMetadata();
     const dispatchSpy = sinon.spy(store, 'dispatch');

--- a/tests/unit/ui/components/TestDismissibleTextForm.js
+++ b/tests/unit/ui/components/TestDismissibleTextForm.js
@@ -74,6 +74,23 @@ describe(__filename, () => {
     );
   });
 
+  it('renders a default cancel button', () => {
+    const root = shallowRender({ dismissButtonText: undefined });
+
+    expect(root.find('.DismissibleTextForm-dismiss').children()).toHaveText(
+      'Cancel',
+    );
+  });
+
+  it('lets you configure the cancel button text', () => {
+    const dismissButtonText = 'Nevermind, cancel it';
+    const root = shallowRender({ dismissButtonText });
+
+    expect(root.find('.DismissibleTextForm-dismiss').children()).toHaveText(
+      dismissButtonText,
+    );
+  });
+
   it('renders a placeholder', () => {
     const root = shallowRender({
       placeholder: 'Enter some text',
@@ -255,26 +272,48 @@ describe(__filename, () => {
   });
 
   it('creates micro buttons when requested', () => {
-    const root = shallowRender({ onDelete: sinon.stub(), microButtons: true });
+    const root = shallowRender({
+      microButtons: true,
+      onDelete: sinon.stub(),
+      onDismiss: sinon.stub(),
+    });
 
     expect(root.find('.DismissibleTextForm-delete')).toHaveProp('micro', true);
     expect(root.find('.DismissibleTextForm-submit')).toHaveProp('micro', true);
+    expect(root.find('.DismissibleTextForm-dismiss')).toHaveProp('micro', true);
   });
 
   it('creates puffy buttons when requested', () => {
-    const root = shallowRender({ puffyButtons: true, onDelete: sinon.stub() });
+    const root = shallowRender({
+      onDelete: sinon.stub(),
+      onDismiss: sinon.stub(),
+      puffyButtons: true,
+    });
 
     expect(root.find('.DismissibleTextForm-delete')).toHaveProp('puffy', true);
     expect(root.find('.DismissibleTextForm-submit')).toHaveProp('puffy', true);
+    expect(root.find('.DismissibleTextForm-dismiss')).toHaveProp('puffy', true);
   });
 
   it('creates non-micro, non-puffy buttons by default', () => {
-    const root = shallowRender({ onDelete: sinon.stub() });
+    const root = shallowRender({
+      onDismiss: sinon.stub(),
+      onDelete: sinon.stub(),
+    });
 
     expect(root.find('.DismissibleTextForm-delete')).toHaveProp('micro', false);
     expect(root.find('.DismissibleTextForm-submit')).toHaveProp('micro', false);
+    expect(root.find('.DismissibleTextForm-dismiss')).toHaveProp(
+      'micro',
+      false,
+    );
+
     expect(root.find('.DismissibleTextForm-delete')).toHaveProp('puffy', false);
     expect(root.find('.DismissibleTextForm-submit')).toHaveProp('puffy', false);
+    expect(root.find('.DismissibleTextForm-dismiss')).toHaveProp(
+      'puffy',
+      false,
+    );
   });
 
   it('cannot create conflicting button types', () => {


### PR DESCRIPTION
~~**This patch depends on** https://github.com/mozilla/addons-frontend/pull/6220~~

<hr>

- Fixes https://github.com/mozilla/addons-frontend/issues/6163 by hooking up the edit button. This involved moving a bunch of code from `RatingManager` to `AddonReviewCard` which makes more sense now.
- Fixes https://github.com/mozilla/addons-frontend/issues/6162 by magic (it just fell into place)

Behold! We now have a complete inline review flow, minus notifications (https://github.com/mozilla/addons-frontend/pull/6213).

<details>
<summary>Screencast</summary>

![addons-frontend-inline-review-all mov](https://user-images.githubusercontent.com/55398/45451937-2b2b1100-b6a2-11e8-8622-ec998076e58b.gif)


</details>

<hr>

I adjusted the buttons on a few other screens for consistency:

<img width="640" alt="screenshot 2018-09-12 15 24 10" src="https://user-images.githubusercontent.com/55398/45451957-3da54a80-b6a2-11e8-8db7-6932044f6314.png">
<img width="640" alt="screenshot 2018-09-12 15 24 24" src="https://user-images.githubusercontent.com/55398/45451958-3da54a80-b6a2-11e8-928e-c911b87e69f1.png">
