### PR TITLE
Tighten up home page shelf on mobile

### DIFF
--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -82,11 +82,12 @@
 .Home-SubjectShelf-list-item {
   flex-grow: 1;
   list-style-type: none;
-  margin: 15px 0;
+  margin: 0;
   text-align: center;
   width: 100%;
 
   @include respond-to(medium) {
+    margin: 12px 0;
     width: 40%;
   }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6286

**Before**

<img width="362" alt="screenshot 2018-09-18 17 16 16" src="https://user-images.githubusercontent.com/55398/45720057-6462f580-bb68-11e8-99e6-3c8008032e97.png">


**After**

<img width="362" alt="screenshot 2018-09-18 17 16 38" src="https://user-images.githubusercontent.com/55398/45720061-6927a980-bb68-11e8-9f5a-8187eccdc8c6.png">


Here are some other screens with the new patch:

<img width="669" alt="screenshot 2018-09-18 17 17 55" src="https://user-images.githubusercontent.com/55398/45720075-75136b80-bb68-11e8-94dd-f43f5d23d18a.png">
<img width="766" alt="screenshot 2018-09-18 17 18 19" src="https://user-images.githubusercontent.com/55398/45720076-75136b80-bb68-11e8-9f7c-13b7ee5b8a7e.png">
