### PR TITLE
Bigger rating stars on small screens when editing a review

### DIFF
--- a/src/amo/components/AddonReviewManager/styles.scss
+++ b/src/amo/components/AddonReviewManager/styles.scss
@@ -5,13 +5,6 @@
 .AddonReviewManager {
   font-size: $font-size-default;
 
-  .AddonReviewManager-Rating.Rating {
-    height: $default-line-height;
-    margin: 0;
-
-    @include margin-start(6px);
-  }
-
   .DismissibleTextForm-formFooter {
     font-size: $font-size-s;
     margin: 0;
@@ -36,7 +29,26 @@
 
 .AddonReviewManager-starRating {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
+
+  .AddonReviewManager-Rating.Rating {
+    height: 36px;
+    margin: 12px 0;
+    width: 100%;
+  }
+
+  @include respond-to(large) {
+    flex-direction: row;
+
+    .AddonReviewManager-Rating.Rating {
+      height: $default-line-height;
+      margin: 0;
+      width: auto;
+
+      @include margin-start(6px);
+    }
+  }
 }
 
 .AddonReviewManager-savedRating {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6272

<hr/>

**Before**

<img width="362" alt="screenshot 2018-09-20 09 59 23" src="https://user-images.githubusercontent.com/55398/45827453-13fcac80-bcbc-11e8-9e63-89b10b7b7df4.png">

<hr/>

**After**

<img width="362" alt="screenshot 2018-09-20 09 57 58" src="https://user-images.githubusercontent.com/55398/45827484-24ad2280-bcbc-11e8-96af-1bd4f263257a.png">

<hr/>

In other locales:

<img width="362" alt="screenshot 2018-09-20 09 57 01" src="https://user-images.githubusercontent.com/55398/45827511-3098e480-bcbc-11e8-9f04-99c3e2d20228.png">
<img width="362" alt="screenshot 2018-09-20 09 58 26" src="https://user-images.githubusercontent.com/55398/45827526-355d9880-bcbc-11e8-8e43-3970442b816e.png">

On larger screens it's the same as before:

<img width="349" alt="screenshot 2018-09-20 09 58 54" src="https://user-images.githubusercontent.com/55398/45827556-4908ff00-bcbc-11e8-904e-dfe70f7524b2.png">
<img width="350" alt="screenshot 2018-09-20 09 57 29" src="https://user-images.githubusercontent.com/55398/45827566-4dcdb300-bcbc-11e8-9c00-ae7b66e9bc8e.png">
