### PR TITLE
Use plain ol' margin-ing instead of row-gap

### DIFF
--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -189,9 +189,12 @@
   flex-direction: column;
   flex-wrap: wrap;
 
-  .ConfirmationDialog-confirm-button,
-  .ConfirmationDialog-cancel-button {
-    &.Button {
+  .Button.ConfirmationDialog-cancel-button {
+    @include margin-start(6px);
+  }
+
+  .Button.ConfirmationDialog-confirm-button {
+    @include respond-to(medium) {
       @include margin-start(6px);
     }
   }

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -188,7 +188,13 @@
   /* stylelint-enable */
   flex-direction: column;
   flex-wrap: wrap;
-  row-gap: 6px;
+
+  .ConfirmationDialog-confirm-button,
+  .ConfirmationDialog-cancel-button {
+    &.Button {
+      @include margin-start(6px);
+    }
+  }
 
   @include respond-to(medium) {
     flex-direction: row;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6612 with a more direct margin approach because [can I use `row-gap`](https://caniuse.com/#feat=multicolumn) is full of lies! Browsers are hard.

**Before**

<img width="565" alt="screenshot 2018-10-12 17 32 11" src="https://user-images.githubusercontent.com/55398/46896865-25615080-ce45-11e8-8159-e51977c324cb.png">
<img width="323" alt="screenshot 2018-10-12 17 39 57" src="https://user-images.githubusercontent.com/55398/46897018-dcf66280-ce45-11e8-93a6-4fb97018447f.png">


**After**

<img width="563" alt="screenshot 2018-10-12 17 32 29" src="https://user-images.githubusercontent.com/55398/46896869-298d6e00-ce45-11e8-8508-5e0f2428f2f4.png">
<img width="563" alt="screenshot 2018-10-12 17 33 04" src="https://user-images.githubusercontent.com/55398/46896879-2d20f500-ce45-11e8-9554-79ad03171de6.png">
<img width="323" alt="screenshot 2018-10-15 09 29 42" src="https://user-images.githubusercontent.com/55398/46957307-e6a5e300-d05c-11e8-9d31-2d2a43c89157.png">

<img width="323" alt="screenshot 2018-10-15 09 27 41" src="https://user-images.githubusercontent.com/55398/46957232-c0804300-d05c-11e8-9c5b-cd940e1b9b30.png">
