### PR TITLE
Fix condition for storybook stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
       <<: *tox
       env: TOXENV=dennis-lint
     - stage: Storybook deployment
-      if: branch = master
+      if: branch = master AND type = push AND fork = false
       language: node_js
       node_js: '8'
       script: echo "Deploying to GitHub Pages..."


### PR DESCRIPTION
The `branch = master` condition is not enough to prevent PR builds to
run the storybook stage. We want to run this stage for commits merged
into the `master` branch *only*.