### PR TITLE
Use node env in Jest

### DIFF
--- a/tests/unit/test_sriDataPlugin.js
+++ b/tests/unit/test_sriDataPlugin.js
@@ -1,3 +1,7 @@
+/**
+ * See: https://github.com/mozilla/addons-frontend/issues/7031
+ * @jest-environment node
+ */
 import fs from 'fs';
 import path from 'path';
 


### PR DESCRIPTION
Fixes #7031

---

~~According to https://github.com/facebook/jest/issues/1909, we should use `node` as the test environment. I am not sure what the implications are, but if the test suite passes with that, I guess it is alright.~~

~~I saw a similar patch related to webpack 4 too: https://github.com/mxmul/closure-loader/pull/40~~

I marked the test file for the `sriDataPlugin` as "requires node", see also: https://github.com/mozilla/addons-frontend/issues/2445