### PR TITLE
Do not log full response object in callApi

### DIFF
--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -83,6 +83,7 @@ type CallApiParams = {|
   schema?: Object,
   _config?: typeof config,
   version?: string,
+  _log?: typeof log,
 |};
 
 export function callApi({
@@ -97,6 +98,7 @@ export function callApi({
   errorHandler,
   _config = config,
   version = _config.get('apiVersion'),
+  _log = log,
 }: CallApiParams): Promise<any> {
   if (!endpoint) {
     return Promise.reject(
@@ -165,16 +167,17 @@ export function callApi({
     : `${adjustedEndpoint}/`;
   let apiURL = `${config.get('apiHost')}${adjustedEndpoint}${queryString}`;
   if (_config.get('server')) {
-    log.debug('Encoding `apiURL` in UTF8 before fetch().');
+    _log.debug('Encoding `apiURL` in UTF8 before fetch().');
     // Workaround for https://github.com/bitinn/node-fetch/issues/245
     apiURL = utf8.encode(apiURL);
   }
 
   return fetch(apiURL, options)
     .then((response) => {
-      // There isn't always a 'Content-Type' in headers, e.g., with a DELETE method.
+      // There isn't always a 'Content-Type' in headers, e.g., with a DELETE
+      // method or 5xx responses.
       let contentType = response.headers.get('Content-Type');
-      contentType = contentType && contentType.toLowerCase();
+      contentType = contentType ? contentType.toLowerCase() : '[unknown]';
 
       // This is a bit paranoid, but we ensure the API returns a JSON response
       // (see https://github.com/mozilla/addons-frontend/issues/1701).
@@ -187,10 +190,12 @@ export function callApi({
           .then((jsonResponse) => ({ response, jsonResponse }));
       }
 
-      log.warn(
-        oneLine`Response from API was not JSON (was Content-Type:
-        ${contentType})`,
-        response,
+      _log.warn(
+        `Response from API was not JSON (was Content-Type: ${contentType})`,
+        {
+          url: response.url || '[unknown]',
+          status: response.status || '[unknown]',
+        },
       );
       return response.text().then(() => {
         // jsonResponse should be an empty object in this case.

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -430,6 +430,39 @@ describe(__filename, () => {
       await api.callApi({ _config, endpoint });
       mockWindow.verify();
     });
+
+    it('logs a warning message when content type is unknown', async () => {
+      const url = 'some-response-url';
+      const status = 'some-response-status';
+
+      mockWindow.expects('fetch').returns(
+        createApiResponse({
+          url,
+          status,
+          headers: generateHeaders({ 'Content-Type': null }),
+          text() {
+            return Promise.resolve('504');
+          },
+        }),
+      );
+
+      const _log = {
+        debug: sinon.stub(),
+        warn: sinon.stub(),
+      };
+
+      await api.callApi({ endpoint: 'resource', _log });
+      mockWindow.verify();
+
+      sinon.assert.calledWith(
+        _log.warn,
+        'Response from API was not JSON (was Content-Type: [unknown])',
+        {
+          url,
+          status,
+        },
+      );
+    });
   });
 
   describe('makeQueryString', () => {

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -432,8 +432,9 @@ describe(__filename, () => {
     });
 
     it('logs a warning message when content type is unknown', async () => {
-      const url = 'some-response-url';
+      const body = 'long body content'.repeat(100);
       const status = 'some-response-status';
+      const url = 'some-response-url';
 
       mockWindow.expects('fetch').returns(
         createApiResponse({
@@ -441,7 +442,7 @@ describe(__filename, () => {
           status,
           headers: generateHeaders({ 'Content-Type': null }),
           text() {
-            return Promise.resolve('504');
+            return Promise.resolve(body);
           },
         }),
       );
@@ -458,8 +459,9 @@ describe(__filename, () => {
         _log.warn,
         'Response from API was not JSON (was Content-Type: [unknown])',
         {
-          url,
+          body: body.substring(0, 100),
           status,
+          url,
         },
       );
     });


### PR DESCRIPTION
Fix #6370

---

This PR should avoid HUGE log entries.