### PR TITLE
Expose JSON linked data on amo detail pages

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -47,7 +47,7 @@ import {
 } from 'core/constants';
 import { withInstallHelpers } from 'core/installAddon';
 import { isTheme, nl2br, sanitizeHTML, sanitizeUserHTML } from 'core/utils';
-import { getErrorMessage } from 'core/utils/addons';
+import { getAddonJsonLinkedData, getErrorMessage } from 'core/utils/addons';
 import { getClientCompatibility as _getClientCompatibility } from 'core/utils/compatibility';
 import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
 import translate from 'core/i18n/translate';
@@ -493,6 +493,16 @@ export class AddonBase extends React.Component {
     return tags;
   }
 
+  renderJsonLinkedData() {
+    const { addon } = this.props;
+
+    return (
+      <script type="application/ld+json">
+        {JSON.stringify(getAddonJsonLinkedData({ addon }))}
+      </script>
+    );
+  }
+
   render() {
     const {
       addon,
@@ -591,6 +601,7 @@ export class AddonBase extends React.Component {
             <link rel="canonical" href={addon.url} />
             <meta name="description" content={this.getPageDescription()} />
             {this.renderMetaOpenGraph()}
+            {this.renderJsonLinkedData()}
           </Helmet>
         )}
 

--- a/src/core/components/ServerHtml/index.js
+++ b/src/core/components/ServerHtml/index.js
@@ -117,6 +117,7 @@ export default class ServerHtml extends Component {
           {head.link.toComponent()}
           {head.title.toComponent()}
           {head.meta.toComponent()}
+          {head.script.toComponent()}
           {this.getStyle()}
           {noScriptStyles ? (
             <noscript>

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -3,6 +3,7 @@ import { oneLine } from 'common-tags';
 
 import { UNLOAD_ADDON_REVIEWS } from 'amo/actions/reviews';
 import { ADDON_TYPE_THEME } from 'core/constants';
+import { removeUndefinedProps } from 'core/utils/addons';
 import type { UnloadAddonReviewsAction } from 'amo/actions/reviews';
 import type { AppState } from 'amo/store';
 import type { AppState as DiscoAppState } from 'disco/store';
@@ -77,16 +78,6 @@ export function getGuid(addon: ExternalAddonType): string {
     return `${addon.id}@personas.mozilla.org`;
   }
   return addon.guid;
-}
-
-export function removeUndefinedProps(object: Object): Object {
-  const newObject = {};
-  Object.keys(object).forEach((key) => {
-    if (typeof object[key] !== 'undefined') {
-      newObject[key] = object[key];
-    }
-  });
-  return newObject;
 }
 
 export function createInternalThemeData(

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1816,4 +1816,12 @@ describe(__filename, () => {
     expect(root.find('link[rel="canonical"]')).toHaveLength(1);
     expect(root.find('link[rel="canonical"]')).toHaveProp('href', addon.url);
   });
+
+  it('renders JSON linked data', () => {
+    const addon = createInternalAddon(fakeAddon);
+
+    const root = shallowRender({ addon });
+
+    expect(root.find('script[type="application/ld+json"]')).toHaveLength(1);
+  });
 });

--- a/tests/unit/core/components/TestServerHtml.js
+++ b/tests/unit/core/components/TestServerHtml.js
@@ -54,6 +54,14 @@ describe(__filename, () => {
     expect(meta).toHaveProp('content', 'test meta');
   });
 
+  it('renders script[type="application/ld+json"] inside helmet', () => {
+    const root = render();
+    // This is defined in the `FakeApp` component.
+    const script = root.find('script[type="application/ld+json"]');
+
+    expect(script).toHaveLength(1);
+  });
+
   it('renders GA script when trackingEnabled is true', () => {
     const root = render({ trackingEnabled: true });
     const ga = root.find({
@@ -85,7 +93,7 @@ describe(__filename, () => {
     const root = render();
     const js = root.find('script');
 
-    expect(js.at(1)).toHaveProp('src', '/foo/disco-blah.js');
+    expect(js.at(2)).toHaveProp('src', '/foo/disco-blah.js');
   });
 
   it('does not render i18n js in the assets list', () => {
@@ -112,8 +120,8 @@ describe(__filename, () => {
     const root = render();
     const js = root.find('script');
 
-    expect(js.at(1)).toHaveProp('integrity', 'sha512-disco-js');
-    expect(js.at(1)).toHaveProp('crossOrigin', 'anonymous');
+    expect(js.at(2)).toHaveProp('integrity', 'sha512-disco-js');
+    expect(js.at(2)).toHaveProp('crossOrigin', 'anonymous');
   });
 
   it('renders state as JSON', () => {

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -17,7 +17,6 @@ import addons, {
   getGuid,
   isAddonLoading,
   loadAddonResults,
-  removeUndefinedProps,
 } from 'core/reducers/addons';
 import {
   createFakeAddon,
@@ -434,28 +433,6 @@ describe(__filename, () => {
         }),
       );
       expect(state.loadingBySlug).toHaveProperty(slug);
-    });
-  });
-
-  describe('removeUndefinedProps', () => {
-    it('removes undefined properties', () => {
-      expect(removeUndefinedProps({ thing: undefined })).toEqual({});
-    });
-
-    it('preserves falsy properties', () => {
-      expect(removeUndefinedProps({ thing: false })).toEqual({ thing: false });
-    });
-
-    it('preserves other properties', () => {
-      expect(removeUndefinedProps({ thing: 'thing' })).toEqual({
-        thing: 'thing',
-      });
-    });
-
-    it('does not modify the original object', () => {
-      const example = { thing: undefined };
-      removeUndefinedProps(example);
-      expect(example).toEqual({ thing: undefined });
     });
   });
 

--- a/tests/unit/core/server/fakeApp.js
+++ b/tests/unit/core/server/fakeApp.js
@@ -36,6 +36,7 @@ export default class FakeApp extends React.Component {
         <Helmet defaultTitle="test title">
           <meta name="description" content="test meta" />
           <link rel="canonical" href="/" />
+          <script type="application/ld+json">{`{}`}</script>
         </Helmet>
         {children}
       </div>


### PR DESCRIPTION
Fixes #4129

---

You can use this tool to verify the structured data: https://search.google.com/structured-data/testing-tool

~~I do not yet expose the number of downloads (as mentioned in #4129) because we don't know if we want to expose it. It can be added later in any case.~~