### PR TITLE
Rename "username" to "userId" in collection saga/api/reducer

### DIFF
--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -95,7 +95,7 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
       dispatch(
         fetchUserCollections({
           errorHandlerId: errorHandler.id,
-          username: currentUsername,
+          userId: currentUsername,
         }),
       );
     }
@@ -129,7 +129,7 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
         collectionId: collection.id,
         slug: collection.slug,
         errorHandlerId: errorHandler.id,
-        username: currentUsername,
+        userId: currentUsername,
       }),
     );
   }

--- a/src/amo/components/CollectionAddAddon/index.js
+++ b/src/amo/components/CollectionAddAddon/index.js
@@ -131,7 +131,7 @@ export class CollectionAddAddonBase extends React.Component<InternalProps> {
         errorHandlerId: errorHandler.id,
         filters,
         slug: collection.slug,
-        username: collection.authorUsername,
+        userId: collection.authorUsername,
       }),
     );
     this.resetMessages();

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -150,7 +150,7 @@ export class CollectionManagerBase extends React.Component<
           // query parameter values are string, not number.
           // $FLOW_FIXME: https://github.com/mozilla/addons-frontend/issues/5737
           includeAddonId: location.query.include_addon_id,
-          username: currentUsername,
+          userId: currentUsername,
         }),
       );
     } else {
@@ -164,7 +164,7 @@ export class CollectionManagerBase extends React.Component<
           collectionSlug: collection.slug,
           defaultLocale: collection.defaultLocale,
           filters,
-          username: collection.authorUsername,
+          userId: collection.authorUsername,
         }),
       );
     }

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -174,7 +174,7 @@ export class CollectionBase extends React.Component<InternalProps> {
       deleteCollection({
         errorHandlerId: errorHandler.id,
         slug,
-        username,
+        userId: username,
       }),
     );
   };
@@ -247,7 +247,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           errorHandlerId: errorHandler.id,
           filters,
           slug: params.slug,
-          username: params.username,
+          userId: params.username,
         }),
       );
 
@@ -260,7 +260,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           errorHandlerId: errorHandler.id,
           filters,
           slug: params.slug,
-          username: params.username,
+          userId: params.username,
         }),
       );
     }
@@ -298,7 +298,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           page,
         },
         slug,
-        username,
+        userId: username,
       }),
     );
 
@@ -334,7 +334,7 @@ export class CollectionBase extends React.Component<InternalProps> {
         errorHandlerId: errorHandler.id,
         filters,
         slug,
-        username,
+        userId: username,
       }),
     );
   };
@@ -360,7 +360,7 @@ export class CollectionBase extends React.Component<InternalProps> {
         notes,
         filters,
         slug,
-        username,
+        userId: username,
       }),
     );
   };

