### PR TITLE
I2664 - When pre-loading reviews, create the respective amount placeholders for reviews

### DIFF
--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -195,6 +195,10 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     );
   }
 
+  generateRandomLoadingReviews(min: number, max: number) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
+  }
+
   render() {
     const {
       addon,
@@ -229,16 +233,6 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       }
     }
 
-    // When reviews have not loaded yet, make a list of 4 empty reviews
-    // as a placeholder.
-    const allReviews = reviews
-      ? // Remove the Featured Review from the array.
-        // TODO: Remove this code and use the API to filter out the featured
-        // review once https://github.com/mozilla/addons-server/issues/9424
-        // is fixed.
-        reviews.filter((review) => review.id.toString() !== reviewId)
-      : Array(4).fill(null);
-
     const header = addon
       ? i18n.sprintf(i18n.gettext('Reviews for %(addonName)s'), {
           addonName: addon.name,
@@ -262,6 +256,20 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       ) : (
         <LoadingText />
       );
+
+    let addonReviewDisplayCount =
+      addonReviewCount || this.generateRandomLoadingReviews(1, 25);
+    if (addonReviewDisplayCount > 25) {
+      addonReviewDisplayCount = 25;
+    }
+
+    const allReviews = reviews
+      ? // Remove the Featured Review from the array.
+        // TODO: Remove this code and use the API to filter out the featured
+        // review once https://github.com/mozilla/addons-server/issues/9424
+        // is fixed.
+        reviews.filter((review) => review.id.toString() !== reviewId)
+      : Array(addonReviewDisplayCount).fill(null);
 
     const paginator =
       addon && reviewCount && pageSize && reviewCount > pageSize ? (

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -257,10 +257,10 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
         <LoadingText />
       );
 
-    let addonReviewDisplayCount =
+    let placeholderCount =
       addonReviewCount || this.generateRandomLoadingReviews(1, 25);
-    if (addonReviewDisplayCount > 25) {
-      addonReviewDisplayCount = 25;
+    if (placeholderCount > 25) {
+      placeholderCount = 25;
     }
 
     const allReviews = reviews
@@ -269,7 +269,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
         // review once https://github.com/mozilla/addons-server/issues/9424
         // is fixed.
         reviews.filter((review) => review.id.toString() !== reviewId)
-      : Array(addonReviewDisplayCount).fill(null);
+      : Array(placeholderCount).fill(null);
 
     const paginator =
       addon && reviewCount && pageSize && reviewCount > pageSize ? (

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -7,6 +7,7 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import AddonReviewCard from 'amo/components/AddonReviewCard';
 import AddonSummaryCard from 'amo/components/AddonSummaryCard';
 import FeaturedAddonReview from 'amo/components/FeaturedAddonReview';
@@ -195,10 +196,6 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     );
   }
 
-  generateRandomLoadingReviews(min: number, max: number) {
-    return Math.floor(Math.random() * (max - min + 1) + min);
-  }
-
   render() {
     const {
       addon,
@@ -257,10 +254,9 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
         <LoadingText />
       );
 
-    let placeholderCount =
-      addonReviewCount || this.generateRandomLoadingReviews(1, 25);
-    if (placeholderCount > 25) {
-      placeholderCount = 25;
+    let placeholderCount = addonReviewCount || 4;
+    if (placeholderCount > DEFAULT_API_PAGE_SIZE) {
+      placeholderCount = DEFAULT_API_PAGE_SIZE;
     }
 
     const allReviews = reviews

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -114,7 +114,17 @@ describe(__filename, () => {
   };
 
   describe('<AddonReviewList/>', () => {
-    it('displays 4 placeholders when there are no reviews yet', () => {
+    it('shows placeholders for reviews without an addon', () => {
+      const root = render({ addon: null });
+
+      // Make sure four review placeholders were rendered.
+      expect(root.find(AddonReviewCard)).toHaveLength(4);
+      // Do a sanity check on the first placeholder;
+      expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
+      expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);
+    });
+
+    it('displays 4 placeholders for an addon with no reviews', () => {
       const externalAddon = {
         ...fakeAddon,
         ratings: {
@@ -135,7 +145,7 @@ describe(__filename, () => {
       });
     });
 
-    it('displays a 1:1 ratio of placeholders to reviews', () => {
+    it('displays the same number of placeholders as there are reviews for an addon', () => {
       const reviewCount = 10;
       const externalAddon = {
         ...fakeAddon,
@@ -157,7 +167,7 @@ describe(__filename, () => {
       });
     });
 
-    it('displays 25 placeholders for more than 25 reviews belonging to an addon', () => {
+    it('displays 25 placeholders for more than 25 reviews for an addon', () => {
       const externalAddon = {
         ...fakeAddon,
         ratings: {
@@ -165,17 +175,12 @@ describe(__filename, () => {
           text_count: DEFAULT_API_PAGE_SIZE + 1,
         },
       };
-      const addon = createInternalAddon(externalAddon);
 
       loadAddon(externalAddon);
 
       const root = render();
 
       expect(root.find(AddonReviewCard)).toHaveLength(DEFAULT_API_PAGE_SIZE);
-      root.find(AddonReviewCard).forEach((card) => {
-        expect(card).toHaveProp('review', null);
-        expect(card).toHaveProp('addon', addon);
-      });
     });
 
     it('renders an AddonSummaryCard with an addon', () => {

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -124,6 +124,41 @@ describe(__filename, () => {
       expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);
     });
 
+    it('shows 1:1 placeholders for reviews belonging to an addon', () => {
+      const numberOfPlaceholders = 10;
+      const reviews = Array(numberOfPlaceholders).fill({
+        ...fakeReview,
+        id: 1,
+        score: 1,
+      });
+      _setAddonReviews({ reviews });
+
+      const root = render();
+
+      // Make sure a 1:1 ratio of reviews to placeholders is rendered.
+      expect(root.find(AddonReviewCard)).toHaveLength(numberOfPlaceholders);
+      // Do a sanity check on the first placeholder;
+      expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
+      expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);
+    });
+
+    it('shows 25 placeholders for more than 25 reviews belonging to an addon', () => {
+      const reviews = Array(DEFAULT_API_PAGE_SIZE + 1).fill({
+        ...fakeReview,
+        id: 1,
+        score: 1,
+      });
+      _setAddonReviews({ reviews });
+
+      const root = render({ addon: null });
+
+      // Make sure twenty-five review placeholders were rendered.
+      expect(root.find(AddonReviewCard)).toHaveLength(DEFAULT_API_PAGE_SIZE);
+      // Do a sanity check on the first placeholder;
+      expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
+      expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);
+    });
+
     it('renders an AddonSummaryCard with an addon', () => {
       const addon = fakeAddon;
       loadAddon(addon);

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -135,39 +135,47 @@ describe(__filename, () => {
       });
     });
 
-    it('shows 1:1 placeholders for reviews belonging to an addon', () => {
-      const numberOfPlaceholders = 10;
-      const reviews = Array(numberOfPlaceholders).fill({
-        ...fakeReview,
-        id: 1,
-        score: 1,
-      });
-      _setAddonReviews({ reviews });
+    it('displays a 1:1 ratio of placeholders to reviews', () => {
+      const reviewCount = 10;
+      const externalAddon = {
+        ...fakeAddon,
+        ratings: {
+          ...fakeAddon.ratings,
+          text_count: reviewCount,
+        },
+      };
+      const addon = createInternalAddon(externalAddon);
+
+      loadAddon(externalAddon);
 
       const root = render();
 
-      // Make sure a 1:1 ratio of reviews to placeholders is rendered.
-      expect(root.find(AddonReviewCard)).toHaveLength(numberOfPlaceholders);
-      // Do a sanity check on the first placeholder;
-      expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
-      expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);
+      expect(root.find(AddonReviewCard)).toHaveLength(reviewCount);
+      root.find(AddonReviewCard).forEach((card) => {
+        expect(card).toHaveProp('review', null);
+        expect(card).toHaveProp('addon', addon);
+      });
     });
 
-    it('shows 25 placeholders for more than 25 reviews belonging to an addon', () => {
-      const reviews = Array(DEFAULT_API_PAGE_SIZE + 1).fill({
-        ...fakeReview,
-        id: 1,
-        score: 1,
-      });
-      _setAddonReviews({ reviews });
+    it('displays 25 placeholders for more than 25 reviews belonging to an addon', () => {
+      const externalAddon = {
+        ...fakeAddon,
+        ratings: {
+          ...fakeAddon.ratings,
+          text_count: DEFAULT_API_PAGE_SIZE + 1,
+        },
+      };
+      const addon = createInternalAddon(externalAddon);
 
-      const root = render({ addon: null });
+      loadAddon(externalAddon);
 
-      // Make sure twenty-five review placeholders were rendered.
+      const root = render();
+
       expect(root.find(AddonReviewCard)).toHaveLength(DEFAULT_API_PAGE_SIZE);
-      // Do a sanity check on the first placeholder;
-      expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
-      expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);
+      root.find(AddonReviewCard).forEach((card) => {
+        expect(card).toHaveProp('review', null);
+        expect(card).toHaveProp('addon', addon);
+      });
     });
 
     it('renders an AddonSummaryCard with an addon', () => {

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -114,14 +114,25 @@ describe(__filename, () => {
   };
 
   describe('<AddonReviewList/>', () => {
-    it('shows placeholders for reviews without an addon', () => {
-      const root = render({ addon: null });
+    it('displays 4 placeholders when there are no reviews yet', () => {
+      const externalAddon = {
+        ...fakeAddon,
+        ratings: {
+          ...fakeAddon.ratings,
+          text_count: 0,
+        },
+      };
+      const addon = createInternalAddon(externalAddon);
 
-      // Make sure four review placeholders were rendered.
+      loadAddon(externalAddon);
+
+      const root = render();
+
       expect(root.find(AddonReviewCard)).toHaveLength(4);
-      // Do a sanity check on the first placeholder;
-      expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
-      expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);
+      root.find(AddonReviewCard).forEach((card) => {
+        expect(card).toHaveProp('review', null);
+        expect(card).toHaveProp('addon', addon);
+      });
     });
 
     it('shows 1:1 placeholders for reviews belonging to an addon', () => {

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -117,10 +117,8 @@ describe(__filename, () => {
     it('shows placeholders for reviews without an addon', () => {
       const root = render({ addon: null });
 
-      // Generate a random amount of placeholders between 1 and 25 inclusive
-      // when the amount of reviews is unknown.
-      expect(root.find(AddonReviewCard).length).toBeGreaterThanOrEqual(1);
-      expect(root.find(AddonReviewCard).length).toBeLessThanOrEqual(25);
+      // Make sure four review placeholders were rendered.
+      expect(root.find(AddonReviewCard)).toHaveLength(4);
       // Do a sanity check on the first placeholder;
       expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
       expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -117,8 +117,10 @@ describe(__filename, () => {
     it('shows placeholders for reviews without an addon', () => {
       const root = render({ addon: null });
 
-      // Make sure four review placeholders were rendered.
-      expect(root.find(AddonReviewCard)).toHaveLength(4);
+      // Generate a random amount of placeholders between 1 and 25 inclusive
+      // when the amount of reviews is unknown.
+      expect(root.find(AddonReviewCard).length).toBeGreaterThanOrEqual(1);
+      expect(root.find(AddonReviewCard).length).toBeLessThanOrEqual(25);
       // Do a sanity check on the first placeholder;
       expect(root.find(AddonReviewCard).at(0)).toHaveProp('addon', null);
       expect(root.find(AddonReviewCard).at(0)).toHaveProp('review', null);


### PR DESCRIPTION
Fixes #2664: When pre-loading reviews, create only the number of reviews that the page will load

This patch will now render the respective amount of `LoadingText`, ie. placeholders, when a user navigates to an addons reviews page, replacing the current implementation of 4 placeholders.

The new criterion is as follows:

1. If the addon has **between 1 and 25 reviews**, render the exact amount (ex. 3 `LoadingText` placeholders for 3 reviews):

   <details>
   	<summary>🎥 Between 1 and 25 reviews (inclusive)</summary>

   ![loadingtext_pagination_exact_limit](https://user-images.githubusercontent.com/13009507/48986656-c8b0b100-f0e5-11e8-928b-7e066a9ec741.gif)

   </details>

2. If the addon has **more than 25 reviews**, render 25 `LoadingText` placeholders (as per the [pagination limit](https://github.com/mozilla/addons-frontend/blob/fda47b4842a7066ce989a7e5a6ec1a84ecd479fc/src/core/api/index.js#L24)):

   <details>
   	<summary>🎥 25+ reviews</summary>

   ![loadingtext_pagination_max_limit](https://user-images.githubusercontent.com/13009507/48986676-feee3080-f0e5-11e8-819d-6e84e26c8d87.gif)

   </details>

3. If the user navigates directly to the addon, bypassing the amount of reviews, render 4 `LoadingText` placeholders.