### PR TITLE
Add admin and review links for add-on details page

### DIFF
--- a/src/amo/components/AddonAdminLinks/index.js
+++ b/src/amo/components/AddonAdminLinks/index.js
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import Link from 'amo/components/Link';
 import {
   ADDONS_CONTENTREVIEW,
   ADDONS_EDIT,
@@ -45,7 +44,7 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
       i18n,
     } = this.props;
 
-    if (!addon) {
+    if (addon === null) {
       return null;
     }
 
@@ -64,68 +63,75 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
 
     const editLink = hasEditPermission ? (
       <li>
-        <Link
+        <a
           className="AddonAdminLinks-edit-link"
           href={`/developers/addon/${addon.slug}/edit`}
         >
           {i18n.gettext('Edit add-on')}
-        </Link>
+        </a>
       </li>
     ) : null;
 
-    const adminLink = hasAdminPermission ? (
+    const adminStatusLink = hasAdminPermission ? (
       <li>
-        <Link
-          className="AddonAdminLinks-admin-link"
+        <a
+          className="AddonAdminLinks-admin-status-link"
           href={`/admin/addon/manage/${addon.slug}/`}
         >
-          {i18n.gettext('Admin add-on')}
-        </Link>
+          {i18n.gettext('Admin add-on status')}
+        </a>
       </li>
     ) : null;
+
+    const adminLink =
+      hasAdminPermission && hasEditPermission ? (
+        <li>
+          <a
+            className="AddonAdminLinks-admin-link"
+            href={`/admin/models/addons/addon/${addon.id}`}
+          >
+            {i18n.gettext('Admin add-on')}
+          </a>
+        </li>
+      ) : null;
 
     const contentReviewLink = hasContentReviewPermission ? (
       <li>
-        <Link
+        <a
           className="AddonAdminLinks-contentReview-link"
           href={`/reviewers/review-content/${addon.slug}`}
         >
           {i18n.gettext('Content review add-on')}
-        </Link>
+        </a>
       </li>
     ) : null;
 
-    const codeReviewLink = showCodeReviewLink ? (
-      <li>
-        <Link
-          className="AddonAdminLinks-codeReview-link"
-          href={`/reviewers/review/${addon.slug}`}
-        >
-          {i18n.gettext('Code review add-on')}
-        </Link>
-      </li>
-    ) : null;
-
-    const themeReviewLink = showThemeReviewLink ? (
-      <li>
-        <Link
-          className="AddonAdminLinks-themeReview-link"
-          href={`/reviewers/review/${addon.slug}`}
-        >
-          {i18n.gettext('Review theme')}
-        </Link>
-      </li>
-    ) : null;
+    const codeReviewLinkText = isTheme(addon.type)
+      ? i18n.gettext('Review theme')
+      : i18n.gettext('Code review add-on');
+    const codeReviewLink =
+      showCodeReviewLink || showThemeReviewLink ? (
+        <li>
+          <a
+            className={`AddonAdminLinks-${
+              isTheme(addon.type) ? 'themeReview' : 'codeReview'
+            }-link`}
+            href={`/reviewers/review/${addon.slug}`}
+          >
+            {codeReviewLinkText}
+          </a>
+        </li>
+      ) : null;
 
     return (
       <DefinitionList className="AddonAdminLinks">
         <Definition term={i18n.gettext('Admin Links')}>
           <ul className="AddonAdminLinks-list">
             {editLink}
+            {adminStatusLink}
             {adminLink}
             {contentReviewLink}
             {codeReviewLink}
-            {themeReviewLink}
           </ul>
         </Definition>
       </DefinitionList>

--- a/src/amo/components/AddonAdminLinks/index.js
+++ b/src/amo/components/AddonAdminLinks/index.js
@@ -1,0 +1,152 @@
+/* @flow */
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import Link from 'amo/components/Link';
+import {
+  ADDONS_CONTENTREVIEW,
+  ADDONS_EDIT,
+  ADDONS_POSTREVIEW,
+  ADMIN_TOOLS_VIEW,
+  THEMES_REVIEW,
+} from 'core/constants';
+import translate from 'core/i18n/translate';
+import { hasPermission } from 'amo/reducers/users';
+import type { AddonType } from 'core/types/addons';
+import { isTheme } from 'core/utils';
+import { Definition } from 'ui/components/DefinitionList';
+import type { I18nType } from 'core/types/i18n';
+import type { AppState } from 'amo/store';
+
+type Props = {|
+  addon: AddonType | null,
+|};
+
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
+  hasAdminPermission: boolean,
+  hasCodeReviewPermission: boolean,
+  hasContentReviewPermission: boolean,
+  hasEditPermission: boolean,
+  hasThemeReviewPermission: boolean,
+|};
+
+export class AddonAdminLinksBase extends React.Component<InternalProps> {
+  render() {
+    const {
+      addon,
+      hasAdminPermission,
+      hasCodeReviewPermission,
+      hasContentReviewPermission,
+      hasEditPermission,
+      hasThemeReviewPermission,
+      i18n,
+    } = this.props;
+
+    if (!addon) {
+      return null;
+    }
+
+    const showCodeReviewLink = hasCodeReviewPermission && !isTheme(addon.type);
+    const showThemeReviewLink = hasThemeReviewPermission && isTheme(addon.type);
+    const hasALink =
+      hasEditPermission ||
+      hasAdminPermission ||
+      hasContentReviewPermission ||
+      showCodeReviewLink ||
+      showThemeReviewLink;
+
+    if (!hasALink) {
+      return null;
+    }
+
+    const editLink = hasEditPermission ? (
+      <li>
+        <Link
+          className="AddonAdminLinks-edit-link"
+          href={`/developers/addon/${addon.slug}/edit`}
+        >
+          {i18n.gettext('Edit add-on')}
+        </Link>
+      </li>
+    ) : null;
+
+    const adminLink = hasAdminPermission ? (
+      <li>
+        <Link
+          className="AddonAdminLinks-admin-link"
+          href={`/admin/addon/manage/${addon.slug}/`}
+        >
+          {i18n.gettext('Admin add-on')}
+        </Link>
+      </li>
+    ) : null;
+
+    const contentReviewLink = hasContentReviewPermission ? (
+      <li>
+        <Link
+          className="AddonAdminLinks-contentReview-link"
+          href={`/reviewers/review-content/${addon.slug}`}
+        >
+          {i18n.gettext('Content review add-on')}
+        </Link>
+      </li>
+    ) : null;
+
+    const codeReviewLink = showCodeReviewLink ? (
+      <li>
+        <Link
+          className="AddonAdminLinks-codeReview-link"
+          href={`/reviewers/review/${addon.slug}`}
+        >
+          {i18n.gettext('Code review add-on')}
+        </Link>
+      </li>
+    ) : null;
+
+    const themeReviewLink = showThemeReviewLink ? (
+      <li>
+        <Link
+          className="AddonAdminLinks-themeReview-link"
+          href={`/reviewers/review/${addon.slug}`}
+        >
+          {i18n.gettext('Review theme')}
+        </Link>
+      </li>
+    ) : null;
+
+    return (
+      <Definition
+        className="AddonAdminLinks"
+        term={i18n.gettext('Admin Links')}
+      >
+        <ul className="AddonAdminLinks-list">
+          {editLink}
+          {adminLink}
+          {contentReviewLink}
+          {codeReviewLink}
+          {themeReviewLink}
+        </ul>
+      </Definition>
+    );
+  }
+}
+
+export const mapStateToProps = (state: AppState) => {
+  return {
+    hasAdminPermission: hasPermission(state, ADMIN_TOOLS_VIEW),
+    hasCodeReviewPermission: hasPermission(state, ADDONS_POSTREVIEW),
+    hasContentReviewPermission: hasPermission(state, ADDONS_CONTENTREVIEW),
+    hasEditPermission: hasPermission(state, ADDONS_EDIT),
+    hasThemeReviewPermission: hasPermission(state, THEMES_REVIEW),
+  };
+};
+
+const AddonAdminLinks: React.ComponentType<Props> = compose(
+  connect(mapStateToProps),
+  translate(),
+)(AddonAdminLinksBase);
+
+export default AddonAdminLinks;

--- a/src/amo/components/AddonAdminLinks/index.js
+++ b/src/amo/components/AddonAdminLinks/index.js
@@ -15,7 +15,7 @@ import translate from 'core/i18n/translate';
 import { hasPermission } from 'amo/reducers/users';
 import type { AddonType } from 'core/types/addons';
 import { isTheme } from 'core/utils';
-import { Definition } from 'ui/components/DefinitionList';
+import DefinitionList, { Definition } from 'ui/components/DefinitionList';
 import type { I18nType } from 'core/types/i18n';
 import type { AppState } from 'amo/store';
 
@@ -118,18 +118,17 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
     ) : null;
 
     return (
-      <Definition
-        className="AddonAdminLinks"
-        term={i18n.gettext('Admin Links')}
-      >
-        <ul className="AddonAdminLinks-list">
-          {editLink}
-          {adminLink}
-          {contentReviewLink}
-          {codeReviewLink}
-          {themeReviewLink}
-        </ul>
-      </Definition>
+      <DefinitionList className="AddonAdminLinks">
+        <Definition term={i18n.gettext('Admin Links')}>
+          <ul className="AddonAdminLinks-list">
+            {editLink}
+            {adminLink}
+            {contentReviewLink}
+            {codeReviewLink}
+            {themeReviewLink}
+          </ul>
+        </Definition>
+      </DefinitionList>
     );
   }
 }

