### PR TITLE
Make user profile reviews look like add-on reviews (mostly) 

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -45,7 +45,6 @@ type Props = {|
   className?: string,
   flaggable?: boolean,
   isReplyToReviewId?: number,
-  isUserProfile?: boolean,
   review?: UserReviewType | null,
   shortByLine?: boolean,
   showRating?: boolean,
@@ -72,7 +71,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   static defaultProps = {
     _config: config,
     flaggable: true,
-    isUserProfile: false,
     shortByLine: false,
     showRating: true,
     verticalButtons: false,
@@ -239,10 +237,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
     return (
       <div className="AddonReviewCard-reply">
-        <h4 className="AddonReviewCard-reply-header">
-          <Icon name="reply-arrow" />
-          {i18n.gettext('Developer response')}
-        </h4>
         {replyingToReview ? (
           <DismissibleTextForm
             className="AddonReviewCard-reply-form"
@@ -283,8 +277,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       errorHandler,
       flaggable,
       i18n,
-      isReplyToReviewId,
-      isUserProfile,
       lang,
       replyingToReview,
       review,
@@ -296,7 +288,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     } = this.props;
 
     let byLine;
-    const noAuthor = shortByLine || this.isReply() || isUserProfile;
+    const noAuthor = shortByLine || this.isReply();
 
     if (review) {
       const timestamp = `
@@ -434,15 +426,12 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
             <UserReview
               controls={controls}
               review={review}
-              byLine={!this.isRatingOnly() && byLine}
+              byLine={byLine}
               showRating={!this.isReply() && showRating}
-              showDeveloperResponseHeading={
-                this.isReply() && !isReplyToReviewId
-              }
+              isReply={this.isReply()}
             />
             {siteUser &&
-              this.isRatingOnly() &&
-              !isUserProfile && (
+              this.isRatingOnly() && (
                 <Button
                   className="AddonReviewCard-writeReviewButton"
                   onClick={this.onClickToEditReview}

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -283,6 +283,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       errorHandler,
       flaggable,
       i18n,
+      isReplyToReviewId,
       isUserProfile,
       lang,
       replyingToReview,
@@ -435,6 +436,9 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
               review={review}
               byLine={!this.isRatingOnly() && byLine}
               showRating={!this.isReply() && showRating}
+              showDeveloperResponseHeading={
+                this.isReply() && !isReplyToReviewId
+              }
             />
             {siteUser &&
               this.isRatingOnly() &&

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -41,11 +41,11 @@ import type { I18nType } from 'core/types/i18n';
 import './styles.scss';
 
 type Props = {|
-  addon: AddonType | null,
+  addon?: AddonType | null,
   className?: string,
   flaggable?: boolean,
   isReplyToReviewId?: number,
-  isUserProfile: boolean,
+  isUserProfile?: boolean,
   review?: UserReviewType | null,
   shortByLine?: boolean,
   showRating?: boolean,
@@ -72,26 +72,20 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   static defaultProps = {
     _config: config,
     flaggable: true,
+    isUserProfile: false,
     shortByLine: false,
     showRating: true,
     verticalButtons: false,
   };
 
   onClickToDeleteReview = (event: SyntheticEvent<HTMLElement>) => {
-    const {
-      addon,
-      dispatch,
-      errorHandler,
-      isReplyToReviewId,
-      review,
-    } = this.props;
+    const { dispatch, errorHandler, isReplyToReviewId, review } = this.props;
     event.preventDefault();
 
-    invariant(addon, 'addon is required');
     invariant(review, 'review is required');
     dispatch(
       deleteAddonReview({
-        addonId: addon.id,
+        addonId: review.reviewAddon.id,
         errorHandlerId: errorHandler.id,
         reviewId: review.id,
         isReplyToReviewId,
@@ -187,7 +181,8 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   isReply() {
     const { isReplyToReviewId, review } = this.props;
     return (
-      isReplyToReviewId !== undefined || (review && review.isDeveloperReply)
+      isReplyToReviewId !== undefined ||
+      Boolean(review && review.isDeveloperReply)
     );
   }
 
@@ -231,7 +226,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
   renderReply() {
     const {
-      addon,
       errorHandler,
       i18n,
       replyingToReview,
@@ -270,7 +264,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           />
         ) : (
           <AddonReviewCard
-            addon={addon}
             isReplyToReviewId={review.id}
             review={review.reply}
           />

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -45,6 +45,7 @@ type Props = {|
   className?: string,
   flaggable?: boolean,
   isReplyToReviewId?: number,
+  isUserProfile: boolean,
   review?: UserReviewType | null,
   shortByLine?: boolean,
   showRating?: boolean,
@@ -184,7 +185,10 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   }
 
   isReply() {
-    return this.props.isReplyToReviewId !== undefined;
+    const { isReplyToReviewId, review } = this.props;
+    return (
+      isReplyToReviewId !== undefined || (review && review.isDeveloperReply)
+    );
   }
 
   editPrompt() {
@@ -286,6 +290,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       errorHandler,
       flaggable,
       i18n,
+      isUserProfile,
       lang,
       replyingToReview,
       review,
@@ -297,7 +302,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     } = this.props;
 
     let byLine;
-    const noAuthor = shortByLine || this.isReply();
+    const noAuthor = shortByLine || this.isReply() || isUserProfile;
 
     if (review) {
       const timestamp = `
@@ -439,7 +444,8 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
               showRating={!this.isReply() && showRating}
             />
             {siteUser &&
-              this.isRatingOnly() && (
+              this.isRatingOnly() &&
+              !isUserProfile && (
                 <Button
                   className="AddonReviewCard-writeReviewButton"
                   onClick={this.onClickToEditReview}

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -72,7 +72,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   static defaultProps = {
     _config: config,
     flaggable: true,
-    smallerWriteReviewButton: false,
+    smallerWriteReviewButton: true,
     shortByLine: false,
     showRating: true,
     verticalButtons: false,

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -45,6 +45,7 @@ type Props = {|
   className?: string,
   flaggable?: boolean,
   isReplyToReviewId?: number,
+  smallerWriteReviewButton?: boolean,
   review?: UserReviewType | null,
   shortByLine?: boolean,
   showRating?: boolean,
@@ -71,6 +72,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   static defaultProps = {
     _config: config,
     flaggable: true,
+    smallerWriteReviewButton: false,
     shortByLine: false,
     showRating: true,
     verticalButtons: false,
@@ -278,6 +280,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       flaggable,
       i18n,
       lang,
+      smallerWriteReviewButton,
       replyingToReview,
       review,
       shortByLine,
@@ -437,7 +440,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
                   onClick={this.onClickToEditReview}
                   href="#writeReview"
                   buttonType="action"
-                  puffy
+                  puffy={!smallerWriteReviewButton}
                 >
                   {i18n.gettext('Write a review')}
                 </Button>

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -99,5 +99,5 @@
 
 .AddonReviewCard-writeReviewButton {
   margin-top: 12px;
-  width: 100%;
+  width: auto;
 }

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -97,14 +97,6 @@
   }
 }
 
-.AddonReviewCard-reply-header {
-  margin: 0 0 6px;
-
-  .Icon-reply-arrow {
-    @include margin-end(12px);
-  }
-}
-
 .AddonReviewCard-writeReviewButton {
   margin-top: 12px;
   width: 100%;

--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -88,7 +88,11 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
           </div>
         </NestedStatus>
       ) : (
-        <AddonReviewCard addon={addon} review={featuredReview} />
+        <AddonReviewCard
+          addon={addon}
+          review={featuredReview}
+          smallerWriteReviewButton
+        />
       );
 
     return (

--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -88,11 +88,7 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
           </div>
         </NestedStatus>
       ) : (
-        <AddonReviewCard
-          addon={addon}
-          review={featuredReview}
-          smallerWriteReviewButton
-        />
+        <AddonReviewCard addon={addon} review={featuredReview} />
       );
 
     return (

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -319,6 +319,7 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
             review={userReview}
             shortByLine
             showRating={false}
+            smallerWriteReviewButton={false}
             verticalButtons
           />
         )}

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -40,6 +40,10 @@
   .DismissibleTextForm-submit {
     width: 100%;
   }
+
+  .UserReview-byLine {
+    display: none;
+  }
 }
 
 .RatingManager-AddonReviewCard.AddonReviewCard-viewOnly:not(.AddonReviewCard-ratingOnly) {

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -44,6 +44,10 @@
   .AddonReviewCard-ratingOnly .UserReview-byLine {
     display: none;
   }
+
+  .AddonReviewCard-writeReviewButton {
+    width: 100%;
+  }
 }
 
 .RatingManager-AddonReviewCard.AddonReviewCard-viewOnly:not(.AddonReviewCard-ratingOnly) {

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -41,7 +41,7 @@
     width: 100%;
   }
 
-  .UserReview-byLine {
+  .AddonReviewCard-ratingOnly .UserReview-byLine {
     display: none;
   }
 }

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -218,7 +218,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
           {reviews.map((review) => {
             return (
               <li key={String(review.id)}>
-                <AddonReviewCard isUserProfile review={review} />
+                <AddonReviewCard review={review} shortByLine />
               </li>
             );
           })}

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -218,7 +218,11 @@ export class UserProfileBase extends React.Component<InternalProps> {
           {reviews.map((review) => {
             return (
               <li key={String(review.id)}>
-                <AddonReviewCard review={review} shortByLine />
+                <AddonReviewCard
+                  review={review}
+                  smallerWriteReviewButton
+                  shortByLine
+                />
               </li>
             );
           })}

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -1,5 +1,4 @@
 /* @flow */
-import makeClassName from 'classnames';
 import invariant from 'invariant';
 import * as React from 'react';
 import Helmet from 'react-helmet';
@@ -8,6 +7,7 @@ import { compose } from 'redux';
 
 import { fetchUserReviews } from 'amo/actions/reviews';
 import AddonsByAuthorsCard from 'amo/components/AddonsByAuthorsCard';
+import AddonReviewCard from 'amo/components/AddonReviewCard';
 import Link from 'amo/components/Link';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ReportUserAbuse from 'amo/components/ReportUserAbuse';
@@ -42,7 +42,6 @@ import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
 import UserAvatar from 'ui/components/UserAvatar';
-import UserReview from 'ui/components/UserReview';
 import type { AppState } from 'amo/store';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { UserType } from 'amo/reducers/users';
@@ -217,30 +216,9 @@ export class UserProfileBase extends React.Component<InternalProps> {
       >
         <ul>
           {reviews.map((review) => {
-            const isDeveloperReply = review && review.isDeveloperReply;
-
-            const byLine = (
-              <span>
-                {isDeveloperReply && i18n.gettext('Developer response')}
-                <Link
-                  title={i18n.gettext('Go to this review')}
-                  to={`/addon/${review.reviewAddon.slug}/reviews/${review.id}/`}
-                >
-                  {i18n.moment(review.created).fromNow()}
-                </Link>
-              </span>
-            );
-
             return (
               <li key={String(review.id)}>
-                <UserReview
-                  className={makeClassName('UserProfile-review', {
-                    'UserProfile-review--is-reply': isDeveloperReply,
-                  })}
-                  review={review}
-                  byLine={byLine}
-                  showRating={!isDeveloperReply}
-                />
+                <AddonReviewCard isUserProfile review={review} />
               </li>
             );
           })}

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -218,11 +218,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
           {reviews.map((review) => {
             return (
               <li key={String(review.id)}>
-                <AddonReviewCard
-                  review={review}
-                  smallerWriteReviewButton
-                  shortByLine
-                />
+                <AddonReviewCard review={review} shortByLine />
               </li>
             );
           })}

--- a/src/amo/pages/UserProfile/styles.scss
+++ b/src/amo/pages/UserProfile/styles.scss
@@ -116,14 +116,8 @@ $avatar-size: 64px;
 
 .UserProfile-reviews {
   margin-top: 0;
-}
 
-.UserProfile-review--is-reply {
-  background-color: transparentize($blue-50, 0.95);
-  border-radius: $border-radius-default;
-  padding: 12px;
-
-  a {
-    @include margin-start(6px);
+  .AddonReviewCard-writeReviewButton {
+    width: auto;
   }
 }

--- a/src/amo/pages/UserProfile/styles.scss
+++ b/src/amo/pages/UserProfile/styles.scss
@@ -116,8 +116,4 @@ $avatar-size: 64px;
 
 .UserProfile-reviews {
   margin-top: 0;
-
-  .AddonReviewCard-writeReviewButton {
-    width: auto;
-  }
 }

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -19,6 +19,7 @@ type Props = {|
   className?: string,
   controls?: React.Node | null,
   review: ?UserReviewType,
+  showDeveloperResponseHeading?: boolean,
   showRating?: boolean,
 |};
 
@@ -67,6 +68,7 @@ export const UserReviewBase = (props: InternalProps) => {
     i18n,
     review,
     showRating = false,
+    showDeveloperResponseHeading = false,
   } = props;
 
   let body = reviewBody({ content: <LoadingText /> });
@@ -88,7 +90,7 @@ export const UserReviewBase = (props: InternalProps) => {
           <UserRating styleSize="small" review={review} readOnly />
         ) : null}
         {review &&
-          !showRating && (
+          showDeveloperResponseHeading && (
             <span className="UserReview-byLine-developerResponse">
               {i18n.gettext('Developer response')}
             </span>

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -87,11 +87,12 @@ export const UserReviewBase = (props: InternalProps) => {
         {review && showRating ? (
           <UserRating styleSize="small" review={review} readOnly />
         ) : null}
-        {!showRating && (
-          <span className="UserReview-byLine-developerResponse">
-            {i18n.gettext('Developer response')}
-          </span>
-        )}
+        {review &&
+          !showRating && (
+            <span className="UserReview-byLine-developerResponse">
+              {i18n.gettext('Developer response')}
+            </span>
+          )}
         {byLine}
       </div>
       {body}

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -2,11 +2,14 @@
 import makeClassName from 'classnames';
 import invariant from 'invariant';
 import * as React from 'react';
+import { compose } from 'redux';
 
+import translate from 'core/i18n/translate';
 import { nl2br, sanitizeHTML } from 'core/utils';
 import LoadingText from 'ui/components/LoadingText';
 import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
+import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
 
@@ -17,6 +20,11 @@ type Props = {|
   controls?: React.Node | null,
   review: ?UserReviewType,
   showRating?: boolean,
+|};
+
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
 |};
 
 function reviewBody({
@@ -50,14 +58,17 @@ function reviewBody({
   );
 }
 
-const UserReview: React.ComponentType<Props> = ({
-  byLine,
-  children,
-  className,
-  controls,
-  review,
-  showRating = false,
-}: Props) => {
+export const UserReviewBase = (props: InternalProps) => {
+  const {
+    byLine,
+    children,
+    className,
+    controls,
+    i18n,
+    review,
+    showRating = false,
+  } = props;
+
   let body = reviewBody({ content: <LoadingText /> });
 
   if (review) {
@@ -76,6 +87,11 @@ const UserReview: React.ComponentType<Props> = ({
         {review && showRating ? (
           <UserRating styleSize="small" review={review} readOnly />
         ) : null}
+        {!showRating && (
+          <span className="UserReview-byLine-developerResponse">
+            {i18n.gettext('Developer response')}
+          </span>
+        )}
         {byLine}
       </div>
       {body}
@@ -84,5 +100,9 @@ const UserReview: React.ComponentType<Props> = ({
     </div>
   );
 };
+
+const UserReview: React.ComponentType<Props> = compose(translate())(
+  UserReviewBase,
+);
 
 export default UserReview;

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -6,6 +6,7 @@ import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';
 import { nl2br, sanitizeHTML } from 'core/utils';
+import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
@@ -18,8 +19,8 @@ type Props = {|
   children?: React.Node,
   className?: string,
   controls?: React.Node | null,
+  isReply?: boolean,
   review: ?UserReviewType,
-  showDeveloperResponseHeading?: boolean,
   showRating?: boolean,
 |};
 
@@ -66,9 +67,9 @@ export const UserReviewBase = (props: InternalProps) => {
     className,
     controls,
     i18n,
+    isReply = false,
     review,
     showRating = false,
-    showDeveloperResponseHeading = false,
   } = props;
 
   let body = reviewBody({ content: <LoadingText /> });
@@ -90,10 +91,11 @@ export const UserReviewBase = (props: InternalProps) => {
           <UserRating styleSize="small" review={review} readOnly />
         ) : null}
         {review &&
-          showDeveloperResponseHeading && (
-            <span className="UserReview-byLine-developerResponse">
+          isReply && (
+            <h4 className="UserReview-reply-header">
+              <Icon name="reply-arrow" />
               {i18n.gettext('Developer response')}
-            </span>
+            </h4>
           )}
         {byLine}
       </div>

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -54,9 +54,14 @@
   }
 }
 
-.UserReview-byLine-developerResponse {
+.UserReview-reply-header {
   @include margin-end(6px);
 
   color: $text-color-default;
-  font-size: $font-size-default;
+  margin-bottom: 6px;
+  margin-top: 0;
+
+  .Icon-reply-arrow {
+    @include margin-end(12px);
+  }
 }

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -53,3 +53,7 @@
     @include focus();
   }
 }
+
+.UserReview-byLine-developerResponse {
+  @include margin-end(6px);
+}

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -56,4 +56,7 @@
 
 .UserReview-byLine-developerResponse {
   @include margin-end(6px);
+
+  color: $text-color-default;
+  font-size: $font-size-default;
 }

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -35,7 +35,6 @@ import {
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
-import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import UserReview from 'ui/components/UserReview';
 
@@ -58,7 +57,6 @@ describe(__filename, () => {
       _config: getFakeConfig({ enableInlineAddonReview: false }),
       addon: createInternalAddon(fakeAddon),
       i18n: fakeI18n(),
-      isUserProfile: false,
       store,
       ...customProps,
     };
@@ -165,6 +163,7 @@ describe(__filename, () => {
     expect(rating).toHaveProp('review', review);
     expect(rating).toHaveProp('showRating', true);
     expect(rating).toHaveProp('byLine');
+    expect(rating).toHaveProp('isReply', false);
   });
 
   it('renders a custom className', () => {
@@ -1010,20 +1009,6 @@ describe(__filename, () => {
 
       expect(getByLineHtml(root)).toContain('posted ');
     });
-
-    it('does not render a byLine for ratings', () => {
-      const review = _setReview(fakeRatingOnly);
-      const root = render({ review });
-
-      expect(root.find(UserReview)).toHaveProp('byLine', false);
-    });
-
-    it('renders a short byLine for user profile reviews', () => {
-      const review = _setReview(fakeReview);
-      const root = render({ isUserProfile: true, review });
-
-      expect(getByLineHtml(root)).toContain('posted ');
-    });
   });
 
   describe('Developer reply to a review', () => {
@@ -1038,20 +1023,17 @@ describe(__filename, () => {
       expect(replyComponent).toHaveProp('isReplyToReviewId', review.id);
     });
 
-    it('does not show an additional Developer response header for a nested reply', () => {
-      const root = renderReply();
-
-      expect(root.find(UserReview)).toHaveProp(
-        'showDeveloperResponseHeading',
-        false,
-      );
-    });
-
     it('hides rating stars', () => {
       const root = renderReply();
 
       const rating = root.find(UserReview);
       expect(rating).toHaveProp('showRating', false);
+    });
+
+    it('passes isReply to the UserReview', () => {
+      const root = renderReply();
+
+      expect(root.find(UserReview)).toHaveProp('isReply', true);
     });
 
     it('hides rating stars even with showRating=true', () => {
@@ -1161,24 +1143,6 @@ describe(__filename, () => {
       );
     });
 
-    it('adds a developer response header to reply forms', () => {
-      const { review } = _setReviewReply();
-      store.dispatch(showReplyToReviewForm({ reviewId: review.id }));
-
-      const root = render({ review });
-
-      const formContainer = root.find('.AddonReviewCard-reply');
-      expect(formContainer).toHaveLength(1);
-      expect(formContainer.find('.AddonReviewCard-reply-header')).toHaveLength(
-        1,
-      );
-
-      const icon = formContainer.find(Icon);
-      expect(icon).toHaveProp('name', 'reply-arrow');
-
-      expect(formContainer.find('.AddonReviewCard-reply-form')).toHaveLength(1);
-    });
-
     it('renders a non-nested reply', () => {
       const review = _setReview({
         ...fakeReview,
@@ -1189,7 +1153,6 @@ describe(__filename, () => {
 
       const reviewComponent = root.find(UserReview);
       expect(reviewComponent).toHaveProp('showRating', false);
-      expect(reviewComponent).toHaveProp('showDeveloperResponseHeading', true);
     });
   });
 });

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -954,8 +954,8 @@ describe(__filename, () => {
   });
 
   describe('byLine', () => {
-    function renderByLine(root) {
-      return shallow(root.find(UserReview).prop('byLine'));
+    function getByLineHtml(root) {
+      return shallow(root.find(UserReview).prop('byLine')).html();
     }
 
     it('renders a byLine with a permalink to the review', () => {
@@ -969,9 +969,9 @@ describe(__filename, () => {
       });
       const root = render({ review, store });
 
-      expect(
-        renderByLine(root).prop('dangerouslySetInnerHTML').__html,
-      ).toContain(`/${lang}/${clientApp}/addon/${slug}/reviews/${review.id}/`);
+      expect(getByLineHtml(root)).toContain(
+        `/${lang}/${clientApp}/addon/${slug}/reviews/${review.id}/`,
+      );
     });
 
     it('renders a byLine with a relative date', () => {
@@ -979,9 +979,9 @@ describe(__filename, () => {
       const review = signInAndDispatchSavedReview();
       const root = render({ i18n, review });
 
-      expect(
-        renderByLine(root).prop('dangerouslySetInnerHTML').__html,
-      ).toContain(i18n.moment(review.created).fromNow());
+      expect(getByLineHtml(root)).toContain(
+        i18n.moment(review.created).fromNow(),
+      );
     });
 
     it('renders a byLine with an author by default', () => {
@@ -991,9 +991,7 @@ describe(__filename, () => {
       });
       const root = render({ review });
 
-      expect(
-        renderByLine(root).prop('dangerouslySetInnerHTML').__html,
-      ).toContain(`by ${name},`);
+      expect(getByLineHtml(root)).toContain(`by ${name},`);
     });
 
     it('renders a short byLine for replies by default', () => {
@@ -1003,18 +1001,14 @@ describe(__filename, () => {
 
       const root = renderReply({ i18n, reply });
 
-      expect(
-        renderByLine(root).prop('dangerouslySetInnerHTML').__html,
-      ).toContain('posted ');
+      expect(getByLineHtml(root)).toContain('posted ');
     });
 
     it('renders a short byLine explicitly', () => {
       const review = _setReview(fakeReview);
       const root = render({ shortByLine: true, review });
 
-      expect(
-        renderByLine(root).prop('dangerouslySetInnerHTML').__html,
-      ).toContain('posted ');
+      expect(getByLineHtml(root)).toContain('posted ');
     });
 
     it('does not render a byLine for ratings', () => {
@@ -1028,9 +1022,7 @@ describe(__filename, () => {
       const review = _setReview(fakeReview);
       const root = render({ isUserProfile: true, review });
 
-      expect(
-        renderByLine(root).prop('dangerouslySetInnerHTML').__html,
-      ).toContain('posted ');
+      expect(getByLineHtml(root)).toContain('posted ');
     });
   });
 
@@ -1044,6 +1036,15 @@ describe(__filename, () => {
       expect(replyComponent).toHaveLength(1);
       expect(replyComponent).toHaveProp('review', reply);
       expect(replyComponent).toHaveProp('isReplyToReviewId', review.id);
+    });
+
+    it('does not show an additional Developer response header for a nested reply', () => {
+      const root = renderReply();
+
+      expect(root.find(UserReview)).toHaveProp(
+        'showDeveloperResponseHeading',
+        false,
+      );
     });
 
     it('hides rating stars', () => {
@@ -1188,6 +1189,7 @@ describe(__filename, () => {
 
       const reviewComponent = root.find(UserReview);
       expect(reviewComponent).toHaveProp('showRating', false);
+      expect(reviewComponent).toHaveProp('showDeveloperResponseHeading', true);
     });
   });
 });

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -877,6 +877,7 @@ describe(__filename, () => {
 
       const writeReview = root.find('.AddonReviewCard-writeReviewButton');
       expect(writeReview).toHaveLength(1);
+      expect(writeReview).toHaveProp('puffy', true);
 
       dispatchSpy.resetHistory();
       writeReview.simulate('click', createFakeEvent());
@@ -901,13 +902,16 @@ describe(__filename, () => {
       expect(root.find('.AddonReviewCard-writeReviewButton')).toHaveLength(0);
     });
 
-    it('does not provide a write review button for ratings on the user profile', () => {
+    it('can render a smaller write review button', () => {
       const review = signInAndDispatchSavedReview({
         externalReview: fakeRatingOnly,
       });
-      const root = renderInline({ isUserProfile: true, review });
+      const root = renderInline({ review, smallerWriteReviewButton: true });
 
-      expect(root.find('.AddonReviewCard-writeReviewButton')).toHaveLength(0);
+      expect(root.find('.AddonReviewCard-writeReviewButton')).toHaveProp(
+        'puffy',
+        false,
+      );
     });
 
     it('prompts to cancel writing a new review', async () => {

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -877,7 +877,7 @@ describe(__filename, () => {
 
       const writeReview = root.find('.AddonReviewCard-writeReviewButton');
       expect(writeReview).toHaveLength(1);
-      expect(writeReview).toHaveProp('puffy', true);
+      expect(writeReview).toHaveProp('puffy', false);
 
       dispatchSpy.resetHistory();
       writeReview.simulate('click', createFakeEvent());
@@ -902,15 +902,15 @@ describe(__filename, () => {
       expect(root.find('.AddonReviewCard-writeReviewButton')).toHaveLength(0);
     });
 
-    it('can render a smaller write review button', () => {
+    it('can render a larger write review button', () => {
       const review = signInAndDispatchSavedReview({
         externalReview: fakeRatingOnly,
       });
-      const root = renderInline({ review, smallerWriteReviewButton: true });
+      const root = renderInline({ review, smallerWriteReviewButton: false });
 
       expect(root.find('.AddonReviewCard-writeReviewButton')).toHaveProp(
         'puffy',
-        false,
+        true,
       );
     });
 

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -606,6 +606,17 @@ describe(__filename, () => {
       expect(reviewCard).toHaveProp('review', createInternalReview(review));
     });
 
+    it('shows an AddonReviewCard with a larger button', () => {
+      const root = renderInline({
+        store: createStoreWithLatestReview(),
+      });
+
+      expect(root.find(AddonReviewCard)).toHaveProp(
+        'smallerWriteReviewButton',
+        false,
+      );
+    });
+
     it('hides UserRating and prompt when editing', () => {
       const review = { ...fakeReview, id: 8877 };
       const store = createStoreWithLatestReview({ review });

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { createInternalReview, setReview } from 'amo/actions/reviews';
+import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import UserRating from 'ui/components/UserRating';
 import UserReview, { UserReviewBase } from 'ui/components/UserReview';
@@ -104,22 +105,24 @@ describe(__filename, () => {
     expect(root.find(UserRating)).toHaveLength(0);
   });
 
-  it('does not show a developer response heading by default', () => {
+  it('adds a developer response header to replies', () => {
+    const root = render({ isReply: true });
+
+    const replyHeader = root.find('.UserReview-reply-header');
+    expect(replyHeader).toHaveLength(1);
+    expect(replyHeader.find(Icon)).toHaveProp('name', 'reply-arrow');
+  });
+
+  it('does not show a developer response header by default', () => {
     const root = render();
 
-    expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(0);
+    expect(root.find('.UserReview-reply-header')).toHaveLength(0);
   });
 
-  it('shows a developer response heading if requested', () => {
-    const root = render({ showDeveloperResponseHeading: true });
+  it('does not show a developer response header for non-replies', () => {
+    const root = render({ isReply: false });
 
-    expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(1);
-  });
-
-  it('does not show a developer response heading if requested not to', () => {
-    const root = render({ showDeveloperResponseHeading: false });
-
-    expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(0);
+    expect(root.find('.UserReview-reply-header')).toHaveLength(0);
   });
 
   it('accepts a class name', () => {

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -1,11 +1,11 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { createInternalReview, setReview } from 'amo/actions/reviews';
 import LoadingText from 'ui/components/LoadingText';
 import UserRating from 'ui/components/UserRating';
-import UserReview from 'ui/components/UserReview';
+import UserReview, { UserReviewBase } from 'ui/components/UserReview';
 import { dispatchClientMetadata, fakeReview } from 'tests/unit/amo/helpers';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   let store;
@@ -17,11 +17,12 @@ describe(__filename, () => {
   const render = (otherProps = {}) => {
     const props = {
       byLine: null,
+      i18n: fakeI18n(),
       review: fakeReview,
       ...otherProps,
     };
 
-    return shallow(<UserReview {...props} />);
+    return shallowUntilTarget(<UserReview {...props} />, UserReviewBase);
   };
 
   const _setReview = (externalReview) => {
@@ -101,6 +102,18 @@ describe(__filename, () => {
     const root = render({ showRating: false });
 
     expect(root.find(UserRating)).toHaveLength(0);
+  });
+
+  it('shows a developer response heading if ratings are hidden', () => {
+    const root = render({ showRating: false });
+
+    expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(1);
+  });
+
+  it('does not show a developer response heading if ratings are shown', () => {
+    const root = render({ showRating: true });
+
+    expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(0);
   });
 
   it('accepts a class name', () => {

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -104,14 +104,20 @@ describe(__filename, () => {
     expect(root.find(UserRating)).toHaveLength(0);
   });
 
-  it('shows a developer response heading if ratings are hidden', () => {
-    const root = render({ showRating: false });
+  it('does not show a developer response heading by default', () => {
+    const root = render();
+
+    expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(0);
+  });
+
+  it('shows a developer response heading if requested', () => {
+    const root = render({ showDeveloperResponseHeading: true });
 
     expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(1);
   });
 
-  it('does not show a developer response heading if ratings are shown', () => {
-    const root = render({ showRating: true });
+  it('does not show a developer response heading if requested not to', () => {
+    const root = render({ showDeveloperResponseHeading: false });
 
     expect(root.find('.UserReview-byLine-developerResponse')).toHaveLength(0);
   });


### PR DESCRIPTION
Fixes #6104 
Also fixes #5495 

As discussed in the issue, this does not add the new information to the User Profile page, such as add-on name and icon, but it does use the same component on both the Add-on Review Listing and User Profile pages so there are now links available on the User Profile to edit and delete a review or reply, as well as to delete a rating.

Before:

![screenshot 2018-09-18 16 45 01](https://user-images.githubusercontent.com/142755/45715718-e6e8b680-bb62-11e8-97dc-4c76059c9ea0.png)

After: 

![screenshot 2018-09-18 16 44 39](https://user-images.githubusercontent.com/142755/45715726-ecde9780-bb62-11e8-8869-78f1e31b2fea.png)

