### PR TITLE
Refactor theme data

### DIFF
--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -27,7 +27,6 @@ import {
 import translate from 'core/i18n/translate';
 import { findInstallURL } from 'core/installAddon';
 import log from 'core/logger';
-import { getThemeData } from 'core/themeInstall';
 import tracking, {
   getAddonTypeForTracking,
   getAddonEventCategory,
@@ -302,7 +301,7 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
           'AMInstallButton-button--enable',
         );
       } else if (addon.type === ADDON_TYPE_THEME) {
-        buttonProps['data-browsertheme'] = JSON.stringify(getThemeData(addon));
+        buttonProps['data-browsertheme'] = JSON.stringify(addon.themeData);
         buttonProps.onClick = this.installTheme;
       } else if (addon.type === ADDON_TYPE_OPENSEARCH) {
         buttonProps.onClick = this.installOpenSearch;

--- a/src/core/components/InstallButton/index.js
+++ b/src/core/components/InstallButton/index.js
@@ -20,7 +20,6 @@ import {
 import translate from 'core/i18n/translate';
 import { findInstallURL } from 'core/installAddon';
 import log from 'core/logger';
-import { getThemeData } from 'core/themeInstall';
 import tracking, {
   getAddonTypeForTracking,
   getAddonEventCategory,
@@ -228,7 +227,7 @@ export class InstallButtonBase extends React.Component {
           buttonType="action"
           className={buttonClass}
           disabled={buttonIsDisabled}
-          data-browsertheme={JSON.stringify(getThemeData(addon))}
+          data-browsertheme={JSON.stringify(addon.themeData)}
           onClick={this.installTheme}
           puffy
         >
@@ -312,8 +311,6 @@ export class InstallButtonBase extends React.Component {
           - a higher-order component (HOC)
           - evil clowns (maybe)
           - or something else we aren't sure of
-          Also, some of these props are not used directly by `InstallSwitch`;
-          they are required for `getThemeData()`.
         */}
         <InstallSwitch
           accentcolor={this.props.accentcolor}

--- a/src/core/components/InstallSwitch/index.js
+++ b/src/core/components/InstallSwitch/index.js
@@ -18,7 +18,6 @@ import {
   validInstallStates as validStates,
 } from 'core/constants';
 import log from 'core/logger';
-import { getThemeData } from 'core/themeInstall';
 import Switch from 'ui/components/Switch';
 
 export class InstallSwitchBase extends React.Component {
@@ -145,26 +144,7 @@ export class InstallSwitchBase extends React.Component {
   };
 
   render() {
-    const browsertheme = JSON.stringify(
-      getThemeData({
-        accentcolor: this.props.accentcolor,
-        author: this.props.author,
-        category: this.props.category,
-        description: this.props.description,
-        detailURL: this.props.detailURL,
-        footer: this.props.footer,
-        footerURL: this.props.footerURL,
-        header: this.props.header,
-        headerURL: this.props.headerURL,
-        iconURL: this.props.iconURL,
-        id: this.props.id,
-        name: this.props.name,
-        previewURL: this.props.previewURL,
-        textcolor: this.props.textcolor,
-        updateURL: this.props.updateURL,
-        version: this.props.version,
-      }),
-    );
+    const browsertheme = JSON.stringify(this.props.addon.themeData);
     const { disabled, handleChange, slug, status, ...otherProps } = this.props;
 
     if (!validStates.includes(status)) {

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -100,16 +100,7 @@ export function createInternalThemeData(
     accentcolor: apiAddon.theme_data.accentcolor,
     author: apiAddon.theme_data.author,
     category: apiAddon.theme_data.category,
-
-    // TODO: Set this back to apiAddon.theme_data.description after
-    // https://github.com/mozilla/addons-frontend/issues/1416 is fixed.
-    // theme_data will contain `description: 'None'` when the description is
-    // actually `null` and we don't want to set that on the addon itself so we
-    // reset it in case it's been overwritten.
-    //
-    // See also https://github.com/mozilla/addons-server/issues/5650.
-    description: apiAddon.description,
-
+    description: apiAddon.theme_data.description,
     detailURL: apiAddon.theme_data.detailURL,
     footer: apiAddon.theme_data.footer,
     footerURL: apiAddon.theme_data.footerURL,
@@ -177,25 +168,9 @@ export function createInternalAddon(apiAddon: ExternalAddonType): AddonType {
     isRestartRequired: false,
     isWebExtension: false,
     isMozillaSignedExtension: false,
+
+    themeData: createInternalThemeData(apiAddon),
   };
-
-  if (addon.type === ADDON_TYPE_THEME && apiAddon.theme_data) {
-    const themeData = createInternalThemeData(apiAddon);
-
-    if (themeData !== null) {
-      // This merges theme_data into the addon.
-      //
-      // TODO: Let's stop doing that because it's confusing. Lots of deep
-      // button/install code will need to be fixed.
-      //
-      // Use addon.themeData[themeProp] instead of addon[themeProp].
-      addon = {
-        ...addon,
-        ...removeUndefinedProps(themeData),
-        themeData,
-      };
-    }
-  }
 
   const currentVersion = apiAddon.current_version;
 

--- a/src/core/themeInstall.js
+++ b/src/core/themeInstall.js
@@ -1,30 +1,11 @@
+/* @flow */
 import { THEME_INSTALL } from 'core/constants';
 
-export default function themeInstall(node, _doc = document) {
+export default function themeInstall(
+  node: Node,
+  _doc: typeof document = document,
+) {
   const event = _doc.createEvent('Events');
   event.initEvent(THEME_INSTALL, true, false);
   node.dispatchEvent(event);
-}
-
-// In theory themeData should be an AddonType but in practice it is
-// sometimes a custom made object.
-export function getThemeData(themeData) {
-  return {
-    accentcolor: themeData.accentcolor,
-    author: themeData.author,
-    category: themeData.category,
-    description: themeData.description,
-    detailURL: themeData.detailURL,
-    footer: themeData.footer,
-    footerURL: themeData.footerURL,
-    header: themeData.header,
-    headerURL: themeData.headerURL,
-    iconURL: themeData.iconURL,
-    id: themeData.id,
-    name: themeData.name,
-    previewURL: themeData.previewURL,
-    textcolor: themeData.textcolor,
-    updateURL: themeData.updateURL,
-    version: themeData.version,
-  };
 }

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -165,7 +165,6 @@ export type ExternalAddonType = {|
  */
 export type AddonType = {|
   ...ExternalAddonType,
-  ...ThemeData,
   // Here are some custom properties for our internal representation.
   platformFiles: {|
     // This seems necessary to help Flow know that computed
@@ -180,7 +179,7 @@ export type AddonType = {|
   isMozillaSignedExtension: boolean,
   isRestartRequired: boolean,
   isWebExtension: boolean,
-  themeData?: ThemeData,
+  themeData: ThemeData | null,
 |};
 
 export type CollectionAddonType = {|

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -24,7 +24,6 @@ import translate from 'core/i18n/translate';
 import { withInstallHelpers } from 'core/installAddon';
 import { getAddonByID } from 'core/reducers/addons';
 import tracking, { getAddonTypeForTracking } from 'core/tracking';
-import { getThemeData } from 'core/themeInstall';
 import { isTheme } from 'core/utils';
 import { getErrorMessage } from 'core/utils/addons';
 import { sanitizeHTMLWithExternalLinks } from 'disco/utils';
@@ -124,7 +123,7 @@ export class AddonBase extends React.Component<InternalProps> {
       imageLinkProps = {
         ...imageLinkProps,
         onClick: this.installTheme,
-        'data-browsertheme': JSON.stringify(getThemeData(addon)),
+        'data-browsertheme': JSON.stringify(addon.themeData),
       };
     }
 

--- a/src/ui/components/ThemeImage/index.js
+++ b/src/ui/components/ThemeImage/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import invariant from 'invariant';
 import makeClassName from 'classnames';
 import * as React from 'react';
 
@@ -33,7 +34,9 @@ export const ThemeImageBase = ({
 
     let previewURL = getPreviewImage(addon);
     if (!previewURL && addon.type === ADDON_TYPE_THEME) {
-      previewURL = addon.previewURL;
+      invariant(addon.themeData, 'themeData is required');
+
+      previewURL = addon.themeData.previewURL;
     }
 
     return (

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -24,7 +24,6 @@ import {
   UNKNOWN,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
-import * as themeInstall from 'core/themeInstall';
 import { getAddonTypeForTracking, getAddonEventCategory } from 'core/tracking';
 import Icon from 'ui/components/Icon';
 import {
@@ -167,7 +166,7 @@ describe(__filename, () => {
     expect(button).toHaveProp('disabled', false);
     expect(button).toHaveProp(
       'data-browsertheme',
-      JSON.stringify(themeInstall.getThemeData(addon)),
+      JSON.stringify(addon.themeData),
     );
     expect(button).toHaveProp('href', installURL);
     expect(button).toHaveProp('onClick', root.instance().installTheme);

--- a/tests/unit/core/components/TestInstallButton.js
+++ b/tests/unit/core/components/TestInstallButton.js
@@ -24,7 +24,6 @@ import {
 } from 'core/constants';
 import { getAddonIconUrl } from 'core/imageUtils';
 import { createInternalAddon } from 'core/reducers/addons';
-import * as themeInstall from 'core/themeInstall';
 import { getAddonTypeForTracking, getAddonEventCategory } from 'core/tracking';
 import { addQueryParamsToHistory } from 'core/utils';
 import {
@@ -139,9 +138,6 @@ describe(__filename, () => {
     expect(switchComponent).toHaveClassName('InstallButton-switch');
     expect(switchComponent).toHaveProp('addon', addon);
     expect(switchComponent).toHaveProp('installURL', installURL);
-
-    // Make sure it passes all theme properties.
-    expect(switchComponent.props()).toMatchObject(addon.themeData);
   });
 
   it('renders a theme button when mozAddonManager is not available', () => {
@@ -158,7 +154,7 @@ describe(__filename, () => {
     expect(button.children().at(1)).toHaveText('Install Theme');
     expect(button).toHaveProp(
       'data-browsertheme',
-      JSON.stringify(themeInstall.getThemeData(addon)),
+      JSON.stringify(addon.themeData),
     );
   });
 

--- a/tests/unit/core/components/TestInstallSwitch.js
+++ b/tests/unit/core/components/TestInstallSwitch.js
@@ -22,6 +22,7 @@ import { fakeI18n, fakeTheme } from 'tests/unit/helpers';
 describe(__filename, () => {
   function renderButton(props = {}) {
     const renderProps = {
+      addon: createInternalAddon(fakeTheme),
       dispatch: sinon.spy(),
       enable: sinon.spy(),
       install: sinon.spy(),

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -124,6 +124,7 @@ describe(__filename, () => {
       isRestartRequired: false,
       isWebExtension: true,
       isMozillaSignedExtension: false,
+      themeData: null,
     });
   });
 
@@ -135,12 +136,7 @@ describe(__filename, () => {
     // what we expect it to below.
     const expectedTheme = {
       ...theme,
-      // Expect theme_data to be merged into the addon.
-      ...theme.theme_data,
-      themeData: {
-        ...theme.theme_data,
-        description: theme.description,
-      },
+      themeData: theme.theme_data,
       description: theme.description,
       guid: getGuid(theme),
       platformFiles: {
@@ -249,26 +245,6 @@ describe(__filename, () => {
         url: 'https://a.m.o/files/somewhere.xpi',
       },
     });
-  });
-
-  it('does not use description from theme_data', () => {
-    // See: https://github.com/mozilla/addons-frontend/issues/2569
-    // Can be removed when
-    // https://github.com/mozilla/addons-frontend/issues/1416 is fixed.
-    const theme = {
-      ...fakeTheme,
-      description: null,
-      slug: 'baz',
-      id: 42,
-      theme_data: {
-        ...fakeTheme.theme_data,
-        description: 'None',
-        id: 42,
-      },
-    };
-    const state = addons({}, loadAddonResults({ addons: [theme] }));
-
-    expect(state.byID[theme.id].description).toEqual(null);
   });
 
   it('exposes `isRestartRequired` attribute from current version files', () => {

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -108,7 +108,7 @@ describe(__filename, () => {
     expect(Object.keys(state.byID)).toEqual([]);
   });
 
-  it('stores a modified extension object', () => {
+  it('stores an internal representation of an extension', () => {
     const extension = { ...fakeAddon, type: ADDON_TYPE_EXTENSION };
     const state = addons(undefined, loadAddonResults({ addons: [extension] }));
 
@@ -128,7 +128,7 @@ describe(__filename, () => {
     });
   });
 
-  it('stores a modified theme object', () => {
+  it('stores an internal representation of a theme', () => {
     const theme = { ...fakeTheme };
     const state = addons(undefined, loadAddonResults({ addons: [theme] }));
 
@@ -137,7 +137,6 @@ describe(__filename, () => {
     const expectedTheme = {
       ...theme,
       themeData: theme.theme_data,
-      description: theme.description,
       guid: getGuid(theme),
       platformFiles: {
         [OS_ALL]: fakeTheme.current_version.files[0],

--- a/tests/unit/core/test_themeInstall.js
+++ b/tests/unit/core/test_themeInstall.js
@@ -1,7 +1,6 @@
-import { createInternalAddon } from 'core/reducers/addons';
-import themeInstall, { getThemeData } from 'core/themeInstall';
+import themeInstall from 'core/themeInstall';
 import { THEME_INSTALL } from 'core/constants';
-import { createFakeEvent, fakeTheme } from 'tests/unit/helpers';
+import { createFakeEvent } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   it('sets-up the event for install', () => {
@@ -21,41 +20,5 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeDoc.createEvent, 'Events');
     sinon.assert.calledWith(fakeEvent.initEvent, THEME_INSTALL, true, false);
     sinon.assert.calledWith(fakeNode.dispatchEvent, fakeEvent);
-  });
-
-  it('returns themeData from getThemeData', () => {
-    const themeData = {
-      accentcolor: '#000',
-      author: 'carmen',
-      category: 'Other',
-      description: 'my theme description',
-      detailURL: 'https://a.m.o/addon/my-theme',
-      footer: 'https://addons.cdn.mozilla.net/footer1.jpg',
-      footerURL: 'https://addons.cdn.mozilla.net/footer2.jpg',
-      header: 'https://addons.cdn.mozilla.net/header1.jpg',
-      headerURL: 'https://addons.cdn.mozilla.net/header2.jpg',
-      iconURL: 'https://addons.cdn.mozilla.net/icon.jpg',
-      id: 50,
-      name: 'my theme',
-      previewURL: 'https://addons.cdn.mozilla.net/preview.jpg',
-      textcolor: '#fff',
-      updateURL: 'https://versioncheck.m.o/themes/update-check/999876',
-      version: '1.0',
-    };
-
-    const addon = createInternalAddon({
-      ...fakeTheme,
-      theme_data: {
-        ...fakeTheme.theme_data,
-        ...themeData,
-      },
-    });
-
-    // Beware that getThemeData() is not always called with an AddonType
-    // object. There are some spreads that combine objects.
-    expect(getThemeData(addon)).toEqual(addon.themeData);
-
-    // Make sure an unknown key is not added to the output.
-    expect(getThemeData({ ...themeData, badKey: true })).toEqual(themeData);
   });
 });


### PR DESCRIPTION
Fixes #3892

---

This PR removes a bunch of code related to `theme_data`. I am confident now that

- the `AMInstallButton` is used on AMO and soon on Disco Pane
- flow coverage on Disco Pane is good
- old `InstallSwitch`/`InstallButton` components are scheduled for deletion

This actually fixes a small issue.

In order to test the old code (not for QA but for reviewers):

- make sure to disable the `enableFeatureAMInstallButton` flag in `config/development-disco.js`
- make sure you have the prefs `xpinstall.signatures.dev-root` and `extensions.webapi.testing` set to `true` too
- you should see the switch buttons with `yarn disco:https`

Installing a LW theme should work. Once done, go to `about:addons` and make sure there is your theme listed as installed (with a description) in the `themes` tab. That's it!

You can also test with the new install button because it is also affected (see STR of #3892).