### PR TITLE
Finish removing current_version and platformFiles from AddonType

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -89,7 +89,6 @@ export class AddonBase extends React.Component {
     installError: PropTypes.string,
     installTheme: PropTypes.func.isRequired,
     lang: PropTypes.string.isRequired,
-    platformFiles: PropTypes.object,
     uninstall: PropTypes.func.isRequired,
     // See ReactRouterLocationType in 'core/types/router'
     location: PropTypes.object.isRequired,
@@ -104,7 +103,6 @@ export class AddonBase extends React.Component {
   static defaultProps = {
     config: defaultConfig,
     RatingManager: DefaultRatingManager,
-    platformFiles: {},
     getClientCompatibility: _getClientCompatibility,
   };
 

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -293,6 +293,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
     const {
       _addonManager,
       addon,
+      currentVersion,
       defaultInstallSource,
       dispatch,
       location,
@@ -308,7 +309,8 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       return Promise.resolve();
     }
 
-    const { guid, platformFiles, type } = addon;
+    const { guid, type } = addon;
+    const { platformFiles } = currentVersion;
 
     const installURL = findInstallURL({
       defaultInstallSource,

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -226,7 +226,7 @@ type WithInstallHelpersProps = {|
 
 type WithInstallHelpersInternalProps = {|
   ...WithInstallHelpersProps,
-  currentVersion: AddonVersionType,
+  currentVersion: AddonVersionType | null,
   dispatch: DispatchFunc,
   location: ReactRouterLocationType,
 |};
@@ -305,7 +305,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       return Promise.resolve();
     }
 
-    if (!addon) {
+    if (!addon || !currentVersion) {
       return Promise.resolve();
     }
 
@@ -403,6 +403,8 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       location,
       userAgentInfo,
     } = this.props;
+
+    invariant(currentVersion, 'currentVersion is required');
 
     const { guid, name, type } = addon;
     const { platformFiles } = currentVersion;

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -274,7 +274,6 @@ export function createInternalAddon(
     isRestartRequired: false,
     isWebExtension: false,
     isMozillaSignedExtension: false,
-    platformFiles: createPlatformFiles(apiAddon.current_version),
     themeData: createInternalThemeData(apiAddon),
   };
 

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -1,18 +1,9 @@
 /* @flow */
 import invariant from 'invariant';
-import { oneLine } from 'common-tags';
 
 import { UNLOAD_ADDON_REVIEWS } from 'amo/actions/reviews';
 import { removeUndefinedProps } from 'core/utils/addons';
-import {
-  ADDON_TYPE_THEME,
-  OS_ALL,
-  OS_ANDROID,
-  OS_LINUX,
-  OS_MAC,
-  OS_WINDOWS,
-} from 'core/constants';
-import log from 'core/logger';
+import { ADDON_TYPE_THEME } from 'core/constants';
 import type { UnloadAddonReviewsAction } from 'amo/actions/reviews';
 import type { ExternalAddonInfoType } from 'amo/api/addonInfo';
 import type { AppState } from 'amo/store';
@@ -20,10 +11,7 @@ import type { ErrorHandlerType } from 'core/errorHandler';
 import type {
   AddonType,
   ExternalAddonType,
-  ExternalAddonVersionType,
-  PlatformFilesType,
   PartialExternalAddonType,
-  PartialExternalAddonVersionType,
   ThemeData,
 } from 'core/types/addons';
 import type { AppState as DiscoAppState } from 'disco/store';
@@ -195,34 +183,6 @@ export function createInternalThemeData(
     version: apiAddon.theme_data.version,
   };
 }
-
-export const defaultPlatformFiles: PlatformFilesType = Object.freeze({
-  [OS_ALL]: undefined,
-  [OS_ANDROID]: undefined,
-  [OS_LINUX]: undefined,
-  [OS_MAC]: undefined,
-  [OS_WINDOWS]: undefined,
-});
-
-export const createPlatformFiles = (
-  version?: ExternalAddonVersionType | PartialExternalAddonVersionType,
-): PlatformFilesType => {
-  const platformFiles = { ...defaultPlatformFiles };
-
-  if (version && version.files.length > 0) {
-    version.files.forEach((file) => {
-      // eslint-disable-next-line no-prototype-builtins
-      if (!platformFiles.hasOwnProperty(file.platform)) {
-        // You wouldn't think this is needed, but Flow.
-        invariant(version, 'version is required');
-        log.warn(oneLine`A version with id ${version.id}
-          has a file with an unknown platform: ${file.platform}`);
-      }
-      platformFiles[file.platform] = file;
-    });
-  }
-  return platformFiles;
-};
 
 export function createInternalAddon(
   apiAddon: ExternalAddonType | PartialExternalAddonType,

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -233,7 +233,6 @@ export function createInternalAddon(
     categories: apiAddon.categories,
     contributions_url: apiAddon.contributions_url,
     created: apiAddon.created,
-    current_version: apiAddon.current_version,
     default_locale: apiAddon.default_locale,
     description: apiAddon.description,
     edit_url: apiAddon.edit_url,

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -183,7 +183,6 @@ export type AddonType = {|
   ...ExternalAddonType,
   // Here are some custom properties for our internal representation.
   currentVersionId: VersionIdType | null,
-  platformFiles: PlatformFilesType,
   isMozillaSignedExtension: boolean,
   isRestartRequired: boolean,
   isWebExtension: boolean,

--- a/tests/unit/amo/components/TestPermissionUtils.js
+++ b/tests/unit/amo/components/TestPermissionUtils.js
@@ -1,7 +1,7 @@
 import UAParser from 'ua-parser-js';
 
 import { PermissionUtils } from 'amo/components/PermissionsCard/permissions';
-import { createPlatformFiles } from 'core/reducers/addons';
+import { createPlatformFiles } from 'core/reducers/versions';
 import {
   fakeI18n,
   fakeVersion,

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -501,7 +501,7 @@ describe(__filename, () => {
   it('dispatches a server redirect when slug is a numeric ID', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
-    const addon = createInternalAddon(fakeAddon);
+    const addon = fakeAddon;
     store.dispatch(_loadAddonResults({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
@@ -526,7 +526,7 @@ describe(__filename, () => {
 
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
-    const addon = createInternalAddon({ ...fakeAddon, slug });
+    const addon = { ...fakeAddon, slug };
     store.dispatch(_loadAddonResults({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
@@ -549,7 +549,7 @@ describe(__filename, () => {
   it('dispatches a server redirect when slug is a stringified integer greater than 0', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
-    const addon = createInternalAddon(fakeAddon);
+    const addon = fakeAddon;
     store.dispatch(_loadAddonResults({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
@@ -573,10 +573,10 @@ describe(__filename, () => {
   it('does not dispatch a server redirect when slug is a stringified integer less than 0', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
-    const addon = createInternalAddon({
+    const addon = {
       ...fakeAddon,
       slug: '-1234',
-    });
+    };
 
     store.dispatch(_loadAddonResults({ addon }));
 
@@ -596,7 +596,7 @@ describe(__filename, () => {
 
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
-    const addon = createInternalAddon({ ...fakeAddon, slug });
+    const addon = { ...fakeAddon, slug };
     store.dispatch(_loadAddonResults({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
@@ -649,10 +649,10 @@ describe(__filename, () => {
 
   it('sanitizes bad description HTML', () => {
     const scriptHTML = '<script>alert(document.cookie);</script>';
-    const addon = createInternalAddon({
+    const addon = {
       ...fakeAddon,
       description: scriptHTML,
-    });
+    };
 
     const { store } = dispatchClientMetadata();
     store.dispatch(_loadAddonResults({ addon }));
@@ -1056,7 +1056,7 @@ describe(__filename, () => {
   });
 
   it('calls getClientCompatibility to determine the compatibility', () => {
-    const addon = createInternalAddon(fakeAddon);
+    const addon = fakeAddon;
     const clientApp = CLIENT_APP_FIREFOX;
     const currentVersion = createInternalVersion(fakeAddon.current_version);
     const getClientCompatibility = sinon.mock().returns({
@@ -1073,7 +1073,7 @@ describe(__filename, () => {
     });
 
     sinon.assert.calledWith(getClientCompatibility, {
-      addon,
+      addon: createInternalAddon(addon),
       clientApp,
       currentVersion,
       userAgentInfo: root.instance().props.userAgentInfo,
@@ -1215,13 +1215,13 @@ describe(__filename, () => {
     });
 
     it('links to all reviews', () => {
-      const addon = createInternalAddon({
+      const addon = {
         ...fakeAddon,
         ratings: {
           ...fakeAddon.ratings,
           text_count: 2,
         },
-      });
+      };
 
       const { store } = dispatchClientMetadata();
       store.dispatch(_loadAddonResults({ addon }));
@@ -1369,7 +1369,7 @@ describe(__filename, () => {
     });
 
     it('displays more add-ons by authors', () => {
-      const addon = createInternalAddon({ ...fakeAddon });
+      const addon = fakeAddon;
       const addonsByAuthors = [
         { ...fakeAddon, slug: 'addon-1', id: 1 },
         { ...fakeAddon, slug: 'addon-2', id: 2 },
@@ -1392,7 +1392,7 @@ describe(__filename, () => {
     });
 
     it('displays more add-ons by authors when add-on is a theme', () => {
-      const addon = createInternalAddon({ ...fakeTheme });
+      const addon = fakeTheme;
       const addonsByAuthors = [
         { ...fakeTheme, slug: 'theme-1', id: 1 },
         { ...fakeTheme, slug: 'theme-2', id: 2 },
@@ -1675,7 +1675,7 @@ describe(__filename, () => {
   });
 
   it('does not render an install error if there is no error', () => {
-    const addon = createInternalAddon(fakeAddon);
+    const addon = fakeAddon;
     const { store } = dispatchClientMetadata();
 
     store.dispatch(_loadAddonResults({ addon }));
@@ -1686,7 +1686,7 @@ describe(__filename, () => {
   });
 
   it('renders an install error if there is one', () => {
-    const addon = createInternalAddon(fakeAddon);
+    const addon = fakeAddon;
     const { store } = dispatchClientMetadata();
 
     store.dispatch(_loadAddonResults({ addon }));

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -289,10 +289,6 @@ describe(__filename, () => {
     expect(root.find(AddonMoreInfo)).toHaveLength(1);
     expect(root.find(AddonTitle)).toHaveProp('addon', null);
     expect(root.find(AddonHead)).toHaveProp('addon', null);
-
-    // Since withInstallHelpers relies on this, make sure it's initialized.
-    expect(root.instance().props.platformFiles).toEqual({});
-
     expect(root.find('.Addon-icon img').prop('alt')).toEqual(null);
   });
 

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -1,10 +1,5 @@
 import { unloadAddonReviews } from 'amo/actions/reviews';
-import {
-  ADDON_TYPE_EXTENSION,
-  OS_ALL,
-  OS_MAC,
-  OS_WINDOWS,
-} from 'core/constants';
+import { ADDON_TYPE_EXTENSION, OS_MAC, OS_WINDOWS } from 'core/constants';
 import addons, {
   createInternalAddon,
   createInternalAddonInfo,

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -126,6 +126,9 @@ describe(__filename, () => {
     const extension = { ...fakeAddon, type: ADDON_TYPE_EXTENSION };
     const state = addons(undefined, loadAddonResults({ addons: [extension] }));
 
+    // We no longer store the current_version from the API addon
+    delete extension.current_version;
+
     expect(state.byID[extension.id]).toEqual({
       ...extension,
       currentVersionId: fakeAddon.current_version.id,
@@ -152,6 +155,9 @@ describe(__filename, () => {
       isMozillaSignedExtension: false,
     };
     delete expectedTheme.theme_data;
+
+    // We no longer store the current_version from the API addon
+    delete expectedTheme.current_version;
 
     expect(state.byID[theme.id]).toEqual(expectedTheme);
   });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -129,10 +129,6 @@ describe(__filename, () => {
     expect(state.byID[extension.id]).toEqual({
       ...extension,
       currentVersionId: fakeAddon.current_version.id,
-      platformFiles: {
-        ...defaultPlatformFiles,
-        [OS_ALL]: fakeAddon.current_version.files[0],
-      },
       isRestartRequired: false,
       isWebExtension: true,
       isMozillaSignedExtension: false,
@@ -151,10 +147,6 @@ describe(__filename, () => {
       themeData: theme.theme_data,
       guid: getGuid(theme),
       currentVersionId: fakeTheme.current_version.id,
-      platformFiles: {
-        ...defaultPlatformFiles,
-        [OS_ALL]: fakeTheme.current_version.files[0],
-      },
       isRestartRequired: false,
       isWebExtension: true,
       isMozillaSignedExtension: false,
@@ -191,46 +183,6 @@ describe(__filename, () => {
     const state = addons(undefined, loadAddonResults({ addons: [fakeTheme] }));
 
     expect(state.byID[fakeTheme.id].guid).toEqual('54321@personas.mozilla.org');
-  });
-
-  it('maps platforms to file objects', () => {
-    const addon = createFakeAddon({
-      files: [
-        {
-          ...fakeAddon.current_version.files[0],
-          platform: OS_MAC,
-          url: 'https://a.m.o/mac.xpi',
-        },
-        {
-          ...fakeAddon.current_version.files[0],
-          platform: OS_WINDOWS,
-          url: 'https://a.m.o/windows.xpi',
-        },
-        {
-          ...fakeAddon.current_version.files[0],
-          platform: OS_ALL,
-          url: 'https://a.m.o/all.xpi',
-        },
-      ],
-    });
-    const state = addons(undefined, loadAddonResults({ addons: [addon] }));
-    expect(state.byID[addon.id].platformFiles[OS_ALL].url).toEqual(
-      'https://a.m.o/all.xpi',
-    );
-    expect(state.byID[addon.id].platformFiles[OS_MAC].url).toEqual(
-      'https://a.m.o/mac.xpi',
-    );
-    expect(state.byID[addon.id].platformFiles[OS_WINDOWS].url).toEqual(
-      'https://a.m.o/windows.xpi',
-    );
-  });
-
-  it('handles an empty array of files', () => {
-    const addon = createFakeAddon({ files: [] });
-    const state = addons(undefined, loadAddonResults({ addons: [addon] }));
-    expect(state.byID[addon.id].platformFiles).toMatchObject(
-      defaultPlatformFiles,
-    );
   });
 
   it('exposes `isRestartRequired` attribute from current version files', () => {

--- a/tests/unit/core/reducers/test_versions.js
+++ b/tests/unit/core/reducers/test_versions.js
@@ -21,16 +21,19 @@ import versionsReducer, {
   getVersionsBySlug,
   initialState,
   loadVersions,
+  createPlatformFiles,
+  defaultPlatformFiles,
 } from 'core/reducers/versions';
 import { DEFAULT_API_PAGE_SIZE } from 'core/api';
-import { ADDON_TYPE_EXTENSION } from 'core/constants';
-import { createPlatformFiles, loadAddonResults } from 'core/reducers/addons';
+import { ADDON_TYPE_EXTENSION, OS_MAC, OS_WINDOWS } from 'core/constants';
+import { loadAddonResults } from 'core/reducers/addons';
 import { searchLoad } from 'core/reducers/search';
 import {
   createAddonsApiResult,
   createFakeCollectionAddon,
   createFakeCollectionDetail,
   fakeAddon,
+  fakePlatformFile,
   fakeVersion,
   userAgentsByPlatform,
 } from 'tests/unit/helpers';
@@ -86,6 +89,56 @@ describe(__filename, () => {
       createInternalVersion(versions[0]),
       createInternalVersion(versions[1]),
     ]);
+  });
+
+  describe('createPlatformFiles', () => {
+    it('creates a default object if there is no version', () => {
+      expect(createPlatformFiles(undefined)).toEqual(defaultPlatformFiles);
+    });
+
+    it('creates a default object if there are no files', () => {
+      expect(createPlatformFiles({ ...fakeVersion, files: [] })).toEqual(
+        defaultPlatformFiles,
+      );
+    });
+
+    it('creates a PlatformFilesType object from a version with files', () => {
+      const windowsFile = {
+        ...fakePlatformFile,
+        platform: OS_WINDOWS,
+      };
+      const macFile = {
+        ...fakePlatformFile,
+        platform: OS_MAC,
+      };
+      expect(
+        createPlatformFiles({
+          ...fakeVersion,
+          files: [windowsFile, macFile],
+        }),
+      ).toEqual({
+        ...defaultPlatformFiles,
+        [OS_WINDOWS]: windowsFile,
+        [OS_MAC]: macFile,
+      });
+    });
+
+    it('handles files for unknown platforms', () => {
+      const unknownPlatform = 'unknownPlatform';
+      const unknownFile = {
+        ...fakePlatformFile,
+        platform: unknownPlatform,
+      };
+      expect(
+        createPlatformFiles({
+          ...fakeVersion,
+          files: [unknownFile],
+        }),
+      ).toEqual({
+        ...defaultPlatformFiles,
+        [unknownPlatform]: unknownFile,
+      });
+    });
   });
 
   describe('createInternalVersion', () => {

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -141,6 +141,12 @@ const _loadVersions = ({ store, versionProps = {} }) => {
 };
 
 describe(__filename, () => {
+  let store;
+
+  beforeEach(() => {
+    store = dispatchClientMetadata().store;
+  });
+
   it('connects mapDispatchToProps for the component', () => {
     const _makeMapDispatchToProps = sinon.spy();
     const WrappedComponent = sinon.stub();
@@ -164,6 +170,7 @@ describe(__filename, () => {
   });
 
   it('sets status when the component is created', () => {
+    _loadVersions({ store });
     const _addonManager = getFakeAddonManagerWrapper({
       getAddon: Promise.resolve({
         isActive: true,
@@ -179,6 +186,8 @@ describe(__filename, () => {
   });
 
   it('sets status when getting updated', () => {
+    _loadVersions({ store });
+
     const _addonManager = getFakeAddonManagerWrapper({
       getAddon: Promise.resolve({
         isActive: true,
@@ -206,6 +215,7 @@ describe(__filename, () => {
       }),
     });
 
+    _loadVersions({ store });
     const root = mountWithInstallHelpers({
       _addonManager,
       addon: null,
@@ -401,17 +411,28 @@ describe(__filename, () => {
     });
 
     describe('setCurrentStatus', () => {
+      const getAddon = ({ type = ADDON_TYPE_EXTENSION } = {}) => {
+        return createInternalAddon({ ...fakeAddon, type });
+      };
+
+      const loadVersionWithInstallUrl = (installURL) => {
+        _loadVersions({
+          store,
+          versionProps: {
+            files: [{ platform: OS_ALL, url: installURL }],
+          },
+        });
+      };
+
       it('sets the status to ENABLED when an enabled add-on found', () => {
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-          }),
-        );
+        const addon = getAddon();
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -429,15 +450,13 @@ describe(__filename, () => {
 
       it('lets you pass custom props to setCurrentStatus', () => {
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-          }),
-        );
+        const addon = getAddon();
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           addon,
           defaultInstallSource: null,
+          store,
         });
 
         const { setCurrentStatus } = root.instance().props;
@@ -457,11 +476,8 @@ describe(__filename, () => {
 
       it('sets the status to DISABLED when a disabled add-on found', () => {
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-          }),
-        );
+        const addon = getAddon();
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: getFakeAddonManagerWrapper({
@@ -472,6 +488,7 @@ describe(__filename, () => {
           }),
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -489,12 +506,8 @@ describe(__filename, () => {
 
       it('sets the status to DISABLED when the extension is inactive and disabled', () => {
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-            type: ADDON_TYPE_EXTENSION,
-          }),
-        );
+        const addon = getAddon({ type: ADDON_TYPE_EXTENSION });
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: getFakeAddonManagerWrapper({
@@ -505,6 +518,7 @@ describe(__filename, () => {
           }),
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -522,12 +536,8 @@ describe(__filename, () => {
 
       it('sets the status to INACTIVE when an inactive extension is found', () => {
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-            type: ADDON_TYPE_EXTENSION,
-          }),
-        );
+        const addon = getAddon({ type: ADDON_TYPE_EXTENSION });
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: getFakeAddonManagerWrapper({
@@ -538,6 +548,7 @@ describe(__filename, () => {
           }),
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -561,17 +572,14 @@ describe(__filename, () => {
           }),
         });
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-            type: ADDON_TYPE_THEME,
-          }),
-        );
+        const addon = getAddon({ type: ADDON_TYPE_THEME });
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: fakeAddonManager,
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -595,17 +603,14 @@ describe(__filename, () => {
           }),
         });
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-            type: ADDON_TYPE_THEME,
-          }),
-        );
+        const addon = getAddon({ type: ADDON_TYPE_THEME });
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: fakeAddonManager,
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -629,17 +634,14 @@ describe(__filename, () => {
           }),
         });
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-            type: ADDON_TYPE_THEME,
-          }),
-        );
+        const addon = getAddon({ type: ADDON_TYPE_THEME });
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: fakeAddonManager,
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -660,16 +662,14 @@ describe(__filename, () => {
           getAddon: Promise.reject(),
         });
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-          }),
-        );
+        const addon = getAddon();
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: fakeAddonManager,
           addon,
           defaultInstallSource: null,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -690,11 +690,13 @@ describe(__filename, () => {
           // Resolve a null addon which will trigger an exception.
           getAddon: Promise.resolve(null),
         });
-        const addon = createInternalAddon(fakeAddon);
+        const addon = getAddon();
+        _loadVersions({ store });
 
         const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: fakeAddonManager,
           addon,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 
@@ -712,15 +714,13 @@ describe(__filename, () => {
 
       it('adds defaultInstallSource to the URL', () => {
         const installURL = 'http://the.url/';
-        const addon = createInternalAddon(
-          createFakeAddon({
-            files: [{ platform: OS_ALL, url: installURL }],
-          }),
-        );
+        const addon = getAddon();
+        loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
           addon,
           defaultInstallSource,
+          store,
         });
         const { setCurrentStatus } = root.instance().props;
 

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -44,6 +44,7 @@ import { createInternalAddon } from 'core/reducers/addons';
 import { showInfoDialog } from 'core/reducers/infoDialog';
 import {
   createFakeAddon,
+  createFakeTracking,
   createFakeLocation,
   createFakeTracking,
   dispatchClientMetadata,
@@ -998,11 +999,6 @@ describe(__filename, () => {
 
     describe('install', () => {
       const installURL = 'https://mysite.com/download.xpi';
-      let store;
-
-      beforeEach(() => {
-        store = dispatchClientMetadata().store;
-      });
 
       it('calls addonManager.install()', () => {
         const hash = 'some-sha-hash';

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -43,8 +43,6 @@ import {
 import { createInternalAddon } from 'core/reducers/addons';
 import { showInfoDialog } from 'core/reducers/infoDialog';
 import {
-  createFakeAddon,
-  createFakeTracking,
   createFakeLocation,
   createFakeTracking,
   dispatchClientMetadata,
@@ -172,6 +170,7 @@ describe(__filename, () => {
 
   it('sets status when the component is created', () => {
     _loadVersions({ store });
+
     const _addonManager = getFakeAddonManagerWrapper({
       getAddon: Promise.resolve({
         isActive: true,
@@ -181,7 +180,7 @@ describe(__filename, () => {
     });
     const addon = createInternalAddon(fakeAddon);
 
-    renderWithInstallHelpers({ _addonManager, addon });
+    renderWithInstallHelpers({ _addonManager, addon, store });
 
     sinon.assert.calledWith(_addonManager.getAddon, addon.guid);
   });
@@ -199,6 +198,7 @@ describe(__filename, () => {
     const root = mountWithInstallHelpers({
       _addonManager,
       addon: createInternalAddon(fakeAddon),
+      store,
     });
     _addonManager.getAddon.resetHistory();
 
@@ -209,6 +209,8 @@ describe(__filename, () => {
   });
 
   it('sets status when add-on is loaded on update', () => {
+    _loadVersions({ store });
+
     const _addonManager = getFakeAddonManagerWrapper({
       getAddon: Promise.resolve({
         isActive: true,
@@ -216,10 +218,10 @@ describe(__filename, () => {
       }),
     });
 
-    _loadVersions({ store });
     const root = mountWithInstallHelpers({
       _addonManager,
       addon: null,
+      store,
     });
     _addonManager.getAddon.resetHistory();
 
@@ -269,7 +271,7 @@ describe(__filename, () => {
       }),
     });
 
-    renderWithInstallHelpers({ _addonManager });
+    renderWithInstallHelpers({ _addonManager, store });
 
     sinon.assert.called(_addonManager.getAddon);
   });
@@ -509,7 +511,7 @@ describe(__filename, () => {
 
       it('sets the status to DISABLED when the extension is inactive and disabled', () => {
         const installURL = 'http://the.url/';
-        const addon = getAddon({ type: ADDON_TYPE_EXTENSION });
+        const addon = getAddon();
         loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({
@@ -539,7 +541,7 @@ describe(__filename, () => {
 
       it('sets the status to INACTIVE when an inactive extension is found', () => {
         const installURL = 'http://the.url/';
-        const addon = getAddon({ type: ADDON_TYPE_EXTENSION });
+        const addon = getAddon();
         loadVersionWithInstallUrl(installURL);
 
         const { root, dispatch } = renderWithInstallHelpers({

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -260,6 +260,8 @@ describe(__filename, () => {
   });
 
   it('sets the current status in componentDidMount with an addonManager', () => {
+    _loadVersions({ store });
+
     const _addonManager = getFakeAddonManagerWrapper({
       getAddon: Promise.resolve({
         isActive: true,

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -599,18 +599,20 @@ describe(__filename, () => {
         ...fakeAddon,
         guid: FACEBOOK_CONTAINER_ADDON_GUID,
       });
+      const currentVersion = createInternalVersion(fakeVersion);
 
       expect(
         _getClientCompatibility({
           addon,
           clientApp,
+          currentVersion,
           userAgentInfo,
         }),
       ).toEqual({
         compatible: false,
         downloadUrl: FACEBOOK_CONTAINER_DOWNLOAD_URL,
-        maxVersion: addon.current_version.compatibility[clientApp].max,
-        minVersion: addon.current_version.compatibility[clientApp].min,
+        maxVersion: currentVersion.compatibility[clientApp].max,
+        minVersion: currentVersion.compatibility[clientApp].min,
         reason: INCOMPATIBLE_NOT_FIREFOX,
       });
     });

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -48,7 +48,8 @@ import {
   trimAndAddProtocolToUrl,
   visibleAddonType,
 } from 'core/utils';
-import { createInternalAddon, createPlatformFiles } from 'core/reducers/addons';
+import { createInternalAddon } from 'core/reducers/addons';
+import { createPlatformFiles } from 'core/reducers/versions';
 import {
   createFakeHistory,
   createFakeLocation,


### PR DESCRIPTION
Fixes #6727 

Note that there is one test that is failing that I cannot seem to figure out. It's `sets the current status in componentDidMount with an addonManager` and it's failing because `mapStateToProps` is not being called so the component doesn't end up with a `currentVersion`. I assume this has to do with the way the test is set up, using 

`mount(<WithInstallHelpers {...props} WrappedComponent={() => <div />} />);`

as opposed to

`mount(<Component {...props} />);`

which many of the other tests do.

Any advice anyone can provide on how to fix this test would be appreciated.

Also note that `LanguageToolType` still uses `current_version` and the reducer just stores the raw data returned from the API in state. I don't think this `current_version` is ever accessed, but I will check and file a follow up to remove it as well.