### PR TITLE
Collapse text in long add-on reviews by using ShowMoreCard

### DIFF
--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -51,7 +51,8 @@ function reviewBody({
   } else {
     bodyAttr.dangerouslySetInnerHTML = html;
   }
-
+  const showMoreCardName = 'UserReview-body';
+  id += '';
   return (
     <ShowMoreCard
       className={makeClassName(

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -8,6 +8,7 @@ import translate from 'core/i18n/translate';
 import { nl2br, sanitizeHTML } from 'core/utils';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
+import ShowMoreCard from 'ui/components/ShowMoreCard';
 import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { I18nType } from 'core/types/i18n';
@@ -49,14 +50,20 @@ function reviewBody({
     bodyAttr.dangerouslySetInnerHTML = html;
   }
 
+  const showMoreCardName = ' ' + Math.random();
   return (
-    <div
-      className={makeClassName('UserReview-body', {
-        // Add an extra class if the content is an empty string.
-        'UserReview-emptyBody': !content && !html,
-      })}
-      {...bodyAttr}
-    />
+    <ShowMoreCard
+      className={makeClassName(
+        { showMoreCardName },
+        {
+          // Add an extra class if the content is an empty string.
+          'UserReview-emptyBody': !content && !html,
+        },
+      )}
+      id={showMoreCardName}
+    >
+      <div {...bodyAttr} />
+    </ShowMoreCard>
   );
 }
 

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -33,9 +33,11 @@ type InternalProps = {|
 function reviewBody({
   content,
   html,
+  id,
 }: {|
   content?: React.Node | string,
   html?: React.Node,
+  id?:number,
 |}) {
   invariant(
     content !== undefined || html !== undefined,
@@ -50,7 +52,6 @@ function reviewBody({
     bodyAttr.dangerouslySetInnerHTML = html;
   }
 
-  const showMoreCardName = ' ' + Math.random();
   return (
     <ShowMoreCard
       className={makeClassName(
@@ -60,7 +61,7 @@ function reviewBody({
           'UserReview-emptyBody': !content && !html,
         },
       )}
-      id={showMoreCardName}
+      id={id}
     >
       <div {...bodyAttr} />
     </ShowMoreCard>
@@ -85,9 +86,10 @@ export const UserReviewBase = (props: InternalProps) => {
     if (review.body) {
       body = reviewBody({
         html: sanitizeHTML(nl2br(review.body), ['br']),
+        id: review.id,
       });
     } else {
-      body = reviewBody({ content: '' });
+      body = reviewBody({ content: '', id: review.id});
     }
   }
 


### PR DESCRIPTION
Fixes #6242, so that long text in add-on reviews gets collapsed and becomes expandable by clicking a 'read more' link (see image for example of problem in the original issue). 

This PR modifies the code in the `reviewBody()` function to use the `ShowMoreCard` for reviews that exceed a certain line height. 

After editing or submitting a review that exceeds maximum height, the review renders and behaves as follows:  
  
![show_more_card](https://user-images.githubusercontent.com/26360553/49330854-6aab2000-f562-11e8-832c-d9da9bf5ec83.gif)  
  
When user navigates to 'Read all reviews' page, long reviews are truncated with expandable read more link:  
  
![review_list](https://user-images.githubusercontent.com/26360553/49330876-e86f2b80-f562-11e8-9441-a76f74abfa70.gif)

I still need to write additional tests for this fix, but thought I'd get the PR open for code review in the meantime. Also if anyone has any suggestions or guidance for tests before I get started, I'm all ears :) 