### PR TITLE
Improve keyboard accessibility for review flow and other forms

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -490,7 +490,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
             <Button
               className="AddonReviewCard-writeReviewButton"
               onClick={this.onClickToEditReview}
-              href="#writeReview"
               buttonType="action"
               puffy={slim}
             >

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -181,7 +181,7 @@
 
   .DismissibleTextForm-buttons {
     display: flex;
-    flex-direction: column-reverse;
+    flex-direction: column;
     margin-top: 24px;
   }
 

--- a/src/amo/components/AddonReviewManager/index.js
+++ b/src/amo/components/AddonReviewManager/index.js
@@ -142,6 +142,7 @@ export class AddonReviewManagerBase extends React.Component<InternalProps> {
           onSubmit={this.onSubmitReview}
           placeholder={placeholder}
           puffyButtons={puffyButtons}
+          reverseButtonOrder
           submitButtonText={submitButtonText}
           submitButtonInProgressText={submitButtonInProgressText}
           text={review.body}

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -33,6 +33,7 @@ type Props = {|
   microButtons?: boolean,
   placeholder?: string,
   puffyButtons?: boolean,
+  reverseButtonOrder?: boolean,
   submitButtonClassName?: string,
   submitButtonText?: string,
   submitButtonInProgressText?: string,
@@ -64,6 +65,7 @@ export class DismissibleTextFormBase extends React.Component<
     isSubmitting: false,
     microButtons: false,
     puffyButtons: false,
+    reverseButtonOrder: false,
   };
 
   constructor(props: InternalProps) {
@@ -115,6 +117,7 @@ export class DismissibleTextFormBase extends React.Component<
       onDismiss,
       placeholder,
       puffyButtons,
+      reverseButtonOrder,
       submitButtonClassName,
       submitButtonText,
       submitButtonInProgressText,
@@ -138,6 +141,72 @@ export class DismissibleTextFormBase extends React.Component<
       'microButtons and puffyButtons cannot both be true; choose one',
     );
 
+    const cancelButton = onDismiss ? (
+      <Button
+        buttonType="neutral"
+        className="DismissibleTextForm-dismiss"
+        disabled={isSubmitting}
+        key="cancel"
+        micro={microButtons}
+        onClick={this.onDismiss}
+        puffy={puffyButtons}
+        type="cancel"
+      >
+        {dismissButtonText || i18n.gettext('Cancel')}
+      </Button>
+    ) : null;
+
+    const deleteButton = onDelete ? (
+      <Button
+        buttonType="alert"
+        className="DismissibleTextForm-delete"
+        disabled={deleteButtonIsDisabled}
+        key="delete"
+        onClick={this.onDelete}
+        micro={microButtons}
+        puffy={puffyButtons}
+        type="button"
+      >
+        {i18n.gettext('Delete')}
+      </Button>
+    ) : null;
+
+    const submitButton = (
+      <Button
+        buttonType="action"
+        className={makeClassName(
+          'DismissibleTextForm-submit',
+          submitButtonClassName,
+        )}
+        disabled={submitButtonIsDisabled}
+        key="submit"
+        onClick={this.onSubmit}
+        micro={microButtons}
+        puffy={puffyButtons}
+      >
+        {isSubmitting ? text.submitButtonInProgressText : text.submitButtonText}
+      </Button>
+    );
+
+    const submitAndDelete = [submitButton, deleteButton];
+    if (reverseButtonOrder) {
+      submitAndDelete.reverse();
+    }
+
+    const submitAndDeleteContainer = (
+      <span
+        className="DismissibleTextForm-delete-submit-buttons"
+        key="submit-and-delete"
+      >
+        {submitAndDelete}
+      </span>
+    );
+
+    const allButtons = [cancelButton, submitAndDeleteContainer];
+    if (reverseButtonOrder) {
+      allButtons.reverse();
+    }
+
     return (
       <form className={makeClassName('DismissibleTextForm-form', className)}>
         <Textarea
@@ -153,51 +222,7 @@ export class DismissibleTextFormBase extends React.Component<
         {formFooter && (
           <div className="DismissibleTextForm-formFooter">{formFooter}</div>
         )}
-        <div className="DismissibleTextForm-buttons">
-          <span className="DismissibleTextForm-delete-submit-buttons">
-            <Button
-              buttonType="action"
-              className={makeClassName(
-                'DismissibleTextForm-submit',
-                submitButtonClassName,
-              )}
-              disabled={submitButtonIsDisabled}
-              onClick={this.onSubmit}
-              micro={microButtons}
-              puffy={puffyButtons}
-            >
-              {isSubmitting
-                ? text.submitButtonInProgressText
-                : text.submitButtonText}
-            </Button>
-            {onDelete && (
-              <Button
-                buttonType="alert"
-                className="DismissibleTextForm-delete"
-                disabled={deleteButtonIsDisabled}
-                onClick={this.onDelete}
-                micro={microButtons}
-                puffy={puffyButtons}
-                type="button"
-              >
-                {i18n.gettext('Delete')}
-              </Button>
-            )}
-          </span>
-          {onDismiss && (
-            <Button
-              buttonType="neutral"
-              className="DismissibleTextForm-dismiss"
-              disabled={isSubmitting}
-              micro={microButtons}
-              onClick={this.onDismiss}
-              puffy={puffyButtons}
-              type="cancel"
-            >
-              {dismissButtonText || i18n.gettext('Cancel')}
-            </Button>
-          )}
-        </div>
+        <div className="DismissibleTextForm-buttons">{allButtons}</div>
       </form>
     );
   }

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -178,6 +178,7 @@ export class DismissibleTextFormBase extends React.Component<
                 onClick={this.onDelete}
                 micro={microButtons}
                 puffy={puffyButtons}
