### PR TITLE
I5893 hide sort filter on collection creation

### DIFF
--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -473,11 +473,13 @@ export class CollectionBase extends React.Component<InternalProps> {
             />
             {this.renderDeleteButton()}
           </Card>
-          <CollectionControls
-            collection={collection}
-            editing={editing}
-            filters={filters}
-          />
+          {!creating && (
+            <CollectionControls
+              collection={collection}
+              editing={editing}
+              filters={filters}
+            />
+          )}
         </div>
         <div className="Collection-items">
           {editing && (

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -837,6 +837,7 @@ describe(__filename, () => {
     expect(wrapper.find('.Collection-wrapper')).toHaveLength(1);
     expect(wrapper.find(AddonsCard)).toHaveLength(0);
     expect(wrapper.find(CollectionDetailsCard)).toHaveProp('creating', true);
+    expect(wrapper.find(CollectionControls)).toHaveLength(0);
   });
 
   it('does not render the pagination when no add-ons in the collection', () => {


### PR DESCRIPTION
Fixes #5893 
The sort filter should be hidden when creating a collection.

Before:
![image](https://user-images.githubusercontent.com/6767433/47264335-7230df80-d547-11e8-9ca2-2046730e46da.png)

After:
![image](https://user-images.githubusercontent.com/6767433/47264328-56c5d480-d547-11e8-960d-7222a0afbca5.png)


