### PR TITLE
Add lint rule to prevent logging objects

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,7 +49,11 @@
     "indent": "off",
     "no-mixed-operators": "off",
     "operator-linebreak": "off",
-    "react/jsx-one-expression-per-line": "off"
+    "react/jsx-one-expression-per-line": "off",
+    // We omit `debug` because we don't turn that on by default.
+    "amo/only-log-strings": ["error", {
+      "methods": ["fatal", "info", "error", "warn"]
+    }]
   },
   "settings": {
     "import/ignore": [

--- a/bin/start-func-test-server.js
+++ b/bin/start-func-test-server.js
@@ -1,5 +1,5 @@
 /* @flow */
-/* eslint-disable no-console */
+/* eslint-disable no-console, amo/only-log-strings */
 // This starts a docker server for functional tests to access.
 // The script waits for the server to start and prints some logs
 // to help with debugging.

--- a/bin/webpack-dev-server.js
+++ b/bin/webpack-dev-server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-/* eslint-disable strict, no-console */
+/* eslint-disable strict, no-console, amo/only-log-strings */
 
 require('babel-register');
 const https = require('https');

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "enzyme-adapter-react-16": "^1.5.0",
     "eslint": "^5.3.0",
     "eslint-config-amo": "^1.8.3",
-    "eslint-plugin-amo": "^1.7.0",
+    "eslint-plugin-amo": "^1.9.0",
     "eslint-plugin-promise": "^4.0.0",
     "file-loader": "^2.0.0",
     "flow-bin": "^0.86.0",

--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "enzyme-adapter-react-16": "^1.5.0",
     "eslint": "^5.3.0",
     "eslint-config-amo": "^1.8.3",
-    "eslint-plugin-amo": "^1.9.0",
+    "eslint-plugin-amo": "^1.9.1",
     "eslint-plugin-promise": "^4.0.0",
     "file-loader": "^2.0.0",
     "flow-bin": "^0.86.0",

--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -87,11 +87,10 @@ export class AddonCompatibilityErrorBase extends React.Component {
         },
       );
     } else {
-      // This is an unknown reason code and a custom error message should
-      // be added.
+      // This is an unknown reason code and a custom error message should be
+      // added.
       log.warn(
-        'Unknown reason code supplied to AddonCompatibilityError',
-        reason,
+        `Unknown reason code supplied to AddonCompatibilityError: ${reason}`,
       );
 
       message = i18n.sprintf(

--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -77,7 +77,6 @@ export class PermissionUtils {
     });
 
     if (!file) {
-      // eslint-disable-next-line amo/only-log-strings
       log.debug(
         `No file exists for os "${userAgentInfo.os.toString()}"; platform files:`,
         platformFiles,

--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -77,6 +77,7 @@ export class PermissionUtils {
     });
 
     if (!file) {
+      // eslint-disable-next-line amo/only-log-strings
       log.debug(
         `No file exists for os "${userAgentInfo.os.toString()}"; platform files:`,
         platformFiles,

--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -198,7 +198,7 @@ export class SearchBase extends React.Component<InternalProps> {
     } = this.props;
 
     if (errorHandler.hasError()) {
-      log.warn('Captured API Error:', errorHandler.capturedError);
+      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -198,7 +198,7 @@ export class SearchBase extends React.Component<InternalProps> {
     } = this.props;
 
     if (errorHandler.hasError()) {
-      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
+      log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -421,7 +421,7 @@ export class AddonBase extends React.Component {
     const isThemeType = addon && isTheme(addon.type);
     let errorBanner = null;
     if (errorHandler.hasError()) {
-      log.warn('Captured API Error:', errorHandler.capturedError);
+      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
 
       // 401 and 403 are made to look like a 404 on purpose.
       // See: https://github.com/mozilla/addons-frontend/issues/3061.

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -421,7 +421,7 @@ export class AddonBase extends React.Component {
     const isThemeType = addon && isTheme(addon.type);
     let errorBanner = null;
     if (errorHandler.hasError()) {
-      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
+      log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
 
       // 401 and 403 are made to look like a 404 on purpose.
       // See: https://github.com/mozilla/addons-frontend/issues/3061.

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -211,7 +211,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     } = this.props;
 
     if (errorHandler.hasError()) {
-      log.warn('Captured API Error:', errorHandler.capturedError);
+      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
       // The following code attempts to recover from a 401 returned
       // by fetchAddon() but may accidentally catch a 401 from
       // fetchReviews(). Oh well.

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -211,7 +211,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     } = this.props;
 
     if (errorHandler.hasError()) {
-      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
+      log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
       // The following code attempts to recover from a 401 returned
       // by fetchAddon() but may accidentally catch a 401 from
       // fetchReviews(). Oh well.

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -516,7 +516,7 @@ export class CollectionBase extends React.Component<InternalProps> {
     const { collection, errorHandler } = this.props;
 
     if (errorHandler.hasError()) {
-      log.warn('Captured API Error:', errorHandler.capturedError);
+      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -516,7 +516,7 @@ export class CollectionBase extends React.Component<InternalProps> {
     const { collection, errorHandler } = this.props;
 
     if (errorHandler.hasError()) {
-      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
+      log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -277,7 +277,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
 
     let errorMessage;
     if (errorHandler.hasError()) {
-      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
+      log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -277,7 +277,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
 
     let errorMessage;
     if (errorHandler.hasError()) {
-      log.warn('Captured API Error:', errorHandler.capturedError);
+      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -430,7 +430,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
     let errorMessage;
     if (errorHandler.hasError()) {
-      log.warn('Captured API Error:', errorHandler.capturedError);
+      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -430,7 +430,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
     let errorMessage;
     if (errorHandler.hasError()) {
-      log.warn(`Captured API Error: ${errorHandler.capturedError}`);
+      log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
 
       if (errorHandler.capturedError.responseStatusCode === 404) {
         return <NotFound errorCode={errorHandler.capturedError.code} />;

--- a/src/amo/sagas/categories.js
+++ b/src/amo/sagas/categories.js
@@ -19,7 +19,7 @@ export function* fetchCategories({ payload: { errorHandlerId } }) {
 
     yield put(categoriesLoad({ results }));
   } catch (error) {
-    log.warn('Categories failed to load:', error);
+    log.warn(`Categories failed to load: ${error}`);
     yield put(errorHandler.createErrorAction(error));
   }
 }

--- a/src/amo/sagas/guides.js
+++ b/src/amo/sagas/guides.js
@@ -29,7 +29,7 @@ export function* fetchGuidesAddons({
     const { results } = yield call(searchApi, params);
     yield put(loadAddonResults({ addons: results }));
   } catch (error) {
-    log.warn('Search for guide addons failed:', error);
+    log.warn(`Search for guide addons failed: ${error}`);
     yield put(errorHandler.createErrorAction(error));
   }
 }

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -92,7 +92,9 @@ export function getAddon(
       if (!addon) {
         throw new Error('Addon not found');
       }
-      log.info('Add-on found', addon);
+      // eslint-disable-next-line amo/only-log-strings
+      log.debug('Add-on found', addon);
+
       return addon;
     });
   }
@@ -170,6 +172,7 @@ export function addChangeListeners(
   function handleChangeEvent(e: AddonChangeEvent) {
     const { id: guid, type, needsRestart } = e;
 
+    // eslint-disable-next-line amo/only-log-strings
     _log.info('Event received', { type, id: guid, needsRestart });
 
     if (type === ON_OPERATION_CANCELLED_EVENT) {
@@ -185,6 +188,7 @@ export function addChangeListeners(
           });
         })
         .catch((error) => {
+          // eslint-disable-next-line amo/only-log-strings
           _log.error(
             'Unexpected error after having received onOperationCancelled event',
             error,

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -92,7 +92,6 @@ export function getAddon(
       if (!addon) {
         throw new Error('Addon not found');
       }
-      // eslint-disable-next-line amo/only-log-strings
       log.debug('Add-on found', addon);
 
       return addon;

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -184,6 +184,7 @@ export function callApi({
       }
 
       return response.text().then((text) => {
+        // eslint-disable-next-line amo/only-log-strings
         _log.warn(
           oneLine`Response from API was not JSON (was Content-Type:
             ${contentType || '[unknown]'})`,

--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -137,6 +137,7 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
 
     const installURL = event.currentTarget.href;
 
+    // eslint-disable-next-line amo/only-log-strings
     _log.info('Adding OpenSearch Provider', { addon });
     _window.external.AddSearchProvider(installURL);
 

--- a/src/core/components/ErrorPage/index.js
+++ b/src/core/components/ErrorPage/index.js
@@ -32,6 +32,7 @@ export class ErrorPageBase extends React.Component<InternalProps> {
     const { dispatch } = this.props;
 
     dispatch(loadErrorPage({ error }));
+    // eslint-disable-next-line amo/only-log-strings
     log.error('Caught application error:', error, info);
   }
 

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -191,7 +191,6 @@ export const findInstallURL = ({
 
   if (!installURL) {
     // This could happen for themes which do not have version files.
-    // eslint-disable-next-line amo/only-log-strings
     log.debug(
       oneLine`No file exists for os "${userAgentInfo.os.toString()}"; platform files:`,
       platformFiles,

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -191,6 +191,7 @@ export const findInstallURL = ({
 
   if (!installURL) {
     // This could happen for themes which do not have version files.
+    // eslint-disable-next-line amo/only-log-strings
     log.debug(
       oneLine`No file exists for os "${userAgentInfo.os.toString()}"; platform files:`,
       platformFiles,
@@ -287,6 +288,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
 
       return clientAddon.isEnabled;
     } catch (error) {
+      // eslint-disable-next-line amo/only-log-strings
       _log.error('could not determine whether the add-on was enabled', error);
     }
 
@@ -392,6 +394,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
         if (err && err.message === SET_ENABLE_NOT_AVAILABLE) {
           _log.info(`addon.setEnabled not available. Unable to enable ${guid}`);
         } else {
+          // eslint-disable-next-line amo/only-log-strings
           _log.error(`Error while trying to enable ${guid}:`, err);
 
           dispatch(

--- a/src/core/middleware/datadogTiming.js
+++ b/src/core/middleware/datadogTiming.js
@@ -22,6 +22,7 @@ export const datadogTiming = ({
     // Log an error to Sentry.
     _log.error(`DataDog client socket error: ${error}`);
     // Log the full stack trace too:
+    // eslint-disable-next-line amo/only-log-strings
     _log.error({ err: error });
   });
 

--- a/src/core/middleware/prefixMiddleware.js
+++ b/src/core/middleware/prefixMiddleware.js
@@ -13,7 +13,6 @@ import log from 'core/logger';
 export function prefixMiddleware(req, res, next, { _config = config } = {}) {
   // Split on slashes after removing the leading slash.
   const URLParts = req.originalUrl.replace(/^\//, '').split('/');
-  log.debug(URLParts);
 
   // Get lang and app parts from the URL. At this stage they may be incorrect
   // or missing.

--- a/src/core/middleware/trailingSlash.js
+++ b/src/core/middleware/trailingSlash.js
@@ -40,8 +40,7 @@ export function trailingSlashesMiddleware(
 
   if (isValidTrailingSlashUrlException(urlToCheck, { _config })) {
     log.info(
-      'Not adding a trailing slash; validTrailingSlashUrlException found',
-      urlToCheck,
+      `Not adding a trailing slash; validTrailingSlashUrlException found: ${urlToCheck}`,
     );
   }
 

--- a/src/core/reducers/categories.js
+++ b/src/core/reducers/categories.js
@@ -36,7 +36,7 @@ export default function categories(state = initialState, action) {
       Object.values(payload.results).forEach((category) => {
         // This category has no data, so skip it.
         if (!category || !category.application) {
-          log.warn('category or category.application was false-y.', category);
+          log.warn(`category or category.application was false-y: ${category}`);
           return;
         }
 

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -22,8 +22,7 @@ function getMessagesFromError(error) {
     code: ERROR_UNKNOWN,
     messages: [],
   };
-  // eslint-disable-next-line amo/only-log-strings
-  log.info('Extracting messages from error object:', error);
+  log.debug('Extracting messages from error object:', error);
 
   const logCodeChange = ({ oldCode, newCode }) => {
     log.warn(`Replacing error code ${oldCode} with ${newCode}`);

--- a/src/core/reducers/errors.js
+++ b/src/core/reducers/errors.js
@@ -22,6 +22,7 @@ function getMessagesFromError(error) {
     code: ERROR_UNKNOWN,
     messages: [],
   };
+  // eslint-disable-next-line amo/only-log-strings
   log.info('Extracting messages from error object:', error);
 
   const logCodeChange = ({ oldCode, newCode }) => {
@@ -69,7 +70,7 @@ function getMessagesFromError(error) {
   }
 
   if (!errorData.messages.length) {
-    log.warn('Error object did not contain any messages', error);
+    log.warn(`Error object did not contain any messages: ${error}`);
   }
 
   return errorData;

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -428,6 +428,7 @@ function baseServer(
       }
 
       _log.error(`Showing 500 page for error: ${error}`);
+      // eslint-disable-next-line amo/only-log-strings
       _log.error(error); // log the stack trace too.
 
       return showErrorPage({
@@ -442,6 +443,7 @@ function baseServer(
     } catch (recoveryError) {
       _log.error(oneLine`Additionally, the error handler caught an error:
         ${recoveryError}`);
+      // eslint-disable-next-line amo/only-log-strings
       _log.error(recoveryError); // log the stack trace too.
 
       // Pass the original error to the next error handler.
@@ -516,6 +518,7 @@ export function runServer({
             }
             const proxyEnabled = convertBoolean(config.get('proxyEnabled'));
             // Not using oneLine here since it seems to change '  ' to ' '.
+            // eslint-disable-next-line amo/only-log-strings
             log.info(
               [
                 `🔥  Addons-frontend server is running`,
@@ -551,7 +554,9 @@ export function runServer({
       });
     })
     .catch((err) => {
+      // eslint-disable-next-line amo/only-log-strings
       log.error({ err });
+
       if (exitProcess) {
         process.exit(1);
       } else {

--- a/src/core/store.js
+++ b/src/core/store.js
@@ -6,7 +6,7 @@ import { createLogger } from 'redux-logger';
 import log from 'core/logger';
 
 export const minimalReduxLogger = () => (next) => (action) => {
-  log.info('Dispatching', action.type);
+  log.info(`Dispatching ${action.type}`);
   return next(action);
 };
 

--- a/src/core/tracking.js
+++ b/src/core/tracking.js
@@ -158,6 +158,7 @@ export class Tracking {
         this.log(logHctReason);
         return hybridContentTelemetry;
       } catch (err) {
+        // eslint-disable-next-line amo/only-log-strings
         log.error('Initialization failed', err);
       }
     }
@@ -167,6 +168,7 @@ export class Tracking {
 
   log(...args) {
     if (this._log) {
+      // eslint-disable-next-line amo/only-log-strings
       this._log.info(this.logPrefix, ...args);
     }
   }

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -61,7 +61,9 @@ export function getCompatibleVersions({
     }
 
     if (!supportsClientApp) {
-      _log.warn('addon is incompatible with clientApp', { addon, clientApp });
+      _log.warn(
+        `addon "${addon.guid}" is incompatible with clientApp: "${clientApp}"`,
+      );
     }
   }
 
@@ -151,11 +153,9 @@ export function isCompatibleWithUserAgent({
   // first.
   if (minVersion && mozCompare(browser.version, minVersion) === -1) {
     if (minVersion === '*') {
-      _log.error(
-        oneLine`minVersion of "*" was passed to isCompatibleWithUserAgent();
-        bad add-on version data`,
-        { browserVersion: browser.version, minVersion },
-      );
+      _log.error(oneLine`minVersion of "*" was passed to
+        isCompatibleWithUserAgent(); bad add-on version data (browserVersion:
+        ${browser.version})`);
     }
 
     // `minVersion` is always respected, regardless of

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -61,9 +61,8 @@ export function getCompatibleVersions({
     }
 
     if (!supportsClientApp) {
-      _log.warn(
-        `addon "${addon.guid}" is incompatible with clientApp: "${clientApp}"`,
-      );
+      _log.warn(oneLine`addon guid: "${addon.guid}" is incompatible with
+        clientApp: "${clientApp}"`);
     }
   }
 

--- a/src/disco/tracking.js
+++ b/src/disco/tracking.js
@@ -21,6 +21,7 @@ export default function getInstallData({ _window = window } = {}) {
         .replace(/^#/, '');
       jsonData = JSON.parse(hash);
     } catch (e) {
+      // eslint-disable-next-line amo/only-log-strings
       log.error(e);
     }
   }

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -108,6 +108,7 @@ export class DismissibleTextFormBase extends React.Component<
   async checkForStoredState() {
     const storedState: State | null = await this.localState.load();
     if (storedState) {
+      // eslint-disable-next-line amo/only-log-strings
       log.debug(
         oneLine`Initializing DismissibleTextForm state from LocalState
           ${this.localState.id}`,

--- a/src/ui/components/DismissibleTextForm/index.js
+++ b/src/ui/components/DismissibleTextForm/index.js
@@ -108,7 +108,6 @@ export class DismissibleTextFormBase extends React.Component<
   async checkForStoredState() {
     const storedState: State | null = await this.localState.load();
     if (storedState) {
-      // eslint-disable-next-line amo/only-log-strings
       log.debug(
         oneLine`Initializing DismissibleTextForm state from LocalState
           ${this.localState.id}`,

--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -56,7 +56,7 @@ export class RatingBase extends React.Component<InternalProps, StateType> {
     event.stopPropagation();
     const button = event.currentTarget;
     const rating = parseInt(button.value, 10);
-    log.debug('Selected rating from form button:', rating);
+    log.debug(`Selected rating from form button: ${rating}`);
 
     if (!this.props.onSelectRating) {
       throw new Error(

--- a/tests/jest-reporters/flow-check.js
+++ b/tests/jest-reporters/flow-check.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, amo/only-log-strings */
 const { spawn } = require('child_process');
 
 const pathToFlowBin = require('flow-bin');

--- a/tests/unit/amo/components/TestAddonCompatibilityError.js
+++ b/tests/unit/amo/components/TestAddonCompatibilityError.js
@@ -223,15 +223,13 @@ describe(__filename, () => {
   it('renders a notice and logs warning when reason code not known', () => {
     _dispatchClientMetadata();
     const fakeLog = getFakeLogger();
-    const root = render({
-      log: fakeLog,
-      reason: 'fake reason',
-    });
+    const reason = 'fake reason';
+
+    const root = render({ log: fakeLog, reason });
 
     sinon.assert.calledWith(
       fakeLog.warn,
-      'Unknown reason code supplied to AddonCompatibilityError',
-      'fake reason',
+      `Unknown reason code supplied to AddonCompatibilityError: ${reason}`,
     );
     expect(
       root

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -1,7 +1,6 @@
 import UAParser from 'ua-parser-js';
 
 import {
-  ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
@@ -387,7 +386,7 @@ describe(__filename, () => {
         compatibility: {},
       });
 
-      const { maxVersion, minVersion } = getCompatibleVersions({
+      const { maxVersion, minVersion } = _getCompatibleVersions({
         clientApp: CLIENT_APP_FIREFOX,
         currentVersion,
       });
@@ -401,7 +400,7 @@ describe(__filename, () => {
         maxVersion,
         minVersion,
         supportsClientApp,
-      } = getCompatibleVersions({
+      } = _getCompatibleVersions({
         clientApp: CLIENT_APP_FIREFOX,
         currentVersion: null,
       });
@@ -412,18 +411,13 @@ describe(__filename, () => {
     });
 
     it('marks clientApp as unsupported without compatibility', () => {
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_EXTENSION,
-      });
       const currentVersion = createInternalVersion({
         ...fakeVersion,
         // This add-on is not compatible with any client apps.
         compatibility: {},
       });
 
-      const { supportsClientApp } = getCompatibleVersions({
-        addon,
+      const { supportsClientApp } = _getCompatibleVersions({
         currentVersion,
         clientApp: CLIENT_APP_FIREFOX,
       });
@@ -433,10 +427,6 @@ describe(__filename, () => {
 
     it('marks clientApp as supported with compatibility', () => {
       const clientApp = CLIENT_APP_ANDROID;
-      const addon = createInternalAddon({
-        ...fakeAddon,
-        type: ADDON_TYPE_EXTENSION,
-      });
       const currentVersion = createInternalVersion({
         ...fakeVersion,
         compatibility: {
@@ -447,8 +437,7 @@ describe(__filename, () => {
         },
       });
 
-      const { supportsClientApp } = getCompatibleVersions({
-        addon,
+      const { supportsClientApp } = _getCompatibleVersions({
         clientApp,
         currentVersion,
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4861,10 +4861,10 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-amo@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-amo/-/eslint-plugin-amo-1.7.0.tgz#5de5d2e1dae8648c733116039c949624bddb40ed"
-  integrity sha512-w/Tz6lLE65RqGrMTGvWw2k4wNy8Sw/T3Z/IddVJpu+MkHm8aNF54ZP2hgQ5vEuP+w8OGi2oGbynioXDJ0MMx9Q==
+eslint-plugin-amo@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-amo/-/eslint-plugin-amo-1.9.0.tgz#c20784fe4d11ecfd8ed5ad83147e5a966777fbae"
+  integrity sha512-ud9heoDI25xZ2yPcdpOaQ4wY07H1ICdMZLBlz4cuUqENZXaLEN0s7//3be7vAhESfaIZ8HsYT5DmbGRSQShMKg==
   dependencies:
     requireindex "~1.1.0"
     string-natural-compare "^2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4861,10 +4861,10 @@ eslint-module-utils@^2.2.0:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-amo@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-amo/-/eslint-plugin-amo-1.9.0.tgz#c20784fe4d11ecfd8ed5ad83147e5a966777fbae"
-  integrity sha512-ud9heoDI25xZ2yPcdpOaQ4wY07H1ICdMZLBlz4cuUqENZXaLEN0s7//3be7vAhESfaIZ8HsYT5DmbGRSQShMKg==
+eslint-plugin-amo@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-amo/-/eslint-plugin-amo-1.9.1.tgz#f2dfe24a0ab5b6a9e8934bbe05729a859bfd245f"
+  integrity sha512-2yvFS/jI+AV8rafT+TY0ntsAItvWF3BnpPMc2QSGNuYh8sfs7R1+1RNR1cf4KkyLuHVM9qZjVToTuwTcobzhcA==
   dependencies:
     requireindex "~1.1.0"
     string-natural-compare "^2.0.2"


### PR DESCRIPTION
Fixes #6512

---

The  lint rule has been added to https://github.com/mozilla/eslint-plugin-amo#only-log-strings. I reviewed each error and tried to fix it in an appropriate manner. We can probably change some fixes. Let's discuss them here.