### PR TITLE
Always render AddonsByAuthorsCard in user profile pages

### DIFF
--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -28,6 +28,7 @@ import {
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import { isTheme } from 'core/utils';
+import LoadingText from 'ui/components/LoadingText';
 import type { FetchAddonsByAuthorsParams } from 'amo/reducers/addonsByAuthors';
 import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
@@ -40,8 +41,8 @@ import './styles.scss';
 
 type Props = {|
   addonType?: string,
-  authorDisplayName: string,
-  authorIds: Array<number>,
+  authorDisplayName: string | null,
+  authorIds: Array<number> | null,
   className?: string,
   errorHandler?: ErrorHandlerType,
   forAddonSlug?: string,
@@ -94,6 +95,10 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       paginate,
     } = props;
 
+    if (!authorIds) {
+      return;
+    }
+
     this.dispatchFetchAddonsByAuthors({
       addonType,
       authorIds,
@@ -116,6 +121,10 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       forAddonSlug: oldForAddonSlug,
       location: oldLocation,
     } = this.props;
+
+    if (!newAuthorIds) {
+      return;
+    }
 
     const newPage = paginate
       ? oldLocation.query[pageParam] !== newLocation.query[pageParam]
@@ -220,93 +229,98 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       return null;
     }
 
-    let header;
-    switch (addonType) {
-      case ADDON_TYPE_DICT:
-        header = showMore
-          ? i18n.ngettext(
-              i18n.sprintf(i18n.gettext('More dictionaries by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('More dictionaries by these translators'),
-              authorIds.length,
-            )
-          : i18n.ngettext(
-              i18n.sprintf(i18n.gettext('Dictionaries by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('Dictionaries by these translators'),
-              authorIds.length,
-            );
-        break;
-      case ADDON_TYPE_EXTENSION:
-        header = showMore
-          ? i18n.ngettext(
-              i18n.sprintf(i18n.gettext('More extensions by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('More extensions by these developers'),
-              authorIds.length,
-            )
-          : i18n.ngettext(
-              i18n.sprintf(i18n.gettext('Extensions by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('Extensions by these developers'),
-              authorIds.length,
-            );
-        break;
-      case ADDON_TYPE_LANG:
-        header = showMore
-          ? i18n.ngettext(
-              i18n.sprintf(i18n.gettext('More language packs by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('More language packs by these translators'),
-              authorIds.length,
-            )
-          : i18n.ngettext(
-              i18n.sprintf(i18n.gettext('Language packs by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('Language packs by these translators'),
-              authorIds.length,
-            );
-        break;
-      case ADDON_TYPE_STATIC_THEME:
-      case ADDON_TYPE_THEME:
-        header = showMore
-          ? i18n.ngettext(
-              i18n.sprintf(i18n.gettext('More themes by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('More themes by these artists'),
-              authorIds.length,
-            )
-          : i18n.ngettext(
-              i18n.sprintf(i18n.gettext('Themes by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('Themes by these artists'),
-              authorIds.length,
-            );
-        break;
-      default:
-        header = showMore
-          ? i18n.ngettext(
-              i18n.sprintf(i18n.gettext('More add-ons by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('More add-ons by these developers'),
-              authorIds.length,
-            )
-          : i18n.ngettext(
-              i18n.sprintf(i18n.gettext('Add-ons by %(author)s'), {
-                author: authorDisplayName,
-              }),
-              i18n.gettext('Add-ons by these developers'),
-              authorIds.length,
-            );
+    let header = <LoadingText />;
+    if (authorIds) {
+      switch (addonType) {
+        case ADDON_TYPE_DICT:
+          header = showMore
+            ? i18n.ngettext(
+                i18n.sprintf(i18n.gettext('More dictionaries by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('More dictionaries by these translators'),
+                authorIds.length,
+              )
+            : i18n.ngettext(
+                i18n.sprintf(i18n.gettext('Dictionaries by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('Dictionaries by these translators'),
+                authorIds.length,
+              );
+          break;
+        case ADDON_TYPE_EXTENSION:
+          header = showMore
+            ? i18n.ngettext(
+                i18n.sprintf(i18n.gettext('More extensions by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('More extensions by these developers'),
+                authorIds.length,
+              )
+            : i18n.ngettext(
+                i18n.sprintf(i18n.gettext('Extensions by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('Extensions by these developers'),
+                authorIds.length,
+              );
+          break;
+        case ADDON_TYPE_LANG:
+          header = showMore
+            ? i18n.ngettext(
+                i18n.sprintf(
+                  i18n.gettext('More language packs by %(author)s'),
+                  {
+                    author: authorDisplayName,
+                  },
+                ),
+                i18n.gettext('More language packs by these translators'),
+                authorIds.length,
+              )
+            : i18n.ngettext(
+                i18n.sprintf(i18n.gettext('Language packs by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('Language packs by these translators'),
+                authorIds.length,
+              );
+          break;
+        case ADDON_TYPE_STATIC_THEME:
+        case ADDON_TYPE_THEME:
+          header = showMore
+            ? i18n.ngettext(
+                i18n.sprintf(i18n.gettext('More themes by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('More themes by these artists'),
+                authorIds.length,
+              )
+            : i18n.ngettext(
+                i18n.sprintf(i18n.gettext('Themes by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('Themes by these artists'),
+                authorIds.length,
+              );
+          break;
+        default:
+          header = showMore
+            ? i18n.ngettext(
+                i18n.sprintf(i18n.gettext('More add-ons by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('More add-ons by these developers'),
+                authorIds.length,
+              )
+            : i18n.ngettext(
+                i18n.sprintf(i18n.gettext('Add-ons by %(author)s'), {
+                  author: authorDisplayName,
+                }),
+                i18n.gettext('Add-ons by these developers'),
+                authorIds.length,
+              );
+      }
     }
 
     const classnames = makeClassName('AddonsByAuthorsCard', className, {
@@ -359,25 +373,29 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
 export const mapStateToProps = (state: AppState, ownProps: Props) => {
   const { addonType, authorIds, forAddonSlug, numberOfAddons } = ownProps;
 
-  let addons = getAddonsForAuthorIds(
-    state.addonsByAuthors,
-    authorIds,
-    addonType,
-    forAddonSlug,
-  );
-  addons = addons ? addons.slice(0, numberOfAddons) : addons;
+  let addons = [];
+  let loading = true;
 
-  const count = getCountForAuthorIds(
-    state.addonsByAuthors,
-    authorIds,
-    addonType,
-  );
+  if (authorIds) {
+    addons = getAddonsForAuthorIds(
+      state.addonsByAuthors,
+      authorIds,
+      addonType,
+      forAddonSlug,
+    );
+    addons = addons ? addons.slice(0, numberOfAddons) : addons;
 
-  const loading = getLoadingForAuthorIds(
-    state.addonsByAuthors,
-    authorIds,
-    addonType,
-  );
+    loading = getLoadingForAuthorIds(
+      state.addonsByAuthors,
+      authorIds,
+      addonType,
+    );
+    loading = loading === null ? true : loading;
+  }
+
+  const count = authorIds
+    ? getCountForAuthorIds(state.addonsByAuthors, authorIds, addonType)
+    : 0;
 
   return {
     addons,

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -109,7 +109,6 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
     location: newLocation,
     pageParam,
     paginate,
-    loading,
   }: InternalProps) {
     const {
       addonType: oldAddonType,

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -59,11 +59,11 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
-  addons?: Array<AddonType>,
+  addons: Array<AddonType> | null,
   count: number | null,
   dispatch: DispatchFunc,
   i18n: I18nType,
-  loading?: boolean,
+  loading: boolean | null,
   location: ReactRouterLocationType,
 |};
 
@@ -225,7 +225,9 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
       return errorHandler.renderError();
     }
 
-    if (!loading && (!addons || !addons.length)) {
+    const inLoadingState = loading === true || loading === null;
+
+    if (!inLoadingState && (!addons || !addons.length)) {
       return null;
     }
 
@@ -360,7 +362,7 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
         className={classnames}
         footer={paginator}
         header={header}
-        loading={loading}
+        loading={inLoadingState}
         placeholderCount={numberOfAddons}
         showMetadata
         showSummary={showSummary}
@@ -370,11 +372,14 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (state: AppState, ownProps: Props) => {
+export const mapStateToProps = (
+  state: AppState,
+  ownProps: Props,
+): $Shape<InternalProps> => {
   const { addonType, authorIds, forAddonSlug, numberOfAddons } = ownProps;
 
-  let addons = [];
-  let loading = true;
+  let addons = null;
+  let loading = null;
 
   if (authorIds) {
     addons = getAddonsForAuthorIds(
@@ -390,7 +395,6 @@ export const mapStateToProps = (state: AppState, ownProps: Props) => {
       authorIds,
       addonType,
     );
-    loading = loading === null ? true : loading;
   }
 
   const count = authorIds

--- a/src/amo/components/AddonsByAuthorsCard/index.js
+++ b/src/amo/components/AddonsByAuthorsCard/index.js
@@ -109,6 +109,7 @@ export class AddonsByAuthorsCardBase extends React.Component<InternalProps> {
     location: newLocation,
     pageParam,
     paginate,
+    loading,
   }: InternalProps) {
     const {
       addonType: oldAddonType,

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -380,39 +380,35 @@ export class UserProfileBase extends React.Component<InternalProps> {
             ) : null}
           </Card>
 
-          {user && (
-            // TODO: use `params.userId` when we switch to user IDs in URLs,
-            // see: https://github.com/mozilla/addons-frontend/issues/6526
-            <div className="UserProfile-addons-and-reviews">
-              <AddonsByAuthorsCard
-                addonType={ADDON_TYPE_EXTENSION}
-                authorDisplayName={user.name}
-                authorIds={[user.id]}
-                errorHandler={errorHandler}
-                numberOfAddons={EXTENSIONS_BY_AUTHORS_PAGE_SIZE}
-                pageParam="page_e"
-                paginate
-                pathname={this.getURL()}
-                showMore={false}
-                showSummary
-                type="vertical"
-              />
+          <div className="UserProfile-addons-and-reviews">
+            <AddonsByAuthorsCard
+              addonType={ADDON_TYPE_EXTENSION}
+              authorDisplayName={user ? user.name : null}
+              authorIds={user ? [user.id] : null}
+              errorHandler={errorHandler}
+              numberOfAddons={EXTENSIONS_BY_AUTHORS_PAGE_SIZE}
+              pageParam="page_e"
+              paginate
+              pathname={this.getURL()}
+              showMore={false}
+              showSummary
+              type="vertical"
+            />
 
-              <AddonsByAuthorsCard
-                addonType={ADDON_TYPE_THEME}
-                authorDisplayName={user.name}
-                authorIds={[user.id]}
-                errorHandler={errorHandler}
-                numberOfAddons={THEMES_BY_AUTHORS_PAGE_SIZE}
-                pageParam="page_t"
-                paginate
-                pathname={this.getURL()}
-                showMore={false}
-              />
+            <AddonsByAuthorsCard
+              addonType={ADDON_TYPE_THEME}
+              authorDisplayName={user ? user.name : null}
+              authorIds={user ? [user.id] : null}
+              errorHandler={errorHandler}
+              numberOfAddons={THEMES_BY_AUTHORS_PAGE_SIZE}
+              pageParam="page_t"
+              paginate
+              pathname={this.getURL()}
+              showMore={false}
+            />
 
-              {this.renderReviews()}
-            </div>
-          )}
+            {this.renderReviews()}
+          </div>
         </div>
       </div>
     );

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -140,11 +140,13 @@ export const getLoadingForAuthorIds = (
   authorIds: Array<number>,
   addonType?: string,
 ): boolean | null => {
-  return (
-    addonsByAuthorsState.loadingFor[
-      joinAuthorIdsAndAddonType(authorIds, addonType)
-    ] || null
-  );
+  const key = joinAuthorIdsAndAddonType(authorIds, addonType);
+
+  if (addonsByAuthorsState.loadingFor[key] === undefined) {
+    return null;
+  }
+
+  return addonsByAuthorsState.loadingFor[key];
 };
 
 export const getCountForAuthorIds = (

--- a/src/amo/reducers/addonsByAuthors.js
+++ b/src/amo/reducers/addonsByAuthors.js
@@ -3,11 +3,8 @@ import deepcopy from 'deepcopy';
 import invariant from 'invariant';
 
 import { createInternalAddon } from 'core/reducers/addons';
-import type {
-  ExternalAddonType,
-  SearchResultAddonType,
-} from 'core/types/addons';
 import { getAddonTypeFilter } from 'core/utils';
+import type { AddonType, ExternalAddonType } from 'core/types/addons';
 
 type AddonId = number;
 
@@ -17,7 +14,7 @@ export type AddonsByAuthorsState = {|
   // That said, these are partial add-ons returned from the search
   // results and fetching all add-on data for each add-on might be too
   // expensive.
-  byAddonId: { [AddonId]: SearchResultAddonType },
+  byAddonId: { [AddonId]: AddonType },
   byAddonSlug: { [string]: Array<AddonId> },
   byAuthorId: { [number]: Array<AddonId> },
   countFor: { [string]: number },
@@ -164,7 +161,7 @@ export const getCountForAuthorIds = (
 export const getAddonsForSlug = (
   addonsByAuthorsState: AddonsByAuthorsState,
   slug: string,
-): Array<SearchResultAddonType> | null => {
+): Array<AddonType> | null => {
   const ids = addonsByAuthorsState.byAddonSlug[slug];
 
   return ids ? ids.map((id) => addonsByAuthorsState.byAddonId[id]) : null;
@@ -175,7 +172,7 @@ export const getAddonsForAuthorIds = (
   authorIds: Array<number>,
   addonType?: string,
   excludeSlug?: string,
-): Array<SearchResultAddonType> | null => {
+): Array<AddonType> | null => {
   invariant(
     authorIds && authorIds.length,
     'At least one authorId is required.',

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -188,9 +188,3 @@ export type CollectionAddonType = {|
   ...AddonType,
   notes: string | null,
 |};
-
-export type SearchResultAddonType = {|
-  ...AddonType,
-  authors?: Array<PartialAddonAuthorType>,
-  current_version?: PartialExternalAddonVersionType,
-|};

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -25,6 +25,7 @@ import {
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import ErrorList from 'ui/components/ErrorList';
+import LoadingText from 'ui/components/LoadingText';
 import {
   createContextWithFakeRouter,
   createStubErrorHandler,
@@ -254,14 +255,14 @@ describe(__filename, () => {
     expect(root.html()).toBeNull();
   });
 
-  it('should render nothing if add-ons are null', () => {
+  it('should render a loading state on first instantiation', () => {
     const root = render({
       addons: null,
       authorIds: [randomAuthorId2],
     });
 
-    expect(root).not.toHaveClassName('AddonsByAuthorsCard');
-    expect(root.html()).toBeNull();
+    expect(root).toHaveClassName('AddonsByAuthorsCard');
+    expect(root).toHaveProp('loading', true);
   });
 
   it('should render a card with loading state if loading', () => {
@@ -997,5 +998,32 @@ describe(__filename, () => {
     });
 
     expect(root.find(ErrorList)).toHaveLength(1);
+  });
+
+  it('renders a LoadingText header when authorIds is null', () => {
+    const root = render({ authorIds: null });
+
+    expect(root.find(AddonsCard)).toHaveProp('header', <LoadingText />);
+  });
+
+  it('does not dispatch an action if authorIds is null', () => {
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    render({ authorIds: null, store });
+
+    sinon.assert.notCalled(dispatchSpy);
+  });
+
+  it('does not dispatch an action if authorIds is null on update', () => {
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    const root = render({ store });
+    dispatchSpy.resetHistory();
+
+    root.setProps({ authorIds: null });
+
+    sinon.assert.notCalled(dispatchSpy);
   });
 });

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -530,11 +530,21 @@ describe(__filename, () => {
     );
   });
 
-  it('does not render AddonsByAuthorsCards without a user', () => {
+  it('renders AddonsByAuthorsCards without a user', () => {
     const username = 'not-loaded';
     const root = renderUserProfile({ params: { username } });
 
-    expect(root.find(AddonsByAuthorsCard)).toHaveLength(0);
+    expect(root.find(AddonsByAuthorsCard)).toHaveLength(2);
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp('authorIds', null);
+    expect(root.find(AddonsByAuthorsCard).at(0)).toHaveProp(
+      'authorDisplayName',
+      null,
+    );
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp('authorIds', null);
+    expect(root.find(AddonsByAuthorsCard).at(1)).toHaveProp(
+      'authorDisplayName',
+      null,
+    );
   });
 
   it('renders AddonsByAuthorsCard for extensions', () => {

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -879,6 +879,19 @@ describe(__filename, () => {
 
       expect(getLoadingForAuthorIds(state, [])).toEqual(null);
     });
+
+    it('returns false when loading is defined', () => {
+      const state = reducer(
+        undefined,
+        loadAddonsByAuthors({
+          ...params,
+          addons: [],
+          count: 0,
+        }),
+      );
+
+      expect(getLoadingForAuthorIds(state, [randomAuthorId1])).toEqual(false);
+    });
   });
 
   describe('getCountForAuthorIds', () => {
@@ -934,7 +947,7 @@ describe(__filename, () => {
     });
 
     it('resets count when fetching add-ons by authors', () => {
-      const count = randomAuthorId1;
+      const count = 123;
 
       const prevState = reducer(
         undefined,

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -390,6 +390,7 @@ describe(__filename, () => {
       const secondAuthorId = fakeAuthorTwo.id;
       const thirdAuthorId = fakeAuthorThree.id;
       const addons = fakeExternalAddons();
+
       const params = getParams({
         addons: Object.values(addons),
         authorIds: [fakeAuthorOne.id, fakeAuthorTwo.id, fakeAuthorThree.id],
@@ -933,7 +934,7 @@ describe(__filename, () => {
     });
 
     it('resets count when fetching add-ons by authors', () => {
-      const count = 123;
+      const count = randomAuthorId1;
 
       const prevState = reducer(
         undefined,


### PR DESCRIPTION
Fixes #6775
~~:warning: depends on #6684~~

---

This PR changes the way we use the `AddonsByAuthorsCard` and adds a
better "loading" state to it. Now, we can render the component all the
time.

The `AddonsByAuthorsCard` is rendered with loading animations on first
render (from the server) and it does not shake.