### PR TITLE
Link the rating graph to reviews filtered by star

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -169,6 +169,7 @@ type FetchReviewsParams = {|
   addonSlug: string,
   errorHandlerId: string,
   page?: string,
+  score?: string,
 |};
 
 export type FetchReviewsAction = {|
@@ -177,6 +178,7 @@ export type FetchReviewsAction = {|
     addonSlug: string,
     errorHandlerId: string,
     page: string,
+    score: string | void,
   |},
 |};
 
@@ -184,6 +186,7 @@ export function fetchReviews({
   addonSlug,
   errorHandlerId,
   page = '1',
+  score,
 }: FetchReviewsParams): FetchReviewsAction {
   if (!errorHandlerId) {
     throw new Error('errorHandlerId cannot be empty');
@@ -193,7 +196,7 @@ export function fetchReviews({
   }
   return {
     type: FETCH_REVIEWS,
-    payload: { addonSlug, errorHandlerId, page },
+    payload: { addonSlug, errorHandlerId, page, score },
   };
 }
 

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -141,6 +141,7 @@ export type GetReviewsParams = {|
   filter?: string,
   page?: string,
   page_size?: number,
+  score?: string,
   show_grouped_ratings?: boolean,
   show_permissions_for?: number,
   user?: number,

--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { compose } from 'redux';
 
 import Link from 'amo/components/Link';
+import { reviewListURL } from 'amo/reducers/reviews';
 import translate from 'core/i18n/translate';
 import type { AddonType } from 'core/types/addons';
 import MetadataCard from 'ui/components/MetadataCard';
@@ -64,7 +65,7 @@ export class AddonMetaBase extends React.Component<InternalProps> {
     }
 
     const reviewsLink =
-      addon && reviewCount ? `/addon/${addon.slug}/reviews/` : null;
+      addon && reviewCount ? reviewListURL({ addonSlug: addon.slug }) : null;
 
     const reviewsContent = reviewsLink ? (
       <Link className="AddonMeta-reviews-content-link" to={reviewsLink}>

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -8,6 +8,7 @@ import { compose } from 'redux';
 import Link from 'amo/components/Link';
 import AddonReviewManager from 'amo/components/AddonReviewManager';
 import FlagReviewMenu from 'amo/components/FlagReviewMenu';
+import { reviewListURL } from 'amo/reducers/reviews';
 import { ADDONS_EDIT } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -360,8 +361,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
         },
       });
 
-      const url = `/addon/${review.reviewAddon.slug}/reviews/${review.id}/`;
-
       byLine = (
         <span
           className={makeClassName('', {
@@ -369,7 +368,13 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           })}
         >
           {linkParts.beforeLinkText}
-          <Link key={review.id} to={url}>
+          <Link
+            key={review.id}
+            to={reviewListURL({
+              addonSlug: review.reviewAddon.slug,
+              id: review.id,
+            })}
+          >
             {linkParts.innerLinkText}
           </Link>
           {linkParts.afterLinkText}

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -101,7 +101,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
       <div className="RatingsByStar">
         {errorHandler.renderErrorIfPresent()}
         <div className="RatingsByStar-graph">
-          {[5, 4, 3, 2, 1].map((star) => {
+          {['5', '4', '3', '2', '1'].map((star) => {
             let starCount;
             let starCountNode;
 

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -5,7 +5,9 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import Link from 'amo/components/Link';
 import { fetchGroupedRatings } from 'amo/actions/reviews';
+import { reviewListURL } from 'amo/reducers/reviews';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import LoadingText from 'ui/components/LoadingText';
@@ -83,7 +85,17 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
 
   render() {
     const { addon, errorHandler, i18n, groupedRatings } = this.props;
-    const loading = !addon || !groupedRatings;
+    const loading = (!addon || !groupedRatings) && !errorHandler.hasError();
+
+    const linkTitles = {
+      /* eslint-disable quote-props */
+      '5': i18n.gettext('Read all five-star reviews'),
+      '4': i18n.gettext('Read all four-star reviews'),
+      '3': i18n.gettext('Read all three-star reviews'),
+      '2': i18n.gettext('Read all two-star reviews'),
+      '1': i18n.gettext('Read all one-star reviews'),
+      /* eslint-enable quote-props */
+    };
 
     return (
       <div className="RatingsByStar">
@@ -93,6 +105,22 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
             let starCount;
             let starCountNode;
 
+            function createLink(text) {
+              invariant(addon, 'addon was unexpectedly empty');
+
+              return (
+                <Link
+                  title={linkTitles[star] || ''}
+                  to={reviewListURL({
+                    addonSlug: addon.slug,
+                    score: star,
+                  })}
+                >
+                  {text}
+                </Link>
+              );
+            }
+
             if (!errorHandler.hasError()) {
               if (groupedRatings) {
                 starCount = groupedRatings[star];
@@ -101,14 +129,18 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
               starCountNode = loading ? (
                 <LoadingText minWidth={95} />
               ) : (
-                i18n.formatNumber(starCount || 0)
+                createLink(i18n.formatNumber(starCount || 0))
               );
             }
 
             return (
               <React.Fragment key={star}>
                 <div className="RatingsByStar-star">
-                  <span>{i18n.formatNumber(star)}</span>
+                  {loading ? (
+                    <LoadingText minWidth={95} />
+                  ) : (
+                    createLink(i18n.formatNumber(star))
+                  )}
                   <Icon name="star-yellow" />
                 </div>
                 <div className="RatingsByStar-barContainer">

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -52,3 +52,13 @@
   justify-content: end;
   min-width: 12px;
 }
+
+.RatingsByStar-star,
+.RatingsByStar-count {
+  a:active,
+  a:link,
+  a:visited {
+    color: $grey-50;
+    font-weight: normal;
+  }
+}

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -61,4 +61,8 @@
     color: $grey-50;
     font-weight: normal;
   }
+
+  a:hover {
+    color: $link-color;
+  }
 }

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -26,6 +26,7 @@ import DefaultRatingManager from 'amo/components/RatingManager';
 import ScreenShots from 'amo/components/ScreenShots';
 import Link from 'amo/components/Link';
 import { getAddonsForSlug } from 'amo/reducers/addonsByAuthors';
+import { reviewListURL } from 'amo/reducers/reviews';
 import { getVersionById } from 'core/reducers/versions';
 import {
   fetchAddon,
@@ -218,7 +219,7 @@ export class AddonBase extends React.Component {
       content = (
         <Link
           className="Addon-all-reviews-link"
-          to={`/addon/${addon.slug}/reviews/`}
+          to={reviewListURL({ addonSlug: addon.slug })}
         >
           {linkText}
         </Link>

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -200,6 +200,10 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     const { addon, i18n, location } = this.props;
     const { score } = location.query;
 
+    if (!score || !addon) {
+      return null;
+    }
+
     const allScoreNotices = {
       /* eslint-disable quote-props */
       '1': i18n.gettext('Only showing one-star reviews'),
@@ -211,7 +215,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     };
     const scoreNotice = allScoreNotices[score];
 
-    if (!score || !addon || !scoreNotice) {
+    if (!scoreNotice) {
       return null;
     }
 

--- a/src/amo/pages/AddonReviewList/styles.scss
+++ b/src/amo/pages/AddonReviewList/styles.scss
@@ -20,6 +20,10 @@
     // https://stackoverflow.com/questions/36150458
     min-width: 50%;
   }
+
+  .Notice-generic {
+    margin-bottom: 12px;
+  }
 }
 
 .AddonReviewList-reviews {
@@ -28,4 +32,9 @@
 
     width: 65%;
   }
+}
+
+.AddonReviewList-noReviews {
+  padding: 48px 0;
+  text-align: center;
 }

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -1,6 +1,7 @@
 /* @flow */
 import { oneLine } from 'common-tags';
 import deepcopy from 'deepcopy';
+import invariant from 'invariant';
 import { LOCATION_CHANGE } from 'connected-react-router';
 
 import {
@@ -63,6 +64,23 @@ import type {
 import type { GroupedRatingsType } from 'amo/api/reviews';
 import type { FlagReviewReasonType } from 'amo/constants';
 import type { AppState } from 'amo/store';
+
+export function reviewListURL({
+  addonSlug,
+  id,
+  score,
+}: {|
+  addonSlug: string,
+  id?: number,
+  score?: number | string,
+|}) {
+  invariant(addonSlug, 'addonSlug is required');
+  let path = `/addon/${addonSlug}/reviews/${id ? `${id}/` : ''}`;
+  if (score) {
+    path = `${path}?score=${score}`;
+  }
+  return path;
+}
 
 type ReviewsById = {
   [id: number]: UserReviewType,

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -84,7 +84,7 @@ type Options = {|
 |};
 
 function* fetchReviews({
-  payload: { errorHandlerId, addonSlug, page },
+  payload: { errorHandlerId, addonSlug, page, score },
 }: FetchReviewsAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -98,6 +98,7 @@ function* fetchReviews({
       // Hide star-only ratings (reviews that do not have a body).
       filter: 'without_empty_body',
       page,
+      score,
     };
 
     const response: GetReviewsApiResponse = yield call(getReviews, params);

--- a/src/core/components/PaginatorLink/index.js
+++ b/src/core/components/PaginatorLink/index.js
@@ -1,3 +1,5 @@
+import url from 'url';
+
 import makeClassName from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
@@ -64,12 +66,17 @@ export default class PaginatorLink extends React.Component {
       );
     }
 
+    const parsedPath = url.parse(pathname, true);
+
     return (
       <Button
         buttonType="cancel"
         className={makeClassName('Paginate-item', className)}
         rel={rel}
-        to={{ pathname, query: { ...queryParams, [pageParam]: page } }}
+        to={{
+          pathname: parsedPath.pathname,
+          query: { ...parsedPath.query, ...queryParams, [pageParam]: page },
+        }}
       >
         {text || page}
       </Button>

--- a/src/core/components/SurveyNotice/index.js
+++ b/src/core/components/SurveyNotice/index.js
@@ -129,6 +129,7 @@ export class SurveyNoticeBase extends React.Component<InternalProps> {
         actionOnClick={this.onClickSurveyLink}
         actionTarget="_blank"
         actionText={i18n.gettext('Take short survey')}
+        againstGrey20
         className="SurveyNotice"
         dismissible
         id="amo-experience-survey"

--- a/src/core/components/SurveyNotice/styles.scss
+++ b/src/core/components/SurveyNotice/styles.scss
@@ -4,10 +4,4 @@
   .Notice-column {
     justify-content: center;
   }
-
-  &.Notice-generic {
-    // This strays from the Photon spec because the Photon background is the
-    // same as the page background which means the notice box could not be seen.
-    background-color: $grey-30;
-  }
 }

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -35,6 +35,9 @@ type Props = {|
   actionTarget?: string,
   actionText?: string,
   actionTo?: string | Object,
+  // This declares that the Notice component will be rendered against
+  // a $grey-20 background.
+  againstGrey20?: boolean,
   children?: React.Node,
   className?: string,
   dismissible?: boolean,
@@ -71,6 +74,7 @@ export class NoticeBase extends React.Component<InternalProps> {
       actionTarget,
       actionText,
       actionTo,
+      againstGrey20,
       children,
       className,
       dismissible,
@@ -110,6 +114,7 @@ export class NoticeBase extends React.Component<InternalProps> {
     }
 
     const finalClass = makeClassName('Notice', `Notice-${type}`, className, {
+      'Notice-againstGrey20': againstGrey20,
       'Notice-dismissible': dismissible,
       'Notice-light': light,
     });

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -77,13 +77,20 @@
 
 @mixin notice_button() {
   &,
-  &.Button--micro {
+  &.Button--micro,
+  &.Button--micro:link {
     border: none;
     font-size: $font-size-s;
     line-height: 1.1;
     padding: 6px;
     text-shadow: none;
     width: max-content;
+
+    &:active:not(.Button--disabled) {
+      // The default styles add padding-top: 1px so this keeps it in
+      // sync with the custom padding added above.
+      padding-top: 7px;
+    }
   }
 }
 
@@ -119,10 +126,10 @@
 .Notice-generic {
   .Notice-button {
     @include button(
-      $background: $blue-60,
-      $background-active: $blue-80,
-      $background-hover: $blue-70,
-      $color: $white
+      $background: $grey-90-a10,
+      $background-active: $grey-90-a30,
+      $background-hover: $grey-90-a20,
+      $color: $grey-90
     );
     @include notice_button();
   }
@@ -137,6 +144,12 @@
 
   background-color: $grey-20;
 
+  &.Notice-againstGrey20 {
+    // When this Notice is rendered against a $grey-20 background, pick a
+    // new background color to avoid a collision.
+    background-color: $grey-30;
+  }
+
   &,
   :link,
   :hover,
@@ -145,7 +158,7 @@
   }
 
   .Button:hover {
-    color: $white;
+    color: $grey-90;
   }
 }
 

--- a/tests/unit/amo/api/test_reviews.js
+++ b/tests/unit/amo/api/test_reviews.js
@@ -156,6 +156,7 @@ describe(__filename, () => {
         user: 123,
         addon: 321,
         show_grouped_ratings: 1,
+        score: 5,
       };
       const fakeResponse = getReviewsResponse({ reviews: [fakeReview] });
       mockApi

--- a/tests/unit/amo/components/TestAddonMeta.js
+++ b/tests/unit/amo/components/TestAddonMeta.js
@@ -7,6 +7,7 @@ import AddonMeta, {
 } from 'amo/components/AddonMeta';
 import Link from 'amo/components/Link';
 import RatingsByStar from 'amo/components/RatingsByStar';
+import { reviewListURL } from 'amo/reducers/reviews';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
   dispatchClientMetadata,
@@ -133,9 +134,12 @@ describe(__filename, () => {
       const reviewTitleLink = getReviewTitle(root).find(Link);
       const reviewCountLink = getReviewCount(root).find(Link);
 
-      expect(reviewTitleLink).toHaveProp('to', `/addon/${slug}/reviews/`);
+      const listURL = reviewListURL({ addonSlug: slug });
+
+      expect(reviewTitleLink).toHaveProp('to', listURL);
       expect(reviewTitleLink.children()).toHaveText('Reviews');
-      expect(reviewCountLink).toHaveProp('to', `/addon/${slug}/reviews/`);
+
+      expect(reviewCountLink).toHaveProp('to', listURL);
       expect(reviewCountLink.children()).toHaveText('5');
     });
 

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -19,6 +19,7 @@ import AddonReviewCard, {
 } from 'amo/components/AddonReviewCard';
 import FlagReviewMenu from 'amo/components/FlagReviewMenu';
 import Link from 'amo/components/Link';
+import { reviewListURL } from 'amo/reducers/reviews';
 import { logOutUser } from 'amo/reducers/users';
 import { ALL_SUPER_POWERS } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
@@ -1025,7 +1026,7 @@ describe(__filename, () => {
 
       expect(renderByLine(root).find(Link)).toHaveProp(
         'to',
-        `/addon/${slug}/reviews/${review.id}/`,
+        reviewListURL({ addonSlug: slug, id: review.id }),
       );
     });
 

--- a/tests/unit/amo/components/TestRatingsByStar.js
+++ b/tests/unit/amo/components/TestRatingsByStar.js
@@ -141,20 +141,20 @@ describe(__filename, () => {
     const root = render({ addon });
     const counts = root.find('.RatingsByStar-star').find(Link);
 
-    function validateLink(link, score) {
+    function validateLink(link, score, expectedTitle) {
       expect(link.children()).toHaveText(score);
       expect(link).toHaveProp(
         'to',
         reviewListURL({ addonSlug: addon.slug, score }),
       );
-      expect(link).toHaveProp('title');
+      expect(link).toHaveProp('title', expectedTitle);
     }
 
-    validateLink(counts.at(0), '5');
-    validateLink(counts.at(1), '4');
-    validateLink(counts.at(2), '3');
-    validateLink(counts.at(3), '2');
-    validateLink(counts.at(4), '1');
+    validateLink(counts.at(0), '5', 'Read all five-star reviews');
+    validateLink(counts.at(1), '4', 'Read all four-star reviews');
+    validateLink(counts.at(2), '3', 'Read all three-star reviews');
+    validateLink(counts.at(3), '2', 'Read all two-star reviews');
+    validateLink(counts.at(4), '1', 'Read all one-star reviews');
   });
 
   it('renders star counts', () => {
@@ -170,20 +170,20 @@ describe(__filename, () => {
     const root = render({ addon });
     const counts = root.find('.RatingsByStar-count').find(Link);
 
-    function validateLink(link, score) {
+    function validateLink(link, score, expectedTitle) {
       expect(link.children()).toHaveText(grouping[score].toString());
       expect(link).toHaveProp(
         'to',
         reviewListURL({ addonSlug: addon.slug, score }),
       );
-      expect(link).toHaveProp('title');
+      expect(link).toHaveProp('title', expectedTitle);
     }
 
-    validateLink(counts.at(0), '5');
-    validateLink(counts.at(1), '4');
-    validateLink(counts.at(2), '3');
-    validateLink(counts.at(3), '2');
-    validateLink(counts.at(4), '1');
+    validateLink(counts.at(0), '5', 'Read all five-star reviews');
+    validateLink(counts.at(1), '4', 'Read all four-star reviews');
+    validateLink(counts.at(2), '3', 'Read all three-star reviews');
+    validateLink(counts.at(3), '2', 'Read all two-star reviews');
+    validateLink(counts.at(4), '1', 'Read all one-star reviews');
   });
 
   it('renders bar value widths based on total ratings', () => {

--- a/tests/unit/amo/components/TestRatingsByStar.js
+++ b/tests/unit/amo/components/TestRatingsByStar.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 
+import Link from 'amo/components/Link';
 import { fetchGroupedRatings, setGroupedRatings } from 'amo/actions/reviews';
 import RatingsByStar, {
   extractId,
   RatingsByStarBase,
 } from 'amo/components/RatingsByStar';
+import { reviewListURL } from 'amo/reducers/reviews';
 import { ErrorHandler } from 'core/errorHandler';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -126,7 +128,7 @@ describe(__filename, () => {
     expect(root.find('.RatingsByStar-count').find(LoadingText)).toHaveLength(5);
   });
 
-  it('renders star labels', () => {
+  it('renders star labels and links', () => {
     const grouping = {
       5: 964,
       4: 821,
@@ -137,13 +139,22 @@ describe(__filename, () => {
     const addon = addonForGrouping(grouping);
     store.dispatch(setGroupedRatings({ addonId: addon.id, grouping }));
     const root = render({ addon });
+    const counts = root.find('.RatingsByStar-star').find(Link);
 
-    const counts = root.find('.RatingsByStar-star span');
-    expect(counts.at(0)).toHaveText('5');
-    expect(counts.at(1)).toHaveText('4');
-    expect(counts.at(2)).toHaveText('3');
-    expect(counts.at(3)).toHaveText('2');
-    expect(counts.at(4)).toHaveText('1');
+    function validateLink(link, score) {
+      expect(link.children()).toHaveText(score);
+      expect(link).toHaveProp(
+        'to',
+        reviewListURL({ addonSlug: addon.slug, score }),
+      );
+      expect(link).toHaveProp('title');
+    }
+
+    validateLink(counts.at(0), '5');
+    validateLink(counts.at(1), '4');
+    validateLink(counts.at(2), '3');
+    validateLink(counts.at(3), '2');
+    validateLink(counts.at(4), '1');
   });
 
   it('renders star counts', () => {
@@ -157,13 +168,22 @@ describe(__filename, () => {
     const addon = addonForGrouping(grouping);
     store.dispatch(setGroupedRatings({ addonId: addon.id, grouping }));
     const root = render({ addon });
+    const counts = root.find('.RatingsByStar-count').find(Link);
 
-    const counts = root.find('.RatingsByStar-count');
-    expect(counts.at(0)).toHaveText(grouping[5].toString());
-    expect(counts.at(1)).toHaveText(grouping[4].toString());
-    expect(counts.at(2)).toHaveText(grouping[3].toString());
-    expect(counts.at(3)).toHaveText(grouping[2].toString());
-    expect(counts.at(4)).toHaveText(grouping[1].toString());
+    function validateLink(link, score) {
+      expect(link.children()).toHaveText(grouping[score].toString());
+      expect(link).toHaveProp(
+        'to',
+        reviewListURL({ addonSlug: addon.slug, score }),
+      );
+      expect(link).toHaveProp('title');
+    }
+
+    validateLink(counts.at(0), '5');
+    validateLink(counts.at(1), '4');
+    validateLink(counts.at(2), '3');
+    validateLink(counts.at(3), '2');
+    validateLink(counts.at(4), '1');
   });
 
   it('renders bar value widths based on total ratings', () => {
@@ -248,7 +268,13 @@ describe(__filename, () => {
     store.dispatch(setGroupedRatings({ addonId: addon.id, grouping }));
     const root = render({ addon, i18n: fakeI18n({ lang: 'de' }) });
 
-    expect(root.find('.RatingsByStar-count').at(0)).toHaveText('1.000');
+    expect(
+      root
+        .find('.RatingsByStar-count')
+        .at(0)
+        .find(Link)
+        .children(),
+    ).toHaveText('1.000');
   });
 
   it('renders errors', () => {
@@ -270,8 +296,8 @@ describe(__filename, () => {
   it('does not render a loading state when there is an error', () => {
     const errorHandler = createErrorHandlerWithError();
 
-    // Render without an add-on to trigger a loading state.
-    const root = render({ addon: null, errorHandler });
+    // Render without setGroupedRatings to trigger a loading state.
+    const root = render({ errorHandler });
 
     expect(root.find(LoadingText)).toHaveLength(0);
   });

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -21,6 +21,7 @@ import InstallButtonWrapper from 'amo/components/InstallButtonWrapper';
 import RatingManager, {
   RatingManagerWithI18n,
 } from 'amo/components/RatingManager';
+import { reviewListURL } from 'amo/reducers/reviews';
 import { createInternalVersion } from 'core/reducers/versions';
 import createStore from 'amo/store';
 import {
@@ -1122,10 +1123,15 @@ describe(__filename, () => {
   });
 
   describe('read reviews footer', () => {
-    function readReviewsCard({ ratingsCount = 1, ...customProps }) {
+    function readReviewsCard({
+      addonSlug = fakeAddon.slug,
+      ratingsCount = 1,
+      ...customProps
+    }) {
       const { store } = dispatchSignInActions();
       const addon = {
         ...fakeAddon,
+        slug: addonSlug,
         ratings: {
           ...fakeAddon.ratings,
           text_count: ratingsCount,
@@ -1134,7 +1140,11 @@ describe(__filename, () => {
 
       store.dispatch(_loadAddonResults({ addon }));
 
-      const root = renderComponent({ store, ...customProps });
+      const root = renderComponent({
+        addon: createInternalAddon(addon),
+        store,
+        ...customProps,
+      });
       return root.find('.Addon-overall-rating');
     }
 
@@ -1178,15 +1188,15 @@ describe(__filename, () => {
     });
 
     it('links to all reviews', () => {
+      const addonSlug = 'adblock-plus';
       const card = readReviewsCard({
+        addonSlug,
         ratingsCount: 2,
       });
 
-      expect(allReviewsLink(card)).toHaveLength(1);
-      expect(allReviewsLink(card)).toHaveProp(
-        'to',
-        '/addon/chill-out/reviews/',
-      );
+      const link = allReviewsLink(card);
+      expect(link).toHaveLength(1);
+      expect(link).toHaveProp('to', reviewListURL({ addonSlug }));
     });
   });
 

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -38,6 +38,7 @@ import reviewsReducer, {
   getReviewsByUserId,
   initialState,
   makeLatestUserReviewKey,
+  reviewListURL,
   reviewsAreLoading,
   selectReviewPermissions,
   storeReviewObjects,
@@ -1723,6 +1724,40 @@ describe(__filename, () => {
       );
 
       expect(state.groupedRatings[addonId][5]).toEqual(fiveStarCount);
+    });
+  });
+
+  describe('reviewListURL', () => {
+    it('returns a URL using the addon slug', () => {
+      const addonSlug = 'adblock-plus';
+      expect(reviewListURL({ addonSlug })).toEqual(
+        `/addon/${addonSlug}/reviews/`,
+      );
+    });
+
+    it('returns a URL using the ID', () => {
+      const addonSlug = 'adblock-plus';
+      const id = 3215;
+      expect(reviewListURL({ addonSlug, id })).toEqual(
+        `/addon/${addonSlug}/reviews/${id}/`,
+      );
+    });
+
+    it('returns a URL using the score', () => {
+      const addonSlug = 'adblock-plus';
+      const score = 5;
+      expect(reviewListURL({ addonSlug, score })).toEqual(
+        `/addon/${addonSlug}/reviews/?score=${score}`,
+      );
+    });
+
+    it('returns a URL using the ID and score', () => {
+      const addonSlug = 'adblock-plus';
+      const id = 4321;
+      const score = 5;
+      expect(reviewListURL({ addonSlug, id, score })).toEqual(
+        `/addon/${addonSlug}/reviews/${id}/?score=${score}`,
+      );
     });
   });
 });

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -97,14 +97,13 @@ describe(__filename, () => {
           apiState,
           filter: 'without_empty_body',
           page: '1',
+          score: undefined,
         })
-        .returns(
-          Promise.resolve(
-            apiResponsePage({
-              page_size: DEFAULT_API_PAGE_SIZE,
-              results: reviews,
-            }),
-          ),
+        .resolves(
+          apiResponsePage({
+            page_size: DEFAULT_API_PAGE_SIZE,
+            results: reviews,
+          }),
         );
 
       _fetchReviews();
@@ -120,6 +119,19 @@ describe(__filename, () => {
           reviews,
         }),
       );
+    });
+
+    it('can filter by rating score', async () => {
+      const score = 5;
+      mockApi
+        .expects('getReviews')
+        .withArgs(sinon.match({ score }))
+        .resolves(apiResponsePage({ results: [fakeReview] }));
+
+      _fetchReviews({ score });
+
+      await sagaTester.waitFor(SET_ADDON_REVIEWS);
+      mockApi.verify();
     });
 
     it('clears the error handler', async () => {

--- a/tests/unit/core/components/TestPaginatorLink.js
+++ b/tests/unit/core/components/TestPaginatorLink.js
@@ -68,6 +68,35 @@ describe(__filename, () => {
     });
   });
 
+  it('preserves `queryParams` when adding the page param', () => {
+    const queryParams = { color: 'red' };
+    const page = 3;
+
+    const root = render({ queryParams, page });
+
+    expect(root.find(Button).prop('to')).toHaveProperty('query', {
+      ...queryParams,
+      page,
+    });
+  });
+
+  it('handles `pathname` with a search string at the end', () => {
+    const pathnameBase = '/somewhere/';
+    const color = 'purple';
+    const pathname = `${pathnameBase}?color=${color}`;
+    const page = 3;
+
+    const root = render({ pathname, page });
+
+    expect(root.find(Button).prop('to')).toMatchObject({
+      pathname: pathnameBase,
+      query: {
+        color,
+        page,
+      },
+    });
+  });
+
   describe('when the link is to the current page', () => {
     it('does not contain a link and is disabled', () => {
       const item = render({ currentPage: 3, page: 3 });

--- a/tests/unit/ui/components/TestNotice.js
+++ b/tests/unit/ui/components/TestNotice.js
@@ -39,6 +39,12 @@ describe(__filename, () => {
     expect(root).toHaveClassName('Notice-error');
   });
 
+  it('renders a class for againstGrey20=true', () => {
+    const root = render({ againstGrey20: true });
+
+    expect(root).toHaveClassName('Notice-againstGrey20');
+  });
+
   it('renders children', () => {
     const root = render({ children: <em>Some text</em> });
 


### PR DESCRIPTION
* Fixes https://github.com/mozilla/addons-frontend/issues/5923 by adding links to the rating graph.
* Fixes https://github.com/mozilla/addons-frontend/issues/4549 by making notice buttons gray.

New screen for viewing filtered reviews:

<img width="760" alt="screenshot 2018-11-30 17 02 49" src="https://user-images.githubusercontent.com/55398/49319335-ee610000-f4c1-11e8-99d8-6c61b012ce69.png">

For stars that have no reviews, it shows a new empty screen:

<img width="761" alt="screenshot 2018-11-30 17 04 25" src="https://user-images.githubusercontent.com/55398/49319351-06388400-f4c2-11e8-96d4-a8e7ac205da5.png">
