### PR TITLE
Revert "Enable HCT in production (#6994)"

### DIFF
--- a/config/default-disco.js
+++ b/config/default-disco.js
@@ -82,9 +82,4 @@ module.exports = {
 
   // https://sentry.prod.mozaws.net/operations/addons-frontend-disco-prod/
   publicSentryDsn: 'https://b9e70d0dca144344a7a5674c29b08355@sentry.prod.mozaws.net/186',
-
-  // Hybrid Content Telemetry: On by default for the Disco Pane.
-  // Note: Further configuration is required to enable collection locally or on -dev or stage.
-  // See the docs `docs/telemetry.md` for details.
-  hctEnabled: true,
 };

--- a/config/dev-disco.js
+++ b/config/dev-disco.js
@@ -25,4 +25,6 @@ module.exports = {
 
   // https://sentry.prod.mozaws.net/operations/addons-frontend-disco-dev/
   publicSentryDsn: 'https://560fc81d9fd14266b99bda032de23c52@sentry.prod.mozaws.net/184',
+
+  hctEnabled: true,
 };

--- a/config/development-disco.js
+++ b/config/development-disco.js
@@ -1,4 +1,7 @@
 module.exports = {
   trackingEnabled: false,
   loggingLevel: 'debug',
+  // This requires further manual configuration to collect data.
+  // Please see docs/telemetry.md for more info.
+  hctEnabled: true,
 };


### PR DESCRIPTION
This reverts commit 9490af7e3f4274dcc4a9a2ccd3a693e131711994.

see https://github.com/mozilla/addons-frontend/issues/6797#issuecomment-440985010 for more details.

Fixes #7025