### PR TITLE
Add config for withExperiment HOC

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -108,6 +108,7 @@ module.exports = {
     'enableExperienceSurvey',
     'enableInlineAddonReview',
     'enableStaticThemes',
+    'experiments',
     'fxaConfig',
     'isDeployed',
     'isDevelopment',
@@ -312,4 +313,10 @@ module.exports = {
   enableAMInstallButton: false,
 
   enableInlineAddonReview: false,
+
+  // The withExperiment HOC relies on this config to enable/disable A/B
+  // experiments.
+  experiments: {
+    home_hero: false,
+  },
 };

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -27,4 +27,8 @@ module.exports = {
 
   enableAMInstallButton: true,
   enableInlineAddonReview: true,
+
+  experiments: {
+    home_hero: true,
+  },
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -13,4 +13,8 @@ module.exports = {
   loggingLevel: 'debug',
   enableAMInstallButton: true,
   enableInlineAddonReview: true,
+
+  experiments: {
+    home_hero: true,
+  },
 };

--- a/src/amo/components/HomeHeroBanner/index.js
+++ b/src/amo/components/HomeHeroBanner/index.js
@@ -30,7 +30,11 @@ export class HomeHeroBannerBase extends React.Component<InternalProps> {
   };
 
   componentDidMount() {
-    const { _tracking, variant } = this.props;
+    const { _tracking, experimentEnabled, variant } = this.props;
+
+    if (!experimentEnabled) {
+      return;
+    }
 
     _tracking.sendEvent({
       action: variant,
@@ -253,7 +257,11 @@ export class HomeHeroBannerBase extends React.Component<InternalProps> {
   }
 
   trackExperimentClick = (e: SyntheticEvent<HTMLElement>, title: string) => {
-    const { _tracking, variant } = this.props;
+    const { _tracking, experimentEnabled, variant } = this.props;
+
+    if (!experimentEnabled) {
+      return;
+    }
 
     _tracking.sendEvent({
       action: variant,

--- a/tests/unit/amo/components/TestHomeHeroBanner.js
+++ b/tests/unit/amo/components/TestHomeHeroBanner.js
@@ -1,28 +1,35 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import {
-  createFakeEvent,
-  createFakeTracking,
-  fakeI18n,
-  shallowUntilTarget,
-} from 'tests/unit/helpers';
 import HomeHeroBanner, {
+  AB_HOME_HERO_EXPERIMENT,
   AB_HOME_HERO_EXPERIMENT_CATEGORY,
   AB_HOME_HERO_VARIANT_A,
   AB_HOME_HERO_VARIANT_B,
   HomeHeroBannerBase,
 } from 'amo/components/HomeHeroBanner';
 import Hero from 'ui/components/Hero';
+import {
+  createFakeEvent,
+  createFakeTracking,
+  fakeI18n,
+  getFakeConfig,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
   const defaultProps = {
+    _config: getFakeConfig({
+      experiments: {
+        [AB_HOME_HERO_EXPERIMENT]: true,
+      },
+    }),
     i18n: fakeI18n(),
     store: dispatchClientMetadata().store,
   };
 
-  function shallowRender(props) {
+  function render(props) {
     return shallowUntilTarget(
       <HomeHeroBanner {...defaultProps} {...props} />,
       HomeHeroBannerBase,
@@ -30,32 +37,31 @@ describe(__filename, () => {
   }
 
   it('renders a HomeHeroBanner', () => {
-    const root = shallowRender();
-
+    const root = render();
     expect(root).toHaveClassName('HomeHeroBanner');
   });
 
   it('renders with the "small" experiment classname', () => {
-    const root = shallowRender({ variant: AB_HOME_HERO_VARIANT_A });
+    const root = render({ variant: AB_HOME_HERO_VARIANT_A });
     expect(root).toHaveClassName('HomeHeroBanner--small');
   });
 
   it('renders without the "small" experiment classname', () => {
-    const root = shallowRender({ variant: AB_HOME_HERO_VARIANT_B });
+    const root = render({ variant: AB_HOME_HERO_VARIANT_B });
     expect(root).not.toHaveClassName('HomeHeroBanner--small');
   });
 
   it('renders a carousel with random sections', () => {
-    const root = shallowRender();
+    const root = render();
     const carousel = root.find(Hero);
 
     expect(carousel).toHaveLength(1);
     expect(carousel).toHaveProp('random', true);
   });
 
-  it('sends a tracking event when first rendered on the client', () => {
+  it('sends a tracking event when first render on the client', () => {
     const fakeTracking = createFakeTracking();
-    const root = shallowRender({ _tracking: fakeTracking });
+    const root = render({ _tracking: fakeTracking });
 
     const { variant } = root.instance().props;
 
@@ -70,7 +76,7 @@ describe(__filename, () => {
   it('sends a tracking event on hero click', () => {
     const fakeTracking = createFakeTracking();
 
-    const root = shallowRender({
+    const root = render({
       _tracking: fakeTracking,
     });
 
@@ -95,5 +101,38 @@ describe(__filename, () => {
       category: `${AB_HOME_HERO_EXPERIMENT_CATEGORY} / Click`,
       label: firstHeroTitle,
     });
+  });
+
+  it('does not send a tracking event on first render when config experiment is disabled', () => {
+    const _config = getFakeConfig({
+      experiments: {
+        [AB_HOME_HERO_EXPERIMENT]: false,
+      },
+    });
+    const fakeTracking = createFakeTracking();
+
+    render({ _config, _tracking: fakeTracking });
+
+    sinon.assert.notCalled(fakeTracking.sendEvent);
+  });
+
+  it('does not send a tracking event on hero click when config experiment is disabled', () => {
+    const _config = getFakeConfig({
+      experiments: {
+        [AB_HOME_HERO_EXPERIMENT]: false,
+      },
+    });
+    const fakeTracking = createFakeTracking();
+
+    const root = render({ _config, _tracking: fakeTracking });
+
+    // We'll use the first item in the home heroes array as an example.
+    const firstHeroItem = root.find(Hero).prop('sections')[0];
+    const firstHeroLink = shallow(firstHeroItem).find(
+      '.HeroSection-link-wrapper',
+    );
+    firstHeroLink.simulate('click', createFakeEvent());
+
+    sinon.assert.notCalled(fakeTracking.sendEvent);
   });
 });

--- a/tests/unit/amo/components/TestHomeHeroBanner.js
+++ b/tests/unit/amo/components/TestHomeHeroBanner.js
@@ -59,7 +59,7 @@ describe(__filename, () => {
     expect(carousel).toHaveProp('random', true);
   });
 
-  it('sends a tracking event when first render on the client', () => {
+  it('sends a tracking event when first rendered on the client', () => {
     const fakeTracking = createFakeTracking();
     const root = render({ _tracking: fakeTracking });
 
@@ -111,8 +111,9 @@ describe(__filename, () => {
     });
     const fakeTracking = createFakeTracking();
 
-    render({ _config, _tracking: fakeTracking });
+    const root = render({ _config, _tracking: fakeTracking });
 
+    expect(root).not.toHaveClassName('HomeHeroBanner--small');
     sinon.assert.notCalled(fakeTracking.sendEvent);
   });
 


### PR DESCRIPTION
Fixes #6274

---

This PR adds two features:

1. make the `witExperiment` HOC config-aware in a generic way
2. disable the home hero experiment by default, and enable it in -dev only