### PR TITLE
API/reducer/saga code for versions

### DIFF
--- a/src/amo/api/versions.js
+++ b/src/amo/api/versions.js
@@ -8,7 +8,7 @@ import type { ExternalAddonVersionType } from 'core/types/addons';
 
 export type GetVersionsParams = {|
   api: ApiState,
-  page?: number,
+  page?: string,
   slug: string,
 |};
 

--- a/src/amo/api/versions.js
+++ b/src/amo/api/versions.js
@@ -1,0 +1,30 @@
+/* @flow */
+import invariant from 'invariant';
+
+import { callApi } from 'core/api';
+import type { ApiState } from 'core/reducers/api';
+import type { PaginatedApiResponse } from 'core/types/api';
+import type { ExternalAddonVersionType } from 'core/types/addons';
+
+export type GetVersionsParams = {|
+  api: ApiState,
+  page?: number,
+  slug: string,
+|};
+
+export const getVersions = ({
+  api,
+  slug,
+  ...params
+}: GetVersionsParams = {}): Promise<
+  PaginatedApiResponse<ExternalAddonVersionType>,
+> => {
+  invariant(slug, 'slug is required');
+
+  return callApi({
+    apiState: api,
+    auth: true,
+    endpoint: `addons/addon/${slug}/versions/`,
+    params,
+  });
+};

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -46,7 +46,7 @@ import type {
 } from 'amo/api/reviews';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ApiState } from 'core/reducers/api';
