### PR TITLE
Fix: #6357, Force Login rate element to be center of parent

### DIFF
--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -12,6 +12,9 @@
   padding: 2px 16px;
   position: absolute;
   width: 100%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .RatingManager {

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -9,12 +9,12 @@
 
 .RatingManager-log-in-to-rate-button {
   font-size: $font-size-s;
+  left: 50%;
   padding: 2px 16px;
   position: absolute;
-  width: 100%;
   top: 50%;
-  left: 50%;
   transform: translate(-50%, -50%);
+  width: 100%;
 }
 
 .RatingManager {


### PR DESCRIPTION
#6357: Force Login rate element to be center of parent.

