### PR TITLE
Move version-related types into versions reducer

### DIFF
--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -6,8 +6,8 @@ import log from 'core/logger';
 import { findFileForPlatform } from 'core/utils';
 import HostPermissions from 'ui/components/HostPermissions';
 import Permission from 'ui/components/Permission';
-import type { PlatformFilesType } from 'core/types/addons';
 import type { UserAgentInfoType } from 'core/reducers/api';
+import type { PlatformFilesType } from 'core/reducers/versions';
 import type { I18nType } from 'core/types/i18n';
 
 export type GetCurrentPermissionsParams = {|

--- a/src/core/api/versions.js
+++ b/src/core/api/versions.js
@@ -3,9 +3,11 @@ import invariant from 'invariant';
 
 import { callApi } from 'core/api';
 import type { ApiState } from 'core/reducers/api';
-import type { VersionIdType } from 'core/reducers/versions';
+import type {
+  ExternalAddonVersionType,
+  VersionIdType,
+} from 'core/reducers/versions';
 import type { PaginatedApiResponse } from 'core/types/api';
-import type { ExternalAddonVersionType } from 'core/types/addons';
 
 export type GetVersionParams = {|
   api: ApiState,

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -48,8 +48,11 @@ import { findFileForPlatform, getDisplayName } from 'core/utils';
 import { getFileHash } from 'core/utils/addons';
 import type { AppState as AmoAppState } from 'amo/store';
 import type { UserAgentInfoType } from 'core/reducers/api';
-import type { AddonVersionType } from 'core/reducers/versions';
-import type { AddonType, PlatformFilesType } from 'core/types/addons';
+import type {
+  AddonVersionType,
+  PlatformFilesType,
+} from 'core/reducers/versions';
+import type { AddonType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocationType } from 'core/types/router';
 import type { AppState as DiscoAppState } from 'disco/store';

--- a/src/core/reducers/versions.js
+++ b/src/core/reducers/versions.js
@@ -23,19 +23,79 @@ import { LOAD_ADDON_RESULTS } from 'core/reducers/addons';
 import { SEARCH_LOADED } from 'core/reducers/search';
 import { findFileForPlatform } from 'core/utils';
 import type { UserAgentInfoType } from 'core/reducers/api';
-import type {
-  AddonCompatibilityType,
-  ExternalAddonVersionType,
-  PlatformFilesType,
-  PartialExternalAddonVersionType,
-} from 'core/types/addons';
+import type { AddonStatusType } from 'core/types/addons';
 
 export const FETCH_VERSION: 'FETCH_VERSION' = 'FETCH_VERSION';
 export const FETCH_VERSIONS: 'FETCH_VERSIONS' = 'FETCH_VERSIONS';
 export const LOAD_VERSIONS: 'LOAD_VERSIONS' = 'LOAD_VERSIONS';
 
 export type VersionIdType = number;
-export type VersionLicenseType = {| name: string, text?: string, url: string |};
+
+export type AddonFileType = {|
+  created: string,
+  hash: string,
+  id: number,
+  is_mozilla_signed_extension: boolean,
+  is_restart_required: boolean,
+  is_webextension: boolean,
+  permissions?: Array<string>,
+  platform: 'all' | 'android' | 'mac' | 'linux' | 'windows',
+  size: number,
+  status: AddonStatusType,
+  url: string,
+|};
+
+export type PlatformFilesType = {|
+  all: ?AddonFileType,
+  android: ?AddonFileType,
+  mac: ?AddonFileType,
+  linux: ?AddonFileType,
+  windows: ?AddonFileType,
+|};
+
+export type AddonCompatibilityType = {|
+  [appName: string]: {|
+    min: string,
+    max: string,
+  |},
+|};
+
+export type PartialExternalAddonVersionType = {|
+  channel: string,
+  compatibility?: AddonCompatibilityType,
+  edit_url: string,
+  files: Array<AddonFileType>,
+  id: number,
+  is_strict_compatibility_enabled: boolean,
+  reviewed: Date,
+  // This is the developer-defined version number.
+  // It could, for example, be set to "0".
+  // See:
+  // https://github.com/mozilla/addons-frontend/pull/3271#discussion_r142159199
+  version: string,
+|};
+
+type PartialVersionLicenseType = {|
+  name: string,
+  text?: string,
+  url: string,
+|};
+
+export type ExternalVersionLicenseType = {|
+  ...PartialVersionLicenseType,
+  is_custom: boolean,
+|};
+
+export type VersionLicenseType = {|
+  ...PartialVersionLicenseType,
+  isCustom: boolean,
+|};
+
+export type ExternalAddonVersionType = {|
+  ...PartialExternalAddonVersionType,
+  license: ExternalVersionLicenseType,
+  release_notes?: string,
+|};
 
 export type AddonVersionType = {
   compatibility?: AddonCompatibilityType,
@@ -103,6 +163,7 @@ export const createInternalVersion = (
     ),
     license: version.license
       ? {
+          isCustom: version.license.is_custom,
           name: version.license.name,
           text: version.license.text,
           url: version.license.url,

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -1,8 +1,12 @@
 /* @flow */
-import type { VersionIdType, VersionLicenseType } from 'core/reducers/versions';
+import type {
+  VersionIdType,
+  ExternalAddonVersionType,
+  PartialExternalAddonVersionType,
+} from 'core/reducers/versions';
 import type { AddonTypeType } from 'core/constants';
 
-type AddonStatus =
+export type AddonStatusType =
   | 'lite'
   | 'public'
   | 'deleted'
@@ -14,48 +18,6 @@ type AddonStatus =
   | 'unreviewed'
   | 'lite-nominated'
   | 'review-pending';
-
-export type AddonFileType = {|
-  created: string,
-  hash: string,
-  id: number,
-  is_mozilla_signed_extension: boolean,
-  is_restart_required: boolean,
-  is_webextension: boolean,
-  permissions?: Array<string>,
-  platform: 'all' | 'android' | 'mac' | 'linux' | 'windows',
-  size: number,
-  status: AddonStatus,
-  url: string,
-|};
-
-export type AddonCompatibilityType = {|
-  [appName: string]: {|
-    min: string,
-    max: string,
-  |},
-|};
-
-export type PartialExternalAddonVersionType = {|
-  channel: string,
-  compatibility?: AddonCompatibilityType,
-  edit_url: string,
-  files: Array<AddonFileType>,
-  id: number,
-  is_strict_compatibility_enabled: boolean,
-  reviewed: Date,
-  // This is the developer-defined version number.
-  // It could, for example, be set to "0".
-  // See:
-  // https://github.com/mozilla/addons-frontend/pull/3271#discussion_r142159199
-  version: string,
-|};
-
-export type ExternalAddonVersionType = {|
-  ...PartialExternalAddonVersionType,
-  license: VersionLicenseType,
-  release_notes?: string,
-|};
 
 type PartialAddonAuthorType = {|
   id: number,
@@ -146,7 +108,7 @@ export type ExternalAddonType = {|
   requires_payment?: boolean,
   review_url?: string,
   slug: string,
-  status?: AddonStatus,
+  status?: AddonStatusType,
   summary?: string,
   support_email?: string,
   support_url?: string,
@@ -161,14 +123,6 @@ export type ExternalAddonType = {|
 export type PartialExternalAddonType = {|
   ...ExternalAddonType,
   current_version?: PartialExternalAddonVersionType,
-|};
-
-export type PlatformFilesType = {|
-  all: ?AddonFileType,
-  android: ?AddonFileType,
-  mac: ?AddonFileType,
-  linux: ?AddonFileType,
-  windows: ?AddonFileType,
 |};
 
 /*

--- a/tests/unit/core/reducers/test_versions.js
+++ b/tests/unit/core/reducers/test_versions.js
@@ -191,6 +191,7 @@ describe(__filename, () => {
           fakeVersion.is_strict_compatibility_enabled,
         ),
         license: {
+          isCustom: fakeVersion.license.is_custom,
           name: fakeVersion.license.name,
           url: fakeVersion.license.url,
         },

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -93,7 +93,11 @@ export const fakeVersion = Object.freeze({
   files: [fakePlatformFile],
   id: 123,
   is_strict_compatibility_enabled: false,
-  license: { name: 'tofulicense', url: 'http://license.com/' },
+  license: {
+    is_custom: false,
+    name: 'tofulicense',
+    url: 'http://license.com/',
+  },
   release_notes: 'Some release notes',
   reviewed: '2014-11-22T10:09:01Z',
   version: '2.0.0',


### PR DESCRIPTION
Fixes #7015 

Note that this also adds the `isCustom` property to `VersionLicenseType`.