### PR TITLE
Add alternate links to add-on detail pages

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -24,6 +24,7 @@ module.exports = {
     'enableDevTools',
     'enableFeatureAMInstallButton',
     'hctEnabled',
+    'hrefLangsMap',
     'isDeployed',
     'isDevelopment',
     'langMap',
@@ -34,6 +35,7 @@ module.exports = {
     'trackingEnabled',
     'trackingId',
     'trackingSendInitPageView',
+    'unsupportedHrefLangs',
   ],
 
   staticHost,

--- a/config/default.js
+++ b/config/default.js
@@ -111,6 +111,7 @@ module.exports = {
     'experiments',
     'fxaConfig',
     'hctEnabled',
+    'hrefLangsMap',
     'isDeployed',
     'isDevelopment',
     'langMap',
@@ -122,6 +123,7 @@ module.exports = {
     'trackingEnabled',
     'trackingId',
     'trackingSendInitPageView',
+    'unsupportedHrefLangs',
     'validClientAppUrlExceptions',
     'validClientApplications',
     'validLocaleUrlExceptions',
@@ -230,6 +232,22 @@ module.exports = {
     'zh-CN',
     'zh-TW',
   ],
+  // Exclusion list of unsupported locales for alternate links, see:
+  // https://github.com/mozilla/addons-frontend/issues/6644
+  unsupportedHrefLangs: [
+    'ast',
+    'cak',
+    'dsb',
+    'hsb',
+    'kab',
+  ],
+  // Map of locale aliases for "alternate" links, see:
+  // https://github.com/mozilla/addons-frontend/issues/6644
+  hrefLangsMap: {
+    'x-default': 'en-US',
+    en: 'en-US',
+    pt: 'pt-PT',
+  },
   // Map of short langs to longer ones.
   langMap: {
     en: 'en-US',

--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -630,10 +630,19 @@ export const unfilteredLanguages = {
 };
 /* eslint-enable */
 
-export default config.get('langs').reduce((object, locale) => {
+const supportedLanguages = config.get('langs').reduce((object, locale) => {
   if (typeof unfilteredLanguages[locale] !== 'undefined') {
     return { ...object, [locale]: unfilteredLanguages[locale] };
   }
 
   return object;
 }, {});
+
+export const hrefLangs = [
+  ...Object.keys(config.get('hrefLangsMap')),
+  ...Object.keys(supportedLanguages).filter(
+    (locale) => !config.get('unsupportedHrefLangs').includes(locale),
+  ),
+];
+
+export default supportedLanguages;

--- a/tests/unit/amo/components/TestAddonHead.js
+++ b/tests/unit/amo/components/TestAddonHead.js
@@ -280,7 +280,7 @@ describe(__filename, () => {
 
   // This test case ensures the production configuration is taken into account.
   it.each([['x-default', 'en-US'], ['pt', 'pt-PT'], ['en', 'en-US']])(
-    'renders a "x-default" alternate link',
+    'renders a "%s" alternate link',
     (hrefLang, locale) => {
       const addon = createInternalAddon(fakeAddon);
       const baseURL = 'https://example.org';

--- a/tests/unit/amo/components/TestAddonHead.js
+++ b/tests/unit/amo/components/TestAddonHead.js
@@ -17,8 +17,9 @@ import { createInternalAddon } from 'core/reducers/addons';
 import {
   dispatchClientMetadata,
   fakeAddon,
-  fakeTheme,
   fakeI18n,
+  fakeTheme,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 
@@ -156,10 +157,19 @@ describe(__filename, () => {
 
   it('renders a canonical link tag', () => {
     const addon = createInternalAddon(fakeAddon);
-    const root = render({ addon });
+    const baseURL = 'https://example.org';
+    const _config = getFakeConfig({ baseURL });
+
+    const pathname = '/this-should-be-an-addon-slug';
+    const { store } = dispatchClientMetadata({ pathname });
+
+    const root = render({ _config, addon, store });
 
     expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp('href', addon.url);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}${pathname}`,
+    );
   });
 
   it('renders JSON linked data', () => {
@@ -196,5 +206,74 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find('meta[name="last-modified"]')).toHaveLength(0);
+  });
+
+  it.each([CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX])(
+    'renders alternate links with hreflang for %s',
+    (clientApp) => {
+      const addon = createInternalAddon(fakeAddon);
+      const baseURL = 'https://example.org';
+
+      const _hrefLangs = ['fr', 'en-US'];
+      const _config = getFakeConfig({ baseURL });
+      const { store } = dispatchClientMetadata({ clientApp });
+
+      const root = render({ _config, _hrefLangs, addon, store });
+
+      expect(root.find('link[rel="alternate"]')).toHaveLength(
+        _hrefLangs.length,
+      );
+      _hrefLangs.forEach((locale, index) => {
+        expect(root.find('link[rel="alternate"]').at(index)).toHaveProp(
+          'hrefLang',
+          locale,
+        );
+        expect(root.find('link[rel="alternate"]').at(index)).toHaveProp(
+          'href',
+          `${baseURL}/${locale}/${clientApp}/addon/${addon.slug}/`,
+        );
+      });
+    },
+  );
+
+  it('renders alternate links for aliased locales', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const baseURL = 'https://example.org';
+    const clientApp = CLIENT_APP_FIREFOX;
+
+    const _hrefLangs = ['x-default'];
+    const hrefLangsMap = {
+      'x-default': 'en-US',
+    };
+    const _config = getFakeConfig({ baseURL, hrefLangsMap });
+    const { store } = dispatchClientMetadata({ clientApp });
+
+    const root = render({ _config, _hrefLangs, addon, store });
+
+    expect(root.find('link[rel="alternate"]')).toHaveLength(_hrefLangs.length);
+    expect(root.find('link[rel="alternate"]').at(0)).toHaveProp(
+      'hrefLang',
+      _hrefLangs[0],
+    );
+    expect(root.find('link[rel="alternate"]').at(0)).toHaveProp(
+      'href',
+      `${baseURL}/${hrefLangsMap[_hrefLangs[0]]}/${clientApp}/addon/${
+        addon.slug
+      }/`,
+    );
+  });
+
+  it('does not render any links for unsupported alternate link locales', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const lang = 'fr';
+
+    const _hrefLangs = ['fr', 'en-US'];
+    // We mark the current locale as excluded.
+    const _config = getFakeConfig({ unsupportedHrefLangs: [lang] });
+    const { store } = dispatchClientMetadata({ lang });
+
+    const root = render({ _config, _hrefLangs, addon, store });
+
+    expect(root.find('link[rel="alternate"]')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Fixes #6644

~~⚠️ depends on #6649~~

---

This PR adds new `link` tags in the add-on detail pages.

You can try it by using https://app.hreflang.org/, which requires three steps:

1. Install `localtunnel`: https://localtunnel.github.io/www/
2. Run it: `lt --port 3000`
3. Update this line to add `xxx.localtunnel.me` instead of `${_config.get('baseURL')}`: https://github.com/mozilla/addons-frontend/blob/7a6dd48ee5050cc863d6fdefff2dd24eafbe24b4/src/amo/utils.js#L64
4. Browse an add-on detail page like: `xxx.localtunnel.me/en-US/firefox/addon/awesome-screenshot-plus-/?`
5. Paste this URL into https://app.hreflang.org/ and click the "test" button
