### PR TITLE
Fix language tools listing

### DIFF
--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -46,6 +46,8 @@ const sortedLanguages = Object.keys(unfilteredLanguages)
   })
   .sort((a, b) => a.english.localeCompare(b.english));
 
+const sortedLocales = sortedLanguages.map((language) => language.locale);
+
 export const LanguageToolList = ({ languageTools }: LanguageToolListProps) => {
   if (!languageTools || !languageTools.length) {
     return null;
@@ -183,7 +185,13 @@ export class LanguageToolsBase extends React.Component<Props> {
             {languageTools.length
               ? sortedLanguages.map((language) => {
                   const toolsInLocale = languageTools.filter((addon) => {
-                    return addon.target_locale === language.locale;
+                    if (sortedLocales.includes(addon.target_locale)) {
+                      return addon.target_locale === language.locale;
+                    }
+
+                    const re = new RegExp(`${language.locale}(-\\w+)?`);
+
+                    return addon.target_locale && re.test(addon.target_locale);
                   });
 
                   // This means there are no language tools available in this

--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -191,6 +191,10 @@ export const unfilteredLanguages = {
     English: 'Persian',
     native: '\u0641\u0627\u0631\u0633\u06cc',
   },
+  'fa-IR': {
+    English: 'Persian (Iran)',
+    native: '(\u0627\u06CC\u0631\u0627\u0646) \u0641\u0627\u0631\u0633\u06CC',
+  },
   ff: {
     English: 'Fulah',
     native: 'Pulaar-Fulfulde',

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -230,7 +230,7 @@ describe(__filename, () => {
     expect(root.find('title')).toHaveText('Dictionaries and Language Packs');
   });
 
-  it('renders add-ons for all variants of a short locale', () => {
+  it('renders add-ons for all variants of a short locale on a single row (only one supported language)', () => {
     // The short locale is `az` here.
     const addons = [
       createFakeLanguageTool({
@@ -264,7 +264,7 @@ describe(__filename, () => {
     ]);
   });
 
-  it('does not render add-ons for all variants of a short locale when the variant is a supported language', () => {
+  it('renders add-ons on two different rows corresponding to two supported languages', () => {
     // The short locale is `fa` here, which is in the list of supported
     // languages (`src/core/languages.js`) together with `fa-IR`.
     const addons = [

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -229,4 +229,78 @@ describe(__filename, () => {
 
     expect(root.find('title')).toHaveText('Dictionaries and Language Packs');
   });
+
+  it('renders add-ons for all variants of a short locale', () => {
+    // The short locale is `az` here.
+    const addons = [
+      createFakeLanguageTool({
+        id: 1,
+        name: 'Azərbaycanca (AZ) Language Pack',
+        target_locale: 'az',
+        type: ADDON_TYPE_LANG,
+      }),
+      createFakeLanguageTool({
+        id: 2,
+        name: 'Azerbaijani Spell Checker',
+        target_locale: 'az-IR',
+        type: ADDON_TYPE_DICT,
+      }),
+    ];
+
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadLanguageTools({ languageTools: addons }));
+
+    const root = renderShallow({ store });
+
+    // We expect only one row with all the add-ons in it.
+    expect(root.find('.LanguageTools-table-row')).toHaveLength(1);
+
+    expect(root.find(LanguageToolList)).toHaveLength(2);
+    expect(root.find(LanguageToolList).at(0)).toHaveProp('languageTools', [
+      addons[0],
+    ]);
+    expect(root.find(LanguageToolList).at(1)).toHaveProp('languageTools', [
+      addons[1],
+    ]);
+  });
+
+  it('does not render add-ons for all variants of a short locale when the variant is a supported language', () => {
+    // The short locale is `fa` here, which is in the list of supported
+    // languages (`src/core/languages.js`) together with `fa-IR`.
+    const addons = [
+      createFakeLanguageTool({
+        id: 1,
+        name: 'Persian Dictionary',
+        target_locale: 'fa',
+        type: ADDON_TYPE_DICT,
+      }),
+      createFakeLanguageTool({
+        id: 2,
+        name: 'Persian (IR) Dictionary',
+        target_locale: 'fa-IR',
+        type: ADDON_TYPE_DICT,
+      }),
+      createFakeLanguageTool({
+        id: 3,
+        name: 'Lilak, Persian Spell Checker Dictionary',
+        target_locale: 'fa-IR',
+        type: ADDON_TYPE_DICT,
+      }),
+    ];
+
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadLanguageTools({ languageTools: addons }));
+
+    const root = renderShallow({ store });
+
+    expect(root.find('.LanguageTools-table-row')).toHaveLength(2);
+
+    expect(root.find(LanguageToolList).at(0)).toHaveProp('languageTools', [
+      addons[0],
+    ]);
+    expect(root.find(LanguageToolList).at(1)).toHaveProp('languageTools', [
+      addons[1],
+      addons[2],
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes #6145

---

This PR fixes #6145 in two ways:

- it adds `fa-IR` (Persian for Iran) in the list of supported languages,
  which creates a new row for the related language tools
- it lists more add-ons by adding the add-ons with a long locale (e.g.,
  `az-IR`) in the sets of add-ons (dict or lang pack) of the
  corresponding short locale (e.g., `az`), but only if this long locale
  is not supported (otherwise there would be add-ons listed multiple
  times (e.g., the Austrian German would be listed in "German" `de` and
  "German (Austria)" `de-AT`).