### PR TITLE
Use `userId` in user profile pages

### DIFF
--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -16,11 +16,6 @@ export type UserApiParams = {|
   userId: UserId,
 |};
 
-export type UserApiParamsWithUsername = {|
-  api: ApiState,
-  username: string,
-|};
-
 export type CurrentUserAccountParams = {|
   api: ApiState,
 |};
@@ -79,28 +74,28 @@ export function updateUserAccount({
 
 export function userAccount({
   api,
-  username,
-}: UserApiParamsWithUsername): Promise<ExternalUserType> {
+  userId,
+}: UserApiParams): Promise<ExternalUserType> {
   invariant(api, 'api state is required.');
-  invariant(username, 'username is required.');
+  invariant(userId, 'userId is required.');
 
   return callApi({
     auth: true,
-    endpoint: `accounts/account/${username}`,
+    endpoint: `accounts/account/${userId}`,
     apiState: api,
   });
 }
 
 export function userNotifications({
   api,
-  username,
-}: UserApiParamsWithUsername): Promise<NotificationsType> {
+  userId,
+}: UserApiParams): Promise<NotificationsType> {
   invariant(api, 'api state is required.');
-  invariant(username, 'username is required.');
+  invariant(userId, 'userId is required.');
 
   return callApi({
     auth: true,
-    endpoint: `accounts/account/${username}/notifications`,
+    endpoint: `accounts/account/${userId}/notifications`,
     apiState: api,
   });
 }

