### PR TITLE
Adjust the appearance of the confirmation buttons when deleting a review/reply

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -386,7 +386,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
                 confirmButtonText={this.confirmButtonText()}
                 id={`${confirmButtonClassName}-${review.id}`}
                 onConfirm={this.onClickToDeleteReview}
-                puffyButtons
+                puffyButtons={verticalButtons}
               >
                 {this.deletePrompt()}
               </ConfirmButton>

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -211,18 +211,32 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     return i18n.gettext('Delete review');
   }
 
-  confirmDeletePrompt() {
+  confirmButtonText() {
     const { i18n } = this.props;
 
     if (this.isReply()) {
-      return i18n.gettext('Do you really want to delete this reply?');
+      return i18n.gettext('Delete reply');
     }
 
     if (this.isRatingOnly()) {
-      return i18n.gettext('Do you really want to delete this rating?');
+      return i18n.gettext('Delete rating');
     }
 
-    return i18n.gettext('Do you really want to delete this review?');
+    return i18n.gettext('Delete review');
+  }
+
+  cancelButtonText() {
+    const { i18n } = this.props;
+
+    if (this.isReply()) {
+      return i18n.gettext('Keep reply');
+    }
+
+    if (this.isRatingOnly()) {
+      return i18n.gettext('Keep rating');
+    }
+
+    return i18n.gettext('Keep review');
   }
 
   renderReply() {
@@ -363,15 +377,16 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
             ) : (
               <ConfirmButton
                 buttonType="cancel"
+                cancelButtonText={this.cancelButtonText()}
                 cancelButtonType="neutral"
                 className={makeClassName(
                   'AddonReviewCard-control',
                   confirmButtonClassName,
                 )}
-                confirmButtonText={i18n.gettext('Delete')}
+                confirmButtonText={this.confirmButtonText()}
                 id={`${confirmButtonClassName}-${review.id}`}
-                message={this.confirmDeletePrompt()}
                 onConfirm={this.onClickToDeleteReview}
+                puffyButtons
               >
                 {this.deletePrompt()}
               </ConfirmButton>

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -65,16 +65,9 @@
 }
 
 .AddonReviewCard-delete {
-  text-align: center;
-  width: 100%;
-
-  .ConfirmButton-buttons {
-    display: block;
-  }
-
   .ConfirmButton-cancel-button,
   .ConfirmButton-confirm-button {
-    width: 100%;
+    margin: 0 6px;
   }
 
   .ConfirmButton-cancel-button,

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -39,6 +39,10 @@
   justify-content: flex-end;
   margin-top: 0;
 
+  .ConfirmButton-buttons {
+    flex-flow: row-reverse;
+  }
+
   a:link,
   a:visited,
   a:hover,

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -65,6 +65,18 @@
 }
 
 .AddonReviewCard-delete {
+  text-align: center;
+  width: 100%;
+
+  .ConfirmButton-buttons {
+    display: block;
+  }
+
+  .ConfirmButton-cancel-button,
+  .ConfirmButton-confirm-button {
+    width: 100%;
+  }
+
   .ConfirmButton-cancel-button,
   .ConfirmButton-confirm-button,
   .ConfirmButton-default-button {
@@ -77,10 +89,6 @@
     color: $blue-50;
     height: auto;
     padding: 0;
-  }
-
-  .ConfirmButton-buttons {
-    flex-flow: row-reverse;
   }
 }
 

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -47,6 +47,7 @@
 
       .ConfirmButton-cancel-button,
       .ConfirmButton-confirm-button {
+        font-size: $font-size-puffy-buttons;
         margin: 0;
         width: 100%;
       }

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -32,8 +32,29 @@
     justify-content: space-between;
   }
 
