### PR TITLE
Update page titles for Android

### DIFF
--- a/src/amo/components/AddonHead/index.js
+++ b/src/amo/components/AddonHead/index.js
@@ -47,36 +47,36 @@ export class AddonHeadBase extends React.Component<InternalProps> {
     if (clientApp === CLIENT_APP_ANDROID) {
       switch (addon.type) {
         case ADDON_TYPE_DICT:
-          // translators: please keep the fox emoji next to "Android".
+          // translators: please keep the fox emoji next to "Firefox Android".
           localizedTitle = i18n.gettext(`%(addonName)s – Get this Dictionary
-            for 🦊 Android (%(locale)s)`);
+            for 🦊 Firefox Android (%(locale)s)`);
           break;
         case ADDON_TYPE_EXTENSION:
-          // translators: please keep the fox emoji next to "Android".
+          // translators: please keep the fox emoji next to "Firefox Android".
           localizedTitle = i18n.gettext(`%(addonName)s – Get this Extension for
-            🦊 Android (%(locale)s)`);
+            🦊 Firefox Android (%(locale)s)`);
           break;
         case ADDON_TYPE_LANG:
-          // translators: please keep the fox emoji next to "Android".
+          // translators: please keep the fox emoji next to "Firefox Android".
           localizedTitle = i18n.gettext(`%(addonName)s – Get this Language Pack
-            for 🦊 Android (%(locale)s)`);
+            for 🦊 Firefox Android (%(locale)s)`);
           break;
         case ADDON_TYPE_STATIC_THEME:
         case ADDON_TYPE_THEME:
-          // translators: please keep the fox emoji next to "Android".
+          // translators: please keep the fox emoji next to "Firefox Android".
           localizedTitle = i18n.gettext(
-            `%(addonName)s – Get this Theme for 🦊 Android (%(locale)s)`,
+            `%(addonName)s – Get this Theme for 🦊 Firefox Android (%(locale)s)`,
           );
           break;
         case ADDON_TYPE_OPENSEARCH:
-          // translators: please keep the fox emoji next to "Android".
+          // translators: please keep the fox emoji next to "Firefox Android".
           localizedTitle = i18n.gettext(`%(addonName)s – Get this Search Tool
-            for 🦊 Android (%(locale)s)`);
+            for 🦊 Firefox Android (%(locale)s)`);
           break;
         default:
-          // translators: please keep the fox emoji next to "Android".
+          // translators: please keep the fox emoji next to "Firefox Android".
           localizedTitle = i18n.gettext(`%(addonName)s – Get this Add-on for 🦊
-            Android (%(locale)s)`);
+            Firefox Android (%(locale)s)`);
       }
     } else {
       switch (addon.type) {

--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -228,11 +228,11 @@ export class AppBase extends React.Component<Props> {
 
     if (clientApp === CLIENT_APP_ANDROID) {
       defaultTitle = i18n.sprintf(
-        i18n.gettext('Add-ons for Android (%(locale)s)'),
+        i18n.gettext('Add-ons for Firefox Android (%(locale)s)'),
         i18nValues,
       );
       titleTemplate = i18n.sprintf(
-        i18n.gettext('%(title)s – Add-ons for Android (%(locale)s)'),
+        i18n.gettext('%(title)s – Add-ons for Firefox Android (%(locale)s)'),
         // We inject `%s` as a named argument to avoid localizer mistakes.
         // Helmet will replace `%s` by the title supplied in other pages.
         { ...i18nValues, title: '%s' },

--- a/tests/unit/amo/components/TestAddonHead.js
+++ b/tests/unit/amo/components/TestAddonHead.js
@@ -79,7 +79,7 @@ describe(__filename, () => {
     const root = render({ addon, store });
 
     expect(root.find('title')).toHaveText(
-      `${addon.name} – Get this ${name} for 🦊 Android (${lang})`,
+      `${addon.name} – Get this ${name} for 🦊 Firefox Android (${lang})`,
     );
   });
 

--- a/tests/unit/amo/components/TestApp.js
+++ b/tests/unit/amo/components/TestApp.js
@@ -164,7 +164,7 @@ describe(__filename, () => {
     const root = render({ store });
     expect(root.find(Helmet)).toHaveProp(
       'defaultTitle',
-      `Add-ons for Android (${lang})`,
+      `Add-ons for Firefox Android (${lang})`,
     );
   });
 
@@ -190,7 +190,7 @@ describe(__filename, () => {
     const root = render({ store });
     expect(root.find(Helmet)).toHaveProp(
       'titleTemplate',
-      `%s – Add-ons for Android (${lang})`,
+      `%s – Add-ons for Firefox Android (${lang})`,
     );
   });
 


### PR DESCRIPTION
Fixes #6648

---

Update the page titles for Android, according to this comment: https://github.com/mozilla/addons-frontend/issues/6648#issuecomment-432236938