### PR TITLE
Revert "Unload related add-on for set-review actions (#6335)"

### DIFF
--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -1,17 +1,9 @@
 /* @flow */
 import { oneLine } from 'common-tags';
 
-import {
-  SET_LATEST_REVIEW,
-  SET_REVIEW,
-  UNLOAD_ADDON_REVIEWS,
-} from 'amo/actions/reviews';
+import { UNLOAD_ADDON_REVIEWS } from 'amo/actions/reviews';
 import { ADDON_TYPE_THEME } from 'core/constants';
-import type {
-  SetLatestReviewAction,
-  SetReviewAction,
-  UnloadAddonReviewsAction,
-} from 'amo/actions/reviews';
+import type { UnloadAddonReviewsAction } from 'amo/actions/reviews';
 import type { AppState } from 'amo/store';
 import type { AppState as DiscoAppState } from 'disco/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
@@ -323,49 +315,15 @@ export const getAllAddons = (state: AppState): Array<AddonType> => {
   return Object.values(addons);
 };
 
-export function unloadAddonFromState(
-  addonsState: AddonsState,
-  addonId: number,
-) {
-  const addon = addonsState.byID[`${addonId}`];
-  if (addon) {
-    return {
-      ...addonsState,
-      byID: {
-        ...addonsState.byID,
-        [`${addonId}`]: undefined,
-      },
-      byGUID: {
-        ...addonsState.byGUID,
-        [addon.guid]: undefined,
-      },
-      bySlug: {
-        ...addonsState.bySlug,
-        [addon.slug]: undefined,
-      },
-      loadingBySlug: {
-        ...addonsState.loadingBySlug,
-        [addon.slug]: false,
-      },
-    };
-  }
-  return addonsState;
-}
-
 type Action =
   | FetchAddonAction
   | LoadAddonsAction
   | LoadAddonResultsAction
