### PR TITLE
Let unlisted add-on owners/developers reply to reviews

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -71,6 +71,7 @@ type InternalProps = {|
   i18n: I18nType,
   replyingToReview: boolean,
   siteUser: UserType | null,
+  siteUserCanManageReplies: boolean,
   siteUserHasReplyPerm: boolean,
   submittingReply: boolean,
 |};
@@ -283,11 +284,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     return i18n.gettext('Keep review');
   }
 
-  siteUserCanManageReplies() {
-    const { siteUserCanReply, siteUserHasReplyPerm } = this.props;
-    return siteUserCanReply || siteUserHasReplyPerm;
-  }
-
   renderReply() {
     const {
       addon,
@@ -354,6 +350,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       showControls,
       showRating,
       siteUser,
+      siteUserCanManageReplies,
       slim,
     } = this.props;
 
@@ -408,7 +405,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       review &&
       siteUser &&
       (review.userId === siteUser.id ||
-        (this.isReply() && this.siteUserCanManageReplies()));
+        (this.isReply() && siteUserCanManageReplies));
 
     const controls = controlsAreVisible ? (
       <div className="AddonReviewCard-allControls">
@@ -455,7 +452,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
         !replyingToReview &&
         !review.reply &&
         !this.isReply() &&
-        this.siteUserCanManageReplies() &&
+        siteUserCanManageReplies &&
         siteUser &&
         review.userId !== siteUser.id ? (
           <a
@@ -559,13 +556,16 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
     }
   }
 
+  const siteUserHasReplyPerm = hasPermission(state, ADDONS_EDIT);
+
   return {
     beginningToDeleteReview,
     deletingReview,
     editingReview,
     replyingToReview,
     siteUser: getCurrentUser(state.users),
-    siteUserHasReplyPerm: hasPermission(state, ADDONS_EDIT),
+    siteUserCanManageReplies: ownProps.siteUserCanReply || siteUserHasReplyPerm,
+    siteUserHasReplyPerm,
     submittingReply,
   };
 }

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -15,7 +15,6 @@ import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import { getCurrentUser, hasPermission } from 'amo/reducers/users';
-import { isAddonAuthor } from 'core/utils';
 import {
   beginDeleteAddonReview,
   cancelDeleteAddonReview,
@@ -52,6 +51,7 @@ type Props = {|
   shortByLine?: boolean,
   showControls?: boolean,
   showRating?: boolean,
+  siteUserCanReply: ?boolean,
   // When true, this renders things *bigger* because the container is
   // more slim than usual, like the Rate Your Experience card.
   //
@@ -63,7 +63,6 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   _config: typeof config,
-  _siteUserCanManageReplies?: () => boolean,
   beginningToDeleteReview: boolean,
   deletingReview: boolean,
   dispatch: DispatchFunc,
@@ -285,22 +284,8 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
   }
 
   siteUserCanManageReplies() {
-    const {
-      addon,
-      siteUser,
-      siteUserHasReplyPerm,
-      _siteUserCanManageReplies,
-    } = this.props;
-    if (_siteUserCanManageReplies) {
-      // Return a stub implementation for testing.
-      return _siteUserCanManageReplies();
-    }
-    if (!siteUser) {
-      return false;
-    }
-    return (
-      isAddonAuthor({ addon, userId: siteUser.id }) || siteUserHasReplyPerm
-    );
+    const { siteUserCanReply, siteUserHasReplyPerm } = this.props;
+    return siteUserCanReply || siteUserHasReplyPerm;
   }
 
   renderReply() {
@@ -311,6 +296,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       replyingToReview,
       review,
       slim,
+      siteUserCanReply,
       submittingReply,
     } = this.props;
 
@@ -345,6 +331,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
             isReplyToReviewId={review.id}
             review={review.reply}
             slim={slim}
+            siteUserCanReply={siteUserCanReply}
           />
         )}
       </div>
@@ -571,6 +558,7 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
       submittingReply = view.submittingReply;
     }
   }
