### PR TITLE
Only use on link-color var in SCSS

### DIFF
--- a/src/core/css/inc/mixins.scss
+++ b/src/core/css/inc/mixins.scss
@@ -1,4 +1,3 @@
-@import '~photon-colors/photon-colors';
 @import './vars';
 
 @mixin page-padding() {

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -1,3 +1,5 @@
+@import '~photon-colors/photon-colors';
+
 // Add-on details
 $primary-font-color: #000;
 $body-font-color: #1d1d1d;
@@ -11,7 +13,7 @@ $sub-text-color: #6a6a6a;
 $form-border-color: $primary-font-color;
 $button-background-color: #0095dd;
 $base-color: #fff;
-$link-color: #0568ba;
+$link-color: $blue-60;
 $warning: #d63920;
 
 // Fonts

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -1,4 +1,3 @@
-@import '~photon-colors/photon-colors';
 @import '~core/css/inc/vars';
 
 // Desktop variables (from specs)
@@ -33,7 +32,6 @@ $block-hover-white-color: #f8f9fa;
 $background-grey: #e9ecef;
 $background-gray: $background-grey;
 $type-black: $black;
-$link-color: #0d96ff;
 $header-accent-color: $link-color;
 $header-text-not-active-color: transparentize($white, 0.5);
 


### PR DESCRIPTION
This PR makes sure we only use one `$link-color` variable in our SCSS code.

`$blue-60` is the Photon color to use for links: https://design.firefox.com/photon/components/links.html.