### PR TITLE
Add mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: addons-frontend
+repo_url: https://github.com/mozilla/addons-frontend
+
+theme:
+  name: "readthedocs"


### PR DESCRIPTION
Old builds were passing this config as command line arguments: https://readthedocs.org/projects/addons-frontend/builds/7827080/.

Things have changed a month ago though... https://readthedocs.org/projects/addons-frontend/builds/8004689/