### PR TITLE
Add canonical link tags

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -4,7 +4,7 @@
 
 import path from 'path';
 
-import { amoProdCDN, apiProdHost, sentryHost } from './lib/shared';
+import { amoProdCDN, apiProdHost, baseUrlProd, sentryHost } from './lib/shared';
 
 const appName = process.env.NODE_APP_INSTANCE || null;
 const validAppNames = [
@@ -22,6 +22,9 @@ if (appName && !validAppNames.includes(appName)) {
 module.exports = {
   appName,
   basePath: path.resolve(__dirname, '../'),
+
+  // The base URL of the site (for SEO purpose).
+  baseURL: baseUrlProd,
 
   // These are reversed in src/core/client/config.js.
   client: false,
@@ -95,6 +98,7 @@ module.exports = {
     'apiVersion',
     'appName',
     'authTokenValidFor',
+    'baseURL',
     'cookieMaxAge',
     'cookieName',
     'cookieSecure',

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -1,8 +1,10 @@
-import { amoDevCDN } from './lib/shared';
+import { amoDevCDN, baseUrlDev } from './lib/shared';
 
 const staticHost = 'https://addons-amo-dev-cdn.allizom.org';
 
 module.exports = {
+  baseURL: baseUrlDev,
+
   staticHost,
 
   CSP: {

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -1,13 +1,18 @@
 module.exports = {
   apiHost: 'http://localhost:3000',
+
+  baseURL: 'http://localhost:3000',
+
   proxyApiHost: 'http://olympia.test',
   proxyPort: 3000,
   proxyEnabled: true,
+
   // Setting this to false returns add-ons that are not compatible but means
   // developers can pull from a much larger dataset on the local/-dev/-stage
   // servers. Set this to true to only get compatible add-ons (this is what
   // happens in production) but get a lot fewer add-ons in search results.
   restrictSearchResultsToAppVersion: false,
+
   fxaConfig: 'local',
   trackingEnabled: false,
   loggingLevel: 'debug',

--- a/config/lib/shared.js
+++ b/config/lib/shared.js
@@ -6,4 +6,8 @@ export const apiDevHost = 'https://addons-dev.allizom.org';
 export const apiProdHost = 'https://addons.mozilla.org';
 export const apiStageHost = 'https://addons.allizom.org';
 
+export const baseUrlDev = 'https://addons-dev.allizom.org';
+export const baseUrlProd = 'https://addons.mozilla.org';
+export const baseUrlStage = 'https://addons.allizom.org';
+
 export const sentryHost = 'https://sentry.prod.mozaws.net';

--- a/config/lib/shared.js
+++ b/config/lib/shared.js
@@ -6,8 +6,8 @@ export const apiDevHost = 'https://addons-dev.allizom.org';
 export const apiProdHost = 'https://addons.mozilla.org';
 export const apiStageHost = 'https://addons.allizom.org';
 
-export const baseUrlDev = 'https://addons-dev.allizom.org';
-export const baseUrlProd = 'https://addons.mozilla.org';
-export const baseUrlStage = 'https://addons.allizom.org';
+export const baseUrlDev = apiDevHost;
+export const baseUrlProd = apiProdHost;
+export const baseUrlStage = apiStageHost;
 
 export const sentryHost = 'https://sentry.prod.mozaws.net';

--- a/config/stage-amo.js
+++ b/config/stage-amo.js
@@ -1,8 +1,10 @@
-import { amoStageCDN } from './lib/shared';
+import { amoStageCDN, baseUrlStage } from './lib/shared';
 
 const staticHost = 'https://addons-amo-cdn.allizom.org';
 
 module.exports = {
+  baseURL: baseUrlStage,
+
   staticHost,
 
   CSP: {

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -608,6 +608,7 @@ export class AddonBase extends React.Component {
         {addon && (
           <Helmet titleTemplate={null}>
             <title>{this.getPageTitle()}</title>
+            <link rel="canonical" href={addon.url} />
             <meta name="description" content={this.getPageDescription()} />
             {this.renderMetaOpenGraph()}
           </Helmet>

--- a/src/amo/pages/Category/index.js
+++ b/src/amo/pages/Category/index.js
@@ -13,6 +13,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import CategoryHeader from 'amo/components/CategoryHeader';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
+import { getCurrentURL } from 'amo/utils';
 import { categoriesFetch } from 'core/actions/categories';
 import {
   ADDON_TYPE_EXTENSION,
@@ -39,6 +40,7 @@ export class CategoryBase extends React.Component {
   static propTypes = {
     _config: PropTypes.object,
     addonTypeOfResults: PropTypes.string,
+    currentURL: PropTypes.string.isRequired,
     categoryOfResults: PropTypes.string,
     categories: PropTypes.object,
     clientApp: PropTypes.string,
@@ -229,6 +231,7 @@ export class CategoryBase extends React.Component {
 
   render() {
     const {
+      currentURL,
       categories,
       clientApp,
       errorHandler,
@@ -271,6 +274,7 @@ export class CategoryBase extends React.Component {
         {category && (
           <Helmet>
             <title>{`${category.name} – ${html.title}`}</title>
+            <link rel="canonical" href={currentURL} />
           </Helmet>
         )}
 
@@ -322,8 +326,9 @@ export class CategoryBase extends React.Component {
   }
 }
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   return {
+    currentURL: getCurrentURL({ state, _config: ownProps._config }),
     categories: state.categories.categories,
     clientApp: state.api.clientApp,
     loading: state.categories.loading || state.landing.loading,

--- a/src/amo/pages/Category/index.js
+++ b/src/amo/pages/Category/index.js
@@ -13,7 +13,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import CategoryHeader from 'amo/components/CategoryHeader';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
-import { getCurrentURL } from 'amo/utils';
+import { getCanonicalURL } from 'amo/utils';
 import { categoriesFetch } from 'core/actions/categories';
 import {
   ADDON_TYPE_EXTENSION,
@@ -40,7 +40,6 @@ export class CategoryBase extends React.Component {
   static propTypes = {
     _config: PropTypes.object,
     addonTypeOfResults: PropTypes.string,
-    currentURL: PropTypes.string.isRequired,
     categoryOfResults: PropTypes.string,
     categories: PropTypes.object,
     clientApp: PropTypes.string,
@@ -50,6 +49,7 @@ export class CategoryBase extends React.Component {
     highlyRatedAddons: PropTypes.array,
     i18n: PropTypes.object.isRequired,
     loading: PropTypes.bool,
+    locationPathname: PropTypes.string.isRequired,
     match: PropTypes.shape({
       params: PropTypes.shape({
         slug: PropTypes.string,
@@ -231,13 +231,14 @@ export class CategoryBase extends React.Component {
 
   render() {
     const {
-      currentURL,
+      _config,
       categories,
       clientApp,
       errorHandler,
       featuredAddons,
       highlyRatedAddons,
       loading,
+      locationPathname,
       match: { params },
       trendingAddons,
     } = this.props;
@@ -274,7 +275,10 @@ export class CategoryBase extends React.Component {
         {category && (
           <Helmet>
             <title>{`${category.name} – ${html.title}`}</title>
-            <link rel="canonical" href={currentURL} />
+            <link
+              rel="canonical"
+              href={getCanonicalURL({ locationPathname, _config })}
+            />
           </Helmet>
         )}
 
@@ -326,18 +330,18 @@ export class CategoryBase extends React.Component {
   }
 }
 
-function mapStateToProps(state, ownProps) {
+function mapStateToProps(state) {
   return {
-    currentURL: getCurrentURL({ state, _config: ownProps._config }),
-    categories: state.categories.categories,
-    clientApp: state.api.clientApp,
-    loading: state.categories.loading || state.landing.loading,
     addonTypeOfResults: state.landing.addonType,
+    categories: state.categories.categories,
     categoryOfResults: state.landing.category,
+    clientApp: state.api.clientApp,
     featuredAddons: state.landing.featured.results,
     highlyRatedAddons: state.landing.highlyRated.results,
-    trendingAddons: state.landing.trending.results,
+    loading: state.categories.loading || state.landing.loading,
+    locationPathname: state.router.location.pathname,
     resultsLoaded: state.landing.resultsLoaded,
+    trendingAddons: state.landing.trending.results,
   };
 }
 

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -3,6 +3,7 @@ import config from 'config';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import Helmet from 'react-helmet';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import CategoryIcon from 'amo/components/CategoryIcon';
@@ -11,6 +12,7 @@ import HomeHeroBanner from 'amo/components/HomeHeroBanner';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import { fetchHomeAddons } from 'amo/reducers/home';
+import { getCurrentURL } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -63,6 +65,7 @@ export const getFeaturedCollectionsMetadata = (i18n) => {
 export class HomeBase extends React.Component {
   static propTypes = {
     _config: PropTypes.object,
+    currentURL: PropTypes.string.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
     collections: PropTypes.array.isRequired,
@@ -199,8 +202,10 @@ export class HomeBase extends React.Component {
 
   render() {
     const {
-      errorHandler,
+      _config,
+      currentURL,
       collections,
+      errorHandler,
       featuredExtensions,
       featuredThemes,
       i18n,
@@ -222,6 +227,10 @@ export class HomeBase extends React.Component {
 
     return (
       <div className="Home">
+        <Helmet>
+          <link rel="canonical" href={currentURL} />
+        </Helmet>
+
         <span
           className="visually-hidden do-not-remove"
           // eslint-disable-next-line react/no-danger
@@ -329,8 +338,9 @@ export class HomeBase extends React.Component {
   }
 }
 
-export function mapStateToProps(state) {
+export function mapStateToProps(state, ownProps) {
   return {
+    currentURL: getCurrentURL({ state, _config: ownProps._config }),
     collections: state.home.collections,
     featuredExtensions: state.home.featuredExtensions,
     resultsLoaded: state.home.resultsLoaded,

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -202,7 +202,6 @@ export class HomeBase extends React.Component {
 
   render() {
     const {
-      _config,
       currentURL,
       collections,
       errorHandler,

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -12,7 +12,7 @@ import HomeHeroBanner from 'amo/components/HomeHeroBanner';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import { fetchHomeAddons } from 'amo/reducers/home';
-import { getCurrentURL } from 'amo/utils';
+import { getCanonicalURL } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -65,14 +65,14 @@ export const getFeaturedCollectionsMetadata = (i18n) => {
 export class HomeBase extends React.Component {
   static propTypes = {
     _config: PropTypes.object,
-    currentURL: PropTypes.string.isRequired,
+    collections: PropTypes.array.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
-    collections: PropTypes.array.isRequired,
     featuredExtensions: PropTypes.array.isRequired,
     featuredThemes: PropTypes.array.isRequired,
     i18n: PropTypes.object.isRequired,
     includeFeaturedThemes: PropTypes.bool,
+    locationPathname: PropTypes.string.isRequired,
     resultsLoaded: PropTypes.bool.isRequired,
     popularExtensions: PropTypes.array.isRequired,
   };
@@ -202,13 +202,14 @@ export class HomeBase extends React.Component {
 
   render() {
     const {
-      currentURL,
+      _config,
       collections,
       errorHandler,
       featuredExtensions,
       featuredThemes,
       i18n,
       includeFeaturedThemes,
+      locationPathname,
       resultsLoaded,
       popularExtensions,
     } = this.props;
@@ -227,7 +228,10 @@ export class HomeBase extends React.Component {
     return (
       <div className="Home">
         <Helmet>
-          <link rel="canonical" href={currentURL} />
+          <link
+            rel="canonical"
+            href={getCanonicalURL({ locationPathname, _config })}
+          />
         </Helmet>
 
         <span
@@ -337,14 +341,14 @@ export class HomeBase extends React.Component {
   }
 }
 
-export function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state) {
   return {
-    currentURL: getCurrentURL({ state, _config: ownProps._config }),
     collections: state.home.collections,
     featuredExtensions: state.home.featuredExtensions,
-    resultsLoaded: state.home.resultsLoaded,
     featuredThemes: state.home.featuredThemes,
+    locationPathname: state.router.location.pathname,
     popularExtensions: state.home.popularExtensions,
+    resultsLoaded: state.home.resultsLoaded,
   };
 }
 

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -12,6 +12,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Categories from 'amo/components/Categories';
+import { getCurrentURL } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -42,6 +43,7 @@ export class LandingPageBase extends React.Component {
     // `componentWillReceiveProps()`.
     // eslint-disable-next-line react/no-unused-prop-types
     addonTypeOfResults: PropTypes.string,
+    currentURL: PropTypes.string.isRequired,
     // This is a bug; context is used in `setViewContextType()`.
     // eslint-disable-next-line react/no-unused-prop-types
     context: PropTypes.string.isRequired,
@@ -210,6 +212,7 @@ export class LandingPageBase extends React.Component {
 
   render() {
     const {
+      currentURL,
       errorHandler,
       featuredAddons,
       highlyRatedAddons,
@@ -247,6 +250,7 @@ export class LandingPageBase extends React.Component {
       >
         <Helmet>
           <title>{headingText[addonType]}</title>
+          <link rel="canonical" href={currentURL} />
         </Helmet>
 
         {errorHandler.renderErrorIfPresent()}
@@ -314,11 +318,12 @@ export class LandingPageBase extends React.Component {
   }
 }
 
-export function mapStateToProps(state) {
+export function mapStateToProps(state, ownProps) {
   const { landing, viewContext } = state;
 
   return {
     addonTypeOfResults: landing.addonType,
+    currentURL: getCurrentURL({ state, _config: ownProps._config }),
     context: viewContext.context,
     featuredAddons: landing.featured.results,
     highlyRatedAddons: landing.highlyRated.results,

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -12,7 +12,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import Categories from 'amo/components/Categories';
-import { getCurrentURL } from 'amo/utils';
+import { getCanonicalURL } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -43,7 +43,6 @@ export class LandingPageBase extends React.Component {
     // `componentWillReceiveProps()`.
     // eslint-disable-next-line react/no-unused-prop-types
     addonTypeOfResults: PropTypes.string,
-    currentURL: PropTypes.string.isRequired,
     // This is a bug; context is used in `setViewContextType()`.
     // eslint-disable-next-line react/no-unused-prop-types
     context: PropTypes.string.isRequired,
@@ -52,6 +51,7 @@ export class LandingPageBase extends React.Component {
     featuredAddons: PropTypes.array.isRequired,
     highlyRatedAddons: PropTypes.array.isRequired,
     loading: PropTypes.bool.isRequired,
+    locationPathname: PropTypes.string.isRequired,
     trendingAddons: PropTypes.array.isRequired,
     i18n: PropTypes.object.isRequired,
     match: PropTypes.shape({
@@ -212,11 +212,12 @@ export class LandingPageBase extends React.Component {
 
   render() {
     const {
-      currentURL,
+      _config,
       errorHandler,
       featuredAddons,
       highlyRatedAddons,
       loading,
+      locationPathname,
       trendingAddons,
       i18n,
     } = this.props;
@@ -250,7 +251,10 @@ export class LandingPageBase extends React.Component {
       >
         <Helmet>
           <title>{headingText[addonType]}</title>
-          <link rel="canonical" href={currentURL} />
+          <link
+            rel="canonical"
+            href={getCanonicalURL({ locationPathname, _config })}
+          />
         </Helmet>
 
         {errorHandler.renderErrorIfPresent()}
@@ -318,16 +322,16 @@ export class LandingPageBase extends React.Component {
   }
 }
 
-export function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state) {
   const { landing, viewContext } = state;
 
   return {
     addonTypeOfResults: landing.addonType,
-    currentURL: getCurrentURL({ state, _config: ownProps._config }),
     context: viewContext.context,
     featuredAddons: landing.featured.results,
     highlyRatedAddons: landing.highlyRated.results,
     loading: landing.loading,
+    locationPathname: state.router.location.pathname,
     trendingAddons: landing.trending.results,
     resultsLoaded: landing.resultsLoaded && landing.category === null,
   };

--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 import makeClassName from 'classnames';
+import config from 'config';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
@@ -9,6 +10,7 @@ import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import Link from 'amo/components/Link';
+import { getCurrentURL } from 'amo/utils';
 import { withErrorHandler } from 'core/errorHandler';
 import {
   ADDON_TYPE_DICT,
@@ -67,14 +69,21 @@ export const LanguageToolList = ({ languageTools }: LanguageToolListProps) => {
 };
 
 type Props = {|
-  languageTools: Array<LanguageToolType>,
+  // eslint-disable-next-line react/no-unused-prop-types
+  _config: typeof config,
+  currentURL: string,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   lang: string,
+  languageTools: Array<LanguageToolType>,
 |};
 
 export class LanguageToolsBase extends React.Component<Props> {
+  static defaultProps = {
+    _config: config,
+  };
+
   constructor(props: Props) {
     super(props);
 
@@ -141,7 +150,7 @@ export class LanguageToolsBase extends React.Component<Props> {
   }
 
   render() {
-    const { languageTools, errorHandler, i18n } = this.props;
+    const { currentURL, languageTools, errorHandler, i18n } = this.props;
 
     const header = i18n.gettext('Dictionaries and Language Packs');
 
@@ -149,6 +158,7 @@ export class LanguageToolsBase extends React.Component<Props> {
       <Card className="LanguageTools" header={header}>
         <Helmet>
           <title>{header}</title>
+          <link rel="canonical" href={currentURL} />
         </Helmet>
 
         {errorHandler.renderErrorIfPresent()}
@@ -264,10 +274,11 @@ export class LanguageToolsBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (state: AppState) => {
+export const mapStateToProps = (state: AppState, ownProps: Props) => {
   return {
-    languageTools: getAllLanguageTools(state),
+    currentURL: getCurrentURL({ state, _config: ownProps._config }),
     lang: state.api.lang,
+    languageTools: getAllLanguageTools(state),
   };
 };
 

--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -10,7 +10,7 @@ import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import Link from 'amo/components/Link';
-import { getCurrentURL } from 'amo/utils';
+import { getCanonicalURL } from 'amo/utils';
 import { withErrorHandler } from 'core/errorHandler';
 import {
   ADDON_TYPE_DICT,
@@ -69,14 +69,13 @@ export const LanguageToolList = ({ languageTools }: LanguageToolListProps) => {
 };
 
 type Props = {|
-  // eslint-disable-next-line react/no-unused-prop-types
   _config: typeof config,
-  currentURL: string,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   lang: string,
   languageTools: Array<LanguageToolType>,
+  locationPathname: string,
 |};
 
 export class LanguageToolsBase extends React.Component<Props> {
@@ -150,7 +149,13 @@ export class LanguageToolsBase extends React.Component<Props> {
   }
 
   render() {
-    const { currentURL, languageTools, errorHandler, i18n } = this.props;
+    const {
+      _config,
+      languageTools,
+      locationPathname,
+      errorHandler,
+      i18n,
+    } = this.props;
 
     const header = i18n.gettext('Dictionaries and Language Packs');
 
@@ -158,7 +163,10 @@ export class LanguageToolsBase extends React.Component<Props> {
       <Card className="LanguageTools" header={header}>
         <Helmet>
           <title>{header}</title>
-          <link rel="canonical" href={currentURL} />
+          <link
+            rel="canonical"
+            href={getCanonicalURL({ locationPathname, _config })}
+          />
         </Helmet>
 
         {errorHandler.renderErrorIfPresent()}
@@ -274,11 +282,11 @@ export class LanguageToolsBase extends React.Component<Props> {
   }
 }
 
-export const mapStateToProps = (state: AppState, ownProps: Props) => {
+export const mapStateToProps = (state: AppState) => {
   return {
-    currentURL: getCurrentURL({ state, _config: ownProps._config }),
     lang: state.api.lang,
     languageTools: getAllLanguageTools(state),
+    locationPathname: state.router.location.pathname,
   };
 };
 

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -1,21 +1,33 @@
+/* @flow */
+import config from 'config';
 import Helmet from 'react-helmet';
-import PropTypes from 'prop-types';
 import * as React from 'react';
 import { compose } from 'redux';
+import { connect } from 'react-redux';
 
+import { getCurrentURL } from 'amo/utils';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
+import type { AppState } from 'amo/store';
+import type { I18nType } from 'core/types/i18n';
 
 import '../styles.scss';
 
-export class AboutBase extends React.Component {
-  static propTypes = {
-    i18n: PropTypes.object.isRequired,
+type Props = {|
+  // eslint-disable-next-line react/no-unused-prop-types
+  _config: typeof config,
+  currentURL: string,
+  i18n: I18nType,
+|};
+
+export class AboutBase extends React.Component<Props> {
+  static defaultProps = {
+    _config: config,
   };
 
   render() {
-    const { i18n } = this.props;
+    const { currentURL, i18n } = this.props;
 
     return (
       <Card
@@ -24,6 +36,7 @@ export class AboutBase extends React.Component {
       >
         <Helmet>
           <title>{i18n.gettext('About Firefox Add-ons')}</title>
+          <link rel="canonical" href={currentURL} />
         </Helmet>
 
         <div className="StaticPageWrapper">
@@ -213,4 +226,13 @@ export class AboutBase extends React.Component {
   }
 }
 
-export default compose(translate())(AboutBase);
+const mapStateToProps = (state: AppState, ownProps: Props) => {
+  return {
+    currentURL: getCurrentURL({ state, _config: ownProps._config }),
+  };
+};
+
+export default compose(
+  connect(mapStateToProps),
+  translate(),
+)(AboutBase);

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
-import { getCurrentURL } from 'amo/utils';
+import { getCanonicalURL } from 'amo/utils';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
@@ -15,10 +15,9 @@ import type { I18nType } from 'core/types/i18n';
 import '../styles.scss';
 
 type Props = {|
-  // eslint-disable-next-line react/no-unused-prop-types
   _config: typeof config,
-  currentURL: string,
   i18n: I18nType,
+  locationPathname: string,
 |};
 
 export class AboutBase extends React.Component<Props> {
@@ -27,7 +26,7 @@ export class AboutBase extends React.Component<Props> {
   };
 
   render() {
-    const { currentURL, i18n } = this.props;
+    const { _config, i18n, locationPathname } = this.props;
 
     return (
       <Card
@@ -36,7 +35,10 @@ export class AboutBase extends React.Component<Props> {
       >
         <Helmet>
           <title>{i18n.gettext('About Firefox Add-ons')}</title>
-          <link rel="canonical" href={currentURL} />
+          <link
+            rel="canonical"
+            href={getCanonicalURL({ locationPathname, _config })}
+          />
         </Helmet>
 
         <div className="StaticPageWrapper">
@@ -226,9 +228,9 @@ export class AboutBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: AppState, ownProps: Props) => {
+const mapStateToProps = (state: AppState) => {
   return {
-    currentURL: getCurrentURL({ state, _config: ownProps._config }),
+    locationPathname: state.router.location.pathname,
   };
 };
 

--- a/src/amo/pages/StaticPages/ReviewGuide/index.js
+++ b/src/amo/pages/StaticPages/ReviewGuide/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 import config from 'config';
 import Helmet from 'react-helmet';
-import PropTypes from 'prop-types';
 import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';

--- a/src/amo/pages/StaticPages/ReviewGuide/index.js
+++ b/src/amo/pages/StaticPages/ReviewGuide/index.js
@@ -1,26 +1,40 @@
+/* @flow */
+import config from 'config';
 import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { compose } from 'redux';
+import { connect } from 'react-redux';
 
+import { getCurrentURL } from 'amo/utils';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
+import type { AppState } from 'amo/store';
+import type { I18nType } from 'core/types/i18n';
 
 import '../styles.scss';
 
-export class ReviewGuideBase extends React.Component {
-  static propTypes = {
-    i18n: PropTypes.object.isRequired,
+type Props = {|
+  // eslint-disable-next-line react/no-unused-prop-types
+  _config: typeof config,
+  currentURL: string,
+  i18n: I18nType,
+|};
+
+export class ReviewGuideBase extends React.Component<Props> {
+  static defaultProps = {
+    _config: config,
   };
 
   render() {
-    const { i18n } = this.props;
+    const { currentURL, i18n } = this.props;
 
     return (
       <Card className="StaticPage" header={i18n.gettext('Review Guidelines')}>
         <Helmet>
           <title>{i18n.gettext('Review Guidelines')}</title>
+          <link rel="canonical" href={currentURL} />
         </Helmet>
 
         <div className="StaticPageWrapper">
@@ -166,4 +180,13 @@ export class ReviewGuideBase extends React.Component {
   }
 }
 
-export default compose(translate())(ReviewGuideBase);
+const mapStateToProps = (state: AppState, ownProps: Props) => {
+  return {
+    currentURL: getCurrentURL({ state, _config: ownProps._config }),
+  };
+};
+
+export default compose(
+  connect(mapStateToProps),
+  translate(),
+)(ReviewGuideBase);

--- a/src/amo/pages/StaticPages/ReviewGuide/index.js
+++ b/src/amo/pages/StaticPages/ReviewGuide/index.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
-import { getCurrentURL } from 'amo/utils';
+import { getCanonicalURL } from 'amo/utils';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
@@ -15,10 +15,9 @@ import type { I18nType } from 'core/types/i18n';
 import '../styles.scss';
 
 type Props = {|
-  // eslint-disable-next-line react/no-unused-prop-types
   _config: typeof config,
-  currentURL: string,
   i18n: I18nType,
+  locationPathname: string,
 |};
 
 export class ReviewGuideBase extends React.Component<Props> {
@@ -27,13 +26,16 @@ export class ReviewGuideBase extends React.Component<Props> {
   };
 
   render() {
-    const { currentURL, i18n } = this.props;
+    const { _config, i18n, locationPathname } = this.props;
 
     return (
       <Card className="StaticPage" header={i18n.gettext('Review Guidelines')}>
         <Helmet>
           <title>{i18n.gettext('Review Guidelines')}</title>
-          <link rel="canonical" href={currentURL} />
+          <link
+            rel="canonical"
+            href={getCanonicalURL({ locationPathname, _config })}
+          />
         </Helmet>
 
         <div className="StaticPageWrapper">
@@ -179,9 +181,9 @@ export class ReviewGuideBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: AppState, ownProps: Props) => {
+const mapStateToProps = (state: AppState) => {
   return {
-    currentURL: getCurrentURL({ state, _config: ownProps._config }),
+    locationPathname: state.router.location.pathname,
   };
 };
 

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -50,10 +50,7 @@ import type { RedirectToState } from 'core/reducers/redirectTo';
 import type { SearchState } from 'core/reducers/search';
 import type { SurveyState } from 'core/reducers/survey';
 import type { UIStateState } from 'core/reducers/uiState';
-import type {
-  ReactRouterHistoryType,
-  LocationType,
-} from 'core/types/router';
+import type { ReactRouterHistoryType, LocationType } from 'core/types/router';
 import type { CreateStoreParams, CreateReducerType } from 'core/types/store';
 
 type AppStateWithoutRouter = {|

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -50,10 +50,13 @@ import type { RedirectToState } from 'core/reducers/redirectTo';
 import type { SearchState } from 'core/reducers/search';
 import type { SurveyState } from 'core/reducers/survey';
 import type { UIStateState } from 'core/reducers/uiState';
-import type { ReactRouterHistoryType } from 'core/types/router';
+import type {
+  ReactRouterHistoryType,
+  LocationType,
+} from 'core/types/router';
 import type { CreateStoreParams, CreateReducerType } from 'core/types/store';
 
-export type AppState = {|
+type AppStateWithoutRouter = {|
   abuse: AbuseState,
   addons: AddonsState,
   addonsByAuthors: AddonsByAuthorsState,
@@ -81,9 +84,17 @@ export type AppState = {|
   viewContext: ViewContextState,
 |};
 
+export type AppState = {|
+  ...AppStateWithoutRouter,
+  router: {|
+    action: 'PUSH' | 'POP',
+    location: LocationType,
+  |},
+|};
+
 // Given AppState, create a type for all possible application reducers.
 // See https://flow.org/en/docs/types/utilities/#toc-objmap
-type AppReducersType = $ObjMap<AppState, CreateReducerType>;
+type AppReducersType = $ObjMap<AppStateWithoutRouter, CreateReducerType>;
 
 type CreateRootReducerParams = {|
   history: ReactRouterHistoryType,
@@ -93,7 +104,7 @@ type CreateRootReducerParams = {|
 export const createRootReducer = ({
   history,
   reducers,
-}: CreateRootReducerParams) => {
+}: CreateRootReducerParams): AppState => {
   return connectRouter(history)(combineReducers(reducers));
 };
 

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -53,7 +53,7 @@ import type { UIStateState } from 'core/reducers/uiState';
 import type { ReactRouterHistoryType, LocationType } from 'core/types/router';
 import type { CreateStoreParams, CreateReducerType } from 'core/types/store';
 
-type AppStateWithoutRouter = {|
+type InternalAppState = {|
   abuse: AbuseState,
   addons: AddonsState,
   addonsByAuthors: AddonsByAuthorsState,
@@ -82,7 +82,7 @@ type AppStateWithoutRouter = {|
 |};
 
 export type AppState = {|
-  ...AppStateWithoutRouter,
+  ...InternalAppState,
   router: {|
     action: 'PUSH' | 'POP',
     location: LocationType,
@@ -91,7 +91,7 @@ export type AppState = {|
 
 // Given AppState, create a type for all possible application reducers.
 // See https://flow.org/en/docs/types/utilities/#toc-objmap
-type AppReducersType = $ObjMap<AppStateWithoutRouter, CreateReducerType>;
+type AppReducersType = $ObjMap<InternalAppState, CreateReducerType>;
 
 type CreateRootReducerParams = {|
   history: ReactRouterHistoryType,

--- a/src/amo/utils.js
+++ b/src/amo/utils.js
@@ -1,12 +1,16 @@
+/* @flow */
 /* eslint camelcase: 0 */
 import base62 from 'base62';
+import config from 'config';
+import invariant from 'invariant';
+import type { AppState } from 'amo/store';
 
 import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
 import { makeQueryString } from 'core/api';
 
-export function getErrorComponent(status) {
+export function getErrorComponent(status: number | null) {
   switch (status) {
     case 401:
       return NotAuthorized;
@@ -38,11 +42,30 @@ export const makeQueryStringWithUTM = ({
   utm_medium = 'referral',
   utm_campaign = 'non-fx-button',
   utm_content,
-}) => {
+}: {|
+  utm_source?: string,
+  utm_medium?: string,
+  utm_campaign?: string,
+  utm_content: string,
+|}): string => {
   return makeQueryString({
     utm_source,
     utm_medium,
     utm_campaign,
     utm_content,
   });
+};
+
+export const getCurrentURL = ({
+  _config = config,
+  state,
+}: {|
+  _config?: typeof config,
+  state: AppState,
+|}): string => {
+  const { location } = state.router;
+
+  invariant(location, 'location is required');
+
+  return `${_config.get('baseURL')}${location.pathname}`;
 };

--- a/src/amo/utils.js
+++ b/src/amo/utils.js
@@ -3,12 +3,12 @@
 import base62 from 'base62';
 import config from 'config';
 import invariant from 'invariant';
-import type { AppState } from 'amo/store';
 
 import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
 import { makeQueryString } from 'core/api';
+import type { AppState } from 'amo/store';
 
 export function getErrorComponent(status: number | null) {
   switch (status) {

--- a/src/amo/utils.js
+++ b/src/amo/utils.js
@@ -2,7 +2,6 @@
 /* eslint camelcase: 0 */
 import base62 from 'base62';
 import config from 'config';
-import invariant from 'invariant';
 
 import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';

--- a/src/amo/utils.js
+++ b/src/amo/utils.js
@@ -8,7 +8,6 @@ import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
 import { makeQueryString } from 'core/api';
-import type { AppState } from 'amo/store';
 
 export function getErrorComponent(status: number | null) {
   switch (status) {
@@ -56,16 +55,12 @@ export const makeQueryStringWithUTM = ({
   });
 };
 
-export const getCurrentURL = ({
+export const getCanonicalURL = ({
   _config = config,
-  state,
+  locationPathname,
 }: {|
   _config?: typeof config,
-  state: AppState,
+  locationPathname: string,
 |}): string => {
-  const { location } = state.router;
-
-  invariant(location, 'location is required');
-
-  return `${_config.get('baseURL')}${location.pathname}`;
+  return `${_config.get('baseURL')}${locationPathname}`;
 };

--- a/src/core/components/ServerHtml/index.js
+++ b/src/core/components/ServerHtml/index.js
@@ -114,6 +114,7 @@ export default class ServerHtml extends Component {
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <link rel="shortcut icon" href={this.getFaviconLink()} />
+          {head.link.toComponent()}
           {head.title.toComponent()}
           {head.meta.toComponent()}
           {this.getStyle()}

--- a/src/core/types/router.js
+++ b/src/core/types/router.js
@@ -7,16 +7,20 @@ type PushParams = {|
   query: QueryParams,
 |};
 
-export type ReactRouterLocationType = {|
-  action: 'POP' | 'PUSH',
+export type LocationType = {|
   hash: string, // e.g. #some-anchor
   key: string,
   pathname: string, // e.g. /en-US/firefox/addon/tab-mix-plus/reviews/
+  search: string, // e.g. ?q=search-string
+  state?: Object,
+|};
+
+export type ReactRouterLocationType = {|
+  ...LocationType,
+  action: 'POP' | 'PUSH',
   // This is a parsed representation of the query string in object form, it is
   // added by the `addQueryParamsToHistory()` helper in `core/utils`.
   query: QueryParams,
-  search: string, // e.g. ?q=search-string
-  state?: Object,
 |};
 
 export type ReactRouterHistoryType = {|

--- a/src/core/types/router.js
+++ b/src/core/types/router.js
@@ -11,8 +11,8 @@ export type LocationType = {|
   hash: string, // e.g. #some-anchor
   key: string,
   pathname: string, // e.g. /en-US/firefox/addon/tab-mix-plus/reviews/
-  search: string, // e.g. ?q=search-string
-  state?: Object,
+  search: string, // e.g. ?q=search-strin
+  state?: Object, // sometimes available, this should probably not be used.
 |};
 
 export type ReactRouterLocationType = {|

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -1,5 +1,6 @@
 import { normalize } from 'normalizr';
 import config from 'config';
+import { LOCATION_CHANGE } from 'connected-react-router';
 
 import createStore from 'amo/store';
 import {
@@ -213,15 +214,33 @@ export const fakeRecommendations = Object.freeze({
   outcome: 'recommended_fallback',
 });
 
+export const pushLocation = ({ pathname, search = '', hash = '' }) => {
+  return {
+    type: LOCATION_CHANGE,
+    payload: {
+      location: {
+        pathname,
+        search,
+        hash,
+      },
+      action: 'PUSH',
+    },
+  };
+};
+
 export function dispatchClientMetadata({
   store = createStore().store,
   clientApp = CLIENT_APP_ANDROID,
   lang = 'en-US',
   userAgent = sampleUserAgent,
+  pathname = `/${lang}/${clientApp}/`,
 } = {}) {
   store.dispatch(setClientApp(clientApp));
   store.dispatch(setLang(lang));
   store.dispatch(setUserAgent(userAgent));
+
+  // Simulate the behavior of connected-react-router.
+  store.dispatch(pushLocation({ pathname }));
 
   return {
     store,

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -214,7 +214,7 @@ export const fakeRecommendations = Object.freeze({
   outcome: 'recommended_fallback',
 });
 
-export const pushLocation = ({ pathname, search = '', hash = '' }) => {
+export const onLocationChanged = ({ pathname, search = '', hash = '' }) => {
   return {
     type: LOCATION_CHANGE,
     payload: {
@@ -239,8 +239,8 @@ export function dispatchClientMetadata({
   store.dispatch(setLang(lang));
   store.dispatch(setUserAgent(userAgent));
 
-  // Simulate the behavior of connected-react-router.
-  store.dispatch(pushLocation({ pathname }));
+  // Simulate the behavior of `connected-react-router`.
+  store.dispatch(onLocationChanged({ pathname }));
 
   return {
     store,

--- a/tests/unit/amo/pages/StaticPages/TestAbout.js
+++ b/tests/unit/amo/pages/StaticPages/TestAbout.js
@@ -1,16 +1,44 @@
 import * as React from 'react';
 
 import About, { AboutBase } from 'amo/pages/StaticPages/About';
-import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+import {
+  fakeI18n,
+  getFakeConfig,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
-  function render() {
-    return shallowUntilTarget(<About i18n={fakeI18n()} />, AboutBase);
+  function render({
+    store = dispatchClientMetadata().store,
+    i18n = fakeI18n(),
+    ...props
+  } = {}) {
+    return shallowUntilTarget(
+      <About store={store} i18n={i18n} {...props} />,
+      AboutBase,
+    );
   }
 
   it('outputs an about page', () => {
     const root = render();
     expect(root).toHaveClassName('StaticPage');
     expect(root.find('#about')).toExist();
+  });
+
+  it('renders a canonical link tag', () => {
+    const baseURL = 'https://example.org';
+    const _config = getFakeConfig({ baseURL });
+
+    const pathname = '/some-about-pathname';
+    const { store } = dispatchClientMetadata({ pathname });
+
+    const root = render({ _config, store });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}${pathname}`,
+    );
   });
 });

--- a/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
+++ b/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
@@ -3,12 +3,21 @@ import * as React from 'react';
 import ReviewGuide, {
   ReviewGuideBase,
 } from 'amo/pages/StaticPages/ReviewGuide';
-import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+import {
+  fakeI18n,
+  getFakeConfig,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
-  function render() {
+  function render({
+    store = dispatchClientMetadata().store,
+    i18n = fakeI18n(),
+    ...props
+  } = {}) {
     return shallowUntilTarget(
-      <ReviewGuide i18n={fakeI18n()} />,
+      <ReviewGuide store={store} i18n={i18n} {...props} />,
       ReviewGuideBase,
     );
   }

--- a/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
+++ b/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
@@ -27,4 +27,20 @@ describe(__filename, () => {
     expect(root).toHaveClassName('StaticPage');
     expect(root.find('#review-guide')).toExist();
   });
+
+  it('renders a canonical link tag', () => {
+    const baseURL = 'https://example.org';
+    const _config = getFakeConfig({ baseURL });
+
+    const pathname = '/some-review-guide-pathname';
+    const { store } = dispatchClientMetadata({ pathname });
+
+    const root = render({ _config, store });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}${pathname}`,
+    );
+  });
 });

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1853,4 +1853,12 @@ describe(__filename, () => {
 
     expect(root.find(`meta[property="og:image"]`)).toHaveLength(0);
   });
+
+  it('renders a canonical link tag', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const root = shallowRender({ addon });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp('href', addon.url);
+  });
 });

--- a/tests/unit/amo/pages/TestCategory.js
+++ b/tests/unit/amo/pages/TestCategory.js
@@ -31,6 +31,7 @@ import {
   dispatchClientMetadata,
   fakeAddon,
   fakeCategory,
+  pushLocation,
 } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
@@ -835,5 +836,21 @@ describe(__filename, () => {
 
       expect(root.find(NotFound)).toHaveLength(0);
     });
+  });
+
+  it('renders a canonical link tag', () => {
+    const baseURL = 'https://example.org';
+    const _config = getFakeConfig({ baseURL });
+
+    const pathname = '/some-category-pathname/';
+    store.dispatch(pushLocation({ pathname }));
+
+    const root = render({ _config });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}${pathname}`,
+    );
   });
 });

--- a/tests/unit/amo/pages/TestCategory.js
+++ b/tests/unit/amo/pages/TestCategory.js
@@ -31,7 +31,7 @@ import {
   dispatchClientMetadata,
   fakeAddon,
   fakeCategory,
-  pushLocation,
+  onLocationChanged,
 } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
@@ -843,7 +843,7 @@ describe(__filename, () => {
     const _config = getFakeConfig({ baseURL });
 
     const pathname = '/some-category-pathname/';
-    store.dispatch(pushLocation({ pathname }));
+    store.dispatch(onLocationChanged({ pathname }));
 
     const root = render({ _config });
 

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -430,4 +430,20 @@ describe(__filename, () => {
       );
     });
   });
+
+  it('renders a canonical link tag', () => {
+    const baseURL = 'https://example.org';
+    const _config = getFakeConfig({ baseURL });
+
+    const pathname = '/some-landing-pathname/';
+    const { store } = dispatchClientMetadata({ pathname });
+
+    const root = render({ _config, store });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}${pathname}`,
+    );
+  });
 });

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -18,6 +18,7 @@ import {
   createAddonsApiResult,
   dispatchClientMetadata,
   fakeAddon,
+  pushLocation,
 } from 'tests/unit/amo/helpers';
 import {
   createStubErrorHandler,
@@ -667,5 +668,21 @@ describe(__filename, () => {
     expect(root.find(LandingAddonsCard)).toHaveLength(2);
     expect(landingShelves.at(0)).toHaveClassName('FeaturedAddons');
     expect(landingShelves.at(1)).toHaveClassName('TrendingAddons');
+  });
+
+  it('renders a canonical link tag', () => {
+    const baseURL = 'https://example.org';
+    const _config = getFakeConfig({ baseURL });
+
+    const pathname = '/some-landing-pathname/';
+    store.dispatch(pushLocation({ pathname }));
+
+    const root = render({ _config, store });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}${pathname}`,
+    );
   });
 });

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -18,7 +18,7 @@ import {
   createAddonsApiResult,
   dispatchClientMetadata,
   fakeAddon,
-  pushLocation,
+  onLocationChanged,
 } from 'tests/unit/amo/helpers';
 import {
   createStubErrorHandler,
@@ -675,7 +675,7 @@ describe(__filename, () => {
     const _config = getFakeConfig({ baseURL });
 
     const pathname = '/some-landing-pathname/';
-    store.dispatch(pushLocation({ pathname }));
+    store.dispatch(onLocationChanged({ pathname }));
 
     const root = render({ _config, store });
 

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -15,6 +15,7 @@ import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import {
   createFakeLanguageTool,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import LoadingText from 'ui/components/LoadingText';
@@ -302,5 +303,21 @@ describe(__filename, () => {
       addons[1],
       addons[2],
     ]);
+  });
+
+  it('renders a canonical link tag', () => {
+    const baseURL = 'https://example.org';
+    const _config = getFakeConfig({ baseURL });
+    const pathname = '/language-tools/';
+
+    const { store } = dispatchClientMetadata({ pathname });
+
+    const root = renderShallow({ _config, store });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}${pathname}`,
+    );
   });
 });

--- a/tests/unit/amo/test_utils.js
+++ b/tests/unit/amo/test_utils.js
@@ -1,7 +1,10 @@
 import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
-import { getErrorComponent } from 'amo/utils';
+import { getCurrentURL, getErrorComponent } from 'amo/utils';
+import { CLIENT_APP_FIREFOX } from 'core/constants';
+import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
+import { getFakeConfig } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('getErrorComponent', () => {
@@ -19,6 +22,21 @@ describe(__filename, () => {
 
     it('returns a ServerError component by default', () => {
       expect(getErrorComponent(501)).toEqual(ServerError);
+    });
+  });
+
+  describe('getCurrentURL', () => {
+    it('returns the base URL of the site with clientApp and lang', () => {
+      const baseURL = 'http://example.org';
+      const clientApp = CLIENT_APP_FIREFOX;
+      const lang = 'fr';
+
+      const _config = getFakeConfig({ baseURL });
+      const { state } = dispatchClientMetadata({ clientApp, lang });
+
+      expect(getCurrentURL({ _config, state })).toEqual(
+        `${baseURL}/${lang}/${clientApp}/`,
+      );
     });
   });
 });

--- a/tests/unit/amo/test_utils.js
+++ b/tests/unit/amo/test_utils.js
@@ -26,7 +26,7 @@ describe(__filename, () => {
   });
 
   describe('getCurrentURL', () => {
-    it('returns the base URL of the site with clientApp and lang', () => {
+    it(`returns the current URL from the router's state`, () => {
       const baseURL = 'http://example.org';
       const clientApp = CLIENT_APP_FIREFOX;
       const lang = 'fr';

--- a/tests/unit/amo/test_utils.js
+++ b/tests/unit/amo/test_utils.js
@@ -1,7 +1,7 @@
 import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
-import { getCurrentURL, getErrorComponent } from 'amo/utils';
+import { getCanonicalURL, getErrorComponent } from 'amo/utils';
 import { CLIENT_APP_FIREFOX } from 'core/constants';
 import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import { getFakeConfig } from 'tests/unit/helpers';
@@ -25,17 +25,14 @@ describe(__filename, () => {
     });
   });
 
-  describe('getCurrentURL', () => {
-    it(`returns the current URL from the router's state`, () => {
-      const baseURL = 'http://example.org';
-      const clientApp = CLIENT_APP_FIREFOX;
-      const lang = 'fr';
-
+  describe('getCanonicalURL', () => {
+    it(`returns an absolute canonical URL`, () => {
+      const locationPathname = '/path/name';
+      const baseURL = 'https://example.org';
       const _config = getFakeConfig({ baseURL });
-      const { state } = dispatchClientMetadata({ clientApp, lang });
 
-      expect(getCurrentURL({ _config, state })).toEqual(
-        `${baseURL}/${lang}/${clientApp}/`,
+      expect(getCanonicalURL({ _config, locationPathname })).toEqual(
+        `${baseURL}/${locationPathname}/`,
       );
     });
   });

--- a/tests/unit/amo/test_utils.js
+++ b/tests/unit/amo/test_utils.js
@@ -2,8 +2,6 @@ import NotAuthorized from 'amo/components/ErrorPage/NotAuthorized';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import ServerError from 'amo/components/ErrorPage/ServerError';
 import { getCanonicalURL, getErrorComponent } from 'amo/utils';
-import { CLIENT_APP_FIREFOX } from 'core/constants';
-import { dispatchClientMetadata } from 'tests/unit/amo/helpers';
 import { getFakeConfig } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -32,7 +30,7 @@ describe(__filename, () => {
       const _config = getFakeConfig({ baseURL });
 
       expect(getCanonicalURL({ _config, locationPathname })).toEqual(
-        `${baseURL}/${locationPathname}/`,
+        `${baseURL}${locationPathname}`,
       );
     });
   });

--- a/tests/unit/core/components/TestServerHtml.js
+++ b/tests/unit/core/components/TestServerHtml.js
@@ -180,4 +180,10 @@ describe(__filename, () => {
     expect(root.find('noscript')).toHaveLength(1);
     expect(root.find('noscript').html()).toContain(noScriptStyles);
   });
+
+  it('renders link[rel="canonical"] inside helmet', () => {
+    const root = render();
+    // This is defined in the `FakeApp` component.
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+  });
 });

--- a/tests/unit/core/server/fakeApp.js
+++ b/tests/unit/core/server/fakeApp.js
@@ -35,6 +35,7 @@ export default class FakeApp extends React.Component {
       <div>
         <Helmet defaultTitle="test title">
           <meta name="description" content="test meta" />
+          <link rel="canonical" href="/" />
         </Helmet>
         {children}
       </div>


### PR DESCRIPTION
Fixes #5755

---

This PR adds canonical link tags to the following pages:

- [x] add-on detail pages
- [x] homepage
- [x] Landing Extensions
- [x] Landing Themes
- [x] Themes / category pages
- [x] About page (component converted to Flow)
- [x] Review guide (component converted to Flow)
- [x] Dictionaries and Lang Packs
- [x] Extensions / category pages

⚠️ in order to avoid hardcoded URLs, I read the router config (`pathname`) from the redux state. It ensures that our canonical URLs are in sync with the router config, but that's why test cases don't have the "production" values. It also avoids issues with trailing slashes (because we can trust the middleware and we don't have to think about them).