+                type="button"
               >
                 {i18n.gettext('Delete')}
               </Button>

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -154,38 +154,7 @@ export class DismissibleTextFormBase extends React.Component<
           <div className="DismissibleTextForm-formFooter">{formFooter}</div>
         )}
         <div className="DismissibleTextForm-buttons">
-          {/*
-            These buttons each have an href so that they become anchor tags.
-            This prevents mobile taps from triggering their hover styles.
-          */}
-          {onDismiss && (
-            <Button
-              buttonType="neutral"
-              className="DismissibleTextForm-dismiss"
-              disabled={isSubmitting}
-              href="#cancel"
-              micro={microButtons}
-              onClick={this.onDismiss}
-              puffy={puffyButtons}
-              type="cancel"
-            >
-              {dismissButtonText || i18n.gettext('Cancel')}
-            </Button>
-          )}
           <span className="DismissibleTextForm-delete-submit-buttons">
-            {onDelete && (
-              <Button
-                buttonType="alert"
-                className="DismissibleTextForm-delete"
-                disabled={deleteButtonIsDisabled}
-                href="#delete"
-                onClick={this.onDelete}
-                micro={microButtons}
-                puffy={puffyButtons}
-              >
-                {i18n.gettext('Delete')}
-              </Button>
-            )}
             <Button
               buttonType="action"
               className={makeClassName(
@@ -193,7 +162,6 @@ export class DismissibleTextFormBase extends React.Component<
                 submitButtonClassName,
               )}
               disabled={submitButtonIsDisabled}
-              href="#submit"
               onClick={this.onSubmit}
               micro={microButtons}
               puffy={puffyButtons}
@@ -202,7 +170,32 @@ export class DismissibleTextFormBase extends React.Component<
                 ? text.submitButtonInProgressText
                 : text.submitButtonText}
             </Button>
+            {onDelete && (
+              <Button
+                buttonType="alert"
+                className="DismissibleTextForm-delete"
+                disabled={deleteButtonIsDisabled}
+                onClick={this.onDelete}
+                micro={microButtons}
+                puffy={puffyButtons}
+              >
+                {i18n.gettext('Delete')}
+              </Button>
+            )}
           </span>
+          {onDismiss && (
+            <Button
+              buttonType="neutral"
+              className="DismissibleTextForm-dismiss"
+              disabled={isSubmitting}
+              micro={microButtons}
+              onClick={this.onDismiss}
+              puffy={puffyButtons}
+              type="cancel"
+            >
+              {dismissButtonText || i18n.gettext('Cancel')}
+            </Button>
+          )}
         </div>
       </form>
     );

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -183,26 +183,27 @@ export class DismissibleTextFormBase extends React.Component<
         onClick={this.onSubmit}
         micro={microButtons}
         puffy={puffyButtons}
+        type="submit"
       >
         {isSubmitting ? text.submitButtonInProgressText : text.submitButtonText}
       </Button>
     );
 
-    const submitAndDelete = [submitButton, deleteButton];
+    const actionButtons = [deleteButton, submitButton];
     if (reverseButtonOrder) {
-      submitAndDelete.reverse();
+      actionButtons.reverse();
     }
 
