### PR TITLE
Minor fix on log calls

### DIFF
--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -1,5 +1,6 @@
 /* @flow */
 import * as React from 'react';
+import { oneLine } from 'common-tags';
 
 import log from 'core/logger';
 import { findFileForPlatform } from 'core/utils';
@@ -78,9 +79,11 @@ export class PermissionUtils {
 
     if (!file) {
       log.debug(
-        `No file exists for os "${userAgentInfo.os.toString()}"; platform files:`,
+        oneLine`No file exists for os
+        ${JSON.stringify(userAgentInfo.os)}; platform files:`,
         platformFiles,
       );
+
       return [];
     }
     return file.permissions || [];

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -192,9 +192,11 @@ export const findInstallURL = ({
   if (!installURL) {
     // This could happen for themes which do not have version files.
     log.debug(
-      oneLine`No file exists for os "${userAgentInfo.os.toString()}"; platform files:`,
+      oneLine`No file exists for os
+      ${JSON.stringify(userAgentInfo.os)}; platform files:`,
       platformFiles,
     );
+
     return undefined;
   }
 

--- a/src/core/reducers/api.js
+++ b/src/core/reducers/api.js
@@ -61,6 +61,7 @@ export type UserAgentInfoType = {|
       | typeof USER_AGENT_OS_LINUX
       | typeof USER_AGENT_OS_MAC
       | typeof USER_AGENT_OS_WINDOWS,
+    version?: string,
   },
 |};
 


### PR DESCRIPTION
I fixed those two log calls while debugging https://github.com/mozilla/addons-frontend/issues/6986. Because I saw `version` in the `userAgentInfo.os` object, I added the property to the flow type.