--- a/src/amo/components/AddonAdminLinks/index.js
+++ b/src/amo/components/AddonAdminLinks/index.js
@@ -108,7 +108,7 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
 
     const codeReviewLinkText = isTheme(addon.type)
       ? i18n.gettext('Review theme')
-      : i18n.gettext('Code review add-on');
+      : i18n.gettext('Review add-on code');
     const codeReviewLink =
       showCodeReviewLink || showThemeReviewLink ? (
         <li>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -180,79 +180,81 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
   }: Object) {
     const { addon, i18n } = this.props;
     return (
-      <DefinitionList className="AddonMoreInfo-dl">
-        {(homepage || supportUrl || supportEmail) && (
-          <Definition
-            className="AddonMoreInfo-links"
-            term={i18n.gettext('Add-on Links')}
-          >
-            <ul className="AddonMoreInfo-links-contents-list">
-              {homepage}
-              {supportUrl}
-              {supportEmail}
-            </ul>
-          </Definition>
-        )}
-        {version && (
-          <Definition
-            className="AddonMoreInfo-version"
-            term={i18n.gettext('Version')}
-          >
-            {version}
-          </Definition>
-        )}
-        {versionLastUpdated && (
-          <Definition
-            className="AddonMoreInfo-last-updated"
-            term={i18n.gettext('Last updated')}
-          >
-            {versionLastUpdated}
-          </Definition>
-        )}
-        {versionLicenseLink && (
-          <Definition
-            className="AddonMoreInfo-license"
-            term={i18n.gettext('License')}
-          >
-            {versionLicenseLink}
-          </Definition>
-        )}
-        {privacyPolicyLink && (
-          <Definition
-            className="AddonMoreInfo-privacy-policy"
-            term={i18n.gettext('Privacy Policy')}
-          >
-            {privacyPolicyLink}
-          </Definition>
-        )}
-        {eulaLink && (
-          <Definition
-            className="AddonMoreInfo-eula"
-            term={i18n.gettext('End-User License Agreement')}
-          >
-            {eulaLink}
-          </Definition>
-        )}
-        {versionHistoryLink && (
-          <Definition
-            className="AddonMoreInfo-version-history"
-            term={i18n.gettext('Version History')}
-          >
-            <ul className="AddonMoreInfo-links-contents-list">
-              {versionHistoryLink}
-            </ul>
-          </Definition>
-        )}
-        {statsLink && (
-          <Definition
-            className="AddonMoreInfo-stats"
-            term={i18n.gettext('Usage Statistics')}
-          >
-            {statsLink}
-          </Definition>
-        )}
+      <React.Fragment>
+        <DefinitionList className="AddonMoreInfo-dl">
+          {(homepage || supportUrl || supportEmail) && (
+            <Definition
+              className="AddonMoreInfo-links"
+              term={i18n.gettext('Add-on Links')}
+            >
+              <ul className="AddonMoreInfo-links-contents-list">
+                {homepage}
+                {supportUrl}
+                {supportEmail}
+              </ul>
+            </Definition>
+          )}
+          {version && (
+            <Definition
+              className="AddonMoreInfo-version"
+              term={i18n.gettext('Version')}
+            >
+              {version}
+            </Definition>
+          )}
+          {versionLastUpdated && (
+            <Definition
+              className="AddonMoreInfo-last-updated"
+              term={i18n.gettext('Last updated')}
+            >
+              {versionLastUpdated}
+            </Definition>
+          )}
+          {versionLicenseLink && (
+            <Definition
+              className="AddonMoreInfo-license"
+              term={i18n.gettext('License')}
+            >
+              {versionLicenseLink}
+            </Definition>
+          )}
+          {privacyPolicyLink && (
+            <Definition
+              className="AddonMoreInfo-privacy-policy"
+              term={i18n.gettext('Privacy Policy')}
+            >
+              {privacyPolicyLink}
+            </Definition>
+          )}
+          {eulaLink && (
+            <Definition
+              className="AddonMoreInfo-eula"
+              term={i18n.gettext('End-User License Agreement')}
+            >
+              {eulaLink}
+            </Definition>
+          )}
+          {versionHistoryLink && (
+            <Definition
+              className="AddonMoreInfo-version-history"
+              term={i18n.gettext('Version History')}
+            >
+              <ul className="AddonMoreInfo-links-contents-list">
+                {versionHistoryLink}
+              </ul>
+            </Definition>
+          )}
+          {statsLink && (
+            <Definition
+              className="AddonMoreInfo-stats"
+              term={i18n.gettext('Usage Statistics')}
+            >
+              {statsLink}
+            </Definition>
+          )}
+        </DefinitionList>
         <AddonAdminLinks addon={addon} />
-      </DefinitionList>
+      </React.Fragment>
     );
   }
 

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -3,22 +3,15 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import AddonAdminLinks from 'amo/components/AddonAdminLinks';
 import Link from 'amo/components/Link';
