### PR TITLE
[WIP] Configuration tweaks for tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -378,5 +378,6 @@
       "maxSize": "30 kB"
     }
   ],
-  "snyk": true
+  "snyk": true,
+  "sideEffects": ["src/core/polyfill.js", "*.scss"]
 }

--- a/webpack-common.js
+++ b/webpack-common.js
@@ -1,4 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import fs from 'fs';
+
 import autoprefixer from 'autoprefixer';
 import CircularDependencyPlugin from 'circular-dependency-plugin';
 import config from 'config';
@@ -7,6 +9,9 @@ import webpack from 'webpack';
 
 import 'core/polyfill';
 import { getClientConfig } from 'core/utils';
+
+const babelrc = fs.readFileSync('./.babelrc');
+export const babelrcObject = JSON.parse(babelrc);
 
 export function getStyleRules({
   bundleStylesWithJs = false,
@@ -91,15 +96,20 @@ export function getAssetRules() {
     {
       test: /\.svg$/,
       use: [{ loader: 'svg-url-loader', options: urlLoaderOptions }],
+      sideEffects: true,
     },
     {
       test: /\.(jpg|png|gif|webm|mp4|otf|woff|woff2)$/,
       use: [{ loader: 'url-loader', options: urlLoaderOptions }],
+      sideEffects: true,
     },
   ];
 }
 
-export function getRules({ babelOptions, bundleStylesWithJs = false } = {}) {
+export function getRules({
+  babelOptions = babelrcObject,
+  bundleStylesWithJs = false,
+} = {}) {
   return [
     {
       test: /\.jsx?$/,

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -1,12 +1,11 @@
 /* eslint-disable max-len, no-console, import/no-extraneous-dependencies */
-import fs from 'fs';
 import path from 'path';
 
 import config from 'config';
 import webpack from 'webpack';
 import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 
-import { getPlugins, getRules } from './webpack-common';
+import { babelrcObject, getPlugins, getRules } from './webpack-common';
 import webpackConfig from './webpack.prod.config.babel';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
 
@@ -15,9 +14,6 @@ const localDevelopment = config.util.getEnv('NODE_ENV') === 'development';
 const webpackIsomorphicToolsPlugin = new WebpackIsomorphicToolsPlugin(
   webpackIsomorphicToolsConfig,
 );
-
-const babelrc = fs.readFileSync('./.babelrc');
-const babelrcObject = JSON.parse(babelrc);
 
 const babelPlugins = babelrcObject.plugins || [];
 const babelDevPlugins = ['react-hot-loader/babel'];


### PR DESCRIPTION
Fixes #2407

---

I updated our config to enable tree shaking, which should work now, according to the data below. With tree shaking enabled, there is a bug that changes the order of the final CSS bundle, which creates UI issues. I cannot find why we have this bug though...

In addition, tree shaking removes our polyfills if we don't configure it properly. We need those polyfills, so the config reflects that. That being said, we don't have a huge gain.

## AMO

without tree shaking:

```
 PASS  ./dist/amo-9a09628a441f60638413.js: 410.5KB < maxSize 430KB (gzip)
```

with tree shaking:

```
 PASS  ./dist/amo-ee2a425f7f0df076aa31.js: 410.6KB < maxSize 430KB (gzip)
```

## Disco

without tree shaking:

```
 PASS  ./dist/disco-6930685d87f49bdfad61.js: 240.84KB < maxSize 430KB (gzip)
```

with tree shaking and polyfills:

```
 PASS  ./dist/disco-bfe300d9524e39d29a6e.js: 240.22KB < maxSize 430KB (gzip)
```

with tree shaking and no polyfills (⚠️):

```
 PASS  ./dist/disco-bcb455f8e4425833966d.js: 213.22KB < maxSize 430KB (gzip)
```