### PR TITLE
Update Sorbian, Upper (hsb) localization of AMO Frontend

### DIFF
--- a/locale/hsb/LC_MESSAGES/amo.po
+++ b/locale/hsb/LC_MESSAGES/amo.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: amo\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2018-10-09 21:07+0000\n"
-"PO-Revision-Date: 2018-10-10 18:10+0000\n"
+"PO-Revision-Date: 2018-10-10 18:13+0000\n"
 "Last-Translator: Michael Wolf <milupo@sorbzilla.de>\n"
 "Language-Team: none\n"
 "Language: hsb\n"
@@ -1166,7 +1166,7 @@ msgstr "Text MultiCopy"
 
 #: src/amo/components/HomeHeroBanner/index.js:288
 msgid "Save snippets of text to paste & organize later"
-msgstr ""
+msgstr "Šlipki za pozdźiše zasadźenje a rjadowanje składować"
 
 #: src/amo/components/HomeHeroBanner/index.js:294
 msgid "Group Speed Dial"


### PR DESCRIPTION
This reapplies the commit from https://github.com/mozilla/addons-frontend/commit/940b1aae3313c3e30ef7019dd216ccee623bfe93