### PR TITLE
Add description meta tag on review pages

### DIFF
--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -1,5 +1,6 @@
 /* @flow */
 /* eslint-disable react/no-unused-prop-types */
+import invariant from 'invariant';
 import makeClassName from 'classnames';
 import * as React from 'react';
 import Helmet from 'react-helmet';
@@ -154,6 +155,18 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     return location.query.page || '1';
   }
 
+  getPageDescription() {
+    const { addon, i18n } = this.props;
+
+    invariant(addon, 'addon is required');
+
+    return i18n.sprintf(
+      i18n.gettext(`Reviews and ratings for %(addonName)s. Find out what other
+        users think about %(addonName)s and add it to your Firefox Browser.`),
+      { addonName: addon.name },
+    );
+  }
+
   render() {
     const {
       addon,
@@ -242,6 +255,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
         {addon && (
           <Helmet>
             <title>{header}</title>
+            <meta name="description" content={this.getPageDescription()} />
             {reviewId && <meta name="robots" content="noindex, follow" />}
           </Helmet>
         )}

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -702,7 +702,11 @@ describe(__filename, () => {
 
     expect(root.find('meta[name="description"]')).toHaveLength(1);
     expect(root.find('meta[name="description"]').prop('content')).toMatch(
-      new RegExp(`Reviews and ratings for ${addon.name}`),
+      new RegExp(
+        `Reviews and ratings for ${
+          addon.name
+        }. Find out what other users think about ${addon.name}`,
+      ),
     );
   });
 

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -694,6 +694,18 @@ describe(__filename, () => {
     });
   });
 
+  it('renders a "description" meta tag', () => {
+    const addon = createInternalAddon(fakeAddon);
+    dispatchAddon(addon);
+
+    const root = render();
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+      new RegExp(`Reviews and ratings for ${addon.name}`),
+    );
+  });
+
   describe('extractId', () => {
     it('returns a unique ID based on the addon slug and page', () => {
       const ownProps = getProps({

--- a/tests/unit/amo/reducers/test_versions.js
+++ b/tests/unit/amo/reducers/test_versions.js
@@ -206,7 +206,7 @@ describe(__filename, () => {
       } = {}) => {
         return loadAddonsByAuthors({
           addons,
-          authorUsernames: [fakeAddon.authors[0].username],
+          authorIds: [fakeAddon.authors[0].id],
           count: addons.length,
           pageSize: DEFAULT_API_PAGE_SIZE,
         });


### PR DESCRIPTION
Refs #5767

---

This PR adds `description` meta tags on review pages.

Please see this doc for the content: https://docs.google.com/document/d/1jCkeuyCuLpcwAVIXnqpYKgqnHnV0y1OkuQ1WHUc-ftI/edit?usp=sharing