### PR TITLE
Add Venetan lang

### DIFF
--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -595,6 +595,10 @@ export const unfilteredLanguages = {
     English: 'Venda',
     native: 'Tshiven\u1e13a',
   },
+  vec: {
+    English: 'Venetan',
+    native: 'V\u00e8neto',
+  },
   vi: {
     English: 'Vietnamese',
     native: 'Ti\u1ebfng Vi\u1ec7t',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/839

---

Please read the original issue.

You will need this patch to test properly, because the add-on is only available in -prod. It must be applied to `config/development-amo.js`:

```diff
diff --git a/config/development-amo.js b/config/development-amo.js
index 452283939..24fc8134e 100644
--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -3,6 +3,8 @@ module.exports = {

   baseURL: 'http://localhost:3000',

+  apiHost: 'https://addons.mozilla.org',
+
   proxyApiHost: 'http://olympia.test',
   proxyPort: 3000,
   proxyEnabled: true,
```

## Screenshots

Before:

![](https://user-images.githubusercontent.com/851903/48920639-48e2d680-ee9a-11e8-89a3-9e79c66b01c2.jpg)

After:

![](https://user-images.githubusercontent.com/217628/48921411-eb518880-ee9f-11e8-96ef-1b3c6ff8a4e4.png)