### PR TITLE
Add OpenGraph tags on other pages (not add-on detail pages)

### DIFF
--- a/src/amo/components/CategoryHead/index.js
+++ b/src/amo/components/CategoryHead/index.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import translate from 'core/i18n/translate';
 import type { CategoryType } from 'amo/types/categories';
@@ -41,18 +42,6 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
     return i18n.sprintf(title, { categoryName: category.name });
   }
 
-  renderMetaDescription() {
-    const { category } = this.props;
-
-    invariant(category, 'category is required');
-
-    if (!category.description) {
-      return null;
-    }
-
-    return <meta name="description" content={category.description} />;
-  }
-
   render() {
     const { category } = this.props;
 
@@ -64,8 +53,12 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
       <React.Fragment>
         <Helmet>
           <title>{this.getPageTitle()}</title>
-          {this.renderMetaDescription()}
         </Helmet>
+
+        <HeadMetaTags
+          description={category.description}
+          title={this.getPageTitle()}
+        />
 
         <HeadLinks />
       </React.Fragment>

--- a/src/amo/components/CategoryHead/index.js
+++ b/src/amo/components/CategoryHead/index.js
@@ -49,16 +49,15 @@ export class CategoryHeadBase extends React.PureComponent<InternalProps> {
       return null;
     }
 
+    const title = this.getPageTitle();
+
     return (
       <React.Fragment>
         <Helmet>
-          <title>{this.getPageTitle()}</title>
+          <title>{title}</title>
         </Helmet>
 
-        <HeadMetaTags
-          description={category.description}
-          title={this.getPageTitle()}
-        />
+        <HeadMetaTags description={category.description} title={title} />
 
         <HeadLinks />
       </React.Fragment>

--- a/src/amo/pages/CategoriesPage/index.js
+++ b/src/amo/pages/CategoriesPage/index.js
@@ -47,7 +47,7 @@ export class CategoriesPageBase extends React.Component<InternalProps> {
       case ADDON_TYPE_THEME:
         return i18n.gettext('All theme categories');
       default:
-        return i18n.gettext('All categories');
+        return null;
     }
   }
 

--- a/src/amo/pages/CategoriesPage/index.js
+++ b/src/amo/pages/CategoriesPage/index.js
@@ -7,6 +7,7 @@ import { compose } from 'redux';
 
 import Categories from 'amo/components/Categories';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import { shouldShowThemes } from 'amo/utils';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
@@ -46,7 +47,7 @@ export class CategoriesPageBase extends React.Component<InternalProps> {
       case ADDON_TYPE_THEME:
         return i18n.gettext('All theme categories');
       default:
-        return null;
+        return i18n.gettext('All categories');
     }
   }
 
@@ -58,11 +59,15 @@ export class CategoriesPageBase extends React.Component<InternalProps> {
       return <NotFound />;
     }
 
+    const title = this.getPageTitle(addonType);
+
     return (
       <React.Fragment>
         <Helmet>
-          <title>{this.getPageTitle(addonType)}</title>
+          <title>{title}</title>
         </Helmet>
+
+        <HeadMetaTags title={title} />
 
         <HeadLinks />
 

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -271,12 +271,15 @@ export class HomeBase extends React.Component {
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: '<!-- Godzilla of browsers -->' }}
         />
+
         {errorHandler.renderErrorIfPresent()}
+
         {_config.get('enableFeatureHomeHeroGuides') ? (
           <HomeHeroGuides />
         ) : (
           <HomeHeroBanner />
         )}
+
         <Card
           className="Home-SubjectShelf Home-CuratedCollections"
           header={extensionsHeader}
@@ -312,6 +315,7 @@ export class HomeBase extends React.Component {
             loading={loading}
           />
         )}
+
         <LandingAddonsCard
           addonInstallSource={INSTALL_SOURCE_FEATURED}
           addons={shelves.featuredExtensions}
@@ -327,6 +331,7 @@ export class HomeBase extends React.Component {
           }}
           loading={loading}
         />
+
         <LandingAddonsCard
           addonInstallSource={INSTALL_SOURCE_FEATURED}
           addons={shelves.popularExtensions}