-import {
-  ADDONS_CONTENTREVIEW,
-  ADDONS_EDIT,
-  ADDONS_POSTREVIEW,
-  ADMIN_TOOLS_VIEW,
-  STATS_VIEW,
-  THEMES_REVIEW,
-} from 'core/constants';
+import { STATS_VIEW } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { hasPermission } from 'amo/reducers/users';
 import type { AddonType } from 'core/types/addons';
 import {
   addonHasVersionHistory,
   isAddonAuthor,
-  isTheme,
   trimAndAddProtocolToUrl,
 } from 'core/utils';
 import Card from 'ui/components/Card';
@@ -35,27 +28,12 @@ type InternalProps = {|
   ...Props,
   i18n: I18nType,
   userId: number | null,
-  hasAdminPermission: boolean,
-  hasCodeReviewPermission: boolean,
-  hasContentReviewPermission: boolean,
-  hasEditPermission: boolean,
   hasStatsPermission: boolean,
-  hasThemeReviewPermission: boolean,
 |};
 
 export class AddonMoreInfoBase extends React.Component<InternalProps> {
   listContent() {
-    const {
-      addon,
-      hasAdminPermission,
-      hasCodeReviewPermission,
-      hasContentReviewPermission,
-      hasEditPermission,
-      hasStatsPermission,
-      hasThemeReviewPermission,
-      i18n,
-      userId,
-    } = this.props;
+    const { addon, i18n, userId, hasStatsPermission } = this.props;
 
     if (!addon) {
       return this.renderDefinitions({
@@ -118,63 +96,6 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       );
     }
 
-    const editLink = hasEditPermission ? (
-      <li>
-        <Link
-          className="AddonMoreInfo-edit-link"
-          href={`/developers/addon/${addon.slug}/edit`}
-        >
-          {i18n.gettext('Edit add-on')}
-        </Link>
-      </li>
-    ) : null;
-
-    const adminLink = hasAdminPermission ? (
-      <li>
-        <Link
-          className="AddonMoreInfo-admin-link"
-          href={`/admin/addon/manage/${addon.slug}/`}
-        >
-          {i18n.gettext('Admin add-on')}
-        </Link>
-      </li>
-    ) : null;
-
-    const contentReviewLink = hasContentReviewPermission ? (
-      <li>
-        <Link
-          className="AddonMoreInfo-contentReview-link"
-          href={`/reviewers/review-content/${addon.slug}`}
-        >
-          {i18n.gettext('Content review add-on')}
-        </Link>
-      </li>
-    ) : null;
-
-    const codeReviewLink =
-      hasCodeReviewPermission && !isTheme(addon.type) ? (
-        <li>
-          <Link
-            className="AddonMoreInfo-codeReview-link"
-            href={`/reviewers/review/${addon.slug}`}
-          >
-            {i18n.gettext('Code review add-on')}
-          </Link>
-        </li>
-      ) : null;
-
-    const themeReviewLink =
-      hasThemeReviewPermission && isTheme(addon.type) ? (
-        <li>
-          <Link
-            className="AddonMoreInfo-themeReview-link"
-            href={`/reviewers/review/${addon.slug}`}
-          >
-            {i18n.gettext('Review theme')}
-          </Link>
-        </li>
-      ) : null;
-
     const currentVersion = addon.current_version;
     const lastUpdated = addon.last_updated;
     const license = currentVersion && currentVersion.license;
@@ -196,45 +117,14 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
     }
 
     return this.renderDefinitions({
-      adminLink,
-      codeReviewLink,
-      contentReviewLink,
-      editLink,
-      eulaLink: addon.has_eula ? (
-        <Link
-          className="AddonMoreInfo-eula-link"
-          href={`/addon/${addon.slug}/eula/`}
-        >
-          {i18n.gettext('Read the license agreement for this add-on')}
-        </Link>
-      ) : null,
       homepage,
-      privacyPolicyLink: addon.has_privacy_policy ? (
-        <Link
-          className="AddonMoreInfo-privacy-policy-link"
-          href={`/addon/${addon.slug}/privacy/`}
-        >
-          {i18n.gettext('Read the privacy policy for this add-on')}
-        </Link>
-      ) : null,
-      statsLink,
       supportUrl,
       supportEmail,
-      themeReviewLink,
+      statsLink,
       version:
         currentVersion && addonHasVersionHistory(addon)
           ? currentVersion.version
           : null,
-      versionHistoryLink: addonHasVersionHistory(addon) ? (
-        <li>
-          <Link
-            className="AddonMoreInfo-version-history-link"
-            href={`/addon/${addon.slug}/versions/`}
-          >
-            {i18n.gettext('See all versions')}
-          </Link>
-        </li>
-      ) : null,
       versionLastUpdated: lastUpdated
         ? i18n.sprintf(
             // translators: This will output, in English:
@@ -247,27 +137,48 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
           )
         : null,
       versionLicenseLink,
+      privacyPolicyLink: addon.has_privacy_policy ? (
+        <Link
+          className="AddonMoreInfo-privacy-policy-link"
+          href={`/addon/${addon.slug}/privacy/`}
+        >
+          {i18n.gettext('Read the privacy policy for this add-on')}
+        </Link>
+      ) : null,
+      eulaLink: addon.has_eula ? (
+        <Link
+          className="AddonMoreInfo-eula-link"
+          href={`/addon/${addon.slug}/eula/`}
+        >
+          {i18n.gettext('Read the license agreement for this add-on')}
+        </Link>
+      ) : null,
+      versionHistoryLink: addonHasVersionHistory(addon) ? (
+        <li>
+          <Link
+            className="AddonMoreInfo-version-history-link"
+            href={`/addon/${addon.slug}/versions/`}
+          >
+            {i18n.gettext('See all versions')}
+          </Link>
+        </li>
+      ) : null,
     });
   }
 
   renderDefinitions({
-    adminLink,
-    codeReviewLink,
-    contentReviewLink,
-    editLink,
-    eulaLink = null,
     homepage = null,
-    privacyPolicyLink = null,
-    statsLink = null,
     supportUrl = null,
     supportEmail = null,
-    themeReviewLink,
+    statsLink = null,
+    privacyPolicyLink = null,
+    eulaLink = null,
     version = null,
-    versionHistoryLink = null,
     versionLastUpdated,
     versionLicenseLink = null,
+    versionHistoryLink = null,
   }: Object) {
-    const { i18n } = this.props;
+    const { addon, i18n } = this.props;
     return (
       <DefinitionList className="AddonMoreInfo-dl">
         {(homepage || supportUrl || supportEmail) && (
@@ -340,24 +251,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
             {statsLink}
           </Definition>
         )}
-        {(editLink ||
-          adminLink ||
-          contentReviewLink ||
-          codeReviewLink ||
-          themeReviewLink) && (
-          <Definition
-            className="AddonMoreInfo-admin-links"
-            term={i18n.gettext('Admin Links')}
-          >
-            <ul className="AddonMoreInfo-admin-links-contents-list">
-              {editLink}
-              {adminLink}
-              {contentReviewLink}
-              {codeReviewLink}
-              {themeReviewLink}
-            </ul>
-          </Definition>
-        )}
+        <AddonAdminLinks addon={addon} />
       </DefinitionList>
     );
   }
@@ -376,12 +270,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
 export const mapStateToProps = (state: AppState) => {
   return {
     userId: state.users.currentUserID,
-    hasAdminPermission: hasPermission(state, ADMIN_TOOLS_VIEW),
-    hasCodeReviewPermission: hasPermission(state, ADDONS_POSTREVIEW),
-    hasContentReviewPermission: hasPermission(state, ADDONS_CONTENTREVIEW),
-    hasEditPermission: hasPermission(state, ADDONS_EDIT),
     hasStatsPermission: hasPermission(state, STATS_VIEW),
-    hasThemeReviewPermission: hasPermission(state, THEMES_REVIEW),
   };
 };
 

--- a/tests/unit/amo/components/TestAddonAdminLinks.js
+++ b/tests/unit/amo/components/TestAddonAdminLinks.js
@@ -1,0 +1,134 @@
+import * as React from 'react';
+
+import AddonAdminLinks, {
+  AddonAdminLinksBase,
+} from 'amo/components/AddonAdminLinks';
+import {
+  ADDONS_CONTENTREVIEW,
+  ADDONS_EDIT,
+  ADDONS_POSTREVIEW,
+  ADMIN_TOOLS_VIEW,
+  THEMES_REVIEW,
+} from 'core/constants';
+import { createInternalAddon } from 'core/reducers/addons';
+import {
+  dispatchClientMetadata,
+  dispatchSignInActions,
+  fakeAddon,
+  fakeTheme,
+} from 'tests/unit/amo/helpers';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  const { store } = dispatchClientMetadata();
+  const slug = 'some-slug';
+
+  function render(props = {}) {
+    return shallowUntilTarget(
+      <AddonAdminLinks
+        addon={props.addon || createInternalAddon(fakeAddon)}
+        i18n={fakeI18n()}
+        store={store}
+        {...props}
+      />,
+      AddonAdminLinksBase,
+    );
+  }
+
+  const renderWithPermission = (permission) => {
+    return render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        slug,
+      }),
+      store: dispatchSignInActions({
+        userProps: { permissions: [permission] },
+      }).store,
+    });
+  };
+
+  it('returns nothing if the user does not have permission for any links', () => {
+    const root = render();
+
+    expect(root.find('.AddonAdminLinks')).toHaveLength(0);
+  });
+
+  it('returns nothing if the add-on is missing', () => {
+    const root = render({ addon: undefined });
+
+    expect(root.find('.AddonAdminLinks')).toHaveLength(0);
+  });
+
+  it('shows the Admin Links heading if the user has permission for a link', () => {
+    const root = renderWithPermission(ADDONS_EDIT);
+
+    expect(root.find('.AddonAdminLinks')).toHaveLength(1);
+  });
+
+  it('shows an edit add-on link if the user has permission', () => {
+    const root = renderWithPermission(ADDONS_EDIT);
+
+    expect(root.find('.AddonAdminLinks-edit-link')).toHaveProp(
+      'href',
+      `/developers/addon/${slug}/edit`,
+    );
+  });
+
+  it('shows an admin add-on link if the user has permission', () => {
+    const root = renderWithPermission(ADMIN_TOOLS_VIEW);
+
+    expect(root.find('.AddonAdminLinks-admin-link')).toHaveProp(
+      'href',
+      `/admin/addon/manage/${slug}/`,
+    );
+  });
+
+  it('shows a content review link if the user has permission', () => {
+    const root = renderWithPermission(ADDONS_CONTENTREVIEW);
+
+    expect(root.find('.AddonAdminLinks-contentReview-link')).toHaveProp(
+      'href',
+      `/reviewers/review-content/${slug}`,
+    );
+  });
+
+  it('shows a code review link for an extension if the user has permission', () => {
+    const root = renderWithPermission(ADDONS_POSTREVIEW);
+
+    expect(root.find('.AddonAdminLinks-codeReview-link')).toHaveProp(
+      'href',
+      `/reviewers/review/${slug}`,
+    );
+  });
+
+  it('shows a theme review link for a theme if the user has permission', () => {
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeTheme,
+        slug,
+      }),
+      store: dispatchSignInActions({
+        userProps: { permissions: [THEMES_REVIEW] },
+      }).store,
+    });
+
+    expect(root.find('.AddonAdminLinks-themeReview-link')).toHaveProp(
+      'href',
+      `/reviewers/review/${slug}`,
+    );
+  });
+
+  it('does not show a theme review link if the user has permission but the add-on is not a theme', () => {
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        slug,
+      }),
+      store: dispatchSignInActions({
+        userProps: { permissions: [THEMES_REVIEW] },
+      }).store,
+    });
+
+    expect(root.find('.AddonAdminLinks-themeReview-link')).toHaveLength(0);
+  });
+});

