### PR TITLE
Unload related add-on for set-review actions

### DIFF
--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -1,10 +1,15 @@
 /* @flow */
 import { oneLine } from 'common-tags';
 
-import { SET_LATEST_REVIEW, UNLOAD_ADDON_REVIEWS } from 'amo/actions/reviews';
+import {
+  SET_LATEST_REVIEW,
+  SET_REVIEW,
+  UNLOAD_ADDON_REVIEWS,
+} from 'amo/actions/reviews';
 import { ADDON_TYPE_THEME } from 'core/constants';
 import type {
   SetLatestReviewAction,
+  SetReviewAction,
   UnloadAddonReviewsAction,
 } from 'amo/actions/reviews';
 import type { AppState } from 'amo/store';
@@ -352,6 +357,7 @@ type Action =
   | LoadAddonsAction
   | LoadAddonResultsAction
   | SetLatestReviewAction
+  | SetReviewAction
   | UnloadAddonReviewsAction;
 
 export default function addonsReducer(
@@ -407,6 +413,8 @@ export default function addonsReducer(
         loadingBySlug,
       };
     }
+    case SET_REVIEW:
+      return _unloadAddonFromState(state, action.payload.addon.id);
     case SET_LATEST_REVIEW:
     case UNLOAD_ADDON_REVIEWS:
       return _unloadAddonFromState(state, action.payload.addonId);

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -1,4 +1,8 @@
-import { setLatestReview, unloadAddonReviews } from 'amo/actions/reviews';
+import {
+  setLatestReview,
+  setReview,
+  unloadAddonReviews,
+} from 'amo/actions/reviews';
 import {
   ADDON_TYPE_EXTENSION,
   OS_ALL,
@@ -740,9 +744,29 @@ describe(__filename, () => {
           userId: 7,
           review: { ...fakeReview },
         }),
-        {
-          _unloadAddonFromState: unloadAddonFromStateStub,
-        },
+        { _unloadAddonFromState: unloadAddonFromStateStub },
+      );
+
+      sinon.assert.calledWith(unloadAddonFromStateStub, state, addonId);
+    });
+  });
+
+  describe('setReview', () => {
+    it('calls unloadAddonFromState', () => {
+      const addonId = 7721;
+      const unloadAddonFromStateStub = sinon.stub();
+
+      const state = initialState;
+      addons(
+        state,
+        setReview({
+          ...fakeReview,
+          addon: {
+            ...fakeReview.addon,
+            id: addonId,
+          },
+        }),
+        { _unloadAddonFromState: unloadAddonFromStateStub },
       );
 
       sinon.assert.calledWith(unloadAddonFromStateStub, state, addonId);


### PR DESCRIPTION
This fixes https://github.com/mozilla/addons-frontend/issues/6265 because `addon.ratings.count` was used by `<RatingsByStar>` to set the width of the bar. This patch fixes a couple other issues where `addon` was used in that same component.