### PR TITLE
Store the versionId of the current version in addon

### DIFF
--- a/src/amo/reducers/versions.js
+++ b/src/amo/reducers/versions.js
@@ -1,7 +1,17 @@
 /* @flow */
 import invariant from 'invariant';
 
-import { createPlatformFiles } from 'core/reducers/addons';
+import { LOAD_ADDONS_BY_AUTHORS } from 'amo/reducers/addonsByAuthors';
+import {
+  LOAD_COLLECTION_ADDONS,
+  LOAD_CURRENT_COLLECTION,
+  LOAD_CURRENT_COLLECTION_PAGE,
+} from 'amo/reducers/collections';
+import { LOAD_HOME_ADDONS } from 'amo/reducers/home';
+import { LOAD_RECOMMENDATIONS } from 'amo/reducers/recommendations';
+import { LANDING_LOADED } from 'core/constants';
+import { LOAD_ADDON_RESULTS, createPlatformFiles } from 'core/reducers/addons';
+import { SEARCH_LOADED } from 'core/reducers/search';
 import { findFileForPlatform } from 'core/utils';
 import type { UserAgentInfoType } from 'core/reducers/api';
 import type {
@@ -13,13 +23,13 @@ import type {
 export const FETCH_VERSIONS: 'FETCH_VERSIONS' = 'FETCH_VERSIONS';
 export const LOAD_VERSIONS: 'LOAD_VERSIONS' = 'LOAD_VERSIONS';
 
-type VersionIdType = number;
+export type VersionIdType = number;
 
 export type AddonVersionType = {
   compatibility?: AddonCompatibilityType,
   platformFiles: PlatformFilesType,
   id: VersionIdType,
-  license: { name: string, url: string },
+  license: { name: string, url: string } | null,
   releaseNotes?: string,
   version: string,
 };
@@ -31,7 +41,9 @@ export const createInternalVersion = (
     compatibility: version.compatibility,
     platformFiles: createPlatformFiles(version),
     id: version.id,
-    license: { name: version.license.name, url: version.license.url },
+    license: version.license
+      ? { name: version.license.name, url: version.license.url }
+      : null,
     releaseNotes: version.release_notes,
     version: version.version,
   };
@@ -230,6 +242,90 @@ const reducer = (
             versionIds: versions.map((version) => version.id),
             loading: false,
           },
+        },
+      };
+    }
+
+    case LOAD_ADDONS_BY_AUTHORS:
+    case LOAD_ADDON_RESULTS:
+    case LOAD_COLLECTION_ADDONS:
+    case LOAD_CURRENT_COLLECTION:
+    case LOAD_CURRENT_COLLECTION_PAGE:
+    case LOAD_RECOMMENDATIONS:
+    case SEARCH_LOADED: {
+      const { addons, results } = action.payload;
+
+      const items = addons || results;
+      const newVersions = {};
+      for (const addon of items) {
+        // For collection related actions, the addon is available in addon.addon.
+        const addonToUse = addon.addon || addon;
+        if (addonToUse.current_version) {
+          const version = createInternalVersion(addonToUse.current_version);
+          newVersions[version.id] = version;
+        }
+      }
+
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          ...newVersions,
+        },
+      };
+    }
+
+    case LOAD_HOME_ADDONS: {
+      const { collections, shelves } = action.payload;
+
+      const newVersions = {};
+      for (const shelf of Object.keys(shelves)) {
+        for (const addon of shelves[shelf].results) {
+          if (addon.current_version) {
+            const version = createInternalVersion(addon.current_version);
+            newVersions[version.id] = version;
+          }
+        }
+      }
+
+      for (const collection of collections) {
+        if (collection && collection.results) {
+          for (const addon of collection.results) {
+            const version = createInternalVersion(addon.addon.current_version);
+            newVersions[version.id] = version;
+          }
+        }
+      }
+
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          ...newVersions,
+        },
+      };
+    }
+
+    case LANDING_LOADED: {
+      const { featured, highlyRated, trending } = action.payload;
+
+      const newVersions = {};
+      for (const apiResponse of [featured, highlyRated, trending]) {
+        if (apiResponse) {
+          for (const addon of apiResponse.results) {
+            if (addon.current_version) {
+              const version = createInternalVersion(addon.current_version);
+              newVersions[version.id] = version;
+            }
+          }
+        }
+      }
+
+      return {
+        ...state,
+        byId: {
+          ...state.byId,
+          ...newVersions,
         },
       };
     }