-import type { AddonType, AddonVersionType } from 'core/types/addons';
+import type { AddonType, ExternalAddonVersionType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
@@ -64,7 +64,7 @@ type SubmitReviewFunc = (SubmitReviewParams) => Promise<void>;
 type Props = {|
   addon: AddonType,
   onReviewSubmitted?: () => void,
-  version: AddonVersionType,
+  version: ExternalAddonVersionType,
 |};
 
 type DispatchMappedProps = {|

--- a/src/amo/reducers/versions.js
+++ b/src/amo/reducers/versions.js
@@ -51,7 +51,7 @@ export const initialState: VersionsState = {
 
 type FetchVersionsParams = {|
   errorHandlerId: string,
-  page?: number,
+  page?: string,
   slug: string,
 |};
 
@@ -62,9 +62,9 @@ export type FetchVersionsAction = {|
 
 export const fetchVersions = ({
   errorHandlerId,
-  page = 1,
+  page = '1',
   slug,
-}: FetchVersionsParams = {}): FetchVersionsAction => {
+}: FetchVersionsParams): FetchVersionsAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(slug, 'slug is required');
 
@@ -97,7 +97,7 @@ export const loadVersions = ({
   };
 };
 
-type GetVersionsBySlugParams = {|
+type GetBySlugParams = {|
   slug: string,
   state: VersionsState,
 |};
@@ -105,7 +105,7 @@ type GetVersionsBySlugParams = {|
 export const getVersionsBySlug = ({
   slug,
   state,
-}: GetVersionsBySlugParams): Array<AddonVersionType> | null => {
+}: GetBySlugParams): Array<AddonVersionType> | null => {
   invariant(slug, 'slug is required');
   invariant(state, 'state is required');
 
@@ -113,15 +113,7 @@ export const getVersionsBySlug = ({
   return (infoForSlug && infoForSlug.versions) || null;
 };
 
-type GetLoadingBySlugParams = {|
-  slug: string,
-  state: VersionsState,
-|};
-
-export const getLoadingBySlug = ({
-  slug,
-  state,
-}: GetLoadingBySlugParams): boolean => {
+export const getLoadingBySlug = ({ slug, state }: GetBySlugParams): boolean => {
   invariant(slug, 'slug is required');
   invariant(state, 'state is required');
 

--- a/src/amo/reducers/versions.js
+++ b/src/amo/reducers/versions.js
@@ -1,0 +1,173 @@
+/* @flow */
+import invariant from 'invariant';
+
+import type {
+  AddonCompatibilityType,
+  AddonFileType,
+  ExternalAddonVersionType,
+} from 'core/types/addons';
+
+export const FETCH_VERSIONS: 'FETCH_VERSIONS' = 'FETCH_VERSIONS';
+export const LOAD_VERSIONS: 'LOAD_VERSIONS' = 'LOAD_VERSIONS';
+
+export type AddonVersionType = {
+  compatibility?: AddonCompatibilityType,
+  created: string,
+  files: Array<AddonFileType>,
+  filesize: number,
+  id: number,
+  license: { name: string, url: string },
+  releaseNotes?: string,
+  version: string,
+};
+
+export const createInternalVersion = (
+  version: ExternalAddonVersionType,
+): AddonVersionType => {
+  // TODO: We should find the correct file, for now we'll just take the first one.
+  // Note that multiple files per version is going away, but not quite yet.
+  const file = version.files[0];
+  return {
+    compatibility: version.compatibility,
+    created: file.created,
+    files: version.files,
+    filesize: file.size,
+    id: version.id,
+    license: { name: version.license.name, url: version.license.url },
+    releaseNotes: version.release_notes,
+    version: version.version,
+  };
+};
+
+export type VersionsState = {
+  bySlug: {
+    [slug: string]: { versions: Array<AddonVersionType>, loading: boolean },
+  },
+};
+
+export const initialState: VersionsState = {
+  bySlug: {},
+};
+
+type FetchVersionsParams = {|
+  errorHandlerId: string,
+  page?: number,
+  slug: string,
+|};
+
+export type FetchVersionsAction = {|
+  type: typeof FETCH_VERSIONS,
+  payload: FetchVersionsParams,
+|};
+
+export const fetchVersions = ({
+  errorHandlerId,
+  page = 1,
+  slug,
+}: FetchVersionsParams = {}): FetchVersionsAction => {
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(slug, 'slug is required');
+
+  return {
+    type: FETCH_VERSIONS,
+    payload: { errorHandlerId, page, slug },
+  };
+};
+
+type LoadVersionsParams = {|
+  slug: string,
+  versions: Array<ExternalAddonVersionType>,
+|};
+
+type LoadVersionsAction = {|
+  type: typeof LOAD_VERSIONS,
+  payload: LoadVersionsParams,
+|};
+
+export const loadVersions = ({
+  slug,
+  versions,
+}: LoadVersionsParams = {}): LoadVersionsAction => {
+  invariant(slug, 'slug is required');
+  invariant(versions, 'versions is required');
+
+  return {
+    type: LOAD_VERSIONS,
+    payload: { slug, versions },
+  };
+};
+
+type GetVersionsBySlugParams = {|
+  slug: string,
+  state: VersionsState,
+|};
+
+export const getVersionsBySlug = ({
+  slug,
+  state,
+}: GetVersionsBySlugParams): Array<AddonVersionType> | null => {
+  invariant(slug, 'slug is required');
+  invariant(state, 'state is required');
+
+  const infoForSlug = state.bySlug[slug];
+  return (infoForSlug && infoForSlug.versions) || null;
+};
+
+type GetLoadingBySlugParams = {|
+  slug: string,
+  state: VersionsState,
+|};
+
+export const getLoadingBySlug = ({
+  slug,
+  state,
+}: GetLoadingBySlugParams): boolean => {
+  invariant(slug, 'slug is required');
+  invariant(state, 'state is required');
+
+  const infoForSlug = state.bySlug[slug];
+  return Boolean(infoForSlug && infoForSlug.loading);
+};
+
+type Action = FetchVersionsAction | LoadVersionsAction;
+
+const reducer = (
+  state: VersionsState = initialState,
+  action: Action,
+): VersionsState => {
+  switch (action.type) {
+    case FETCH_VERSIONS: {
+      const { slug } = action.payload;
+      return {
+        ...state,
+        bySlug: {
+          ...state.bySlug,
+          [slug]: {
+            versions: null,
+            loading: true,
+          },
+        },
+      };
+    }
+
+    case LOAD_VERSIONS: {
+      const { slug, versions } = action.payload;
+
+      return {
+        ...state,
+        bySlug: {
+          ...state.bySlug,
+          [slug]: {
+            versions: versions.map(createInternalVersion),
+            loading: false,
+          },
+        },
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/amo/sagas/index.js
+++ b/src/amo/sagas/index.js
@@ -18,6 +18,7 @@ import autocomplete from 'core/sagas/autocomplete';
 import languageTools from 'core/sagas/languageTools';
 import userAbuseReports from 'amo/sagas/userAbuseReports';
 import users from 'amo/sagas/users';
+import versions from 'amo/sagas/versions';
 
 // Export all sagas for this app so runSaga can consume them.
 export default function* rootSaga() {
@@ -36,5 +37,6 @@ export default function* rootSaga() {
     fork(search),
     fork(userAbuseReports),
     fork(users),
+    fork(versions),
   ]);
 }

--- a/src/amo/sagas/versions.js
+++ b/src/amo/sagas/versions.js
@@ -1,0 +1,36 @@
+/* @flow */
+import { call, put, select, takeLatest } from 'redux-saga/effects';
+import { getVersions } from 'amo/api/versions';
+import { FETCH_VERSIONS, loadVersions } from 'amo/reducers/versions';
+import log from 'core/logger';
+import { createErrorHandler, getState } from 'core/sagas/utils';
+import type { GetVersionsParams } from 'amo/api/versions';
+import type { FetchVersionsAction } from 'amo/reducers/versions';
+
+export function* fetchVersions({
+  payload: { errorHandlerId, page, slug },
+}: FetchVersionsAction): Generator<any, any, any> {
+  const errorHandler = createErrorHandler(errorHandlerId);
+
+  yield put(errorHandler.createClearingAction());
+
+  try {
+    const state = yield select(getState);
+
+    const params: GetVersionsParams = {
+      api: state.api,
+      page,
+      slug,
+    };
+    const versions = yield call(getVersions, params);
+
+    yield put(loadVersions({ slug, versions }));
+  } catch (error) {
+    log.warn(`Failed to fetch versions: ${error}`);
+    yield put(errorHandler.createErrorAction(error));
+  }
+}
+
+export default function* collectionsSaga(): Generator<any, any, any> {
+  yield takeLatest(FETCH_VERSIONS, fetchVersions);
+}

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -14,7 +14,7 @@ type AddonStatus =
   | 'lite-nominated'
   | 'review-pending';
 
-type AddonFileType = {|
+export type AddonFileType = {|
   created: string,
   hash: string,
   id: number,
@@ -23,18 +23,21 @@ type AddonFileType = {|
   is_webextension: boolean,
   permissions?: Array<string>,
   platform: 'all' | 'android' | 'mac' | 'linux' | 'windows',
+  size: number,
   status: AddonStatus,
   url: string,
 |};
 
-type PartialAddonVersionType = {|
+export type AddonCompatibilityType = {|
+  [appName: string]: {|
+    min: string,
+    max: string,
+  |},
+|};
+
+type PartialExternalAddonVersionType = {|
   channel: string,
-  compatibility?: {
-    [appName: string]: {|
-      min: string,
-      max: string,
-    |},
-  },
+  compatibility?: AddonCompatibilityType,
   edit_url: string,
   files: Array<AddonFileType>,
   id: number,
@@ -46,8 +49,8 @@ type PartialAddonVersionType = {|
   version: string,
 |};
 
-export type AddonVersionType = {|
-  ...PartialAddonVersionType,
+export type ExternalAddonVersionType = {|
+  ...PartialExternalAddonVersionType,
   // The `text` property is omitted from addon.current_version.license.
   license: { name: string, url: string },
   release_notes?: string,
@@ -66,7 +69,7 @@ export type AddonAuthorType = {|
 |};
 
 export type LanguageToolType = {|
-  current_version: AddonVersionType,
+  current_version: ExternalAddonVersionType,
   default_locale: string,
   guid: string,
   id: number,
@@ -112,7 +115,7 @@ export type ExternalAddonType = {|
   contributions_url?: string,
   // If you make an API request as an admin for an incomplete
   // add-on (status=0) then the current_version could be null.
-  current_version?: AddonVersionType,
+  current_version?: ExternalAddonVersionType,
   default_locale: string,
   description?: string,
   edit_url?: string,
@@ -127,7 +130,7 @@ export type ExternalAddonType = {|
   is_featured?: boolean,
   is_source_public?: boolean,
   last_updated: Date | null,
-  latest_unlisted_version?: ?AddonVersionType,
+  latest_unlisted_version?: ?ExternalAddonVersionType,
   locale_disambiguation?: string,
   name: string,
   previews?: Array<Object>,
@@ -188,5 +191,5 @@ export type CollectionAddonType = {|
 export type SearchResultAddonType = {|
   ...AddonType,
   authors?: Array<PartialAddonAuthorType>,
-  current_version?: PartialAddonVersionType,
+  current_version?: PartialExternalAddonVersionType,
 |};

--- a/tests/unit/amo/api/test_versions.js
+++ b/tests/unit/amo/api/test_versions.js
@@ -10,7 +10,7 @@ describe(__filename, () => {
       const mockApi = sinon.mock(api);
       const slug = 'some-slug';
       const params = {
-        page: 123,
+        page: '123',
       };
 
       mockApi

--- a/tests/unit/amo/api/test_versions.js
+++ b/tests/unit/amo/api/test_versions.js
@@ -1,0 +1,31 @@
+import { getVersions } from 'amo/api/versions';
+import * as api from 'core/api';
+import { createApiResponse } from 'tests/unit/helpers';
+import { dispatchSignInActions } from 'tests/unit/amo/helpers';
+
+describe(__filename, () => {
+  describe('getVersions', () => {
+    it('calls the version list API', async () => {
+      const apiState = dispatchSignInActions().state.api;
+      const mockApi = sinon.mock(api);
+      const slug = 'some-slug';
+      const params = {
+        page: 123,
+      };
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          apiState,
+          auth: true,
+          endpoint: `addons/addon/${slug}/versions/`,
+          params,
+        })
+        .once()
+        .resolves(createApiResponse());
+
+      await getVersions({ api: apiState, slug, ...params });
+      mockApi.verify();
+    });
+  });
+});

--- a/tests/unit/amo/helpers.js
+++ b/tests/unit/amo/helpers.js
@@ -49,6 +49,7 @@ export const fakePlatformFile = Object.freeze({
   is_webextension: true,
   permissions: ['activeTab', 'webRequest'],
   platform: OS_ALL,
+  size: 123,
   status: 'public',
   url: 'https://a.m.o/files/321/addon.xpi',
 });
@@ -61,27 +62,33 @@ export const fakeAuthor = Object.freeze({
   username: 'krupa',
 });
 
+export const fakeVersion = Object.freeze({
+  channel: 'listed',
+  compatibility: {
+    [CLIENT_APP_ANDROID]: {
+      min: '48.0',
+      max: '*',
+    },
+    [CLIENT_APP_FIREFOX]: {
+      min: '48.0',
+      max: '*',
+    },
+  },
+  edit_url: 'https://addons.m.o/addon/chill-out/edit',
+  files: [fakePlatformFile],
+  id: 123,
+  is_strict_compatibility_enabled: false,
+  license: { name: 'tofulicense', url: 'http://license.com/' },
+  release_notes: 'Some release notes',
+  reviewed: '2014-11-22T10:09:01Z',
+  version: '2.0.0',
+});
+
 export const fakeAddon = Object.freeze({
   authors: [fakeAuthor],
   average_daily_users: 100,
   categories: { firefox: ['other'] },
-  current_version: {
-    compatibility: {
-      [CLIENT_APP_ANDROID]: {
-        min: '48.0',
-        max: '*',
-      },
-      [CLIENT_APP_FIREFOX]: {
-        min: '48.0',
-        max: '*',
-      },
-    },
-    id: 123,
-    license: { name: 'tofulicense', url: 'http://license.com/' },
-    version: '2.0.0',
-    files: [fakePlatformFile],
-    is_strict_compatibility_enabled: false,
-  },
+  current_version: fakeVersion,
   description: 'This is a longer description of the chill out add-on',
   default_locale: 'en-US',
   edit_url: 'https://addons.m.o/addon/chill-out/edit',

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1317,7 +1317,7 @@ describe(__filename, () => {
     }
 
     it('is hidden when an add-on has not loaded yet', () => {
-      const root = shallowRender({ addon: undefined });
+      const root = shallowRender({ addon: null });
       expect(root.find('.AddonDescription-version-notes div')).toHaveLength(0);
     });
 

--- a/tests/unit/amo/reducers/test_versions.js
+++ b/tests/unit/amo/reducers/test_versions.js
@@ -62,14 +62,14 @@ describe(__filename, () => {
   });
 
   describe(getLoadingBySlug, () => {
-    it('retuns false if versions have never been loaded', () => {
+    it('returns false if versions have never been loaded', () => {
       const state = versionsReducer(undefined, { type: 'SOME_OTHER_ACTION' });
       expect(getLoadingBySlug({ slug: 'some-slug', state })).toBe(false);
     });
   });
 
   describe(getVersionsBySlug, () => {
-    it('retuns null if no versions have been loaded', () => {
+    it('returns null if no versions have been loaded', () => {
       const state = versionsReducer(undefined, { type: 'SOME_OTHER_ACTION' });
       expect(getVersionsBySlug({ slug: 'some-slug', state })).toBe(null);
     });

--- a/tests/unit/amo/reducers/test_versions.js
+++ b/tests/unit/amo/reducers/test_versions.js
@@ -1,0 +1,77 @@
+import versionsReducer, {
+  createInternalVersion,
+  fetchVersions,
+  getLoadingBySlug,
+  getVersionsBySlug,
+  initialState,
+  loadVersions,
+} from 'amo/reducers/versions';
+import { fakeVersion } from 'tests/unit/amo/helpers';
+
+describe(__filename, () => {
+  it('defaults to its initial state', () => {
+    expect(versionsReducer(undefined, { type: 'SOME_OTHER_ACTION' })).toEqual(
+      initialState,
+    );
+  });
+
+  it('sets a loading flag when fetching versions', () => {
+    const slug = 'some-slug';
+    const state = versionsReducer(
+      undefined,
+      fetchVersions({ errorHandlerId: 1, slug }),
+    );
+
+    expect(getLoadingBySlug({ state, slug })).toBe(true);
+  });
+
+  it('clears versions when fetching versions', () => {
+    const slug = 'some-slug';
+    const state = versionsReducer(
+      undefined,
+      fetchVersions({ errorHandlerId: 1, slug }),
+    );
+
+    expect(getVersionsBySlug({ slug, state })).toBe(null);
+  });
+
+  it('clears the loading flag when loading versions', () => {
+    let state;
+    const slug = 'some-slug';
+    state = versionsReducer(
+      undefined,
+      fetchVersions({ errorHandlerId: 1, slug }),
+    );
+    state = versionsReducer(
+      state,
+      loadVersions({ slug, versions: [fakeVersion] }),
+    );
+
+    expect(getLoadingBySlug({ slug, state })).toBe(false);
+  });
+
+  it('loads versions', () => {
+    const slug = 'some-slug';
+    const versions = [fakeVersion, fakeVersion];
+    const state = versionsReducer(undefined, loadVersions({ slug, versions }));
+
+    expect(getVersionsBySlug({ slug, state })).toEqual([
+      createInternalVersion(versions[0]),
+      createInternalVersion(versions[1]),
+    ]);
+  });
+
+  describe(getLoadingBySlug, () => {
+    it('retuns false if versions have never been loaded', () => {
+      const state = versionsReducer(undefined, { type: 'SOME_OTHER_ACTION' });
+      expect(getLoadingBySlug({ slug: 'some-slug', state })).toBe(false);
+    });
+  });
+
+  describe(getVersionsBySlug, () => {
+    it('retuns null if no versions have been loaded', () => {
+      const state = versionsReducer(undefined, { type: 'SOME_OTHER_ACTION' });
+      expect(getVersionsBySlug({ slug: 'some-slug', state })).toBe(null);
+    });
+  });
+});

--- a/tests/unit/amo/sagas/test_versions.js
+++ b/tests/unit/amo/sagas/test_versions.js
@@ -11,7 +11,7 @@ import { createStubErrorHandler } from 'tests/unit/helpers';
 import { dispatchClientMetadata, fakeVersion } from 'tests/unit/amo/helpers';
 
 describe(__filename, () => {
-  const page = 2;
+  const page = '2';
   const slug = 'some-slug';
 
   let clientData;

--- a/tests/unit/amo/sagas/test_versions.js
+++ b/tests/unit/amo/sagas/test_versions.js
@@ -1,0 +1,94 @@
+import SagaTester from 'redux-saga-tester';
+
+import * as versionsApi from 'amo/api/versions';
+import versionsReducer, {
+  fetchVersions,
+  loadVersions,
+} from 'amo/reducers/versions';
+import versionsSaga from 'amo/sagas/versions';
+import apiReducer from 'core/reducers/api';
+import { createStubErrorHandler } from 'tests/unit/helpers';
+import { dispatchClientMetadata, fakeVersion } from 'tests/unit/amo/helpers';
+
+describe(__filename, () => {
+  const page = 2;
+  const slug = 'some-slug';
+
+  let clientData;
+  let errorHandler;
+  let mockApi;
+  let sagaTester;
+
+  beforeEach(() => {
+    errorHandler = createStubErrorHandler();
+    mockApi = sinon.mock(versionsApi);
+    clientData = dispatchClientMetadata();
+    sagaTester = new SagaTester({
+      initialState: clientData.state,
+      reducers: {
+        api: apiReducer,
+        versions: versionsReducer,
+      },
+    });
+    sagaTester.start(versionsSaga);
+  });
+
+  describe('fetchVersions', () => {
+    function _fetchVersions(params) {
+      sagaTester.dispatch(
+        fetchVersions({
+          errorHandlerId: errorHandler.id,
+          ...params,
+        }),
+      );
+    }
+
+    it('calls the API to fetch versions', async () => {
+      const state = sagaTester.getState();
+
+      const versions = { results: [fakeVersion] };
+
+      mockApi
+        .expects('getVersions')
+        .withArgs({
+          api: state.api,
+          page,
+          slug,
+        })
+        .once()
+        .resolves(versions);
+
+      _fetchVersions({ page, slug });
+
+      const expectedAction = loadVersions({ slug, versions });
+
+      const loadAction = await sagaTester.waitFor(expectedAction.type);
+      expect(loadAction).toEqual(expectedAction);
+      mockApi.verify();
+    });
+
+    it('clears the error handler', async () => {
+      _fetchVersions({ page, slug });
+
+      const expectedAction = errorHandler.createClearingAction();
+
+      const action = await sagaTester.waitFor(expectedAction.type);
+      expect(action).toEqual(expectedAction);
+    });
+
+    it('dispatches an error', async () => {
+      const error = new Error('some API error maybe');
+
+      mockApi
+        .expects('getVersions')
+        .once()
+        .rejects(error);
+
+      _fetchVersions({ page, slug });
+
+      const expectedAction = errorHandler.createErrorAction(error);
+      const action = await sagaTester.waitFor(expectedAction.type);
+      expect(action).toEqual(expectedAction);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6473 

There are a couple of issues with this PR:

1. We need to find the correct file to use for each version, but I haven't implemented that code yet, so instead I'm just taking the first file found. To do this properly will likely require refactoring some other components for reuse, so I didn't want to include it in this patch. If it's deemed acceptable to just use the first file found, for now, I will open a follow-up issue to deal with finding the correct file.
  * Note that I opened https://github.com/mozilla/addons-frontend/issues/6510 to track this.

2. There is a test that is failing for `Addon/index.js` and I cannot for the life of me figure out how this patch is causing it to fail. I can fit it by setting `addon` to `null` instead of `undefined`, but I'd really like to figure out how my patch has caused that test to fail. Whoever takes a look at this PR, can you also take a look at that and let me know if you have any ideas?

Also, it's possible that `AddonVersionType` may change when I implement the features that will make use of it, but I think that's fine. This is my current best guess for what `AddonVersionType` needs to look like.