### PR TITLE
Fix download button width

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -126,6 +126,8 @@
 
 .Header-download-button {
   @include margin-start(12px);
+
+  width: auto;
 }
 
 .Header-authenticate-button {


### PR DESCRIPTION
Fixes #7020

---

See before here: https://github.com/mozilla/addons-frontend/issues/7020#issuecomment-440957324

After:

<img width="367" alt="screen shot 2018-11-22 at 10 03 45" src="https://user-images.githubusercontent.com/217628/48892327-1c00d600-ee3e-11e8-92d8-84ab37320f0e.png">
<img width="402" alt="screen shot 2018-11-22 at 10 03 54" src="https://user-images.githubusercontent.com/217628/48892328-1c00d600-ee3e-11e8-96f5-f8c0730645f7.png">
<img width="463" alt="screen shot 2018-11-22 at 10 03 50" src="https://user-images.githubusercontent.com/217628/48892329-1c00d600-ee3e-11e8-92ec-08df115e0cd0.png">
