### PR TITLE
Fix the test that was written for an add-on without a version

### DIFF
--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -294,15 +294,6 @@ describe(__filename, () => {
     expect(root.find('.Addon-icon img').prop('alt')).toEqual(null);
   });
 
-  it('renders without a version', () => {
-    const root = shallowRender({
-      currentVersion: null,
-    });
-
-    // Make sure an element we expect to be rendered exists.
-    expect(root.find('.Addon-header')).toHaveLength(1);
-  });
-
   it('dispatches fetchAddon when rendering without an add-on', () => {
     const slug = 'some-addon';
     const { store } = dispatchClientMetadata();
@@ -1525,6 +1516,19 @@ describe(__filename, () => {
 
       const { currentVersion } = _mapStateToProps();
       expect(currentVersion).toEqual(createInternalVersion(apiVersion));
+    });
+
+    it('sets the version to null for an add-on without a version', () => {
+      signIn();
+      fetchAddon({
+        addon: {
+          ...fakeAddon,
+          current_version: null,
+        },
+      });
+
+      const { currentVersion } = _mapStateToProps();
+      expect(currentVersion).toEqual(null);
     });
 
     it('sets installStatus to INSTALLED when add-on is installed', () => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -294,6 +294,18 @@ describe(__filename, () => {
     expect(root.find('.Addon-icon img').prop('alt')).toEqual(null);
   });
 
+  it('renders without a version', () => {
+    const { store } = dispatchSignInActions();
+    const addon = { ...fakeAddon, current_version: null };
+
+    store.dispatch(_loadAddonResults({ addon }));
+
+    const root = renderComponent({ store });
+
+    expect(root.find('.Addon')).toHaveLength(1);
+    expect(root.find('.Addon')).toHaveProp('data-site-identifier', addon.id);
+  });
+
   it('dispatches fetchAddon when rendering without an add-on', () => {
     const slug = 'some-addon';
     const { store } = dispatchClientMetadata();
@@ -1516,19 +1528,6 @@ describe(__filename, () => {
 
       const { currentVersion } = _mapStateToProps();
       expect(currentVersion).toEqual(createInternalVersion(apiVersion));
-    });
-
-    it('sets the version to null for an add-on without a version', () => {
-      signIn();
-      fetchAddon({
-        addon: {
-          ...fakeAddon,
-          current_version: null,
-        },
-      });
-
-      const { currentVersion } = _mapStateToProps();
-      expect(currentVersion).toEqual(null);
     });
 
     it('sets installStatus to INSTALLED when add-on is installed', () => {


### PR DESCRIPTION
I realized that the test I wrote originally for #6944 was not accurate and would always pass. I committed the cardinal sin of not seeing the test fail, which I try to always do, but in this case I was in a hurry to fix the bug. My apologies. This should fix it.

It doesn't help that the tests for `Addon` are pretty crazy and all over the place, but that's a different issue.