### PR TITLE
Fixes #6755: Remove outline from a Rating Star

### DIFF
--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -54,8 +54,11 @@
 
 .Rating-star {
   background: url('./img/closed-star-dim-gray.svg') center/contain no-repeat;
-  outline: none;
   padding: 0;
+
+  &:not(.focus-visible) {
+    outline: none;
+  }
 
   .Rating--small & {
     min-width: 13px;

--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -55,6 +55,7 @@
 .Rating-star {
   background: url('./img/closed-star-dim-gray.svg') center/contain no-repeat;
   padding: 0;
+  outline: none;
 
   .Rating--small & {
     min-width: 13px;

--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -54,8 +54,8 @@
 
 .Rating-star {
   background: url('./img/closed-star-dim-gray.svg') center/contain no-repeat;
-  padding: 0;
   outline: none;
+  padding: 0;
 
   .Rating--small & {
     min-width: 13px;


### PR DESCRIPTION

- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add `Fixes #ISSUENUM` at the top of your PR.
- [x] Add a description of the the changes introduced in this PR.
- [x] The change has been successfully run locally.
- [x] Add before and after screenshots (Only for changes that impact the UI).

Fixes #6755. This PR removes outline from rating star when selecting/unselecting the star on Chrome.  CSS property "outline" with value "none" fixes it. Below is screenshot comparison before and after the change.

**Before**:
![47557889-86dfef80-d91a-11e8-90c9-1b82534194b5](https://user-images.githubusercontent.com/26641473/47607007-ac3b2f00-d9e8-11e8-82a1-2be88cc7ed89.png)

**After**:
<img width="490" alt="screen shot 2018-10-27 at 1 00 59 pm" src="https://user-images.githubusercontent.com/26641473/47607013-c248ef80-d9e8-11e8-9972-5ca67c5e2676.png">