@@ -342,6 +347,7 @@ export class HomeBase extends React.Component {
           }}
           loading={loading}
         />
+
         {includeTrendingExtensions && (
           <LandingAddonsCard
             addonInstallSource={INSTALL_SOURCE_FEATURED}

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -3,7 +3,6 @@ import config from 'config';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import Helmet from 'react-helmet';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import CategoryIcon from 'amo/components/CategoryIcon';
@@ -11,6 +10,7 @@ import FeaturedCollectionCard from 'amo/components/FeaturedCollectionCard';
 import HomeHeroBanner from 'amo/components/HomeHeroBanner';
 import HomeHeroGuides from 'amo/components/HomeHeroGuides';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import { fetchHomeAddons } from 'amo/reducers/home';
@@ -258,14 +258,11 @@ export class HomeBase extends React.Component {
 
     return (
       <div className="Home">
-        <Helmet>
-          <meta
-            name="description"
-            content={i18n.gettext(`Download Firefox extensions and themes.
-              They’re like apps for your browser. They can block annoying ads,
-              protect passwords, change browser appearance, and more.`)}
-          />
-        </Helmet>
+        <HeadMetaTags
+          description={i18n.gettext(`Download Firefox extensions and themes.
+            They’re like apps for your browser. They can block annoying ads,
+            protect passwords, change browser appearance, and more.`)}
+        />
 
         <HeadLinks />
 
@@ -274,15 +271,12 @@ export class HomeBase extends React.Component {
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: '<!-- Godzilla of browsers -->' }}
         />
-
         {errorHandler.renderErrorIfPresent()}
-
         {_config.get('enableFeatureHomeHeroGuides') ? (
           <HomeHeroGuides />
         ) : (
           <HomeHeroBanner />
         )}
-
         <Card
           className="Home-SubjectShelf Home-CuratedCollections"
           header={extensionsHeader}
@@ -318,7 +312,6 @@ export class HomeBase extends React.Component {
             loading={loading}
           />
         )}
-
         <LandingAddonsCard
           addonInstallSource={INSTALL_SOURCE_FEATURED}
           addons={shelves.featuredExtensions}
@@ -334,7 +327,6 @@ export class HomeBase extends React.Component {
           }}
           loading={loading}
         />
-
         <LandingAddonsCard
           addonInstallSource={INSTALL_SOURCE_FEATURED}
           addons={shelves.popularExtensions}
@@ -350,7 +342,6 @@ export class HomeBase extends React.Component {
           }}
           loading={loading}
         />
