### PR TITLE
Simplify the 'rating saved' notification

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -49,6 +49,7 @@ type Props = {|
   smallerWriteReviewButton?: boolean,
   review?: UserReviewType | null,
   shortByLine?: boolean,
+  showControls?: boolean,
   showRating?: boolean,
   verticalButtons?: boolean,
 |};
@@ -73,6 +74,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     flaggable: true,
     smallerWriteReviewButton: true,
     shortByLine: false,
+    showControls: true,
     showRating: true,
     verticalButtons: false,
   };
@@ -281,6 +283,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       replyingToReview,
       review,
       shortByLine,
+      showControls,
       showRating,
       siteUser,
       siteUserHasReplyPerm,
@@ -329,7 +332,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
     const confirmButtonClassName = 'AddonReviewCard-delete';
 
-    const controls = (
+    const controls = showControls ? (
       <div className="AddonReviewCard-allControls">
         {siteUser && review && review.userId === siteUser.id ? (
           <React.Fragment>
@@ -401,7 +404,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           />
         ) : null}
       </div>
-    );
+    ) : null;
 
     return (
       <div

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -260,6 +260,12 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
     );
   }
 
+  isMessageVisible() {
+    const { flashMessage } = this.props;
+
+    return [STARTED_SAVE_RATING, SAVED_RATING].includes(flashMessage);
+  }
+
   renderUserRatingForm() {
     const { addon, i18n, flashMessage, userReview } = this.props;
 
@@ -287,10 +293,7 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
                 ? 'RatingManager-savedRating-withReview'
                 : null
             }