+
   return {
     beginningToDeleteReview,
     deletingReview,

--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -23,6 +23,7 @@ import './styles.scss';
 type Props = {|
   addon: AddonType | null,
   reviewId: number,
+  siteUserCanReply: ?boolean,
 |};
 
 type InternalProps = {|
@@ -71,7 +72,13 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
   }
 
   render() {
-    const { addon, errorHandler, featuredReview, i18n } = this.props;
+    const {
+      addon,
+      errorHandler,
+      featuredReview,
+      i18n,
+      siteUserCanReply,
+    } = this.props;
 
     const featuredReviewHeader = featuredReview
       ? i18n.sprintf(
@@ -93,7 +100,11 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
           </div>
         </NestedStatus>
       ) : (
-        <AddonReviewCard addon={addon} review={featuredReview} />
+        <AddonReviewCard
+          addon={addon}
+          review={featuredReview}
+          siteUserCanReply={siteUserCanReply}
+        />
       );
 
     return (

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -365,6 +365,7 @@ export class RatingManagerBase extends React.Component<InternalProps, State> {
             shortByLine
             showControls={!this.isMessageVisible()}
             showRating={false}
+            siteUserCanReply={false}
             slim
           />
         )}

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -9,9 +9,14 @@ import { compose } from 'redux';
 import AddonReviewCard from 'amo/components/AddonReviewCard';
 import AddonSummaryCard from 'amo/components/AddonSummaryCard';
 import FeaturedAddonReview from 'amo/components/FeaturedAddonReview';
-import { fetchReviews } from 'amo/actions/reviews';
+import { fetchReviewPermissions, fetchReviews } from 'amo/actions/reviews';
 import { setViewContext } from 'amo/actions/viewContext';
-import { expandReviewObjects, reviewsAreLoading } from 'amo/reducers/reviews';
+import {
+  expandReviewObjects,
+  reviewsAreLoading,
+  selectReviewPermissions,
+} from 'amo/reducers/reviews';
+import { getCurrentUser } from 'amo/reducers/users';
 import {
   fetchAddon,
   getAddonBySlug,
@@ -25,6 +30,7 @@ import Link from 'amo/components/Link';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import CardList from 'ui/components/CardList';
 import LoadingText from 'ui/components/LoadingText';
+import type { UserType } from 'amo/reducers/users';
 import type { AppState } from 'amo/store';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { ErrorHandlerType } from 'core/errorHandler';
@@ -47,6 +53,8 @@ type InternalProps = {|
   ...Props,
   addon: AddonType | null,
   addonIsLoading: boolean,
+  areReviewsLoading: boolean,
+  checkingIfSiteUserCanReply: boolean,
   clientApp: string,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
@@ -63,7 +71,8 @@ type InternalProps = {|
   pageSize: number | null,
   reviewCount?: number,
   reviews?: Array<UserReviewType>,
-  areReviewsLoading: boolean,
+  siteUser: UserType | null,
+  siteUserCanReplyToReviews: ?boolean,
 |};
 
 export class AddonReviewListBase extends React.Component<InternalProps> {
@@ -83,13 +92,13 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     const {
       addon,
       addonIsLoading,
+      areReviewsLoading,
       dispatch,
       errorHandler,
       match: {
         params: { addonSlug },
       },
       reviews,
-      areReviewsLoading,
     } = {
       ...this.props,
       ...nextProps,
@@ -138,6 +147,35 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     }
   }
 
+  componentDidMount() {
+    const {
+      addon,
+      checkingIfSiteUserCanReply,
+      dispatch,
+      errorHandler,
+      siteUser,
+      siteUserCanReplyToReviews,
+    } = this.props;
+
+    if (
+      addon &&
+      siteUser &&
+      siteUserCanReplyToReviews === undefined &&
+      !checkingIfSiteUserCanReply
+    ) {
+      // Permissions are fetched in componentDidMount because siteUser
+      // is not reliable while server rendering.
+      // https://github.com/mozilla/addons-frontend/issues/6717
+      dispatch(
+        fetchReviewPermissions({
+          addonId: addon.id,
+          errorHandlerId: errorHandler.id,
+          userId: siteUser.id,
+        }),
+      );
+    }
+  }
+
   addonURL() {
     const { addon } = this.props;
     if (!addon) {
@@ -166,6 +204,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       pageSize,
       reviewCount,
       reviews,
+      siteUserCanReplyToReviews,
     } = this.props;
 
     if (errorHandler.hasError()) {
@@ -252,7 +291,11 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
 
         <div className="AddonReviewList-reviews">
           {reviewId && (
-            <FeaturedAddonReview addon={addon} reviewId={reviewId} />
+            <FeaturedAddonReview
+              addon={addon}
+              reviewId={reviewId}
+              siteUserCanReply={siteUserCanReplyToReviews}
+            />
           )}
           {allReviews.length ? (
             <CardList
@@ -264,7 +307,11 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
                 {allReviews.map((review, index) => {
                   return (
                     <li key={String(index)}>
-                      <AddonReviewCard addon={addon} review={review} />
+                      <AddonReviewCard
+                        addon={addon}
+                        review={review}
+                        siteUserCanReply={siteUserCanReplyToReviews}
+                      />
                     </li>
                   );
                 })}
@@ -279,11 +326,29 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
 
 export function mapStateToProps(state: AppState, ownProps: InternalProps) {
   const { addonSlug } = ownProps.match.params;
+  const addon = getAddonBySlug(state, addonSlug);
   const reviewData = state.reviews.byAddon[addonSlug];
 
+  const siteUser = getCurrentUser(state.users);
+  let checkingIfSiteUserCanReply = false;
+  let siteUserCanReplyToReviews;
+  if (addon && siteUser) {
+    const permissions = selectReviewPermissions({
+      reviewsState: state.reviews,
+      addonId: addon.id,
+      userId: siteUser.id,
+    });
+    if (permissions) {
+      checkingIfSiteUserCanReply = permissions.loading;
+      siteUserCanReplyToReviews = permissions.canReplyToReviews;
+    }
+  }
+
   return {
-    addon: getAddonBySlug(state, addonSlug),
+    addon,
     addonIsLoading: isAddonLoading(state, addonSlug),
+    areReviewsLoading: reviewsAreLoading(state, addonSlug),
+    checkingIfSiteUserCanReply,
     clientApp: state.api.clientApp,
     lang: state.api.lang,
     pageSize: reviewData ? reviewData.pageSize : null,
@@ -294,7 +359,8 @@ export function mapStateToProps(state: AppState, ownProps: InternalProps) {
         state: state.reviews,
         reviews: reviewData.reviews,
       }),
-    areReviewsLoading: reviewsAreLoading(state, addonSlug),
+    siteUserCanReplyToReviews,
+    siteUser,
   };
 }
 

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -72,7 +72,7 @@ type InternalProps = {|
   reviewCount?: number,
   reviews?: Array<UserReviewType>,
   siteUser: UserType | null,
-  siteUserCanReplyToReviews: ?boolean,
+  siteUserCanReplyToReviews: boolean | void,
 |};
 
 export class AddonReviewListBase extends React.Component<InternalProps> {

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -47,6 +47,13 @@ import './styles.scss';
 
 type Props = {|
   location: ReactRouterLocationType,
+  match: {|
+    ...ReactRouterMatchType,
+    params: {
+      addonSlug: string,
+      reviewId?: number,
+    },
+  |},
 |};
 
 type InternalProps = {|
@@ -55,24 +62,17 @@ type InternalProps = {|
   addonIsLoading: boolean,
   areReviewsLoading: boolean,
   checkingIfSiteUserCanReply: boolean,
-  clientApp: string,
+  clientApp: ?string,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   history: ReactRouterHistoryType,
   i18n: I18nType,
-  lang: string,
-  match: {|
-    ...ReactRouterMatchType,
-    params: {
-      addonSlug: string,
-      reviewId?: number,
-    },
-  |},
+  lang: ?string,
   pageSize: number | null,
-  reviewCount?: number,
-  reviews?: Array<UserReviewType>,
+  reviewCount: ?number,
+  reviews: ?Array<UserReviewType>,
   siteUser: UserType | null,
-  siteUserCanReplyToReviews: boolean | void,
+  siteUserCanReplyToReviews: boolean | null,
 |};
 
 export class AddonReviewListBase extends React.Component<InternalProps> {
@@ -160,7 +160,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     if (
       addon &&
       siteUser &&
-      siteUserCanReplyToReviews === undefined &&
+      siteUserCanReplyToReviews === null &&
       !checkingIfSiteUserCanReply
     ) {
       // Permissions are fetched in componentDidMount because siteUser
@@ -324,14 +324,17 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
   }
 }
 
-export function mapStateToProps(state: AppState, ownProps: InternalProps) {
+export function mapStateToProps(
+  state: AppState,
+  ownProps: Props,
+): $Shape<InternalProps> {
   const { addonSlug } = ownProps.match.params;
   const addon = getAddonBySlug(state, addonSlug);
   const reviewData = state.reviews.byAddon[addonSlug];
 
   const siteUser = getCurrentUser(state.users);
   let checkingIfSiteUserCanReply = false;
-  let siteUserCanReplyToReviews;
+  let siteUserCanReplyToReviews = null;
   if (addon && siteUser) {
     const permissions = selectReviewPermissions({
       reviewsState: state.reviews,

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -216,7 +216,11 @@ export class UserProfileBase extends React.Component<InternalProps> {
           {reviews.map((review) => {
             return (
               <li key={String(review.id)}>
-                <AddonReviewCard review={review} shortByLine />
+                <AddonReviewCard
+                  review={review}
+                  shortByLine
+                  siteUserCanReply={false}
+                />
               </li>
             );
           })}

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -102,10 +102,10 @@ type ViewStateByReviewId = {|
 
 export type ReviewsState = {|
   permissions: {
-    [addonIdAndUserId: string]: ?{|
+    [addonIdAndUserId: string]: {|
       loading: boolean,
-      canReplyToReviews: boolean | void,
-    |},
+      canReplyToReviews: boolean | null,
+    |} | void,
   },
   byAddon: ReviewsByAddon,
   byId: ReviewsById,
@@ -668,7 +668,7 @@ export default function reviewsReducer(
           ...state.permissions,
           [makePermissionsKey({ addonId, userId })]: {
             loading: true,
-            canReplyToReviews: undefined,
+            canReplyToReviews: null,
           },
         },
       };

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -104,7 +104,7 @@ export type ReviewsState = {|
   permissions: {
     [addonIdAndUserId: string]: ?{|
       loading: boolean,
-      canReplyToReviews: ?boolean,
+      canReplyToReviews: boolean | void,
     |},
   },
   byAddon: ReviewsByAddon,

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1389,7 +1389,7 @@ describe(__filename, () => {
       dispatchSignInActions({ store });
       const root = render({ siteUserCanReply: false });
 
-      expect(root.instance().siteUserCanManageReplies()).toEqual(false);
+      expect(root.instance().props.siteUserCanManageReplies).toEqual(false);
     });
 
     it('lets any admin reply', () => {
@@ -1401,14 +1401,14 @@ describe(__filename, () => {
       // Admin super powers should override siteUserCanReply.
       const root = render({ siteUserCanReply: false });
 
-      expect(root.instance().siteUserCanManageReplies()).toEqual(true);
+      expect(root.instance().props.siteUserCanManageReplies).toEqual(true);
     });
 
     it('lets you reply when siteUserCanReply is true', () => {
       dispatchSignInActions({ store });
       const root = render({ siteUserCanReply: true });
 
-      expect(root.instance().siteUserCanManageReplies()).toEqual(true);
+      expect(root.instance().props.siteUserCanManageReplies).toEqual(true);
     });
   });
 });

--- a/tests/unit/amo/components/TestFeaturedAddonReview.js
+++ b/tests/unit/amo/components/TestFeaturedAddonReview.js
@@ -35,6 +35,7 @@ describe(__filename, () => {
       errorHandler: createStubErrorHandler(),
       i18n: fakeI18n(),
       location,
+      siteUserCanReply: false,
       store,
       ...customProps,
     };
@@ -174,6 +175,17 @@ describe(__filename, () => {
     const card = root.find(AddonReviewCard);
     expect(card).toHaveLength(1);
     expect(card.prop('review').id).toEqual(reviewId);
+  });
+
+  it('passes siteUserCanReply to AddonReviewCard', () => {
+    const reviewId = 123;
+    store.dispatch(setReview({ ...fakeReview, id: reviewId }));
+
+    const siteUserCanReply = true;
+    const root = render({ reviewId, siteUserCanReply });
+
+    const card = root.find(AddonReviewCard);
+    expect(card).toHaveProp('siteUserCanReply', siteUserCanReply);
   });
 
   it('displays the correct header for a review', () => {

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -841,7 +841,7 @@ describe(__filename, () => {
 
   it('renders a "description" meta tag', () => {
     const addon = createInternalAddon(fakeAddon);
-    dispatchAddon(addon);
+    loadAddon(addon);
 
     const root = render();
 

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -81,11 +81,11 @@ describe(__filename, () => {
     );
   };
 
-  const dispatchAddon = (addon = fakeAddon) => {
+  const loadAddon = (addon = fakeAddon) => {
     store.dispatch(loadAddonResults({ addons: [addon] }));
   };
 
-  const dispatchAddonReviews = ({
+  const _setAddonReviews = ({
     addon = fakeAddon,
     reviews = [{ ...fakeReview, id: 1 }],
   } = {}) => {
@@ -98,7 +98,7 @@ describe(__filename, () => {
     store.dispatch(action);
   };
 
-  const dispatchUserReviewPermissions = ({
+  const signInAndSetReviewPermissions = ({
     addonId = fakeAddon.id,
     userId = 12345,
     ...permissions
@@ -126,7 +126,7 @@ describe(__filename, () => {
 
     it('renders an AddonSummaryCard with an addon', () => {
       const addon = fakeAddon;
-      dispatchAddon(addon);
+      loadAddon(addon);
       const root = render();
 
       const summary = root.find(AddonSummaryCard);
@@ -143,7 +143,7 @@ describe(__filename, () => {
     });
 
     it('does not paginate before reviews have loaded', () => {
-      dispatchAddon(fakeAddon);
+      loadAddon(fakeAddon);
       const root = render({ reviews: null });
 
       expect(root.find(Paginate)).toHaveLength(0);
@@ -193,7 +193,7 @@ describe(__filename, () => {
     });
 
     it('ignores other add-ons', () => {
-      dispatchAddon();
+      loadAddon();
       const root = render({
         params: { addonSlug: 'other-slug' },
       });
@@ -202,7 +202,7 @@ describe(__filename, () => {
 
     it('fetches reviews if needed', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
-      dispatchAddon(addon);
+      loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');
       const errorHandler = createStubErrorHandler();
 
@@ -224,7 +224,7 @@ describe(__filename, () => {
     it('does not fetch reviews if they are already loading', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
       const errorHandler = createStubErrorHandler();
-      dispatchAddon(addon);
+      loadAddon(addon);
       store.dispatch(
         fetchReviews({
           addonSlug: addon.slug,
@@ -375,7 +375,7 @@ describe(__filename, () => {
 
     it('dispatches a view context for the add-on', () => {
       const addon = fakeAddon;
-      dispatchAddon(addon);
+      loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');
       render();
 
@@ -395,8 +395,8 @@ describe(__filename, () => {
 
     it('does not dispatch a view context for similar add-ons', () => {
       const addon1 = fakeAddon;
-      dispatchAddon(addon1);
-      dispatchAddonReviews();
+      loadAddon(addon1);
+      _setAddonReviews();
       const dispatch = sinon.stub(store, 'dispatch');
       const root = render();
 
@@ -413,7 +413,7 @@ describe(__filename, () => {
       const addon1 = { ...fakeAddon, type: ADDON_TYPE_EXTENSION };
       const addon2 = { ...addon1, type: ADDON_TYPE_THEME };
 
-      dispatchAddon(addon1);
+      loadAddon(addon1);
       const dispatch = sinon.stub(store, 'dispatch');
       const root = render();
 
@@ -494,8 +494,8 @@ describe(__filename, () => {
         { ...fakeReview, id: 1, score: 1 },
         { ...fakeReview, id: 2, score: 2 },
       ];
-      dispatchAddon(addon);
-      dispatchAddonReviews({ reviews });
+      loadAddon(addon);
+      _setAddonReviews({ reviews });
 
       const tree = render();
 
@@ -526,7 +526,7 @@ describe(__filename, () => {
         { ...fakeReview, id: 1, score: 1 },
         { ...fakeReview, id: 2, score: 2 },
       ];
-      dispatchAddonReviews({ reviews });
+      _setAddonReviews({ reviews });
 
       const root = render({
         params: { reviewId: reviews[0].id.toString() },
@@ -545,7 +545,7 @@ describe(__filename, () => {
     it('does not display a listing if the only review is also featured', () => {
       const reviewId = 1;
       const reviews = [{ ...fakeReview, id: reviewId }];
-      dispatchAddonReviews({ reviews });
+      _setAddonReviews({ reviews });
 
       const root = render({
         params: { reviewId: reviewId.toString() },
@@ -555,7 +555,7 @@ describe(__filename, () => {
     });
 
     it('renders a class name with its type', () => {
-      dispatchAddon({
+      loadAddon({
         ...fakeAddon,
         type: ADDON_TYPE_STATIC_THEME,
       });
@@ -568,7 +568,7 @@ describe(__filename, () => {
 
     it('produces an addon URL', () => {
       const addon = fakeAddon;
-      dispatchAddon(addon);
+      loadAddon(addon);
       expect(
         render()
           .instance()
@@ -578,7 +578,7 @@ describe(__filename, () => {
 
     it('produces a URL to itself', () => {
       const addon = fakeAddon;
-      dispatchAddon(addon);
+      loadAddon(addon);
       expect(
         render()
           .instance()
@@ -595,7 +595,7 @@ describe(__filename, () => {
     });
 
     it('configures CardList with a count of text reviews', () => {
-      dispatchAddon({
+      loadAddon({
         ...fakeAddon,
         ratings: {
           ...fakeAddon.ratings,
@@ -605,7 +605,7 @@ describe(__filename, () => {
           text_count: 1,
         },
       });
-      dispatchAddonReviews();
+      _setAddonReviews();
       const root = render();
 
       const cardList = root.find('.AddonReviewList-reviews-listing');
@@ -618,8 +618,8 @@ describe(__filename, () => {
         reviews = Array(DEFAULT_API_PAGE_SIZE + 2).fill(fakeReview),
         ...otherProps
       } = {}) => {
-        dispatchAddon();
-        dispatchAddonReviews({ reviews });
+        loadAddon();
+        _setAddonReviews({ reviews });
 
         return render(otherProps);
       };
@@ -673,7 +673,7 @@ describe(__filename, () => {
 
     it('renders an HTML title', () => {
       const addon = fakeAddon;
-      dispatchAddon(addon);
+      loadAddon(addon);
       const root = render();
       expect(root.find('title')).toHaveText(`Reviews for ${addon.name}`);
     });
@@ -688,8 +688,8 @@ describe(__filename, () => {
         { ...fakeReview, id: 1, score: 1 },
         { ...fakeReview, id: 2, score: 2 },
       ];
-      dispatchAddon(createInternalAddon(fakeAddon));
-      dispatchAddonReviews({ reviews });
+      loadAddon(createInternalAddon(fakeAddon));
+      _setAddonReviews({ reviews });
 
       const root = render();
 
@@ -701,8 +701,8 @@ describe(__filename, () => {
         { ...fakeReview, id: 1, score: 1 },
         { ...fakeReview, id: 2, score: 2 },
       ];
-      dispatchAddon(createInternalAddon(fakeAddon));
-      dispatchAddonReviews({ reviews });
+      loadAddon(createInternalAddon(fakeAddon));
+      _setAddonReviews({ reviews });
 
       const root = render({
         params: { reviewId: reviews[0].id.toString() },
@@ -718,8 +718,8 @@ describe(__filename, () => {
     it('renders FeaturedAddonReview', () => {
       const reviewId = 8765;
       const addon = { ...fakeAddon };
-      dispatchAddon(addon);
-      dispatchAddonReviews({ reviews: [{ ...fakeReview }] });
+      loadAddon(addon);
+      _setAddonReviews({ reviews: [{ ...fakeReview }] });
 
       const root = render({ params: { reviewId } });
 
@@ -732,7 +732,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      dispatchAddon(addon);
+      loadAddon(addon);
       dispatchSignInActions({ store, userId });
       const dispatchSpy = sinon.spy(store, 'dispatch');
 
@@ -752,7 +752,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      dispatchAddon(addon);
+      loadAddon(addon);
       dispatchSignInActions({ store, userId });
 
       const fetchAction = fetchReviewPermissions({
@@ -775,8 +775,8 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      dispatchAddon(addon);
-      dispatchUserReviewPermissions({
+      loadAddon(addon);
+      signInAndSetReviewPermissions({
         addonId: addon.id,
         userId,
         canReplyToReviews: true,
@@ -804,9 +804,9 @@ describe(__filename, () => {
       ];
       const userId = 99654;
 
-      dispatchAddon(addon);
-      dispatchAddonReviews({ reviews });
-      dispatchUserReviewPermissions({
+      loadAddon(addon);
+      _setAddonReviews({ reviews });
+      signInAndSetReviewPermissions({
         addonId: addon.id,
         userId,
         canReplyToReviews: true,
@@ -824,9 +824,9 @@ describe(__filename, () => {
     it('passes siteUserCanReply to FeaturedAddonReview', () => {
       const reviewId = 8765;
       const addon = { ...fakeAddon };
-      dispatchAddon(addon);
-      dispatchAddonReviews({ reviews: [{ ...fakeReview }] });
-      dispatchUserReviewPermissions({
+      loadAddon(addon);
+      _setAddonReviews({ reviews: [{ ...fakeReview }] });
+      signInAndSetReviewPermissions({
         addonId: addon.id,
         userId: 6745,
         canReplyToReviews: true,

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -1543,7 +1543,7 @@ describe(__filename, () => {
         userId,
       });
       expect(permissions.loading).toEqual(true);
-      expect(permissions.canReplyToReviews).toEqual(undefined);
+      expect(permissions.canReplyToReviews).toEqual(null);
     });
   });
 
@@ -1602,7 +1602,7 @@ describe(__filename, () => {
       });
       expect(permissions).toEqual({
         loading: true,
-        canReplyToReviews: undefined,
+        canReplyToReviews: null,
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/526

Originally I wanted to modify the current [`fetchReviews`](https://github.com/mozilla/addons-frontend/blob/12ad39894c60fa462ce06edb8b60029d8e029d5a/src/amo/pages/AddonReviewList/index.js#L128-L137) call but this is complicated because I can't depend on `siteUser` (https://github.com/mozilla/addons-frontend/issues/6717). My current patch just introduces a separate dispatch which is fine, I guess. We could fix it up later.