### PR TITLE
Add `hrefLang` on other pages (not add-on detail pages)

### DIFF
--- a/src/amo/components/AddonHead/index.js
+++ b/src/amo/components/AddonHead/index.js
@@ -183,7 +183,7 @@ export class AddonHeadBase extends React.Component<InternalProps> {
           </script>
         </Helmet>
 
-        <HeadLinks to={`/addon/${addon.slug}/`} />
+        <HeadLinks />
       </React.Fragment>
     );
   }

--- a/src/amo/components/CategoryHead/index.js
+++ b/src/amo/components/CategoryHead/index.js
@@ -1,27 +1,22 @@
 /* @flow */
-import config from 'config';
 import invariant from 'invariant';
 import * as React from 'react';
 import Helmet from 'react-helmet';
-import { connect } from 'react-redux';
-import { compose } from 'redux';
 
-import { getCanonicalURL } from 'amo/utils';
+import HeadLinks from 'amo/components/HeadLinks';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import translate from 'core/i18n/translate';
-import type { AppState } from 'amo/store';
 import type { CategoryType } from 'amo/types/categories';
 import type { I18nType } from 'core/types/i18n';
 
 type Props = {|
   category: CategoryType | null,
+  visibleAddonType: string,
 |};
 
 type InternalProps = {|
   ...Props,
-  _config: typeof config,
   i18n: I18nType,
-  locationPathname: string,
 |};
 
 export class CategoryHeadBase extends React.PureComponent<InternalProps> {
@@ -60,36 +55,25 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
   }
 
   render() {
-    const { _config, category, locationPathname } = this.props;
+    const { category, visibleAddonType } = this.props;
 
     if (!category) {
       return null;
     }
 
     return (
-      <Helmet>
-        <title>{this.getPageTitle()}</title>
-        <link
-          rel="canonical"
-          href={getCanonicalURL({ locationPathname, _config })}
-        />
-        {this.renderMetaDescription()}
-      </Helmet>
+      <React.Fragment>
+        <Helmet>
+          <title>{this.getPageTitle()}</title>
+          {this.renderMetaDescription()}
+        </Helmet>
+
+        <HeadLinks to={`/${visibleAddonType}/${category.slug}/`} />
+      </React.Fragment>
     );
   }
 }
 
-const mapStateToProps = (state: AppState) => {
-  const locationPathname = state.router.location.pathname;
-
-  return {
-    locationPathname,
-  };
-};
-
-const CategoryHead: React.ComponentType<Props> = compose(
-  translate(),
-  connect(mapStateToProps),
-)(CategoryHeadBase);
+const CategoryHead: React.ComponentType<Props> = translate()(CategoryHeadBase);
 
 export default CategoryHead;

--- a/src/amo/components/CategoryHead/index.js
+++ b/src/amo/components/CategoryHead/index.js
@@ -11,7 +11,6 @@ import type { I18nType } from 'core/types/i18n';
 
 type Props = {|
   category: CategoryType | null,
-  visibleAddonType: string,
 |};
 
 type InternalProps = {|
@@ -55,7 +54,7 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
   }
 
   render() {
-    const { category, visibleAddonType } = this.props;
+    const { category } = this.props;
 
     if (!category) {
       return null;
@@ -68,7 +67,7 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
           {this.renderMetaDescription()}
         </Helmet>
 
-        <HeadLinks to={`/${visibleAddonType}/${category.slug}/`} />
+        <HeadLinks />
       </React.Fragment>
     );
   }

--- a/src/amo/components/HeadLinks/index.js
+++ b/src/amo/components/HeadLinks/index.js
@@ -11,6 +11,7 @@ import { hrefLangs } from 'core/languages';
 import type { AppState } from 'amo/store';
 
 type Props = {|
+  prependClientApp?: boolean,
   to: string,
 |};
 
