### PR TITLE
Add Open Graph meta tags

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -48,7 +48,7 @@ import { withInstallHelpers } from 'core/installAddon';
 import { isTheme, nl2br, sanitizeHTML, sanitizeUserHTML } from 'core/utils';
 import { getErrorMessage } from 'core/utils/addons';
 import { getClientCompatibility as _getClientCompatibility } from 'core/utils/compatibility';
-import { getAddonIconUrl } from 'core/imageUtils';
+import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import Button from 'ui/components/Button';
@@ -398,18 +398,16 @@ export class AddonBase extends React.Component {
     );
   }
 
-  getMetaDescription() {
+  getPageDescription() {
     const { addon, i18n } = this.props;
 
-    const content = i18n.sprintf(
+    return i18n.sprintf(
       i18n.gettext('Download %(addonName)s for Firefox. %(summary)s'),
       {
         addonName: addon.name,
         summary: addon.summary,
       },
     );
-
-    return <meta name="description" content={content} />;
   }
 
   getPageTitle() {
@@ -465,6 +463,30 @@ export class AddonBase extends React.Component {
           i18nValues,
         );
     }
+  }
+
+  renderMetaOpenGraph() {
+    const { addon, lang } = this.props;
+
+    const tags = [
+      <meta key="og:type" property="og:type" content="website" />,
+      <meta key="og:url" property="og:url" content={addon.url} />,
+      <meta key="og:title" property="og:title" content={this.getPageTitle()} />,
+      <meta
+        key="og:description"
+        property="og:description"
+        content={this.getPageDescription()}
+      />,
+      <meta key="og:locale" property="og:locale" content={lang} />,
+    ];
+
+    const image = getPreviewImage(addon);
+
+    if (image) {
+      tags.push(<meta key="og:image" property="og:image" content={image} />);
+    }
+
+    return tags;
   }
 
   render() {
@@ -586,7 +608,8 @@ export class AddonBase extends React.Component {
         {addon && (
           <Helmet titleTemplate={null}>
             <title>{this.getPageTitle()}</title>
-            {this.getMetaDescription()}
+            <meta name="description" content={this.getPageDescription()} />
+            {this.renderMetaOpenGraph()}
           </Helmet>
         )}
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1812,4 +1812,45 @@ describe(__filename, () => {
       `Download ${addon.name} for Firefox. ${addon.summary}`,
     );
   });
+
+  it('renders Open Graph meta tags', () => {
+    const lang = 'fr';
+
+    const addon = createInternalAddon(fakeAddon);
+    const { store } = dispatchClientMetadata({ lang });
+
+    store.dispatch(_loadAddons({ addon }));
+
+    const root = renderComponent({ params: { slug: addon.slug }, store });
+
+    [
+      ['og:type', 'website'],
+      ['og:url', addon.url],
+      ['og:locale', lang],
+      ['og:image', addon.previews[0].image_url],
+    ].forEach(([property, expectedValue]) => {
+      expect(root.find(`meta[property="${property}"]`)).toHaveProp(
+        'content',
+        expectedValue,
+      );
+    });
+
+    expect(root.find(`meta[property="og:title"]`).prop('content')).toContain(
+      addon.name,
+    );
+    expect(
+      root.find(`meta[property="og:description"]`).prop('content'),
+    ).toContain(addon.summary);
+  });
+
+  it('does not render a "og:image" meta tag if add-on has no previews', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      previews: [],
+    });
+
+    const root = shallowRender({ addon });
+
+    expect(root.find(`meta[property="og:image"]`)).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Fixes #3969 

---

This PR adds OpenGraph meta tags. It is useful for Facebook, Twitter, etc. In order to verify it, one can use:

- https://cards-dev.twitter.com/validator
- https://iframely.com/embed (sometimes fails for no reason)
- https://developers.facebook.com/tools/debug/ (requires a FB account, which I don't have..)

In order to use those tools, you need to proxy your local env to the outside world with `ngrok` or http://serveo.net/.