-    const submitAndDeleteContainer = (
+    const actionButtonsContainer = (
       <span
         className="DismissibleTextForm-delete-submit-buttons"
-        key="submit-and-delete"
+        key="actionButtons"
       >
-        {submitAndDelete}
+        {actionButtons}
       </span>
     );
 
-    const allButtons = [cancelButton, submitAndDeleteContainer];
+    const allButtons = [cancelButton, actionButtonsContainer];
     if (reverseButtonOrder) {
       allButtons.reverse();
     }

--- a/src/ui/components/DismissibleTextForm/styles.scss
+++ b/src/ui/components/DismissibleTextForm/styles.scss
@@ -10,7 +10,6 @@
 
 .DismissibleTextForm-buttons {
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
   margin-top: 6px;
 

--- a/src/ui/components/DismissibleTextForm/styles.scss
+++ b/src/ui/components/DismissibleTextForm/styles.scss
@@ -10,9 +10,7 @@
 
 .DismissibleTextForm-buttons {
   display: flex;
-  // The submit button is rendered first for keyboard accessibility but
-  // we want it to appear last as a final call to action.
-  flex-direction: row-reverse;
+  flex-direction: row;
   justify-content: space-between;
   margin-top: 6px;
 

--- a/src/ui/components/DismissibleTextForm/styles.scss
+++ b/src/ui/components/DismissibleTextForm/styles.scss
@@ -10,6 +10,9 @@
 
 .DismissibleTextForm-buttons {
   display: flex;
+  // The submit button is rendered first for keyboard accessibility but
+  // we want it to appear last as a final call to action.
+  flex-direction: row-reverse;
   justify-content: space-between;
   margin-top: 6px;
 

--- a/tests/unit/ui/components/TestDismissibleTextForm.js
+++ b/tests/unit/ui/components/TestDismissibleTextForm.js
@@ -379,4 +379,55 @@ describe(__filename, () => {
       root.find('.DismissibleTextForm-formFooter .custom-formFooter'),
     ).toHaveLength(1);
   });
+
+  it('renders all buttons in a default order', () => {
+    const root = shallowRender({
+      onDelete: sinon.stub(),
+      onDismiss: sinon.stub(),
+    });
+
+    const allButtons = root.find('.DismissibleTextForm-buttons');
+    expect(allButtons.childAt(0)).toHaveClassName(
+      'DismissibleTextForm-dismiss',
+    );
+    expect(allButtons.childAt(1)).toHaveClassName(
+      'DismissibleTextForm-delete-submit-buttons',
+    );
+
+    const submitButtons = root.find(
+      '.DismissibleTextForm-delete-submit-buttons',
+    );
+    expect(submitButtons.childAt(0)).toHaveClassName(
+      'DismissibleTextForm-submit',
+    );
+    expect(submitButtons.childAt(1)).toHaveClassName(
+      'DismissibleTextForm-delete',
+    );
+  });
+
+  it('can reverse the button order', () => {
+    const root = shallowRender({
+      onDelete: sinon.stub(),
+      onDismiss: sinon.stub(),
+      reverseButtonOrder: true,
+    });
+
+    const allButtons = root.find('.DismissibleTextForm-buttons');
+    expect(allButtons.childAt(0)).toHaveClassName(
+      'DismissibleTextForm-delete-submit-buttons',
+    );
+    expect(allButtons.childAt(1)).toHaveClassName(
+      'DismissibleTextForm-dismiss',
+    );
+
+    const submitButtons = root.find(
+      '.DismissibleTextForm-delete-submit-buttons',
+    );
+    expect(submitButtons.childAt(0)).toHaveClassName(
+      'DismissibleTextForm-delete',
+    );
+    expect(submitButtons.childAt(1)).toHaveClassName(
+      'DismissibleTextForm-submit',
+    );
+  });
 });

--- a/tests/unit/ui/components/TestDismissibleTextForm.js
+++ b/tests/unit/ui/components/TestDismissibleTextForm.js
@@ -398,10 +398,10 @@ describe(__filename, () => {
       '.DismissibleTextForm-delete-submit-buttons',
     );
     expect(submitButtons.childAt(0)).toHaveClassName(
-      'DismissibleTextForm-submit',
+      'DismissibleTextForm-delete',
     );
     expect(submitButtons.childAt(1)).toHaveClassName(
-      'DismissibleTextForm-delete',
+      'DismissibleTextForm-submit',
     );
   });
 
@@ -424,10 +424,10 @@ describe(__filename, () => {
       '.DismissibleTextForm-delete-submit-buttons',
     );
     expect(submitButtons.childAt(0)).toHaveClassName(
-      'DismissibleTextForm-delete',
+      'DismissibleTextForm-submit',
     );
     expect(submitButtons.childAt(1)).toHaveClassName(
-      'DismissibleTextForm-submit',
+      'DismissibleTextForm-delete',
     );
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6579 and fixes https://github.com/mozilla/addons-frontend/issues/6246 by using buttons instead of anchors.

There is some code lore about how we switched from buttons to links in order to workaround a bug in Firefox for Android that triggered hover styles on the first tap (see https://github.com/mozilla/addons-frontend/issues/3458). It would require two taps to trigger the button but the problem went away with an anchor tag. That original problem affected Firefox 58. I tested today with Firefox 62 (release) on Android and I no longer see the problem. I'm not sure when it was fixed but I think it's safe to proceed here.

This patch fixes the same problem for all instances of `<DismissibleText>`. I have manually tested those for regressions.