### PR TITLE
Fix import errors when running tox with Python 2

### DIFF
--- a/tests/ui/requirements/requirements.txt
+++ b/tests/ui/requirements/requirements.txt
@@ -8,6 +8,7 @@ FoxPuppet==1.0.1
 funcsigs==1.0.2
 idna==2.7
 more-itertools==4.3.0
+pathlib2==2.3.2
 pluggy==0.7.1
 py==1.6.0
 PyPOM==2.1.0
@@ -23,6 +24,7 @@ pytest-variables==1.7.1
 pytest-xdist==1.23.2
 atomicwrites==1.2.0
 requests==2.19.1
+scandir==1.9.0
 selenium==3.14.1
 six==1.11.0
 urllib3==1.22


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6503 by supporting Python 2 in addition to Python 3. For some reason, my tox is still linked to Python 2 even though I have Python 3 installed.