### PR TITLE
Redirect user profile pages

### DIFF
--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -196,7 +196,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
 
     invariant(currentUser, 'currentUser is required');
 
-    if (`${currentUser.id}` === params.userId) {
+    if (String(currentUser.id) === params.userId) {
       return `/users/edit`;
     }
 

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -722,6 +722,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
               </p>
 
               <UserProfileEditNotifications
+                key={user && user.id}
                 onChange={this.onNotificationChange}
                 user={user}
               />

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -362,7 +362,7 @@ export const loadUserNotifications = ({
 };
 
 export const getUserById = (users: UsersState, userId: UserId) => {
-  invariant(userId, 'userId is required');
+  invariant(typeof userId === 'number', 'userId is required');
   return users.byID[userId];
 };
 

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -22,9 +22,11 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
   ADMIN_TOOLS,
+  CLIENT_APP_FIREFOX,
   USERS_EDIT,
 } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
+import { sendServerRedirect } from 'core/reducers/redirectTo';
 import ErrorList from 'ui/components/ErrorList';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
@@ -67,7 +69,7 @@ describe(__filename, () => {
   function renderUserProfile({
     i18n = fakeI18n(),
     location = createFakeLocation(),
-    params = { userId: 100 },
+    params = { userId: '100' },
     store = dispatchSignInActions({ userId: 100 }).store,
     ...props
   } = {}) {
@@ -1027,6 +1029,32 @@ describe(__filename, () => {
     const root = renderUserProfile({ params: { userId: 1234 } });
 
     expect(root.find('meta[name="description"]')).toHaveLength(0);
+  });
+
+  it('sends a server redirect when user profile is loaded with a "username" in the URL', () => {
+    const clientApp = CLIENT_APP_FIREFOX;
+    const lang = 'fr';
+    const userId = 1;
+    const { store } = dispatchSignInActions({ clientApp, lang, userId });
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    // Create a user with another userId.
+    const anotherUserId = 222;
+    const user = createUserAccountResponse({ id: anotherUserId });
+    store.dispatch(loadUserAccount({ user }));
+
+    dispatchSpy.resetHistory();
+
+    renderUserProfile({ params: { userId: user.name }, store });
+
+    sinon.assert.calledWith(
+      dispatchSpy,
+      sendServerRedirect({
+        status: 301,
+        url: `/${lang}/${clientApp}/user/${anotherUserId}/`,
+      }),
+    );
+    sinon.assert.calledOnce(dispatchSpy);
   });
 
   describe('errorHandler - extractId', () => {

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -376,6 +376,16 @@ describe(__filename, () => {
 
       expect(getUserById(state.users, 441)).toBeUndefined();
     });
+
+    it('does not throw when userId is 0', () => {
+      const { state } = dispatchSignInActions({
+        userProps: { id: 500, username: 'Tupac' },
+      });
+
+      expect(() => {
+        getUserById(state.users, 0);
+      }).not.toThrow();
+    });
   });
 
   describe('getUserByUsername selector', () => {


### PR DESCRIPTION
Fixes #6915
~~:warning: depends on #6904~~

---

This PR allows to keep backward compatibility with the previous URL scheme. User profiles loaded _via_ the `username` in the URL will be redirected to the URL with the user ID.

I double checked with product: we do not need to setup a redirect for the "edit" pages (private pages).

I also inlined a few comments for context. There is #6769 for the `componentWillReceiveProps()` but the logic in this component is tough...