--- a/src/amo/pages/CollectionList/index.js
+++ b/src/amo/pages/CollectionList/index.js
@@ -50,7 +50,7 @@ export class CollectionListBase extends React.Component<InternalProps> {
       dispatch(
         fetchUserCollections({
           errorHandlerId: errorHandler.id,
-          username: currentUsername,
+          userId: currentUsername,
         }),
       );
     }

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -87,14 +87,14 @@ export type CollectionsState = {
     loading: boolean,
   |},
   userCollections: {
-    [username: string]: {|
+    [userId: string]: {|
       // This is a list of all collections belonging to the user.
       collections: Array<CollectionId> | null,
       loading: boolean,
     |},
   },
   addonInCollections: {
-    [username: string]: {
+    [userId: string]: {
       [addonId: number]: {|
         // This is a list of all user collections that the add-on
         // is a part of.
@@ -125,7 +125,7 @@ type FetchCurrentCollectionParams = {|
   errorHandlerId: string,
   filters?: CollectionFilters,
   slug: string,
-  username: string,
+  userId: string,
 |};
 
 export type FetchCurrentCollectionAction = {|
@@ -137,21 +137,21 @@ export const fetchCurrentCollection = ({
   errorHandlerId,
   filters,
   slug,
-  username,
+  userId,
 }: FetchCurrentCollectionParams = {}): FetchCurrentCollectionAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(slug, 'slug is required');
-  invariant(username, 'username is required');
+  invariant(userId, 'userId is required');
 
   return {
     type: FETCH_CURRENT_COLLECTION,
-    payload: { errorHandlerId, filters, slug, username },
+    payload: { errorHandlerId, filters, slug, userId },
   };
 };
 
 type FetchUserCollectionsParams = {|
   errorHandlerId: string,
-  username: string,
+  userId: string,
 |};
 
 export type FetchUserCollectionsAction = {|
@@ -161,23 +161,19 @@ export type FetchUserCollectionsAction = {|
 
 export const fetchUserCollections = ({
   errorHandlerId,
-  username,
+  userId,
 }: FetchUserCollectionsParams = {}): FetchUserCollectionsAction => {
-  if (!errorHandlerId) {
-    throw new Error('errorHandlerId is required');
-  }
-  if (!username) {
-    throw new Error('username is required');
-  }
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(userId, 'userId is required');
 
   return {
     type: FETCH_USER_COLLECTIONS,
-    payload: { errorHandlerId, username },
+    payload: { errorHandlerId, userId },
   };
 };
 
 type AbortFetchUserCollectionsParams = {|
-  username: string,
+  userId: string,
 |};
 
 type AbortFetchUserCollectionsAction = {|
@@ -186,21 +182,19 @@ type AbortFetchUserCollectionsAction = {|
 |};
 
 export const abortFetchUserCollections = ({
-  username,
+  userId,
 }: AbortFetchUserCollectionsParams = {}): AbortFetchUserCollectionsAction => {
-  if (!username) {
-    throw new Error('username is required');
-  }
+  invariant(userId, 'userId is required');
 
   return {
     type: ABORT_FETCH_USER_COLLECTIONS,
-    payload: { username },
+    payload: { userId },
   };
 };
 
 type AbortAddAddonToCollectionParams = {|
   addonId: number,
-  username: string,
+  userId: string,
 |};
 
 type AbortAddAddonToCollectionAction = {|
@@ -210,18 +204,14 @@ type AbortAddAddonToCollectionAction = {|
 
 export const abortAddAddonToCollection = ({
   addonId,
-  username,
+  userId,
 }: AbortAddAddonToCollectionParams = {}): AbortAddAddonToCollectionAction => {
-  if (!username) {
-    throw new Error('username is required');
-  }
-  if (!addonId) {
-    throw new Error('addonId is required');
-  }
+  invariant(userId, 'userId is required');
+  invariant(addonId, 'addonId is required');
 
   return {
     type: ABORT_ADD_ADDON_TO_COLLECTION,
-    payload: { username, addonId },
+    payload: { userId, addonId },
   };
 };
 
@@ -234,21 +224,15 @@ export const fetchCurrentCollectionPage = ({
   errorHandlerId,
   filters,
   slug,
-  username,
+  userId,
 }: FetchCurrentCollectionParams = {}): FetchCurrentCollectionPageAction => {
-  if (!errorHandlerId) {
-    throw new Error('errorHandlerId is required');
-  }
-  if (!slug) {
-    throw new Error('slug is required');
-  }
-  if (!username) {
-    throw new Error('username is required');
-  }
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(slug, 'slug is required');
+  invariant(userId, 'userId is required');
 
   return {
     type: FETCH_CURRENT_COLLECTION_PAGE,
-    payload: { errorHandlerId, filters, slug, username },
+    payload: { errorHandlerId, filters, slug, userId },
   };
 };
 
@@ -374,7 +358,7 @@ export const loadCollectionAddons = ({
 
 type LoadUserCollectionsParams = {|
   collections: Array<ExternalCollectionDetail>,
-  username: string,
+  userId: string,
 |};
 
 type LoadUserCollectionsAction = {|
@@ -384,25 +368,21 @@ type LoadUserCollectionsAction = {|
 
 export const loadUserCollections = ({
   collections,
-  username,
+  userId,
 }: LoadUserCollectionsParams = {}): LoadUserCollectionsAction => {
-  if (!username) {
-    throw new Error('The username parameter is required');
-  }
-  if (!collections) {
-    throw new Error('The collections parameter is required');
-  }
+  invariant(userId, 'userId is required');
+  invariant(collections, 'collections are required');
 
   return {
     type: LOAD_USER_COLLECTIONS,
-    payload: { username, collections },
+    payload: { userId, collections },
   };
 };
 
 type AddonAddedToCollectionParams = {|
   addonId: number,
   collectionId: CollectionId,
-  username: string,
+  userId: string,
 |};
 
 type AddonAddedToCollectionAction = {|
@@ -413,21 +393,15 @@ type AddonAddedToCollectionAction = {|
 export const addonAddedToCollection = ({
   addonId,
   collectionId,
-  username,
+  userId,
 }: AddonAddedToCollectionParams = {}): AddonAddedToCollectionAction => {
-  if (!addonId) {
-    throw new Error('The addonId parameter is required');
-  }
-  if (!username) {
-    throw new Error('The username parameter is required');
-  }
-  if (!collectionId) {
-    throw new Error('The collectionId parameter is required');
-  }
+  invariant(addonId, 'addonId is required');
+  invariant(userId, 'userId is required');
+  invariant(collectionId, 'collectionId is required');
 
   return {
     type: ADDON_ADDED_TO_COLLECTION,
-    payload: { addonId, collectionId, username },
+    payload: { addonId, collectionId, userId },
   };
 };
 
@@ -447,7 +421,7 @@ type AddAddonToCollectionParams = {|
   filters?: CollectionFilters,
   notes?: string,
   slug: string,
-  username: string,
+  userId: string,
 |};
 
 export type AddAddonToCollectionAction = {|
@@ -463,13 +437,13 @@ export const addAddonToCollection = ({
   filters,
   notes,
   slug,
-  username,
+  userId,
 }: AddAddonToCollectionParams = {}): AddAddonToCollectionAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(collectionId, 'The collectionId parameter is required');
   invariant(slug, 'The slug parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
-  invariant(username, 'The username parameter is required');
+  invariant(userId, 'The userId parameter is required');
 
   if (editing) {
     invariant(filters, 'The filters parameter is required when editing');
@@ -485,14 +459,14 @@ export const addAddonToCollection = ({
       filters,
       notes,
       slug,
-      username,
+      userId,
     },
   };
 };
 
 export type RequiredModifyCollectionParams = {|
   errorHandlerId: string,
-  username: string,
+  userId: string,
 |};
 
 export type OptionalModifyCollectionParams = {|
@@ -534,10 +508,10 @@ export const createCollection = ({
   includeAddonId,
   name,
   slug,
-  username,
+  userId,
 }: CreateCollectionParams = {}): CreateCollectionAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(username, 'username is required');
+  invariant(userId, 'userId is required');
   invariant(name, 'name is required when creating a collection');
   invariant(slug, 'slug is required when creating a collection');
 
@@ -550,7 +524,7 @@ export const createCollection = ({
       includeAddonId,
       name,
       slug,
-      username,
+      userId,
     },
   };
 };
@@ -563,12 +537,12 @@ export const updateCollection = ({
   filters,
   name,
   slug,
-  username,
+  userId,
 }: UpdateCollectionParams = {}): UpdateCollectionAction => {
   invariant(collectionSlug, 'collectionSlug is required when updating');
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(filters, 'filters is required');
-  invariant(username, 'username is required');
+  invariant(userId, 'userId is required');
 
   return {
     type: UPDATE_COLLECTION,
@@ -580,7 +554,7 @@ export const updateCollection = ({
       filters,
       name,
       slug,
-      username,
+      userId,
     },
   };
 };
@@ -632,7 +606,7 @@ type RemoveAddonFromCollectionParams = {|
   errorHandlerId: string,
   filters: CollectionFilters,
   slug: string,
-  username: string,
+  userId: string,
 |};
 
 export type RemoveAddonFromCollectionAction = {|
@@ -645,13 +619,13 @@ export const removeAddonFromCollection = ({
   errorHandlerId,
   filters,
   slug,
-  username,
+  userId,
 }: RemoveAddonFromCollectionParams = {}): RemoveAddonFromCollectionAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
   invariant(filters, 'The filters parameter is required');
   invariant(slug, 'The slug parameter is required');
-  invariant(username, 'The username parameter is required');
+  invariant(userId, 'The userId parameter is required');
 
   return {
     type: REMOVE_ADDON_FROM_COLLECTION,
@@ -660,7 +634,7 @@ export const removeAddonFromCollection = ({
       errorHandlerId,
       filters,
       slug,
-      username,
+      userId,
     },
   };
 };
@@ -678,7 +652,7 @@ export const addonRemovedFromCollection = (): AddonRemovedFromCollectionAction =
 type DeleteCollectionParams = {|
   errorHandlerId: string,
   slug: string,
-  username: string,
+  userId: string,
 |};
 
 export type DeleteCollectionAction = {|
@@ -689,18 +663,18 @@ export type DeleteCollectionAction = {|
 export const deleteCollection = ({
   errorHandlerId,
   slug,
-  username,
+  userId,
 }: DeleteCollectionParams = {}): DeleteCollectionAction => {
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
   invariant(slug, 'The slug parameter is required');
-  invariant(username, 'The username parameter is required');
+  invariant(userId, 'The userId parameter is required');
 
   return {
     type: DELETE_COLLECTION,
     payload: {
       errorHandlerId,
       slug,
-      username,
+      userId,
     },
   };
 };
@@ -711,7 +685,7 @@ type UpdateCollectionAddonParams = {|
   filters: CollectionFilters,
   notes: string,
   slug: string,
-  username: string,
+  userId: string,
 |};
 
 export type UpdateCollectionAddonAction = {|
@@ -725,7 +699,7 @@ export const updateCollectionAddon = ({
   notes,
   filters,
   slug,
-  username,
+  userId,
 }: UpdateCollectionAddonParams = {}): UpdateCollectionAddonAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
@@ -735,7 +709,7 @@ export const updateCollectionAddon = ({
   );
   invariant(filters, 'The filters parameter is required');
   invariant(slug, 'The slug parameter is required');
-  invariant(username, 'The username parameter is required');
+  invariant(userId, 'The userId parameter is required');
 
   return {
     type: UPDATE_COLLECTION_ADDON,
@@ -745,7 +719,7 @@ export const updateCollectionAddon = ({
       notes,
       filters,
       slug,
-      username,
+      userId,
     },
   };
 };
@@ -755,7 +729,7 @@ type DeleteCollectionAddonNotesParams = {|
   errorHandlerId: string,
   filters: CollectionFilters,
   slug: string,
-  username: string,
+  userId: string,
 |};
 
 export type DeleteCollectionAddonNotesAction = {|
@@ -768,13 +742,13 @@ export const deleteCollectionAddonNotes = ({
   errorHandlerId,
   filters,
   slug,
-  username,
+  userId,
 }: DeleteCollectionAddonNotesParams = {}): DeleteCollectionAddonNotesAction => {
   invariant(addonId, 'The addonId parameter is required');
   invariant(errorHandlerId, 'The errorHandlerId parameter is required');
   invariant(filters, 'The filters parameter is required');
   invariant(slug, 'The slug parameter is required');
-  invariant(username, 'The username parameter is required');
+  invariant(userId, 'The userId parameter is required');
 
   // For delete we set the notes field to an empty string and call update.
   // TODO: Use a null instead when https://github.com/mozilla/addons-server/issues/7832 is fixed.
@@ -786,7 +760,7 @@ export const deleteCollectionAddonNotes = ({
       filters,
       notes: '',
       slug,
-      username,
+      userId,
     },
   };
 };
@@ -926,23 +900,23 @@ type ChangeAddonCollectionsLoadingFlagParams = {|
   addonId: number,
   loading: boolean,
   state: CollectionsState,
-  username: string,
+  userId: string,
 |};
 
 export const changeAddonCollectionsLoadingFlag = ({
   addonId,
   loading,
   state,
-  username,
+  userId,
 }: ChangeAddonCollectionsLoadingFlagParams = {}): CollectionsState => {
-  const userState = state.addonInCollections[username];
+  const userState = state.addonInCollections[userId];
   const addonState = userState && userState[addonId];
 
   return {
     ...state,
     addonInCollections: {
       ...state.addonInCollections,
-      [username]: {
+      [userId]: {
         ...userState,
         [addonId]: {
           collections: addonState ? addonState.collections : null,
@@ -955,18 +929,18 @@ export const changeAddonCollectionsLoadingFlag = ({
 
 type UnloadUserCollectionsParams = {|
   state: CollectionsState,
-  username: string,
+  userId: string,
 |};
 
 const unloadUserCollections = ({
   state,
-  username,
+  userId,
 }: UnloadUserCollectionsParams = {}): CollectionsState => {
   return {
     ...state,
     userCollections: {
       ...state.userCollections,
-      [username]: {
+      [userId]: {
         collections: null,
         loading: false,
       },
@@ -1201,13 +1175,13 @@ const reducer = (
       };
 
     case FETCH_USER_COLLECTIONS: {
-      const { username } = action.payload;
+      const { userId } = action.payload;
 
       return {
         ...state,
         userCollections: {
           ...state.userCollections,
-          [username]: {
+          [userId]: {
             collections: null,
             loading: true,
           },
@@ -1216,13 +1190,13 @@ const reducer = (
     }
 
     case ABORT_FETCH_USER_COLLECTIONS: {
-      const { username } = action.payload;
+      const { userId } = action.payload;
 
       return {
         ...state,
         userCollections: {
           ...state.userCollections,
-          [username]: {
+          [userId]: {
             collections: null,
             loading: false,
           },
@@ -1231,7 +1205,7 @@ const reducer = (
     }
 
     case LOAD_USER_COLLECTIONS: {
-      const { collections, username } = action.payload;
+      const { collections, userId } = action.payload;
 
       let newState = { ...state };
       collections.forEach((collection) => {
@@ -1246,7 +1220,7 @@ const reducer = (
         ...newState,
         userCollections: {
           ...state.userCollections,
-          [username]: {
+          [userId]: {
             collections: collections.map((collection) => collection.id),
             loading: false,
           },
@@ -1255,15 +1229,12 @@ const reducer = (
     }
 
     case ADDON_ADDED_TO_COLLECTION: {
-      const { addonId, collectionId, username } = action.payload;
+      const { addonId, collectionId, userId } = action.payload;
       const { addonInCollections } = state;
       let collections = [];
-      if (
-        addonInCollections[username] &&
-        addonInCollections[username][addonId]
-      ) {
+      if (addonInCollections[userId] && addonInCollections[userId][addonId]) {
         const existingCollections =
-          addonInCollections[username][addonId].collections;
+          addonInCollections[userId][addonId].collections;
         if (existingCollections) {
           collections = existingCollections;
         }
@@ -1273,8 +1244,8 @@ const reducer = (
         ...state,
         addonInCollections: {
           ...state.addonInCollections,
-          [username]: {
-            ...state.addonInCollections[username],
+          [userId]: {
+            ...state.addonInCollections[userId],
             [addonId]: {
               collections: collections.concat([collectionId]),
               loading: false,
@@ -1286,11 +1257,11 @@ const reducer = (
     }
 
     case ADD_ADDON_TO_COLLECTION: {
-      const { addonId, username } = action.payload;
+      const { addonId, userId } = action.payload;
 
       const newState = changeAddonCollectionsLoadingFlag({
         addonId,
-        username,
+        userId,
         state,
         loading: true,
       });
@@ -1301,11 +1272,11 @@ const reducer = (
     }
 
     case ABORT_ADD_ADDON_TO_COLLECTION: {
-      const { addonId, username } = action.payload;
+      const { addonId, userId } = action.payload;
 
       const newState = changeAddonCollectionsLoadingFlag({
         addonId,
-        username,
+        userId,
         state,
         loading: false,
       });
@@ -1348,8 +1319,8 @@ const reducer = (
     case CREATE_COLLECTION:
     case DELETE_COLLECTION:
     case UPDATE_COLLECTION: {
-      const { username } = action.payload;
-      return unloadUserCollections({ state, username });
+      const { userId } = action.payload;
+      return unloadUserCollections({ state, userId });
     }
 
     case REMOVE_ADDON_FROM_COLLECTION: {

--- a/src/amo/sagas/collections.js
+++ b/src/amo/sagas/collections.js
@@ -58,7 +58,7 @@ import type {
 import type { Saga } from 'core/types/sagas';
 
 export function* fetchCurrentCollection({
-  payload: { errorHandlerId, filters, slug, username },
+  payload: { errorHandlerId, filters, slug, userId },
 }: FetchCurrentCollectionAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -70,7 +70,7 @@ export function* fetchCurrentCollection({
     const baseParams = {
       api: state.api,
       slug,
-      username,
+      userId,
     };
 
     const detailParams: $Shape<GetCollectionParams> = {
@@ -103,7 +103,7 @@ export function* fetchCurrentCollection({
 }
 
 export function* fetchCurrentCollectionPage({
-  payload: { errorHandlerId, filters, slug, username },
+  payload: { errorHandlerId, filters, slug, userId },
 }: FetchCurrentCollectionPageAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -116,7 +116,7 @@ export function* fetchCurrentCollectionPage({
       api: state.api,
       filters,
       slug,
-      username,
+      userId,
     };
     const addons = yield call(api.getCollectionAddons, params);
 
@@ -135,7 +135,7 @@ export function* fetchCurrentCollectionPage({
 }
 
 export function* fetchUserCollections({
-  payload: { errorHandlerId, username },
+  payload: { errorHandlerId, userId },
 }: FetchUserCollectionsAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -145,15 +145,15 @@ export function* fetchUserCollections({
 
     const params: GetAllUserCollectionsParams = {
       api: state.api,
-      username,
+      userId,
     };
     const collections = yield call(api.getAllUserCollections, params);
 
-    yield put(loadUserCollections({ username, collections }));
+    yield put(loadUserCollections({ userId, collections }));
   } catch (error) {
     log.warn(`Failed to fetch user collections: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortFetchUserCollections({ username }));
+    yield put(abortFetchUserCollections({ userId }));
   }
 }
 
@@ -166,7 +166,7 @@ export function* addAddonToCollection({
     filters,
     notes,
     slug,
-    username,
+    userId,
   },
 }: AddAddonToCollectionAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -180,7 +180,7 @@ export function* addAddonToCollection({
       api: state.api,
       slug,
       notes,
-      username,
+      userId,
     };
     yield call(api.createCollectionAddon, params);
 
@@ -192,21 +192,21 @@ export function* addAddonToCollection({
           errorHandlerId: errorHandler.id,
           filters,
           slug,
-          username,
+          userId,
         }),
       );
     }
     yield put(
       addonAddedToCollection({
         addonId,
-        username,
+        userId,
         collectionId,
       }),
     );
   } catch (error) {
     log.warn(`Failed to add add-on to collection: ${error}`);
     yield put(errorHandler.createErrorAction(error));
-    yield put(abortAddAddonToCollection({ addonId, username }));
+    yield put(abortAddAddonToCollection({ addonId, userId }));
   }
 }
 
@@ -222,7 +222,7 @@ export function* modifyCollection(
     errorHandlerId,
     name,
     slug,
-    username,
+    userId,
   } = payload;
 
   yield put(beginCollectionModification());
@@ -249,7 +249,7 @@ export function* modifyCollection(
       api: state.api,
       defaultLocale,
       description,
-      username,
+      userId,
     };
 
     if (creating) {
@@ -267,7 +267,7 @@ export function* modifyCollection(
           addonId: includeAddonId,
           api: state.api,
           slug,
-          username,
+          userId,
         };
         yield call(api.createCollectionAddon, params);
       }
@@ -285,7 +285,7 @@ export function* modifyCollection(
     const { lang, clientApp } = state.api;
     const effectiveSlug = (response && response.slug) || slug || collectionSlug;
     invariant(effectiveSlug, 'Both slug and collectionSlug cannot be empty');
-    const newLocation = `/${lang}/${clientApp}/collections/${username}/${effectiveSlug}/edit/`;
+    const newLocation = `/${lang}/${clientApp}/collections/${userId}/${effectiveSlug}/edit/`;
 
     if (creating) {
       invariant(response, 'response is required when creating');
@@ -340,7 +340,7 @@ export function* modifyCollection(
 }
 
 export function* removeAddonFromCollection({
-  payload: { addonId, errorHandlerId, filters, slug, username },
+  payload: { addonId, errorHandlerId, filters, slug, userId },
 }: RemoveAddonFromCollectionAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -352,7 +352,7 @@ export function* removeAddonFromCollection({
       addonId,
       api: state.api,
       slug,
-      username,
+      userId,
     };
     yield call(api.removeAddonFromCollection, params);
 
@@ -363,7 +363,7 @@ export function* removeAddonFromCollection({
         errorHandlerId: errorHandler.id,
         filters,
         slug,
-        username,
+        userId,
       }),
     );
   } catch (error) {
@@ -373,7 +373,7 @@ export function* removeAddonFromCollection({
 }
 
 export function* deleteCollection({
-  payload: { errorHandlerId, slug, username },
+  payload: { errorHandlerId, slug, userId },
 }: DeleteCollectionAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -385,7 +385,7 @@ export function* deleteCollection({
     const params: DeleteCollectionParams = {
       api: state.api,
       slug,
-      username,
+      userId,
     };
 
     yield call(api.deleteCollection, params);
@@ -401,7 +401,7 @@ export function* deleteCollection({
 }
 
 export function* updateCollectionAddon({
-  payload: { addonId, errorHandlerId, filters, notes, slug, username },
+  payload: { addonId, errorHandlerId, filters, notes, slug, userId },
 }: UpdateCollectionAddonAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -414,7 +414,7 @@ export function* updateCollectionAddon({
       api: state.api,
       notes,
       slug,
-      username,
+      userId,
     };
     yield call(api.updateCollectionAddon, params);
 
@@ -423,7 +423,7 @@ export function* updateCollectionAddon({
         errorHandlerId: errorHandler.id,
         filters,
         slug,
-        username,
+        userId,
       }),
     );
   } catch (error) {

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -44,7 +44,7 @@ export function* fetchHomeAddons({
       const params: GetCollectionAddonsParams = {
         api: state.api,
         slug: collection.slug,
-        username: collection.username,
+        userId: collection.username,
       };
       const result = yield call(getCollectionAddons, params);
       collections.push(result);

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -33,7 +33,7 @@ describe(__filename, () => {
     return {
       api: apiState,
       slug: 'some-slug',
-      username: 'some-user',
+      userId: 123,
       ...otherParams,
     };
   };
@@ -53,13 +53,13 @@ describe(__filename, () => {
       }).toThrow('slug is required');
     });
 
-    it('throws an error when username is missing', () => {
+    it('throws an error when userId is missing', () => {
       const params = getParams();
-      delete params.username;
+      delete params.userId;
 
       expect(() => {
         getCollectionDetail(params);
-      }).toThrow('username is required');
+      }).toThrow('userId is required');
     });
 
     it('calls the collection detail API', async () => {
@@ -69,7 +69,9 @@ describe(__filename, () => {
         .expects('callApi')
         .withArgs({
           auth: true,
-          endpoint: 'accounts/account/some-user/collections/some-slug',
+          endpoint: `accounts/account/${params.userId}/collections/${
+            params.slug
+          }`,
           apiState,
         })
         .once()
@@ -90,13 +92,13 @@ describe(__filename, () => {
       }).toThrow('slug is required');
     });
 
-    it('throws an error when username is missing', () => {
+    it('throws an error when userId is missing', () => {
       const params = getParams();
-      delete params.username;
+      delete params.userId;
 
       expect(() => {
         getCollectionAddons(params);
-      }).toThrow('username is required');
+      }).toThrow('userId is required');
     });
 
     it('calls the collection add-ons list API', async () => {
@@ -111,7 +113,9 @@ describe(__filename, () => {
         .expects('callApi')
         .withArgs({
           auth: true,
-          endpoint: 'accounts/account/some-user/collections/some-slug/addons',
+          endpoint: `accounts/account/${params.userId}/collections/${
+            params.slug
+          }/addons`,
           params: { page: filters.page, sort: filters.collectionSort },
           apiState,
         })
@@ -125,7 +129,7 @@ describe(__filename, () => {
 
   describe('getAllCollectionAddons', () => {
     it('gets all pages of the collection add-ons list API', async () => {
-      const username = 'example-username';
+      const userId = 123;
       const slug = 'example-collection-slug';
       const addonResults = createFakeCollectionAddonsListResponse().results;
 
@@ -138,7 +142,7 @@ describe(__filename, () => {
 
       const addons = await getAllCollectionAddons({
         api: apiState,
-        username,
+        userId,
         slug,
         _allPages,
         _getCollectionAddons,
@@ -148,7 +152,7 @@ describe(__filename, () => {
       sinon.assert.called(_getCollectionAddons);
       expect(_getCollectionAddons.firstCall.args[0]).toEqual({
         api: apiState,
-        username,
+        userId,
         slug,
         nextURL,
       });
@@ -159,34 +163,32 @@ describe(__filename, () => {
     const getListParams = (params = {}) => {
       return {
         api: apiState,
-        username: 'some-user',
+        userId: 123,
         ...params,
       };
     };
 
-    it('throws an error when the username parameter is missing', () => {
+    it('throws an error when the userId parameter is missing', () => {
       const params = getListParams();
-      delete params.username;
+      delete params.userId;
 
-      expect(() => listCollections(params)).toThrow(
-        /username parameter is required/,
-      );
+      expect(() => listCollections(params)).toThrow(/userId is required/);
     });
 
     it('calls the list collections API', async () => {
-      const username = 'some-user';
+      const userId = 345;
 
       mockApi
         .expects('callApi')
         .withArgs({
           auth: true,
-          endpoint: `accounts/account/${username}/collections`,
+          endpoint: `accounts/account/${userId}/collections`,
           apiState,
         })
         .once()
         .returns(createApiResponse());
 
-      const params = getListParams({ username });
+      const params = getListParams({ userId });
       await listCollections(params);
       mockApi.verify();
     });
@@ -194,7 +196,7 @@ describe(__filename, () => {
 
   describe('getAllUserCollections', () => {
     it('returns collections from multiple pages', async () => {
-      const username = 'some-user';
+      const userId = 456;
 
       const collectionResults = [createFakeCollectionDetail({ slug: 'first' })];
 
@@ -207,7 +209,7 @@ describe(__filename, () => {
 
       const collections = await getAllUserCollections({
         api: apiState,
-        username,
+        userId,
         _allPages,
         _listCollections,
       });
@@ -216,7 +218,7 @@ describe(__filename, () => {
       sinon.assert.called(_listCollections);
       expect(_listCollections.firstCall.args[0]).toEqual({
         api: apiState,
-        username,
+        userId,
         nextURL,
       });
     });
@@ -230,7 +232,7 @@ describe(__filename, () => {
       return {
         api: apiState,
         name,
-        username: 'some-user',
+        userId: 456,
         ...params,
       };
     };
@@ -268,7 +270,7 @@ describe(__filename, () => {
     it('makes a POST request to the API for create', async () => {
       const params = defaultParams({ slug });
 
-      const endpoint = `accounts/account/${params.username}/collections/`;
+      const endpoint = `accounts/account/${params.userId}/collections/`;
       mockApi
         .expects('callApi')
         .withArgs({
@@ -294,9 +296,7 @@ describe(__filename, () => {
     it('makes a PATCH request to the API for update', async () => {
       const params = defaultParams({ collectionSlug: slug });
 
-      const endpoint = `accounts/account/${
-        params.username
-      }/collections/${slug}`;
+      const endpoint = `accounts/account/${params.userId}/collections/${slug}`;
       mockApi
         .expects('callApi')
         .withArgs({
@@ -331,7 +331,7 @@ describe(__filename, () => {
         description: undefined,
         name: undefined,
         slug: undefined,
-        username: 'some-user',
+        userId: 456,
         _validateLocalizedString: validator,
       };
       const updateParams = {
@@ -355,7 +355,7 @@ describe(__filename, () => {
         description: undefined,
         name: undefined,
         slug: 'collection-slug',
-        username: 'some-user',
+        userId: 456,
         _validateLocalizedString: validator,
       };
       const createParams = {
@@ -376,7 +376,7 @@ describe(__filename, () => {
         addonId: 123458,
         api: apiState,
         slug: 'some-collection',
-        username: 'some-user',
+        userId: 456,
         ...params,
       };
     };
@@ -386,11 +386,11 @@ describe(__filename, () => {
         action: 'create',
         addonId: 987675,
         slug: 'my-collection',
-        username: 'some-user',
+        userId: 456,
       });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.username}/collections/
+        accounts/account/${params.userId}/collections/
         ${params.slug}/addons
       `;
       mockApi
@@ -415,7 +415,7 @@ describe(__filename, () => {
       const params = defaultParams({ action: 'create', notes });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.username}/collections/
+        accounts/account/${params.userId}/collections/
         ${params.slug}/addons
       `;
       mockApi
@@ -441,11 +441,11 @@ describe(__filename, () => {
         addonId: 987675,
         slug: 'my-collection',
         notes,
-        username: 'some-user',
+        userId: 456,
       });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.username}/collections/
+        accounts/account/${params.userId}/collections/
         ${params.slug}/addons/${params.addonId}
       `;
       mockApi
@@ -470,7 +470,7 @@ describe(__filename, () => {
       const params = defaultParams({ action: 'update', notes });
 
       const endpoint = oneLineTrim`
-        accounts/account/${params.username}/collections/
+        accounts/account/${params.userId}/collections/
         ${params.slug}/addons/${params.addonId}
       `;
       mockApi
@@ -497,7 +497,7 @@ describe(__filename, () => {
         api: apiState,
         slug: 'the-collection',
         notes: 'Beware of this one weird bug',
-        username: 'some-user',
+        userId: 456,
       };
 
       const modifier = sinon.spy(() => Promise.resolve());
@@ -518,7 +518,7 @@ describe(__filename, () => {
         api: apiState,
         slug: 'cool-collection',
         notes: 'This add-on speaks to my soul',
-        username: 'cool-user',
+        userId: 789,
       };
 
       const modifier = sinon.spy(() => Promise.resolve());
@@ -536,9 +536,9 @@ describe(__filename, () => {
     it('sends a request to remove an add-on from a collection', async () => {
       const addonId = 123;
       const slug = 'my-collection';
-      const username = 'my-user';
+      const userId = 157;
 
-      const endpoint = `accounts/account/${username}/collections/${slug}/addons/${addonId}`;
+      const endpoint = `accounts/account/${userId}/collections/${slug}/addons/${addonId}`;
 
       mockApi
         .expects('callApi')
@@ -555,7 +555,7 @@ describe(__filename, () => {
         addonId,
         api,
         slug,
-        username,
+        userId,
       });
 
       mockApi.verify();
@@ -565,9 +565,9 @@ describe(__filename, () => {
   describe('deleteCollection', () => {
     it('sends a request to delete a collection', async () => {
       const slug = 'my-collection';
-      const username = 'my-user';
+      const userId = 157;
 
-      const endpoint = `accounts/account/${username}/collections/${slug}`;
+      const endpoint = `accounts/account/${userId}/collections/${slug}`;
 
       mockApi
         .expects('callApi')
@@ -583,7 +583,7 @@ describe(__filename, () => {
       await deleteCollection({
         api,
         slug,
-        username,
+        userId,
       });
 
       mockApi.verify();

--- a/tests/unit/amo/api/test_collections.js
+++ b/tests/unit/amo/api/test_collections.js
@@ -44,24 +44,6 @@ describe(__filename, () => {
   });
 
   describe('getCollectionDetail', () => {
-    it('throws an error when slug is missing', () => {
-      const params = getParams();
-      delete params.slug;
-
-      expect(() => {
-        getCollectionDetail(params);
-      }).toThrow('slug is required');
-    });
-
-    it('throws an error when userId is missing', () => {
-      const params = getParams();
-      delete params.userId;
-
-      expect(() => {
-        getCollectionDetail(params);
-      }).toThrow('userId is required');
-    });
-
     it('calls the collection detail API', async () => {
       const params = getParams();
 
@@ -83,24 +65,6 @@ describe(__filename, () => {
   });
 
   describe('getCollectionAddons', () => {
-    it('throws an error when slug is missing', () => {
-      const params = getParams();
-      delete params.slug;
-
-      expect(() => {
-        getCollectionAddons(params);
-      }).toThrow('slug is required');
-    });
-
-    it('throws an error when userId is missing', () => {
-      const params = getParams();
-      delete params.userId;
-
-      expect(() => {
-        getCollectionAddons(params);
-      }).toThrow('userId is required');
-    });
-
     it('calls the collection add-ons list API', async () => {
       const filters = {
         page: '1',
@@ -167,13 +131,6 @@ describe(__filename, () => {
         ...params,
       };
     };
-
-    it('throws an error when the userId parameter is missing', () => {
-      const params = getListParams();
-      delete params.userId;
-
-      expect(() => listCollections(params)).toThrow(/userId is required/);
-    });
 
     it('calls the list collections API', async () => {
       const userId = 345;

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -72,7 +72,7 @@ describe(__filename, () => {
       userId,
       userProps: { username },
     });
-    store.dispatch(loadUserCollections({ username, collections }));
+    store.dispatch(loadUserCollections({ userId: username, collections }));
   };
 
   const createSomeCollections = ({ username = 'some-user' } = {}) => {
@@ -99,7 +99,7 @@ describe(__filename, () => {
         dispatchSpy,
         fetchUserCollections({
           errorHandlerId: root.instance().props.errorHandler.id,
-          username,
+          userId: username,
         }),
       );
     });
@@ -118,7 +118,7 @@ describe(__filename, () => {
         dispatchSpy,
         fetchUserCollections({
           errorHandlerId: root.instance().props.errorHandler.id,
-          username,
+          userId: username,
         }),
       );
     });
@@ -159,7 +159,7 @@ describe(__filename, () => {
       store.dispatch(
         fetchUserCollections({
           errorHandlerId: 'some-id',
-          username,
+          userId: username,
         }),
       );
 
@@ -185,7 +185,7 @@ describe(__filename, () => {
       store.dispatch(
         fetchUserCollections({
           errorHandlerId: 'some-id',
-          username,
+          userId: username,
         }),
       );
 
@@ -203,7 +203,7 @@ describe(__filename, () => {
       store.dispatch(
         addAddonToCollection({
           addonId: addon.id,
-          username,
+          userId: username,
           collectionId: 321,
           slug: 'some-collection',
           errorHandlerId: 'error-handler',
@@ -260,7 +260,7 @@ describe(__filename, () => {
           addonId: addon.id,
           collectionId: secondCollection.id,
           slug: secondCollection.slug,
-          username,
+          userId: username,
         }),
       );
     });
@@ -298,7 +298,7 @@ describe(__filename, () => {
       store.dispatch(
         addonAddedToCollection({
           addonId: addon.id,
-          username,
+          userId: username,
           collectionId: firstCollection.id,
         }),
       );
@@ -325,7 +325,7 @@ describe(__filename, () => {
         collections: [firstCollection, secondCollection],
       });
 
-      const addParams = { addonId: addon.id, username };
+      const addParams = { addonId: addon.id, userId: username };
 
       // Add the add-on to both collections.
       store.dispatch(

--- a/tests/unit/amo/components/TestCollectionAddAddon.js
+++ b/tests/unit/amo/components/TestCollectionAddAddon.js
@@ -39,12 +39,12 @@ const simulateAutoSearchCallback = (props = {}) => {
   });
 };
 
-const _addonAddedToCollection = ({ username, root, store }) => {
+const _addonAddedToCollection = ({ userId, root, store }) => {
   store.dispatch(
     addonAddedToCollection({
       addonId: 123,
       collectionId: 321,
-      username,
+      userId,
     }),
   );
 
@@ -65,7 +65,6 @@ const _addonRemovedFromCollection = ({ root, store }) => {
 
 describe(__filename, () => {
   const signedInUserId = 123;
-  const signedInUsername = 'user123';
 
   let clock;
 
@@ -77,14 +76,8 @@ describe(__filename, () => {
     clock.restore();
   });
 
-  const dispatchSignedInUser = ({
-    userId = signedInUserId,
-    username = signedInUsername,
-  }) => {
-    return dispatchSignInActions({
-      userId,
-      userProps: { username },
-    });
+  const dispatchSignedInUser = ({ userId = signedInUserId }) => {
+    return dispatchSignInActions({ userId });
   };
 
   const getProps = ({
@@ -128,10 +121,10 @@ describe(__filename, () => {
 
   it('dispatches addAddonToCollection when selecting an add-on', () => {
     const authorUsername = 'non-signed-in-user';
-    const currentUsername = 'signed-in-user';
+    const currentUserId = 569;
 
     const { store } = dispatchSignedInUser({
-      username: currentUsername,
+      userId: currentUserId,
     });
     const filters = { page: 2 };
     const errorHandler = createStubErrorHandler();
@@ -160,20 +153,20 @@ describe(__filename, () => {
         editing: true,
         errorHandlerId: errorHandler.id,
         filters,
-        username: authorUsername,
+        userId: authorUsername,
       }),
     );
   });
 
   it('displays a notification for 5 seconds after an add-on has been added', () => {
     const { store } = dispatchSignedInUser({
-      username: signedInUsername,
+      userId: signedInUserId,
     });
     const root = render({ setTimeout: window.setTimeout, store });
 
     expect(root.find(Notice)).toHaveLength(0);
 
-    _addonAddedToCollection({ username: signedInUsername, root, store });
+    _addonAddedToCollection({ userId: signedInUserId, root, store });
 
     expect(root.find(Notice)).toHaveLength(1);
     expect(root.find(Notice).children()).toHaveText('Added to collection');
@@ -191,7 +184,7 @@ describe(__filename, () => {
 
   it('displays a notification for 5 seconds after an add-on has been removed', () => {
     const { store } = dispatchSignedInUser({
-      username: signedInUsername,
+      userId: signedInUserId,
     });
     const root = render({ setTimeout: window.setTimeout, store });
 
@@ -221,12 +214,12 @@ describe(__filename, () => {
     );
     const clearStub = sinon.stub(errorHandler, 'clear');
     const { store } = dispatchSignedInUser({
-      username: signedInUsername,
+      userId: signedInUserId,
     });
 
     const root = render({ errorHandler, store });
 
-    _addonAddedToCollection({ username: signedInUsername, root, store });
+    _addonAddedToCollection({ userId: signedInUserId, root, store });
 
     sinon.assert.called(clearStub);
   });
@@ -247,7 +240,7 @@ describe(__filename, () => {
 
   it('calls clearTimeout when unmounting and timeout is set', () => {
     const { store } = dispatchSignedInUser({
-      username: signedInUsername,
+      userId: signedInUserId,
     });
     const timeoutID = 123;
     const setTimeoutSpy = sinon.spy(() => timeoutID);
@@ -258,7 +251,7 @@ describe(__filename, () => {
       store,
     });
 
-    _addonAddedToCollection({ username: signedInUsername, root, store });
+    _addonAddedToCollection({ userId: signedInUserId, root, store });
     sinon.assert.called(setTimeoutSpy);
 
     root.unmount();
@@ -277,13 +270,13 @@ describe(__filename, () => {
 
   it('removes the notification after a new add-on has been selected', () => {
     const { store } = dispatchSignedInUser({
-      username: signedInUsername,
+      userId: signedInUserId,
     });
     const root = render({ store });
 
     expect(root.find(Notice)).toHaveLength(0);
 
-    _addonAddedToCollection({ username: signedInUsername, root, store });
+    _addonAddedToCollection({ userId: signedInUserId, root, store });
 
     expect(root.find(Notice)).toHaveLength(1);
 

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -310,7 +310,7 @@ describe(__filename, () => {
         errorHandlerId: root.instance().props.errorHandler.id,
         name: { [lang]: name },
         slug,
-        username: signedInUsername,
+        userId: signedInUsername,
       }),
     );
   });
@@ -347,7 +347,7 @@ describe(__filename, () => {
         includeAddonId: id,
         name: { [lang]: name },
         slug,
-        username: signedInUsername,
+        userId: signedInUsername,
       }),
     );
   });
@@ -382,7 +382,7 @@ describe(__filename, () => {
         filters,
         name: { [lang]: name },
         slug,
-        username: signedInUsername,
+        userId: signedInUsername,
       }),
     );
   });
@@ -560,7 +560,7 @@ describe(__filename, () => {
         filters,
         name: { [lang]: name },
         slug,
-        username: signedInUsername,
+        userId: signedInUsername,
       }),
     );
   });
@@ -649,7 +649,7 @@ describe(__filename, () => {
         filters,
         name: { [lang]: collection.name },
         slug: collection.slug,
-        username: signedInUsername,
+        userId: signedInUsername,
       }),
     );
   });

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -239,7 +239,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters,
         slug,
-        username,
+        userId: username,
       }),
     );
   });
@@ -291,7 +291,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug,
-        username,
+        userId: username,
       }),
     );
   });
@@ -340,7 +340,7 @@ describe(__filename, () => {
       fetchCurrentCollection({
         errorHandlerId: errorHandler.id,
         slug,
-        username,
+        userId: username,
       }),
     );
 
@@ -362,7 +362,7 @@ describe(__filename, () => {
       fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         slug,
-        username,
+        userId: username,
       }),
     );
 
@@ -430,7 +430,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug: newSlug,
-        username,
+        userId: username,
       }),
     );
   });
@@ -463,7 +463,7 @@ describe(__filename, () => {
       fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         filters: newFilters,
-        username: defaultUser,
+        userId: defaultUser,
         slug: defaultSlug,
       }),
     );
@@ -500,7 +500,7 @@ describe(__filename, () => {
       fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         filters: newFilters,
-        username: defaultUser,
+        userId: defaultUser,
         slug: defaultSlug,
       }),
     );
@@ -534,7 +534,8 @@ describe(__filename, () => {
       fetchCurrentCollection({
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
-        ...newParams,
+        slug: newParams.slug,
+        userId: newParams.username,
       }),
     );
   });
@@ -567,7 +568,8 @@ describe(__filename, () => {
       fetchCurrentCollection({
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
-        ...newParams,
+        slug: newParams.slug,
+        userId: newParams.username,
       }),
     );
   });
@@ -880,7 +882,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page: 2 },
         slug,
-        username,
+        userId: username,
       }),
     );
 
@@ -1107,7 +1109,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        username: detail.author.username,
+        userId: detail.author.username,
       }),
     );
     sinon.assert.callCount(fakeDispatch, 1);
@@ -1163,7 +1165,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        username: detail.author.username,
+        userId: detail.author.username,
       }),
     );
     sinon.assert.callCount(fakeDispatch, 1);
@@ -1220,7 +1222,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page: newPage, collectionSort: sort },
         slug: detail.slug,
-        username: detail.author.username,
+        userId: detail.author.username,
       }),
     );
     sinon.assert.callCount(fakeDispatch, 1);
@@ -1271,7 +1273,7 @@ describe(__filename, () => {
       deleteCollection({
         errorHandlerId: errorHandler.id,
         slug,
-        username,
+        userId: username,
       }),
     );
   });
@@ -1318,7 +1320,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        username: detail.author.username,
+        userId: detail.author.username,
       }),
     );
   });
@@ -1366,7 +1368,7 @@ describe(__filename, () => {
         notes,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        username: detail.author.username,
+        userId: detail.author.username,
       }),
     );
   });

--- a/tests/unit/amo/pages/TestCollectionList.js
+++ b/tests/unit/amo/pages/TestCollectionList.js
@@ -53,7 +53,7 @@ describe(__filename, () => {
       fakeDispatch,
       fetchUserCollections({
         errorHandlerId: errorHandler.id,
-        username,
+        userId: username,
       }),
     );
   });
@@ -77,7 +77,7 @@ describe(__filename, () => {
     store.dispatch(
       fetchUserCollections({
         errorHandlerId: errorHandler.id,
-        username,
+        userId: username,
       }),
     );
 
@@ -96,7 +96,7 @@ describe(__filename, () => {
     store.dispatch(
       loadUserCollections({
         collections: [createFakeCollectionDetail()],
-        username,
+        userId: username,
       }),
     );
 
@@ -149,7 +149,7 @@ describe(__filename, () => {
     store.dispatch(
       loadUserCollections({
         collections: [],
-        username,
+        userId: username,
       }),
     );
 
@@ -174,7 +174,7 @@ describe(__filename, () => {
     store.dispatch(
       fetchUserCollections({
         errorHandlerId: createStubErrorHandler().id,
-        username,
+        userId: username,
       }),
     );
 
@@ -215,7 +215,7 @@ describe(__filename, () => {
     store.dispatch(
       loadUserCollections({
         collections,
-        username,
+        userId: username,
       }),
     );
 

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -61,7 +61,7 @@ describe(__filename, () => {
         fetchCurrentCollection({
           errorHandlerId: createStubErrorHandler().id,
           slug: 'some-collection-slug',
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -75,7 +75,7 @@ describe(__filename, () => {
         fetchCurrentCollectionPage({
           errorHandlerId: createStubErrorHandler().id,
           slug: 'some-collection-slug',
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -100,7 +100,7 @@ describe(__filename, () => {
         fetchCurrentCollectionPage({
           errorHandlerId: createStubErrorHandler().id,
           slug: collectionDetail.slug,
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -153,7 +153,7 @@ describe(__filename, () => {
         fetchCurrentCollection({
           errorHandlerId: createStubErrorHandler().id,
           slug: 'some-collection-slug',
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -181,7 +181,7 @@ describe(__filename, () => {
         fetchCurrentCollectionPage({
           errorHandlerId: createStubErrorHandler().id,
           slug: 'some-collection-slug',
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -256,7 +256,7 @@ describe(__filename, () => {
         fetchCurrentCollection({
           errorHandlerId: createStubErrorHandler().id,
           slug: 'some-collection-slug',
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -305,7 +305,7 @@ describe(__filename, () => {
         undefined,
         fetchUserCollections({
           errorHandlerId: 'some-error-id',
-          username,
+          userId: username,
         }),
       );
 
@@ -322,11 +322,11 @@ describe(__filename, () => {
         undefined,
         fetchUserCollections({
           errorHandlerId: 'some-error-id',
-          username,
+          userId: username,
         }),
       );
 
-      state = reducer(state, abortFetchUserCollections({ username }));
+      state = reducer(state, abortFetchUserCollections({ userId: username }));
 
       const userState = state.userCollections[username];
       expect(userState.loading).toEqual(false);
@@ -341,7 +341,7 @@ describe(__filename, () => {
       const state = reducer(
         undefined,
         loadUserCollections({
-          username,
+          userId: username,
           collections: [firstCollection, secondCollection],
         }),
       );
@@ -371,7 +371,7 @@ describe(__filename, () => {
       const state = reducer(
         undefined,
         loadUserCollections({
-          username,
+          userId: username,
           collections: [collection],
         }),
       );
@@ -389,7 +389,7 @@ describe(__filename, () => {
       let state = reducer(
         undefined,
         loadUserCollections({
-          username,
+          userId: username,
           collections: [collection],
         }),
       );
@@ -402,7 +402,7 @@ describe(__filename, () => {
           errorHandlerId: createStubErrorHandler().id,
           name: 'some-collection',
           slug: 'some-slug',
-          username,
+          userId: username,
         }),
       );
 
@@ -416,7 +416,7 @@ describe(__filename, () => {
       let state = reducer(
         undefined,
         loadUserCollections({
-          username,
+          userId: username,
           collections: [collection],
         }),
       );
@@ -430,7 +430,7 @@ describe(__filename, () => {
           errorHandlerId: createStubErrorHandler().id,
           filters: {},
           name: 'some-collection',
-          username,
+          userId: username,
         }),
       );
 
@@ -444,7 +444,7 @@ describe(__filename, () => {
       let state = reducer(
         undefined,
         loadUserCollections({
-          username,
+          userId: username,
           collections: [collection],
         }),
       );
@@ -456,7 +456,7 @@ describe(__filename, () => {
         deleteCollection({
           errorHandlerId: createStubErrorHandler().id,
           slug: 'some-slug',
-          username,
+          userId: username,
         }),
       );
 
@@ -471,7 +471,7 @@ describe(__filename, () => {
         undefined,
         addAddonToCollection({
           addonId,
-          username,
+          userId: username,
           collectionId: 321,
           slug: 'some-collection',
           errorHandlerId: 'error-handler',
@@ -494,7 +494,7 @@ describe(__filename, () => {
         addonAddedToCollection({
           addonId,
           collectionId,
-          username,
+          userId: username,
         }),
       );
 
@@ -505,7 +505,7 @@ describe(__filename, () => {
           collectionId,
           errorHandlerId: 'error-handler',
           slug: 'some-collection',
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -523,7 +523,7 @@ describe(__filename, () => {
           errorHandlerId: 'error-handler',
           filters: {},
           slug: 'some-collection',
-          username: 'some-user',
+          userId: 'some-user',
         }),
       );
 
@@ -539,7 +539,7 @@ describe(__filename, () => {
       let state = reducer(
         undefined,
         addonAddedToCollection({
-          username,
+          userId: username,
           addonId,
           collectionId: collection.id,
         }),
@@ -549,7 +549,7 @@ describe(__filename, () => {
         state,
         addAddonToCollection({
           addonId,
-          username,
+          userId: username,
           collectionId: 321,
           slug: 'some-collection',
           errorHandlerId: 'error-handler',
@@ -570,14 +570,17 @@ describe(__filename, () => {
         undefined,
         addAddonToCollection({
           addonId,
-          username,
+          userId: username,
           collectionId: 321,
           slug: 'some-collection',
           errorHandlerId: 'error-handler',
         }),
       );
 
-      state = reducer(state, abortAddAddonToCollection({ addonId, username }));
+      state = reducer(
+        state,
+        abortAddAddonToCollection({ addonId, userId: username }),
+      );
 
       const savedState = state.addonInCollections[username][addonId];
       expect(savedState.collections).toEqual(null);
@@ -594,7 +597,7 @@ describe(__filename, () => {
       let state = reducer(
         undefined,
         addonAddedToCollection({
-          username,
+          userId: username,
           addonId,
           collectionId: collection.id,
         }),
@@ -605,14 +608,17 @@ describe(__filename, () => {
         state,
         addAddonToCollection({
           addonId,
-          username,
+          userId: username,
           collectionId: 321,
           slug: 'some-collection',
           errorHandlerId: 'error-handler',
         }),
       );
 
-      state = reducer(state, abortAddAddonToCollection({ addonId, username }));
+      state = reducer(
+        state,
+        abortAddAddonToCollection({ addonId, userId: username }),
+      );
 
       const savedState = state.addonInCollections[username][addonId];
       // The old collections should be preserved.
@@ -627,7 +633,7 @@ describe(__filename, () => {
       const state = reducer(
         undefined,
         addonAddedToCollection({
-          username,
+          userId: username,
           addonId,
           collectionId: collection.id,
         }),
@@ -642,7 +648,7 @@ describe(__filename, () => {
       const state = reducer(
         undefined,
         addonAddedToCollection({
-          username: 'some-user',
+          userId: 'some-user',
           addonId: 2,
           collectionId: 3,
         }),
@@ -666,7 +672,7 @@ describe(__filename, () => {
       let state = reducer(
         undefined,
         addonAddedToCollection({
-          username,
+          userId: username,
           addonId,
           collectionId: firstCollection.id,
         }),
@@ -674,7 +680,7 @@ describe(__filename, () => {
       state = reducer(
         state,
         addonAddedToCollection({
-          username,
+          userId: username,
           addonId,
           collectionId: secondCollection.id,
         }),
@@ -748,244 +754,10 @@ describe(__filename, () => {
     });
   });
 
-  describe('fetchCurrentCollection()', () => {
-    const defaultParams = {
-      errorHandlerId: 'some-error-handler-id',
-      slug: 'some-collection-slug',
-      username: 'some-user',
-    };
-
-    it('throws an error when errorHandlerId is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.errorHandlerId;
-
-      expect(() => {
-        fetchCurrentCollection(partialParams);
-      }).toThrow('errorHandlerId is required');
-    });
-
-    it('throws an error when slug is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.slug;
-
-      expect(() => {
-        fetchCurrentCollection(partialParams);
-      }).toThrow('slug is required');
-    });
-
-    it('throws an error when username is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.username;
-
-      expect(() => {
-        fetchCurrentCollection(partialParams);
-      }).toThrow('username is required');
-    });
-  });
-
-  describe('fetchUserCollections', () => {
-    const defaultParams = {
-      errorHandlerId: 'some-error-handler-id',
-      username: 'some-user',
-    };
-
-    it('throws an error when username is missing', () => {
-      const params = { ...defaultParams };
-      delete params.username;
-
-      expect(() => fetchUserCollections(params)).toThrow(
-        /username is required/,
-      );
-    });
-
-    it('throws an error when errorHandlerId is missing', () => {
-      const params = { ...defaultParams };
-      delete params.errorHandlerId;
-
-      expect(() => fetchUserCollections(params)).toThrow(
-        /errorHandlerId is required/,
-      );
-    });
-  });
-
-  describe('abortFetchUserCollections', () => {
-    const defaultParams = { username: 'some-user' };
-
-    it('throws an error when username is missing', () => {
-      const params = { ...defaultParams };
-      delete params.username;
-
-      expect(() => abortFetchUserCollections(params)).toThrow(
-        /username is required/,
-      );
-    });
-  });
-
-  describe('abortAddAddonToCollection', () => {
-    const defaultParams = { username: 'some-user', addonId: 2 };
-
-    it('throws an error when username is missing', () => {
-      const params = { ...defaultParams };
-      delete params.username;
-
-      expect(() => abortAddAddonToCollection(params)).toThrow(
-        /username is required/,
-      );
-    });
-
-    it('throws an error when addonId is missing', () => {
-      const params = { ...defaultParams };
-      delete params.addonId;
-
-      expect(() => abortAddAddonToCollection(params)).toThrow(
-        /addonId is required/,
-      );
-    });
-  });
-
-  describe('loadUserCollections', () => {
-    const defaultParams = {
-      username: 'some-user',
-      collections: [createFakeCollectionDetail()],
-    };
-
-    it('throws an error when collections is missing', () => {
-      const params = { ...defaultParams };
-      delete params.collections;
-
-      expect(() => loadUserCollections(params)).toThrow(
-        /collections parameter is required/,
-      );
-    });
-
-    it('throws an error when username is missing', () => {
-      const params = { ...defaultParams };
-      delete params.username;
-
-      expect(() => loadUserCollections(params)).toThrow(
-        /username parameter is required/,
-      );
-    });
-  });
-
-  describe('addonAddedToCollection', () => {
-    const defaultParams = {
-      addonId: 2221,
-      username: 'some-user',
-      collectionId: 2345,
-    };
-
-    it('throws an error when collectionId is missing', () => {
-      const params = { ...defaultParams };
-      delete params.collectionId;
-
-      expect(() => addonAddedToCollection(params)).toThrow(
-        /collectionId parameter is required/,
-      );
-    });
-
-    it('throws an error when username is missing', () => {
-      const params = { ...defaultParams };
-      delete params.username;
-
-      expect(() => addonAddedToCollection(params)).toThrow(
-        /username parameter is required/,
-      );
-    });
-
-    it('throws an error when addonId is missing', () => {
-      const params = { ...defaultParams };
-      delete params.addonId;
-
-      expect(() => addonAddedToCollection(params)).toThrow(
-        /addonId parameter is required/,
-      );
-    });
-  });
-
-  describe('loadCurrentCollection()', () => {
-    const defaultParams = {
-      addons: createFakeCollectionAddons(),
-      detail: createFakeCollectionDetail(),
-      pageSize: DEFAULT_API_PAGE_SIZE,
-    };
-
-    it('throws an error when addons are missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.addons;
-
-      expect(() => {
-        loadCurrentCollection(partialParams);
-      }).toThrow('addons are required');
-    });
-
-    it('throws an error when detail is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.detail;
-
-      expect(() => {
-        loadCurrentCollection(partialParams);
-      }).toThrow('detail is required');
-    });
-  });
-
-  describe('fetchCurrentCollectionPage()', () => {
-    const defaultParams = {
-      errorHandlerId: 'some-error-handler-id',
-      slug: 'some-collection-slug',
-      username: 'some-user',
-    };
-
-    it('throws an error when errorHandlerId is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.errorHandlerId;
-
-      expect(() => {
-        fetchCurrentCollectionPage(partialParams);
-      }).toThrow('errorHandlerId is required');
-    });
-
-    it('throws an error when slug is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.slug;
-
-      expect(() => {
-        fetchCurrentCollectionPage(partialParams);
-      }).toThrow('slug is required');
-    });
-
-    it('throws an error when username is missing', () => {
-      const partialParams = { ...defaultParams };
-      delete partialParams.username;
-
-      expect(() => {
-        fetchCurrentCollectionPage(partialParams);
-      }).toThrow('username is required');
-    });
-  });
-
   describe('getCollectionById', () => {
     const getParams = (params = {}) => {
       return { state: initialState, id: 4321, ...params };
     };
-
-    it('requires a state parameter', () => {
-      const params = getParams();
-      delete params.state;
-
-      expect(() => getCollectionById(params)).toThrow(
-        /state parameter is required/,
-      );
-    });
-
-    it('requires an id parameter', () => {
-      const params = getParams();
-      delete params.id;
-
-      expect(() => getCollectionById(params)).toThrow(
-        /id parameter is required/,
-      );
-    });
 
     it('returns a collection', () => {
       const id = 45321;
@@ -1018,12 +790,6 @@ describe(__filename, () => {
   });
 
   describe('getCurrentCollection', () => {
-    it('requires the state parameter', () => {
-      expect(() => getCurrentCollection()).toThrow(
-        /collectionsState parameter is required/,
-      );
-    });
-
     it('returns null if the current collection does not exist', () => {
       expect(getCurrentCollection(initialState)).toEqual(null);
     });
@@ -1262,7 +1028,7 @@ describe(__filename, () => {
       const state = reducer(
         undefined,
         loadUserCollections({
-          username,
+          userId: username,
           collections: [firstCollection, secondCollection],
         }),
       );
@@ -1293,7 +1059,7 @@ describe(__filename, () => {
       const state = reducer(
         undefined,
         loadUserCollections({
-          username,
+          userId: username,
           collections: [firstCollection],
         }),
       );

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -39,7 +39,7 @@ import {
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  const username = 'some-user';
+  const userId = 'some-user';
   const slug = 'collection-slug';
   const filters = { page: '1' };
 
@@ -83,7 +83,7 @@ describe(__filename, () => {
         .withArgs({
           api: state.api,
           slug,
-          username,
+          userId,
         })
         .once()
         .returns(Promise.resolve(collectionDetail));
@@ -94,12 +94,12 @@ describe(__filename, () => {
           api: state.api,
           filters,
           slug,
-          username,
+          userId,
         })
         .once()
         .returns(Promise.resolve(collectionAddons));
 
-      _fetchCurrentCollection({ filters, slug, username });
+      _fetchCurrentCollection({ filters, slug, userId });
 
       const expectedLoadAction = loadCurrentCollection({
         addons: collectionAddons.results,
@@ -113,7 +113,7 @@ describe(__filename, () => {
     });
 
     it('clears the error handler', async () => {
-      _fetchCurrentCollection({ slug, username });
+      _fetchCurrentCollection({ slug, userId });
 
       const expectedAction = errorHandler.createClearingAction();
 
@@ -134,7 +134,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchCurrentCollection({ slug, username });
+      _fetchCurrentCollection({ slug, userId });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
@@ -165,12 +165,12 @@ describe(__filename, () => {
           api: state.api,
           filters,
           slug,
-          username,
+          userId,
         })
         .once()
         .returns(Promise.resolve(collectionAddons));
 
-      _fetchCurrentCollectionPage({ filters, slug, username });
+      _fetchCurrentCollectionPage({ filters, slug, userId });
 
       const expectedLoadAction = loadCurrentCollectionPage({
         addons: collectionAddons.results,
@@ -184,7 +184,7 @@ describe(__filename, () => {
     });
 
     it('clears the error handler', async () => {
-      _fetchCurrentCollectionPage({ filters, slug, username });
+      _fetchCurrentCollectionPage({ filters, slug, userId });
 
       const expectedAction = errorHandler.createClearingAction();
 
@@ -200,7 +200,7 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchCurrentCollectionPage({ filters, slug, username });
+      _fetchCurrentCollectionPage({ filters, slug, userId });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
@@ -216,7 +216,7 @@ describe(__filename, () => {
       sagaTester.dispatch(
         fetchUserCollections({
           errorHandlerId: errorHandler.id,
-          username: 'some-user',
+          userId: 'some-user',
           ...params,
         }),
       );
@@ -233,15 +233,15 @@ describe(__filename, () => {
         .expects('getAllUserCollections')
         .withArgs({
           api: state.api,
-          username,
+          userId,
         })
         .once()
         .returns(Promise.resolve(externalCollections));
 
-      _fetchUserCollections({ username });
+      _fetchUserCollections({ userId });
 
       const expectedLoadAction = loadUserCollections({
-        username,
+        userId,
         collections: externalCollections,
       });
 
@@ -267,13 +267,13 @@ describe(__filename, () => {
         .once()
         .returns(Promise.reject(error));
 
-      _fetchUserCollections({ username });
+      _fetchUserCollections({ userId });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
       expect(sagaTester.getCalledActions()[3]).toEqual(
-        abortFetchUserCollections({ username }),
+        abortFetchUserCollections({ userId }),
       );
     });
   });
@@ -286,7 +286,7 @@ describe(__filename, () => {
           collectionId: 321,
           slug: 'some-collection',
           errorHandlerId: errorHandler.id,
-          username: 'some-user',
+          userId: 'some-user',
           ...params,
         }),
       );
@@ -297,7 +297,7 @@ describe(__filename, () => {
         addonId: 123,
         collectionId: 5432,
         slug: 'a-collection',
-        username: 'some-user',
+        userId: 'some-user',
       };
       const state = sagaTester.getState();
 
@@ -308,7 +308,7 @@ describe(__filename, () => {
           api: state.api,
           slug: params.slug,
           notes: undefined,
-          username: params.username,
+          userId: params.userId,
         })
         .once()
         .returns(Promise.resolve());
@@ -318,7 +318,7 @@ describe(__filename, () => {
       const expectedAddedAction = addonAddedToCollection({
         addonId: params.addonId,
         collectionId: params.collectionId,
-        username: params.username,
+        userId: params.userId,
       });
 
       const addedAction = await sagaTester.waitFor(expectedAddedAction.type);
@@ -328,7 +328,7 @@ describe(__filename, () => {
         filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        username: params.username,
+        userId: params.userId,
       });
 
       expect(sagaTester.wasCalled(unexpectedFetchAction.type)).toEqual(false);
@@ -342,7 +342,7 @@ describe(__filename, () => {
         slug: 'a-collection',
         editing: true,
         filters: { page: '1' },
-        username: 'some-user',
+        userId: 'some-user',
       };
       const state = sagaTester.getState();
 
@@ -353,7 +353,7 @@ describe(__filename, () => {
           api: state.api,
           slug: params.slug,
           notes: undefined,
-          username: params.username,
+          userId: params.userId,
         })
         .once()
         .returns(Promise.resolve());
@@ -364,7 +364,7 @@ describe(__filename, () => {
         filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        username: params.username,
+        userId: params.userId,
       });
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);
@@ -373,7 +373,7 @@ describe(__filename, () => {
       const expectedAddedAction = addonAddedToCollection({
         addonId: params.addonId,
         collectionId: params.collectionId,
-        username: params.username,
+        userId: params.userId,
       });
 
       const addedAction = await sagaTester.waitFor(expectedAddedAction.type);
@@ -397,13 +397,13 @@ describe(__filename, () => {
 
       mockApi.expects('createCollectionAddon').returns(Promise.reject(error));
 
-      _addAddonToCollection({ addonId, username });
+      _addAddonToCollection({ addonId, userId });
 
       const expectedAction = errorHandler.createErrorAction(error);
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
       expect(sagaTester.getCalledActions()[3]).toEqual(
-        abortAddAddonToCollection({ addonId, username }),
+        abortAddAddonToCollection({ addonId, userId }),
       );
     });
   });
@@ -415,7 +415,7 @@ describe(__filename, () => {
           errorHandlerId: errorHandler.id,
           name: 'some-collection-name',
           slug,
-          username,
+          userId,
           ...params,
         }),
       );
@@ -428,7 +428,7 @@ describe(__filename, () => {
           errorHandlerId: errorHandler.id,
           filters: { page: '1' },
           slug,
-          username,
+          userId,
           ...params,
         }),
       );
@@ -536,7 +536,7 @@ describe(__filename, () => {
           description: { 'en-US': 'New collection description' },
           name: { 'en-US': 'New collection name' },
           slug: 'new-slug',
-          username,
+          userId,
         };
         const state = sagaTester.getState();
 
@@ -549,7 +549,7 @@ describe(__filename, () => {
             description: params.description,
             name: params.name,
             slug: params.slug,
-            username,
+            userId,
           })
           .once()
           .returns(Promise.resolve());
@@ -614,12 +614,12 @@ describe(__filename, () => {
           collectionSlug,
           filters: updateFilters,
           slug: submittedSlug,
-          username,
+          userId,
         });
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation({
-          pathname: `/${lang}/${clientApp}/collections/${username}/${returnedSlug}/edit/`,
+          pathname: `/${lang}/${clientApp}/collections/${userId}/${returnedSlug}/edit/`,
           query: convertFiltersToQueryParams(updateFilters),
         });
 
@@ -636,7 +636,7 @@ describe(__filename, () => {
           description: { [lang]: 'Collection description' },
           name: { [lang]: 'Collection name' },
           slug,
-          username,
+          userId,
         };
       };
 
@@ -654,7 +654,7 @@ describe(__filename, () => {
             description: params.description,
             name: params.name,
             slug,
-            username,
+            userId: params.userId,
           })
           .once()
           .returns(Promise.resolve(collectionDetailResponse));
@@ -675,7 +675,7 @@ describe(__filename, () => {
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${username}/${slug}/edit/`,
+          `/${lang}/${clientApp}/collections/${userId}/${slug}/edit/`,
         );
 
         await sagaTester.waitFor(expectedAction.type);
@@ -703,7 +703,7 @@ describe(__filename, () => {
             addonId: id,
             api: state.api,
             slug: params.slug,
-            username: params.username,
+            userId: params.userId,
           })
           .once()
           .returns(Promise.resolve());
@@ -712,7 +712,7 @@ describe(__filename, () => {
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${username}/${slug}/edit/`,
+          `/${lang}/${clientApp}/collections/${userId}/${slug}/edit/`,
         );
 
         await sagaTester.waitFor(expectedAction.type);
@@ -739,7 +739,7 @@ describe(__filename, () => {
 
         const { lang, clientApp } = clientData.state.api;
         const expectedAction = pushLocation(
-          `/${lang}/${clientApp}/collections/${username}/${returnedSlug}/edit/`,
+          `/${lang}/${clientApp}/collections/${userId}/${returnedSlug}/edit/`,
         );
 
         const action = await sagaTester.waitFor(expectedAction.type);
@@ -758,7 +758,7 @@ describe(__filename, () => {
           errorHandlerId: errorHandler.id,
           filters: { page: '1' },
           slug: 'some-collection',
-          username: 'some-user',
+          userId: 'some-user',
           ...params,
         }),
       );
@@ -787,7 +787,7 @@ describe(__filename, () => {
         addonId: 123,
         filters: { page: 2 },
         slug: 'some-other-slug',
-        username: 'some-other-user',
+        userId: 'some-other-user',
       };
       const state = sagaTester.getState();
 
@@ -797,7 +797,7 @@ describe(__filename, () => {
           addonId: params.addonId,
           api: state.api,
           slug: params.slug,
-          username: params.username,
+          userId: params.userId,
         })
         .once()
         .returns(Promise.resolve());
@@ -808,7 +808,7 @@ describe(__filename, () => {
         filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        username: params.username,
+        userId: params.userId,
       });
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);
@@ -846,7 +846,7 @@ describe(__filename, () => {
         deleteCollection({
           errorHandlerId: errorHandler.id,
           slug: 'some-collection',
-          username: 'some-user',
+          userId: 'some-user',
           ...params,
         }),
       );
@@ -855,7 +855,7 @@ describe(__filename, () => {
     it('deletes a collection', async () => {
       const params = {
         slug: 'some-other-slug',
-        username: 'some-other-user',
+        userId: 'some-other-user',
       };
       const state = sagaTester.getState();
       const { lang, clientApp } = state.api;
@@ -865,7 +865,7 @@ describe(__filename, () => {
         .withArgs({
           api: state.api,
           slug: params.slug,
-          username: params.username,
+          userId: params.userId,
         })
         .once()
         .returns(Promise.resolve());
@@ -918,7 +918,7 @@ describe(__filename, () => {
           notes: '',
           filters: { page: '1' },
           slug: 'some-collection',
-          username: 'some-user',
+          userId: 'some-user',
           ...params,
         }),
       );
@@ -930,7 +930,7 @@ describe(__filename, () => {
         notes: 'Here are some notes',
         filters: { page: '2' },
         slug: 'some-other-slug',
-        username: 'some-other-user',
+        userId: 'some-other-user',
       };
       const state = sagaTester.getState();
 
@@ -941,7 +941,7 @@ describe(__filename, () => {
           api: state.api,
           notes: params.notes,
           slug: params.slug,
-          username: params.username,
+          userId: params.userId,
         })
         .once()
         .returns(Promise.resolve());
@@ -952,7 +952,7 @@ describe(__filename, () => {
         filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        username: params.username,
+        userId: params.userId,
       });
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);
@@ -988,7 +988,7 @@ describe(__filename, () => {
         addonId: 123,
         filters: { page: '2' },
         slug: 'some-other-slug',
-        username: 'some-other-user',
+        userId: 'some-other-user',
       };
       const state = sagaTester.getState();
 
@@ -999,7 +999,7 @@ describe(__filename, () => {
           api: state.api,
           notes: '',
           slug: params.slug,
-          username: params.username,
+          userId: params.userId,
         })
         .once()
         .returns(Promise.resolve());
@@ -1015,7 +1015,7 @@ describe(__filename, () => {
         filters: params.filters,
         errorHandlerId: errorHandler.id,
         slug: params.slug,
-        username: params.username,
+        userId: params.userId,
       });
 
       const fetchAction = await sagaTester.waitFor(expectedFetchAction.type);

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -80,7 +80,7 @@ describe(__filename, () => {
         .withArgs({
           ...baseArgs,
           slug: firstCollectionSlug,
-          username: firstCollectionUser,
+          userId: firstCollectionUser,
         })
         .returns(Promise.resolve(firstCollection));
       mockCollectionsApi
@@ -88,7 +88,7 @@ describe(__filename, () => {
         .withArgs({
           ...baseArgs,
           slug: secondCollectionSlug,
-          username: secondCollectionUser,
+          userId: secondCollectionUser,
         })
         .returns(Promise.resolve(secondCollection));
       const collections = [firstCollection, secondCollection];
@@ -334,7 +334,7 @@ describe(__filename, () => {
         .withArgs({
           ...baseArgs,
           slug,
-          username,
+          userId: username,
         })
         .returns(Promise.resolve(firstCollection));
 


### PR DESCRIPTION
Fixes #7135 

---

It is a bit weird to see `userId: username` in some component codes but that will be removed very soon.

It is a small step to fix #6609. I removed test cases that covered the `throw Error()` statements that I removed too (replaced with `invariant` calls instead).