### PR TITLE
Prevent AddonRecommendations from dispatching fetchRecommendations unless the add-on is actually changed

### DIFF
--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -74,7 +74,10 @@ export class AddonRecommendationsBase extends React.Component<Props> {
     } = this.props;
 
     // Fetch recommendations when the add-on changes.
-    if (newAddon && oldAddon !== newAddon) {
+    if (
+      newAddon &&
+      (!oldAddon || (oldAddon && oldAddon.guid !== newAddon.guid))
+    ) {
       this.dispatchFetchRecommendations(newAddon.guid);
     }
 

--- a/tests/unit/amo/components/TestAddonRecommendations.js
+++ b/tests/unit/amo/components/TestAddonRecommendations.js
@@ -196,7 +196,7 @@ describe(__filename, () => {
 
     dispatchSpy.resetHistory();
 
-    root.setProps({ addon });
+    root.setProps({ addon: { ...addon } });
 
     sinon.assert.notCalled(dispatchSpy);
   });


### PR DESCRIPTION
Fixes #6805 

This was happening because in `componentDidUpdate` we were checking `oldAddon !== newAddon` and although the contents of the objects are identical, they are not the same object, so that statement was evaluating to `true`. I changed it to check `oldAddon.guid !== newAddon.guid`, which works in this case. I wonder how many other places in our code base we've done this same thing? Perhaps it would be worth opening a code quality issue to audit for that?
