### PR TITLE
Fix regression in flag menu log in button styles

### DIFF
--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -35,8 +35,7 @@
   justify-content: flex-start;
   margin-top: 0;
 
-  a,
-  button {
+  .AddonReviewCard-control {
     &,
     &:link,
     &:visited,

--- a/src/ui/components/TooltipMenu/styles.scss
+++ b/src/ui/components/TooltipMenu/styles.scss
@@ -55,7 +55,9 @@
 
   .ListItem,
   .CardList .ListItem {
+    align-items: center;
     background: none;
+    display: flex;
     margin: 0;
     padding: 6px;
     padding-top: 0;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6656

**Before**

<img width="515" alt="screenshot 2018-10-16 12 37 13" src="https://user-images.githubusercontent.com/55398/47035790-77a1ba80-d140-11e8-9809-e0844c2531bb.png">

**After**

<img width="489" alt="screenshot 2018-10-16 12 36 06" src="https://user-images.githubusercontent.com/55398/47035802-7d979b80-d140-11e8-9599-d5f14cfb7416.png">
<img width="457" alt="screenshot 2018-10-16 12 35 40" src="https://user-images.githubusercontent.com/55398/47035810-80928c00-d140-11e8-808e-ff2a71548d8f.png">

I also made sure the review control links still look the same.