### PR TITLE
Use official babel-gettext-extractor

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
     "autoprefixer": "^9.0.0",
     "babel-core": "^6.24.1",
     "babel-eslint": "^10.0.1",
-    "babel-gettext-extractor": "git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6",
+    "babel-gettext-extractor": "^3.0.0",
     "babel-jest": "^23.0.0",
     "babel-loader": "^7.0.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",

--- a/src/core/i18n/utils.js
+++ b/src/core/i18n/utils.js
@@ -223,8 +223,8 @@ export function makeMomentLocale(locale: string) {
 }
 
 // Functionality based on oneLine form declandewet/common-tags https://goo.gl/4PzaJI
-// If this function is changed https://github.com/muffinresearch/babel-gettext-extractor/
-// also needs to be updated.
+// If this function is changed, `babel-gettext-extractor` also needs to be
+// updated.
 function oneLineTranslationString(translationKey) {
   if (translationKey && translationKey.replace && translationKey.trim) {
     return translationKey.replace(/(?:\n(?:\s*))+/g, ' ').trim();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,9 +1356,10 @@ babel-generator@^6.18.0, babel-generator@^6.26.0:
     source-map "^0.5.7"
     trim-right "^1.0.1"
 
-"babel-gettext-extractor@git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6":
-  version "1.0.2"
-  resolved "git+https://github.com/muffinresearch/babel-gettext-extractor.git#0d39d3882bc846e7dcb6c9ff6463896c96920ce6"
+babel-gettext-extractor@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-gettext-extractor/-/babel-gettext-extractor-3.0.0.tgz#6ce4a501feaf7e52777d8c373e29e3ee271793b5"
+  integrity sha512-CRUGczXp1oKjghE9iSGhIoWJqYe8UFY5W1bNqP7mZ9BAfSv0ywmcXgV7HRCD02JtQpOI3AoLRnBAR5Ruw/NKGw==
   dependencies:
     babel-core "^6.0.0"
     gettext-parser "^1.1.2"


### PR DESCRIPTION
Fixes #6457

---

I manually verified this PR by:

- looking at the fork and upstream libs to make sure all changes in the fork have been added to the upstream/original lib
- extracting/merging the locales for `amo` on `master` and on this PR and compared both results (changes are similar, so that looks good)