### PR TITLE
Fix react warning in CollectionManager

### DIFF
--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -189,10 +189,11 @@ export class CollectionManagerBase extends React.Component<
     // Decode HTML entities so the user sees real symbols in the form.
     return {
       customSlug: false,
-      description:
-        props.collection && decodeHtmlEntities(props.collection.description),
-      name: props.collection && decodeHtmlEntities(props.collection.name),
-      slug: props.collection && props.collection.slug,
+      description: props.collection
+        ? decodeHtmlEntities(props.collection.description)
+        : '',
+      name: props.collection ? decodeHtmlEntities(props.collection.name) : '',
+      slug: props.collection ? props.collection.slug : '',
     };
   }
 

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -147,9 +147,9 @@ describe(__filename, () => {
     });
 
     const expectedUrlPrefix = `${apiHost}/${newLang}/${clientApp}/collections/${username}/`;
-    expect(root.find('#collectionName')).toHaveProp('value', null);
-    expect(root.find('#collectionDescription')).toHaveProp('value', null);
-    expect(root.find('#collectionSlug')).toHaveProp('value', null);
+    expect(root.find('#collectionName')).toHaveProp('value', '');
+    expect(root.find('#collectionDescription')).toHaveProp('value', '');
+    expect(root.find('#collectionSlug')).toHaveProp('value', '');
     expect(root.find('#collectionUrlPrefix')).toHaveProp(
       'title',
       expectedUrlPrefix,


### PR DESCRIPTION
Fixes #5234

---

We need empty strings because controlled inputs in React don't accept `null`.