@@ -27,15 +28,26 @@ export class HeadLinksBase extends React.PureComponent<InternalProps> {
   static defaultProps = {
     _config: config,
     _hrefLangs: hrefLangs,
+    prependClientApp: true,
   };
 
   render() {
-    const { _config, _hrefLangs, currentURL, clientApp, lang, to } = this.props;
+    const {
+      _config,
+      _hrefLangs,
+      clientApp,
+      currentURL,
+      lang,
+      prependClientApp,
+      to,
+    } = this.props;
 
     invariant(to.charAt(0) === '/', 'The `to` prop must start with a slash.');
 
     const hrefLangsMap = _config.get('hrefLangsMap');
-    const canonicalURL = `/${lang}/${clientApp}${to}`;
+
+    const path = prependClientApp ? `/${clientApp}${to}` : to;
+    const canonicalURL = `/${lang}${path}`;
 
     const includeAlternateLinks =
       _config.get('unsupportedHrefLangs').includes(lang) === false &&
@@ -51,13 +63,11 @@ export class HeadLinksBase extends React.PureComponent<InternalProps> {
         {includeAlternateLinks &&
           _hrefLangs.map((hrefLang) => {
             const locale = hrefLangsMap[hrefLang] || hrefLang;
+            const locationPathname = `/${locale}${path}`;
 
             return (
               <link
-                href={getCanonicalURL({
-                  _config,
-                  locationPathname: `/${locale}/${clientApp}${to}`,
-                })}
+                href={getCanonicalURL({ _config, locationPathname })}
                 hrefLang={hrefLang}
                 key={hrefLang}
                 rel="alternate"

--- a/src/amo/components/HeadLinks/index.js
+++ b/src/amo/components/HeadLinks/index.js
@@ -35,11 +35,11 @@ export class HeadLinksBase extends React.PureComponent<InternalProps> {
       locationPathname,
     } = this.props;
 
-    const urlWithoutLocale = locationPathname
+    const pathWithoutLocale = locationPathname
       .split('/')
       .slice(2)
       .join('/');
-    const canonicalURL = `/${lang}/${urlWithoutLocale}`;
+    const canonicalURL = `/${lang}/${pathWithoutLocale}`;
 
     const hrefLangsMap = _config.get('hrefLangsMap');
     const includeAlternateLinks =
@@ -56,7 +56,7 @@ export class HeadLinksBase extends React.PureComponent<InternalProps> {
         {includeAlternateLinks &&
           _hrefLangs.map((hrefLang) => {
             const locale = hrefLangsMap[hrefLang] || hrefLang;
-            const alternateURL = `/${locale}/${urlWithoutLocale}`;
+            const alternateURL = `/${locale}/${pathWithoutLocale}`;
 
             return (
               <link

--- a/src/amo/pages/CategoriesPage/index.js
+++ b/src/amo/pages/CategoriesPage/index.js
@@ -1,11 +1,14 @@
 /* @flow */
 import * as React from 'react';
-import { compose } from 'redux';
+import Helmet from 'react-helmet';
 
 import Categories from 'amo/components/Categories';
+import HeadLinks from 'amo/components/HeadLinks';
+import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import { apiAddonType } from 'core/utils';
 import translate from 'core/i18n/translate';
 import type { ReactRouterMatchType } from 'core/types/router';
+import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
 
@@ -16,16 +19,44 @@ type Props = {|
   |},
 |};
 
-export class CategoriesPageBase extends React.Component<Props> {
-  render() {
-    const { params } = this.props.match;
-    const addonType = apiAddonType(params.visibleAddonType);
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
+|};
 
-    return <Categories addonType={addonType} className="CategoriesPage" />;
+export class CategoriesPageBase extends React.Component<InternalProps> {
+  getPageTitle(addonType: string) {
+    const { i18n } = this.props;
+
+    switch (addonType) {
+      case ADDON_TYPE_EXTENSION:
+        return i18n.gettext('All extension categories');
+      case ADDON_TYPE_THEME:
+        return i18n.gettext('All theme categories');
+      default:
+        return null;
+    }
+  }
+
+  render() {
+    const { match } = this.props;
+    const addonType = apiAddonType(match.params.visibleAddonType);
+
+    return (
+      <React.Fragment>
+        <Helmet>
+          <title>{this.getPageTitle(addonType)}</title>
+        </Helmet>
+
+        <HeadLinks />
+
+        <Categories addonType={addonType} className="CategoriesPage" />
+      </React.Fragment>
+    );
   }
 }
 
-const CategoriesPage: React.ComponentType<Props> = compose(translate())(
+const CategoriesPage: React.ComponentType<Props> = translate()(
   CategoriesPageBase,
 );
 

--- a/src/amo/pages/Category/index.js
+++ b/src/amo/pages/Category/index.js
@@ -252,7 +252,10 @@ export class CategoryBase extends React.Component {
           'Category--theme': isAddonTheme,
         })}
       >
-        <CategoryHead category={category} />
+        <CategoryHead
+          category={category}
+          visibleAddonType={params.visibleAddonType}
+        />
 
         {errorHandler.renderErrorIfPresent()}
 

--- a/src/amo/pages/Category/index.js
+++ b/src/amo/pages/Category/index.js
@@ -252,10 +252,7 @@ export class CategoryBase extends React.Component {
           'Category--theme': isAddonTheme,
         })}
       >
-        <CategoryHead
-          category={category}
-          visibleAddonType={params.visibleAddonType}
-        />
+        <CategoryHead category={category} />
 
         {errorHandler.renderErrorIfPresent()}
 

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -237,7 +237,7 @@ export class HomeBase extends React.Component {
           />
         </Helmet>
 
-        <HeadLinks to="/" />
+        <HeadLinks />
 
         <span
           className="visually-hidden do-not-remove"

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -10,10 +10,10 @@ import CategoryIcon from 'amo/components/CategoryIcon';
 import FeaturedCollectionCard from 'amo/components/FeaturedCollectionCard';
 import HomeHeroBanner from 'amo/components/HomeHeroBanner';
 import HomeHeroGuides from 'amo/components/HomeHeroGuides';
+import HeadLinks from 'amo/components/HeadLinks';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import { fetchHomeAddons } from 'amo/reducers/home';
-import { getCanonicalURL } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -70,12 +70,11 @@ export class HomeBase extends React.Component {
     collections: PropTypes.array.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
-    shelves: PropTypes.object.isRequired,
     i18n: PropTypes.object.isRequired,
     includeFeaturedThemes: PropTypes.bool,
     includeTrendingExtensions: PropTypes.bool,
-    locationPathname: PropTypes.string.isRequired,
     resultsLoaded: PropTypes.bool.isRequired,
+    shelves: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -209,12 +208,11 @@ export class HomeBase extends React.Component {
       _config,
       collections,
       errorHandler,
-      shelves,
       i18n,
       includeFeaturedThemes,
       includeTrendingExtensions,
-      locationPathname,
       resultsLoaded,
+      shelves,
     } = this.props;
 
     // translators: The ending ellipsis alludes to a row of icons for each type
@@ -231,10 +229,6 @@ export class HomeBase extends React.Component {
     return (
       <div className="Home">
         <Helmet>
-          <link
-            rel="canonical"
-            href={getCanonicalURL({ locationPathname, _config })}
-          />
           <meta
             name="description"
             content={i18n.gettext(`Download Firefox extensions and themes.
@@ -242,6 +236,8 @@ export class HomeBase extends React.Component {
               protect passwords, change browser appearance, and more.`)}
           />
         </Helmet>
+
+        <HeadLinks to="/" />
 
         <span
           className="visually-hidden do-not-remove"
@@ -376,7 +372,6 @@ export function mapStateToProps(state) {
   return {
     collections: state.home.collections,
     shelves: state.home.shelves,
-    locationPathname: state.router.location.pathname,
     resultsLoaded: state.home.resultsLoaded,
   };
 }

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -11,7 +11,7 @@ import { getLanding } from 'amo/actions/landing';
 import { setViewContext } from 'amo/actions/viewContext';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Categories from 'amo/components/Categories';
-import { getCanonicalURL } from 'amo/utils';
+import HeadLinks from 'amo/components/HeadLinks';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -47,7 +47,6 @@ export class LandingPageBase extends React.Component {
     featuredAddons: PropTypes.array.isRequired,
     highlyRatedAddons: PropTypes.array.isRequired,
     loading: PropTypes.bool.isRequired,
-    locationPathname: PropTypes.string.isRequired,
     trendingAddons: PropTypes.array.isRequired,
     i18n: PropTypes.object.isRequired,
     match: PropTypes.shape({
@@ -214,12 +213,10 @@ export class LandingPageBase extends React.Component {
 
   render() {
     const {
-      _config,
       errorHandler,
       featuredAddons,
       highlyRatedAddons,
       loading,
-      locationPathname,
       trendingAddons,
       i18n,
     } = this.props;
@@ -247,12 +244,10 @@ export class LandingPageBase extends React.Component {
       >
         <Helmet>
           <title>{headingText[addonType]}</title>
-          <link
-            rel="canonical"
-            href={getCanonicalURL({ locationPathname, _config })}
-          />
           <meta name="description" content={this.getPageDescription()} />
         </Helmet>
+
+        <HeadLinks to={`/${getVisibleAddonType(addonType)}/`} />
 
         {errorHandler.renderErrorIfPresent()}
 
@@ -328,7 +323,6 @@ export function mapStateToProps(state) {
     featuredAddons: landing.featured.results,
     highlyRatedAddons: landing.highlyRated.results,
     loading: landing.loading,
-    locationPathname: state.router.location.pathname,
     trendingAddons: landing.trending.results,
     resultsLoaded: landing.resultsLoaded && landing.category === null,
   };

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -247,7 +247,7 @@ export class LandingPageBase extends React.Component {
           <meta name="description" content={this.getPageDescription()} />
         </Helmet>
 
-        <HeadLinks to={`/${getVisibleAddonType(addonType)}/`} />
+        <HeadLinks />
 
         {errorHandler.renderErrorIfPresent()}
 

--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -1,6 +1,5 @@
 /* @flow */
 import makeClassName from 'classnames';
-import config from 'config';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
@@ -10,7 +9,7 @@ import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import Link from 'amo/components/Link';
-import { getCanonicalURL } from 'amo/utils';
+import HeadLinks from 'amo/components/HeadLinks';
 import { withErrorHandler } from 'core/errorHandler';
 import {
   ADDON_TYPE_DICT,
@@ -69,20 +68,14 @@ export const LanguageToolList = ({ languageTools }: LanguageToolListProps) => {
 };
 
 type Props = {|
-  _config: typeof config,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
   lang: string,
   languageTools: Array<LanguageToolType>,
-  locationPathname: string,
 |};
 
 export class LanguageToolsBase extends React.Component<Props> {
-  static defaultProps = {
-    _config: config,
-  };
-
   constructor(props: Props) {
     super(props);
 
@@ -149,13 +142,7 @@ export class LanguageToolsBase extends React.Component<Props> {
   }
 
   render() {
-    const {
-      _config,
-      languageTools,
-      locationPathname,
-      errorHandler,
-      i18n,
-    } = this.props;
+    const { languageTools, errorHandler, i18n } = this.props;
 
     const header = i18n.gettext('Dictionaries and Language Packs');
 
@@ -163,10 +150,6 @@ export class LanguageToolsBase extends React.Component<Props> {
       <Card className="LanguageTools" header={header}>
         <Helmet>
           <title>{header}</title>
-          <link
-            rel="canonical"
-            href={getCanonicalURL({ locationPathname, _config })}
-          />
           <meta
             name="description"
             content={i18n.gettext(`Download Firefox dictionaries and language
@@ -174,6 +157,8 @@ export class LanguageToolsBase extends React.Component<Props> {
               spell-checker, or change the browser's interface language.`)}
           />
         </Helmet>
+
+        <HeadLinks to="/language-tools/" />
 
         {errorHandler.renderErrorIfPresent()}
 
@@ -292,7 +277,6 @@ export const mapStateToProps = (state: AppState) => {
   return {
     lang: state.api.lang,
     languageTools: getAllLanguageTools(state),
-    locationPathname: state.router.location.pathname,
   };
 };
 

--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -158,7 +158,7 @@ export class LanguageToolsBase extends React.Component<Props> {
           />
         </Helmet>
 
-        <HeadLinks to="/language-tools/" />
+        <HeadLinks />
 
         {errorHandler.renderErrorIfPresent()}
 

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -54,9 +54,7 @@ export function mapStateToProps() {
     sort: SEARCH_SORT_RELEVANCE,
   };
 
-  return {
-    filters,
-  };
+  return { filters };
 }
 
 const SearchTools: React.ComponentType<Props> = compose(

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -5,6 +5,7 @@ import { compose } from 'redux';
 import Helmet from 'react-helmet';
 
 import Search from 'amo/components/Search';
+import HeadLinks from 'amo/components/HeadLinks';
 import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_RELEVANCE } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
@@ -35,6 +36,8 @@ export class SearchToolsBase extends React.Component<InternalProps> {
           />
         </Helmet>
 
+        <HeadLinks to="/search-tools/" />
+
         <Search
           enableSearchFilters
           filters={filters}
@@ -51,7 +54,9 @@ export function mapStateToProps() {
     sort: SEARCH_SORT_RELEVANCE,
   };
 
-  return { filters };
+  return {
+    filters,
+  };
 }
 
 const SearchTools: React.ComponentType<Props> = compose(

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -36,7 +36,7 @@ export class SearchToolsBase extends React.Component<InternalProps> {
           />
         </Helmet>
 
-        <HeadLinks to="/search-tools/" />
+        <HeadLinks />
 
         <Search
           enableSearchFilters

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -1,32 +1,22 @@
 /* @flow */
-import config from 'config';
 import Helmet from 'react-helmet';
 import * as React from 'react';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
 
-import { getCanonicalURL } from 'amo/utils';
+import HeadLinks from 'amo/components/HeadLinks';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
-import type { AppState } from 'amo/store';
 import type { I18nType } from 'core/types/i18n';
 
 import '../styles.scss';
 
 type Props = {|
-  _config: typeof config,
   i18n: I18nType,
-  locationPathname: string,
 |};
 
 export class AboutBase extends React.Component<Props> {
-  static defaultProps = {
-    _config: config,
-  };
-
   render() {
-    const { _config, i18n, locationPathname } = this.props;
+    const { i18n } = this.props;
 
     return (
       <Card
@@ -35,10 +25,6 @@ export class AboutBase extends React.Component<Props> {
       >
         <Helmet>
           <title>{i18n.gettext('About Firefox Add-ons')}</title>
-          <link
-            rel="canonical"
-            href={getCanonicalURL({ locationPathname, _config })}
-          />
           <meta
             name="description"
             content={i18n.gettext(`The official Mozilla site for downloading
@@ -46,6 +32,8 @@ export class AboutBase extends React.Component<Props> {
               browser’s appearance to customize your web experience.`)}
           />
         </Helmet>
+
+        <HeadLinks to="/about" prependClientApp={false} />
 
         <div className="StaticPageWrapper">
           <div id="about">
@@ -234,13 +222,4 @@ export class AboutBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: AppState) => {
-  return {
-    locationPathname: state.router.location.pathname,
-  };
-};
-
-export default compose(
-  connect(mapStateToProps),
-  translate(),
-)(AboutBase);
+export default translate()(AboutBase);

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -33,7 +33,7 @@ export class AboutBase extends React.Component<Props> {
           />
         </Helmet>
 
-        <HeadLinks to="/about" prependClientApp={false} />
+        <HeadLinks />
 
         <div className="StaticPageWrapper">
           <div id="about">

--- a/src/amo/pages/StaticPages/ReviewGuide/index.js
+++ b/src/amo/pages/StaticPages/ReviewGuide/index.js
@@ -1,41 +1,27 @@
 /* @flow */
-import config from 'config';
 import Helmet from 'react-helmet';
 import * as React from 'react';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
 
-import { getCanonicalURL } from 'amo/utils';
+import HeadLinks from 'amo/components/HeadLinks';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
-import type { AppState } from 'amo/store';
 import type { I18nType } from 'core/types/i18n';
 
 import '../styles.scss';
 
 type Props = {|
-  _config: typeof config,
   i18n: I18nType,
-  locationPathname: string,
 |};
 
 export class ReviewGuideBase extends React.Component<Props> {
-  static defaultProps = {
-    _config: config,
-  };
-
   render() {
-    const { _config, i18n, locationPathname } = this.props;
+    const { i18n } = this.props;
 
     return (
       <Card className="StaticPage" header={i18n.gettext('Review Guidelines')}>
         <Helmet>
           <title>{i18n.gettext('Review Guidelines')}</title>
-          <link
-            rel="canonical"
-            href={getCanonicalURL({ locationPathname, _config })}
-          />
           <meta
             name="description"
             content={i18n.gettext(`Guidelines, tips, and Frequently Asked
@@ -43,6 +29,8 @@ export class ReviewGuideBase extends React.Component<Props> {
               downloaded and used on Firefox.`)}
           />
         </Helmet>
+
+        <HeadLinks to="/review_guide" prependClientApp={false} />
 
         <div className="StaticPageWrapper">
           <section id="review-guide">
@@ -187,13 +175,4 @@ export class ReviewGuideBase extends React.Component<Props> {
   }
 }
 
-const mapStateToProps = (state: AppState) => {
-  return {
-    locationPathname: state.router.location.pathname,
-  };
-};
-
-export default compose(
-  connect(mapStateToProps),
-  translate(),
-)(ReviewGuideBase);
+export default translate()(ReviewGuideBase);

--- a/src/amo/pages/StaticPages/ReviewGuide/index.js
+++ b/src/amo/pages/StaticPages/ReviewGuide/index.js
@@ -30,7 +30,7 @@ export class ReviewGuideBase extends React.Component<Props> {
           />
         </Helmet>
 
-        <HeadLinks to="/review_guide" prependClientApp={false} />
+        <HeadLinks />
 
         <div className="StaticPageWrapper">
           <section id="review-guide">

--- a/tests/unit/amo/components/TestAddonHead.js
+++ b/tests/unit/amo/components/TestAddonHead.js
@@ -197,6 +197,5 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find(HeadLinks)).toHaveLength(1);
-    expect(root.find(HeadLinks)).toHaveProp('to', `/addon/${addon.slug}/`);
   });
 });

--- a/tests/unit/amo/components/TestCategoryHead.js
+++ b/tests/unit/amo/components/TestCategoryHead.js
@@ -1,23 +1,14 @@
 import * as React from 'react';
 
 import CategoryHead, { CategoryHeadBase } from 'amo/components/CategoryHead';
+import HeadLinks from 'amo/components/HeadLinks';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
-import {
-  dispatchClientMetadata,
-  fakeCategory,
-  fakeI18n,
-  getFakeConfig,
-  onLocationChanged,
-  shallowUntilTarget,
-} from 'tests/unit/helpers';
+import { fakeCategory, fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  const render = ({
-    store = dispatchClientMetadata().store,
-    ...props
-  } = {}) => {
+  const render = ({ ...props } = {}) => {
     return shallowUntilTarget(
-      <CategoryHead i18n={fakeI18n()} store={store} {...props} />,
+      <CategoryHead i18n={fakeI18n()} {...props} />,
       CategoryHeadBase,
     );
   };
@@ -26,23 +17,6 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.html()).toBeNull();
-  });
-
-  it('renders a canonical link tag', () => {
-    const baseURL = 'https://example.org';
-    const _config = getFakeConfig({ baseURL });
-    const { store } = dispatchClientMetadata();
-
-    const pathname = '/some-category-pathname/';
-    store.dispatch(onLocationChanged({ pathname }));
-
-    const root = render({ _config, category: fakeCategory, store });
-
-    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp(
-      'href',
-      `${baseURL}${pathname}`,
-    );
   });
 
   it('renders an HTML title for a theme category', () => {
@@ -90,5 +64,18 @@ describe(__filename, () => {
     const root = render({ category });
 
     expect(root.find('meta[name="description"]')).toHaveLength(0);
+  });
+
+  it('renders a HeadLinks component', () => {
+    const category = { ...fakeCategory };
+    const visibleAddonType = 'addon-type';
+
+    const root = render({ category, visibleAddonType });
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
+    expect(root.find(HeadLinks)).toHaveProp(
+      'to',
+      `/${visibleAddonType}/${category.slug}/`,
+    );
   });
 });

--- a/tests/unit/amo/components/TestCategoryHead.js
+++ b/tests/unit/amo/components/TestCategoryHead.js
@@ -68,14 +68,8 @@ describe(__filename, () => {
 
   it('renders a HeadLinks component', () => {
     const category = { ...fakeCategory };
-    const visibleAddonType = 'addon-type';
-
-    const root = render({ category, visibleAddonType });
+    const root = render({ category });
 
     expect(root.find(HeadLinks)).toHaveLength(1);
-    expect(root.find(HeadLinks)).toHaveProp(
-      'to',
-      `/${visibleAddonType}/${category.slug}/`,
-    );
   });
 });

--- a/tests/unit/amo/components/TestHeadLinks.js
+++ b/tests/unit/amo/components/TestHeadLinks.js
@@ -14,7 +14,7 @@ describe(__filename, () => {
     ...props
   } = {}) => {
     return shallowUntilTarget(
-      <HeadLinks store={store} to="/foo" {...props} />,
+      <HeadLinks store={store} {...props} />,
       HeadLinksBase,
     );
   };
@@ -34,7 +34,7 @@ describe(__filename, () => {
         pathname: `/${lang}/${clientApp}${to}`,
       });
 
-      const root = render({ _config, _hrefLangs, store, to });
+      const root = render({ _config, _hrefLangs, store });
 
       expect(root.find('link[rel="alternate"]')).toHaveLength(
         _hrefLangs.length,
@@ -72,7 +72,7 @@ describe(__filename, () => {
       pathname: `/${lang}/${clientApp}${to}`,
     });
 
-    const root = render({ _config, _hrefLangs, store, to });
+    const root = render({ _config, _hrefLangs, store });
 
     expect(root.find('link[rel="alternate"]')).toHaveLength(_hrefLangs.length);
     expect(root.find('link[rel="alternate"]').at(0)).toHaveProp(
@@ -125,7 +125,7 @@ describe(__filename, () => {
         pathname: `/${lang}/${clientApp}${to}`,
       });
 
-      const root = render({ _config, store, to });
+      const root = render({ _config, store });
 
       expect(root.find(`link[hrefLang="${hrefLang}"]`)).toHaveProp(
         'href',
@@ -133,12 +133,6 @@ describe(__filename, () => {
       );
     },
   );
-
-  it('throws an invariant error when the `to` prop does not start with a slash', () => {
-    expect(() => {
-      render({ to: 'no-slash' });
-    }).toThrow();
-  });
 
   it('renders a canonical link tag', () => {
     const baseURL = 'https://example.org';
@@ -153,7 +147,7 @@ describe(__filename, () => {
       pathname: `/${lang}/${clientApp}${to}`,
     });
 
-    const root = render({ _config, store, to });
+    const root = render({ _config, store });
 
     expect(root.find('link[rel="canonical"]')).toHaveLength(1);
     expect(root.find('link[rel="canonical"]')).toHaveProp(
@@ -173,50 +167,12 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata({
       clientApp,
       lang,
-      pathname: `/${lang}/${clientApp}${to}?src=hotness`,
+      pathname: `/${lang}/${clientApp}${to}`,
+      search: '?src=hotness',
     });
 
-    const root = render({ _config, _hrefLangs, store, to });
+    const root = render({ _config, _hrefLangs, store });
 
     expect(root.find('link[rel="alternate"]')).toHaveLength(0);
-  });
-
-  it('does not prepend the clientApp when prependClientApp prop is set to `false`', () => {
-    const baseURL = 'https://example.org';
-    const lang = 'de';
-    const to = '/some-url';
-
-    const _hrefLangs = ['fr', 'en-US'];
-    const _config = getFakeConfig({ baseURL });
-    const { store } = dispatchClientMetadata({
-      lang,
-      pathname: `/${lang}${to}`,
-    });
-
-    const root = render({
-      _config,
-      _hrefLangs,
-      prependClientApp: false,
-      store,
-      to,
-    });
-
-    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp(
-      'href',
-      `${baseURL}/${lang}${to}`,
-    );
-
-    expect(root.find('link[rel="alternate"]')).toHaveLength(_hrefLangs.length);
-    _hrefLangs.forEach((locale, index) => {
-      expect(root.find('link[rel="alternate"]').at(index)).toHaveProp(
-        'hrefLang',
-        locale,
-      );
-      expect(root.find('link[rel="alternate"]').at(index)).toHaveProp(
-        'href',
-        `${baseURL}/${locale}${to}`,
-      );
-    });
   });
 });

--- a/tests/unit/amo/components/TestHeadLinks.js
+++ b/tests/unit/amo/components/TestHeadLinks.js
@@ -180,4 +180,43 @@ describe(__filename, () => {
 
     expect(root.find('link[rel="alternate"]')).toHaveLength(0);
   });
+
+  it('does not prepend the clientApp when prependClientApp prop is set to `false`', () => {
+    const baseURL = 'https://example.org';
+    const lang = 'de';
+    const to = '/some-url';
+
+    const _hrefLangs = ['fr', 'en-US'];
+    const _config = getFakeConfig({ baseURL });
+    const { store } = dispatchClientMetadata({
+      lang,
+      pathname: `/${lang}${to}`,
+    });
+
+    const root = render({
+      _config,
+      _hrefLangs,
+      prependClientApp: false,
+      store,
+      to,
+    });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}/${lang}${to}`,
+    );
+
+    expect(root.find('link[rel="alternate"]')).toHaveLength(_hrefLangs.length);
+    _hrefLangs.forEach((locale, index) => {
+      expect(root.find('link[rel="alternate"]').at(index)).toHaveProp(
+        'hrefLang',
+        locale,
+      );
+      expect(root.find('link[rel="alternate"]').at(index)).toHaveProp(
+        'href',
+        `${baseURL}/${locale}${to}`,
+      );
+    });
+  });
 });

--- a/tests/unit/amo/pages/StaticPages/TestAbout.js
+++ b/tests/unit/amo/pages/StaticPages/TestAbout.js
@@ -1,45 +1,18 @@
 import * as React from 'react';
 
 import About, { AboutBase } from 'amo/pages/StaticPages/About';
-import {
-  dispatchClientMetadata,
-  fakeI18n,
-  getFakeConfig,
-  shallowUntilTarget,
-} from 'tests/unit/helpers';
+import HeadLinks from 'amo/components/HeadLinks';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  function render({
-    store = dispatchClientMetadata().store,
-    i18n = fakeI18n(),
-    ...props
-  } = {}) {
-    return shallowUntilTarget(
-      <About store={store} i18n={i18n} {...props} />,
-      AboutBase,
-    );
+  function render({ i18n = fakeI18n(), ...props } = {}) {
+    return shallowUntilTarget(<About i18n={i18n} {...props} />, AboutBase);
   }
 
   it('outputs an about page', () => {
     const root = render();
     expect(root).toHaveClassName('StaticPage');
     expect(root.find('#about')).toExist();
-  });
-
-  it('renders a canonical link tag', () => {
-    const baseURL = 'https://example.org';
-    const _config = getFakeConfig({ baseURL });
-
-    const pathname = '/some-about-pathname';
-    const { store } = dispatchClientMetadata({ pathname });
-
-    const root = render({ _config, store });
-
-    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp(
-      'href',
-      `${baseURL}${pathname}`,
-    );
   });
 
   it('renders a "description" meta tag', () => {
@@ -49,5 +22,13 @@ describe(__filename, () => {
     expect(root.find('meta[name="description"]').prop('content')).toMatch(
       /The official Mozilla site/,
     );
+  });
+
+  it('renders a HeadLinks component', () => {
+    const root = render();
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
+    expect(root.find(HeadLinks)).toHaveProp('to', '/about');
+    expect(root.find(HeadLinks)).toHaveProp('prependClientApp', false);
   });
 });

--- a/tests/unit/amo/pages/StaticPages/TestAbout.js
+++ b/tests/unit/amo/pages/StaticPages/TestAbout.js
@@ -28,7 +28,5 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(HeadLinks)).toHaveLength(1);
-    expect(root.find(HeadLinks)).toHaveProp('to', '/about');
-    expect(root.find(HeadLinks)).toHaveProp('prependClientApp', false);
   });
 });

--- a/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
+++ b/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
@@ -33,7 +33,5 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(HeadLinks)).toHaveLength(1);
-    expect(root.find(HeadLinks)).toHaveProp('to', '/review_guide');
-    expect(root.find(HeadLinks)).toHaveProp('prependClientApp', false);
   });
 });

--- a/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
+++ b/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
@@ -3,21 +3,13 @@ import * as React from 'react';
 import ReviewGuide, {
   ReviewGuideBase,
 } from 'amo/pages/StaticPages/ReviewGuide';
-import {
-  dispatchClientMetadata,
-  fakeI18n,
-  getFakeConfig,
-  shallowUntilTarget,
-} from 'tests/unit/helpers';
+import HeadLinks from 'amo/components/HeadLinks';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  function render({
-    store = dispatchClientMetadata().store,
-    i18n = fakeI18n(),
-    ...props
-  } = {}) {
+  function render({ i18n = fakeI18n(), ...props } = {}) {
     return shallowUntilTarget(
-      <ReviewGuide store={store} i18n={i18n} {...props} />,
+      <ReviewGuide i18n={i18n} {...props} />,
       ReviewGuideBase,
     );
   }
@@ -28,22 +20,6 @@ describe(__filename, () => {
     expect(root.find('#review-guide')).toExist();
   });
 
-  it('renders a canonical link tag', () => {
-    const baseURL = 'https://example.org';
-    const _config = getFakeConfig({ baseURL });
-
-    const pathname = '/some-review-guide-pathname';
-    const { store } = dispatchClientMetadata({ pathname });
-
-    const root = render({ _config, store });
-
-    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp(
-      'href',
-      `${baseURL}${pathname}`,
-    );
-  });
-
   it('renders a "description" meta tag', () => {
     const root = render();
 
@@ -51,5 +27,13 @@ describe(__filename, () => {
     expect(root.find('meta[name="description"]').prop('content')).toMatch(
       /Guidelines, tips, and/,
     );
+  });
+
+  it('renders a HeadLinks component', () => {
+    const root = render();
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
+    expect(root.find(HeadLinks)).toHaveProp('to', '/review_guide');
+    expect(root.find(HeadLinks)).toHaveProp('prependClientApp', false);
   });
 });

--- a/tests/unit/amo/pages/TestCategoriesPage.js
+++ b/tests/unit/amo/pages/TestCategoriesPage.js
@@ -3,16 +3,54 @@ import * as React from 'react';
 
 import Categories from 'amo/components/Categories';
 import { CategoriesPageBase } from 'amo/pages/CategoriesPage';
-import { ADDON_TYPE_EXTENSION } from 'core/constants';
+import HeadLinks from 'amo/components/HeadLinks';
+import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import { visibleAddonType } from 'core/utils';
+import { fakeI18n } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  it('renders Categories', () => {
-    const params = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+  const render = ({ params, ...props } = {}) => {
+    const allProps = {
+      i18n: fakeI18n(),
+      match: {
+        params: {
+          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+          ...params,
+        },
+      },
+      ...props,
     };
-    const root = shallow(<CategoriesPageBase match={{ params }} />);
 
-    expect(root.find(Categories)).toHaveProp('addonType', ADDON_TYPE_EXTENSION);
+    return shallow(<CategoriesPageBase {...allProps} />);
+  };
+
+  it.each([ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME])(
+    'renders the %s categories',
+    (addonType) => {
+      const params = { visibleAddonType: visibleAddonType(addonType) };
+
+      const root = render({ params });
+
+      expect(root.find(Categories)).toHaveLength(1);
+      expect(root.find(Categories)).toHaveProp('addonType', addonType);
+    },
+  );
+
+  it.each([
+    [ADDON_TYPE_EXTENSION, /All extension/],
+    [ADDON_TYPE_THEME, /All theme/],
+  ])('renders an HTML title for %s', (addonType, expectedMatch) => {
+    const params = { visibleAddonType: visibleAddonType(addonType) };
+
+    const root = render({ params });
+
+    expect(root.find('title')).toHaveLength(1);
+    expect(root.find('title').text()).toMatch(expectedMatch);
+  });
+
+  it('renders a HeadLinks component', () => {
+    const root = render();
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
   });
 });

--- a/tests/unit/amo/pages/TestCategory.js
+++ b/tests/unit/amo/pages/TestCategory.js
@@ -19,7 +19,7 @@ import {
   SEARCH_SORT_TOP_RATED,
 } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
-import { visibleAddonType } from 'core/utils';
+import { visibleAddonType as getVisibleAddonType } from 'core/utils';
 import ErrorList from 'ui/components/ErrorList';
 import {
   createAddonsApiResult,
@@ -94,7 +94,7 @@ describe(__filename, () => {
       match: {
         params: {
           slug: fakeCategory.slug,
-          visibleAddonType: visibleAddonType(fakeCategory.type),
+          visibleAddonType: getVisibleAddonType(fakeCategory.type),
           ...paramOverrides,
         },
       },
@@ -128,6 +128,30 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(CategoryHead)).toHaveLength(1);
+  });
+
+  it('passes the visibleAddonType param to CategoryHead', () => {
+    const category = { ...fakeCategory, type: ADDON_TYPE_EXTENSION };
+    const visibleAddonType = getVisibleAddonType(category.type);
+
+    _categoriesLoad({ results: [category] });
+
+    const root = render(
+      {},
+      {
+        autoDispatchCategories: false,
+        paramOverrides: {
+          slug: category.slug,
+          visibleAddonType,
+        },
+      },
+    );
+
+    expect(root.find(CategoryHead)).toHaveLength(1);
+    expect(root.find(CategoryHead)).toHaveProp(
+      'visibleAddonType',
+      visibleAddonType,
+    );
   });
 
   it('should render an error', () => {
@@ -313,7 +337,7 @@ describe(__filename, () => {
       {
         autoDispatchCategories: false,
         paramOverrides: {
-          visibleAddonType: visibleAddonType(addonType),
+          visibleAddonType: getVisibleAddonType(addonType),
         },
       },
     );
@@ -366,7 +390,7 @@ describe(__filename, () => {
       {
         autoDispatchCategories: false,
         paramOverrides: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+          visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION),
         },
       },
     );
@@ -457,7 +481,7 @@ describe(__filename, () => {
       {
         autoDispatchCategories: false,
         paramOverrides: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+          visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME),
         },
       },
     );
@@ -476,7 +500,7 @@ describe(__filename, () => {
       {
         autoDispatchCategories: false,
         paramOverrides: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+          visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME),
         },
       },
     );
@@ -490,7 +514,7 @@ describe(__filename, () => {
       {
         autoDispatchCategories: false,
         paramOverrides: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+          visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION),
         },
       },
     );
@@ -611,11 +635,9 @@ describe(__filename, () => {
       slug: 'target-slug',
     };
 
-    const _dispatchClientApp = (clientApp) =>
-      dispatchClientMetadata({
-        store,
-        clientApp,
-      });
+    const _dispatchClientApp = (clientApp) => {
+      return dispatchClientMetadata({ store, clientApp });
+    };
 
     function _render(
       props = {},
@@ -639,7 +661,7 @@ describe(__filename, () => {
         {
           paramOverrides: {
             slug: targetCategory.slug,
-            visibleAddonType: visibleAddonType(targetCategory.type),
+            visibleAddonType: getVisibleAddonType(targetCategory.type),
           },
         },
       );
@@ -664,7 +686,7 @@ describe(__filename, () => {
       const root = _render({
         params: {
           slug: targetCategory.slug,
-          visibleAddonType: visibleAddonType(targetCategory.type),
+          visibleAddonType: getVisibleAddonType(targetCategory.type),
         },
       });
 
@@ -677,7 +699,7 @@ describe(__filename, () => {
       const root = _render({
         params: {
           slug: targetCategory.slug,
-          visibleAddonType: visibleAddonType(decoyCategory.type),
+          visibleAddonType: getVisibleAddonType(decoyCategory.type),
         },
       });
 
@@ -703,7 +725,7 @@ describe(__filename, () => {
       const root = _render({
         params: {
           slug: targetCategory.slug,
-          visibleAddonType: visibleAddonType(targetCategory.type),
+          visibleAddonType: getVisibleAddonType(targetCategory.type),
         },
       });
 

--- a/tests/unit/amo/pages/TestCategory.js
+++ b/tests/unit/amo/pages/TestCategory.js
@@ -130,30 +130,6 @@ describe(__filename, () => {
     expect(root.find(CategoryHead)).toHaveLength(1);
   });
 
-  it('passes the visibleAddonType param to CategoryHead', () => {
-    const category = { ...fakeCategory, type: ADDON_TYPE_EXTENSION };
-    const visibleAddonType = getVisibleAddonType(category.type);
-
-    _categoriesLoad({ results: [category] });
-
-    const root = render(
-      {},
-      {
-        autoDispatchCategories: false,
-        paramOverrides: {
-          slug: category.slug,
-          visibleAddonType,
-        },
-      },
-    );
-
-    expect(root.find(CategoryHead)).toHaveLength(1);
-    expect(root.find(CategoryHead)).toHaveProp(
-      'visibleAddonType',
-      visibleAddonType,
-    );
-  });
-
   it('should render an error', () => {
     const customErrorHandler = new ErrorHandler({
       id: 'some-error-handler-id',

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -460,6 +460,5 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(HeadLinks)).toHaveLength(1);
-    expect(root.find(HeadLinks)).toHaveProp('to', '/');
   });
 });

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -10,6 +10,7 @@ import Home, {
 import FeaturedCollectionCard from 'amo/components/FeaturedCollectionCard';
 import HomeHeroGuides from 'amo/components/HomeHeroGuides';
 import HomeHeroBanner from 'amo/components/HomeHeroBanner';
+import HeadLinks from 'amo/components/HeadLinks';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import { fetchHomeAddons, loadHomeAddons } from 'amo/reducers/home';
 import { createInternalCollection } from 'amo/reducers/collections';
@@ -432,22 +433,6 @@ describe(__filename, () => {
     });
   });
 
-  it('renders a canonical link tag', () => {
-    const baseURL = 'https://example.org';
-    const _config = getFakeConfig({ baseURL });
-
-    const pathname = '/some-landing-pathname/';
-    const { store } = dispatchClientMetadata({ pathname });
-
-    const root = render({ _config, store });
-
-    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp(
-      'href',
-      `${baseURL}${pathname}`,
-    );
-  });
-
   it('renders a "description" meta tag', () => {
     const root = render();
 
@@ -469,5 +454,12 @@ describe(__filename, () => {
     const root = render({ _config });
 
     expect(root.find(HomeHeroGuides)).toHaveLength(1);
+  });
+
+  it('renders a HeadLinks component', () => {
+    const root = render();
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
+    expect(root.find(HeadLinks)).toHaveProp('to', '/');
   });
 });

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -609,15 +609,9 @@ describe(__filename, () => {
     );
   });
 
-  it.each([ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME])(
-    'renders a HeadLinks component for %s',
-    (addonType) => {
-      const visibleAddonType = getVisibleAddonType(addonType);
+  it('renders a HeadLinks component', () => {
+    const root = render();
 
-      const root = render({ match: { params: { visibleAddonType } } });
-
-      expect(root.find(HeadLinks)).toHaveLength(1);
-      expect(root.find(HeadLinks)).toHaveProp('to', `/${visibleAddonType}/`);
-    },
-  );
+    expect(root.find(HeadLinks)).toHaveLength(1);
+  });
 });

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -4,6 +4,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import * as landingActions from 'amo/actions/landing';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import LandingPage, { LandingPageBase } from 'amo/pages/LandingPage';
+import HeadLinks from 'amo/components/HeadLinks';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -11,15 +12,16 @@ import {
   SEARCH_SORT_TOP_RATED,
 } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
-import { visibleAddonType, getAddonTypeFilter } from 'core/utils';
+import {
+  visibleAddonType as getVisibleAddonType,
+  getAddonTypeFilter,
+} from 'core/utils';
 import {
   createAddonsApiResult,
   createStubErrorHandler,
   dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
-  getFakeConfig,
-  onLocationChanged,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import ErrorList from 'ui/components/ErrorList';
@@ -32,7 +34,7 @@ describe(__filename, () => {
       errorHandler: createStubErrorHandler(),
       i18n: fakeI18n(),
       match: {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) },
+        params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION) },
       },
       store: _store,
       ...otherProps,
@@ -87,7 +89,7 @@ describe(__filename, () => {
     fakeDispatch.resetHistory();
     root.setProps({
       match: {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
+        params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME) },
       },
     });
 
@@ -122,7 +124,7 @@ describe(__filename, () => {
     const root = render({
       errorHandler,
       match: {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
+        params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME) },
       },
       store,
     });
@@ -131,7 +133,7 @@ describe(__filename, () => {
     // Now we request extension add-ons.
     root.setProps({
       match: {
-        params: { visibleAddonType: visibleAddonType(addonType) },
+        params: { visibleAddonType: getVisibleAddonType(addonType) },
       },
     });
 
@@ -148,7 +150,7 @@ describe(__filename, () => {
 
   it('does not dispatch getLanding when addon type does not change', () => {
     const addonType = ADDON_TYPE_EXTENSION;
-    const params = { visibleAddonType: visibleAddonType(addonType) };
+    const params = { visibleAddonType: getVisibleAddonType(addonType) };
     const match = { params };
     const errorHandler = createStubErrorHandler();
 
@@ -211,7 +213,7 @@ describe(__filename, () => {
   it('renders a LandingPage with no addons set', () => {
     const root = render({
       match: {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) },
+        params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION) },
       },
     });
 
@@ -220,7 +222,7 @@ describe(__filename, () => {
 
   it('renders a link to all categories', () => {
     const fakeParams = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+      visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION),
     };
     const match = { params: fakeParams };
 
@@ -234,7 +236,7 @@ describe(__filename, () => {
 
   it('does not render a theme class name when page type is extensions', () => {
     const root = render({
-      params: { visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION) },
+      params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION) },
     });
     expect(root).not.toHaveClassName('.LandingPage--theme');
   });
@@ -242,7 +244,7 @@ describe(__filename, () => {
   it('renders a theme class name when page type is themes', () => {
     const root = render({
       match: {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
+        params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME) },
       },
     });
     expect(root).toHaveClassName('.LandingPage--theme');
@@ -265,7 +267,7 @@ describe(__filename, () => {
     );
 
     const fakeParams = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+      visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION),
     };
     const match = { params: fakeParams };
 
@@ -292,7 +294,7 @@ describe(__filename, () => {
     _getAndLoadLandingAddons({ addonType });
 
     const fakeParams = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+      visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME),
     };
 
     const match = { params: fakeParams };
@@ -320,7 +322,7 @@ describe(__filename, () => {
     const root = render({
       match: {
         params: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+          visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME),
         },
       },
     });
@@ -336,7 +338,7 @@ describe(__filename, () => {
     const root = render({
       match: {
         params: {
-          visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+          visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION),
         },
       },
     });
@@ -349,7 +351,7 @@ describe(__filename, () => {
   it('renders a LandingPage with themes HTML', () => {
     const root = render({
       match: {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
+        params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME) },
       },
     });
 
@@ -379,7 +381,7 @@ describe(__filename, () => {
 
     const root = render({
       match: {
-        params: { visibleAddonType: visibleAddonType(ADDON_TYPE_THEME) },
+        params: { visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME) },
       },
     });
 
@@ -452,7 +454,7 @@ describe(__filename, () => {
   it('does not dispatch setViewContext when addonType does not change', () => {
     const addonType = ADDON_TYPE_EXTENSION;
     const errorHandler = createStubErrorHandler();
-    const params = { visibleAddonType: visibleAddonType(addonType) };
+    const params = { visibleAddonType: getVisibleAddonType(addonType) };
     const match = { params };
 
     store.dispatch(
@@ -475,7 +477,7 @@ describe(__filename, () => {
   it('does not dispatch setViewContext when context does not change', () => {
     const addonType = ADDON_TYPE_EXTENSION;
     const errorHandler = createStubErrorHandler();
-    const params = { visibleAddonType: visibleAddonType(addonType) };
+    const params = { visibleAddonType: getVisibleAddonType(addonType) };
     const match = { params };
 
     store.dispatch(
@@ -499,7 +501,7 @@ describe(__filename, () => {
 
   it('renders an HTML title for themes', () => {
     const fakeParams = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_THEME),
+      visibleAddonType: getVisibleAddonType(ADDON_TYPE_THEME),
     };
     const match = { params: fakeParams };
 
@@ -509,7 +511,7 @@ describe(__filename, () => {
 
   it('renders an HTML title for extensions', () => {
     const fakeParams = {
-      visibleAddonType: visibleAddonType(ADDON_TYPE_EXTENSION),
+      visibleAddonType: getVisibleAddonType(ADDON_TYPE_EXTENSION),
     };
     const match = { params: fakeParams };
 
@@ -591,29 +593,13 @@ describe(__filename, () => {
     expect(landingShelves.at(1)).toHaveClassName('TrendingAddons');
   });
 
-  it('renders a canonical link tag', () => {
-    const baseURL = 'https://example.org';
-    const _config = getFakeConfig({ baseURL });
-
-    const pathname = '/some-landing-pathname/';
-    store.dispatch(onLocationChanged({ pathname }));
-
-    const root = render({ _config, store });
-
-    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp(
-      'href',
-      `${baseURL}${pathname}`,
-    );
-  });
-
   it.each([
     [ADDON_TYPE_EXTENSION, /Download Firefox Extensions to add features/],
     [ADDON_TYPE_THEME, /Download themes to change/],
   ])('renders a "description" meta tag for %s', (addonType, partialContent) => {
     const root = render({
       match: {
-        params: { visibleAddonType: visibleAddonType(addonType) },
+        params: { visibleAddonType: getVisibleAddonType(addonType) },
       },
     });
 
@@ -622,4 +608,16 @@ describe(__filename, () => {
       partialContent,
     );
   });
+
+  it.each([ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME])(
+    'renders a HeadLinks component for %s',
+    (addonType) => {
+      const visibleAddonType = getVisibleAddonType(addonType);
+
+      const root = render({ match: { params: { visibleAddonType } } });
+
+      expect(root.find(HeadLinks)).toHaveLength(1);
+      expect(root.find(HeadLinks)).toHaveProp('to', `/${visibleAddonType}/`);
+    },
+  );
 });

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -318,6 +318,5 @@ describe(__filename, () => {
     const root = renderShallow();
 
     expect(root.find(HeadLinks)).toHaveLength(1);
-    expect(root.find(HeadLinks)).toHaveProp('to', '/language-tools/');
   });
 });

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -6,6 +6,7 @@ import LanguageTools, {
   LanguageToolList,
 } from 'amo/pages/LanguageTools';
 import Link from 'amo/components/Link';
+import HeadLinks from 'amo/components/HeadLinks';
 import { ADDON_TYPE_DICT, ADDON_TYPE_LANG } from 'core/constants';
 import {
   getAllLanguageTools,
@@ -15,7 +16,6 @@ import {
   createFakeLanguageTool,
   dispatchClientMetadata,
   fakeI18n,
-  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import LoadingText from 'ui/components/LoadingText';
@@ -305,22 +305,6 @@ describe(__filename, () => {
     ]);
   });
 
-  it('renders a canonical link tag', () => {
-    const baseURL = 'https://example.org';
-    const _config = getFakeConfig({ baseURL });
-    const pathname = '/language-tools/';
-
-    const { store } = dispatchClientMetadata({ pathname });
-
-    const root = renderShallow({ _config, store });
-
-    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
-    expect(root.find('link[rel="canonical"]')).toHaveProp(
-      'href',
-      `${baseURL}${pathname}`,
-    );
-  });
-
   it('renders a "description" meta tag', () => {
     const root = renderShallow();
 
@@ -328,5 +312,12 @@ describe(__filename, () => {
     expect(root.find('meta[name="description"]').prop('content')).toMatch(
       /Download Firefox dictionaries and language/,
     );
+  });
+
+  it('renders a HeadLinks component', () => {
+    const root = renderShallow();
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
+    expect(root.find(HeadLinks)).toHaveProp('to', '/language-tools/');
   });
 });

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import SearchTools, { SearchToolsBase } from 'amo/pages/SearchTools';
 import Search from 'amo/components/Search';
+import HeadLinks from 'amo/components/HeadLinks';
 import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_RELEVANCE } from 'core/constants';
 import {
   dispatchClientMetadata,
@@ -43,5 +44,12 @@ describe(__filename, () => {
     expect(root.find('meta[name="description"]').prop('content')).toMatch(
       /Download Firefox extensions to customize/,
     );
+  });
+
+  it('renders a HeadLinks component', () => {
+    const root = render();
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
+    expect(root.find(HeadLinks)).toHaveProp('to', '/search-tools/');
   });
 });

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -50,6 +50,5 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(HeadLinks)).toHaveLength(1);
-    expect(root.find(HeadLinks)).toHaveProp('to', '/search-tools/');
   });
 });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -262,13 +262,14 @@ export function dispatchClientMetadata({
   lang = 'en-US',
   userAgent = sampleUserAgent,
   pathname = `/${lang}/${clientApp}/`,
+  search = '',
 } = {}) {
   store.dispatch(setClientApp(clientApp));
   store.dispatch(setLang(lang));
   store.dispatch(setUserAgent(userAgent));
 
   // Simulate the behavior of `connected-react-router`.
-  store.dispatch(onLocationChanged({ pathname }));
+  store.dispatch(onLocationChanged({ pathname, search }));
 
   return {
     store,


### PR DESCRIPTION
Fixes #6774
Fixes #6841
~~:warning: depends on #6794~~

---

Alternate links have been added to all pages containing a `canonical` link. I also added the canonical link to the `SearchTools` component (search tools page) because it was missing. => This PR uses the new `HeadLinks` component, which renders both `canonical` and `alternate` links.