### PR TITLE
Show Flow errors in `yarn test` (as a Jest reporter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,17 @@ yarn test-once
 
 ### Flow
 
-There is limited support for using [Flow](https://flowtype.org/) to check for problems in the source code.
+There is limited support for using [Flow](https://flowtype.org/) to validate the intention of our program.
 
-To check for Flow issues during development while you edit files, run:
+As you run tests you will see a report of Flow errors at the end of the test output:
+
+    yarn test
+
+If you would like to run tests without Flow checks, set an environment variable:
+
+    NO_FLOW=1 yarn test
+
+To only check for Flow issues during development while you edit files, run:
 
     yarn flow:dev
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
   reporters: [
     '<rootDir>/tests/jest-reporters/fingers-crossed.js',
     '<rootDir>/tests/jest-reporters/summary.js',
+    '<rootDir>/tests/jest-reporters/flow-check.js',
   ],
   setupTestFrameworkScriptFile: '<rootDir>/tests/setup.js',
   testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
       "env": {
         "NODE_ICU_DATA": "./node_modules/full-icu",
         "NODE_PATH": "./:./src",
-        "NODE_ENV": "test"
+        "NODE_ENV": "test",
+        "NO_FLOW": "1"
       }
     },
     "webpack-dev-server": {

--- a/tests/jest-reporters/flow-check.js
+++ b/tests/jest-reporters/flow-check.js
@@ -1,0 +1,120 @@
+/* eslint-disable no-console */
+const { spawn } = require('child_process');
+
+const pathToFlowBin = require('flow-bin');
+
+const NO_FLOW_ENV_VAR = 'NO_FLOW';
+
+const magicExitCodes = {
+  someFileHadAFlowError: 2,
+  serverAlreadyRunning: 11,
+};
+
+function execFlow(commandArgs) {
+  return new Promise((resolve, reject) => {
+    const flow = spawn(pathToFlowBin, commandArgs, {
+      cwd: process.cwd(),
+    });
+
+    const stdout = [];
+    const stderr = [];
+
+    flow.stdout.on('data', (data) => {
+      stdout.push(data);
+    });
+
+    flow.stderr.on('data', (data) => {
+      stderr.push(data);
+    });
+
+    flow.on('error', (error) => {
+      reject(
+        new Error(`Could not execute Flow binary (${pathToFlowBin}): ${error}`),
+      );
+    });
+
+    flow.on('close', (code) => {
+      resolve({ code, stdout: stdout.join(''), stderr: stderr.join('') });
+    });
+  });
+}
+
+class FlowCheckReporter {
+  constructor() {
+    this.flowErrorOutput = null;
+    this.displayedSlowStartupMessage = false;
+  }
+
+  isDisabled() {
+    return process.env[NO_FLOW_ENV_VAR] === '1';
+  }
+
+  async onRunStart() {
+    if (this.isDisabled()) {
+      return;
+    }
+
+    const { code, stdout, stderr } = await execFlow(['start']);
+    if (code !== 0 && code !== magicExitCodes.serverAlreadyRunning) {
+      console.error(stdout);
+      console.error(stderr);
+      throw new Error(`'flow start' exited ${code}`);
+    }
+  }
+
+  async onTestStart() {
+    if (this.isDisabled()) {
+      return;
+    }
+
+    const slowStartUpNotice = setTimeout(() => {
+      if (this.displayedSlowStartupMessage) {
+        return;
+      }
+      console.log('Flow: hold on a sec while the server starts 💅');
+      console.log('');
+      this.displayedSlowStartupMessage = true;
+    }, 800);
+
+    const { code, stdout, stderr } = await execFlow([
+      'status',
+      '--color',
+      'always',
+    ]);
+
+    clearTimeout(slowStartUpNotice);
+
+    if (code === 0) {
+      // All good.
+      this.flowErrorOutput = null;
+    } else if (code === magicExitCodes.someFileHadAFlowError) {
+      this.flowErrorOutput = stdout;
+      // We ignore stderr here because it contains messages like
+      // 'Server is handling a request (starting up)'
+    } else {
+      console.error(stdout);
+      console.error(stderr);
+      throw new Error(`'flow status' exited ${code}`);
+    }
+  }
+
+  getLastError() {
+    if (this.isDisabled()) {
+      return undefined;
+    }
+
+    console.log('');
+    if (this.flowErrorOutput) {
+      console.log(this.flowErrorOutput.trim());
+      console.log(
+        `Set ${NO_FLOW_ENV_VAR}=1 in the environment to disable Flow checks`,
+      );
+      return new Error('Flow errors');
+    }
+    console.log('Flow: no errors 🌈  ✨');
+
+    return undefined;
+  }
+}
+
+module.exports = FlowCheckReporter;


### PR DESCRIPTION
This adds a custom Jest reporter that shows Flow errors in our test output. 

In practical usage, I don't think there will be any impact to speed. There might be a couple seconds of delay when the server starts for the first time but that happens in parallel to the tests anyway.

This fixes https://github.com/mozilla/addons-frontend/issues/6550 by removing the need to run `yarn flow:dev`. It even implements part of https://github.com/mozilla/addons-frontend/issues/2281 🍰 

I've actually wanted to see Flow errors in test output for a while but for some reason it never struck me to create a reporter! It also seems like a decent workaround to https://github.com/facebook/jest/issues/7124

Some examples:

<details>
<summary>Flow failures</summary>

<img width="931" alt="screenshot 2018-10-12 11 40 19" src="https://user-images.githubusercontent.com/55398/46886877-bd4d4300-ce21-11e8-9900-b116788ec555.png">

</details>

<details>
<summary>No Flow errors</summary>
<img width="930" alt="screenshot 2018-10-12 11 53 20" src="https://user-images.githubusercontent.com/55398/46886895-cdfdb900-ce21-11e8-9f5b-c14045ac1cf3.png">

</details>