### PR TITLE
Fixes #6374: Removed All occurences of enableFeatureAddonRecommendations

### DIFF
--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -117,8 +117,5 @@ module.exports = {
   // https://github.com/mozilla/addons-server/blob/master/src/olympia/lib/settings_base.py#L990
   authTokenValidFor: 2592000, // 30 days
 
-  // Turn on recommendations in details pages.
-  enableFeatureAddonRecommendations: true,
-
   enableFeatureAMInstallButton: true,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -102,7 +102,6 @@ module.exports = {
     'dismissedExperienceSurveyCookieName',
     'enableDevTools',
     'enableFeatureAMInstallButton',
-    'enableFeatureAddonRecommendations',
     'enableFeatureExperienceSurvey',
     'enableFeatureInlineAddonReview',
     'enableFeatureStaticThemes',
@@ -313,7 +312,6 @@ module.exports = {
   // https://github.com/mozilla/addons-frontend/issues/6362.
 
   // Enable the TAAR Lite A/B test.
-  enableFeatureAddonRecommendations: false,
 
   // Enable static themes.
   enableFeatureStaticThemes: true,

--- a/config/default.js
+++ b/config/default.js
@@ -311,8 +311,6 @@ module.exports = {
   // Please use the `enableFeature` prefix, see:
   // https://github.com/mozilla/addons-frontend/issues/6362.
 
-  // Enable the TAAR Lite A/B test.
-
   // Enable static themes.
   enableFeatureStaticThemes: true,
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -502,9 +502,6 @@ export class AddonBase extends React.Component {
 
     const isFireFox =
       compatibility && compatibility.reason !== INCOMPATIBLE_NOT_FIREFOX;
-    const enableFeatureAddonRecommendations =
-      config.get('enableFeatureAddonRecommendations') &&
-      addonType === ADDON_TYPE_EXTENSION;
     const showInstallButton = addon && isFireFox;
     const showGetFirefoxButton = addon && !isFireFox;
 
@@ -627,9 +624,7 @@ export class AddonBase extends React.Component {
 
             {this.renderShowMoreCard()}
 
-            {enableFeatureAddonRecommendations && (
-              <AddonRecommendations addon={addon} />
-            )}
+            { <AddonRecommendations addon={addon} /> }
           </div>
 
           {this.renderRatingsCard()}

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -624,7 +624,9 @@ export class AddonBase extends React.Component {
 
             {this.renderShowMoreCard()}
 
-            { <AddonRecommendations addon={addon} /> }
+            {addonType === ADDON_TYPE_EXTENSION && (
+              <AddonRecommendations addon={addon} />
+            )}
           </div>
 
           {this.renderRatingsCard()}

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1190,18 +1190,34 @@ describe(__filename, () => {
   });
 
   it('renders recommendations for an extension', () => {
-    const fakeConfig = getFakeConfig();
     const addon = createInternalAddon(fakeAddon);
-    const root = shallowRender({ addon, config: fakeConfig });
+    const root = shallowRender({ addon });
     expect(root.find(AddonRecommendations)).toHaveLength(1);
     expect(root.find(AddonRecommendations)).toHaveProp('addon', addon);
   });
 
   it('renders recommendations for an extension with no loaded add-on', () => {
-    const fakeConfig = getFakeConfig();
-    const root = shallowRender({ addon: null, config: fakeConfig });
+    const root = shallowRender({ addon: null });
     expect(root.find(AddonRecommendations)).toHaveLength(1);
     expect(root.find(AddonRecommendations)).toHaveProp('addon', null);
+  });
+
+  it('does not render recommendations if the add-on is not an extension', () => {
+    for (const addonType of [
+      ADDON_TYPE_COMPLETE_THEME,
+      ADDON_TYPE_DICT,
+      ADDON_TYPE_LANG,
+      ADDON_TYPE_OPENSEARCH,
+      ADDON_TYPE_THEME,
+    ]) {
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        type: addonType,
+      });
+      const root = shallowRender({ addon });
+      console.log(root.debug());
+      expect(root.find(AddonRecommendations)).toHaveLength(0);
+    }
   });
 
   describe('read reviews footer', () => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1190,9 +1190,7 @@ describe(__filename, () => {
   });
 
   it('renders recommendations for an extension', () => {
-    const fakeConfig = getFakeConfig({
-      enableFeatureAddonRecommendations: true,
-    });
+    const fakeConfig = getFakeConfig();
     const addon = createInternalAddon(fakeAddon);
     const root = shallowRender({ addon, config: fakeConfig });
     expect(root.find(AddonRecommendations)).toHaveLength(1);
@@ -1200,41 +1198,10 @@ describe(__filename, () => {
   });
 
   it('renders recommendations for an extension with no loaded add-on', () => {
-    const fakeConfig = getFakeConfig({
-      enableFeatureAddonRecommendations: true,
-    });
+    const fakeConfig = getFakeConfig();
     const root = shallowRender({ addon: null, config: fakeConfig });
     expect(root.find(AddonRecommendations)).toHaveLength(1);
     expect(root.find(AddonRecommendations)).toHaveProp('addon', null);
-  });
-
-  it('does not render recommendations if the config flag is false', () => {
-    const fakeConfig = getFakeConfig({
-      enableFeatureAddonRecommendations: false,
-    });
-    const addon = createInternalAddon(fakeAddon);
-    const root = shallowRender({ addon, config: fakeConfig });
-    expect(root.find(AddonRecommendations)).toHaveLength(0);
-  });
-
-  it('does not render recommendations if the add-on is not an extension', () => {
-    const fakeConfig = getFakeConfig({
-      enableFeatureAddonRecommendations: true,
-    });
-    for (const addonType of [
-      ADDON_TYPE_COMPLETE_THEME,
-      ADDON_TYPE_DICT,
-      ADDON_TYPE_LANG,
-      ADDON_TYPE_OPENSEARCH,
-      ADDON_TYPE_THEME,
-    ]) {
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        type: addonType,
-      });
-      const root = shallowRender({ addon, config: fakeConfig });
-      expect(root.find(AddonRecommendations)).toHaveLength(0);
-    }
   });
 
   describe('read reviews footer', () => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1215,7 +1215,6 @@ describe(__filename, () => {
         type: addonType,
       });
       const root = shallowRender({ addon });
-      console.log(root.debug());
       expect(root.find(AddonRecommendations)).toHaveLength(0);
     }
   });


### PR DESCRIPTION
Removed All occurrences of enableFeatureAddonRecommendations from the following 4 files as the feature has been adopted.
1. config/default-amo.js
2. config/default.js
3. tests/unit/amo/pages/TestAddon.js
4. src/amo/pages/Addon/index.js