### PR TITLE
Optimistically update star breakdown for ratings

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -53,6 +53,8 @@ export const CANCEL_DELETE_ADDON_REVIEW: 'CANCEL_DELETE_ADDON_REVIEW' =
   'CANCEL_DELETE_ADDON_REVIEW';
 export const UNLOAD_ADDON_REVIEWS: 'UNLOAD_ADDON_REVIEWS' =
   'UNLOAD_ADDON_REVIEWS';
+export const UPDATE_RATING_COUNTS: 'UPDATE_RATING_COUNTS' =
+  'UPDATE_RATING_COUNTS';
 
 export type ReviewAddonType = {|
   iconUrl: string,
@@ -291,6 +293,30 @@ export function setGroupedRatings({
   return {
     type: SET_GROUPED_RATINGS,
     payload: { addonId, grouping },
+  };
+}
+
+type UpdateRatingCountsParams = {|
+  addonId: number,
+  oldReview: UserReviewType | null,
+  newReview: UserReviewType,
+|};
+
+export type UpdateRatingCountsAction = {|
+  type: typeof UPDATE_RATING_COUNTS,
+  payload: UpdateRatingCountsParams,
+|};
+
+export function updateRatingCounts({
+  addonId,
+  oldReview,
+  newReview,
+}: UpdateRatingCountsParams): UpdateRatingCountsAction {
+  invariant(addonId, 'addonId is required');
+  invariant(newReview, 'newReview is required');
+  return {
+    type: UPDATE_RATING_COUNTS,
+    payload: { addonId, oldReview, newReview },
   };
 }
 

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -347,9 +347,9 @@ function* manageAddonReview(
       );
 
       // Reload the add-on to update its rating and review counts.
-      //yield put(
-      //  fetchAddon({ errorHandler, slug: reviewFromResponse.addon.slug }),
-      //);
+      yield put(
+        fetchAddon({ errorHandler, slug: reviewFromResponse.addon.slug }),
+      );
 
       yield put(
         updateRatingCounts({

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -174,10 +174,6 @@ export type PlatformFilesType = {|
 
 /*
  * This is our internal representation of an add-on, found in Redux state.
- *
- * TODO: for better protection, turn this into an Exact Type. This is
- * not currently possible because of:
- * https://github.com/facebook/flow/issues/4818
  */
 export type AddonType = {|
   ...ExternalAddonType,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -211,6 +211,38 @@ export const fakeReview = Object.freeze({
   body: 'It is Okay',
 });
 
+export function createExternalReview({
+  addonId = fakeReview.addon.id,
+  addonSlug = fakeReview.addon.slug,
+  body,
+  id = 76654,
+  isDeveloperReply = false,
+  score = 4,
+  userId = fakeReview.user.id,
+  versionId = fakeReview.version.id,
+} = {}) {
+  return {
+    ...fakeReview,
+    addon: {
+      ...fakeAddon,
+      id: addonId,
+      slug: addonSlug,
+    },
+    body,
+    id,
+    is_developer_reply: isDeveloperReply,
+    score,
+    user: {
+      ...fakeReview.user,
+      id: userId,
+    },
+    version: {
+      ...fakeReview.version,
+      id: versionId,
+    },
+  };
+}
+
 export const fakeCategory = Object.freeze({
   application: CLIENT_APP_FIREFOX,
   description: 'I am a cool category for doing things',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/5986 by directly adjusting star rating counts after creating / editing a review instead of relying on the API response to adjust those values. We can't rely on the immediate API response because star rating counts are recalculated on the server in a background task. The server is eventually consistent.