### PR TITLE
Move userAgentInfo into mapStateToProps in withInstallHelpers and remove `mapDispatchToProps` stuff

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -639,14 +639,14 @@ export function mapStateToProps(state, ownProps) {
     addonIsLoading: isAddonLoading(state, slug),
     addonsByAuthors,
     clientApp: state.api.clientApp,
+    currentVersion,
     installError: installedAddon.error,
     installStatus: installedAddon.status || UNKNOWN,
     lang: state.api.lang,
+    userAgentInfo: state.api.userAgentInfo,
     // In addition to this component, this also is required by the
     // `withInstallHelpers()` HOC.
     addon,
-    userAgentInfo: state.api.userAgentInfo,
-    currentVersion,
   };
 }
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -644,8 +644,7 @@ export function mapStateToProps(state, ownProps) {
     installStatus: installedAddon.status || UNKNOWN,
     lang: state.api.lang,
     userAgentInfo: state.api.userAgentInfo,
-    // In addition to this component, this also is required by the
-    // `withInstallHelpers()` HOC.
+    // The `withInstallHelpers()` HOC requires an `addon` prop too:
     addon,
   };
 }

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -331,8 +331,7 @@ function mapStateToProps(state: AppState, ownProps: Props) {
     error: installation.error,
     status: installation.status || UNKNOWN,
     userAgentInfo: state.api.userAgentInfo,
-    // In addition to this component, this also is required by the
-    // `withInstallHelpers()` HOC.
+    // The `withInstallHelpers()` HOC requires an `addon` prop too:
     addon,
   };
 }

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -326,14 +326,14 @@ function mapStateToProps(state: AppState, ownProps: Props) {
   }
 
   return {
-    addon,
-    error: installation.error,
-    status: installation.status || UNKNOWN,
     clientApp: state.api.clientApp,
     currentVersion,
+    error: installation.error,
+    status: installation.status || UNKNOWN,
+    userAgentInfo: state.api.userAgentInfo,
     // In addition to this component, this also is required by the
     // `withInstallHelpers()` HOC.
-    userAgentInfo: state.api.userAgentInfo,
+    addon,
   };
 }
 

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -133,6 +133,12 @@ const _loadVersions = ({ store, versionProps = {} }) => {
 };
 
 describe(__filename, () => {
+  let store;
+
+  beforeEach(() => {
+    store = dispatchClientMetadata().store;
+  });
+
   it('wraps the component in WithInstallHelpers', () => {
     const Component = componentWithInstallHelpers();
 

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -763,6 +763,18 @@ describe(__filename, () => {
           'no addon, aborting setCurrentStatus()',
         );
       });
+
+      it('does nothing when currentVersion is `null`', () => {
+        const _log = getFakeLogger();
+
+        const { dispatch } = renderWithInstallHelpers({ _log });
+
+        sinon.assert.notCalled(dispatch);
+        sinon.assert.calledWith(
+          _log.debug,
+          'no currentVersion, aborting setCurrentStatus()',
+        );
+      });
     });
 
     describe('makeProgressHandler', () => {


### PR DESCRIPTION
Fixes #6878

---

Not only this patch moves `userAgentInfo` into `mapStateToProps` but it also completely removes the weird logic around `mapDispatchToProps`. The logger is injected via a prop too and Flow types have been updated to reflect the reality: the `addon` prop is nullable.