### PR TITLE
Use getFileHash in installAddon HOC

### DIFF
--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -29,7 +29,7 @@ type FirefoxAddon = {|
 
 export type MozAddonManagerType = {|
   addEventListener: (eventName: string, handler: Function) => void,
-  createInstall: ({| url: string |}) => Promise<any>,
+  createInstall: ({| url: string, hash?: string | null |}) => Promise<any>,
   getAddonByID: (guid: string) => Promise<FirefoxAddon>,
   permissionPromptsEnabled: boolean,
 |};
@@ -102,6 +102,7 @@ export function getAddon(
 type OptionalInstallParams = {|
   ...OptionalParams,
   src: string,
+  hash?: string | null,
 |};
 
 export function install(
@@ -110,6 +111,7 @@ export function install(
   {
     _mozAddonManager = window.navigator.mozAddonManager,
     src,
+    hash,
   }: OptionalInstallParams = {},
 ) {
   if (src === undefined) {
@@ -117,7 +119,7 @@ export function install(
   }
   const url = addQueryParams(_url, { src });
 
-  return _mozAddonManager.createInstall({ url }).then((installObj) => {
+  return _mozAddonManager.createInstall({ url, hash }).then((installObj) => {
     const callback = (e) => eventCallback(installObj, e);
     for (const event of INSTALL_EVENT_LIST) {
       log.info(`[install] Adding listener for ${event}`);

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -26,41 +26,12 @@ import tracking, {
   getAddonEventCategory,
 } from 'core/tracking';
 import { isTheme } from 'core/utils';
+import { getFileHash } from 'core/utils/addons';
 import { getClientCompatibility as _getClientCompatibility } from 'core/utils/compatibility';
 import Button from 'ui/components/Button';
 import Icon from 'ui/components/Icon';
 
 import './styles.scss';
-
-export const getFileHash = ({ addon, installURL } = {}) => {
-  if (!addon) {
-    throw new Error('The addon parameter cannot be empty');
-  }
-  if (!installURL) {
-    throw new Error('The installURL parameter cannot be empty');
-  }
-
-  const urlKey = installURL.split('?')[0];
-
-  // TODO: refactor createInternalAddon() to expose file objects
-  // per platform so we don't have to do this.
-  // https://github.com/mozilla/addons-frontend/issues/3871
-
-  if (addon.current_version) {
-    for (const file of addon.current_version.files) {
-      // The API sometimes appends ?src= to URLs so we just check the
-      // basename.
-      if (file.url.startsWith(urlKey)) {
-        return file.hash;
-      }
-    }
-  }
-
-  log.warn(oneLine`No file hash found for addon "${addon.slug}",
-    installURL "${installURL}" (as "${urlKey}")`);
-
-  return undefined;
-};
 
 export class InstallButtonBase extends React.Component {
   static propTypes = {

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -75,6 +75,7 @@ import {
 } from 'core/reducers/api';
 import { showInfoDialog } from 'core/reducers/infoDialog';
 import { getDisplayName } from 'core/utils';
+import { getFileHash } from 'core/utils/addons';
 import type { UserAgentInfoType } from 'core/reducers/api';
 import type { AddonType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
@@ -493,6 +494,8 @@ export class WithInstallHelpers extends React.Component<
       resolve(installURL);
     })
       .then((installURL) => {
+        const hash = installURL && getFileHash({ addon, installURL });
+
         return _addonManager.install(
           installURL,
           makeProgressHandler({
@@ -502,7 +505,7 @@ export class WithInstallHelpers extends React.Component<
             name,
             type,
           }),
-          { src: defaultInstallSource },
+          { src: defaultInstallSource, hash },
         );
       })
       .then(() => {

--- a/src/core/utils/addons.js
+++ b/src/core/utils/addons.js
@@ -1,4 +1,5 @@
 /* @flow */
+import { oneLine } from 'common-tags';
 import invariant from 'invariant';
 
 import {
@@ -8,6 +9,8 @@ import {
   FATAL_UNINSTALL_ERROR,
   INSTALL_FAILED,
 } from 'core/constants';
+import log from 'core/logger';
+import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 
 export const getErrorMessage = ({
@@ -34,4 +37,28 @@ export const getErrorMessage = ({
     default:
       return i18n.gettext('An unexpected error occurred.');
   }
+};
+
+export const getFileHash = ({
+  addon,
+  installURL,
+}: {|
+  addon: AddonType,
+  installURL: string,
+|}): string | void => {
+  const urlKey = installURL.split('?')[0];
+
+  if (addon.current_version) {
+    for (const file of addon.current_version.files) {
+      // The API sometimes appends ?src= to URLs so we just check the basename.
+      if (file.url.startsWith(urlKey)) {
+        return file.hash;
+      }
+    }
+  }
+
+  log.warn(oneLine`No file hash found for addon "${addon.slug}", installURL
+    "${installURL}" (as "${urlKey}")`);
+
+  return undefined;
 };

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -6,7 +6,6 @@ import { mount } from 'enzyme';
 
 import createStore from 'amo/store';
 import InstallButton, {
-  getFileHash,
   InstallButtonBase,
 } from 'core/components/InstallButton';
 import InstallSwitch from 'core/components/InstallSwitch';
@@ -21,8 +20,6 @@ import {
   INSTALL_ACTION,
   INSTALL_STARTED_ACTION,
   OS_ALL,
-  OS_MAC,
-  OS_WINDOWS,
   UNKNOWN,
 } from 'core/constants';
 import { getAddonIconUrl } from 'core/imageUtils';
@@ -554,110 +551,6 @@ describe(__filename, () => {
       action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
       category: getAddonEventCategory(ADDON_TYPE_EXTENSION, INSTALL_ACTION),
       label: addon.name,
-    });
-  });
-
-  describe('getFileHash', () => {
-    const _getFileHash = ({
-      addon = createInternalAddon(fakeAddon),
-      installURL = 'https://a.m.o/addons/file.xpi',
-    } = {}) => {
-      return getFileHash({ addon, installURL });
-    };
-
-    it('requires an addon parameter', () => {
-      expect(() => _getFileHash({ addon: null })).toThrow(
-        /addon parameter cannot be empty/,
-      );
-    });
-
-    it('requires an installURL parameter', () => {
-      expect(() => _getFileHash({ installURL: null })).toThrow(
-        /installURL parameter cannot be empty/,
-      );
-    });
-
-    it('finds a file hash matching the URL', () => {
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [
-            {
-              platform: OS_MAC,
-              url: 'https://first-url',
-              hash: 'hash-of-first-file',
-            },
-            {
-              platform: OS_WINDOWS,
-              url: 'https://second-url',
-              hash: 'hash-of-second-file',
-            },
-          ],
-        }),
-      );
-
-      expect(_getFileHash({ addon, installURL: 'https://second-url' })).toEqual(
-        'hash-of-second-file',
-      );
-    });
-
-    it('strips query string parameters from the URL', () => {
-      const url = 'https://a.m.o/addons/file.xpi';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [{ platform: OS_ALL, url, hash: 'hash-of-file' }],
-        }),
-      );
-
-      expect(
-        _getFileHash({
-          addon,
-          installURL: `${url}?src=some-install-source`,
-        }),
-      ).toEqual('hash-of-file');
-    });
-
-    it('handles addon file URLs with unrelated query strings', () => {
-      const url = 'https://a.m.o/addons/file.xpi';
-      const addon = createInternalAddon(
-        createFakeAddon({
-          files: [
-            {
-              platform: OS_ALL,
-              url: `${url}?src=some-install-source`,
-              hash: 'hash-of-file',
-            },
-          ],
-        }),
-      );
-
-      expect(
-        _getFileHash({
-          addon,
-          installURL: `${url}?src=some-install-source`,
-        }),
-      ).toEqual('hash-of-file');
-    });
-
-    it('does not find a file hash without a current version', () => {
-      const addon = createInternalAddon(
-        createFakeAddon({
-          current_version: undefined,
-        }),
-      );
-
-      expect(_getFileHash({ addon })).toBeUndefined();
-    });
-
-    it('does not find a file hash without files', () => {
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        current_version: {
-          ...fakeAddon.current_version,
-          files: [],
-        },
-      });
-
-      expect(_getFileHash({ addon })).toBeUndefined();
     });
   });
 });

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -138,6 +138,22 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
         url: `${fakeInstallUrl}?src=home`,
+        hash: undefined,
+      });
+    });
+
+    it('passes the hash to createInstall() if provided', async () => {
+      const hash = 'some-sha-hash';
+
+      await addonManager.install(fakeInstallUrl, fakeCallback, {
+        _mozAddonManager: fakeMozAddonManager,
+        src: 'home',
+        hash,
+      });
+
+      sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
+        url: `${fakeInstallUrl}?src=home`,
+        hash,
       });
     });
 