-  | SetLatestReviewAction
-  | SetReviewAction
   | UnloadAddonReviewsAction;
 
 export default function addonsReducer(
   state: AddonsState = initialState,
   action: Action,
-  {
-    _unloadAddonFromState = unloadAddonFromState,
-  }: {| _unloadAddonFromState: typeof unloadAddonFromState |} = {},
 ) {
   switch (action.type) {
     case FETCH_ADDON: {
@@ -413,11 +371,32 @@ export default function addonsReducer(
         loadingBySlug,
       };
     }
-    case SET_REVIEW:
-      return _unloadAddonFromState(state, action.payload.addon.id);
-    case SET_LATEST_REVIEW:
-    case UNLOAD_ADDON_REVIEWS:
-      return _unloadAddonFromState(state, action.payload.addonId);
+    case UNLOAD_ADDON_REVIEWS: {
+      const { addonId } = action.payload;
+      const addon = state.byID[`${addonId}`];
+      if (addon) {
+        return {
+          ...state,
+          byID: {
+            ...state.byID,
+            [`${addonId}`]: undefined,
+          },
+          byGUID: {
+            ...state.byGUID,
+            [addon.guid]: undefined,
+          },
+          bySlug: {
+            ...state.bySlug,
+            [addon.slug]: undefined,
+          },
+          loadingBySlug: {
+            ...state.loadingBySlug,
+            [addon.slug]: false,
+          },
+        };
+      }
+      return state;
+    }
     default:
       return state;
   }

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -1,8 +1,4 @@
-import {
-  setLatestReview,
-  setReview,
-  unloadAddonReviews,
-} from 'amo/actions/reviews';
+import { unloadAddonReviews } from 'amo/actions/reviews';
 import {
   ADDON_TYPE_EXTENSION,
   OS_ALL,
@@ -19,12 +15,10 @@ import addons, {
   getAddonBySlug,
   getAllAddons,
   getGuid,
-  initialState,
   isAddonLoading,
   loadAddons,
   loadAddonResults,
   removeUndefinedProps,
-  unloadAddonFromState,
 } from 'core/reducers/addons';
 import {
   createFetchAddonResult,
@@ -35,7 +29,6 @@ import {
   createFakeAddon,
   dispatchClientMetadata,
   fakeAddon,
-  fakeReview,
   fakeTheme,
 } from 'tests/unit/amo/helpers';
 
@@ -654,7 +647,7 @@ describe(__filename, () => {
     });
   });
 
-  describe('unloadAddonFromState', () => {
+  describe('unloadAddonReviews', () => {
     it('unloads all data for an add-on', () => {
       const guid1 = '1@mozilla.com';
       const id1 = 1;
@@ -672,104 +665,23 @@ describe(__filename, () => {
         addon1,
         {
           ...fakeAddon,
+          ...fakeAddon,
           guid: guid2,
           id: id2,
           slug: slug2,
         },
       ];
-
-      let state;
-
-      state = addons(
-        state,
+      let state = addons(
+        undefined,
         loadAddons(createFetchAllAddonsResult(addonResults).entities),
       );
-      state = addons(
-        state,
-        fetchAddon({
-          slug: slug1,
-          errorHandler: createStubErrorHandler(),
-        }),
-      );
 
-      state = unloadAddonFromState(state, id1);
+      state = addons(state, unloadAddonReviews({ addonId: id1, reviewId: 1 }));
 
       expect(state.byGUID[addon1.guid]).toEqual(undefined);
       expect(state.byID[addon1.id]).toEqual(undefined);
       expect(state.bySlug[addon1.slug]).toEqual(undefined);
       expect(state.loadingBySlug[addon1.slug]).toEqual(false);
-    });
-
-    it('ignores non-existent add-ons', () => {
-      let state;
-
-      state = addons(
-        state,
-        loadAddons(
-          createFetchAllAddonsResult([{ ...fakeAddon, id: 1 }]).entities,
-        ),
-      );
-      state = unloadAddonFromState(state, 2);
-
-      expect(state.byID[1]).toBeDefined();
-    });
-  });
-
-  describe('unloadAddonReviews', () => {
-    it('calls unloadAddonFromState', () => {
-      const addonId = 4321;
-      const unloadAddonFromStateStub = sinon.stub();
-
-      const state = initialState;
-      addons(state, unloadAddonReviews({ addonId, reviewId: 1 }), {
-        _unloadAddonFromState: unloadAddonFromStateStub,
-      });
-
-      sinon.assert.calledWith(unloadAddonFromStateStub, state, addonId);
-    });
-  });
-
-  describe('setLatestReview', () => {
-    it('calls unloadAddonFromState', () => {
-      const addonId = 7721;
-      const unloadAddonFromStateStub = sinon.stub();
-
-      const state = initialState;
-      addons(
-        state,
-        setLatestReview({
-          addonId,
-          addonSlug: 'some-slug',
-          versionId: 8,
-          userId: 7,
-          review: { ...fakeReview },
-        }),
-        { _unloadAddonFromState: unloadAddonFromStateStub },
-      );
-
-      sinon.assert.calledWith(unloadAddonFromStateStub, state, addonId);
-    });
-  });
-
-  describe('setReview', () => {
-    it('calls unloadAddonFromState', () => {
-      const addonId = 7721;
-      const unloadAddonFromStateStub = sinon.stub();
-
-      const state = initialState;
-      addons(
-        state,
-        setReview({
-          ...fakeReview,
-          addon: {
-            ...fakeReview.addon,
-            id: addonId,
-          },
-        }),
-        { _unloadAddonFromState: unloadAddonFromStateStub },
-      );
-
-      sinon.assert.calledWith(unloadAddonFromStateStub, state, addonId);
     });
   });
 });


### PR DESCRIPTION
This reverts commit 40d1ba4e8fe83bfdcf4bc44ba3854a5ba8a4ea61 and will close https://github.com/mozilla/addons-frontend/issues/6372

The patch I'm reverting was causing https://github.com/mozilla/addons-frontend/issues/6381 ; we need to fix the original bug in a different way. I have a new patch but it might not be ready before today's tag.