### PR TITLE
Remove AMInstallButton config, use it everywhere

### DIFF
--- a/config/default-amo.js
+++ b/config/default-amo.js
@@ -116,6 +116,4 @@ module.exports = {
   // This needs to match the SESSION_COOKIE_AGE in addons-server:
   // https://github.com/mozilla/addons-server/blob/master/src/olympia/lib/settings_base.py#L990
   authTokenValidFor: 2592000, // 30 days
-
-  enableFeatureAMInstallButton: true,
 };

--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -22,7 +22,6 @@ module.exports = {
     'defaultLang',
     'discoParamsToUse',
     'enableDevTools',
-    'enableFeatureAMInstallButton',
     'enableRequestID',
     'hctEnabled',
     'hrefLangsMap',

--- a/config/default.js
+++ b/config/default.js
@@ -108,7 +108,6 @@ module.exports = {
     'defaultLang',
     'dismissedExperienceSurveyCookieName',
     'enableDevTools',
-    'enableFeatureAMInstallButton',
     'enableFeatureExperienceSurvey',
     'enableFeatureInlineAddonReview',
     'enableRequestID',
@@ -347,9 +346,6 @@ module.exports = {
 
   enableFeatureExperienceSurvey: false,
   dismissedExperienceSurveyCookieName: 'dismissedExperienceSurvey',
-
-  // Enable new InstallButton with mozAddonManager.
-  enableFeatureAMInstallButton: false,
 
   enableFeatureInlineAddonReview: true,
 

--- a/config/dev-disco.js
+++ b/config/dev-disco.js
@@ -25,6 +25,4 @@ module.exports = {
 
   // https://sentry.prod.mozaws.net/operations/addons-frontend-disco-dev/
   publicSentryDsn: 'https://560fc81d9fd14266b99bda032de23c52@sentry.prod.mozaws.net/184',
-
-  enableFeatureAMInstallButton: true,
 };

--- a/config/development-disco.js
+++ b/config/development-disco.js
@@ -1,5 +1,4 @@
 module.exports = {
   trackingEnabled: false,
   loggingLevel: 'debug',
-  enableFeatureAMInstallButton: true,
 };

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -32,7 +32,6 @@ import {
 } from 'core/reducers/addons';
 import { sendServerRedirect } from 'core/reducers/redirectTo';
 import { withFixedErrorHandler } from 'core/errorHandler';
-import InstallButton from 'core/components/InstallButton';
 import AMInstallButton from 'core/components/AMInstallButton';
 import {
   ADDON_TYPE_DICT,
@@ -405,7 +404,6 @@ export class AddonBase extends React.Component {
       addon,
       addonsByAuthors,
       clientApp,
-      config,
       defaultInstallSource,
       enable,
       errorHandler,
@@ -530,32 +528,21 @@ export class AddonBase extends React.Component {
                   <p className="Addon-summary" {...summaryProps} />
                 ) : null}
 
-                {showInstallButton &&
-                  config.get('enableFeatureAMInstallButton') && (
-                    <AMInstallButton
-                      addon={addon}
-                      defaultInstallSource={defaultInstallSource}
-                      disabled={!isCompatible}
-                      enable={enable}
-                      hasAddonManager={hasAddonManager}
-                      install={install}
-                      installTheme={installTheme}
-                      setCurrentStatus={setCurrentStatus}
-                      status={installStatus}
-                      uninstall={uninstall}
-                      isAddonEnabled={isAddonEnabled}
-                    />
-                  )}
-                {showInstallButton &&
-                  config.get('enableFeatureAMInstallButton') === false && (
-                    <InstallButton
-                      {...this.props}
-                      disabled={!isCompatible}
-                      defaultInstallSource={defaultInstallSource}
-                      status={installStatus}
-                      useButton
-                    />
-                  )}
+                {showInstallButton && (
+                  <AMInstallButton
+                    addon={addon}
+                    defaultInstallSource={defaultInstallSource}
+                    disabled={!isCompatible}
+                    enable={enable}
+                    hasAddonManager={hasAddonManager}
+                    install={install}
+                    installTheme={installTheme}
+                    setCurrentStatus={setCurrentStatus}
+                    status={installStatus}
+                    uninstall={uninstall}
+                    isAddonEnabled={isAddonEnabled}
+                  />
+                )}
                 {showGetFirefoxButton && (
                   <Button
                     buttonType="confirm"

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -1,5 +1,4 @@
 /* @flow */
-import config from 'config';
 import makeClassName from 'classnames';
 import * as React from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -8,7 +7,6 @@ import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import AddonCompatibilityError from 'disco/components/AddonCompatibilityError';
-import InstallButton from 'core/components/InstallButton';
 import AMInstallButton from 'core/components/AMInstallButton';
 import {
   ADDON_TYPE_EXTENSION,
@@ -51,7 +49,6 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   ...WithInstallHelpersInjectedProps,
-  _config: typeof config,
   _getClientCompatibility: typeof getClientCompatibility,
   _tracking: typeof tracking,
   addon: AddonType,
@@ -65,7 +62,6 @@ type InternalProps = {|
 
 export class AddonBase extends React.Component<InternalProps> {
   static defaultProps = {
-    _config: config,
     _tracking: tracking,
     _getClientCompatibility: getClientCompatibility,
   };
@@ -211,7 +207,6 @@ export class AddonBase extends React.Component<InternalProps> {
 
   render() {
     const {
-      _config,
       _getClientCompatibility,
       addon,
       clientApp,
@@ -285,31 +280,21 @@ export class AddonBase extends React.Component<InternalProps> {
             {this.getDescription()}
           </div>
 
-          {_config.get('enableFeatureAMInstallButton') ? (
-            <AMInstallButton
-              addon={addon}
-              className="Addon-install-button"
-              defaultInstallSource={defaultInstallSource}
-              disabled={!compatible}
-              enable={enable}
-              hasAddonManager={hasAddonManager}
-              install={install}
-              installTheme={installTheme}
-              isAddonEnabled={isAddonEnabled}
-              puffy={false}
-              setCurrentStatus={setCurrentStatus}
-              status={status || UNKNOWN}
-              uninstall={uninstall}
-            />
-          ) : (
-            <InstallButton
-              {...this.props.addon}
-              {...this.props}
-              className="Addon-install-button"
-              defaultInstallSource={defaultInstallSource}
-              size="small"
-            />
-          )}
+          <AMInstallButton
+            addon={addon}
+            className="Addon-install-button"
+            defaultInstallSource={defaultInstallSource}
+            disabled={!compatible}
+            enable={enable}
+            hasAddonManager={hasAddonManager}
+            install={install}
+            installTheme={installTheme}
+            isAddonEnabled={isAddonEnabled}
+            puffy={false}
+            setCurrentStatus={setCurrentStatus}
+            status={status || UNKNOWN}
+            uninstall={uninstall}
+          />
         </div>
 
         {!compatible ? <AddonCompatibilityError reason={reason} /> : null}

--- a/tests/ui/pages/discopane.py
+++ b/tests/ui/pages/discopane.py
@@ -55,8 +55,12 @@ class DiscoveryPane(Page):
     class Addon(Region):
         """Contains all locators and functions for extensions and themes."""
 
-        _install_button_locator = (By.CLASS_NAME, 'InstallButton-switch')
-        _success_switch_locator = (By.CLASS_NAME, 'Switch--success')
+        _install_button_locator = (By.CLASS_NAME, 'AMInstallButton')
+        # When an add-on is installed/enabled, the AMInstallButton shows an
+        # "uninstall" button. If we see it, it means the add-on has been
+        # successfully installed.
+        _uninstall_button_locator = (By.CLASS_NAME,
+                                     'AMInstallButton-button--uninstall')
 
         def install(self):
             """Install the theme or extension."""
@@ -65,4 +69,4 @@ class DiscoveryPane(Page):
         @property
         def is_installed(self):
             """Check if theme or extensions is installed."""
-            return self.is_element_displayed(*self._success_switch_locator)
+            return self.is_element_displayed(*self._uninstall_button_locator)

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -46,10 +46,8 @@ import {
   INCOMPATIBLE_UNDER_MIN_VERSION,
   INSTALLED,
   INSTALLING,
-  INSTALL_SOURCE_DETAIL_PAGE,
   UNKNOWN,
 } from 'core/constants';
-import InstallButton from 'core/components/InstallButton';
 import AMInstallButton from 'core/components/AMInstallButton';
 import { ErrorHandler } from 'core/errorHandler';
 import I18nProvider from 'core/i18n/Provider';
@@ -65,7 +63,6 @@ import {
   fakeI18n,
   fakeInstalledAddon,
   fakeTheme,
-  getFakeConfig,
   sampleUserAgentParsed,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
@@ -261,7 +258,7 @@ describe(__filename, () => {
     });
 
     // These should be empty:
-    expect(root.find(InstallButton)).toHaveLength(0);
+    expect(root.find(AMInstallButton)).toHaveLength(0);
     expect(root.find(AddonCompatibilityError)).toHaveLength(0);
     expect(root.find(RatingManager)).toHaveLength(0);
 
@@ -641,16 +638,6 @@ describe(__filename, () => {
     expect(root.find('.AddonDescription-contents').html()).toEqual(
       '<div class="AddonDescription-contents"></div>',
     );
-  });
-
-  it('configures the install button', () => {
-    const root = shallowRender().find(InstallButton);
-    expect(root.prop('slug')).toEqual(fakeAddon.slug);
-  });
-
-  it('always uses a button and not a switch for the InstallButton', () => {
-    const root = shallowRender().find(InstallButton);
-    expect(root.prop('useButton')).toEqual(true);
   });
 
   it('sets a title for the description of an extension', () => {
@@ -1039,15 +1026,6 @@ describe(__filename, () => {
     expect(root.find('.Addon-theme')).toHaveLength(1);
   });
 
-  it('disables install button for incompatibility with firefox version', () => {
-    const root = shallowRender({
-      getClientCompatibility: () => ({
-        reason: INCOMPATIBLE_UNDER_MIN_VERSION,
-      }),
-    });
-    expect(root.find(InstallButton).prop('disabled')).toBe(true);
-  });
-
   it('passes the downloadUrl from getClientCompatibility', () => {
     const root = shallowRender({
       getClientCompatibility: () => ({
@@ -1067,34 +1045,6 @@ describe(__filename, () => {
     });
     expect(root.find(AddonCompatibilityError)).toHaveLength(0);
     expect(root.find(Button)).toHaveLength(1);
-  });
-
-  it('passes installStatus to InstallButton, not add-on status', () => {
-    const root = shallowRender({
-      addon: createInternalAddon(fakeAddon),
-      installStatus: UNKNOWN,
-    });
-
-    const button = root.find(InstallButton);
-    expect(button.prop('status')).not.toEqual(fakeAddon.status);
-    expect(button.prop('status')).toEqual(UNKNOWN);
-  });
-
-  it('sets an install source', () => {
-    const addon = fakeAddon;
-    const { store } = dispatchClientMetadata();
-    store.dispatch(_loadAddonResults({ addon }));
-    const root = renderComponent({
-      params: { slug: addon.slug },
-      store,
-    });
-
-    const button = root.find(InstallButton);
-    // This value is passed to <Addon/> by the withInstallHelpers() HOC.
-    expect(button).toHaveProp(
-      'defaultInstallSource',
-      INSTALL_SOURCE_DETAIL_PAGE,
-    );
   });
 
   it('renders a ThemeImage in the header', () => {
@@ -1565,16 +1515,14 @@ describe(__filename, () => {
   describe('AMInstallButton', () => {
     const renderWithAMInstallButton = (props = {}) => {
       return shallowRender({
-        config: getFakeConfig({ enableFeatureAMInstallButton: true }),
         hasAddonManager: true,
         ...props,
       });
     };
 
-    it('renders the AMInstallButton when config allows it', () => {
+    it('renders the AMInstallButton', () => {
       const root = renderWithAMInstallButton();
 
-      expect(root.find(InstallButton)).toHaveLength(0);
       expect(root.find(AMInstallButton)).toHaveLength(1);
     });
 

--- a/tests/unit/disco/components/TestAddon.js
+++ b/tests/unit/disco/components/TestAddon.js
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { oneLine } from 'common-tags';
-import { shallow } from 'enzyme';
 
 import Addon, { AddonBase } from 'disco/components/Addon';
 import { setInstallError, setInstallState } from 'core/actions/installations';
-import InstallButton from 'core/components/InstallButton';
 import AMInstallButton from 'core/components/AMInstallButton';
 import {
   ADDON_TYPE_EXTENSION,
@@ -21,11 +19,7 @@ import {
   UNINSTALLED,
 } from 'core/constants';
 import { getErrorMessage } from 'core/utils/addons';
-import {
-  createInternalAddon,
-  getAddonByID,
-  getGuid,
-} from 'core/reducers/addons';
+import { getGuid } from 'core/reducers/addons';
 import AddonCompatibilityError from 'disco/components/AddonCompatibilityError';
 import createStore from 'disco/store';
 import {
@@ -33,7 +27,6 @@ import {
   createFakeEvent,
   createFakeTracking,
   fakeI18n,
-  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import {
@@ -99,26 +92,6 @@ describe(__filename, () => {
     });
 
     expect(root.find(LoadingText)).toHaveLength(1);
-  });
-
-  it('passes install helper functions to the install button', () => {
-    const enable = sinon.stub();
-    const install = sinon.stub();
-    const installTheme = sinon.stub();
-    const uninstall = sinon.stub();
-
-    const root = render({
-      enable,
-      install,
-      installTheme,
-      uninstall,
-    });
-
-    const installButton = root.find(InstallButton);
-    expect(installButton).toHaveProp('enable', enable);
-    expect(installButton).toHaveProp('install', install);
-    expect(installButton).toHaveProp('installTheme', installTheme);
-    expect(installButton).toHaveProp('uninstall', uninstall);
   });
 
   describe('<Addon type="extension"/>', () => {
@@ -438,29 +411,6 @@ describe(__filename, () => {
       });
     });
 
-    it('passes some props to the install button', () => {
-      const { addonId, i18n, ...otherProps } = getProps();
-      const defaultInstallSource = 'fake-discopane-source';
-
-      const addon = getAddonByID(store.getState(), addonId);
-      const allProps = {
-        ...otherProps,
-        addon,
-        defaultInstallSource,
-        i18n,
-      };
-
-      // We use shallow to be able to inject `defaultInstallSource` here.
-      const root = shallow(<AddonBase {...allProps} />, { context: { i18n } });
-
-      const button = root.find(InstallButton);
-
-      expect(button).toHaveLength(1);
-      expect(button).toHaveProp('addon', createInternalAddon(addon));
-      expect(button).toHaveProp('className', 'Addon-install-button');
-      expect(button).toHaveProp('defaultInstallSource', defaultInstallSource);
-    });
-
     it('disables incompatible add-ons', () => {
       const reason = 'WHATEVER';
 
@@ -673,16 +623,14 @@ describe(__filename, () => {
   describe('AMInstallButton', () => {
     const renderWithAMInstallButton = (props = {}) => {
       return render({
-        _config: getFakeConfig({ enableFeatureAMInstallButton: true }),
         hasAddonManager: true,
         ...props,
       });
     };
 
-    it('renders the AMInstallButton when config allows it', () => {
+    it('renders the AMInstallButton', () => {
       const root = renderWithAMInstallButton();
 
-      expect(root.find(InstallButton)).toHaveLength(0);
       expect(root.find(AMInstallButton)).toHaveLength(1);
       expect(root.find(AMInstallButton)).toHaveProp('puffy', false);
       expect(root.find(AMInstallButton)).toHaveProp('hasAddonManager', true);


### PR DESCRIPTION
Fixes #6539

---

Given that the `AMInstallButton` has been in-use for a while on AMO, I decided to remove the feature flag and make it the only button on both AMO and Disco Pane.