### PR TITLE
Expose "og:image" meta property for lw themes

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -480,7 +480,9 @@ export class AddonBase extends React.Component {
       <meta key="og:locale" property="og:locale" content={lang} />,
     ];
 
-    const image = getPreviewImage(addon);
+    const image = addon.themeData
+      ? addon.themeData.previewURL
+      : getPreviewImage(addon);
 
     if (image) {
       tags.push(<meta key="og:image" property="og:image" content={image} />);

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1854,6 +1854,32 @@ describe(__filename, () => {
     expect(root.find(`meta[property="og:image"]`)).toHaveLength(0);
   });
 
+  it('renders a "og:image" meta tag with the preview URL if add-on is a lightweight theme', () => {
+    const addon = createInternalAddon(fakeTheme);
+
+    const root = shallowRender({ addon });
+
+    expect(root.find(`meta[property="og:image"]`)).toHaveLength(1);
+    expect(root.find(`meta[property="og:image"]`)).toHaveProp(
+      'content',
+      addon.themeData.previewURL,
+    );
+  });
+
+  it('does not render a "og:image" meta tag if lightweight theme does not have a preview URL', () => {
+    const addon = createInternalAddon({
+      ...fakeTheme,
+      theme_data: {
+        ...fakeTheme.theme_data,
+        previewURL: null,
+      },
+    });
+
+    const root = shallowRender({ addon });
+
+    expect(root.find(`meta[property="og:image"]`)).toHaveLength(0);
+  });
+
   it('renders a canonical link tag', () => {
     const addon = createInternalAddon(fakeAddon);
     const root = shallowRender({ addon });


### PR DESCRIPTION
Fixes #6587

---

I check `themeData` because the reducer ensures `themeData` is only available for LWT.

Note: `ngrok` + slack (pasting the URL in DM to the `slackbot`) is a nice way to try this PR.