@@ -194,14 +210,15 @@ describe(__filename, () => {
       sinon.assert.calledWith(fakeCallback, fakeInstallObj, fakeEvent);
     });
 
-    it('requires a src', () =>
-      addonManager
+    it('requires a src', () => {
+      return addonManager
         .install(fakeInstallUrl, fakeCallback, {
           _mozAddonManager: fakeMozAddonManager,
         })
-        .then(unexpectedSuccess, (e) =>
-          expect(e.message).toEqual('No src for add-on install'),
-        ));
+        .then(unexpectedSuccess, (e) => {
+          expect(e.message).toEqual('No src for add-on install');
+        });
+    });
   });
 
   describe('uninstall()', () => {

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -1235,9 +1235,16 @@ describe(__filename, () => {
       const installURL = 'https://mysite.com/download.xpi';
 
       it('calls addonManager.install()', () => {
+        const hash = 'some-sha-hash';
         const addon = createInternalAddon(
           createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
+            files: [
+              {
+                platform: OS_ALL,
+                url: installURL,
+                hash,
+              },
+            ],
           }),
         );
         const fakeAddonManager = getFakeAddonManagerWrapper();
@@ -1253,7 +1260,36 @@ describe(__filename, () => {
             fakeAddonManager.install,
             `${installURL}?src=${defaultInstallSource}`,
             sinon.match.func,
-            { src: defaultInstallSource },
+            { src: defaultInstallSource, hash },
+          );
+        });
+      });
+
+      it('passes an undefined hash when installURL is not found', () => {
+        const addon = createInternalAddon(
+          createFakeAddon({
+            files: [
+              {
+                platform: OS_ANDROID,
+                url: installURL,
+              },
+            ],
+          }),
+        );
+        const fakeAddonManager = getFakeAddonManagerWrapper();
+        const { root } = renderWithInstallHelpers({
+          _addonManager: fakeAddonManager,
+          addon,
+          defaultInstallSource,
+        });
+        const { install } = root.instance().props;
+
+        return install(addon).then(() => {
+          sinon.assert.calledWith(
+            fakeAddonManager.install,
+            undefined,
+            sinon.match.func,
+            { src: defaultInstallSource, hash: undefined },
           );
         });
       });

--- a/tests/unit/core/utils/test_addons.js
+++ b/tests/unit/core/utils/test_addons.js
@@ -4,9 +4,14 @@ import {
   FATAL_INSTALL_ERROR,
   FATAL_UNINSTALL_ERROR,
   INSTALL_FAILED,
+  OS_ALL,
+  OS_MAC,
+  OS_WINDOWS,
 } from 'core/constants';
-import { getErrorMessage } from 'core/utils/addons';
+import { createInternalAddon } from 'core/reducers/addons';
+import { getErrorMessage, getFileHash } from 'core/utils/addons';
 import { fakeI18n } from 'tests/unit/helpers';
+import { createFakeAddon, fakeAddon } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
   describe('getErrorMessage', () => {
@@ -21,6 +26,98 @@ describe(__filename, () => {
       expect(getErrorMessage({ i18n: fakeI18n(), error })).toMatch(
         new RegExp(message),
       );
+    });
+  });
+
+  describe('getFileHash', () => {
+    const _getFileHash = ({
+      addon = createInternalAddon(fakeAddon),
+      installURL = 'https://a.m.o/addons/file.xpi',
+    } = {}) => {
+      return getFileHash({ addon, installURL });
+    };
+
+    it('finds a file hash matching the URL', () => {
+      const addon = createInternalAddon(
+        createFakeAddon({
+          files: [
+            {
+              platform: OS_MAC,
+              url: 'https://first-url',
+              hash: 'hash-of-first-file',
+            },
+            {
+              platform: OS_WINDOWS,
+              url: 'https://second-url',
+              hash: 'hash-of-second-file',
+            },
+          ],
+        }),
+      );
+
+      expect(_getFileHash({ addon, installURL: 'https://second-url' })).toEqual(
+        'hash-of-second-file',
+      );
+    });
+
+    it('strips query string parameters from the URL', () => {
+      const url = 'https://a.m.o/addons/file.xpi';
+      const addon = createInternalAddon(
+        createFakeAddon({
+          files: [{ platform: OS_ALL, url, hash: 'hash-of-file' }],
+        }),
+      );
+
+      expect(
+        _getFileHash({
+          addon,
+          installURL: `${url}?src=some-install-source`,
+        }),
+      ).toEqual('hash-of-file');
+    });
+
+    it('handles addon file URLs with unrelated query strings', () => {
+      const url = 'https://a.m.o/addons/file.xpi';
+      const addon = createInternalAddon(
+        createFakeAddon({
+          files: [
+            {
+              platform: OS_ALL,
+              url: `${url}?src=some-install-source`,
+              hash: 'hash-of-file',
+            },
+          ],
+        }),
+      );
+
+      expect(
+        _getFileHash({
+          addon,
+          installURL: `${url}?src=some-install-source`,
+        }),
+      ).toEqual('hash-of-file');
+    });
+
+    it('does not find a file hash without a current version', () => {
+      const addon = createInternalAddon(
+        createFakeAddon({
+          current_version: undefined,
+        }),
+      );
+
+      expect(_getFileHash({ addon })).toBeUndefined();
+    });
+
+    it('does not find a file hash without files', () => {
+      const addon = createInternalAddon({
+        ...fakeAddon,
+        current_version: {
+          ...fakeAddon.current_version,
+          files: [],
+        },
+      });
+
+      expect(_getFileHash({ addon })).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Fixes #1208 

---

I reused an existing function (moved to `core/utils/addons`), so the diff looks big but it is not. The main part is calling `getFileHash` in the `install()` method of the HOC.