### PR TITLE
Do not send a tracking event when variant is null

### DIFF
--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -110,6 +110,11 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
       return;
     }
 
+    if (!variant) {
+      _log.debug(`No variant for experiment ${EXPERIMENT_ID}.`);
+      return;
+    }
+
     _tracking.sendEvent({
       action: variant,
       category: EXPERIMENT_CATEGORY,

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -676,13 +676,15 @@ describe(__filename, () => {
 
     it('handles a `null` variant prop', () => {
       const _log = getFakeLogger();
+      const _tracking = createFakeTracking();
 
-      renderWithExperiment({ _log, variant: null });
+      renderWithExperiment({ _log, _tracking, variant: null });
 
       sinon.assert.calledWith(
         _log.debug,
         sinon.match(/No variant for experiment/),
       );
+      sinon.assert.notCalled(_tracking.sendEvent);
     });
   });
 });

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -673,5 +673,16 @@ describe(__filename, () => {
 
       sinon.assert.notCalled(_tracking.sendEvent);
     });
+
+    it('handles a `null` variant prop', () => {
+      const _log = getFakeLogger();
+
+      renderWithExperiment({ _log, variant: null });
+
+      sinon.assert.calledWith(
+        _log.debug,
+        sinon.match(/No variant for experiment/),
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #6964
Fixes #6962

---

I believe we missed this use case because we do not test with all cookies disabled.

In addition, I think Flow coverage in `tracking` would have helped. I filed #6968.