### PR TITLE
Do not render report flag for reviews by the current user

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -481,7 +481,8 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           </a>
         ) : null}
 
-        {flaggable && review ? (
+        {/* Do not render the "flag" button for replies made by the current user */}
+        {flaggable && review && siteUser && siteUser.id !== review.userId ? (
           <FlagReviewMenu
             isDeveloperReply={this.isReply()}
             openerClass="AddonReviewCard-control"

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -423,6 +423,11 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       (review.userId === siteUser.id ||
         (this.isReply() && this.siteUserCanManageReplies()));
 
+    /* Do not render the "flag" button for reviews made by the current user */
+    const showFlagButton = !siteUser
+      ? true
+      : !(review && siteUser.id === review.userId);
+
     const controls = controlsAreVisible ? (
       <div className="AddonReviewCard-allControls">
         {review && showEditControls ? (
@@ -481,8 +486,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           </a>
         ) : null}
 
-        {/* Do not render the "flag" button for replies made by the current user */}
-        {flaggable && review && siteUser && siteUser.id !== review.userId ? (
+        {flaggable && review && showFlagButton ? (
           <FlagReviewMenu
             isDeveloperReply={this.isReply()}
             openerClass="AddonReviewCard-control"

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -423,11 +423,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       (review.userId === siteUser.id ||
         (this.isReply() && this.siteUserCanManageReplies()));
 
-    /* Do not render the "flag" button for reviews made by the current user */
-    const showFlagButton = !siteUser
-      ? true
-      : !(review && siteUser.id === review.userId);
-
     const controls = controlsAreVisible ? (
       <div className="AddonReviewCard-allControls">
         {review && showEditControls ? (
@@ -486,7 +481,8 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           </a>
         ) : null}
 
-        {flaggable && review && showFlagButton ? (
+        {/* Do not render the "flag" button for reviews made by the current user */}
+        {flaggable && review && (!siteUser || siteUser.id !== review.userId) ? (
           <FlagReviewMenu
             isDeveloperReply={this.isReply()}
             openerClass="AddonReviewCard-control"

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -554,7 +554,7 @@ describe(__filename, () => {
   });
 
   it('lets you flag a review', () => {
-    const review = createReviewAndSignInAsUnrelatedUser();
+    const review = _setReview(fakeReview);
     const root = render({ review });
 
     const flag = renderControls(root).find(FlagReviewMenu);
@@ -569,12 +569,11 @@ describe(__filename, () => {
   });
 
   it('lets you flag a developer reply', () => {
-    const review = createReviewAndSignInAsUnrelatedUser();
-    review.isDeveloperReply = true;
-    const root = render({ review });
+    const { reply } = _setReviewReply();
+    const root = renderReply({ reply });
 
     const flag = renderControls(root).find(FlagReviewMenu);
-    expect(flag).toHaveProp('review', review);
+    expect(flag).toHaveProp('review', reply);
     expect(flag).toHaveProp('isDeveloperReply', true);
   });
 

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -554,7 +554,7 @@ describe(__filename, () => {
   });
 
   it('lets you flag a review', () => {
-    const review = _setReview(fakeReview);
+    const review = createReviewAndSignInAsUnrelatedUser();
     const root = render({ review });
 
     const flag = renderControls(root).find(FlagReviewMenu);
@@ -569,11 +569,12 @@ describe(__filename, () => {
   });
 
   it('lets you flag a developer reply', () => {
-    const { reply } = _setReviewReply();
-    const root = renderReply({ reply });
+    const review = createReviewAndSignInAsUnrelatedUser();
+    review.isDeveloperReply = true;
+    const root = render({ review });
 
     const flag = renderControls(root).find(FlagReviewMenu);
-    expect(flag).toHaveProp('review', reply);
+    expect(flag).toHaveProp('review', review);
     expect(flag).toHaveProp('isDeveloperReply', true);
   });
 

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -553,7 +553,7 @@ describe(__filename, () => {
     expect(reviewComponent).toHaveProp('review', review);
   });
 
-  it('lets you flag a review', () => {
+  it('shows FlagReviewMenu when signed out', () => {
     const review = _setReview(fakeReview);
     const root = render({ review });
 
@@ -581,12 +581,6 @@ describe(__filename, () => {
     const root = render({ review: null });
 
     expect(root.find(FlagReviewMenu)).toHaveLength(0);
-  });
-
-  it('renders the flag button when not signed in', () => {
-    const root = render({ review: _setReview(fakeReview) });
-
-    expect(renderControls(root).find(FlagReviewMenu)).toHaveLength(1);
   });
 
   it('hides the flag button if you wrote the review', () => {

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -583,7 +583,13 @@ describe(__filename, () => {
     expect(root.find(FlagReviewMenu)).toHaveLength(0);
   });
 
-  it('hides flag button if you wrote the review', () => {
+  it('renders the flag button when not signed in', () => {
+    const root = render({ review: _setReview(fakeReview) });
+
+    expect(renderControls(root).find(FlagReviewMenu)).toHaveLength(1);
+  });
+
+  it('hides the flag button if you wrote the review', () => {
     const review = createReviewAndSignInAsSameUser();
     const root = render({ review });
 

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -180,13 +180,6 @@ describe(__filename, () => {
     });
   }
 
-  function createReviewAndSignInAsSameUser() {
-    return signInAndDispatchSavedReview({
-      siteUserId: 123,
-      reviewUserId: 123,
-    });
-  }
-
   it('renders a review', () => {
     const review = _setReview({
       ...fakeReview,
@@ -584,12 +577,18 @@ describe(__filename, () => {
   });
 
   it('hides the flag button if you wrote the review', () => {
-    const review = createReviewAndSignInAsSameUser();
-    const root = render({ review });
+    const originalReviewId = 123;
+    const review = signInAndDispatchSavedReview({
+      siteUserId: originalReviewId,
+    });
+    let root = render({ review });
 
-    expect(
-      renderControls(root).find('.TooltipMenu-opener AddonReviewCard-control'),
-    ).toHaveLength(0);
+    expect(renderControls(root).find(FlagReviewMenu)).toHaveLength(0);
+
+    store.dispatch(logOutUser());
+
+    root = render({ review });
+    expect(renderControls(root).find(FlagReviewMenu)).toHaveLength(1);
   });
 
   it('allows review replies when siteUserCanManageReplies() is true', () => {

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -180,6 +180,13 @@ describe(__filename, () => {
     });
   }
 
+  function createReviewAndSignInAsSameUser() {
+    return signInAndDispatchSavedReview({
+      siteUserId: 123,
+      reviewUserId: 123,
+    });
+  }
+
   it('renders a review', () => {
     const review = _setReview({
       ...fakeReview,
@@ -574,6 +581,15 @@ describe(__filename, () => {
     const root = render({ review: null });
 
     expect(root.find(FlagReviewMenu)).toHaveLength(0);
+  });
+
+  it('hides flag button if you wrote the review', () => {
+    const review = createReviewAndSignInAsSameUser();
+    const root = render({ review });
+
+    expect(
+      renderControls(root).find('.TooltipMenu-opener AddonReviewCard-control'),
+    ).toHaveLength(0);
   });
 
   it('allows review replies when siteUserCanManageReplies() is true', () => {

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -577,18 +577,14 @@ describe(__filename, () => {
   });
 
   it('hides the flag button if you wrote the review', () => {
-    const originalReviewId = 123;
+    const siteUserId = 123;
     const review = signInAndDispatchSavedReview({
-      siteUserId: originalReviewId,
+      siteUserId,
+      reviewUserId: siteUserId,
     });
-    let root = render({ review });
+    const root = render({ review });
 
     expect(renderControls(root).find(FlagReviewMenu)).toHaveLength(0);
-
-    store.dispatch(logOutUser());
-
-    root = render({ review });
-    expect(renderControls(root).find(FlagReviewMenu)).toHaveLength(1);
   });
 
   it('allows review replies when siteUserCanManageReplies() is true', () => {


### PR DESCRIPTION
Fixes #6416: "Flag" should be removed from the profile page

This PR prevents the "flag" button from being rendered for reviews made by the current user. Essentially, if Sean leaves a review, he should not be allowed to flag his own comment.

**Before:**

![before_removing_flag](https://user-images.githubusercontent.com/13009507/46899863-14c1d200-ce67-11e8-8be0-886cf5cfa1e4.gif)

**After:**

![after_removing_flag](https://user-images.githubusercontent.com/13009507/46899867-18edef80-ce67-11e8-81da-4e32cb892e00.gif)