--- a/src/amo/components/AddonTitle/index.js
+++ b/src/amo/components/AddonTitle/index.js
@@ -44,7 +44,7 @@ export const AddonTitleBase = ({
     addonAuthors.forEach((author, index) => {
       authors.push(
         author.url ? (
-          <Link key={author.id} to={`/user/${author.username}/`}>
+          <Link key={author.id} to={`/user/${author.id}/`}>
             {author.name}
           </Link>
         ) : (

--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -100,7 +100,7 @@ export class HeaderBase extends React.Component {
               <DropdownMenuItem>
                 <Link
                   className="Header-user-menu-view-profile-link"
-                  to={siteUser ? `/user/${siteUser.username}/` : null}
+                  to={siteUser ? `/user/${siteUser.id}/` : null}
                 >
                   {i18n.gettext('View My Profile')}
                 </Link>

--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -89,12 +89,12 @@ const Routes = ({ _config = config }: Props = {}) => (
     />
     <Route
       exact
-      path="/:lang/:application/user/:username/edit/"
+      path="/:lang/:application/user/:userId/edit/"
       component={UserProfileEdit}
     />
     <Route
       exact
-      path="/:lang/:application/user/:username/"
+      path="/:lang/:application/user/:userId/"
       component={UserProfile}
     />
 

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -18,7 +18,7 @@ import {
   fetchUserAccount,
   fetchUserNotifications,
   getCurrentUser,
-  getUserByUsername,
+  getUserById,
   hasPermission,
   isDeveloper,
   logOutUser,
@@ -33,7 +33,11 @@ import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
 import Notice from 'ui/components/Notice';
 import OverlayCard from 'ui/components/OverlayCard';
-import type { NotificationsUpdateType, UserType } from 'amo/reducers/users';
+import type {
+  NotificationsUpdateType,
+  UserId,
+  UserType,
+} from 'amo/reducers/users';
 import type { AppState } from 'amo/store';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ErrorHandlerType } from 'core/errorHandler';
@@ -57,12 +61,14 @@ type Props = {|
   i18n: I18nType,
   isUpdating: boolean,
   lang: string,
+  // `match` is used in `mapStateToProps()`
+  // eslint-disable-next-line react/no-unused-prop-types
   match: {|
     ...ReactRouterMatchType,
-    params: {| username: string |},
+    params: {| userId: string |},
   |},
   user: UserType | null,
-  username: string,
+  userId: UserId,
 |};
 
 type FormValues = {|
@@ -97,7 +103,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const { dispatch, errorHandler, username, user } = props;
+    const { dispatch, errorHandler, userId, user } = props;
 
     this.state = {
       showProfileDeletionModal: false,
@@ -111,20 +117,20 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       return;
     }
 
-    if (!user && username) {
+    if (!user && userId) {
       dispatch(
         fetchUserAccount({
           errorHandlerId: errorHandler.id,
-          username,
+          userId,
         }),
       );
     }
 
-    if ((!user && username) || (user && !user.notifications)) {
+    if ((!user && userId) || (user && !user.notifications)) {
       dispatch(
         fetchUserNotifications({
           errorHandlerId: errorHandler.id,
-          username,
+          userId,
         }),
       );
     }
@@ -134,7 +140,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     const {
       isUpdating: wasUpdating,
       user: oldUser,
-      username: oldUsername,
+      userId: oldUserId,
     } = this.props;
 
     const {
@@ -145,26 +151,25 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       i18n,
       isUpdating,
       lang,
-      match: { params },
       user: newUser,
-      username: newUsername,
+      userId: newUserId,
     } = props;
 
-    if (oldUsername !== newUsername) {
-      if (!newUser && newUsername) {
+    if (oldUserId !== newUserId) {
+      if (!newUser && newUserId) {
         dispatch(
           fetchUserAccount({
             errorHandlerId: errorHandler.id,
-            username: newUsername,
+            userId: newUserId,
           }),
         );
       }
 
-      if ((!newUser && newUsername) || (newUser && !newUser.notifications)) {
+      if ((!newUser && newUserId) || (newUser && !newUser.notifications)) {
         dispatch(
           fetchUserNotifications({
             errorHandlerId: errorHandler.id,
-            username: newUser ? newUser.username : newUsername,
+            userId: newUser ? newUser.id : newUserId,
           }),
         );
       }
@@ -188,12 +193,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     }
 
     if (wasUpdating && !isUpdating && !errorHandler.hasError()) {
-      history.push(`/${lang}/${clientApp}/user/${newUsername}/`);
-      return;
-    }
-
-    if (params.username && oldUsername !== newUsername) {
-      history.push(`/${lang}/${clientApp}/user/${newUsername}/edit/`);
+      history.push(`/${lang}/${clientApp}/user/${newUserId}/`);
     }
   }
 
@@ -362,7 +362,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       notifications: {},
       occupation: '',
       picture: null,
-      username: this.props.username,
+      username: '',
     };
 
     if (!user) {
@@ -412,7 +412,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       i18n,
       isUpdating,
       user,
-      username,
+      userId,
     } = this.props;
 
     if (!currentUser) {
@@ -446,7 +446,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     const isEditingCurrentUser =
       currentUser && user ? currentUser.id === user.id : false;
 
-    const userProfileURL = `/user/${username}/`;
+    const userProfileURL = `/user/${userId}/`;
 
     const overlayClassName = 'UserProfileEdit-deletion-modal';
 
@@ -494,7 +494,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 isEditingCurrentUser
                   ? i18n.gettext('Account')
                   : i18n.sprintf(i18n.gettext('Account for %(username)s'), {
-                      username,
+                      username: user ? user.username : userId,
                     })
               }
             >
@@ -568,7 +568,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                     fields are optional, but they'll help other users get to
                     know %(username)s better.`,
                       ),
-                      { username },
+                      { username: user ? user.username : userId },
                     )}
               </p>
 
@@ -653,7 +653,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                     )
                   : i18n.sprintf(
                       i18n.gettext(`Introduce %(username)s to the community`),
-                      { username },
+                      { username: user ? user.username : userId },
                     )}
               </label>
               <Textarea
@@ -855,12 +855,15 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
 export function mapStateToProps(state: AppState, ownProps: Props) {
   const { clientApp, lang } = state.api;
+
   const { params } = ownProps.match;
+  const userId = Number(params.userId);
 
   const currentUser = getCurrentUser(state.users);
-  const user = params.username
-    ? getUserByUsername(state.users, params.username)
-    : currentUser;
+  const user =
+    params.userId && !Number.isNaN(userId)
+      ? getUserById(state.users, userId)
+      : currentUser;
 
   let hasEditPermission = currentUser && user && currentUser.id === user.id;
   if (currentUser && hasPermission(state, USERS_EDIT)) {
@@ -874,12 +877,12 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
     isUpdating: state.users.isUpdating,
     lang,
     user,
-    username: user ? user.username : params.username,
+    userId: user ? user.id : userId,
   };
 }
 
 export const extractId = (ownProps: Props) => {
-  return ownProps.match.params.username;
+  return ownProps.match.params.userId;
 };
 
 const UserProfileEdit: React.ComponentType<Props> = compose(

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -860,10 +860,7 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
   const userId = Number(params.userId);
 
   const currentUser = getCurrentUser(state.users);
-  const user =
-    params.userId && !Number.isNaN(userId)
-      ? getUserById(state.users, userId)
-      : currentUser;
+  const user = params.userId ? getUserById(state.users, userId) : currentUser;
 
   let hasEditPermission = currentUser && user && currentUser.id === user.id;
   if (currentUser && hasPermission(state, USERS_EDIT)) {

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -110,7 +110,7 @@ export const initialState: UsersState = {
 
 type FetchUserAccountParams = {|
   errorHandlerId: string,
-  username: string,
+  userId: UserId,
 |};
 
 export type FetchUserAccountAction = {|
@@ -120,16 +120,16 @@ export type FetchUserAccountAction = {|
 
 export const fetchUserAccount = ({
   errorHandlerId,
-  username,
+  userId,
 }: FetchUserAccountParams): FetchUserAccountAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(username, 'username is required');
+  invariant(userId, 'userId is required');
 
   return {
     type: FETCH_USER_ACCOUNT,
     payload: {
       errorHandlerId,
-      username,
+      userId,
     },
   };
 };
@@ -317,7 +317,7 @@ export const deleteUserPicture = ({
 
 type FetchUserNotificationsParams = {|
   errorHandlerId: string,
-  username: string,
+  userId: UserId,
 |};
 
 export type FetchUserNotificationsAction = {|
@@ -327,20 +327,20 @@ export type FetchUserNotificationsAction = {|
 
 export const fetchUserNotifications = ({
   errorHandlerId,
-  username,
+  userId,
 }: FetchUserNotificationsParams): FetchUserNotificationsAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(username, 'username is required');
+  invariant(userId, 'userId is required');
 
   return {
     type: FETCH_USER_NOTIFICATIONS,
-    payload: { errorHandlerId, username },
+    payload: { errorHandlerId, userId },
   };
 };
 
 type LoadUserNotificationsParams = {|
   notifications: NotificationsType,
-  username: string,
+  userId: UserId,
 |};
 
 type LoadUserNotificationsAction = {|
@@ -350,18 +350,18 @@ type LoadUserNotificationsAction = {|
 
 export const loadUserNotifications = ({
   notifications,
-  username,
+  userId,
 }: LoadUserNotificationsParams): LoadUserNotificationsAction => {
   invariant(notifications, 'notifications is required');
-  invariant(username, 'username is required');
+  invariant(userId, 'userId is required');
 
   return {
     type: LOAD_USER_NOTIFICATIONS,
-    payload: { notifications, username },
+    payload: { notifications, userId },
   };
 };
 
-export const getUserById = (users: UsersState, userId: number) => {
+export const getUserById = (users: UsersState, userId: UserId) => {
   invariant(userId, 'userId is required');
   return users.byID[userId];
 };
@@ -518,9 +518,9 @@ const reducer = (
       };
     }
     case LOAD_USER_NOTIFICATIONS: {
-      const { notifications, username } = action.payload;
+      const { notifications, userId } = action.payload;
 
-      const user = getUserByUsername(state, username);
+      const user = getUserById(state, userId);
 
       invariant(user, 'user is required');
       invariant(notifications, 'notifications are required');

--- a/src/amo/sagas/users.js
+++ b/src/amo/sagas/users.js
@@ -22,7 +22,6 @@ import type {
   UpdateUserAccountParams,
   UpdateUserNotificationsParams,
   UserApiParams,
-  UserApiParamsWithUsername,
 } from 'amo/api/users';
 import type {
   DeleteUserAccountAction,
@@ -119,7 +118,7 @@ export function* updateUserAccount({
       yield put(
         loadUserNotifications({
           notifications: allNotifications,
-          username: user.username,
+          userId: user.id,
         }),
       );
     }
@@ -132,7 +131,7 @@ export function* updateUserAccount({
 }
 
 export function* fetchUserAccount({
-  payload: { errorHandlerId, username },
+  payload: { errorHandlerId, userId },
 }: FetchUserAccountAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -141,9 +140,9 @@ export function* fetchUserAccount({
   try {
     const state = yield select(getState);
 
-    const params: UserApiParamsWithUsername = {
+    const params: UserApiParams = {
       api: state.api,
-      username,
+      userId,
     };
 
     const user = yield call(api.userAccount, params);
@@ -156,7 +155,7 @@ export function* fetchUserAccount({
 }
 
 export function* fetchUserNotifications({
-  payload: { errorHandlerId, username },
+  payload: { errorHandlerId, userId },
 }: FetchUserNotificationsAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -165,12 +164,14 @@ export function* fetchUserNotifications({
   try {
     const state = yield select(getState);
 
-    const notifications = yield call(api.userNotifications, {
+    const params: UserApiParams = {
       api: state.api,
-      username,
-    });
+      userId,
+    };
 
-    yield put(loadUserNotifications({ notifications, username }));
+    const notifications = yield call(api.userNotifications, params);
+
+    yield put(loadUserNotifications({ notifications, userId }));
   } catch (error) {
     log.warn(`User notifications failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -51,13 +51,13 @@ describe(__filename, () => {
 
   describe('updateUserAccount', () => {
     const getParams = (params = {}) => {
-      const state = dispatchSignInActions().store.getState();
+      const { state } = dispatchSignInActions();
       const userId = getCurrentUser(state.users).id;
 
       return { api: state.api, userId, ...params };
     };
 
-    it('updates a userProfile and returns the new profile', async () => {
+    it('updates a user profile and returns the new profile', async () => {
       const editableFields = {
         biography: 'I am a cool tester.',
         display_name: 'Super Krupa',
@@ -141,16 +141,15 @@ describe(__filename, () => {
   });
 
   describe('userAccount', () => {
-    it('fetches a user profile based on username', async () => {
-      const state = dispatchSignInActions().store.getState();
-      const username = 'tofumatt';
-      const params = { api: state.api, username };
+    it('fetches a user profile based on user ID', async () => {
+      const { state } = dispatchSignInActions();
+      const params = { api: state.api, userId: 123 };
 
       mockApi
         .expects('callApi')
         .withArgs({
           auth: true,
-          endpoint: `accounts/account/${params.username}`,
+          endpoint: `accounts/account/${params.userId}`,
           apiState: params.api,
         })
         .returns(mockResponse());
@@ -161,9 +160,9 @@ describe(__filename, () => {
   });
 
   describe('userNotifications', () => {
-    it('fetches user notifications based on username', async () => {
-      const state = dispatchClientMetadata().store.getState();
-      const params = { api: state.api, username: 'tofumatt' };
+    it('fetches user notifications based on user ID', async () => {
+      const { state } = dispatchSignInActions();
+      const params = { api: state.api, userId: 123 };
 
       const notificationsResponse = createApiResponse({
         jsonData: createUserNotificationsResponse(),
@@ -173,7 +172,7 @@ describe(__filename, () => {
         .expects('callApi')
         .withArgs({
           auth: true,
-          endpoint: `accounts/account/${params.username}/notifications`,
+          endpoint: `accounts/account/${params.userId}/notifications`,
           apiState: params.api,
         })
         .returns(notificationsResponse);
@@ -185,7 +184,7 @@ describe(__filename, () => {
 
   describe('deleteUserPicture', () => {
     it('deletes a user profile picture for a given user', async () => {
-      const state = dispatchSignInActions().store.getState();
+      const { state } = dispatchSignInActions();
       const userId = getCurrentUser(state.users).id;
       const params = { api: state.api, userId };
 
@@ -206,7 +205,7 @@ describe(__filename, () => {
 
   describe('deleteUserAccount', () => {
     it('deletes a user profile', async () => {
-      const state = dispatchSignInActions().store.getState();
+      const { state } = dispatchSignInActions();
       const userId = getCurrentUser(state.users).id;
       const params = { api: state.api, userId };
 
@@ -228,7 +227,7 @@ describe(__filename, () => {
 
   describe('updateUserNotifications', () => {
     it('updates the user notifications of a given user', async () => {
-      const state = dispatchSignInActions().store.getState();
+      const { state } = dispatchSignInActions();
       const userId = getCurrentUser(state.users).id;
 
       const notifications = { reply: true };

--- a/tests/unit/amo/components/TestAddonTitle.js
+++ b/tests/unit/amo/components/TestAddonTitle.js
@@ -57,13 +57,11 @@ describe(__filename, () => {
     const author1 = {
       ...fakeAddon.authors[0],
       name: 'Author 1',
-      username: 'author-1',
       id: 101,
     };
     const author2 = {
       ...fakeAddon.authors[0],
       name: 'Author 2',
-      username: 'author-2',
       id: 102,
     };
 
@@ -140,13 +138,11 @@ describe(__filename, () => {
     const author1 = {
       ...fakeAddon.authors[0],
       name: 'Author 1',
-      username: 'author-1',
       id: 101,
     };
     const author2 = {
       ...fakeAddon.authors[0],
       name: 'Author 2',
-      username: 'author-2',
       id: 102,
     };
 

--- a/tests/unit/amo/components/TestAddonTitle.js
+++ b/tests/unit/amo/components/TestAddonTitle.js
@@ -41,6 +41,7 @@ describe(__filename, () => {
   it('renders a single author', () => {
     const author = {
       ...fakeAddon.authors[0],
+      id: 123,
     };
 
     const root = render({
@@ -49,7 +50,7 @@ describe(__filename, () => {
 
     expect(root.find(Link)).toHaveLength(1);
     expect(root.find(Link)).toHaveProp('children', author.name);
-    expect(root.find(Link)).toHaveProp('to', `/user/${author.username}/`);
+    expect(root.find(Link)).toHaveProp('to', `/user/${author.id}/`);
   });
 
   it('renders multiple authors', () => {
@@ -57,11 +58,13 @@ describe(__filename, () => {
       ...fakeAddon.authors[0],
       name: 'Author 1',
       username: 'author-1',
+      id: 101,
     };
     const author2 = {
       ...fakeAddon.authors[0],
       name: 'Author 2',
       username: 'author-2',
+      id: 102,
     };
 
     const root = render({
@@ -70,10 +73,7 @@ describe(__filename, () => {
 
     expect(root.find(Link)).toHaveLength(2);
     expect(root.find(Link).at(1)).toHaveProp('children', author2.name);
-    expect(root.find(Link).at(1)).toHaveProp(
-      'to',
-      `/user/${author2.username}/`,
-    );
+    expect(root.find(Link).at(1)).toHaveProp('to', `/user/${author2.id}/`);
 
     const authors = root.find('.AddonTitle-author');
 
@@ -84,13 +84,13 @@ describe(__filename, () => {
     // Then it should be a Link
     expect(authors.childAt(2)).toHaveProp('to');
     expect(authors.childAt(2)).toHaveProp('children', author1.name);
-    expect(authors.childAt(2)).toHaveProp('to', `/user/${author1.username}/`);
+    expect(authors.childAt(2)).toHaveProp('to', `/user/${author1.id}/`);
     // Then, it should be a separator (comma)
     expect(authors.childAt(3).text()).toEqual(', ');
     // Then, it should be the second Link
     expect(authors.childAt(4)).toHaveProp('to');
     expect(authors.childAt(4)).toHaveProp('children', author2.name);
-    expect(authors.childAt(4)).toHaveProp('to', `/user/${author2.username}/`);
+    expect(authors.childAt(4)).toHaveProp('to', `/user/${author2.id}/`);
   });
 
   it('renders without authors', () => {
@@ -141,11 +141,13 @@ describe(__filename, () => {
       ...fakeAddon.authors[0],
       name: 'Author 1',
       username: 'author-1',
+      id: 101,
     };
     const author2 = {
       ...fakeAddon.authors[0],
       name: 'Author 2',
       username: 'author-2',
+      id: 102,
     };
 
     const root = render({
@@ -157,12 +159,12 @@ describe(__filename, () => {
 
     // First child should be a Link
     expect(authors.childAt(0)).toHaveProp('children', author1.name);
-    expect(authors.childAt(0)).toHaveProp('to', `/user/${author1.username}/`);
+    expect(authors.childAt(0)).toHaveProp('to', `/user/${author1.id}/`);
     // Then, it should be a separator (comma)
     expect(authors.childAt(1).text()).toEqual(' ,');
     // Then it should be a second Link
     expect(authors.childAt(2)).toHaveProp('children', author2.name);
-    expect(authors.childAt(2)).toHaveProp('to', `/user/${author2.username}/`);
+    expect(authors.childAt(2)).toHaveProp('to', `/user/${author2.id}/`);
     // Then it should be the empty space between "by" and the links
     expect(authors.childAt(3).text()).toEqual(' ');
     // Finally, it should be the "by"

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -66,7 +66,6 @@ describe(__filename, () => {
     const { store } = dispatchSignInActions({
       userProps: {
         display_name: displayName,
-        username: 'babar',
       },
     });
     const wrapper = renderHeader({ store });
@@ -98,7 +97,7 @@ describe(__filename, () => {
   it('displays a view profile link when user is signed in', () => {
     const id = 124;
     const { store } = dispatchSignInActions({
-      userProps: { username: 'babar', id },
+      userProps: { id },
     });
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-view-profile-link');
@@ -109,9 +108,7 @@ describe(__filename, () => {
   });
 
   it('displays an edit profile link when user is signed in', () => {
-    const { store } = dispatchSignInActions({
-      userProps: { username: 'babar' },
-    });
+    const { store } = dispatchSignInActions();
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-edit-profile-link');
 
@@ -121,9 +118,7 @@ describe(__filename, () => {
   });
 
   it('allows a signed-in user to log out', () => {
-    const { store } = dispatchSignInActions({
-      userProps: { username: 'babar' },
-    });
+    const { store } = dispatchSignInActions();
     const handleLogOut = sinon.stub();
 
     const wrapper = renderHeader({ store, handleLogOut });
@@ -140,7 +135,6 @@ describe(__filename, () => {
     const { store } = dispatchSignInActions({
       userProps: {
         permissions: ['Addons:PostReview'],
-        username: 'babar',
       },
     });
     const wrapper = renderHeader({ store });
@@ -152,9 +146,7 @@ describe(__filename, () => {
   });
 
   it('does not display the reviewer tools link when user does not have permission', () => {
-    const { store } = dispatchSignInActions({
-      userProps: { username: 'babar' },
-    });
+    const { store } = dispatchSignInActions();
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-reviewer-tools-link');
 
@@ -162,10 +154,7 @@ describe(__filename, () => {
   });
 
   it('displays a "manage my submissions" link when user is logged in', () => {
-    const username = 'championshuttler';
-    const { store } = dispatchSignInActions({
-      userProps: { username },
-    });
+    const { store } = dispatchSignInActions();
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-developers-submissions-link');
 

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -96,15 +96,16 @@ describe(__filename, () => {
   });
 
   it('displays a view profile link when user is signed in', () => {
+    const id = 124;
     const { store } = dispatchSignInActions({
-      userProps: { username: 'babar' },
+      userProps: { username: 'babar', id },
     });
     const wrapper = renderHeader({ store });
     const link = wrapper.find('.Header-user-menu-view-profile-link');
 
     expect(link).toHaveLength(1);
     expect(link.prop('children')).toEqual('View My Profile');
-    expect(link.prop('to')).toEqual('/user/babar/');
+    expect(link.prop('to')).toEqual(`/user/${id}/`);
   });
 
   it('displays an edit profile link when user is signed in', () => {

--- a/tests/unit/amo/components/TestUserProfileEditNotifications.js
+++ b/tests/unit/amo/components/TestUserProfileEditNotifications.js
@@ -47,8 +47,8 @@ describe(__filename, () => {
   });
 
   it(`renders loading notifications when user's notifications are not loaded`, () => {
-    const username = 'johnedoe';
-    const { store } = dispatchSignInActions({ userProps: { username } });
+    const userId = 123;
+    const { store } = dispatchSignInActions({ userId });
     const { users } = store.getState();
 
     const user = getCurrentUser(users);
@@ -59,11 +59,11 @@ describe(__filename, () => {
   });
 
   it(`renders notifications when the user's notifications are loaded`, () => {
-    const username = 'johnedoe';
+    const userId = 123;
     const notifications = createUserNotificationsResponse();
 
-    const { store } = dispatchSignInActions({ userProps: { username } });
-    store.dispatch(loadUserNotifications({ username, notifications }));
+    const { store } = dispatchSignInActions({ userId });
+    store.dispatch(loadUserNotifications({ userId, notifications }));
 
     const { users } = store.getState();
     const user = getCurrentUser(users);
@@ -99,13 +99,13 @@ describe(__filename, () => {
   });
 
   it('does not render a notification if there is no corresponding label', () => {
-    const username = 'johnedoe';
+    const userId = 123;
     const notifications = [
       { name: 'invalid-notification-name', enabled: true, mandatory: false },
     ];
 
-    const { store } = dispatchSignInActions({ userProps: { username } });
-    store.dispatch(loadUserNotifications({ username, notifications }));
+    const { store } = dispatchSignInActions({ userId });
+    store.dispatch(loadUserNotifications({ userId, notifications }));
 
     const { users } = store.getState();
     const user = getCurrentUser(users);

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -314,7 +314,7 @@ describe(__filename, () => {
     );
   });
 
-  it('does not dispatch fetchUserAccount if username does not change', () => {
+  it('does not dispatch fetchUserAccount if userId does not change', () => {
     const { params, store } = signInUserWithUserId(123);
     const dispatchSpy = sinon.spy(store, 'dispatch');
 

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -27,6 +27,7 @@ import AuthenticateButton from 'core/components/AuthenticateButton';
 import { ErrorHandler } from 'core/errorHandler';
 import ErrorList from 'ui/components/ErrorList';
 import Notice from 'ui/components/Notice';
+import LoadingText from 'ui/components/LoadingText';
 import {
   createFakeEvent,
   createFakeHistory,
@@ -1556,6 +1557,32 @@ describe(__filename, () => {
     expect(root.find('.UserProfileEdit-manage-account-link')).toHaveProp(
       'href',
       link,
+    );
+  });
+
+  it('renders without a user loaded when current logged-in user is an admin', () => {
+    const userId = 123;
+    const { store } = signInUserWithProps({
+      userId,
+      permissions: [USERS_EDIT],
+    });
+
+    // Create a user with another ID, but do not load it.
+    const user = createUserAccountResponse({ id: userId + 999 });
+
+    // Try to edit this user with another ID.
+    const params = { userId: user.id };
+    const root = renderUserProfileEdit({ params, store });
+
+    expect(root.find('.UserProfileEdit--Card').at(0)).toHaveProp(
+      'header',
+      'Account',
+    );
+    expect(
+      root.find('.UserProfileEdit-profile-aside').find(LoadingText),
+    ).toHaveLength(2);
+    expect(root.find('.UserProfileEdit--label').find(LoadingText)).toHaveLength(
+      1,
     );
   });
 });

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -149,7 +149,7 @@ describe(__filename, () => {
         // 1. load the user
         reducer(initialState, loadUserAccount({ user })),
         // 2. load their notifications
-        loadUserNotifications({ notifications, username: user.username }),
+        loadUserNotifications({ notifications, userId: user.id }),
       );
 
       expect(prevState.byID[user.id]).toEqual({
@@ -203,7 +203,7 @@ describe(__filename, () => {
         prevState,
         loadUserNotifications({
           notifications,
-          username: user.username,
+          userId: user.id,
         }),
       );
 

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -96,7 +96,7 @@ describe(__filename, () => {
       sagaTester.dispatch(
         fetchUserAccount({
           errorHandlerId: errorHandler.id,
-          username: 'tofumatt',
+          userId: 123,
         }),
       );
 
@@ -116,7 +116,7 @@ describe(__filename, () => {
       sagaTester.dispatch(
         fetchUserAccount({
           errorHandlerId: errorHandler.id,
-          username: 'tofumatt',
+          userId: 123,
         }),
       );
 
@@ -222,8 +222,8 @@ describe(__filename, () => {
     it('can receive a non-empty notifications object (dict) in payload', async () => {
       const state = sagaTester.getState();
 
-      const username = 'babar';
-      const user = createUserAccountResponse({ id: 5001, username });
+      const userId = 5001;
+      const user = createUserAccountResponse({ id: userId, username: 'babar' });
 
       const notifications = {
         reply: false,
@@ -269,7 +269,7 @@ describe(__filename, () => {
 
       const expectedCalledAction = loadUserNotifications({
         notifications: allNotifications,
-        username,
+        userId,
       });
 
       const calledAction = await sagaTester.waitFor(expectedCalledAction.type);
@@ -314,8 +314,8 @@ describe(__filename, () => {
 
       const state = sagaTester.getState();
 
-      const username = 'babar';
-      const user = createUserAccountResponse({ id: 5001, username });
+      const userId = 5001;
+      const user = createUserAccountResponse({ id: userId, username: 'babar' });
 
       // Set the "announcements" notification to false by default.
       const currentNotifications = createUserNotificationsResponse().map(
@@ -380,7 +380,7 @@ describe(__filename, () => {
 
       const expectedCalledAction = loadUserNotifications({
         notifications: newNotifications,
-        username,
+        userId,
       });
 
       const calledAction = await sagaTester.waitFor(expectedCalledAction.type);
@@ -438,9 +438,9 @@ describe(__filename, () => {
 
   describe('fetchUserNotifications', () => {
     it('calls the API to fetch the notifications of a user', async () => {
-      const username = 'tofumatt';
+      const userId = 'tofumatt';
 
-      const user = createUserAccountResponse({ username });
+      const user = createUserAccountResponse({ id: userId });
       sagaTester.dispatch(loadCurrentUserAccount({ user }));
 
       const notifications = createUserNotificationsResponse();
@@ -453,13 +453,13 @@ describe(__filename, () => {
       sagaTester.dispatch(
         fetchUserNotifications({
           errorHandlerId: errorHandler.id,
-          username,
+          userId,
         }),
       );
 
       const expectedCalledAction = loadUserNotifications({
         notifications,
-        username,
+        userId,
       });
 
       const calledAction = await sagaTester.waitFor(expectedCalledAction.type);
@@ -475,7 +475,7 @@ describe(__filename, () => {
       sagaTester.dispatch(
         fetchUserNotifications({
           errorHandlerId: errorHandler.id,
-          username: 'tofumatt',
+          userId: 123,
         }),
       );
 

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -223,7 +223,7 @@ describe(__filename, () => {
       const state = sagaTester.getState();
 
       const userId = 5001;
-      const user = createUserAccountResponse({ id: userId, username: 'babar' });
+      const user = createUserAccountResponse({ id: userId });
 
       const notifications = {
         reply: false,
@@ -315,7 +315,7 @@ describe(__filename, () => {
       const state = sagaTester.getState();
 
       const userId = 5001;
-      const user = createUserAccountResponse({ id: userId, username: 'babar' });
+      const user = createUserAccountResponse({ id: userId });
 
       // Set the "announcements" notification to false by default.
       const currentNotifications = createUserNotificationsResponse().map(
@@ -438,7 +438,7 @@ describe(__filename, () => {
 
   describe('fetchUserNotifications', () => {
     it('calls the API to fetch the notifications of a user', async () => {
-      const userId = 'tofumatt';
+      const userId = 123;
 
       const user = createUserAccountResponse({ id: userId });
       sagaTester.dispatch(loadCurrentUserAccount({ user }));


### PR DESCRIPTION
Fixes #6526 

---

⚠️ ⚠️ ⚠️ This PR does NOT add a server redirect when a user profile page is accessed using a `username` in the URL (i.e. `/user/willdurand/`). We should add a server redirect to load a user profile page by `username` and `301` to the URL with the user ID. I have a patch locally, but this PR is big enough. I filed #6915 for that.