### PR TITLE
Fixes #6413. Use `getFakeLogger()` everywhere in test suite

### DIFF
--- a/tests/unit/amo/components/TestAddonCompatibilityError.js
+++ b/tests/unit/amo/components/TestAddonCompatibilityError.js
@@ -18,6 +18,7 @@ import Notice from 'ui/components/Notice';
 import {
   dispatchClientMetadata,
   fakeI18n,
+  getFakeLogger,
   shallowUntilTarget,
   userAgentsByPlatform,
 } from 'tests/unit/helpers';
@@ -221,7 +222,7 @@ describe(__filename, () => {
 
   it('renders a notice and logs warning when reason code not known', () => {
     _dispatchClientMetadata();
-    const fakeLog = { warn: sinon.stub() };
+    const fakeLog = getFakeLogger();
     const root = render({
       log: fakeLog,
       reason: 'fake reason',

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -20,6 +20,7 @@ import {
   dispatchSignInActions,
   generateHeaders,
   getFakeConfig,
+  getFakeLogger,
   unexpectedSuccess,
   urlWithTheseParams,
 } from 'tests/unit/helpers';
@@ -446,10 +447,7 @@ describe(__filename, () => {
         }),
       );
 
-      const _log = {
-        debug: sinon.stub(),
-        warn: sinon.stub(),
-      };
+      const _log = getFakeLogger();
 
       await api.callApi({ endpoint: 'resource', _log });
       mockWindow.verify();

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -37,6 +37,7 @@ import {
   fakeTheme,
   createFakeLocation,
   getFakeConfig,
+  getFakeLogger,
   sampleUserAgentParsed,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
@@ -317,7 +318,7 @@ describe(__filename, () => {
   });
 
   it('calls `window.external.AddSearchProvider` to install a search provider', () => {
-    const fakeLog = { info: sinon.stub() };
+    const fakeLog = getFakeLogger();
     const fakeWindow = createFakeMozWindow();
     const installURL = 'https://a.m.o/files/addon.xpi';
 

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -63,9 +63,7 @@ describe(__filename, () => {
     });
 
     it('logs if no match found', () => {
-      const fakeLog = {
-        error: sinon.stub(),
-      };
+      const fakeLog = getFakeLogger();
       utils.langToLocale('whatevs-this-is-really-odd', fakeLog);
       sinon.assert.called(fakeLog.error);
     });
@@ -90,9 +88,7 @@ describe(__filename, () => {
     });
 
     it('logs if too many parts found', () => {
-      const fakeLog = {
-        error: sinon.stub(),
-      };
+      const fakeLog = getFakeLogger();
       utils.localeToLang('what_the_heck_is_this', fakeLog);
       sinon.assert.called(fakeLog.error);
     });

--- a/tests/unit/core/middleware/test_datadogTiming.js
+++ b/tests/unit/core/middleware/test_datadogTiming.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 
 import { datadogTiming } from 'core/middleware/datadogTiming';
-import { getFakeConfig } from 'tests/unit/helpers';
+import { getFakeConfig, getFakeLogger } from 'tests/unit/helpers';
 import { ServerTestHelper } from 'tests/unit/core/server/test_server';
 
 describe(__filename, () => {
@@ -152,7 +152,7 @@ describe(__filename, () => {
     });
 
     it('sets up error handling', () => {
-      const _log = { error: sinon.stub() };
+      const _log = getFakeLogger();
       datadogTiming({ _log, _HotShots: StubHotShots });
 
       const error = new Error('some socket error');

--- a/tests/unit/core/sagas/test_utils.js
+++ b/tests/unit/core/sagas/test_utils.js
@@ -8,11 +8,11 @@ import { put, select } from 'redux-saga/effects';
 
 import apiReducer from 'core/reducers/api';
 import { createErrorHandler, getState } from 'core/sagas/utils';
-import { dispatchSignInActions } from 'tests/unit/helpers';
+import { dispatchSignInActions, getFakeLogger } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   it('does not allow usage of dispatch from a saga', () => {
-    const fakeLog = { error: sinon.stub() };
+    const fakeLog = getFakeLogger();
     const errorHandler = createErrorHandler('some-error-handler', {
       log: fakeLog,
     });

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -6,7 +6,7 @@ import {
   ON_OPERATION_CANCELLED_EVENT,
   SET_ENABLE_NOT_AVAILABLE,
 } from 'core/constants';
-import { unexpectedSuccess } from 'tests/unit/helpers';
+import { getFakeLogger, unexpectedSuccess } from 'tests/unit/helpers';
 
 const fakeClientAddon = (overrides = {}) => ({
   canUninstall: false,
@@ -319,10 +319,7 @@ describe(__filename, () => {
     });
 
     it('calls the callback when onOperationCancelled is received', async () => {
-      const _log = {
-        info: sinon.stub(),
-        error: sinon.spy(),
-      };
+      const _log = getFakeLogger();
       const fakeAddon = fakeClientAddon();
       fakeMozAddonManager.getAddonByID.resolves(fakeAddon);
 
@@ -350,10 +347,7 @@ describe(__filename, () => {
     });
 
     it('logs an error when onOperationCancelled has failed', async () => {
-      const _log = {
-        info: sinon.stub(),
-        error: sinon.spy(),
-      };
+      const _log = getFakeLogger();
       fakeMozAddonManager.getAddonByID.resolves(null);
 
       const handleChangeEvent = addonManager.addChangeListeners(

--- a/tests/unit/core/test_tracking.js
+++ b/tests/unit/core/test_tracking.js
@@ -40,7 +40,7 @@ import {
   UNINSTALL_EXTENSION_CATEGORY,
   UNINSTALL_THEME_CATEGORY,
 } from 'core/constants';
-import { getFakeConfig } from 'tests/unit/helpers';
+import { getFakeConfig, getFakeLogger } from 'tests/unit/helpers';
 
 function createTracking({ paramOverrides = {}, configOverrides = {} } = {}) {
   return new Tracking({
@@ -411,7 +411,7 @@ describe(__filename, () => {
     });
 
     it('should log that DNT disabled tracking', () => {
-      const fakeLog = { info: sinon.stub() };
+      const fakeLog = getFakeLogger();
       isDoNotTrackEnabled({
         _log: fakeLog,
         _navigator: { doNotTrack: '1' },

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -32,6 +32,7 @@ import {
   createFakeAddon,
   createFakeMozWindow,
   fakeAddon,
+  getFakeLogger,
   userAgents,
   userAgentsByPlatform,
 } from 'tests/unit/helpers';
@@ -264,7 +265,7 @@ describe(__filename, () => {
       // Note that this should never happen as addons-server will mark a
       // WebExtension with no minVersion as having a minVersion of "48".
       // Still, we accept it (but it will log a warning).
-      const fakeLog = { error: sinon.stub() };
+      const fakeLog = getFakeLogger();
       const userAgentInfo = {
         browser: { name: 'Firefox', version: '54.0' },
         os: { name: 'Windows' },

--- a/tests/unit/core/utils/test_server.js
+++ b/tests/unit/core/utils/test_server.js
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import MockExpressResponse from 'mock-express-response';
 
 import { viewFrontendVersionHandler } from 'core/utils/server';
-import { getFakeConfig } from 'tests/unit/helpers';
+import { getFakeConfig, getFakeLogger } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('viewFrontendVersionHandler', () => {
@@ -62,9 +62,7 @@ describe(__filename, () => {
 
     it('returns a 415 and logs an error when file does not exist', (done) => {
       const _config = getFakeConfig({ basePath: '/some/invalid/path' });
-      const _log = {
-        error: sinon.stub(),
-      };
+      const _log = getFakeLogger();
 
       const handler = viewFrontendVersionHandler({ _config, _log });
 


### PR DESCRIPTION
- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] The change has been successfully run locally.

Fixes #6413.
All the test ran successfully after these changes.