--- a/src/amo/reducers/versions.js
+++ b/src/amo/reducers/versions.js
@@ -311,12 +311,10 @@ const reducer = (
 
       const newVersions = {};
       for (const apiResponse of [featured, highlyRated, trending]) {
-        if (apiResponse) {
-          for (const addon of apiResponse.results) {
-            if (addon.current_version) {
-              const version = createInternalVersion(addon.current_version);
-              newVersions[version.id] = version;
-            }
+        for (const addon of apiResponse.results) {
+          if (addon.current_version) {
+            const version = createInternalVersion(addon.current_version);
+            newVersions[version.id] = version;
           }
         }
       }

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -12,6 +12,7 @@ import recommendations from 'amo/reducers/recommendations';
 import reviews from 'amo/reducers/reviews';
 import userAbuseReports from 'amo/reducers/userAbuseReports';
 import users from 'amo/reducers/users';
+import versions from 'amo/reducers/versions';
 import viewContext from 'amo/reducers/viewContext';
 import abuse from 'core/reducers/abuse';
 import addons from 'core/reducers/addons';
@@ -37,6 +38,7 @@ import type { RecommendationsState } from 'amo/reducers/recommendations';
 import type { ReviewsState } from 'amo/reducers/reviews';
 import type { UserAbuseReportsState } from 'amo/reducers/userAbuseReports';
 import type { UsersState } from 'amo/reducers/users';
+import type { VersionsState } from 'amo/reducers/versions';
 import type { ViewContextState } from 'amo/reducers/viewContext';
 import type { AbuseState } from 'core/reducers/abuse';
 import type { AddonsState } from 'core/reducers/addons';
@@ -78,6 +80,7 @@ type InternalAppState = {|
   uiState: UIStateState,
   userAbuseReports: UserAbuseReportsState,
   users: UsersState,
+  versions: VersionsState,
   viewContext: ViewContextState,
 |};
 
@@ -130,6 +133,7 @@ export const reducers: AppReducersType = {
   uiState,
   userAbuseReports,
   users,
+  versions,
   viewContext,
 };
 

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -187,11 +187,13 @@ export function createInternalAddon(apiAddon: ExternalAddonType): AddonType {
     weekly_downloads: apiAddon.weekly_downloads,
 
     // These are custom properties not in the API response.
-    platformFiles: createPlatformFiles(apiAddon.current_version),
+    currentVersionId: apiAddon.current_version
+      ? apiAddon.current_version.id
+      : null,
     isRestartRequired: false,
     isWebExtension: false,
     isMozillaSignedExtension: false,
-
+    platformFiles: createPlatformFiles(apiAddon.current_version),
     themeData: createInternalThemeData(apiAddon),
   };
 

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -1,4 +1,5 @@
 /* @flow */
+import type { VersionIdType } from 'amo/reducers/versions';
 import type { AddonTypeType } from 'core/constants';
 
 type AddonStatus =
@@ -175,6 +176,7 @@ export type PlatformFilesType = {|
 export type AddonType = {|
   ...ExternalAddonType,
   // Here are some custom properties for our internal representation.
+  currentVersionId: VersionIdType | null,
   platformFiles: PlatformFilesType,
   isMozillaSignedExtension: boolean,
   isRestartRequired: boolean,

--- a/tests/unit/amo/reducers/test_versions.js
+++ b/tests/unit/amo/reducers/test_versions.js
@@ -201,21 +201,19 @@ describe(__filename, () => {
     const version = { ...fakeVersion, id: versionId };
 
     describe('LOAD_ADDONS_BY_AUTHORS', () => {
+      const _loadAddonsByAuthors = ({
+        addons = [{ ...fakeAddon, current_version: version }],
+      } = {}) => {
+        return loadAddonsByAuthors({
+          addons,
+          authorUsernames: [fakeAddon.authors[0].username],
+          count: addons.length,
+          pageSize: DEFAULT_API_PAGE_SIZE,
+        });
+      };
+
       it('loads versions', () => {
-        const state = versionsReducer(
-          undefined,
-          loadAddonsByAuthors({
-            addons: [
-              {
-                ...fakeAddon,
-                current_version: version,
-              },
-            ],
-            authorUsernames: [fakeAddon.authors[0].username],
-            count: 1,
-            pageSize: DEFAULT_API_PAGE_SIZE,
-          }),
-        );
+        const state = versionsReducer(undefined, _loadAddonsByAuthors());
 
         expect(
           getVersionById({
@@ -228,12 +226,7 @@ describe(__filename, () => {
       it('handles no add-ons', () => {
         const state = versionsReducer(
           undefined,
-          loadAddonsByAuthors({
-            addons: [],
-            authorUsernames: [fakeAddon.authors[0].username],
-            count: 1,
-            pageSize: DEFAULT_API_PAGE_SIZE,
-          }),
+          _loadAddonsByAuthors({ addons: [] }),
         );
 
         expect(state.byId).toEqual({});
@@ -242,16 +235,13 @@ describe(__filename, () => {
       it('handles an add-on without a current_version', () => {
         const state = versionsReducer(
           undefined,
-          loadAddonsByAuthors({
+          _loadAddonsByAuthors({
             addons: [
               {
                 ...fakeAddon,
                 current_version: undefined,
               },
             ],
-            authorUsernames: [fakeAddon.authors[0].username],
-            count: 1,
-            pageSize: DEFAULT_API_PAGE_SIZE,
           }),
         );
 

--- a/tests/unit/amo/reducers/test_versions.js
+++ b/tests/unit/amo/reducers/test_versions.js
@@ -1,5 +1,17 @@
 import UAParser from 'ua-parser-js';
 
+import { loadAddonsByAuthors } from 'amo/reducers/addonsByAuthors';
+import {
+  loadCollectionAddons,
+  loadCurrentCollectionPage,
+  loadCurrentCollection,
+} from 'amo/reducers/collections';
+import { loadHomeAddons } from 'amo/reducers/home';
+import { loadLanding } from 'amo/actions/landing';
+import {
+  OUTCOME_RECOMMENDED,
+  loadRecommendations,
+} from 'amo/reducers/recommendations';
 import versionsReducer, {
   createInternalVersion,
   fetchVersions,
@@ -10,8 +22,18 @@ import versionsReducer, {
   initialState,
   loadVersions,
 } from 'amo/reducers/versions';
-import { createPlatformFiles } from 'core/reducers/addons';
-import { fakeVersion, userAgentsByPlatform } from 'tests/unit/helpers';
+import { DEFAULT_API_PAGE_SIZE } from 'core/api';
+import { ADDON_TYPE_EXTENSION } from 'core/constants';
+import { createPlatformFiles, loadAddonResults } from 'core/reducers/addons';
+import { searchLoad } from 'core/reducers/search';
+import {
+  createAddonsApiResult,
+  createFakeCollectionAddon,
+  createFakeCollectionDetail,
+  fakeAddon,
+  fakeVersion,
+  userAgentsByPlatform,
+} from 'tests/unit/helpers';
 
 describe(__filename, () => {
   it('defaults to its initial state', () => {
@@ -171,6 +193,337 @@ describe(__filename, () => {
           id: fakeVersion.id,
         }),
       ).toEqual(null);
+    });
+  });
+
+  describe('load versions for add-ons', () => {
+    const versionId = 99;
+    const version = { ...fakeVersion, id: versionId };
+
+    describe('LOAD_ADDONS_BY_AUTHORS', () => {
+      it('loads versions', () => {
+        const state = versionsReducer(
+          undefined,
+          loadAddonsByAuthors({
+            addons: [
+              {
+                ...fakeAddon,
+                current_version: version,
+              },
+            ],
+            authorUsernames: [fakeAddon.authors[0].username],
+            count: 1,
+            pageSize: DEFAULT_API_PAGE_SIZE,
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+
+      it('handles no add-ons', () => {
+        const state = versionsReducer(
+          undefined,
+          loadAddonsByAuthors({
+            addons: [],
+            authorUsernames: [fakeAddon.authors[0].username],
+            count: 1,
+            pageSize: DEFAULT_API_PAGE_SIZE,
+          }),
+        );
+
+        expect(state.byId).toEqual({});
+      });
+
+      it('handles an add-on without a current_version', () => {
+        const state = versionsReducer(
+          undefined,
+          loadAddonsByAuthors({
+            addons: [
+              {
+                ...fakeAddon,
+                current_version: undefined,
+              },
+            ],
+            authorUsernames: [fakeAddon.authors[0].username],
+            count: 1,
+            pageSize: DEFAULT_API_PAGE_SIZE,
+          }),
+        );
+
+        expect(state.byId).toEqual({});
+      });
+    });
+
+    describe('LOAD_CURRENT_COLLECTION', () => {
+      it('loads versions', () => {
+        const fakeCollectionAddon = createFakeCollectionAddon({
+          addon: { ...fakeAddon, current_version: version },
+        });
+
+        const state = versionsReducer(
+          undefined,
+          loadCurrentCollection({
+            addons: [fakeCollectionAddon],
+            detail: createFakeCollectionDetail(),
+            pageSize: DEFAULT_API_PAGE_SIZE,
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+    });
+
+    describe('LOAD_CURRENT_COLLECTION_PAGE', () => {
+      it('loads versions', () => {
+        const fakeCollectionAddon = createFakeCollectionAddon({
+          addon: { ...fakeAddon, current_version: version },
+        });
+
+        const state = versionsReducer(
+          undefined,
+          loadCurrentCollectionPage({
+            addons: [fakeCollectionAddon],
+            numberOfAddons: 1,
+            pageSize: DEFAULT_API_PAGE_SIZE,
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+    });
+
+    describe('LOAD_COLLECTION_ADDONS', () => {
+      it('loads versions', () => {
+        const fakeCollectionAddon = createFakeCollectionAddon({
+          addon: { ...fakeAddon, current_version: version },
+        });
+
+        const state = versionsReducer(
+          undefined,
+          loadCollectionAddons({
+            addons: [fakeCollectionAddon],
+            slug: 'sone-slug',
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+    });
+
+    describe('LOAD_HOME_ADDONS', () => {
+      it('loads versions from shelves', () => {
+        const state = versionsReducer(
+          undefined,
+          loadHomeAddons({
+            collections: [],
+            shelves: {
+              featuredExtensions: createAddonsApiResult([
+                { ...fakeAddon, current_version: version },
+              ]),
+            },
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+
+      it('loads versions for collections', () => {
+        const versionId2 = 111;
+        const version2 = { ...fakeVersion, id: versionId2 };
+        const fakeCollectionAddon1 = createFakeCollectionAddon({
+          addon: { ...fakeAddon, current_version: version },
+        });
+        const fakeCollectionAddon2 = createFakeCollectionAddon({
+          addon: { ...fakeAddon, current_version: version2 },
+        });
+
+        const state = versionsReducer(
+          undefined,
+          loadHomeAddons({
+            collections: [
+              { results: [fakeCollectionAddon1] },
+              { results: [fakeCollectionAddon2] },
+            ],
+            shelves: {},
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+        expect(
+          getVersionById({
+            state,
+            id: versionId2,
+          }),
+        ).toEqual(createInternalVersion(version2));
+      });
+    });
+
+    describe('LANDING_LOADED', () => {
+      it('loads versions for featured add-ons', () => {
+        const state = versionsReducer(
+          undefined,
+          loadLanding({
+            addonType: ADDON_TYPE_EXTENSION,
+            featured: createAddonsApiResult([
+              { ...fakeAddon, current_version: version },
+            ]),
+            highlyRated: createAddonsApiResult([]),
+            trending: createAddonsApiResult([]),
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+
+      it('loads versions for highlyRated add-ons', () => {
+        const state = versionsReducer(
+          undefined,
+          loadLanding({
+            addonType: ADDON_TYPE_EXTENSION,
+            featured: createAddonsApiResult([]),
+            highlyRated: createAddonsApiResult([
+              { ...fakeAddon, current_version: version },
+            ]),
+            trending: createAddonsApiResult([]),
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+
+      it('loads versions for trending add-ons', () => {
+        const state = versionsReducer(
+          undefined,
+          loadLanding({
+            addonType: ADDON_TYPE_EXTENSION,
+            featured: createAddonsApiResult([]),
+            highlyRated: createAddonsApiResult([]),
+            trending: createAddonsApiResult([
+              { ...fakeAddon, current_version: version },
+            ]),
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+    });
+
+    describe('LOAD_RECOMMENDATIONS', () => {
+      it('loads versions', () => {
+        const state = versionsReducer(
+          undefined,
+          loadRecommendations({
+            addons: [
+              {
+                ...fakeAddon,
+                current_version: version,
+              },
+            ],
+            guid: fakeAddon.guid,
+            outcome: OUTCOME_RECOMMENDED,
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+    });
+
+    describe('LOAD_ADDON_RESULTS', () => {
+      it('loads versions', () => {
+        const state = versionsReducer(
+          undefined,
+          loadAddonResults({
+            addons: [
+              {
+                ...fakeAddon,
+                current_version: version,
+              },
+            ],
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
+    });
+
+    describe('SEARCH_LOADED', () => {
+      it('loads versions', () => {
+        const state = versionsReducer(
+          undefined,
+          searchLoad({
+            count: 1,
+            pageSize: DEFAULT_API_PAGE_SIZE,
+            results: [
+              {
+                ...fakeAddon,
+                current_version: version,
+              },
+            ],
+          }),
+        );
+
+        expect(
+          getVersionById({
+            state,
+            id: versionId,
+          }),
+        ).toEqual(createInternalVersion(version));
+      });
     });
   });
 });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -115,6 +115,7 @@ describe(__filename, () => {
 
     expect(state.byID[extension.id]).toEqual({
       ...extension,
+      currentVersionId: fakeAddon.current_version.id,
       platformFiles: {
         ...defaultPlatformFiles,
         [OS_ALL]: fakeAddon.current_version.files[0],
@@ -136,6 +137,7 @@ describe(__filename, () => {
       ...theme,
       themeData: theme.theme_data,
       guid: getGuid(theme),
+      currentVersionId: fakeTheme.current_version.id,
       platformFiles: {
         ...defaultPlatformFiles,
         [OS_ALL]: fakeTheme.current_version.files[0],


### PR DESCRIPTION
Fixes #6634 

This stores the `versionId` of the `current_version` in the `addon` object. It also updates the versions reducer so that every time an add-on is loaded we also load data for the add-on's `current_version` in the versions redux state.

This does not remove `current_version` from `addon` nor does it update any components to access the version via `currentVersionId`. That will be done in small pieces in separate PRs after this change lands.