### PR TITLE
I6916 updates to get firefox btn on non firefox client (on guides pages)

### DIFF
--- a/src/amo/components/GuidesAddonCard/index.js
+++ b/src/amo/components/GuidesAddonCard/index.js
@@ -153,6 +153,7 @@ export class GuidesAddonCardBase extends React.Component<InternalProps> {
               <GetFirefoxButton
                 addon={addon}
                 buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+                className="GetFirefoxButton--guides"
               />
             )}
           </div>

--- a/src/amo/components/GuidesAddonCard/index.js
+++ b/src/amo/components/GuidesAddonCard/index.js
@@ -6,7 +6,9 @@ import { withRouter } from 'react-router-dom';
 
 import AddonTitle from 'amo/components/AddonTitle';
 import AddonCompatibilityError from 'amo/components/AddonCompatibilityError';
-import { makeQueryStringWithUTM } from 'amo/utils';
+import GetFirefoxButton, {
+  GET_FIREFOX_BUTTON_TYPE_ADDON,
+} from 'amo/components/GetFirefoxButton';
 import AMInstallButton from 'core/components/AMInstallButton';
 import {
   INCOMPATIBLE_NOT_FIREFOX,
@@ -21,7 +23,6 @@ import { getErrorMessage } from 'core/utils/addons';
 import { getClientCompatibility } from 'core/utils/compatibility';
 import Card from 'ui/components/Card';
 import Icon from 'ui/components/Icon';
-import Button from 'ui/components/Button';
 import Notice from 'ui/components/Notice';
 import type { AddonType } from 'core/types/addons';
 import type { AddonVersionType } from 'core/reducers/versions';
@@ -101,11 +102,6 @@ export class GuidesAddonCardBase extends React.Component<InternalProps> {
       compatibility && compatibility.reason !== INCOMPATIBLE_NOT_FIREFOX;
     const showInstallButton = addon && isFireFox;
 
-    // TODO: waiting to hear back on how to handle "+Add" buttons on non
-    // firefox browsers. See:
-    // https://github.com/mozilla/addons-frontend/issues/6916.
-    const showGetFirefoxButton = addon && !isFireFox;
-
     return addon ? (
       <Card>
         {this.renderInstallError()}
@@ -153,20 +149,11 @@ export class GuidesAddonCardBase extends React.Component<InternalProps> {
                 puffy={false}
               />
             )}
-            {/* TODO: See https://github.com/mozilla/addons-frontend/issues/6901. */}
-            {showGetFirefoxButton && (
-              <Button
-                buttonType="confirm"
-                href={`https://www.mozilla.org/firefox/new/${makeQueryStringWithUTM(
-                  {
-                    utm_content: addon.guid,
-                  },
-                )}`}
-                puffy
-                className="Button--get-firefox"
-              >
-                {i18n.gettext('Only with Firefox—Get Firefox Now')}
-              </Button>
+            {addon && (
+              <GetFirefoxButton
+                addon={addon}
+                buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+              />
             )}
           </div>
         </div>

--- a/src/amo/components/GuidesAddonCard/index.js
+++ b/src/amo/components/GuidesAddonCard/index.js
@@ -149,13 +149,11 @@ export class GuidesAddonCardBase extends React.Component<InternalProps> {
                 puffy={false}
               />
             )}
-            {addon && (
-              <GetFirefoxButton
-                addon={addon}
-                buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
-                className="GetFirefoxButton--guides"
-              />
-            )}
+            <GetFirefoxButton
+              addon={addon}
+              buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+              className="GetFirefoxButton--guides"
+            />
           </div>
         </div>
       </Card>

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -15,10 +15,13 @@
 
   .GetFirefoxButton--guides.GetFirefoxButton {
     font-size: $font-size-default;
-    max-width: 170px;
-    min-width: 160px;
     text-align: center;
     white-space: normal;
+
+    @include respond-to(medium) {
+      max-width: 170px;
+      min-width: 160px;
+    }
   }
 
   .Icon-trophy {

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -4,13 +4,20 @@
   display: flex;
   flex-direction: column;
 
-  .Button--get-firefox,
+  .GetFirefoxButton,
   .AMInstallButton {
     @include respond-to(medium) {
       @include margin-start(auto);
 
       align-self: center;
     }
+  }
+
+  .Button--confirm.Button--puffy.GetFirefoxButton {
+    font-size: $font-size-default;
+    min-width: 160px;
+    text-align: center;
+    white-space: normal;
   }
 
   .Icon-trophy {

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -13,8 +13,9 @@
     }
   }
 
-  .Button--confirm.Button--puffy.GetFirefoxButton {
+  .GetFirefoxButton--guides.GetFirefoxButton {
     font-size: $font-size-default;
+    max-width: 170px;
     min-width: 160px;
     text-align: center;
     white-space: normal;

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -54,6 +54,10 @@
     font-size: $font-size-default;
     text-align: center;
     white-space: normal;
+
+    @include respond-to(medium) {
+      flex: 0 0 180px;
+    }
   }
 }
 

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -13,17 +13,6 @@
     }
   }
 
-  .GetFirefoxButton--guides.GetFirefoxButton {
-    font-size: $font-size-default;
-    text-align: center;
-    white-space: normal;
-
-    @include respond-to(medium) {
-      max-width: 170px;
-      min-width: 160px;
-    }
-  }
-
   .Icon-trophy {
     @include margin-end(4px);
   }
@@ -59,6 +48,12 @@
 
   @include respond-to(medium) {
     flex-wrap: nowrap;
+  }
+
+  .GetFirefoxButton {
+    font-size: $font-size-default;
+    text-align: center;
+    white-space: normal;
   }
 }
 

