### PR TITLE
Initialize the client with a predictable app state

### DIFF
--- a/src/core/components/ServerHtml/index.js
+++ b/src/core/components/ServerHtml/index.js
@@ -15,6 +15,7 @@ const JS_CHUNK_EXCLUDES = new RegExp(
 export default class ServerHtml extends Component {
   static propTypes = {
     appName: PropTypes.string.isRequired,
+    appState: PropTypes.object.isRequired,
     assets: PropTypes.object.isRequired,
     component: PropTypes.element.isRequired,
     htmlDir: PropTypes.string,
@@ -22,7 +23,6 @@ export default class ServerHtml extends Component {
     includeSri: PropTypes.bool.isRequired,
     noScriptStyles: PropTypes.string,
     sriData: PropTypes.object.isRequired,
-    store: PropTypes.object.isRequired,
     trackingEnabled: PropTypes.bool,
     _config: PropTypes.object,
   };
@@ -101,7 +101,13 @@ export default class ServerHtml extends Component {
   }
 
   render() {
-    const { component, htmlLang, htmlDir, noScriptStyles, store } = this.props;
+    const {
+      appState,
+      component,
+      htmlLang,
+      htmlDir,
+      noScriptStyles,
+    } = this.props;
 
     // This must happen before Helmet.rewind() see
     // https://github.com/nfl/react-helmet#server-usage for more info.
@@ -128,7 +134,7 @@ export default class ServerHtml extends Component {
         <body>
           <div id="react-view" dangerouslySetInnerHTML={{ __html: content }} />
           <script
-            dangerouslySetInnerHTML={{ __html: serialize(store.getState()) }}
+            dangerouslySetInnerHTML={{ __html: serialize(appState) }}
             type="application/json"
             id="redux-store-state"
           />

--- a/tests/unit/core/components/TestServerHtml.js
+++ b/tests/unit/core/components/TestServerHtml.js
@@ -21,17 +21,13 @@ describe(__filename, () => {
     Helmet.canUseDOM = _helmetCanUseDOM;
   });
 
-  const fakeStore = {
-    getState: () => ({ foo: 'bar' }),
-  };
-
   function render(opts = {}) {
     const pageProps = {
       appName: 'disco',
+      appState: { appStateExample: { things: 'lots-of-things' } },
       component: <FakeApp />,
       assets: fakeAssets,
       includeSri: true,
-      store: fakeStore,
       trackingEnabled: false,
       sriData: fakeSRIData,
       ...opts,
@@ -125,13 +121,13 @@ describe(__filename, () => {
   });
 
   it('renders state as JSON', () => {
-    const store = fakeStore;
-    const root = render({ store });
+    const appState = { usersExample: ['first-user', 'second-user'] };
+    const root = render({ appState });
     const json = root.find('#redux-store-state');
 
     expect(json).toHaveLength(1);
     expect(JSON.parse(json.prop('dangerouslySetInnerHTML').__html)).toEqual(
-      store.getState(),
+      appState,
     );
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6729 by serializing the application state immediately after all sagas have finished and *before* the final application component begins rendering. 

This ensures that the client always has a predictable app state. In other words, we already know that we only get *one* chance to load data: the first render and any saga that was triggered by it. This patch makes that implementation detail predictable. 

Before this patch, the constructors of components in the *second* render might have been able to modify the initial state, depending on timing. I don't know if any page was relying on that buggy behavior but I tested cold loads of many pages with this patch and they seem to work.

The steps in https://github.com/mozilla/addons-frontend/issues/6729 for reproducing the bug are no longer possible after this patch. I no longer see the page render in an infinite loading state.