### PR TITLE
Always load the latest saved review, regardless of version

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -296,7 +296,6 @@ export function setGroupedRatings({
 
 type FetchLatestUserReviewParams = {|
   addonId: number,
-  addonSlug: string,
   errorHandlerId: string,
   userId: number,
 |};
@@ -308,12 +307,10 @@ export type FetchLatestUserReviewAction = {|
 
 export function fetchLatestUserReview({
   addonId,
-  addonSlug,
   errorHandlerId,
   userId,
 }: FetchLatestUserReviewParams): FetchLatestUserReviewAction {
   invariant(addonId, 'addonId is required');
-  invariant(addonSlug, 'addonSlug is required');
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(userId, 'userId is required');
 
@@ -321,7 +318,6 @@ export function fetchLatestUserReview({
     type: FETCH_LATEST_USER_REVIEW,
     payload: {
       addonId,
-      addonSlug,
       errorHandlerId,
       userId,
     },
@@ -613,7 +609,6 @@ export const setReviewWasFlagged = ({
 
 type SetLatestReviewParams = {|
   addonId: number,
-  addonSlug: string,
   review: ExternalReviewType | null,
   userId: number,
 |};
@@ -625,18 +620,16 @@ export type SetLatestReviewAction = {|
 
 export const setLatestReview = ({
   addonId,
-  addonSlug,
   review,
   userId,
 }: SetLatestReviewParams): SetLatestReviewAction => {
   invariant(addonId, 'addonId is required');
-  invariant(addonSlug, 'addonSlug is required');
   invariant(review !== undefined, 'review is required');
   invariant(userId, 'userId is required');
 
   return {
     type: SET_LATEST_REVIEW,
-    payload: { addonId, addonSlug, review, userId },
+    payload: { addonId, review, userId },
   };
 };
 

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -20,6 +20,8 @@ export const FETCH_REVIEW: 'FETCH_REVIEW' = 'FETCH_REVIEW';
 export const FETCH_REVIEW_PERMISSIONS: 'FETCH_REVIEW_PERMISSIONS' =
   'FETCH_REVIEW_PERMISSIONS';
 export const FETCH_REVIEWS: 'FETCH_REVIEWS' = 'FETCH_REVIEWS';
+export const FETCH_LATEST_USER_REVIEW: 'FETCH_LATEST_USER_REVIEW' =
+  'FETCH_LATEST_USER_REVIEW';
 export const FETCH_USER_REVIEWS: 'FETCH_USER_REVIEWS' = 'FETCH_USER_REVIEWS';
 export const FLASH_REVIEW_MESSAGE: 'FLASH_REVIEW_MESSAGE' =
   'FLASH_REVIEW_MESSAGE';
@@ -292,11 +294,43 @@ export function setGroupedRatings({
   };
 }
 
-type FetchUserReviewsParams = {|
+type FetchLatestUserReviewParams = {|
+  addonId: number,
+  addonSlug: string,
   errorHandlerId: string,
-  page?: string,
   userId: number,
+  versionId: number,
 |};
+
+export type FetchLatestUserReviewAction = {|
+  type: typeof FETCH_LATEST_USER_REVIEW,
+  payload: FetchLatestUserReviewParams,
+|};
+
+export function fetchLatestUserReview({
+  addonId,
+  addonSlug,
+  errorHandlerId,
+  userId,
+  versionId,
+}: FetchLatestUserReviewParams): FetchLatestUserReviewAction {
+  invariant(addonId, 'addonId is required');
+  invariant(addonSlug, 'addonSlug is required');
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(userId, 'userId is required');
+  invariant(userId, 'versionId is required');
+
+  return {
+    type: FETCH_LATEST_USER_REVIEW,
+    payload: {
+      addonId,
+      addonSlug,
+      errorHandlerId,
+      userId,
+      versionId,
+    },
+  };
+}
 
 export type FetchUserReviewsAction = {|
   type: typeof FETCH_USER_REVIEWS,
@@ -311,7 +345,11 @@ export function fetchUserReviews({
   errorHandlerId,
   userId,
   page = '1',
-}: FetchUserReviewsParams): FetchUserReviewsAction {
+}: {|
+  errorHandlerId: string,
+  page?: string,
+  userId: number,
+|}): FetchUserReviewsAction {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(userId, 'userId is required');
 

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -299,7 +299,6 @@ type FetchLatestUserReviewParams = {|
   addonSlug: string,
   errorHandlerId: string,
   userId: number,
-  versionId: number,
 |};
 
 export type FetchLatestUserReviewAction = {|
@@ -312,13 +311,11 @@ export function fetchLatestUserReview({
   addonSlug,
   errorHandlerId,
   userId,
-  versionId,
 }: FetchLatestUserReviewParams): FetchLatestUserReviewAction {
   invariant(addonId, 'addonId is required');
   invariant(addonSlug, 'addonSlug is required');
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(userId, 'userId is required');
-  invariant(userId, 'versionId is required');
 
   return {
     type: FETCH_LATEST_USER_REVIEW,
@@ -327,7 +324,6 @@ export function fetchLatestUserReview({
       addonSlug,
       errorHandlerId,
       userId,
-      versionId,
     },
   };
 }
@@ -620,7 +616,6 @@ type SetLatestReviewParams = {|
   addonSlug: string,
   review: ExternalReviewType | null,
   userId: number,
-  versionId: number,
 |};
 
 export type SetLatestReviewAction = {|
@@ -631,7 +626,6 @@ export type SetLatestReviewAction = {|
 export const setLatestReview = ({
   addonId,
   addonSlug,
-  versionId,
   review,
   userId,
 }: SetLatestReviewParams): SetLatestReviewAction => {
@@ -639,11 +633,10 @@ export const setLatestReview = ({
   invariant(addonSlug, 'addonSlug is required');
   invariant(review !== undefined, 'review is required');
   invariant(userId, 'userId is required');
-  invariant(versionId, 'versionId is required');
 
   return {
     type: SET_LATEST_REVIEW,
-    payload: { addonId, addonSlug, review, userId, versionId },
+    payload: { addonId, addonSlug, review, userId },
   };
 };
 

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -190,7 +190,6 @@ export type GetLatestUserReviewParams = {|
   addon: number,
   apiState: ApiState,
   user: number,
-  version?: number,
 |};
 
 export type GetLatestUserReviewResponse = null | ExternalReviewType;
@@ -199,14 +198,12 @@ export async function getLatestUserReview({
   apiState,
   user,
   addon,
-  version,
 }: GetLatestUserReviewParams = {}): Promise<GetLatestUserReviewResponse> {
   invariant(user, 'The user parameter is required');
   invariant(addon, 'The addon parameter is required');
 
-  // When version is undefined, the API returns the latest user review
-  // for this add-on.
-  const response = await getReviews({ apiState, user, addon, version });
+  // Since version is omitted, the API returns only the latest review.
+  const response = await getReviews({ apiState, user, addon });
 
   const reviews = response.results;
   if (reviews.length === 1) {

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -187,7 +187,8 @@ export function getReviews({
 }
 
 export type GetLatestUserReviewParams = {|
-  addon: number,
+  // This is the addon ID, slug, or guid.
+  addon: number | string,
   apiState: ApiState,
   user: number,
 |};

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -215,8 +215,8 @@ export async function getLatestUserReview({
   if (reviews.length === 0) {
     return null;
   }
-  // There are enough constraints in the database where we should never
-  // receive multiple objects so throw an error for that case.
+  // Theoretcially, there are enough constraints in the database where we
+  // should never receive multiple objects.
   throw new Error(oneLine`Unexpectedly received multiple review objects:
       ${reviews.map((r) => r.id)}`);
 }

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -186,19 +186,21 @@ export function getReviews({
   });
 }
 
-export type GetLatestReviewParams = {|
+export type GetLatestUserReviewParams = {|
   addon: number,
   apiState: ApiState,
   user: number,
   version?: number,
 |};
 
+export type GetLatestUserReviewResponse = null | ExternalReviewType;
+
 export async function getLatestUserReview({
   apiState,
   user,
   addon,
   version,
-}: GetLatestReviewParams = {}): Promise<null | ExternalReviewType> {
+}: GetLatestUserReviewParams = {}): Promise<GetLatestUserReviewResponse> {
   invariant(user, 'The user parameter is required');
   invariant(addon, 'The addon parameter is required');
 

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -217,9 +217,8 @@ export async function getLatestUserReview({
   }
   // There are enough constraints in the database where we should never
   // receive multiple objects so throw an error for that case.
-  // TODO: do not stringify the entier review objects.
   throw new Error(oneLine`Unexpectedly received multiple review objects:
-      ${JSON.stringify(reviews)}`);
+      ${reviews.map((r) => r.id)}`);
 }
 
 type FlagReviewParams = {|

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -64,13 +64,7 @@ type InternalProps = {|
 
 export class RatingManagerBase extends React.Component<InternalProps> {
   componentDidMount() {
-    const {
-      addon,
-      dispatch,
-      errorHandler,
-      userId,
-      userReview,
-    } = this.props;
+    const { addon, dispatch, errorHandler, userId, userReview } = this.props;
 
     if (userId && userReview === undefined) {
       log.debug(`Loading a saved rating (if it exists) for user ${userId}`);

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -88,13 +88,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
   }
 
   onSelectRating = (score: number) => {
-    const {
-      addon,
-      dispatch,
-      errorHandler,
-      userReview,
-      version,
-    } = this.props;
+    const { addon, dispatch, errorHandler, userReview, version } = this.props;
 
     if (userReview) {
       dispatch(

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -70,7 +70,6 @@ export class RatingManagerBase extends React.Component<InternalProps> {
       errorHandler,
       userId,
       userReview,
-      version,
     } = this.props;
 
     if (userId && userReview === undefined) {
@@ -81,7 +80,6 @@ export class RatingManagerBase extends React.Component<InternalProps> {
           addonId: addon.id,
           addonSlug: addon.slug,
           errorHandlerId: errorHandler.id,
-          versionId: version.id,
         }),
       );
     }
@@ -277,16 +275,14 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
   let userReview;
   if (userId && ownProps.addon) {
     const addonId = ownProps.addon.id;
-    const versionId = ownProps.version.id;
 
     log.debug(oneLine`Looking for latest review of
-      addon:${addonId}/version:${versionId} by user:${userId}`);
+      addonId "${addonId}" by userId "${userId}"`);
 
     userReview = selectLatestUserReview({
       reviewsState: state.reviews,
       userId,
       addonId,
-      versionId,
     });
   }
 

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -72,7 +72,6 @@ export class RatingManagerBase extends React.Component<InternalProps> {
         fetchLatestUserReview({
           userId,
           addonId: addon.id,
-          addonSlug: addon.slug,
           errorHandlerId: errorHandler.id,
         }),
       );

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -10,11 +10,9 @@ import {
   SAVED_RATING,
   STARTED_SAVE_RATING,
   createAddonReview,
-  setLatestReview,
-  setReview,
+  fetchLatestUserReview,
   updateAddonReview,
 } from 'amo/actions/reviews';
-import * as reviewsApi from 'amo/api/reviews';
 import AddonReviewCard from 'amo/components/AddonReviewCard';
 import AddonReviewManagerRating from 'amo/components/AddonReviewManagerRating';
 import RatingManagerNotice from 'amo/components/RatingManagerNotice';
@@ -40,38 +38,22 @@ import type { AddonVersionType } from 'core/reducers/versions';
 import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { FlashMessageType, UserReviewType } from 'amo/actions/reviews';
-import type { GetLatestReviewParams } from 'amo/api/reviews';
 import type { DispatchFunc } from 'core/types/redux';
-import type { ApiState } from 'core/reducers/api';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
-
-type LoadSavedReviewFunc = ({|
-  addonId: $PropertyType<GetLatestReviewParams, 'addon'>,
-  addonSlug: string,
-  apiState: ApiState,
-  userId: $PropertyType<GetLatestReviewParams, 'user'>,
-  versionId: number,
-|}) => Promise<any>;
 
 type Props = {|
   addon: AddonType,
   version: AddonVersionType,
 |};
 
-type DispatchMappedProps = {|
-  dispatch: DispatchFunc,
-  loadSavedReview: LoadSavedReviewFunc,
-|};
-
 type InternalProps = {|
   ...Props,
-  ...DispatchMappedProps,
-  apiState: ApiState,
   beginningToDeleteReview: boolean,
   deletingReview: boolean,
+  dispatch: DispatchFunc,
   editingReview: boolean,
   errorHandler: ErrorHandlerType,
   flashMessage?: FlashMessageType | void,
@@ -84,8 +66,8 @@ export class RatingManagerBase extends React.Component<InternalProps> {
   componentDidMount() {
     const {
       addon,
-      apiState,
-      loadSavedReview,
+      dispatch,
+      errorHandler,
       userId,
       userReview,
       version,
@@ -93,42 +75,26 @@ export class RatingManagerBase extends React.Component<InternalProps> {
 
     if (userId && userReview === undefined) {
       log.debug(`Loading a saved rating (if it exists) for user ${userId}`);
-      loadSavedReview({
-        apiState,
-        userId,
-        addonId: addon.id,
-        addonSlug: addon.slug,
-        versionId: version.id,
-      });
+      dispatch(
+        fetchLatestUserReview({
+          userId,
+          addonId: addon.id,
+          addonSlug: addon.slug,
+          errorHandlerId: errorHandler.id,
+          versionId: version.id,
+        }),
+      );
     }
   }
 
   onSelectRating = (score: number) => {
     const {
       addon,
-      apiState,
       dispatch,
       errorHandler,
       userReview,
       version,
     } = this.props;
-
-    const params = {
-      errorHandler,
-      score,
-      apiState,
-      addonId: addon.id,
-      reviewId: undefined,
-      versionId: version.id,
-    };
-
-    if (userReview) {
-      log.debug(`Editing reviewId ${userReview.id}`);
-      params.reviewId = userReview.id;
-    } else {
-      log.debug(oneLine`Submitting a new review for
-        versionId ${params.versionId || '[empty]'}`);
-    }
 
     if (userReview) {
       dispatch(
@@ -343,7 +309,6 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
   }
 
   return {
-    apiState: state.api,
     beginningToDeleteReview,
     deletingReview,
     editingReview,
@@ -353,63 +318,11 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
   };
 };
 
-export const mapDispatchToProps = (
-  dispatch: DispatchFunc,
-  // We add `DispatchMappedProps` to override these functions in the tests.
-  ownProps: Props | DispatchMappedProps,
-): DispatchMappedProps => {
-  const loadSavedReview = ({
-    apiState,
-    userId,
-    addonId,
-    addonSlug,
-    versionId,
-  }) => {
-    return reviewsApi
-      .getLatestUserReview({
-        apiState,
-        user: userId,
-        addon: addonId,
-        // TODO: omit this.
-        version: versionId,
-      })
-      .then((review) => {
-        const _setLatestReview = (value) => {
-          return setLatestReview({
-            userId,
-            addonId,
-            addonSlug,
-            versionId,
-            review: value,
-          });
-        };
-
-        if (review) {
-          dispatch(setReview(review));
-          dispatch(_setLatestReview(review));
-        } else {
-          log.debug(
-            `No saved review found for userId ${userId}, addonId ${addonId}`,
-          );
-          dispatch(_setLatestReview(null));
-        }
-      });
-  };
-
-  return {
-    dispatch,
-    loadSavedReview: ownProps.loadSavedReview || loadSavedReview,
-  };
-};
-
 export const RatingManagerWithI18n = translate()(RatingManagerBase);
 
 const RatingManager: React.ComponentType<Props> = compose(
   withRenderedErrorHandler({ name: 'RatingManager' }),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps),
 )(RatingManagerWithI18n);
 
 export default RatingManager;

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -53,7 +53,7 @@ type LoadSavedReviewFunc = ({|
   addonSlug: string,
   apiState: ApiState,
   userId: $PropertyType<GetLatestReviewParams, 'user'>,
-  versionId: $PropertyType<GetLatestReviewParams, 'version'>,
+  versionId: number,
 |}) => Promise<any>;
 
 type Props = {|
@@ -370,6 +370,7 @@ export const mapDispatchToProps = (
         apiState,
         user: userId,
         addon: addonId,
+        // TODO: omit this.
         version: versionId,
       })
       .then((review) => {

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -111,9 +111,9 @@ export type ReviewsState = {|
   byId: ReviewsById,
   byUserId: ReviewsByUserId,
   latestUserReview: {
-    // The latest user review for add-on / version
+    // The latest user review for an add-on
     // or null if one does not exist yet.
-    [userIdAddonIdVersionId: string]: number | null,
+    [userIdAddonId: string]: number | null,
   },
   groupedRatings: {
     [addonId: number]: ?GroupedRatingsType,
@@ -265,27 +265,23 @@ export const getReviewsByUserId = (
 export const makeLatestUserReviewKey = ({
   userId,
   addonId,
-  versionId,
 }: {|
   userId: number,
   addonId: number,
-  versionId: number,
 |}) => {
-  return `user-${userId}/addon-${addonId}/version-${versionId}`;
+  return `user-${userId}/addon-${addonId}`;
 };
 
 export const selectLatestUserReview = ({
   reviewsState,
   userId,
   addonId,
-  versionId,
 }: {|
   reviewsState: ReviewsState,
   userId: number,
   addonId: number,
-  versionId: number,
 |}): UserReviewType | null | void => {
-  const key = makeLatestUserReviewKey({ userId, addonId, versionId });
+  const key = makeLatestUserReviewKey({ userId, addonId });
   const userReviewId = reviewsState.latestUserReview[key];
 
   if (userReviewId === null) {
@@ -444,8 +440,8 @@ export default function reviewsReducer(
       });
     case SET_LATEST_REVIEW: {
       const { payload } = action;
-      const { addonId, userId, review, versionId } = payload;
-      const key = makeLatestUserReviewKey({ addonId, userId, versionId });
+      const { addonId, userId, review } = payload;
+      const key = makeLatestUserReviewKey({ addonId, userId });
 
       if (review && !selectReview(state, review.id)) {
         throw new Error(

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -77,6 +77,7 @@ import type {
   SendReplyToReviewAction,
   UpdateAddonReviewAction,
 } from 'amo/actions/reviews';
+import type { Saga } from 'core/types/sagas';
 
 // Number of millesconds that a message should be flashed on screen.
 export const FLASH_SAVED_MESSAGE_DURATION = 2000;
@@ -87,7 +88,7 @@ type Options = {|
 
 function* fetchReviews({
   payload: { errorHandlerId, addonSlug, page },
-}: FetchReviewsAction): Generator<any, any, any> {
+}: FetchReviewsAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   try {
@@ -120,7 +121,7 @@ function* fetchReviews({
 
 function* fetchReviewPermissions({
   payload: { errorHandlerId, addonId, userId },
-}: FetchReviewPermissionsAction): Generator<any, any, any> {
+}: FetchReviewPermissionsAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   try {
@@ -156,7 +157,7 @@ function* fetchReviewPermissions({
 
 function* fetchGroupedRatings({
   payload: { errorHandlerId, addonId },
-}: FetchGroupedRatingsAction): Generator<any, any, any> {
+}: FetchGroupedRatingsAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
   try {
     const state = yield select(getState);
@@ -191,7 +192,7 @@ function* fetchGroupedRatings({
 
 function* fetchUserReviews({
   payload: { errorHandlerId, page, userId },
-}: FetchUserReviewsAction): Generator<any, any, any> {
+}: FetchUserReviewsAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   try {
@@ -221,7 +222,7 @@ function* fetchUserReviews({
 
 function* handleReplyToReview({
   payload: { errorHandlerId, originalReviewId, body, title },
-}: SendReplyToReviewAction): Generator<any, any, any> {
+}: SendReplyToReviewAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -246,7 +247,7 @@ function* handleReplyToReview({
 
 function* handleFlagReview({
   payload: { errorHandlerId, note, reason, reviewId },
-}: FlagReviewAction): Generator<any, any, any> {
+}: FlagReviewAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -356,7 +357,7 @@ function* manageAddonReview(
 
 function* deleteAddonReview({
   payload: { addonId, errorHandlerId, isReplyToReviewId, reviewId },
-}: DeleteAddonReviewAction): Generator<any, any, any> {
+}: DeleteAddonReviewAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -380,7 +381,7 @@ function* deleteAddonReview({
 
 function* fetchLatestUserReview({
   payload: { addonId, errorHandlerId, userId },
-}: FetchLatestUserReviewAction): Generator<any, any, any> {
+}: FetchLatestUserReviewAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -426,7 +427,7 @@ function* fetchLatestUserReview({
 
 function* fetchReview({
   payload: { errorHandlerId, reviewId },
-}: FetchReviewAction): Generator<any, any, any> {
+}: FetchReviewAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
@@ -448,9 +449,7 @@ function* fetchReview({
   }
 }
 
-export default function* reviewsSaga(
-  options?: Options,
-): Generator<any, any, any> {
+export default function* reviewsSaga(options?: Options): Saga {
   yield takeLatest(FETCH_GROUPED_RATINGS, fetchGroupedRatings);
   yield takeLatest(FETCH_LATEST_USER_REVIEW, fetchLatestUserReview);
   yield takeLatest(FETCH_REVIEW, fetchReview);

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -331,7 +331,6 @@ function* manageAddonReview(
       yield put(
         setLatestReview({
           addonId: reviewFromResponse.addon.id,
-          addonSlug: reviewFromResponse.addon.slug,
           review: reviewFromResponse,
           userId: reviewFromResponse.user.id,
         }),
@@ -380,7 +379,7 @@ function* deleteAddonReview({
 }
 
 function* fetchLatestUserReview({
-  payload: { addonId, addonSlug, errorHandlerId, userId },
+  payload: { addonId, errorHandlerId, userId },
 }: FetchLatestUserReviewAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -404,7 +403,6 @@ function* fetchLatestUserReview({
       return setLatestReview({
         userId,
         addonId,
-        addonSlug,
         review: value,
       });
     };

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -328,14 +328,12 @@ function* manageAddonReview(
     }
 
     if (!reviewFromResponse.is_developer_reply) {
-      invariant(reviewFromResponse.version, 'version is required');
       yield put(
         setLatestReview({
           addonId: reviewFromResponse.addon.id,
           addonSlug: reviewFromResponse.addon.slug,
           review: reviewFromResponse,
           userId: reviewFromResponse.user.id,
-          versionId: reviewFromResponse.version.id,
         }),
       );
 
@@ -382,7 +380,7 @@ function* deleteAddonReview({
 }
 
 function* fetchLatestUserReview({
-  payload: { addonId, addonSlug, errorHandlerId, userId, versionId },
+  payload: { addonId, addonSlug, errorHandlerId, userId },
 }: FetchLatestUserReviewAction): Generator<any, any, any> {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -407,7 +405,6 @@ function* fetchLatestUserReview({
         userId,
         addonId,
         addonSlug,
-        versionId,
         review: value,
       });
     };

--- a/src/core/types/sagas.js
+++ b/src/core/types/sagas.js
@@ -1,3 +1,6 @@
 /* @flow */
 
-export type Saga = Generator<any, any, any>;
+// A saga is a generator that yields any effect creator (such as put(action))
+// and receives any value (such as response = yield call(someApiFunction).
+// This type is loose; we don't use it to cover what a given saga can yield/receive.
+export type Saga = Generator<any, void, any>;

--- a/tests/unit/amo/api/test_reviews.js
+++ b/tests/unit/amo/api/test_reviews.js
@@ -218,12 +218,10 @@ describe(__filename, () => {
           },
           apiState: undefined,
         })
-        .returns(
-          Promise.resolve(
-            getReviewsResponse({
-              reviews: [expectedReview],
-            }),
-          ),
+        .resolves(
+          getReviewsResponse({
+            reviews: [expectedReview],
+          }),
         );
 
       const review = await getLatestUserReview(params);
@@ -232,13 +230,11 @@ describe(__filename, () => {
     });
 
     it('throws an error if multple reviews are received', async () => {
-      mockApi.expects('callApi').returns(
-        Promise.resolve(
-          getReviewsResponse({
-            // In real life, the API should never return multiple reviews like this.
-            reviews: [{ ...fakeReview, id: 1 }, { ...fakeReview, id: 2 }],
-          }),
-        ),
+      mockApi.expects('callApi').resolves(
+        getReviewsResponse({
+          // In real life, the API should never return multiple reviews like this.
+          reviews: [{ ...fakeReview, id: 1 }, { ...fakeReview, id: 2 }],
+        }),
       );
 
       await getLatestUserReview({
@@ -250,52 +246,15 @@ describe(__filename, () => {
       });
     });
 
-    it('returns latest review as null when there are no reviews at all', () => {
-      mockApi
-        .expects('callApi')
-        .returns(Promise.resolve(getReviewsResponse({ reviews: [] })));
+    it('returns latest review as null when there are no reviews at all', async () => {
+      mockApi.expects('callApi').resolves(getReviewsResponse({ reviews: [] }));
 
-      return getLatestUserReview({ user: 123, addon: 321, version: 456 }).then(
-        (review) => {
-          expect(review).toBe(null);
-        },
-      );
-    });
-
-    it('requires user, addon, and version', () => {
-      mockApi.expects('callApi').returns(Promise.resolve(getReviewsResponse()));
-
-      return getLatestUserReview().then(unexpectedSuccess, (error) => {
-        expect(error.message).toMatch(
-          /user, addon, and version must be specified/,
-        );
+      const review = await getLatestUserReview({
+        user: 123,
+        addon: 321,
+        version: 456,
       });
-    });
-
-    it('requires addon and version', () => {
-      mockApi.expects('callApi').returns(Promise.resolve(getReviewsResponse()));
-
-      return getLatestUserReview({ user: 123 }).then(
-        unexpectedSuccess,
-        (error) => {
-          expect(error.message).toMatch(
-            /user, addon, and version must be specified/,
-          );
-        },
-      );
-    });
-
-    it('requires a version', () => {
-      mockApi.expects('callApi').returns(Promise.resolve(getReviewsResponse()));
-
-      return getLatestUserReview({ addon: 321, user: 123 }).then(
-        unexpectedSuccess,
-        (error) => {
-          expect(error.message).toMatch(
-            /user, addon, and version must be specified/,
-          );
-        },
-      );
+      expect(review).toBe(null);
     });
   });
 

--- a/tests/unit/amo/api/test_reviews.js
+++ b/tests/unit/amo/api/test_reviews.js
@@ -203,7 +203,7 @@ describe(__filename, () => {
 
   describe('getLatestUserReview', () => {
     it('returns the lone review result since that is the latest', async () => {
-      const params = { user: 123, addon: 321, version: 456 };
+      const params = { user: 123, addon: 321 };
       const expectedReview = { ...fakeReview, id: 34 };
       mockApi
         .expects('callApi')
@@ -214,7 +214,6 @@ describe(__filename, () => {
           params: {
             addon: params.addon,
             user: params.user,
-            version: params.version,
           },
           apiState: undefined,
         })
@@ -240,7 +239,6 @@ describe(__filename, () => {
       await getLatestUserReview({
         user: 123,
         addon: fakeReview.addon.id,
-        version: fakeReview.version.id,
       }).then(unexpectedSuccess, (error) => {
         expect(error.message).toMatch(/received multiple review objects/);
       });
@@ -252,7 +250,6 @@ describe(__filename, () => {
       const review = await getLatestUserReview({
         user: 123,
         addon: 321,
-        version: 456,
       });
       expect(review).toBe(null);
     });

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -72,7 +72,6 @@ describe(__filename, () => {
     store.dispatch(
       setLatestReview({
         addonId: addon.id,
-        addonSlug: addon.slug,
         review,
         userId,
       }),

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -979,9 +979,9 @@ describe(__filename, () => {
 
   describe('makeLatestUserReviewKey', () => {
     it('makes a key', () => {
-      expect(
-        makeLatestUserReviewKey({ userId: 1, addonId: 2 }),
-      ).toEqual('user-1/addon-2');
+      expect(makeLatestUserReviewKey({ userId: 1, addonId: 2 })).toEqual(
+        'user-1/addon-2',
+      );
     });
   });
 
@@ -1021,9 +1021,7 @@ describe(__filename, () => {
       );
 
       expect(
-        state.latestUserReview[
-          makeLatestUserReviewKey({ addonId, userId })
-        ],
+        state.latestUserReview[makeLatestUserReviewKey({ addonId, userId })],
       ).toEqual(review.id);
     });
 
@@ -1037,9 +1035,7 @@ describe(__filename, () => {
       );
 
       expect(
-        state.latestUserReview[
-          makeLatestUserReviewKey({ addonId, userId })
-        ],
+        state.latestUserReview[makeLatestUserReviewKey({ addonId, userId })],
       ).toBeNull();
     });
 

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -992,7 +992,6 @@ describe(__filename, () => {
     } = {}) => {
       return setLatestReview({
         addonId: 9,
-        addonSlug: 'some-slug',
         userId: 7,
         review,
         ...params,

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -980,8 +980,8 @@ describe(__filename, () => {
   describe('makeLatestUserReviewKey', () => {
     it('makes a key', () => {
       expect(
-        makeLatestUserReviewKey({ userId: 1, addonId: 2, versionId: 3 }),
-      ).toEqual('user-1/addon-2/version-3');
+        makeLatestUserReviewKey({ userId: 1, addonId: 2 }),
+      ).toEqual('user-1/addon-2');
     });
   });
 
@@ -993,7 +993,6 @@ describe(__filename, () => {
       return setLatestReview({
         addonId: 9,
         addonSlug: 'some-slug',
-        versionId: 8,
         userId: 7,
         review,
         ...params,
@@ -1011,7 +1010,6 @@ describe(__filename, () => {
 
     it('sets the latest review', () => {
       const addonId = 1;
-      const versionId = 2;
       const userId = 3;
       const review = { ...fakeReview, id: 2 };
 
@@ -1019,36 +1017,34 @@ describe(__filename, () => {
       state = reviewsReducer(state, setReview(review));
       state = reviewsReducer(
         state,
-        _setLatestReview({ addonId, versionId, userId, review }),
+        _setLatestReview({ addonId, userId, review }),
       );
 
       expect(
         state.latestUserReview[
-          makeLatestUserReviewKey({ addonId, userId, versionId })
+          makeLatestUserReviewKey({ addonId, userId })
         ],
       ).toEqual(review.id);
     });
 
     it('can set the latest review to null', () => {
       const addonId = 1;
-      const versionId = 2;
       const userId = 3;
 
       const state = reviewsReducer(
         undefined,
-        _setLatestReview({ addonId, versionId, userId, review: null }),
+        _setLatestReview({ addonId, userId, review: null }),
       );
 
       expect(
         state.latestUserReview[
-          makeLatestUserReviewKey({ addonId, userId, versionId })
+          makeLatestUserReviewKey({ addonId, userId })
         ],
       ).toBeNull();
     });
 
     it('preserves other latest reviews', () => {
       const userId = 1;
-      const addonId = 1;
       const review1 = { ...fakeReview, id: 1 };
       const review2 = { ...fakeReview, id: 2 };
 
@@ -1058,8 +1054,7 @@ describe(__filename, () => {
         state,
         _setLatestReview({
           userId,
-          addonId,
-          versionId: 1,
+          addonId: 1,
           review: review1,
         }),
       );
@@ -1068,21 +1063,16 @@ describe(__filename, () => {
         state,
         _setLatestReview({
           userId,
-          addonId,
-          versionId: 2,
+          addonId: 2,
           review: review2,
         }),
       );
 
       expect(
-        state.latestUserReview[
-          makeLatestUserReviewKey({ userId, addonId, versionId: 1 })
-        ],
+        state.latestUserReview[makeLatestUserReviewKey({ userId, addonId: 1 })],
       ).toEqual(1);
       expect(
-        state.latestUserReview[
-          makeLatestUserReviewKey({ userId, addonId, versionId: 2 })
-        ],
+        state.latestUserReview[makeLatestUserReviewKey({ userId, addonId: 2 })],
       ).toEqual(2);
     });
   });

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -856,14 +856,12 @@ describe(__filename, () => {
 
     it('dispatches setLatestReview after saving a review', async () => {
       const addonId = 98767;
-      const addonSlug = 'some-slug';
       const body = 'This add-on works pretty well for me';
       const score = 4;
       const userId = 12345;
 
       const externalReview = createExternalReview({
         addonId,
-        addonSlug,
         body,
         score,
         userId,
@@ -875,7 +873,6 @@ describe(__filename, () => {
 
       const expectedAction = setLatestReview({
         addonId,
-        addonSlug,
         review: externalReview,
         userId,
       });
@@ -885,14 +882,12 @@ describe(__filename, () => {
 
     it('does not dispatch setLatestReview after saving a reply', async () => {
       const addonId = 98767;
-      const addonSlug = 'some-slug';
       const body = 'This add-on works pretty well for me';
       const rating = 4;
       const userId = 12345;
 
       const externalReview = createExternalReview({
         addonId,
-        addonSlug,
         body,
         isDeveloperReply: true,
         rating,
@@ -908,7 +903,6 @@ describe(__filename, () => {
 
       const unexpectedAction = setLatestReview({
         addonId,
-        addonSlug,
         review: externalReview,
         userId,
       });
@@ -1087,7 +1081,6 @@ describe(__filename, () => {
       sagaTester.dispatch(
         fetchLatestUserReview({
           addonId: fakeAddon.id,
-          addonSlug: fakeAddon.slug,
           errorHandlerId: 'any-error-handler',
           userId: 9876,
           ...params,
@@ -1107,7 +1100,6 @@ describe(__filename, () => {
     it('fetches and sets the latest user review', async () => {
       const review = { ...fakeReview, id: 34421 };
       const addonId = review.addon.id;
-      const addonSlug = review.addon.slug;
       const userId = review.user.id;
       mockApi
         .expects('getLatestUserReview')
@@ -1120,7 +1112,6 @@ describe(__filename, () => {
 
       _fetchLatestUserReview({
         addonId,
-        addonSlug,
         userId,
       });
 
@@ -1131,7 +1122,6 @@ describe(__filename, () => {
       const expectedSetLatestAction = setLatestReview({
         userId,
         addonId,
-        addonSlug,
         review,
       });
       const setLatestAction = await matchingSagaAction(
@@ -1147,20 +1137,17 @@ describe(__filename, () => {
     it('sets the latest review to null when none exists', async () => {
       const review = { ...fakeReview, id: 34421 };
       const addonId = review.addon.id;
-      const addonSlug = review.addon.slug;
       const userId = review.user.id;
 
       mockApi.expects('getLatestUserReview').resolves(null);
 
       _fetchLatestUserReview({
         addonId,
-        addonSlug,
         userId,
       });
 
       const expectedAction = setLatestReview({
         addonId,
-        addonSlug,
         userId,
         review: null,
       });

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -860,7 +860,6 @@ describe(__filename, () => {
       const body = 'This add-on works pretty well for me';
       const score = 4;
       const userId = 12345;
-      const versionId = 7653;
 
       const externalReview = createExternalReview({
         addonId,
@@ -868,19 +867,17 @@ describe(__filename, () => {
         body,
         score,
         userId,
-        versionId,
       });
 
       mockApi.expects('submitReview').resolves(externalReview);
 
-      _createAddonReview({ addonId, body, score, versionId });
+      _createAddonReview({ addonId, body, score });
 
       const expectedAction = setLatestReview({
         addonId,
         addonSlug,
         review: externalReview,
         userId,
-        versionId,
       });
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
@@ -892,7 +889,6 @@ describe(__filename, () => {
       const body = 'This add-on works pretty well for me';
       const rating = 4;
       const userId = 12345;
-      const versionId = 7653;
 
       const externalReview = createExternalReview({
         addonId,
@@ -901,7 +897,6 @@ describe(__filename, () => {
         isDeveloperReply: true,
         rating,
         userId,
-        versionId,
       });
 
       mockApi.expects('submitReview').resolves(externalReview);
@@ -916,7 +911,6 @@ describe(__filename, () => {
         addonSlug,
         review: externalReview,
         userId,
-        versionId,
       });
 
       expect(sagaTester.numCalled(unexpectedAction.type)).toEqual(0);
@@ -1096,7 +1090,6 @@ describe(__filename, () => {
           addonSlug: fakeAddon.slug,
           errorHandlerId: 'any-error-handler',
           userId: 9876,
-          versionId: 1234,
           ...params,
         }),
       );
@@ -1116,7 +1109,6 @@ describe(__filename, () => {
       const addonId = review.addon.id;
       const addonSlug = review.addon.slug;
       const userId = review.user.id;
-      const versionId = review.version.id;
       mockApi
         .expects('getLatestUserReview')
         .withArgs({
@@ -1130,7 +1122,6 @@ describe(__filename, () => {
         addonId,
         addonSlug,
         userId,
-        versionId,
       });
 
       const expectedAction = setReview(review);
@@ -1141,7 +1132,6 @@ describe(__filename, () => {
         userId,
         addonId,
         addonSlug,
-        versionId,
         review,
       });
       const setLatestAction = await matchingSagaAction(
@@ -1159,7 +1149,6 @@ describe(__filename, () => {
       const addonId = review.addon.id;
       const addonSlug = review.addon.slug;
       const userId = review.user.id;
-      const versionId = review.version.id;
 
       mockApi.expects('getLatestUserReview').resolves(null);
 
@@ -1167,14 +1156,12 @@ describe(__filename, () => {
         addonId,
         addonSlug,
         userId,
-        versionId,
       });
 
       const expectedAction = setLatestReview({
         addonId,
         addonSlug,
         userId,
-        versionId,
         review: null,
       });
       const action = await sagaTester.waitFor(expectedAction.type);

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1126,7 +1126,7 @@ export async function matchingSagaAction(
 
       ${isMatch}
 
-      The saga called these action types: ${calledActions
+      The saga dispatched these action types: ${calledActions
         .map((action) => action.type)
         .join(', ') || '(none at all)'}`,
     );

--- a/tests/unit/test_helpers.js
+++ b/tests/unit/test_helpers.js
@@ -277,7 +277,7 @@ describe(__filename, () => {
       });
 
       expect(error.message).toMatch(
-        /saga called these action types.*none at all/,
+        /saga dispatched these action types.*none at all/,
       );
     });
   });


### PR DESCRIPTION
This fixes https://github.com/mozilla/addons-frontend/issues/4529 by removing the `versionId` parameter when looking for saved reviews. I confirmed that when omitting this parameter, the API returns the latest saved review for the add-on, regardless of version. I also verified that no errors are thrown if the user had reviewed an add-on multiple times at different versions.

As part of this patch, I moved the old review fetching logic to a saga. 

