### PR TITLE
Remove duplicate call to updateRatingCounts()

### DIFF
--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -347,14 +347,6 @@ function* manageAddonReview(
           newReview: createInternalReview(reviewFromResponse),
         }),
       );
-
-      yield put(
-        updateRatingCounts({
-          addonId: reviewFromResponse.addon.id,
-          oldReview,
-          newReview: createInternalReview(reviewFromResponse),
-        }),
-      );
     }
 
     // Make the message disappear after some time.

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -642,6 +642,12 @@ describe(__filename, () => {
       });
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
+
+      // It's important that the update only runs once because otherwise
+      // it will double all the review counts.
+      expect(
+        sagaTester.getCalledActions().filter((a) => a.type === action.type),
+      ).toHaveLength(1);
     });
 
     it('updates an add-on review', async () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/6958 (again). The symptom was that when you rated an add-on, the star count incremented by two instead of one.

The call to `updateRatingCounts()` was first added in https://github.com/mozilla/addons-frontend/commit/d4c2a0ddbf#diff-170eeec007168b88041e21f7420f424aR350 for https://github.com/mozilla/addons-frontend/pull/6957

A follow-up patch was originally based on that branch and then rebased on master. This follow-up landed in https://github.com/mozilla/addons-frontend/commit/4a81aae5e9#diff-170eeec007168b88041e21f7420f424aR344 but, as you can see from diff, git automerged the code incorrectly. This resulted in a duplicate call to `updateRatingCounts()`.