### PR TITLE
Fix how we fetch add-ons for a guide page

### DIFF
--- a/src/amo/pages/Guides/index.js
+++ b/src/amo/pages/Guides/index.js
@@ -8,7 +8,7 @@ import GuidesAddonCard from 'amo/components/GuidesAddonCard';
 import Link from 'amo/components/Link';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import HeadLinks from 'amo/components/HeadLinks';
-import { fetchGuidesAddons } from 'amo/reducers/guides';
+import { fetchGuidesAddons, getGUIDsBySlug } from 'amo/reducers/guides';
 import { getAddonByGUID } from 'core/reducers/addons';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -313,6 +313,7 @@ export class GuidesBase extends React.Component<InternalProps> {
       );
       this.props.dispatch(
         fetchGuidesAddons({
+          slug,
           guids,
           errorHandlerId: errorHandler.id,
         }),
@@ -383,12 +384,16 @@ export class GuidesBase extends React.Component<InternalProps> {
   }
 }
 
-export const mapStateToProps = (state: AppState): $Shape<InternalProps> => {
-  const { guids, loading } = state.guides;
+export const mapStateToProps = (
+  state: AppState,
+  ownProps: InternalProps,
+): $Shape<InternalProps> => {
+  const { guides: guidesState } = state;
+  const { loading } = guidesState;
+  const { slug } = ownProps.match.params;
 
   const addons = {};
-
-  guids.forEach((guid) => {
+  getGUIDsBySlug({ guidesState, slug }).forEach((guid) => {
     addons[guid] = getAddonByGUID(state, guid);
   });
 

--- a/src/amo/reducers/guides.js
+++ b/src/amo/reducers/guides.js
@@ -6,14 +6,14 @@ import { LOAD_ADDON_RESULTS } from 'core/reducers/addons';
 export const FETCH_GUIDES_ADDONS: 'FETCH_GUIDES_ADDONS' = 'FETCH_GUIDES_ADDONS';
 
 export type GuidesState = {|
-  bySlug: {
+  guidsBySlug: {
     [slug: string]: Array<string>,
   },
   loading: boolean,
 |};
 
 export const initialState: GuidesState = {
-  bySlug: {},
+  guidsBySlug: {},
   loading: false,
 };
 
@@ -50,7 +50,7 @@ export const getGUIDsBySlug = ({
   guidesState: GuidesState,
   slug: string,
 |}): Array<string> => {
-  return guidesState.bySlug[slug] || [];
+  return guidesState.guidsBySlug[slug] || [];
 };
 
 const reducer = (
@@ -63,8 +63,8 @@ const reducer = (
 
       return {
         ...state,
-        bySlug: {
-          ...state.bySlug,
+        guidsBySlug: {
+          ...state.guidsBySlug,
           [slug]: guids,
         },
         loading: true,

--- a/src/amo/reducers/guides.js
+++ b/src/amo/reducers/guides.js
@@ -6,18 +6,21 @@ import { LOAD_ADDON_RESULTS } from 'core/reducers/addons';
 export const FETCH_GUIDES_ADDONS: 'FETCH_GUIDES_ADDONS' = 'FETCH_GUIDES_ADDONS';
 
 export type GuidesState = {|
-  guids: Array<string>,
+  bySlug: {
+    [slug: string]: Array<string>,
+  },
   loading: boolean,
 |};
 
 export const initialState: GuidesState = {
-  guids: [],
+  bySlug: {},
   loading: false,
 };
 
 export type FetchGuidesParams = {|
   errorHandlerId: string,
   guids: Array<string>,
+  slug: string,
 |};
 
 export type FetchGuidesAction = {|
@@ -28,14 +31,26 @@ export type FetchGuidesAction = {|
 export const fetchGuidesAddons = ({
   errorHandlerId,
   guids,
+  slug,
 }: FetchGuidesParams): FetchGuidesAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(guids, 'guids is required');
+  invariant(slug, 'slug is required');
 
   return {
     type: FETCH_GUIDES_ADDONS,
-    payload: { guids, errorHandlerId },
+    payload: { guids, errorHandlerId, slug },
   };
+};
+
+export const getGUIDsBySlug = ({
+  guidesState,
+  slug,
+}: {|
+  guidesState: GuidesState,
+  slug: string,
+|}): Array<string> => {
+  return guidesState.bySlug[slug] || [];
 };
 
 const reducer = (
@@ -43,12 +58,18 @@ const reducer = (
   action: FetchGuidesAction,
 ): GuidesState => {
   switch (action.type) {
-    case FETCH_GUIDES_ADDONS:
+    case FETCH_GUIDES_ADDONS: {
+      const { guids, slug } = action.payload;
+
       return {
         ...state,
-        guids: action.payload.guids,
+        bySlug: {
+          ...state.bySlug,
+          [slug]: guids,
+        },
         loading: true,
       };
+    }
     case LOAD_ADDON_RESULTS:
       return {
         ...state,

--- a/tests/unit/amo/reducers/test_guides.js
+++ b/tests/unit/amo/reducers/test_guides.js
@@ -33,17 +33,24 @@ describe(__filename, () => {
       expect(newState.loading).toEqual(false);
     });
 
-    it('stores the add-on GUIDs by slug', () => {
-      const slug = 'some-slug';
-      const guids = ['test', 'test2'];
-      const state = guidesReducer(
+    it('stores add-on GUIDs by slug', () => {
+      const slug1 = 'some-slug-1';
+      const guids1 = ['guid-11', 'guid-12'];
+
+      const slug2 = 'some-slug-2';
+      const guids2 = ['guid-21', 'guid-22'];
+
+      let guidesState = guidesReducer(
         undefined,
-        fetchGuidesAddons({ slug, guids, errorHandlerId: 'test' }),
+        fetchGuidesAddons({ slug: slug1, guids: guids1, errorHandlerId: 'id' }),
+      );
+      guidesState = guidesReducer(
+        guidesState,
+        fetchGuidesAddons({ slug: slug2, guids: guids2, errorHandlerId: 'id' }),
       );
 
-      expect(state.bySlug).toEqual({
-        [slug]: guids,
-      });
+      expect(getGUIDsBySlug({ guidesState, slug: slug1 })).toEqual(guids1);
+      expect(getGUIDsBySlug({ guidesState, slug: slug2 })).toEqual(guids2);
     });
   });
 
@@ -53,17 +60,6 @@ describe(__filename, () => {
       const guids = getGUIDsBySlug({ guidesState: initialState, slug });
 
       expect(guids).toEqual([]);
-    });
-
-    it('returns the GUIDs for a given slug', () => {
-      const slug = 'some-slug';
-      const guids = ['test', 'test2'];
-      const guidesState = guidesReducer(
-        undefined,
-        fetchGuidesAddons({ slug, guids, errorHandlerId: 'test' }),
-      );
-
-      expect(getGUIDsBySlug({ guidesState, slug })).toEqual(guids);
     });
   });
 });

--- a/tests/unit/amo/reducers/test_guides.js
+++ b/tests/unit/amo/reducers/test_guides.js
@@ -1,5 +1,6 @@
 import guidesReducer, {
   fetchGuidesAddons,
+  getGUIDsBySlug,
   initialState,
 } from 'amo/reducers/guides';
 import { loadAddonResults } from 'core/reducers/addons';
@@ -15,7 +16,11 @@ describe(__filename, () => {
     it('updates the loading flag status', () => {
       const state = guidesReducer(
         undefined,
-        fetchGuidesAddons({ guids: 'test,test2', errorHandlerId: 'test' }),
+        fetchGuidesAddons({
+          slug: 'some-slug',
+          guids: 'test,test2',
+          errorHandlerId: 'test',
+        }),
       );
 
       expect(state.loading).toEqual(true);
@@ -28,14 +33,37 @@ describe(__filename, () => {
       expect(newState.loading).toEqual(false);
     });
 
-    it('stores the add-on GUIDs', () => {
+    it('stores the add-on GUIDs by slug', () => {
+      const slug = 'some-slug';
       const guids = ['test', 'test2'];
       const state = guidesReducer(
         undefined,
-        fetchGuidesAddons({ guids, errorHandlerId: 'test' }),
+        fetchGuidesAddons({ slug, guids, errorHandlerId: 'test' }),
       );
 
-      expect(state.guids).toEqual(guids);
+      expect(state.bySlug).toEqual({
+        [slug]: guids,
+      });
+    });
+  });
+
+  describe('getGUIDsBySlug', () => {
+    it('returns an empty array when there is no corresponding slug', () => {
+      const slug = 'some-slug';
+      const guids = getGUIDsBySlug({ guidesState: initialState, slug });
+
+      expect(guids).toEqual([]);
+    });
+
+    it('returns the GUIDs for a given slug', () => {
+      const slug = 'some-slug';
+      const guids = ['test', 'test2'];
+      const guidesState = guidesReducer(
+        undefined,
+        fetchGuidesAddons({ slug, guids, errorHandlerId: 'test' }),
+      );
+
+      expect(getGUIDsBySlug({ guidesState, slug })).toEqual(guids);
     });
   });
 });

--- a/tests/unit/amo/sagas/test_guides.js
+++ b/tests/unit/amo/sagas/test_guides.js
@@ -38,6 +38,7 @@ describe(__filename, () => {
     function _fetchGuidesAddons(params) {
       sagaTester.dispatch(
         fetchGuidesAddons({
+          slug: 'some-slug',
           errorHandlerId: errorHandler.id,
           ...params,
         }),


### PR DESCRIPTION
Fixes #7019

---

I changed the shape of the state to use a map <slug, Array<GUID>> so that we can load other add-ons for another guide page, while keeping our strategy to avoid double-fetch. I also cleaned up the test file for the `Guides` component.