### PR TITLE
Add "description" meta tags on landing, home, about, lang packs and search tools pages

### DIFF
--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -228,6 +228,13 @@ export class HomeBase extends React.Component {
             rel="canonical"
             href={getCanonicalURL({ locationPathname, _config })}
           />
+          <meta
+            name="description"
+            content={i18n.gettext(`Customize Firefox with extensions and
+              themes. They’re like apps for your browser, and they can block
+              annoying ads, protect passwords, change browser appearance, and
+              more.`)}
+          />
         </Helmet>
 
         <span

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -210,6 +210,26 @@ export class LandingPageBase extends React.Component {
     return component;
   }
 
+  getPageDescription() {
+    const {
+      i18n,
+      match: { params },
+    } = this.props;
+
+    const addonType = apiAddonType(params.visibleAddonType);
+
+    if (isTheme(addonType)) {
+      return i18n.gettext(`Change how Firefox looks with themes. Tailor your
+        experience to your tastes. Cute critters, evil robots, beautiful
+        landscapes...choose from thousands of options.`);
+    }
+
+    return i18n.gettext(`Extensions add features to Firefox so you can
+      customize your browsing experience. Protect passwords, download videos,
+      find deals, block annoying ads, and more with these apps for your
+      browser.`);
+  }
+
   render() {
     const {
       _config,
@@ -255,6 +275,7 @@ export class LandingPageBase extends React.Component {
             rel="canonical"
             href={getCanonicalURL({ locationPathname, _config })}
           />
+          <meta name="description" content={this.getPageDescription()} />
         </Helmet>
 
         {errorHandler.renderErrorIfPresent()}

--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -167,6 +167,13 @@ export class LanguageToolsBase extends React.Component<Props> {
             rel="canonical"
             href={getCanonicalURL({ locationPathname, _config })}
           />
+          <meta
+            name="description"
+            content={i18n.gettext(`Dictionaries and language pack extensions
+              for Firefox. Dictionaries add a new language option to your
+              browser spell-checker. Language packs change the browser's
+              interface language, including menu options and settings.`)}
+          />
         </Helmet>
 
         {errorHandler.renderErrorIfPresent()}

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -2,26 +2,45 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import Helmet from 'react-helmet';
 
 import Search from 'amo/components/Search';
 import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_RELEVANCE } from 'core/constants';
+import translate from 'core/i18n/translate';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { SearchFilters } from 'amo/components/AutoSearchInput';
+import type { I18nType } from 'core/types/i18n';
 
 type Props = {|
   filters: SearchFilters,
 |};
 
-export class SearchToolsBase extends React.Component<Props> {
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
+|};
+
+export class SearchToolsBase extends React.Component<InternalProps> {
   render() {
-    const { filters } = this.props;
+    const { filters, i18n } = this.props;
 
     return (
-      <Search
-        enableSearchFilters
-        filters={filters}
-        paginationQueryParams={convertFiltersToQueryParams(filters)}
-      />
+      <React.Fragment>
+        <Helmet>
+          <meta
+            name="description"
+            content={i18n.gettext(`Firefox extensions that customize the way
+              you search—everything from privacy-enhanced searching to
+              website-specific searches, image searching, and more.`)}
+          />
+        </Helmet>
+
+        <Search
+          enableSearchFilters
+          filters={filters}
+          paginationQueryParams={convertFiltersToQueryParams(filters)}
+        />
+      </React.Fragment>
     );
   }
 }
@@ -36,6 +55,7 @@ export function mapStateToProps() {
 }
 
 const SearchTools: React.ComponentType<Props> = compose(
+  translate(),
   connect(mapStateToProps),
 )(SearchToolsBase);
 

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -39,6 +39,13 @@ export class AboutBase extends React.Component<Props> {
             rel="canonical"
             href={getCanonicalURL({ locationPathname, _config })}
           />
+          <meta
+            name="description"
+            content={i18n.gettext(`The official Mozilla site for installing
+              extensions and themes on the Firefox browser. Add new features
+              and change the browser’s appearance to customize your web
+              experience.`)}
+          />
         </Helmet>
 
         <div className="StaticPageWrapper">

--- a/tests/unit/amo/pages/StaticPages/TestAbout.js
+++ b/tests/unit/amo/pages/StaticPages/TestAbout.js
@@ -41,4 +41,13 @@ describe(__filename, () => {
       `${baseURL}${pathname}`,
     );
   });
+
+  it('renders a "description" meta tag', () => {
+    const root = render();
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+      /The official Mozilla site/,
+    );
+  });
 });

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -429,4 +429,13 @@ describe(__filename, () => {
       `${baseURL}${pathname}`,
     );
   });
+
+  it('renders a "description" meta tag', () => {
+    const root = render();
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+      /Customize Firefox with extensions/,
+    );
+  });
 });

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -622,4 +622,20 @@ describe(__filename, () => {
       `${baseURL}${pathname}`,
     );
   });
+
+  it.each([
+    [ADDON_TYPE_EXTENSION, /Extensions add/],
+    [ADDON_TYPE_THEME, /Change how Firefox looks/],
+  ])('renders a "description" meta tag for %s', (addonType, partialContent) => {
+    const root = render({
+      match: {
+        params: { visibleAddonType: visibleAddonType(addonType) },
+      },
+    });
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+      partialContent,
+    );
+  });
 });

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -320,4 +320,13 @@ describe(__filename, () => {
       `${baseURL}${pathname}`,
     );
   });
+
+  it('renders a "description" meta tag', () => {
+    const root = renderShallow();
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+      /Dictionaries and language pack extensions/,
+    );
+  });
 });

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -3,14 +3,18 @@ import * as React from 'react';
 import SearchTools, { SearchToolsBase } from 'amo/pages/SearchTools';
 import Search from 'amo/components/Search';
 import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_RELEVANCE } from 'core/constants';
-import { dispatchClientMetadata, shallowUntilTarget } from 'tests/unit/helpers';
+import {
+  dispatchClientMetadata,
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
 
 describe(__filename, () => {
   let store;
 
   function render({ ...props } = {}) {
     return shallowUntilTarget(
-      <SearchTools store={store} {...props} />,
+      <SearchTools store={store} i18n={fakeI18n()} {...props} />,
       SearchToolsBase,
     );
   }
@@ -30,5 +34,14 @@ describe(__filename, () => {
       addonType: ADDON_TYPE_OPENSEARCH,
       sort: SEARCH_SORT_RELEVANCE,
     });
+  });
+
+  it('renders a "description" meta tag', () => {
+    const root = render();
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+      /Firefox extensions that customize the way you search/,
+    );
   });
 });


### PR DESCRIPTION
Refs #5767

---

- [x] homepage
- [x] landing pages
- [x] about
- [x] Dictionaries and Lang Packs
- [x] Search tools

Please see this doc for the content: https://docs.google.com/document/d/1jCkeuyCuLpcwAVIXnqpYKgqnHnV0y1OkuQ1WHUc-ftI/edit?usp=sharing

This is the batch #1, I'll open another PR for the categories and yet another one for the more "dynamic" descriptions (reviews, user profiles, etc.)