### PR TITLE
Add a test case for `onLocationChanged`

### DIFF
--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -227,14 +227,22 @@ export const fakeRecommendations = Object.freeze({
   outcome: 'recommended_fallback',
 });
 
-export const onLocationChanged = ({ pathname, search = '', hash = '' }) => {
+export const onLocationChanged = ({
+  pathname,
+  search = '',
+  hash = '',
+  state,
+  ...others
+}) => {
   return {
     type: LOCATION_CHANGE,
     payload: {
       location: {
+        hash,
         pathname,
         search,
-        hash,
+        state,
+        ...others,
       },
       action: 'PUSH',
     },


### PR DESCRIPTION
Fixes #6560

---

This test case makes sure our helper function is always in sync with the
upstream lib.