### PR TITLE
Optimistically recalculate the average rating for an add-on

### DIFF
--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -342,9 +342,9 @@ function* manageAddonReview(
       );
 
       // Reload the add-on to update its rating and review counts.
-      //yield put(
-      //  fetchAddon({ errorHandler, slug: reviewFromResponse.addon.slug }),
-      //);
+      yield put(
+        fetchAddon({ errorHandler, slug: reviewFromResponse.addon.slug }),
+      );
 
       yield put(
         updateRatingCounts({

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -47,7 +47,6 @@ import {
   updateRatingCounts,
 } from 'amo/actions/reviews';
 import log from 'core/logger';
-import { fetchAddon } from 'core/reducers/addons';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 import type { AppState } from 'amo/store';
 import type {
@@ -339,11 +338,6 @@ function* manageAddonReview(
           review: reviewFromResponse,
           userId: reviewFromResponse.user.id,
         }),
-      );
-
-      // Reload the add-on to update its rating and review counts.
-      yield put(
-        fetchAddon({ errorHandler, slug: reviewFromResponse.addon.slug }),
       );
 
       yield put(

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -342,8 +342,16 @@ function* manageAddonReview(
       );
 
       // Reload the add-on to update its rating and review counts.
+      //yield put(
+      //  fetchAddon({ errorHandler, slug: reviewFromResponse.addon.slug }),
+      //);
+
       yield put(
-        fetchAddon({ errorHandler, slug: reviewFromResponse.addon.slug }),
+        updateRatingCounts({
+          addonId: reviewFromResponse.addon.id,
+          oldReview,
+          newReview: createInternalReview(reviewFromResponse),
+        }),
       );
 
       yield put(

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -454,7 +454,8 @@ export default function addonsReducer(
 
       let countForAverage = ratingCount;
       if (average && countForAverage && oldReview && oldReview.score) {
-        // Begin by subtracting the old rating to reset the baseline.
+        // If average and countForAverage are defined and greater than 0,
+        // begin by subtracting the old rating to reset the baseline.
         const countAfterRemoval = countForAverage - 1;
 
         if (countAfterRemoval === 0) {

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -1,10 +1,16 @@
 /* @flow */
 import invariant from 'invariant';
 
-import { UNLOAD_ADDON_REVIEWS } from 'amo/actions/reviews';
+import {
+  UNLOAD_ADDON_REVIEWS,
+  UPDATE_RATING_COUNTS,
+} from 'amo/actions/reviews';
 import { removeUndefinedProps } from 'core/utils/addons';
 import { ADDON_TYPE_THEME } from 'core/constants';
-import type { UnloadAddonReviewsAction } from 'amo/actions/reviews';
+import type {
+  UnloadAddonReviewsAction,
+  UpdateRatingCountsAction,
+} from 'amo/actions/reviews';
 import type { ExternalAddonInfoType } from 'amo/api/addonInfo';
 import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
@@ -352,7 +358,8 @@ type Action =
   | FetchAddonInfoAction
   | LoadAddonInfoAction
   | LoadAddonResultsAction
-  | UnloadAddonReviewsAction;
+  | UnloadAddonReviewsAction
+  | UpdateRatingCountsAction;
 
 export default function addonsReducer(
   state: AddonsState = initialState,
@@ -430,6 +437,72 @@ export default function addonsReducer(
         };
       }
       return state;
+    }
+
+    case UPDATE_RATING_COUNTS: {
+      const { addonId, oldReview, newReview } = action.payload;
+
+      const addon = state.byID[`${addonId}`];
+      if (!addon) {
+        return state;
+      }
+
+      const { ratings } = addon;
+      let average = ratings ? ratings.average : 0;
+      let ratingCount = ratings ? ratings.count : 0;
+      let reviewCount = ratings ? ratings.text_count : 0;
+
+      // Recalculate the overall average rating.
+      let countForAverage = ratingCount;
+      if (average && countForAverage && oldReview && oldReview.score) {
+        const countAfterRemoval = countForAverage - 1;
+
+        if (countAfterRemoval === 0) {
+          // There are no ratings left.
+          average = 0;
+        } else {
+          // Take away the old score and recalculate the average.
+          average =
+            (average * countForAverage - oldReview.score) / countAfterRemoval;
+        }
+        countForAverage = countAfterRemoval;
+      }
+
+      // Add in the new score and recalculate the average.
+      average =
+        (average * countForAverage + newReview.score) / (countForAverage + 1);
+
+      // Adjust rating / review counts.
+      if (!oldReview) {
+        // A new rating / review was added.
+        ratingCount += 1;
+        if (newReview.body) {
+          reviewCount += 1;
+        }
+      } else if (!oldReview.body && newReview.body) {
+        // A rating was converted into a review.
+        reviewCount += 1;
+      }
+
+      return {
+        ...state,
+        byID: {
+          ...state.byID,
+          [addonId]: {
+            ...addon,
+            ratings: {
+              ...ratings,
+              average,
+              // It's impossible to recalculate the bayesian_average
+              // (i.e. median) so we set it to the average as an
+              // approximation.
+              bayesian_average: average,
+              count: ratingCount,
+              text_count: reviewCount,
+            },
+          },
+        },
+      };
     }
 
     case FETCH_ADDON_INFO: {

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -452,23 +452,25 @@ export default function addonsReducer(
       let ratingCount = ratings ? ratings.count : 0;
       let reviewCount = ratings ? ratings.text_count : 0;
 
-      // Recalculate the overall average rating.
       let countForAverage = ratingCount;
       if (average && countForAverage && oldReview && oldReview.score) {
+        // Begin by subtracting the old rating to reset the baseline.
         const countAfterRemoval = countForAverage - 1;
 
         if (countAfterRemoval === 0) {
           // There are no ratings left.
           average = 0;
         } else {
-          // Take away the old score and recalculate the average.
+          // Expand all existing rating scores, take away the old score,
+          // and recalculate the average.
           average =
             (average * countForAverage - oldReview.score) / countAfterRemoval;
         }
         countForAverage = countAfterRemoval;
       }
 
-      // Add in the new score and recalculate the average.
+      // Expand all existing rating scores, add in the new score,
+      // and recalculate the average.
       average =
         (average * countForAverage + newReview.score) / (countForAverage + 1);
 

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -42,7 +42,6 @@ import {
 } from 'amo/constants';
 import reviewsReducer from 'amo/reducers/reviews';
 import reviewsSaga, { FLASH_SAVED_MESSAGE_DURATION } from 'amo/sagas/reviews';
-import { fetchAddon } from 'core/reducers/addons';
 import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import apiReducer from 'core/reducers/api';
 import {
@@ -767,37 +766,6 @@ describe(__filename, () => {
       const exampleHideAction = hideEditReviewForm({ reviewId: oldReview.id });
 
       expect(sagaTester.numCalled(exampleHideAction.type)).toEqual(0);
-    });
-
-    it('re-fetches the add-on after submitting a review', async () => {
-      const slug = 'the-addon-slug';
-      mockApi
-        .expects('submitReview')
-        .resolves(createExternalReview({ addonSlug: slug }));
-
-      _createAddonReview();
-
-      const expectedAction = fetchAddon({ errorHandler, slug });
-      const action = await sagaTester.waitFor(expectedAction.type);
-      expect(action).toEqual(expectedAction);
-    });
-
-    it('does not re-fetch the add-on after updating a reply', async () => {
-      const slug = 'the-addon-slug';
-      mockApi
-        .expects('submitReview')
-        .resolves(
-          createExternalReview({ addonSlug: slug, isDeveloperReply: true }),
-        );
-
-      _updateAddonReview();
-
-      const expectedAction = hideFlashedReviewMessage();
-      await sagaTester.waitFor(expectedAction.type);
-
-      const unexpectedAction = fetchAddon({ errorHandler, slug });
-
-      expect(sagaTester.numCalled(unexpectedAction.type)).toEqual(0);
     });
 
     it('dispatches an error', async () => {

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -687,7 +687,9 @@ describe(__filename, () => {
         }),
       );
 
-      expect(state.byID[addon.id].ratings.text_count).toEqual(reviewCount);
+      const newAddon = state.byID[addon.id];
+      expect(newAddon.ratings.count).toEqual(ratingCount);
+      expect(newAddon.ratings.text_count).toEqual(reviewCount);
     });
 
     it('increments counts even when no counts existed before', () => {

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -1,4 +1,8 @@
-import { unloadAddonReviews } from 'amo/actions/reviews';
+import {
+  createInternalReview,
+  unloadAddonReviews,
+  updateRatingCounts,
+} from 'amo/actions/reviews';
 import { ADDON_TYPE_EXTENSION } from 'core/constants';
 import addons, {
   createInternalAddon,
@@ -22,6 +26,7 @@ import {
   dispatchClientMetadata,
   fakeAddon,
   fakeAddonInfo,
+  fakeReview,
   fakeTheme,
 } from 'tests/unit/helpers';
 
@@ -550,6 +555,289 @@ describe(__filename, () => {
       expect(state.byID[addon1.id]).toEqual(undefined);
       expect(state.bySlug).toEqual({ [slug2]: id2 });
       expect(state.loadingBySlug).toEqual({ [slug2]: false });
+    });
+  });
+
+  describe('updateRatingCounts', () => {
+    function _updateRatingCounts({
+      addonId = 321,
+      oldReview = null,
+      newReview = createInternalReview({ ...fakeReview }),
+    } = {}) {
+      return updateRatingCounts({ addonId, oldReview, newReview });
+    }
+
+    function addonWithRatings(ratings = {}) {
+      return {
+        ...fakeAddon,
+        ratings: {
+          ...fakeAddon.ratings,
+          ...ratings,
+        },
+      };
+    }
+
+    function initStateWithAddon(addon = { ...fakeAddon }) {
+      return addons(undefined, loadAddonResults({ addons: [addon] }));
+    }
+
+    function average(numbers) {
+      return numbers.reduce((total, num) => total + num, 0) / numbers.length;
+    }
+
+    it('does nothing if the add-on has not been loaded', () => {
+      const state = addons(initialState, _updateRatingCounts());
+
+      expect(state).toEqual(initialState);
+    });
+
+    it('increments only the rating count for a newly added score', () => {
+      const ratingCount = 300;
+      const reviewCount = 200;
+      const addon = addonWithRatings({
+        count: ratingCount,
+        text_count: reviewCount,
+      });
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: null,
+          newReview: createInternalReview({
+            ...fakeReview,
+            body: null,
+            score: 5,
+          }),
+        }),
+      );
+
+      const storedAddon = state.byID[addon.id];
+      expect(storedAddon.ratings.count).toEqual(ratingCount + 1);
+      // Since a review without a body was added, no change.
+      expect(storedAddon.ratings.text_count).toEqual(reviewCount);
+    });
+
+    it('increments the review count for newly added bodies', () => {
+      const reviewCount = 200;
+      const addon = addonWithRatings({
+        text_count: reviewCount,
+      });
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: null,
+          newReview: createInternalReview({
+            ...fakeReview,
+            body: 'Fantastic add-on',
+            score: 5,
+          }),
+        }),
+      );
+
+      expect(state.byID[addon.id].ratings.text_count).toEqual(reviewCount + 1);
+    });
+
+    it('increments the review count for reviews updated to include a body', () => {
+      const reviewCount = 200;
+      const addon = addonWithRatings({
+        text_count: reviewCount,
+      });
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: createInternalReview({
+            ...fakeReview,
+            body: null,
+            score: 5,
+          }),
+          newReview: createInternalReview({
+            ...fakeReview,
+            body: 'Fantastic add-on',
+            score: 5,
+          }),
+        }),
+      );
+
+      expect(state.byID[addon.id].ratings.text_count).toEqual(reviewCount + 1);
+    });
+
+    it('does not increment rating or review counts for existing reviews', () => {
+      const ratingCount = 100;
+      const reviewCount = 200;
+      const addon = addonWithRatings({
+        count: ratingCount,
+        text_count: reviewCount,
+      });
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: createInternalReview({ ...fakeReview }),
+          newReview: createInternalReview({ ...fakeReview }),
+        }),
+      );
+
+      expect(state.byID[addon.id].ratings.text_count).toEqual(reviewCount);
+    });
+
+    it('increments counts even when no counts existed before', () => {
+      const addon = { ...fakeAddon, ratings: null };
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: null,
+          newReview: createInternalReview({
+            ...fakeReview,
+            body: 'This add-on is nice',
+            score: 5,
+          }),
+        }),
+      );
+
+      const storedAddon = state.byID[addon.id];
+      expect(storedAddon.ratings.count).toEqual(1);
+      expect(storedAddon.ratings.text_count).toEqual(1);
+    });
+
+    it('recalculates average rating when the score changes', () => {
+      const ratings = [4, 4, 3, 5];
+      const addon = addonWithRatings({
+        average: average(ratings),
+        count: ratings.length,
+      });
+
+      const oldScore = ratings.pop();
+      const newScore = 1;
+      ratings.push(newScore);
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: createInternalReview({ ...fakeReview, score: oldScore }),
+          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+        }),
+      );
+
+      expect(state.byID[addon.id].ratings.average.toFixed(3)).toEqual(
+        average(ratings).toFixed(3),
+      );
+    });
+
+    it('recalculates average rating for new scores', () => {
+      const ratings = [4, 4, 5];
+      const addon = addonWithRatings({
+        average: average(ratings),
+        count: ratings.length,
+      });
+
+      const newScore = 1;
+      ratings.push(newScore);
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: null,
+          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+        }),
+      );
+
+      expect(state.byID[addon.id].ratings.average.toFixed(3)).toEqual(
+        average(ratings).toFixed(3),
+      );
+    });
+
+    it('calculates an average if one did not exist before', () => {
+      const addon = { ...fakeAddon, ratings: null };
+
+      const newScore = 1;
+      const ratings = [newScore];
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: null,
+          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+        }),
+      );
+
+      expect(state.byID[addon.id].ratings.average.toFixed(3)).toEqual(
+        average(ratings).toFixed(3),
+      );
+    });
+
+    it('can handle rating counts of 1', () => {
+      const oldAverage = 5;
+      const count = 1;
+      const addon = addonWithRatings({
+        average: oldAverage,
+        count,
+      });
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: createInternalReview({
+            ...fakeReview,
+            body: null,
+            score: 5,
+          }),
+          newReview: createInternalReview({
+            ...fakeReview,
+            body: 'Fantastic add-on',
+            score: 5,
+          }),
+        }),
+      );
+
+      // Make sure average is not NaN
+      expect(state.byID[addon.id].ratings.average).toEqual(oldAverage);
+    });
+
+    it('sets bayesian_average to average', () => {
+      const ratings = [5, 5, 5];
+      const addon = addonWithRatings({
+        average: average(ratings),
+        bayesian_average: average(ratings),
+        count: ratings.length,
+      });
+
+      const newScore = 1;
+      ratings.push(newScore);
+
+      let state = initStateWithAddon(addon);
+      state = addons(
+        state,
+        _updateRatingCounts({
+          addonId: addon.id,
+          oldReview: null,
+          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+        }),
+      );
+
+      expect(state.byID[addon.id].ratings.bayesian_average.toFixed(3)).toEqual(
+        average(ratings).toFixed(3),
+      );
     });
   });
 


### PR DESCRIPTION
~~⚠️ Depends on https://github.com/mozilla/addons-frontend/pull/6957~~

<hr>

Fixes https://github.com/mozilla/addons-frontend/issues/6958 by optimistically recalculating average ratings for an add-on after adding / updating a rating.