### PR TITLE
I7138-updating guides link hover color

### DIFF
--- a/src/amo/components/HomeHeroGuides/styles.scss
+++ b/src/amo/components/HomeHeroGuides/styles.scss
@@ -49,37 +49,37 @@ $icon-size: 40px;
     padding: 0 0 4px;
   }
 
+  .HeroSection-link-wrapper {
+    color: $black;
+    display: block;
+    min-height: 0;
+    padding: 0;
+    text-decoration: none;
+
+    &:hover {
+      .HomeHeroGuides-section-title {
+        color: $link-color;
+      }
+    }
+
+    .HeroSection-content {
+      outline: none;
+    }
+
+    &.focus-visible .HeroSection-content {
+      // Fix outline for Firefox
+      outline: 1px dotted $link-color;
+      // Restore default outline for webkit.
+      outline: auto 5px -webkit-focus-ring-color;
+    }
+  }
+
   .Hero-contents {
     @include respond-to(large) {
       display: grid;
       grid-gap: 0 30px;
       grid-template-columns: 1fr 1fr 1fr;
       margin-bottom: 24px;
-    }
-
-    .HeroSection-link-wrapper {
-      color: $black;
-      display: block;
-      min-height: 0;
-      padding: 0;
-      text-decoration: none;
-
-      &:hover {
-        .HomeHeroGuides-section-title {
-          color: $link-color;
-        }
-      }
-
-      .HeroSection-content {
-        outline: none;
-      }
-
-      &.focus-visible .HeroSection-content {
-        // Fix outline for Firefox
-        outline: 1px dotted $link-color;
-        // Restore default outline for webkit.
-        outline: auto 5px -webkit-focus-ring-color;
-      }
     }
 
     .HeroSection {

--- a/src/amo/components/HomeHeroGuides/styles.scss
+++ b/src/amo/components/HomeHeroGuides/styles.scss
@@ -64,6 +64,12 @@ $icon-size: 40px;
       padding: 0;
       text-decoration: none;
 
+      &:hover {
+        .HomeHeroGuides-section-title {
+          color: $link-color;
+        }
+      }
+
       .HeroSection-content {
         outline: none;
       }

--- a/src/amo/components/HomeHeroGuides/styles.scss
+++ b/src/amo/components/HomeHeroGuides/styles.scss
@@ -56,10 +56,8 @@ $icon-size: 40px;
     padding: 0;
     text-decoration: none;
 
-    &:hover {
-      .HomeHeroGuides-section-title {
-        color: $link-color;
-      }
+    &:hover .HomeHeroGuides-section-title {
+      color: $link-color;
     }
 
     .HeroSection-content {


### PR DESCRIPTION
fixes #7138 

it seems that there are 2 link-colors (the one referenced in the issue looks more like the one set in ui but I am using the one in core). let me know if this is an issue.

## after

hover on "Organize Tabs & Bookmarks" card:
![Alt text](https://monosnap.com/image/jj5MO7xg6oTB7WI7RJRmyqaB65SpQT.png)