### PR TITLE
Use -dev API for ui tests

### DIFF
--- a/bin/start-func-test-server.js
+++ b/bin/start-func-test-server.js
@@ -15,7 +15,7 @@ const containerIdFile = path.join(root, 'docker-container-id.txt');
 // TODO: make these configurable when we need to start
 // servers for multiple apps.
 const appInstance = 'disco';
-const nodeEnv = 'uitests';
+const nodeConfigEnv = 'uitests';
 
 function logDivider(heading) {
   console.log(`${'='.repeat(35)} ${heading} ${'='.repeat(35)}`);
@@ -121,7 +121,9 @@ new Promise((resolve) => {
       '-e',
       `NODE_APP_INSTANCE=${appInstance}`,
       '-e',
-      `NODE_ENV=${nodeEnv}`,
+      `NODE_ENV=production`,
+      '-e',
+      `NODE_CONFIG_ENV=${nodeConfigEnv}`,
       '-e',
       `USE_HTTPS_FOR_DEV=true`,
       `-e`,

--- a/config/uitests-disco.js
+++ b/config/uitests-disco.js
@@ -1,6 +1,9 @@
-import { amoProdCDN } from './lib/shared';
+import { amoDevCDN, apiDevHost } from './lib/shared';
 
 module.exports = {
+  apiHost: apiDevHost,
+  amoCDN: amoDevCDN,
+
   staticHost: '',
 
   CSP: {
@@ -13,7 +16,7 @@ module.exports = {
       imgSrc: [
         "'self'",
         'data:',
-        amoProdCDN,
+        amoDevCDN,
         'https://www.google-analytics.com',
       ],
       mediaSrc: ["'self'"],

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -51,4 +51,5 @@ def firefox_options(firefox_options):
         'extensions.install.requireBuiltInCerts', False)
     firefox_options.add_argument('-foreground')
     firefox_options.set_preference('ui.popup.disable_autohide', True)
+    firefox_options.set_preference('xpinstall.signatures.dev-root', True)
     return firefox_options

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -44,12 +44,8 @@ def discovery_pane(selenium, my_base_url):
 @pytest.fixture
 def firefox_options(firefox_options):
     """Configure Firefox preferences and additonal arguments."""
-    firefox_options.set_preference('extensions.legacy.enabled', True)
-    firefox_options.set_preference('extensions.webapi.testing', True)
-    firefox_options.set_preference('xpinstall.signatures.required', False)
-    firefox_options.set_preference(
-        'extensions.install.requireBuiltInCerts', False)
     firefox_options.add_argument('-foreground')
+    firefox_options.set_preference('extensions.webapi.testing', True)
     firefox_options.set_preference('ui.popup.disable_autohide', True)
     firefox_options.set_preference('xpinstall.signatures.dev-root', True)
     return firefox_options

--- a/tests/ui/tests/test_discopane.py
+++ b/tests/ui/tests/test_discopane.py
@@ -45,7 +45,8 @@ def test_addon_installs(discovery_pane, firefox, notifications):
 @pytest.mark.nondestructive
 def test_theme_installs(discovery_pane, firefox, notifications):
     """Test theme install from discovery pane."""
-    theme = discovery_pane.themes[0]
+    # We want to install a LWT, not a static theme.
+    theme = discovery_pane.themes[2]
     theme.install()
     firefox.browser.wait_for_notification(
         notifications.AddOnInstallConfirmation).install()


### PR DESCRIPTION
Fixes #6836

---

This PR changes the `uitests` config to use the -dev API instead of -prod.

It fixes the test case that installs an extension, ~~but not (yet) the theme install one.~~ Fixed by installing a LWT and not a static theme.