### PR TITLE
Increase the bundlesize to address build-ci failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
   "bundlesize": [
     {
       "path": "./dist/@(amo|disco)-!(i18n-)*.js",
-      "maxSize": "410 kB"
+      "maxSize": "420 kB"
     },
     {
       "path": "./dist/@(amo|disco)-i18n-*.js",


### PR DESCRIPTION
This is to address failures like https://travis-ci.org/mozilla/addons-frontend/jobs/437296070

The [last time we did this](https://github.com/mozilla/addons-frontend/commit/c64bbcbfe14fd59b5a7203b6a02662dba9c1a0e5#diff-b9cfc7f2cdf78a7f4b91a753d10865a2), we increased it from 400kB to 410kB.