### PR TITLE
Create and use a `UserProfileHead` component

### DIFF
--- a/src/amo/components/HeadLinks/index.js
+++ b/src/amo/components/HeadLinks/index.js
@@ -9,7 +9,9 @@ import { getCanonicalURL } from 'amo/utils';
 import { hrefLangs } from 'core/languages';
 import type { AppState } from 'amo/store';
 
-type Props = {||};
+type Props = {|
+  queryString?: string,
+|};
 
 type InternalProps = {|
   ...Props,
@@ -33,13 +35,14 @@ export class HeadLinksBase extends React.PureComponent<InternalProps> {
       currentURL,
       lang,
       locationPathname,
+      queryString,
     } = this.props;
 
     const pathWithoutLocale = locationPathname
       .split('/')
       .slice(2)
       .join('/');
-    const canonicalURL = `/${lang}/${pathWithoutLocale}`;
+    const canonicalURL = `/${lang}/${pathWithoutLocale}${queryString || ''}`;
 
     const hrefLangsMap = _config.get('hrefLangsMap');
     const includeAlternateLinks =
@@ -62,7 +65,7 @@ export class HeadLinksBase extends React.PureComponent<InternalProps> {
               <link
                 href={getCanonicalURL({
                   _config,
-                  locationPathname: alternateURL,
+                  locationPathname: `${alternateURL}${queryString || ''}`,
                 })}
                 hrefLang={hrefLang}
                 key={hrefLang}

--- a/src/amo/components/HeadMetaTags/index.js
+++ b/src/amo/components/HeadMetaTags/index.js
@@ -13,12 +13,13 @@ import type { I18nType } from 'core/types/i18n';
 
 import defaultImage from './img/default-og-image.png';
 
-type Props = {|
+export type Props = {|
   appendDefaultTitle?: boolean,
   date?: Date | null,
   description?: string | null,
   image?: string | null,
   lastModified?: Date | null,
+  queryString?: string,
   title?: string | null,
 |};
 
@@ -80,15 +81,22 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
   }
 
   renderOpenGraph() {
-    const { _config, description, lang, locationPathname } = this.props;
+    const {
+      _config,
+      description,
+      lang,
+      locationPathname,
+      queryString,
+    } = this.props;
+
+    const url = `${getCanonicalURL({
+      _config,
+      locationPathname,
+    })}${queryString || ''}`;
 
     const tags = [
       <meta key="og:type" property="og:type" content="website" />,
-      <meta
-        key="og:url"
-        property="og:url"
-        content={getCanonicalURL({ _config, locationPathname })}
-      />,
+      <meta key="og:url" property="og:url" content={url} />,
       <meta key="og:title" property="og:title" content={this.getTitle()} />,
       <meta key="og:locale" property="og:locale" content={lang} />,
       <meta key="og:image" property="og:image" content={this.getImage()} />,

--- a/src/amo/components/UserProfileHead/index.js
+++ b/src/amo/components/UserProfileHead/index.js
@@ -1,0 +1,84 @@
+/* @flow */
+/* eslint camelcase: 0 */
+import * as React from 'react';
+import { withRouter } from 'react-router-dom';
+import Helmet from 'react-helmet';
+
+import HeadLinks from 'amo/components/HeadLinks';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
+import type { Props as HeadMetaTagsProps } from 'amo/components/HeadMetaTags';
+import type { ReactRouterLocationType } from 'core/types/router';
+
+type Props = {|
+  ...HeadMetaTagsProps,
+|};
+
+type InternalProps = {|
+  ...Props,
+  location: ReactRouterLocationType,
+|};
+
+export class UserProfileHeadBase extends React.Component<InternalProps> {
+  computeQueryString() {
+    const { query, search } = this.props.location;
+
+    // `page_e` and `page_t` are defined in the `UserProfile` component.
+    let page_e = Number(query.page_e);
+    let page_t = Number(query.page_t);
+
+    // We don't want to return a query string when values are '1'.
+    if (page_e === 1) {
+      page_e = null;
+    }
+
+    if (page_t === 1) {
+      page_t = null;
+    }
+
+    let queryString = '';
+    if (page_e && page_t) {
+      // When both parameters are provided, we take the one with the highest
+      // value. When both values are equal, we must respect the order in the
+      // query string.
+      if (page_e > page_t) {
+        queryString = `?page_e=${page_e}`;
+      } else if (page_e < page_t) {
+        queryString = `?page_t=${page_t}`;
+      } else if (search.indexOf('page_e') > search.indexOf('page_t')) {
+        queryString = `?page_t=${page_t}`;
+      } else {
+        queryString = `?page_e=${page_e}`;
+      }
+    } else if (page_e) {
+      queryString = `?page_e=${page_e}`;
+    } else if (page_t) {
+      queryString = `?page_t=${page_t}`;
+    }
+
+    return queryString;
+  }
+
+  render() {
+    const { location, ...props } = this.props;
+
+    const queryString = this.computeQueryString();
+
+    return (
+      <React.Fragment>
+        <Helmet>
+          <title>{props.title}</title>
+        </Helmet>
+
+        <HeadMetaTags {...props} queryString={queryString} />
+
+        <HeadLinks queryString={queryString} />
+      </React.Fragment>
+    );
+  }
+}
+
+const UserProfileHead: React.ComponentType<Props> = withRouter(
+  UserProfileHeadBase,
+);
+
+export default UserProfileHead;

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 import invariant from 'invariant';
 import * as React from 'react';
-import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
@@ -10,6 +9,7 @@ import AddonsByAuthorsCard from 'amo/components/AddonsByAuthorsCard';
 import AddonReviewCard from 'amo/components/AddonReviewCard';
 import Link from 'amo/components/Link';
 import NotFound from 'amo/components/ErrorPage/NotFound';
+import UserProfileHead from 'amo/components/UserProfileHead';
 import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import {
   EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
@@ -256,7 +256,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
     );
   }
 
-  renderMetaDescription() {
+  getMetaDescription() {
     const { i18n, user } = this.props;
 
     if (!user) {
@@ -280,12 +280,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
       return null;
     }
 
-    return (
-      <meta
-        name="description"
-        content={i18n.sprintf(description, { user: user.display_name })}
-      />
-    );
+    return i18n.sprintf(description, { user: user.display_name });
   }
 
   render() {
@@ -344,10 +339,10 @@ export class UserProfileBase extends React.Component<InternalProps> {
 
     return (
       <div className="UserProfile">
-        <Helmet>
-          <title>{userProfileTitle}</title>
-          {this.renderMetaDescription()}
-        </Helmet>
+        <UserProfileHead
+          title={userProfileTitle}
+          description={this.getMetaDescription()}
+        />
 
         {errorMessage}
 

--- a/tests/unit/amo/components/TestHeadLinks.js
+++ b/tests/unit/amo/components/TestHeadLinks.js
@@ -175,4 +175,32 @@ describe(__filename, () => {
 
     expect(root.find('link[rel="alternate"]')).toHaveLength(0);
   });
+
+  it('accepts a queryString prop that is added to the URLs', () => {
+    const baseURL = 'https://example.org';
+    const clientApp = CLIENT_APP_FIREFOX;
+    const lang = 'de';
+    const to = '/some-canonical-url';
+    const queryString = '?foo=bar';
+
+    const _config = getFakeConfig({ baseURL });
+    const { store } = dispatchClientMetadata({
+      clientApp,
+      lang,
+      pathname: `/${lang}/${clientApp}${to}`,
+      search: queryString,
+    });
+
+    const root = render({ _config, store, queryString });
+
+    expect(root.find('link[rel="canonical"]')).toHaveLength(1);
+    expect(root.find('link[rel="canonical"]')).toHaveProp(
+      'href',
+      `${baseURL}/${lang}/${clientApp}${to}${queryString}`,
+    );
+    expect(root.find(`link[hrefLang="${lang}"]`)).toHaveProp(
+      'href',
+      `${baseURL}/${lang}/${clientApp}${to}${queryString}`,
+    );
+  });
 });

--- a/tests/unit/amo/components/TestUserProfileHead.js
+++ b/tests/unit/amo/components/TestUserProfileHead.js
@@ -1,0 +1,94 @@
+import * as React from 'react';
+
+import HeadLinks from 'amo/components/HeadLinks';
+import UserProfileHead, {
+  UserProfileHeadBase,
+} from 'amo/components/UserProfileHead';
+import HeadMetaTags from 'amo/components/HeadMetaTags';
+import {
+  createContextWithFakeRouter,
+  createFakeLocation,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  const render = ({ location = createFakeLocation(), ...props } = {}) => {
+    return shallowUntilTarget(
+      <UserProfileHead {...props} />,
+      UserProfileHeadBase,
+      {
+        shallowOptions: createContextWithFakeRouter({ location }),
+      },
+    );
+  };
+
+  it('renders an HTML title', () => {
+    const title = 'some user';
+    const root = render({ title });
+
+    expect(root.find('title')).toHaveLength(1);
+    expect(root.find('title')).toHaveText(title);
+  });
+
+  it('renders a HeadMetaTags component', () => {
+    const root = render();
+
+    expect(root.find(HeadMetaTags)).toHaveLength(1);
+  });
+
+  it('passes its props to the HeadMetaTags component', () => {
+    const description = 'some user';
+    const title = 'some user';
+
+    const root = render({ description, title });
+
+    expect(root.find(HeadMetaTags)).toHaveProp('title', title);
+    expect(root.find(HeadMetaTags)).toHaveProp('description', description);
+  });
+
+  it('renders a HeadLinks component', () => {
+    const root = render();
+
+    expect(root.find(HeadLinks)).toHaveLength(1);
+  });
+
+  it.each([
+    ['no query parameters', {}, ''],
+    ['other query parameters', { foo: '123' }, ''],
+    ['only page_e provided', { page_e: '123' }, '?page_e=123'],
+    ['only page_t provided', { page_t: '123' }, '?page_t=123'],
+    ['page_t and another param', { page_t: '123', foo: 'bar' }, '?page_t=123'],
+    ['page_e = 1', { page_e: '1' }, ''],
+    ['page_t = 1', { page_t: '1' }, ''],
+    ['page_e = 1 and page_t = 1', { page_e: '1', page_t: '1' }, ''],
+    ['page_t = 1 and page_e = 1', { page_t: '1', page_e: '1' }, ''],
+    ['page_e = 1 and page_t = 2', { page_e: '1', page_t: '2' }, '?page_t=2'],
+    ['page_t = 1 and page_e = 2', { page_t: '1', page_e: '2' }, '?page_e=2'],
+    ['page_e = 2 and page_t = 1', { page_e: '2', page_t: '1' }, '?page_e=2'],
+    ['page_t = 2 and page_e = 1', { page_t: '2', page_e: '1' }, '?page_t=2'],
+    ['page_e = 2 and page_t = 2', { page_e: '2', page_t: '2' }, '?page_e=2'],
+    ['page_t = 2 and page_e = 2', { page_t: '2', page_e: '2' }, '?page_t=2'],
+    ['page_e = 3 and page_t = 4', { page_e: '3', page_t: '4' }, '?page_t=4'],
+    ['page_e = 4 and page_t = 3', { page_e: '4', page_t: '3' }, '?page_e=4'],
+  ])(
+    'passes a `queryString` prop to HeadMetaTags and HeadLinks with %s',
+    (feature, query, expectedQueryString) => {
+      const location = createFakeLocation({
+        query,
+        search: Object.keys(query)
+          .map((k) => `${k}=${query[k]}`)
+          .join('&'),
+      });
+      const root = render({ location });
+
+      expect(root.find(HeadMetaTags)).toHaveProp(
+        'queryString',
+        expectedQueryString,
+      );
+      expect(root.find(HeadLinks)).toHaveProp(
+        'queryString',
+        expectedQueryString,
+      );
+    },
+  );
+});

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -10,6 +10,7 @@ import AddonsByAuthorsCard from 'amo/components/AddonsByAuthorsCard';
 import AddonReviewCard from 'amo/components/AddonReviewCard';
 import UserProfile, { extractId, UserProfileBase } from 'amo/pages/UserProfile';
 import NotFound from 'amo/components/ErrorPage/NotFound';
+import UserProfileHead from 'amo/components/UserProfileHead';
 import ReportUserAbuse from 'amo/components/ReportUserAbuse';
 import {
   fetchUserAccount,
@@ -953,7 +954,7 @@ describe(__filename, () => {
     expect(paginator).toHaveProp('pathname', `/user/${userId}/`);
   });
 
-  it('renders a "description" meta tag when user is a developer', () => {
+  it('renders a UserProfileHead component when user is a developer', () => {
     const displayName = 'John Doe';
     const { params, store } = signInUserWithProps({
       display_name: displayName,
@@ -963,16 +964,16 @@ describe(__filename, () => {
 
     const root = renderUserProfile({ params, store });
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(UserProfileHead)).toHaveLength(1);
+    expect(root.find(UserProfileHead).prop('description')).toMatch(
       new RegExp(`The profile of ${displayName}, Firefox extension author.`),
     );
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(UserProfileHead).prop('description')).toMatch(
       new RegExp(`by ${displayName}`),
     );
   });
 
-  it('renders a "description" meta tag when user is an artist', () => {
+  it('renders a UserProfileHead component when user is an artist', () => {
     const displayName = 'John Doe';
     const { params, store } = signInUserWithProps({
       display_name: displayName,
@@ -982,16 +983,16 @@ describe(__filename, () => {
 
     const root = renderUserProfile({ params, store });
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(UserProfileHead)).toHaveLength(1);
+    expect(root.find(UserProfileHead).prop('description')).toMatch(
       new RegExp(`The profile of ${displayName}, Firefox theme author.`),
     );
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(UserProfileHead).prop('description')).toMatch(
       new RegExp(`by ${displayName}`),
     );
   });
 
-  it('renders a "description" meta tag when user is a developer and an artist', () => {
+  it('renders a UserProfileHead component when user is a developer and an artist', () => {
     const displayName = 'John Doe';
     const { params, store } = signInUserWithProps({
       display_name: displayName,
@@ -1001,18 +1002,18 @@ describe(__filename, () => {
 
     const root = renderUserProfile({ params, store });
 
-    expect(root.find('meta[name="description"]')).toHaveLength(1);
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(UserProfileHead)).toHaveLength(1);
+    expect(root.find(UserProfileHead).prop('description')).toMatch(
       new RegExp(
         `The profile of ${displayName}, a Firefox extension and theme author`,
       ),
     );
-    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+    expect(root.find(UserProfileHead).prop('description')).toMatch(
       new RegExp(`by ${displayName}`),
     );
   });
 
-  it('does not render a "description" meta tag when user is neither a developer nor an artist', () => {
+  it('sets the description to `null` to UserProfileHead when user is neither a developer nor an artist', () => {
     const displayName = 'John Doe';
     const { params, store } = signInUserWithProps({
       display_name: displayName,
@@ -1022,13 +1023,13 @@ describe(__filename, () => {
 
     const root = renderUserProfile({ params, store });
 
-    expect(root.find('meta[name="description"]')).toHaveLength(0);
+    expect(root.find(UserProfileHead)).toHaveProp('description', null);
   });
 
-  it('does not render a "description" meta tag when there is no user loaded', () => {
+  it('sets description to `null` to UserProfileHead when there is no user loaded', () => {
     const root = renderUserProfile({ params: { userId: 1234 } });
 
-    expect(root.find('meta[name="description"]')).toHaveLength(0);
+    expect(root.find(UserProfileHead)).toHaveProp('description', null);
   });
 
   it('sends a server redirect when the current user loads their profile with their "username" in the URL', () => {


### PR DESCRIPTION
Fixes #6527
~~:warning: depends on #6937~~

---

This PR adds a `UserProfileHead` component, similar to the `AddonHead` and `CategoryHead` components. It allows to configure SEO metadata for the user profile pages (not the edit pages). It reuses the `HeadLinks` and `HeadMetaTags` comoponents, but it has some logic to compute a sort of "canonical query string" as defined here: https://github.com/mozilla/addons-frontend/issues/6527#issuecomment-436243834. 