### PR TITLE
Add description meta tag on category pages

### DIFF
--- a/src/amo/components/CategoryHead/index.js
+++ b/src/amo/components/CategoryHead/index.js
@@ -47,6 +47,18 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
     return i18n.sprintf(title, { categoryName: category.name });
   }
 
+  renderMetaDescription() {
+    const { category } = this.props;
+
+    invariant(category, 'category is required');
+
+    if (!category.description) {
+      return null;
+    }
+
+    return <meta name="description" content={category.description} />;
+  }
+
   render() {
     const { _config, category, locationPathname } = this.props;
 
@@ -61,6 +73,7 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
           rel="canonical"
           href={getCanonicalURL({ locationPathname, _config })}
         />
+        {this.renderMetaDescription()}
       </Helmet>
     );
   }

--- a/src/amo/types/categories.js
+++ b/src/amo/types/categories.js
@@ -2,7 +2,7 @@
 
 export type CategoryType = {|
   application: string,
-  description: string,
+  description: string | null,
   id: number,
   misc: boolean,
   name: string,

--- a/tests/unit/amo/components/TestCategoryHead.js
+++ b/tests/unit/amo/components/TestCategoryHead.js
@@ -65,4 +65,30 @@ describe(__filename, () => {
 
     expect(root.find('title')).toHaveText(category.name);
   });
+
+  it('renders a "description" meta tag when category description is available', () => {
+    const description = 'some description for a category';
+    const category = { ...fakeCategory, description };
+    const root = render({ category });
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]')).toHaveProp(
+      'content',
+      description,
+    );
+  });
+
+  it('does not render a "description" meta tag when category description is null', () => {
+    const category = { ...fakeCategory, description: null };
+    const root = render({ category });
+
+    expect(root.find('meta[name="description"]')).toHaveLength(0);
+  });
+
+  it('does not render a "description" meta tag when category description is empty', () => {
+    const category = { ...fakeCategory, description: '' };
+    const root = render({ category });
+
+    expect(root.find('meta[name="description"]')).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
Refs #5767
~~:warning: depends on #6739~~

---

The categories API now exposes the descriptions, so we can just use them in the frontend.