### PR TITLE
Add a check for non-restartless add-ons

### DIFF
--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -173,8 +173,19 @@ export function getClientCompatibility({
     downloadUrl = FACEBOOK_CONTAINER_DOWNLOAD_URL;
   }
 
+  let compatible = agent.compatible && supportsClientApp;
+
+  const { browser } = userAgentInfo;
+  const isFF61 =
+    browser.name === 'Firefox' && mozCompare(browser.version, '61.0') >= 0;
+
+  if (compatible && isFF61 && addon && addon.isRestartRequired === true) {
+    compatible = false;
+    reason = INCOMPATIBLE_UNSUPPORTED_PLATFORM;
+  }
+
   return {
-    compatible: agent.compatible && supportsClientApp,
+    compatible,
     downloadUrl,
     maxVersion,
     minVersion,

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -145,6 +145,7 @@ export function getClientCompatibility({
   clientApp,
   userAgentInfo,
   _window = typeof window !== 'undefined' ? window : {},
+  _log = log,
 } = {}) {
   // Check compatibility with client app.
   const { supportsClientApp, maxVersion, minVersion } = getCompatibleVersions({
@@ -175,13 +176,20 @@ export function getClientCompatibility({
 
   let compatible = agent.compatible && supportsClientApp;
 
-  const { browser } = userAgentInfo;
-  const isFF61 =
-    browser.name === 'Firefox' && mozCompare(browser.version, '61.0') >= 0;
+  if (compatible && addon && addon.isRestartRequired === true) {
+    const { browser } = userAgentInfo;
 
-  if (compatible && isFF61 && addon && addon.isRestartRequired === true) {
-    compatible = false;
-    reason = INCOMPATIBLE_UNSUPPORTED_PLATFORM;
+    if (
+      browser.name === 'Firefox' &&
+      mozCompare(browser.version, '61.0') >= 0
+    ) {
+      compatible = false;
+      reason = INCOMPATIBLE_UNSUPPORTED_PLATFORM;
+
+      _log.debug(
+        'add-on is incompatible because it is a non-restartless add-on',
+      );
+    }
   }
 
   return {

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -726,10 +726,8 @@ describe(__filename, () => {
           clientApp,
           userAgentInfo,
         }),
-      ).toEqual({
+      ).toMatchObject({
         compatible: false,
-        maxVersion: addon.current_version.compatibility[clientApp].max,
-        minVersion: addon.current_version.compatibility[clientApp].min,
         reason: INCOMPATIBLE_UNSUPPORTED_PLATFORM,
       });
     });
@@ -756,10 +754,8 @@ describe(__filename, () => {
           clientApp,
           userAgentInfo,
         }),
-      ).toEqual({
+      ).toMatchObject({
         compatible: true,
-        maxVersion: addon.current_version.compatibility[clientApp].max,
-        minVersion: addon.current_version.compatibility[clientApp].min,
         reason: null,
       });
     });

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -702,6 +702,67 @@ describe(__filename, () => {
         reason: INCOMPATIBLE_UNSUPPORTED_PLATFORM,
       });
     });
+
+    // See: https://github.com/mozilla/addons-frontend/issues/6240
+    it('returns incompatible when add-on is non-restartless and FF version >= 61.0', () => {
+      const userAgentInfo = UAParser(userAgentsByPlatform.mac.firefox61);
+      const clientApp = CLIENT_APP_FIREFOX;
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          files: [
+            {
+              ...fakeAddon.current_version.files[0],
+              is_restart_required: true,
+            },
+          ],
+        },
+      });
+
+      expect(
+        getClientCompatibility({
+          addon,
+          clientApp,
+          userAgentInfo,
+        }),
+      ).toEqual({
+        compatible: false,
+        maxVersion: addon.current_version.compatibility[clientApp].max,
+        minVersion: addon.current_version.compatibility[clientApp].min,
+        reason: INCOMPATIBLE_UNSUPPORTED_PLATFORM,
+      });
+    });
+
+    it('returns compatible when add-on is non-restartless and FF version < 61.0', () => {
+      const userAgentInfo = UAParser(userAgentsByPlatform.mac.firefox57);
+      const clientApp = CLIENT_APP_FIREFOX;
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          files: [
+            {
+              ...fakeAddon.current_version.files[0],
+              is_restart_required: true,
+            },
+          ],
+        },
+      });
+
+      expect(
+        getClientCompatibility({
+          addon,
+          clientApp,
+          userAgentInfo,
+        }),
+      ).toEqual({
+        compatible: true,
+        maxVersion: addon.current_version.compatibility[clientApp].max,
+        minVersion: addon.current_version.compatibility[clientApp].min,
+        reason: null,
+      });
+    });
   });
 
   describe('isQuantumCompatible', () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -167,6 +167,8 @@ export const userAgentsByPlatform = {
       rv:33.0) Gecko/20100101 Firefox/33.0`,
     firefox57: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0)
       Gecko/20100101 Firefox/57.1`,
+    firefox61: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0)
+      Gecko/20100101 Firefox/61.0`,
   },
   unix: {
     firefox51: oneLine`Mozilla/51.0.2 (X11; Unix x86_64; rv:29.0)

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -167,7 +167,7 @@ export const userAgentsByPlatform = {
       rv:33.0) Gecko/20100101 Firefox/33.0`,
     firefox57: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0)
       Gecko/20100101 Firefox/57.1`,
-    firefox61: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0)
+    firefox61: oneLine`Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:61.0)
       Gecko/20100101 Firefox/61.0`,
   },
   unix: {


### PR DESCRIPTION
Fix #6240 

---

~~I think we still need to know when non-restartless add-on support has been dropped because the current patch makes all non-restartless add-ons incompatible.~~ FF 61 is the answer.