-            hideMessage={
-              flashMessage !== STARTED_SAVE_RATING &&
-              flashMessage !== SAVED_RATING
-            }
+            hideMessage={!this.isMessageVisible()}
             message={
               flashMessage === STARTED_SAVE_RATING
                 ? i18n.gettext('Saving star rating')
@@ -306,7 +309,7 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
   }
 
   renderInlineReviewControls() {
-    const { addon, editingReview, flashMessage, userReview } = this.props;
+    const { addon, editingReview, userReview } = this.props;
 
     return (
       <React.Fragment>
@@ -318,10 +321,7 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
             flaggable={false}
             review={userReview}
             shortByLine
-            showControls={
-              flashMessage !== STARTED_SAVE_RATING &&
-              flashMessage !== SAVED_RATING
-            }
+            showControls={!this.isMessageVisible()}
             showRating={false}
             smallerWriteReviewButton={false}
             verticalButtons

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -306,7 +306,7 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
   }
 
   renderInlineReviewControls() {
-    const { addon, editingReview, userReview } = this.props;
+    const { addon, editingReview, flashMessage, userReview } = this.props;
 
     return (
       <React.Fragment>
@@ -318,6 +318,10 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
             flaggable={false}
             review={userReview}
             shortByLine
+            showControls={
+              flashMessage !== STARTED_SAVE_RATING &&
+              flashMessage !== SAVED_RATING
+            }
             showRating={false}
             smallerWriteReviewButton={false}
             verticalButtons

--- a/src/amo/components/RatingManagerNotice/index.js
+++ b/src/amo/components/RatingManagerNotice/index.js
@@ -28,7 +28,7 @@ const RatingManagerNotice = ({
 
   if (type) {
     return (
-      <Notice type={type} {...props}>
+      <Notice type={type} light {...props}>
         {message}
       </Notice>
     );

--- a/src/amo/components/RatingManagerNotice/styles.scss
+++ b/src/amo/components/RatingManagerNotice/styles.scss
@@ -1,10 +1,5 @@
 @import '~amo/css/styles';
 
-.RatingManager .AddonReviewCard-allControls {
-  padding-bottom: 3px;
-  padding-top: 2px;
-}
-
 .RatingManager .RatingManagerNotice-savedRating-hidden {
   display: none;
 }

--- a/src/amo/components/RatingManagerNotice/styles.scss
+++ b/src/amo/components/RatingManagerNotice/styles.scss
@@ -5,6 +5,6 @@
   text-align: center;
 }
 
-.RatingManagerNotice-savedRating-hidden {
+.RatingManager .RatingManagerNotice-savedRating-hidden {
   display: none;
 }

--- a/src/amo/components/RatingManagerNotice/styles.scss
+++ b/src/amo/components/RatingManagerNotice/styles.scss
@@ -1,8 +1,8 @@
 @import '~amo/css/styles';
 
-.RatingManagerNotice-savedRating {
-  margin-bottom: 12px;
-  text-align: center;
+.RatingManager .AddonReviewCard-allControls {
+  padding-bottom: 3px;
+  padding-top: 2px;
 }
 
 .RatingManager .RatingManagerNotice-savedRating-hidden {

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -39,6 +39,7 @@ type Props = {|
   className?: string,
   dismissible?: boolean,
   id?: string,
+  light?: boolean,
   onDismiss?: (SyntheticEvent<any>) => void,
   type: NoticeType,
 |};
@@ -74,6 +75,7 @@ export class NoticeBase extends React.Component<InternalProps> {
       className,
       dismissible,
       i18n,
+      light,
       type,
       uiState,
     } = this.props;
@@ -109,6 +111,7 @@ export class NoticeBase extends React.Component<InternalProps> {
 
     const finalClass = makeClassName('Notice', `Notice-${type}`, className, {
       'Notice-dismissible': dismissible,
+      'Notice-light': light,
     });
     return (
       <div className={finalClass}>

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -14,6 +14,7 @@
     background-color: transparent;
     display: flex;
     justify-content: center;
+    padding: 0;
   }
 
   &.Notice-dismissible {

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -14,6 +14,7 @@
     background-color: transparent;
     display: flex;
     justify-content: center;
+    line-height: $default-line-height;
     padding: 0;
   }
 
@@ -45,6 +46,14 @@
   width: 16px;
 }
 
+.Notice-light .Notice-icon {
+  // Reduce the icon size for light notices so that the total
+  // height of the notice adds up to $default-line-height.
+  background-size: 11px 11px;
+  height: 11px;
+  width: 11px;
+}
+
 .Notice-dismisser-button {
   cursor: pointer;
   padding: 0;
@@ -54,6 +63,10 @@
   display: inline-block;
   margin: 0;
   padding: 4px 0;
+
+  .Notice-light & {
+    padding: 0;
+  }
 
   // The spec calls for additional spacing
   // in front of the action button. This is

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -10,6 +10,12 @@
   line-height: 1.1;
   padding: 4px;
 
+  &.Notice-light {
+    background-color: transparent;
+    display: flex;
+    justify-content: center;
+  }
+
   &.Notice-dismissible {
     grid-template-columns: min-content auto min-content;
   }

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -181,6 +181,15 @@ describe(__filename, () => {
     expect(rating).toHaveProp('showRating', false);
   });
 
+  it('can hide controls', () => {
+    const root = render({
+      review: _setReview(fakeReview),
+      showControls: false,
+    });
+
+    expect(root.find(UserReview)).toHaveProp('controls', null);
+  });
+
   it('renders loading text for falsy reviews', () => {
     const root = render({ review: null });
 

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -617,6 +617,42 @@ describe(__filename, () => {
       );
     });
 
+    it('shows controls by default', () => {
+      const root = renderInline({
+        store: createStoreWithLatestReview(),
+      });
+
+      expect(root.find(AddonReviewCard)).toHaveProp('showControls', true);
+    });
+
+    it('hides controls while showing a saving notification', () => {
+      const store = createStoreWithLatestReview();
+
+      store.dispatch(flashReviewMessage(STARTED_SAVE_RATING));
+      const root = renderInline({ store });
+
+      expect(root.find(AddonReviewCard)).toHaveProp('showControls', false);
+    });
+
+    it('hides controls while showing a saved notification', () => {
+      const store = createStoreWithLatestReview();
+
+      store.dispatch(flashReviewMessage(SAVED_RATING));
+      const root = renderInline({ store });
+
+      expect(root.find(AddonReviewCard)).toHaveProp('showControls', false);
+    });
+
+    it('shows controls when a notification is hidden', () => {
+      const store = createStoreWithLatestReview();
+      // Set a message then hide it.
+      store.dispatch(flashReviewMessage(SAVED_RATING));
+      store.dispatch(hideFlashedReviewMessage());
+      const root = renderInline({ store });
+
+      expect(root.find(AddonReviewCard)).toHaveProp('showControls', true);
+    });
+
     it('hides UserRating and prompt when editing', () => {
       const review = { ...fakeReview, id: 8877 };
       const store = createStoreWithLatestReview({ review });

--- a/tests/unit/ui/components/TestNotice.js
+++ b/tests/unit/ui/components/TestNotice.js
@@ -163,4 +163,10 @@ describe(__filename, () => {
     const button = root.find('.Notice-button');
     expect(button).toHaveProp('target', actionTarget);
   });
+
+  it('can render a light notice', () => {
+    const root = render({ light: true });
+
+    expect(root).toHaveClassName('Notice-light');
+  });
 });


### PR DESCRIPTION
Fixes #6345 

New "saving" message:

![screenshot 2018-09-25 10 13 19](https://user-images.githubusercontent.com/142755/46020137-aaa9de80-c0ab-11e8-84b5-f860a79047be.png)

New "saved" message:

![screenshot 2018-09-25 10 12 08](https://user-images.githubusercontent.com/142755/46020154-b3021980-c0ab-11e8-9d9b-371b3a98e11b.png)
