### PR TITLE
Do not dispatch setLatestReview after updating a review

### DIFF
--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -39,7 +39,6 @@ import {
   hideReplyToReviewForm,
   setAddonReviews,
   setGroupedRatings,
-  setLatestReview,
   setReview,
   setReviewReply,
   setReviewWasFlagged,
@@ -279,17 +278,6 @@ function* manageAddonReview(
       yield put(flashReviewMessage(SAVED_REVIEW));
       yield put(hideEditReviewForm({ reviewId: reviewFromResponse.id }));
     }
-
-    invariant(reviewFromResponse.version, 'version is required');
-    yield put(
-      setLatestReview({
-        addonId: reviewFromResponse.addon.id,
-        addonSlug: reviewFromResponse.addon.slug,
-        review: reviewFromResponse,
-        userId: reviewFromResponse.user.id,
-        versionId: reviewFromResponse.version.id,
-      }),
-    );
 
     // Make the message disappear after some time.
     yield _delay(FLASH_SAVED_MESSAGE_DURATION);

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -25,7 +25,6 @@ import {
   flashReviewMessage,
   setReview,
   setReviewReply,
-  setLatestReview,
   setReviewWasFlagged,
   setUserReviews,
   updateAddonReview,
@@ -745,38 +744,6 @@ describe(__filename, () => {
 
       const expectedAction = flashReviewMessage(ABORTED);
       await matchingSagaAction(sagaTester, matchMessage(expectedAction));
-    });
-
-    it('dispatches setLatestReview after saving a review', async () => {
-      const addonId = 98767;
-      const addonSlug = 'some-slug';
-      const body = 'This add-on works pretty well for me';
-      const rating = 4;
-      const userId = 12345;
-      const versionId = 7653;
-
-      const externalReview = createExternalReview({
-        addonId,
-        addonSlug,
-        body,
-        rating,
-        userId,
-        versionId,
-      });
-
-      mockApi.expects('submitReview').resolves(externalReview);
-
-      _createAddonReview({ addonId, body, rating, versionId });
-
-      const expectedAction = setLatestReview({
-        addonId,
-        addonSlug,
-        review: externalReview,
-        userId,
-        versionId,
-      });
-      const action = await sagaTester.waitFor(expectedAction.type);
-      expect(action).toEqual(expectedAction);
     });
   });
 


### PR DESCRIPTION
Fixes #6271 

This is a bit odd. The thing that's causing the list of reviews to reload is the call to `setLatestReview` in the reviews saga. I added that in https://github.com/mozilla/addons-frontend/commit/e4e68bb734b272cabf5723ddd8b66e459bc058a7#diff-170eeec007168b88041e21f7420f424a in order to fix https://github.com/mozilla/addons-frontend/issues/5941, but now it seems that we do not need that anymore. If I remove the call to `setLatestReview` from the saga, the notifications still work.

I'm not sure if this is because of other things that have landed in the meantime, but it is a bit confusing. From what I can tell this change does not break anything and fixes the issue.
