### PR TITLE
Auto-save text written in DismissibleTextForm

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -12,6 +12,7 @@ import { ADDONS_EDIT } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
+import { normalizeFileNameId } from 'core/utils';
 import { getCurrentUser, hasPermission } from 'amo/reducers/users';
 import {
   beginDeleteAddonReview,
@@ -275,11 +276,20 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       return null;
     }
 
+    const formId = [
+      normalizeFileNameId(__filename),
+      'addon',
+      addon ? addon.id.toString() : 'no-addon',
+      'review',
+      review ? review.id.toString() : 'unsaved-review',
+    ].join('-');
+
     return (
       <div className="AddonReviewCard-reply">
         {replyingToReview ? (
           <DismissibleTextForm
             className="AddonReviewCard-reply-form"
+            id={formId}
             isSubmitting={submittingReply && !errorHandler.hasError()}
             onDismiss={this.onDismissReviewReply}
             onSubmit={this.onSubmitReviewReply}

--- a/src/amo/components/AddonReviewManager/index.js
+++ b/src/amo/components/AddonReviewManager/index.js
@@ -13,7 +13,7 @@ import {
 import AddonReviewManagerRating from 'amo/components/AddonReviewManagerRating';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
-import { sanitizeHTML } from 'core/utils';
+import { normalizeFileNameId, sanitizeHTML } from 'core/utils';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import type { AppState } from 'amo/store';
 import type { DispatchFunc } from 'core/types/redux';
@@ -37,6 +37,10 @@ type InternalProps = {|
   i18n: I18nType,
   flashMessage?: FlashMessageType | void,
 |};
+
+export const extractId = (props: Props | InternalProps): string => {
+  return props.review.id.toString();
+};
 
 export class AddonReviewManagerBase extends React.Component<InternalProps> {
   static defaultProps = {
@@ -137,6 +141,7 @@ export class AddonReviewManagerBase extends React.Component<InternalProps> {
         <DismissibleTextForm
           dismissButtonText={i18n.gettext('Cancel')}
           formFooter={formFooter}
+          id={`${normalizeFileNameId(__filename)}-${extractId(this.props)}`}
           isSubmitting={flashMessage === STARTED_SAVE_REVIEW}
           onDismiss={onCancel}
           onSubmit={this.onSubmitReview}
@@ -156,10 +161,6 @@ const mapStateToProps = (state: AppState) => {
   return {
     flashMessage: state.reviews.flashMessage,
   };
-};
-
-export const extractId = (props: Props): string => {
-  return props.review.id.toString();
 };
 
 const AddonReviewManager: React.ComponentType<Props> = compose(

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -8,7 +8,7 @@ import { withFixedErrorHandler } from 'core/errorHandler';
 import { getAddonIconUrl } from 'core/imageUtils';
 import translate from 'core/i18n/translate';
 import withUIState from 'core/withUIState';
-import { nl2br, sanitizeHTML } from 'core/utils';
+import { nl2br, normalizeFileNameId, sanitizeHTML } from 'core/utils';
 import Button from 'ui/components/Button';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import Icon from 'ui/components/Icon';
@@ -45,6 +45,11 @@ type InternalProps = {|
   setUIState: ($Shape<UIStateType>) => void,
   uiState: UIStateType,
 |};
+
+export const extractId = (ownProps: Props | InternalProps) => {
+  const { addon } = ownProps;
+  return `editable-collection-addon-${addon.id}`;
+};
 
 export class EditableCollectionAddonBase extends React.Component<InternalProps> {
   onEditNote = (event: SyntheticEvent<HTMLElement>) => {
@@ -95,8 +100,8 @@ export class EditableCollectionAddonBase extends React.Component<InternalProps> 
   render() {
     const { addon, className, errorHandler, i18n } = this.props;
     const showNotes = addon.notes || this.props.uiState.editingNote;
-
     const iconURL = getAddonIconUrl(addon);
+
     return (
       <li
         className={makeClassName(
@@ -150,6 +155,9 @@ export class EditableCollectionAddonBase extends React.Component<InternalProps> 
                 {errorHandler.renderErrorIfPresent()}
                 <DismissibleTextForm
                   className="EditableCollectionAddon-notes-form"
+                  id={`${normalizeFileNameId(__filename)}-${extractId(
+                    this.props,
+                  )}`}
                   microButtons
                   onDelete={addon.notes ? this.onDeleteNote : null}
                   onDismiss={this.onDismissNoteForm}
@@ -187,11 +195,6 @@ export class EditableCollectionAddonBase extends React.Component<InternalProps> 
     );
   }
 }
-
-export const extractId = (ownProps: Props) => {
-  const { addon } = ownProps;
-  return `editable-collection-addon-${addon.id}`;
-};
 
 const EditableCollectionAddon: React.ComponentType<Props> = compose(
   translate(),

--- a/src/amo/components/ReportUserAbuse/index.js
+++ b/src/amo/components/ReportUserAbuse/index.js
@@ -11,7 +11,7 @@ import {
 } from 'amo/reducers/userAbuseReports';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
-import { sanitizeHTML } from 'core/utils';
+import { normalizeFileNameId, sanitizeHTML } from 'core/utils';
 import Button from 'ui/components/Button';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import type { AppState } from 'amo/store';
@@ -134,6 +134,7 @@ export class ReportUserAbuseBase extends React.Component<InternalProps> {
             </p>
 
             <DismissibleTextForm
+              id={normalizeFileNameId(__filename)}
               isSubmitting={isSubmitting}
               onDismiss={this.hideReportUI}
               onSubmit={this.sendReport}

--- a/src/core/localState.js
+++ b/src/core/localState.js
@@ -2,6 +2,7 @@
 import defaultLocalForage from 'localforage';
 
 import log from 'core/logger';
+import { normalizeFileNameId } from 'core/utils';
 
 export function configureLocalForage({
   localForage = defaultLocalForage,
@@ -11,7 +12,7 @@ export function configureLocalForage({
   localForage.config({
     name: 'addons-frontend',
     version: '1.0',
-    storeName: 'core.LocalState',
+    storeName: normalizeFileNameId(__filename),
   });
 }
 
@@ -43,14 +44,14 @@ export class LocalState {
         return data;
       })
       .catch((error) => {
-        log.error(`Error with localForage.getItem("${this.id}"): ${error}`);
+        log.info(`Error with localForage.getItem("${this.id}"): ${error}`);
         throw error;
       });
   }
 
   clear(): Promise<void> {
     return this.localForage.removeItem(this.id).catch((error) => {
-      log.error(`Error with localForage.removeItem("${this.id}"): ${error}`);
+      log.info(`Error with localForage.removeItem("${this.id}"): ${error}`);
       throw error;
     });
   }
@@ -62,7 +63,7 @@ export class LocalState {
       );
     }
     return this.localForage.setItem(this.id, data).catch((error) => {
-      log.error(`Error with localForage.setItem("${this.id}"): ${error}`);
+      log.info(`Error with localForage.setItem("${this.id}"): ${error}`);
       throw error;
     });
   }

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -1,11 +1,15 @@
 /* @flow */
 import makeClassName from 'classnames';
+import { oneLine } from 'common-tags';
+import defaultDebounce from 'lodash.debounce';
 import invariant from 'invariant';
 import * as React from 'react';
 import { compose } from 'redux';
 import Textarea from 'react-textarea-autosize';
 
 import translate from 'core/i18n/translate';
+import log from 'core/logger';
+import defaultLocalStateCreator, { LocalState } from 'core/localState';
 import Button from 'ui/components/Button';
 import type { ElementEvent } from 'core/types/dom';
 import type { I18nType } from 'core/types/i18n';
@@ -26,6 +30,7 @@ type Props = {|
   className?: string,
   dismissButtonText?: string,
   formFooter?: React.Element<any>,
+  id: string,
   onDelete?: null | (() => void),
   onDismiss?: () => void,
   onSubmit: (params: OnSubmitParams) => void,
@@ -42,6 +47,8 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
+  createLocalState: typeof defaultLocalStateCreator,
+  debounce: typeof defaultDebounce,
   i18n: I18nType,
 |};
 
@@ -59,9 +66,13 @@ export class DismissibleTextFormBase extends React.Component<
   InternalProps,
   State,
 > {
+  localState: LocalState;
+
   textarea: React.ElementRef<typeof Textarea>;
 
   static defaultProps = {
+    createLocalState: defaultLocalStateCreator,
+    debounce: defaultDebounce,
     isSubmitting: false,
     microButtons: false,
     puffyButtons: false,
@@ -72,11 +83,37 @@ export class DismissibleTextFormBase extends React.Component<
     super(props);
     const initialText = props.text || '';
     this.state = { initialText, text: initialText };
+    this.localState = this.createLocalState();
   }
 
   componentDidMount() {
     if (this.textarea) {
       this.textarea.focus();
+    }
+    this.checkForStoredState();
+  }
+
+  componentDidUpdate(prevProps: InternalProps) {
+    if (this.props.id !== prevProps.id) {
+      this.localState = this.createLocalState();
+      this.checkForStoredState();
+    }
+  }
+
+  createLocalState() {
+    const { createLocalState, id } = this.props;
+    return createLocalState(id);
+  }
+
+  async checkForStoredState() {
+    const storedState: State | null = await this.localState.load();
+    if (storedState) {
+      log.debug(
+        oneLine`Initializing DismissibleTextForm state from LocalState
+          ${this.localState.id}`,
+        storedState,
+      );
+      this.setState(storedState);
     }
   }
 
@@ -85,6 +122,7 @@ export class DismissibleTextFormBase extends React.Component<
 
     invariant(this.props.onDelete, 'onDelete() is not defined');
     this.props.onDelete();
+    this.localState.clear();
   };
 
   onDismiss = (event: SyntheticEvent<any>) => {
@@ -93,16 +131,31 @@ export class DismissibleTextFormBase extends React.Component<
     invariant(onDismiss, 'onDismiss() is required');
 
     onDismiss();
+    this.localState.clear();
   };
 
   onSubmit = (event: SyntheticEvent<any>) => {
     event.preventDefault();
     this.props.onSubmit({ event, text: this.state.text });
+    this.localState.clear();
   };
+
+  persistState = this.props.debounce(
+    (state) => {
+      // After a few keystrokes, save the text to a local store
+      // so we can recover from crashes.
+      this.localState.save(state);
+    },
+    800,
+    { trailing: true },
+  );
 
   onTextChange = (event: ElementEvent<HTMLInputElement>) => {
     event.preventDefault();
-    this.setState({ text: event.target.value });
+
+    const newState = { text: event.target.value };
+    this.setState(newState);
+    this.persistState(newState);
   };
 
   render() {
@@ -211,7 +264,6 @@ export class DismissibleTextFormBase extends React.Component<
     return (
       <form className={makeClassName('DismissibleTextForm-form', className)}>
         <Textarea
-          defaultValue={this.state.text}
           disabled={isSubmitting}
           className="DismissibleTextForm-textarea"
           inputRef={(ref) => {
@@ -219,6 +271,7 @@ export class DismissibleTextFormBase extends React.Component<
           }}
           onChange={this.onTextChange}
           placeholder={text.placeholder}
+          value={this.state.text}
         />
         {formFooter && (
           <div className="DismissibleTextForm-formFooter">{formFooter}</div>

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -33,6 +33,7 @@ import {
   fakeReview,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
+import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
 import UserReview from 'ui/components/UserReview';
@@ -458,7 +459,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(
       dispatchSpy,
       deleteAddonReview({
-        addonId: fakeAddon.id,
+        addonId: review.reviewAddon.id,
         errorHandlerId: errorHandler.id,
         reviewId: review.id,
       }),
@@ -1273,7 +1274,7 @@ describe(__filename, () => {
       sinon.assert.calledWith(
         dispatchSpy,
         deleteAddonReview({
-          addonId: fakeAddon.id,
+          addonId: review.reviewAddon.id,
           errorHandlerId: errorHandler.id,
           reviewId: review.id,
           isReplyToReviewId: originalReviewId,
@@ -1291,6 +1292,22 @@ describe(__filename, () => {
 
       const reviewComponent = root.find(UserReview);
       expect(reviewComponent).toHaveProp('showRating', false);
+    });
+
+    it('configures DismissibleTextForm with an ID', () => {
+      const { review } = _setReviewReply();
+      store.dispatch(showReplyToReviewForm({ reviewId: review.id }));
+
+      const root = render({ review });
+
+      const form = root.find(DismissibleTextForm);
+
+      expect(form).toHaveProp('id');
+      const formId = form.prop('id');
+
+      expect(formId).toContain('AddonReviewCard');
+      expect(formId).toContain(`addon-${review.reviewAddon.id}`);
+      expect(formId).toContain(`review-${review.id}`);
     });
   });
 

--- a/tests/unit/amo/components/TestAddonReviewManager.js
+++ b/tests/unit/amo/components/TestAddonReviewManager.js
@@ -80,6 +80,17 @@ describe(__filename, () => {
     expect(formFooter.find('a').text()).toEqual('review guidelines');
   });
 
+  it('configures DismissibleTextForm with an ID', () => {
+    const root = render({ review: createInternalReview({ ...fakeReview }) });
+
+    const form = root.find(DismissibleTextForm);
+    expect(form).toHaveProp('id');
+
+    const formId = form.prop('id');
+    expect(formId).toMatch(/AddonReviewManager/);
+    expect(formId).toMatch(extractId(root.instance().props));
+  });
+
   it('does not configure DismissibleTextForm for cancellation by default', () => {
     const root = render();
 

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -19,6 +19,7 @@ import {
 import {
   createContextWithFakeRouter,
   createFakeAutocompleteResult,
+  createFakeDebounce,
   createFakeEvent,
   createFakeLocation,
   createStubErrorHandler,
@@ -36,8 +37,7 @@ describe(__filename, () => {
     ...customProps
   } = {}) => {
     return {
-      // This simulates debounce() without any debouncing.
-      debounce: (callback) => (...args) => callback(...args),
+      debounce: createFakeDebounce(),
       i18n: fakeI18n(),
       inputName: 'query',
       location: createFakeLocation(),

--- a/tests/unit/amo/components/TestEditableCollectionAddon.js
+++ b/tests/unit/amo/components/TestEditableCollectionAddon.js
@@ -18,6 +18,7 @@ import {
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import Button from 'ui/components/Button';
+import DismissibleTextForm from 'ui/components/DismissibleTextForm';
 import Icon from 'ui/components/Icon';
 
 describe(__filename, () => {
@@ -276,7 +277,7 @@ describe(__filename, () => {
       expect(notesForm).toHaveLength(0);
     });
 
-    it('calls deleteNote when the delete button is clicked on the DismissibleTextForm', () => {
+    it('calls deleteNote when clicking delete on DismissibleTextForm', () => {
       const notes = 'Some notes.';
       const addon = {
         ...fakeAddon,
@@ -297,7 +298,7 @@ describe(__filename, () => {
       sinon.assert.calledWith(deleteNote, addon.id, errorHandler);
     });
 
-    it('calls saveNote when the save button is clicked on the DismissibleTextForm', () => {
+    it('calls saveNote when saving DismissibleTextForm', () => {
       const notes = 'Some notes.';
       const addon = {
         ...fakeAddon,
@@ -315,6 +316,16 @@ describe(__filename, () => {
       onSaveNote({ text: notes });
       sinon.assert.callCount(saveNote, 1);
       sinon.assert.calledWith(saveNote, addon.id, errorHandler, notes);
+    });
+
+    it('configures DismissibleTextForm with an id', () => {
+      const { store } = dispatchClientMetadata();
+
+      const root = renderAndEditNote({ notes: 'This add-on is buggy', store });
+
+      const formId = root.find(DismissibleTextForm).prop('id');
+      expect(formId).toMatch(/EditableCollectionAddon/);
+      expect(formId).toMatch(extractId(root.instance().props));
     });
   });
 

--- a/tests/unit/amo/components/TestReportUserAbuse.js
+++ b/tests/unit/amo/components/TestReportUserAbuse.js
@@ -101,19 +101,21 @@ describe(__filename, () => {
       to report bugs or contact this user; your report will only be sent to
       Mozilla and not to this user.`);
 
-    expect(root.find(DismissibleTextForm)).toHaveLength(1);
-    expect(root.find(DismissibleTextForm)).toHaveProp('isSubmitting', false);
-    expect(root.find(DismissibleTextForm)).toHaveProp(
+    const form = root.find(DismissibleTextForm);
+    expect(form).toHaveLength(1);
+    expect(form).toHaveProp('isSubmitting', false);
+    expect(form).toHaveProp(
       'placeholder',
       'Explain how this user is violating our policies.',
     );
-    expect(root.find(DismissibleTextForm)).toHaveProp(
-      'submitButtonText',
-      'Send abuse report',
-    );
-    expect(root.find(DismissibleTextForm)).toHaveProp(
+    expect(form).toHaveProp('submitButtonText', 'Send abuse report');
+    expect(form).toHaveProp(
       'submitButtonInProgressText',
       'Sending abuse report',
+    );
+    expect(form).toHaveProp(
+      'id',
+      'src/amo/components/ReportUserAbuse/index.js',
     );
   });
 

--- a/tests/unit/core/test_localState.js
+++ b/tests/unit/core/test_localState.js
@@ -28,6 +28,17 @@ describe(__filename, () => {
     return localState.localForage.clear();
   });
 
+  it('configures storage', () => {
+    const localForage = fakeLocalForage();
+    configureLocalForage({ localForage });
+
+    sinon.assert.calledWith(localForage.config, {
+      name: sinon.match.string,
+      version: sinon.match.string,
+      storeName: 'src/core/localState.js',
+    });
+  });
+
   it('lets you save and load data', () => {
     const state = { name: 'Aristotle' };
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -194,7 +194,7 @@ export const fakeReview = Object.freeze({
   // The API only provides a minimal add-on representation.
   addon: {
     icon_url: 'https://addons.cdn.mozilla.net/webdev-64.png',
-    id: fakeAddon.id,
+    id: 28014,
     name: 'fake add-on name',
     slug: fakeAddon.slug,
   },
@@ -1151,3 +1151,19 @@ export const getFakeLogger = (params = {}) => {
     ...params,
   };
 };
+
+// This simulates debounce() without any debouncing.
+export function createFakeDebounce() {
+  return sinon.spy((callback) => (...args) => callback(...args));
+}
+
+// This creates a fake instance with the same interface as
+// LocalState in core/localState
+export function createFakeLocalState(overrides = {}) {
+  return {
+    clear: sinon.spy(() => Promise.resolve()),
+    load: sinon.spy(() => Promise.resolve(null)),
+    save: sinon.spy(() => Promise.resolve()),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6348 by auto-saving text in `DismissibleTextForm` (which fixes https://github.com/mozilla/addons-frontend/issues/6883).

I made two separate issues so that QA knows which scenarios to cover.