### PR TITLE
Add prev/next rel attributes to paginator links

### DIFF
--- a/src/core/components/PaginatorLink/index.js
+++ b/src/core/components/PaginatorLink/index.js
@@ -45,6 +45,13 @@ export default class PaginatorLink extends React.Component {
       throw new Error('The pageCount property cannot be undefined');
     }
 
+    let rel = null;
+    if (page + 1 === currentPage) {
+      rel = 'prev';
+    } else if (page - 1 === currentPage) {
+      rel = 'next';
+    }
+
     if (currentPage === page || page < 1 || page > pageCount) {
       const classNames = makeClassName('Paginate-item', className, {
         'Paginate-item--current-page': currentPage === page,
@@ -61,6 +68,7 @@ export default class PaginatorLink extends React.Component {
       <Button
         buttonType="cancel"
         className={makeClassName('Paginate-item', className)}
+        rel={rel}
         to={{ pathname, query: { ...queryParams, [pageParam]: page } }}
       >
         {text || page}

--- a/tests/unit/core/components/TestPaginatorLink.js
+++ b/tests/unit/core/components/TestPaginatorLink.js
@@ -122,4 +122,25 @@ describe(__filename, () => {
       expect(link.prop('children')).toEqual('go to next page');
     });
   });
+
+  describe('"rel" attributes', () => {
+    it('adds a rel="prev" attribute when it is the immediate preceding page', () => {
+      const root = render({ page: 2, currentPage: 3 });
+
+      expect(root).toHaveProp('rel', 'prev');
+    });
+
+    it('adds a rel="next" attribute when it is the immediate next page', () => {
+      const root = render({ page: 4, currentPage: 3 });
+
+      expect(root).toHaveProp('rel', 'next');
+    });
+
+    it('does not add a rel attribute to a disabled link', () => {
+      const root = render({ currentPage: 3, page: 3 });
+
+      expect(root).toHaveProp('disabled', true);
+      expect(root).not.toHaveProp('rel');
+    });
+  });
 });

--- a/tests/unit/core/components/TestPaginatorLink.js
+++ b/tests/unit/core/components/TestPaginatorLink.js
@@ -136,11 +136,22 @@ describe(__filename, () => {
       expect(root).toHaveProp('rel', 'next');
     });
 
-    it('does not add a rel attribute to a disabled link', () => {
-      const root = render({ currentPage: 3, page: 3 });
+    it('does not add a rel attribute when the page is the current page', () => {
+      const root = render({ page: 3, currentPage: 3 });
 
-      expect(root).toHaveProp('disabled', true);
       expect(root).not.toHaveProp('rel');
+    });
+
+    it('does not add a rel attribute when the page is not the immediate preceding page', () => {
+      const root = render({ page: 1, currentPage: 3, pageCount: 6 });
+
+      expect(root).toHaveProp('rel', null);
+    });
+
+    it('does not add a rel attribute when the page is not the immediate next page', () => {
+      const root = render({ page: 5, currentPage: 3, pageCount: 6 });
+
+      expect(root).toHaveProp('rel', null);
     });
   });
 });


### PR DESCRIPTION
Fix #5757

---

This PR adds new `rel` attributes to paginator links.