### PR TITLE
Add description meta tag on add-on detail pages

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -398,6 +398,24 @@ export class AddonBase extends React.Component {
     );
   }
 
+  getMetaDescription() {
+    const { addon, i18n } = this.props;
+
+    if (!addon) {
+      return null;
+    }
+
+    const content = i18n.sprintf(
+      i18n.gettext('Download %(addonName)s for Firefox. %(summary)s'),
+      {
+        addonName: addon.name,
+        summary: addon.summary,
+      },
+    );
+
+    return <meta name="description" content={content} />;
+  }
+
   render() {
     const {
       addon,
@@ -517,6 +535,7 @@ export class AddonBase extends React.Component {
         {addon && (
           <Helmet>
             <title>{addon.name}</title>
+            {this.getMetaDescription()}
           </Helmet>
         )}
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1784,4 +1784,16 @@ describe(__filename, () => {
       getErrorMessage({ i18n: fakeI18n(), error }),
     );
   });
+
+  it('renders a description meta tag containing the add-on summary', () => {
+    const addon = createInternalAddon(fakeAddon);
+
+    const root = shallowRender({ addon });
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]')).toHaveProp(
+      'content',
+      `Download ${addon.name} for Firefox. ${addon.summary}`,
+    );
+  });
 });


### PR DESCRIPTION
Fixes #5766 

---

I did not provide a fallback in case the summary is not available since the content should be truncated if we use the full description (and that might lead to a weird content).

Because the name of the add-on is part of the content, there is no risk of similar content if we don't have a summary (content will still be unique).