-
         {includeTrendingExtensions && (
           <LandingAddonsCard
             addonInstallSource={INSTALL_SOURCE_FEATURED}
@@ -390,8 +381,8 @@ export function mapStateToProps(state) {
   return {
     clientApp: state.api.clientApp,
     collections: state.home.collections,
-    shelves: state.home.shelves,
     resultsLoaded: state.home.resultsLoaded,
+    shelves: state.home.shelves,
   };
 }
 

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -241,6 +241,7 @@ export class LandingPageBase extends React.Component {
     };
 
     const isAddonTheme = isTheme(addonType);
+    const title = headingText[addonType];
 
     if (isAddonTheme && !shouldShowThemes({ _config, clientApp })) {
       return <NotFound />;
@@ -253,13 +254,10 @@ export class LandingPageBase extends React.Component {
         })}
       >
         <Helmet>
-          <title>{headingText[addonType]}</title>
+          <title>{title}</title>
         </Helmet>
 
-        <HeadMetaTags
-          description={this.getPageDescription()}
-          title={headingText[addonType]}
-        />
+        <HeadMetaTags description={this.getPageDescription()} title={title} />
 
         <HeadLinks />
 

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -12,6 +12,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Categories from 'amo/components/Categories';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import { shouldShowThemes } from 'amo/utils';
 import {
@@ -253,8 +254,12 @@ export class LandingPageBase extends React.Component {
       >
         <Helmet>
           <title>{headingText[addonType]}</title>
-          <meta name="description" content={this.getPageDescription()} />
         </Helmet>
+
+        <HeadMetaTags
+          description={this.getPageDescription()}
+          title={headingText[addonType]}
+        />
 
         <HeadLinks />
 

--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -10,6 +10,7 @@ import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css';
 import { setViewContext } from 'amo/actions/viewContext';
 import Link from 'amo/components/Link';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { withErrorHandler } from 'core/errorHandler';
 import {
   ADDON_TYPE_DICT,
@@ -150,13 +151,14 @@ export class LanguageToolsBase extends React.Component<Props> {
       <Card className="LanguageTools" header={header}>
         <Helmet>
           <title>{header}</title>
-          <meta
-            name="description"
-            content={i18n.gettext(`Download Firefox dictionaries and language
-              pack extensions. Add a new language option to your browser
-              spell-checker, or change the browser's interface language.`)}
-          />
         </Helmet>
+
+        <HeadMetaTags
+          description={i18n.gettext(`Download Firefox dictionaries and language
+            pack extensions. Add a new language option to your browser
+            spell-checker, or change the browser's interface language.`)}
+          title={header}
+        />
 
         <HeadLinks />
 

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -2,10 +2,10 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import Helmet from 'react-helmet';
 
 import Search from 'amo/components/Search';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_RELEVANCE } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
@@ -27,14 +27,12 @@ export class SearchToolsBase extends React.Component<InternalProps> {
 
     return (
       <React.Fragment>
-        <Helmet>
-          <meta
-            name="description"
-            content={i18n.gettext(`Download Firefox extensions to customize the
-              way you search—everything from privacy-enhanced searching to
-              website-specific searches, image searching, and more.`)}
-          />
-        </Helmet>
+        <HeadMetaTags
+          description={i18n.gettext(`Download Firefox extensions to customize
+            the way you search—everything from privacy-enhanced searching to
+            website-specific searches, image searching, and more.`)}
+          title={i18n.gettext('Search Tools')}
+        />
 
         <HeadLinks />
 

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet';
 import * as React from 'react';
 
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
@@ -18,20 +19,20 @@ export class AboutBase extends React.Component<Props> {
   render() {
     const { i18n } = this.props;
 
+    const title = i18n.gettext('About Firefox Add-ons');
+
     return (
-      <Card
-        className="StaticPage"
-        header={i18n.gettext('About Firefox Add-ons')}
-      >
+      <Card className="StaticPage" header={title}>
         <Helmet>
-          <title>{i18n.gettext('About Firefox Add-ons')}</title>
-          <meta
-            name="description"
-            content={i18n.gettext(`The official Mozilla site for downloading
-              Firefox extensions and themes. Add new features and change the
-              browser’s appearance to customize your web experience.`)}
-          />
+          <title>{title}</title>
         </Helmet>
+
+        <HeadMetaTags
+          description={i18n.gettext(`The official Mozilla site for downloading
+            Firefox extensions and themes. Add new features and change the
+            browser’s appearance to customize your web experience.`)}
+          title={title}
+        />
 
         <HeadLinks />
 

--- a/src/amo/pages/StaticPages/ReviewGuide/index.js
+++ b/src/amo/pages/StaticPages/ReviewGuide/index.js
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet';
 import * as React from 'react';
 
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import Card from 'ui/components/Card';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
@@ -18,17 +19,20 @@ export class ReviewGuideBase extends React.Component<Props> {
   render() {
     const { i18n } = this.props;
 
+    const title = i18n.gettext('Review Guidelines');
+
     return (
-      <Card className="StaticPage" header={i18n.gettext('Review Guidelines')}>
+      <Card className="StaticPage" header={title}>
         <Helmet>
-          <title>{i18n.gettext('Review Guidelines')}</title>
-          <meta
-            name="description"
-            content={i18n.gettext(`Guidelines, tips, and Frequently Asked
+          <title>{title}</title>
+        </Helmet>
+
+        <HeadMetaTags
+          description={i18n.gettext(`Guidelines, tips, and Frequently Asked
               Questions to leave a review for the extensions and themes you’ve
               downloaded and used on Firefox.`)}
-          />
-        </Helmet>
+          title={title}
+        />
 
         <HeadLinks />
 

--- a/tests/unit/amo/components/TestCategoryHead.js
+++ b/tests/unit/amo/components/TestCategoryHead.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import CategoryHead, { CategoryHeadBase } from 'amo/components/CategoryHead';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { ADDON_TYPE_EXTENSION, ADDON_TYPE_THEME } from 'core/constants';
 import { fakeCategory, fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
@@ -40,36 +41,26 @@ describe(__filename, () => {
     expect(root.find('title')).toHaveText(category.name);
   });
 
-  it('renders a "description" meta tag when category description is available', () => {
-    const description = 'some description for a category';
-    const category = { ...fakeCategory, description };
-    const root = render({ category });
-
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]')).toHaveProp(
-      'content',
-      description,
-    );
-  });
-
-  it('does not render a "description" meta tag when category description is null', () => {
-    const category = { ...fakeCategory, description: null };
-    const root = render({ category });
-
-    expect(root.find('meta[name="description"]')).toHaveLength(0);
-  });
-
-  it('does not render a "description" meta tag when category description is empty', () => {
-    const category = { ...fakeCategory, description: '' };
-    const root = render({ category });
-
-    expect(root.find('meta[name="description"]')).toHaveLength(0);
-  });
-
   it('renders a HeadLinks component', () => {
     const category = { ...fakeCategory };
     const root = render({ category });
 
     expect(root.find(HeadLinks)).toHaveLength(1);
+  });
+
+  it('renders a HeadMetaTags component', () => {
+    const category = { ...fakeCategory, type: ADDON_TYPE_THEME };
+
+    const root = render({ category });
+
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+    expect(root.find(HeadMetaTags)).toHaveProp(
+      'title',
+      `${category.name} – Themes`,
+    );
+    expect(root.find(HeadMetaTags)).toHaveProp(
+      'description',
+      category.description,
+    );
   });
 });

--- a/tests/unit/amo/pages/StaticPages/TestAbout.js
+++ b/tests/unit/amo/pages/StaticPages/TestAbout.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import About, { AboutBase } from 'amo/pages/StaticPages/About';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -15,11 +16,14 @@ describe(__filename, () => {
     expect(root.find('#about')).toExist();
   });
 
-  it('renders a "description" meta tag', () => {
+  it('renders a HeadMetaTags component', () => {
     const root = render();
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+    expect(root.find(HeadMetaTags).prop('title')).toEqual(
+      'About Firefox Add-ons',
+    );
+    expect(root.find(HeadMetaTags).prop('description')).toMatch(
       /The official Mozilla site/,
     );
   });

--- a/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
+++ b/tests/unit/amo/pages/StaticPages/TestReviewGuide.js
@@ -4,6 +4,7 @@ import ReviewGuide, {
   ReviewGuideBase,
 } from 'amo/pages/StaticPages/ReviewGuide';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -20,11 +21,12 @@ describe(__filename, () => {
     expect(root.find('#review-guide')).toExist();
   });
 
-  it('renders a "description" meta tag', () => {
+  it('renders a HeadMetaTags component', () => {
     const root = render();
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+    expect(root.find(HeadMetaTags).prop('title')).toEqual('Review Guidelines');
+    expect(root.find(HeadMetaTags).prop('description')).toMatch(
       /Guidelines, tips, and/,
     );
   });

--- a/tests/unit/amo/pages/TestCategoriesPage.js
+++ b/tests/unit/amo/pages/TestCategoriesPage.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import Categories from 'amo/components/Categories';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import CategoriesPage, { CategoriesPageBase } from 'amo/pages/CategoriesPage';
 import {
   ADDON_TYPE_EXTENSION,
@@ -121,5 +122,17 @@ describe(__filename, () => {
 
     expect(root.find(NotFound)).toHaveLength(0);
     expect(root.find(Categories)).toHaveLength(1);
+  });
+
+  it.each([
+    [ADDON_TYPE_EXTENSION, /All extension/],
+    [ADDON_TYPE_THEME, /All theme/],
+  ])('renders a HeadMetaTags component for %s', (addonType, expectedMatch) => {
+    const params = { visibleAddonType: visibleAddonType(addonType) };
+
+    const root = render({ params });
+
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+    expect(root.find(HeadMetaTags).prop('title')).toMatch(expectedMatch);
   });
 });

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -11,6 +11,7 @@ import FeaturedCollectionCard from 'amo/components/FeaturedCollectionCard';
 import HomeHeroGuides from 'amo/components/HomeHeroGuides';
 import HomeHeroBanner from 'amo/components/HomeHeroBanner';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import { fetchHomeAddons, loadHomeAddons } from 'amo/reducers/home';
 import { createInternalCollection } from 'amo/reducers/collections';
@@ -443,11 +444,11 @@ describe(__filename, () => {
     });
   });
 
-  it('renders a "description" meta tag', () => {
+  it('renders a HeadMetaTags component', () => {
     const root = render();
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+    expect(root.find(HeadMetaTags).prop('description')).toMatch(
       /Download Firefox extensions and themes/,
     );
   });

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -5,6 +5,7 @@ import * as landingActions from 'amo/actions/landing';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import LandingPage, { LandingPageBase } from 'amo/pages/LandingPage';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import {
   ADDON_TYPE_EXTENSION,
@@ -607,20 +608,28 @@ describe(__filename, () => {
   });
 
   it.each([
-    [ADDON_TYPE_EXTENSION, /Download Firefox Extensions to add features/],
-    [ADDON_TYPE_THEME, /Download themes to change/],
-  ])('renders a "description" meta tag for %s', (addonType, partialContent) => {
-    const root = render({
-      match: {
-        params: { visibleAddonType: getVisibleAddonType(addonType) },
-      },
-    });
+    [
+      ADDON_TYPE_EXTENSION,
+      'Extensions',
+      /Download Firefox Extensions to add features/,
+    ],
+    [ADDON_TYPE_THEME, 'Themes', /Download themes to change/],
+  ])(
+    'renders a HeadMetaTags component for %s',
+    (addonType, expectedTitle, expectedDescriptionMatch) => {
+      const root = render({
+        match: {
+          params: { visibleAddonType: getVisibleAddonType(addonType) },
+        },
+      });
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
-      partialContent,
-    );
-  });
+      expect(root.find(HeadMetaTags)).toHaveLength(1);
+      expect(root.find(HeadMetaTags).prop('title')).toEqual(expectedTitle);
+      expect(root.find(HeadMetaTags).prop('description')).toMatch(
+        expectedDescriptionMatch,
+      );
+    },
+  );
 
   it('renders a HeadLinks component', () => {
     const root = render();

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -7,6 +7,7 @@ import LanguageTools, {
 } from 'amo/pages/LanguageTools';
 import Link from 'amo/components/Link';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { ADDON_TYPE_DICT, ADDON_TYPE_LANG } from 'core/constants';
 import {
   getAllLanguageTools,
@@ -305,11 +306,14 @@ describe(__filename, () => {
     ]);
   });
 
-  it('renders a "description" meta tag', () => {
+  it('renders a HeadMetaTags component', () => {
     const root = renderShallow();
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+    expect(root.find(HeadMetaTags).prop('title')).toEqual(
+      'Dictionaries and Language Packs',
+    );
+    expect(root.find(HeadMetaTags).prop('description')).toMatch(
       /Download Firefox dictionaries and language/,
     );
   });

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import SearchTools, { SearchToolsBase } from 'amo/pages/SearchTools';
 import Search from 'amo/components/Search';
 import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_RELEVANCE } from 'core/constants';
 import {
   dispatchClientMetadata,
@@ -37,11 +38,12 @@ describe(__filename, () => {
     });
   });
 
-  it('renders a "description" meta tag', () => {
+  it('renders a HeadMetaTags component', () => {
     const root = render();
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+    expect(root.find(HeadMetaTags).prop('title')).toEqual('Search Tools');
+    expect(root.find(HeadMetaTags).prop('description')).toMatch(
       /Download Firefox extensions to customize/,
     );
   });


### PR DESCRIPTION
Fixes #6555
~~⚠️ depends on #6868~~

---

**Important:** there is no `image` yet (as described in the original issue) because we don't have an image :D 