--- a/tests/unit/amo/components/TestGuidesAddonCard.js
+++ b/tests/unit/amo/components/TestGuidesAddonCard.js
@@ -6,6 +6,7 @@ import GuidesAddonCard, {
 import AddonTitle from 'amo/components/AddonTitle';
 import AMInstallButton from 'core/components/AMInstallButton';
 import AddonCompatibilityError from 'amo/components/AddonCompatibilityError';
+import GetFirefoxButton from 'amo/components/GetFirefoxButton';
 import {
   createContextWithFakeRouter,
   createFakeLocation,
@@ -178,8 +179,6 @@ describe(__filename, () => {
     expect(installButton).toHaveProp('uninstall', uninstall);
   });
 
-  // TODO: This will probably change; I'm waiting for feedback on this.
-  // See https://github.com/mozilla/addons-frontend/issues/6916.
   it('renders "Get Firefox Now" button when the client is not Firefox', () => {
     const root = render({
       _getClientCompatibility: sinon.stub().returns({
@@ -188,28 +187,7 @@ describe(__filename, () => {
       }),
     });
 
-    expect(root.find('.Button--get-firefox')).toHaveLength(1);
-  });
-
-  it('passes the addon GUID to the Firefox install button', () => {
-    const guid = 'some-guid';
-    const addon = createInternalAddon({
-      ...fakeAddon,
-      guid,
-    });
-
-    const root = render({
-      _getClientCompatibility: sinon.stub().returns({
-        compatible: false,
-        reason: INCOMPATIBLE_NOT_FIREFOX,
-      }),
-      addon,
-    });
-
-    expect(root.find('.Button--get-firefox')).toHaveLength(1);
-    expect(root.find('.Button--get-firefox').prop('href')).toMatch(
-      `&utm_content=${guid}`,
-    );
+    expect(root.find(GetFirefoxButton)).toHaveLength(1);
   });
 
   // TODO: https://github.com/mozilla/addons-frontend/issues/6902


### PR DESCRIPTION
fixes #6916 

## Desktop
![Alt text](https://monosnap.com/image/5J5LFcRgTp5mzKq1R3j35j6npU5icb.png)


## Mobile
![Alt text](https://monosnap.com/image/gdw3roRxLIi7r4DRGYkc0GIrKz8ff9.png)
