### PR TITLE
More space between review controls on small screen

### DIFF
--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -91,7 +91,12 @@
 
   // This adjusts the max-width when there are only two items. It selects
   // the element based on its position then selects all siblings.
+
+  /* stylelint-disable max-line-length */
+
   // https://stackoverflow.com/questions/8720931/can-css-detect-the-number-of-children-an-element-has
+
+  /* stylelint-enable max-line-length */
   &:first-child:nth-last-child(2),
   &:first-child:nth-last-child(2) ~ & {
     max-width: 50%;

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -32,8 +32,13 @@
 .AddonReviewCard-allControls {
   align-items: flex-start;
   display: flex;
-  justify-content: flex-start;
+  flex-wrap: wrap;
+  justify-content: space-between;
   margin-top: 0;
+
+  @include respond-to(medium) {
+    justify-content: flex-start;
+  }
 
   .AddonReviewCard-control {
     &,
@@ -76,7 +81,9 @@
 }
 
 .AddonReviewCard-control {
-  @include margin-end(6px);
+  display: flex;
+  max-width: 33%;
+  text-align: center;
 
   @include respond-to(medium) {
     @include margin-end(24px);

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -85,6 +85,18 @@
   max-width: 33%;
   text-align: center;
 
+  &:only-child {
+    max-width: 100%;
+  }
+
+  // This adjusts the max-width when there are only two items. It selects
+  // the element based on its position then selects all siblings.
+  // https://stackoverflow.com/questions/8720931/can-css-detect-the-number-of-children-an-element-has
+  &:first-child:nth-last-child(2),
+  &:first-child:nth-last-child(2) ~ & {
+    max-width: 50%;
+  }
+
   @include respond-to(medium) {
     @include margin-end(24px);
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6613

**Before**

<img width="322" alt="screenshot 2018-10-18 12 01 58" src="https://user-images.githubusercontent.com/55398/47171648-dac15780-d2ce-11e8-878a-21fe0c9d4487.png">
<img width="322" alt="screenshot 2018-10-18 12 02 27" src="https://user-images.githubusercontent.com/55398/47171649-dac15780-d2ce-11e8-84ab-0be62059784e.png">


<hr/>

**After**

<img width="324" alt="screenshot 2018-10-18 12 03 46" src="https://user-images.githubusercontent.com/55398/47171658-e14fcf00-d2ce-11e8-9395-12930babda71.png">
<img width="323" alt="screenshot 2018-10-18 12 04 10" src="https://user-images.githubusercontent.com/55398/47171659-e14fcf00-d2ce-11e8-93e4-e0b12b30c4e0.png">
<img width="850" alt="screenshot 2018-10-18 12 04 40" src="https://user-images.githubusercontent.com/55398/47171660-e14fcf00-d2ce-11e8-9e43-7a12b57b0466.png">
<img width="553" alt="screenshot 2018-10-18 12 04 59" src="https://user-images.githubusercontent.com/55398/47171661-e14fcf00-d2ce-11e8-864a-beab62f850cb.png">
<img width="480" alt="screenshot 2018-10-18 12 05 29" src="https://user-images.githubusercontent.com/55398/47171662-e14fcf00-d2ce-11e8-9e73-8c4984f4057e.png">
