### PR TITLE
Fixes 6735 | Blank space in URLs redirect

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -611,7 +611,8 @@ export class AddonBase extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const { slug } = ownProps.match.params;
+  let { slug = '' } = ownProps.match.params;
+  slug = typeof slug === 'string' ? slug.trim() : slug;
   let addon = getAddonBySlug(state, slug);
 
   // It is possible to load an add-on by its ID but in the routing parameters,

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -611,7 +611,7 @@ export class AddonBase extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  let { slug = '' } = ownProps.match.params;
+  let { slug } = ownProps.match.params;
   slug = typeof slug === 'string' ? slug.trim() : slug;
   let addon = getAddonBySlug(state, slug);
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -524,6 +524,31 @@ describe(__filename, () => {
     sinon.assert.callCount(fakeDispatch, 1);
   });
 
+  it('dispatches a server redirect when slug has trailing spaces', () => {
+    const slug = 'some-slug';
+
+    const clientApp = CLIENT_APP_FIREFOX;
+    const { store } = dispatchClientMetadata({ clientApp });
+    const addon = createInternalAddon({ ...fakeAddon, slug });
+    store.dispatch(_loadAddonResults({ addon }));
+
+    const fakeDispatch = sinon.spy(store, 'dispatch');
+    renderComponent({
+      // Add trailing spaces to the slug
+      params: { slug: `${slug}  ` },
+      store,
+    });
+
+    sinon.assert.calledWith(
+      fakeDispatch,
+      sendServerRedirect({
+        status: 301,
+        url: `/en-US/${clientApp}/addon/${slug}/`,
+      }),
+    );
+    sinon.assert.callCount(fakeDispatch, 1);
+  });
+
   it('dispatches a server redirect when slug is a stringified integer greater than 0', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });


### PR DESCRIPTION
Fixes #6735 
Trims the trailing spaces of `slug` in `match.params`. This triggers 301 redirect to and hence removes loading state.

- [x] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
- [x] Add `Fixes #ISSUENUM` at the top of your PR.
- [x] Add a description of the the changes introduced in this PR.
- [x] The change has been successfully run locally.
- [x] Add tests to cover the changes added in this PR.