### PR TITLE
Fix :focus button style

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "express": "4.16.2",
     "extract-text-webpack-plugin": "3.0.2",
     "fastclick": "1.0.6",
+    "focus-visible": "4.1.5",
     "full-icu": "1.2.1",
     "helmet": "3.13.0",
     "history": "4.7.2",

--- a/src/core/polyfill.js
+++ b/src/core/polyfill.js
@@ -1,3 +1,4 @@
 import 'babel-polyfill';
 import 'raf/polyfill';
 import 'isomorphic-fetch';
+import 'focus-visible';

--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -107,6 +107,11 @@ $puffy-font-size: 15px;
 
   &:focus {
     @include focus();
+
+    // See: https://github.com/WICG/focus-visible
+    &:not(.focus-visible) {
+      box-shadow: none;
+    }
   }
 
   &.Button--disabled {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4735,6 +4735,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+focus-visible@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-4.1.5.tgz#50b44e2e84c24b831ceca3cce84d57c2b311c855"
+
 follow-redirects@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"


### PR DESCRIPTION
Fix #6251

---

I found the polyfill in this article (which contains information about why it is needed): https://fvsch.com/styling-buttons/#sticky-focus

We never noticed that before because most of our buttons disappear on click or we redirect users somewhere else.