-  .AddonReviewCard-ratingOnly .AddonReviewCard-allControls {
-    justify-content: center;
+  .AddonReviewCard-ratingOnly {
+    .AddonReviewCard-allControls {
+      justify-content: center;
+    }
+
+    .AddonReviewCard-delete {
+      text-align: center;
+      width: 100%;
+
+      .ConfirmButton-buttons {
+        display: block;
+      }
+
+      .ConfirmButton-cancel-button,
+      .ConfirmButton-confirm-button {
+        margin: 0;
+        width: 100%;
+      }
+
+      .ConfirmButton-cancel-button {
+        margin-top: 12px;
+      }
+    }
   }
 
   .DismissibleTextForm-delete-submit-buttons,

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -26,6 +26,7 @@ $font-size-l: 28px;
 $font-size-xl: 36px;
 $font-size-xxl: 42px;
 $font-size-form-header: 24px;
+$font-size-puffy-buttons: 15px;
 
 // Animation Variables
 $transition-short: 150ms;

--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -2,7 +2,6 @@
 
 $micro-font-size: 11px;
 $default-font-size: 13px;
-$puffy-font-size: 15px;
 
 /* Button */
 @mixin button(
@@ -47,7 +46,7 @@ $puffy-font-size: 15px;
 
     &.Button--puffy {
       border-radius: 4px;
-      font-size: $puffy-font-size;
+      font-size: $font-size-puffy-buttons;
       height: auto;
       min-height: 48px;
       padding: 0 16px;
@@ -55,8 +54,8 @@ $puffy-font-size: 15px;
       .Icon {
         @include margin-end(8px);
 
-        height: $puffy-font-size;
-        width: $puffy-font-size;
+        height: $font-size-puffy-buttons;
+        width: $font-size-puffy-buttons;
       }
     }
 

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -21,8 +21,9 @@ type Props = {|
   confirmButtonText?: string | null,
   confirmButtonType?: ButtonType,
   id: string,
-  message: string,
+  message?: string,
   onConfirm: Function,
+  puffyButtons?: boolean,
 |};
 
 type UIStateType = {|
@@ -73,12 +74,12 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
       id,
       message,
       onConfirm,
+      puffyButtons,
       uiState,
     } = this.props;
 
     invariant(children, 'The children property is required');
     invariant(id, 'The id property is required');
-    invariant(message, 'The message property is required');
     invariant(onConfirm, 'The onConfirm property is required');
 
     const { showConfirmation } = uiState;
@@ -90,23 +91,28 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
     if (showConfirmation) {
       return (
         <div className={classNames}>
-          <span className="ConfirmButton-message">{message}</span>
-
+          {message && <span className="ConfirmButton-message">{message}</span>}
           <div className="ConfirmButton-buttons">
-            <Button
-              buttonType={confirmButtonType}
-              className="ConfirmButton-confirm-button"
-              onClick={this.onConfirm}
-            >
-              {confirmButtonText || i18n.gettext('Confirm')}
-            </Button>
-            <Button
-              buttonType={cancelButtonType}
-              className="ConfirmButton-cancel-button"
-              onClick={this.toggleConfirmation}
-            >
-              {cancelButtonText || i18n.gettext('Cancel')}
-            </Button>
+            <div className="ConfirmButton-confirm-button-container">
+              <Button
+                buttonType={confirmButtonType}
+                className="ConfirmButton-confirm-button"
+                onClick={this.onConfirm}
+                puffy={puffyButtons}
+              >
+                {confirmButtonText || i18n.gettext('Confirm')}
+              </Button>
+            </div>
+            <div className="ConfirmButton-cancel-button-container">
+              <Button
+                buttonType={cancelButtonType}
+                className="ConfirmButton-cancel-button"
+                onClick={this.toggleConfirmation}
+                puffy={puffyButtons}
+              >
+                {cancelButtonText || i18n.gettext('Cancel')}
+              </Button>
+            </div>
           </div>
         </div>
       );

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -93,26 +93,22 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
         <div className={classNames}>
           {message && <span className="ConfirmButton-message">{message}</span>}
           <div className="ConfirmButton-buttons">
-            <div className="ConfirmButton-confirm-button-container">
-              <Button
-                buttonType={confirmButtonType}
-                className="ConfirmButton-confirm-button"
-                onClick={this.onConfirm}
-                puffy={puffyButtons}
-              >
-                {confirmButtonText || i18n.gettext('Confirm')}
-              </Button>
-            </div>
-            <div className="ConfirmButton-cancel-button-container">
-              <Button
-                buttonType={cancelButtonType}
-                className="ConfirmButton-cancel-button"
-                onClick={this.toggleConfirmation}
-                puffy={puffyButtons}
-              >
-                {cancelButtonText || i18n.gettext('Cancel')}
-              </Button>
-            </div>
+            <Button
+              buttonType={confirmButtonType}
+              className="ConfirmButton-confirm-button"
+              onClick={this.onConfirm}
+              puffy={puffyButtons}
+            >
+              {confirmButtonText || i18n.gettext('Confirm')}
+            </Button>
+            <Button
+              buttonType={cancelButtonType}
+              className="ConfirmButton-cancel-button"
+              onClick={this.toggleConfirmation}
+              puffy={puffyButtons}
+            >
+              {cancelButtonText || i18n.gettext('Cancel')}
+            </Button>
           </div>
         </div>
       );

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -230,10 +230,8 @@ describe(__filename, () => {
     const deleteLink = renderControls(root).find('.AddonReviewCard-delete');
     expect(deleteLink).toHaveLength(1);
     expect(deleteLink.children()).toHaveText('Delete review');
-    expect(deleteLink).toHaveProp(
-      'message',
-      'Do you really want to delete this review?',
-    );
+    expect(deleteLink).toHaveProp('cancelButtonText', 'Keep review');
+    expect(deleteLink).toHaveProp('confirmButtonText', 'Delete review');
   });
 
   it('renders a delete link for a user rating', () => {
@@ -245,10 +243,8 @@ describe(__filename, () => {
     const deleteLink = renderControls(root).find('.AddonReviewCard-delete');
     expect(deleteLink).toHaveLength(1);
     expect(deleteLink.children()).toHaveText('Delete rating');
-    expect(deleteLink).toHaveProp(
-      'message',
-      'Do you really want to delete this rating?',
-    );
+    expect(deleteLink).toHaveProp('cancelButtonText', 'Keep rating');
+    expect(deleteLink).toHaveProp('confirmButtonText', 'Delete rating');
   });
 
   it('does not render delete link when review belongs to another user', () => {
@@ -1124,10 +1120,8 @@ describe(__filename, () => {
       const deleteLink = renderControls(root).find('.AddonReviewCard-delete');
       expect(deleteLink).toHaveLength(1);
       expect(deleteLink.children()).toHaveText('Delete reply');
-      expect(deleteLink).toHaveProp(
-        'message',
-        'Do you really want to delete this reply?',
-      );
+      expect(deleteLink).toHaveProp('cancelButtonText', 'Keep reply');
+      expect(deleteLink).toHaveProp('confirmButtonText', 'Delete reply');
     });
 
     it('dispatches deleteReview when a user deletes a developer reply', () => {

--- a/tests/unit/ui/components/TestConfirmButton.js
+++ b/tests/unit/ui/components/TestConfirmButton.js
@@ -114,6 +114,10 @@ describe(__filename, () => {
       'buttonType',
       confirmButtonType,
     );
+    expect(root.find('.ConfirmButton-confirm-button')).toHaveProp(
+      'puffy',
+      false,
+    );
     expect(root.find('.ConfirmButton-confirm-button').children()).toHaveText(
       confirmButtonText,
     );
@@ -133,9 +137,39 @@ describe(__filename, () => {
       'buttonType',
       cancelButtonType,
     );
+    expect(root.find('.ConfirmButton-cancel-button')).toHaveProp(
+      'puffy',
+      false,
+    );
     expect(root.find('.ConfirmButton-cancel-button').children()).toHaveText(
       cancelButtonText,
     );
+  });
+
+  it('can make the buttons in the confirmation panel puffy', () => {
+    const { store } = dispatchClientMetadata();
+    const root = render({ puffyButtons: true, store });
+
+    // Show the confirmation panel.
+    root.find(Button).simulate('click', createFakeEvent());
+    applyUIStateChanges({ root, store });
+
+    expect(root.find('.ConfirmButton-cancel-button')).toHaveProp('puffy', true);
+    expect(root.find('.ConfirmButton-confirm-button')).toHaveProp(
+      'puffy',
+      true,
+    );
+  });
+
+  it('can render a confirmation without a message', () => {
+    const { store } = dispatchClientMetadata();
+    const root = render({ message: undefined, store });
+
+    // Show the confirmation panel.
+    root.find(Button).simulate('click', createFakeEvent());
+    applyUIStateChanges({ root, store });
+
+    expect(root.find('.ConfirmButton-message')).toHaveLength(0);
   });
 
   it('closes the confirmation panel on cancel ', () => {


### PR DESCRIPTION
Fixes #6454 

Note that this looks a bit odd when rendered for a review as opposed to a rating, but I think that's okay as a short-term issue until #6347 is fixed entirely.

Deleting a rating (before):

![screenshot 2018-09-28 11 18 49](https://user-images.githubusercontent.com/142755/46217551-4b98d380-c310-11e8-8535-00adf8cf5eb9.png)

Deleting a rating (after):

![screenshot 2018-09-28 11 17 55](https://user-images.githubusercontent.com/142755/46217517-30c65f00-c310-11e8-82b6-b91fea7b78fd.png)

Deleting a review (before):

![screenshot 2018-09-28 11 19 38](https://user-images.githubusercontent.com/142755/46217599-68cda200-c310-11e8-887b-ee66bec87254.png)

Deleting a review (after):

![screenshot 2018-09-28 11 20 25](https://user-images.githubusercontent.com/142755/46217633-8569da00-c310-11e8-8ba6-c79573af7fed.png)
