### PR TITLE
Don't center shelf descriptions on smaller screens

### DIFF
--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -82,7 +82,6 @@
 .Home-SubjectShelf-list-item {
   flex-grow: 1;
   list-style-type: none;
-  text-align: center;
   width: 100%;
 
   @include respond-to(medium) {
@@ -92,6 +91,7 @@
 
   @include respond-to(large) {
     margin: 0;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6588

I checked other locales but here are screenshots in `es`.

**Before**

<img width="617" alt="screenshot 2018-10-11 09 54 03" src="https://user-images.githubusercontent.com/55398/46813536-818c7d80-cd3c-11e8-8fa2-7b3ad37515f6.png">

**After**

<img width="618" alt="screenshot 2018-10-11 09 54 19" src="https://user-images.githubusercontent.com/55398/46813547-87825e80-cd3c-11e8-8056-55a7eac55b16.png">

**Before**

<img width="322" alt="screenshot 2018-10-11 09 54 51" src="https://user-images.githubusercontent.com/55398/46813556-8cdfa900-cd3c-11e8-8414-2a6a7a0a1f9c.png">

**After**

<img width="323" alt="screenshot 2018-10-11 09 55 10" src="https://user-images.githubusercontent.com/55398/46813567-91a45d00-cd3c-11e8-981d-e7f333576038.png">

**No changes**

<img width="878" alt="screenshot 2018-10-11 09 55 56" src="https://user-images.githubusercontent.com/55398/46813589-99fc9800-cd3c-11e8-9dd2-55476baad846.png">
<img width="1157" alt="screenshot 2018-10-11 09 56 15" src="https://user-images.githubusercontent.com/55398/46813590-99fc9800-cd3c-11e8-9f7f-b1ba4dd9d679.png">
