### PR TITLE
Add request ID to Sentry errors

### DIFF
--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -254,11 +254,10 @@ export class AppBase extends React.Component<Props> {
 
             <div className="App-content">
               <div className="App-content-wrapper">
+                <div className="App-banner">
+                  <SurveyNotice location={location} />
+                </div>
                 <ErrorPage getErrorComponent={getErrorComponent}>
-                  <div className="App-banner">
-                    <SurveyNotice location={location} />
-                  </div>
-
                   <Routes />
                 </ErrorPage>
               </div>

--- a/src/core/actions/index.js
+++ b/src/core/actions/index.js
@@ -61,12 +61,12 @@ export function setUserAgent(userAgent: string): SetUserAgentAction {
   };
 }
 
-export type SetRequestId = {|
+export type SetRequestIdAction = {|
   payload: {| requestId: string |},
   type: typeof SET_REQUEST_ID,
 |};
 
-export function setRequestId(requestId: string): SetRequestId {
+export function setRequestId(requestId: string): SetRequestIdAction {
   return {
     type: SET_REQUEST_ID,
     payload: { requestId },

--- a/src/core/actions/index.js
+++ b/src/core/actions/index.js
@@ -3,6 +3,7 @@ import {
   SET_AUTH_TOKEN,
   SET_CLIENT_APP,
   SET_LANG,
+  SET_REQUEST_ID,
   SET_USER_AGENT,
 } from 'core/constants';
 
@@ -57,5 +58,17 @@ export function setUserAgent(userAgent: string): SetUserAgentAction {
   return {
     type: SET_USER_AGENT,
     payload: { userAgent },
+  };
+}
+
+export type SetRequestId = {|
+  payload: {| requestId: string |},
+  type: typeof SET_REQUEST_ID,
+|};
+
+export function setRequestId(requestId: string): SetRequestId {
+  return {
+    type: SET_REQUEST_ID,
+    payload: { requestId },
   };
 }

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -169,6 +169,7 @@ export const SET_CLIENT_APP = 'SET_CLIENT_APP';
 export const SET_ERROR = 'SET_ERROR';
 export const SET_ERROR_MESSAGE = 'SET_ERROR_MESSAGE';
 export const SET_LANG = 'SET_LANG';
+export const SET_REQUEST_ID = 'SET_REQUEST_ID';
 export const SET_USER_AGENT = 'SET_USER_AGENT';
 export const SET_VIEW_CONTEXT = 'SET_VIEW_CONTEXT';
 

--- a/src/core/middleware/requestId.js
+++ b/src/core/middleware/requestId.js
@@ -13,6 +13,8 @@ const requestId = (
   { _httpContext = httpContext }: {| _httpContext: typeof httpContext |} = {},
 ): Middleware => {
   const amoRequestId = req.headers[AMO_REQUEST_ID_HEADER] || uuidv4();
+  // Make sure a request header is always set. This is mainly for Sentry errors.
+  req.headers[AMO_REQUEST_ID_HEADER] = amoRequestId;
 
   _httpContext.set(AMO_REQUEST_ID_HEADER, amoRequestId);
   res.setHeader(AMO_REQUEST_ID_HEADER, amoRequestId);

--- a/src/core/pages/error-simulation/SimulateClientError/styles.scss
+++ b/src/core/pages/error-simulation/SimulateClientError/styles.scss
@@ -4,6 +4,7 @@
   flex-direction: column;
   height: 300px;
   justify-content: center;
+  padding: 0 24px;
 
   .Button {
     margin: 10px;

--- a/src/core/reducers/api.js
+++ b/src/core/reducers/api.js
@@ -14,7 +14,7 @@ import type {
   SetAuthTokenAction,
   SetClientAppAction,
   SetLangAction,
-  SetRequestId,
+  SetRequestIdAction,
   SetUserAgentAction,
 } from 'core/actions/index';
 import type { Exact } from 'core/types/util';
@@ -87,7 +87,7 @@ type Action =
   | SetAuthTokenAction
   | SetLangAction
   | SetClientAppAction
-  | SetRequestId
+  | SetRequestIdAction
   | SetUserAgentAction
   | LogOutUserAction;
 

--- a/src/core/reducers/api.js
+++ b/src/core/reducers/api.js
@@ -6,6 +6,7 @@ import {
   SET_AUTH_TOKEN,
   SET_LANG,
   SET_CLIENT_APP,
+  SET_REQUEST_ID,
   SET_USER_AGENT,
 } from 'core/constants';
 import type { LogOutUserAction } from 'amo/reducers/users';
@@ -13,6 +14,7 @@ import type {
   SetAuthTokenAction,
   SetClientAppAction,
   SetLangAction,
+  SetRequestId,
   SetUserAgentAction,
 } from 'core/actions/index';
 import type { Exact } from 'core/types/util';
@@ -66,6 +68,7 @@ export type ApiState = {
   clientApp: ?string,
   // See config.get('langs') for all possible values.
   lang: ?string,
+  requestId: string | null,
   token: ?string,
   userAgent: ?string,
   userAgentInfo: UserAgentInfoType,
@@ -74,6 +77,7 @@ export type ApiState = {
 export const initialApiState: ApiState = {
   clientApp: null,
   lang: null,
+  requestId: null,
   token: null,
   userAgent: null,
   userAgentInfo: { browser: {}, os: {} },
@@ -83,6 +87,7 @@ type Action =
   | SetAuthTokenAction
   | SetLangAction
   | SetClientAppAction
+  | SetRequestId
   | SetUserAgentAction
   | LogOutUserAction;
 
@@ -100,6 +105,8 @@ export default function api(
       return { ...state, lang: action.payload.lang };
     case SET_CLIENT_APP:
       return { ...state, clientApp: action.payload.clientApp };
+    case SET_REQUEST_ID:
+      return { ...state, requestId: action.payload.requestId };
     case SET_USER_AGENT: {
       const { browser, os } = UAParser(action.payload.userAgent);
 

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -20,6 +20,7 @@ import WebpackIsomorphicTools from 'webpack-isomorphic-tools';
 import log from 'core/logger';
 import { createApiError } from 'core/api';
 import Root from 'core/components/Root';
+import { AMO_REQUEST_ID_HEADER } from 'core/constants';
 import ServerHtml from 'core/components/ServerHtml';
 import * as middleware from 'core/middleware';
 import requestId from 'core/middleware/requestId';
@@ -31,6 +32,7 @@ import {
   setAuthToken,
   setClientApp,
   setLang,
+  setRequestId,
   setUserAgent,
 } from 'core/actions';
 import {
@@ -298,6 +300,11 @@ function baseServer(
 
       let pageProps;
       let runningSagas;
+
+      const thisRequestId = res.get(AMO_REQUEST_ID_HEADER);
+      if (thisRequestId) {
+        store.dispatch(setRequestId(thisRequestId));
+      }
 
       try {
         let sagas = appSagas;

--- a/tests/unit/core/reducers/test_api.js
+++ b/tests/unit/core/reducers/test_api.js
@@ -102,4 +102,11 @@ describe(__filename, () => {
       expect(setAndReduceToken(token)).toHaveProperty('token', token);
     });
   });
+
+  describe('setRequestId', () => {
+    const requestId = 'uuid4-set-by-middleware';
+    const state = api(undefined, actions.setRequestId(requestId));
+
+    expect(state.requestId).toEqual(requestId);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6908 and fixes some style issues on error pages.

The client side Sentry reporter will contain a request ID tag now:

<img width="645" alt="screenshot 2018-11-13 14 40 54" src="https://user-images.githubusercontent.com/55398/48442154-fb0bf700-e752-11e8-8291-3c35c893c3b5.png">

I couldn't think of a way to add this tag to the server side reporter. The best idea I had was to ensure that a request header is set. It seems to work:

<img width="483" alt="screenshot 2018-11-13 14 41 22" src="https://user-images.githubusercontent.com/55398/48442123-dfa0ec00-e752-11e8-9f49-34226eae41d9.png">

The downside is that we'd have to remember to check the request header (not the tag) when viewing server errors.