### PR TITLE
Allow to link back to the add-on detail page from the `AddonTitle` component

### DIFF
--- a/src/amo/components/AddonTitle/index.js
+++ b/src/amo/components/AddonTitle/index.js
@@ -15,6 +15,7 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType | null,
+  linkToAddon?: boolean,
 |};
 
 type InternalProps = {|
@@ -23,7 +24,12 @@ type InternalProps = {|
   isRTL: boolean,
 |};
 
-export const AddonTitleBase = ({ addon, i18n, isRTL }: InternalProps) => {
+export const AddonTitleBase = ({
+  addon,
+  i18n,
+  isRTL,
+  linkToAddon = false,
+}: InternalProps) => {
   const authors = [];
 
   if (addon && addon.authors) {
@@ -54,7 +60,11 @@ export const AddonTitleBase = ({ addon, i18n, isRTL }: InternalProps) => {
     <h1 className="AddonTitle">
       {addon ? (
         <React.Fragment>
-          {addon.name}
+          {linkToAddon ? (
+            <Link to={`/addon/${addon.slug}/`}>{addon.name}</Link>
+          ) : (
+            addon.name
+          )}
           {authors.length > 0 && (
             <span className="AddonTitle-author">
               {isRTL ? (

--- a/tests/unit/amo/components/TestAddonTitle.js
+++ b/tests/unit/amo/components/TestAddonTitle.js
@@ -168,4 +168,20 @@ describe(__filename, () => {
     // Finally, it should be the "by"
     expect(authors.childAt(4).text()).toEqual('by');
   });
+
+  it('does not link to the add-on detail page when the "linkToAddon" prop is false', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const root = render({ addon, linkToAddon: false });
+
+    expect(root.find(Link)).toHaveLength(1);
+  });
+
+  it('links to the add-on detail page when the "linkToAddon" prop is true', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const root = render({ addon, linkToAddon: true });
+
+    expect(root.find(Link)).toHaveLength(2);
+    expect(root.find(Link).at(0)).toHaveProp('children', addon.name);
+    expect(root.find(Link).at(0)).toHaveProp('to', `/addon/${addon.slug}/`);
+  });
 });


### PR DESCRIPTION
Fixes #6631

---

This PR adds a new prop to the `AddonTitle` component that adds a link
to the detail page on the add-on name, when the prop is set to `true`.