--- a/tests/unit/amo/components/TestAddonAdminLinks.js
+++ b/tests/unit/amo/components/TestAddonAdminLinks.js
@@ -157,6 +157,9 @@ describe(__filename, () => {
       'href',
       `/reviewers/review/${slug}`,
     );
+    expect(root.find('.AddonAdminLinks-codeReview-link').children()).toHaveText(
+      'Review add-on code',
+    );
   });
 
   it('does not show a code review link if the user does not have permission', () => {
@@ -179,6 +182,9 @@ describe(__filename, () => {
       'href',
       `/reviewers/review/${slug}`,
     );
+    expect(
+      root.find('.AddonAdminLinks-themeReview-link').children(),
+    ).toHaveText('Review theme');
   });
 
   it('does not show a theme review link if the user does not have permission', () => {

--- a/tests/unit/amo/components/TestAddonAdminLinks.js
+++ b/tests/unit/amo/components/TestAddonAdminLinks.js
@@ -39,20 +39,16 @@ describe(__filename, () => {
     );
   }
 
-  const renderWithPermissions = ({ addon, permissions }) => {
+  const renderWithPermissions = ({
+    addon = createInternalAddon({
+      ...fakeAddon,
+      slug,
+    }),
+    permissions,
+  }) => {
     const perms = Array.isArray(permissions) ? permissions : [permissions];
-    return render({
-      addon:
-        addon === undefined
-          ? createInternalAddon({
-              ...fakeAddon,
-              slug,
-            })
-          : addon,
-      store: dispatchSignInActions({
-        userProps: { permissions: perms },
-      }).store,
-    });
+    dispatchSignInActions({ store, userProps: { permissions: perms } });
+    return render({ addon });
   };
 
   it('returns nothing if the user does not have permission for any links', () => {
@@ -171,14 +167,12 @@ describe(__filename, () => {
   });
 
   it('shows a theme review link for a theme if the user has permission', () => {
-    const root = render({
+    const root = renderWithPermissions({
       addon: createInternalAddon({
         ...fakeTheme,
         slug,
       }),
-      store: dispatchSignInActions({
-        userProps: { permissions: [THEMES_REVIEW] },
-      }).store,
+      permissions: THEMES_REVIEW,
     });
 
     expect(root.find('.AddonAdminLinks-themeReview-link')).toHaveProp(
@@ -188,14 +182,12 @@ describe(__filename, () => {
   });
 
   it('does not show a theme review link if the user does not have permission', () => {
-    const root = render({
+    const root = renderWithPermissions({
       addon: createInternalAddon({
         ...fakeTheme,
         slug,
       }),
-      store: dispatchSignInActions({
-        userProps: { permissions: [ADDONS_EDIT] },
-      }).store,
+      permissions: ADDONS_EDIT,
     });
 
     expect(root.find('.AddonAdminLinks')).toHaveLength(1);
@@ -203,14 +195,12 @@ describe(__filename, () => {
   });
 
   it('does not show a theme review link if the user has permission but the add-on is not a theme', () => {
-    const root = render({
+    const root = renderWithPermissions({
       addon: createInternalAddon({
         ...fakeAddon,
         slug,
       }),
-      store: dispatchSignInActions({
-        userProps: { permissions: [ADDONS_EDIT, THEMES_REVIEW] },
-      }).store,
+      permissions: [ADDONS_EDIT, THEMES_REVIEW],
     });
 
     expect(root.find('.AddonAdminLinks')).toHaveLength(1);

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -7,7 +7,12 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
+  ADDONS_CONTENTREVIEW,
+  ADDONS_EDIT,
+  ADDONS_POSTREVIEW,
+  ADMIN_TOOLS_VIEW,
   STATS_VIEW,
+  THEMES_REVIEW,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -22,7 +27,7 @@ import LoadingText from 'ui/components/LoadingText';
 describe(__filename, () => {
   const { store } = dispatchClientMetadata();
 
-  function render(props) {
+  function render(props = {}) {
     return shallowUntilTarget(
       <AddonMoreInfo
         addon={props.addon || createInternalAddon(fakeAddon)}
@@ -465,5 +470,85 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find('.AddonMoreInfo-last-updated')).toHaveLength(0);
+  });
+
+  describe('Admin links', () => {
+    const slug = 'some-slug';
+    const renderWithPermission = (permission) => {
+      return render({
+        addon: createInternalAddon({
+          ...fakeAddon,
+          slug,
+        }),
+        store: dispatchSignInActions({
+          userProps: { permissions: [permission] },
+        }).store,
+      });
+    };
+
+    it('hides Admin Links heading if the user does not have permission for any links', () => {
+      const root = render();
+
+      expect(root.find('.AddonMoreInfo-admin-links')).toHaveLength(0);
+    });
+
+    it('shows the Admin Links heading if the user has permission for a link', () => {
+      const root = renderWithPermission(ADDONS_EDIT);
+
+      expect(root.find('.AddonMoreInfo-admin-links')).toHaveLength(1);
+    });
+
+    it('shows an edit add-on link if the user has permission', () => {
+      const root = renderWithPermission(ADDONS_EDIT);
+
+      expect(root.find('.AddonMoreInfo-edit-link')).toHaveProp(
+        'href',
+        `/developers/addon/${slug}/edit`,
+      );
+    });
+
+    it('shows an admin add-on link if the user has permission', () => {
+      const root = renderWithPermission(ADMIN_TOOLS_VIEW);
+
+      expect(root.find('.AddonMoreInfo-admin-link')).toHaveProp(
+        'href',
+        `/admin/addon/manage/${slug}/`,
+      );
+    });
+
+    it('shows a content review link if the user has permission', () => {
+      const root = renderWithPermission(ADDONS_CONTENTREVIEW);
+
+      expect(root.find('.AddonMoreInfo-contentReview-link')).toHaveProp(
+        'href',
+        `/reviewers/review-content/${slug}`,
+      );
+    });
+
+    it('shows a code review link if the user has permission', () => {
+      const root = renderWithPermission(ADDONS_POSTREVIEW);
+
+      expect(root.find('.AddonMoreInfo-codeReview-link')).toHaveProp(
+        'href',
+        `/reviewers/review/${slug}`,
+      );
+    });
+
+    it('shows a theme review link if the user has permission', () => {
+      const root = render({
+        addon: createInternalAddon({
+          ...fakeTheme,
+          slug,
+        }),
+        store: dispatchSignInActions({
+          userProps: { permissions: [THEMES_REVIEW] },
+        }).store,
+      });
+
+      expect(root.find('.AddonMoreInfo-themeReview-link')).toHaveProp(
+        'href',
+        `/reviewers/review/${slug}`,
+      );
+    });
   });
 });

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import AddonAdminLinks from 'amo/components/AddonAdminLinks';
 import AddonMoreInfo, { AddonMoreInfoBase } from 'amo/components/AddonMoreInfo';
 import Link from 'amo/components/Link';
 import {
@@ -7,12 +8,7 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_LANG,
   ADDON_TYPE_OPENSEARCH,
-  ADDONS_CONTENTREVIEW,
-  ADDONS_EDIT,
-  ADDONS_POSTREVIEW,
-  ADMIN_TOOLS_VIEW,
   STATS_VIEW,
-  THEMES_REVIEW,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -27,7 +23,7 @@ import LoadingText from 'ui/components/LoadingText';
 describe(__filename, () => {
   const { store } = dispatchClientMetadata();
 
-  function render(props = {}) {
+  function render(props) {
     return shallowUntilTarget(
       <AddonMoreInfo
         addon={props.addon || createInternalAddon(fakeAddon)}
@@ -472,83 +468,10 @@ describe(__filename, () => {
     expect(root.find('.AddonMoreInfo-last-updated')).toHaveLength(0);
   });
 
-  describe('Admin links', () => {
-    const slug = 'some-slug';
-    const renderWithPermission = (permission) => {
-      return render({
-        addon: createInternalAddon({
-          ...fakeAddon,
-          slug,
-        }),
-        store: dispatchSignInActions({
-          userProps: { permissions: [permission] },
-        }).store,
-      });
-    };
+  it('renders admin links', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const root = render({ addon });
 
-    it('hides Admin Links heading if the user does not have permission for any links', () => {
-      const root = render();
-
-      expect(root.find('.AddonMoreInfo-admin-links')).toHaveLength(0);
-    });
-
-    it('shows the Admin Links heading if the user has permission for a link', () => {
-      const root = renderWithPermission(ADDONS_EDIT);
-
-      expect(root.find('.AddonMoreInfo-admin-links')).toHaveLength(1);
-    });
-
-    it('shows an edit add-on link if the user has permission', () => {
-      const root = renderWithPermission(ADDONS_EDIT);
-
-      expect(root.find('.AddonMoreInfo-edit-link')).toHaveProp(
-        'href',
-        `/developers/addon/${slug}/edit`,
-      );
-    });
-
-    it('shows an admin add-on link if the user has permission', () => {
-      const root = renderWithPermission(ADMIN_TOOLS_VIEW);
-
-      expect(root.find('.AddonMoreInfo-admin-link')).toHaveProp(
-        'href',
-        `/admin/addon/manage/${slug}/`,
-      );
-    });
-
-    it('shows a content review link if the user has permission', () => {
-      const root = renderWithPermission(ADDONS_CONTENTREVIEW);
-
-      expect(root.find('.AddonMoreInfo-contentReview-link')).toHaveProp(
-        'href',
-        `/reviewers/review-content/${slug}`,
-      );
-    });
-
-    it('shows a code review link if the user has permission', () => {
-      const root = renderWithPermission(ADDONS_POSTREVIEW);
-
-      expect(root.find('.AddonMoreInfo-codeReview-link')).toHaveProp(
-        'href',
-        `/reviewers/review/${slug}`,
-      );
-    });
-
-    it('shows a theme review link if the user has permission', () => {
-      const root = render({
-        addon: createInternalAddon({
-          ...fakeTheme,
-          slug,
-        }),
-        store: dispatchSignInActions({
-          userProps: { permissions: [THEMES_REVIEW] },
-        }).store,
-      });
-
-      expect(root.find('.AddonMoreInfo-themeReview-link')).toHaveProp(
-        'href',
-        `/reviewers/review/${slug}`,
-      );
-    });
+    expect(root.find(AddonAdminLinks)).toHaveProp('addon', addon);
   });
 });


### PR DESCRIPTION
Fixes #4632 

Here's an example for an extension for a user with all of the permissions:

![screenshot 2018-10-01 11 11 12](https://user-images.githubusercontent.com/142755/46297475-c0ffe080-c56a-11e8-9c77-dd1e9960fa0b.png)
