### PR TITLE
User ID in collection URLs

### DIFF
--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -43,7 +43,7 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   clientApp: string,
-  currentUsername: string,
+  currentUserId: string,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   history: ReactRouterHistoryType,
@@ -116,7 +116,7 @@ export class CollectionManagerBase extends React.Component<
     const {
       collection,
       creating,
-      currentUsername,
+      currentUserId,
       dispatch,
       errorHandler,
       filters,
@@ -150,7 +150,7 @@ export class CollectionManagerBase extends React.Component<
           // query parameter values are string, not number.
           // $FLOW_FIXME: https://github.com/mozilla/addons-frontend/issues/5737
           includeAddonId: location.query.include_addon_id,
-          userId: currentUsername,
+          userId: currentUserId,
         }),
       );
     } else {
@@ -164,7 +164,7 @@ export class CollectionManagerBase extends React.Component<
           collectionSlug: collection.slug,
           defaultLocale: collection.defaultLocale,
           filters,
-          userId: collection.authorUsername,
+          userId: String(collection.authorId),
         }),
       );
     }
@@ -205,7 +205,7 @@ export class CollectionManagerBase extends React.Component<
     const {
       collection,
       creating,
-      currentUsername,
+      currentUserId,
       errorHandler,
       i18n,
       isCollectionBeingModified,
@@ -216,7 +216,7 @@ export class CollectionManagerBase extends React.Component<
     const collectionUrlPrefix = oneLineTrim`${config.get(
       'apiHost',
     )}/${siteLang}/firefox/collections/
-       ${(collection && collection.authorUsername) || currentUsername}/`;
+       ${(collection && collection.authorId) || currentUserId}/`;
 
     const formIsUnchanged =
       collection &&
@@ -333,7 +333,7 @@ export const mapStateToProps = (state: AppState) => {
 
   return {
     clientApp: state.api.clientApp,
-    currentUsername: currentUser && currentUser.username,
+    currentUserId: currentUser && String(currentUser.id),
     isCollectionBeingModified: state.collections.isCollectionBeingModified,
     siteLang: state.api.lang,
   };

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -162,7 +162,7 @@ export class CollectionBase extends React.Component<InternalProps> {
 
     invariant(collection, 'collection is required');
 
-    const { slug, authorUsername: userId } = collection;
+    const { slug, authorId: userId } = collection;
 
     invariant(slug, 'slug is required');
     invariant(userId, 'userId is required');
@@ -171,7 +171,7 @@ export class CollectionBase extends React.Component<InternalProps> {
       deleteCollection({
         errorHandlerId: errorHandler.id,
         slug,
-        userId,
+        userId: String(userId),
       }),
     );
   };
@@ -209,32 +209,42 @@ export class CollectionBase extends React.Component<InternalProps> {
       addonsPageChanged = true;
     }
 
-    if (
-      collection &&
-      (collection.slug.toLowerCase() !== params.slug.toLowerCase() ||
-        collection.authorUsername.toLowerCase() !== params.userId.toLowerCase())
-    ) {
-      collectionChanged = true;
+    if (collection) {
+      let isSameCollectionUser;
+      // Is `userId` a numeric ID?
+      if (/^\d+$/.test(params.userId)) {
+        isSameCollectionUser = `${collection.authorId}` === params.userId;
+      } else {
+        isSameCollectionUser =
+          collection.authorUsername.toLowerCase() ===
+          params.userId.toLowerCase();
+      }
+
+      if (
+        collection.slug.toLowerCase() !== params.slug.toLowerCase() ||
+        isSameCollectionUser === false
+      ) {
+        collectionChanged = true;
+      }
     }
 
     // See: https://github.com/mozilla/addons-frontend/issues/4271
-    if (
-      !collectionChanged &&
-      collection &&
-      (params.userId !== collection.authorUsername ||
-        params.slug !== collection.slug)
-    ) {
-      const { lang, clientApp } = this.props;
+    if (!collectionChanged && collection) {
+      if (params.slug !== collection.slug || !/^\d+$/.test(params.userId)) {
+        const { editing, lang, clientApp } = this.props;
 
-      this.props.dispatch(
-        sendServerRedirect({
-          status: 301,
-          url: `/${lang}/${clientApp}/collections/${
-            collection.authorUsername
-          }/${collection.slug}/`,
-        }),
-      );
-      return;
+        const path = editing
+          ? collectionEditUrl({ collection })
+          : collectionUrl({ collection });
+
+        this.props.dispatch(
+          sendServerRedirect({
+            status: 301,
+            url: `/${lang}/${clientApp}${path}`,
+          }),
+        );
+        return;
+      }
     }
 
     if (!collection || collectionChanged) {
@@ -243,7 +253,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           errorHandlerId: errorHandler.id,
           filters,
           slug: params.slug,
-          userId: params.userId,
+          userId: String(params.userId),
         }),
       );
 
@@ -256,7 +266,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           errorHandlerId: errorHandler.id,
           filters,
           slug: params.slug,
-          userId: params.userId,
+          userId: String(params.userId),
         }),
       );
     }
@@ -267,7 +277,7 @@ export class CollectionBase extends React.Component<InternalProps> {
 
     invariant(collection, 'collection is required');
 
-    const { slug, authorUsername: userId } = collection;
+    const { slug, authorId: userId } = collection;
 
     invariant(slug, 'slug is required');
     invariant(userId, 'userId is required');
@@ -294,7 +304,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           page,
         },
         slug,
-        userId,
+        userId: String(userId),
       }),
     );
 
@@ -319,7 +329,7 @@ export class CollectionBase extends React.Component<InternalProps> {
 
     invariant(collection, 'collection is required');
 
-    const { slug, authorUsername: userId } = collection;
+    const { slug, authorId: userId } = collection;
 
     invariant(slug, 'slug is required');
     invariant(userId, 'userId is required');
@@ -330,7 +340,7 @@ export class CollectionBase extends React.Component<InternalProps> {
         errorHandlerId: errorHandler.id,
         filters,
         slug,
-        userId,
+        userId: String(userId),
       }),
     );
   };
@@ -344,7 +354,7 @@ export class CollectionBase extends React.Component<InternalProps> {
 
     invariant(collection, 'collection is required');
 
-    const { slug, authorUsername: userId } = collection;
+    const { slug, authorId: userId } = collection;
 
     invariant(slug, 'slug is required');
     invariant(userId, 'userId is required');
@@ -356,7 +366,7 @@ export class CollectionBase extends React.Component<InternalProps> {
         notes,
         filters,
         slug,
-        userId,
+        userId: String(userId),
       }),
     );
   };

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -253,7 +253,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           errorHandlerId: errorHandler.id,
           filters,
           slug: params.slug,
-          userId: String(params.userId),
+          userId: params.userId,
         }),
       );
 
@@ -266,7 +266,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           errorHandlerId: errorHandler.id,
           filters,
           slug: params.slug,
-          userId: String(params.userId),
+          userId: params.userId,
         }),
       );
     }

--- a/src/amo/pages/CollectionList/index.js
+++ b/src/amo/pages/CollectionList/index.js
@@ -28,7 +28,7 @@ export type Props = {||};
 export type InternalProps = {|
   ...Props,
   collections: Array<CollectionType> | null,
-  currentUsername: string | null,
+  currentUserId: number | null,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
@@ -40,17 +40,17 @@ export class CollectionListBase extends React.Component<InternalProps> {
   componentDidMount() {
     const {
       collections,
-      currentUsername,
+      currentUserId,
       dispatch,
       errorHandler,
       loadingUserCollections,
     } = this.props;
 
-    if (currentUsername && !loadingUserCollections && !collections) {
+    if (currentUserId && !loadingUserCollections && !collections) {
       dispatch(
         fetchUserCollections({
           errorHandlerId: errorHandler.id,
-          userId: currentUsername,
+          userId: String(currentUserId),
         }),
       );
     }
@@ -64,10 +64,11 @@ export class CollectionListBase extends React.Component<InternalProps> {
 
     if (collections) {
       collections.forEach((collection) => {
-        const { authorUsername, id, name, numberOfAddons, slug } = collection;
+        const { authorId, id, name, numberOfAddons, slug } = collection;
+
         collectionElements.push(
           <UserCollection
-            authorUsername={authorUsername}
+            authorId={authorId}
             id={id}
             key={id}
             name={name}
@@ -118,8 +119,9 @@ export class CollectionListBase extends React.Component<InternalProps> {
             ) : (
               <React.Fragment>
                 <p className="CollectionList-info-text">
-                  {i18n.gettext(`Collections make it easy to keep track of favorite
-                    add-ons and share your perfectly customized browser with others.`)}
+                  {i18n.gettext(`Collections make it easy to keep track of
+                    favorite add-ons and share your perfectly customized browser
+                    with others.`)}
                 </p>
                 <Button
                   buttonType="action"
@@ -143,16 +145,16 @@ export const mapStateToProps = (state: AppState) => {
   const { collections, users } = state;
 
   const currentUser = getCurrentUser(users);
-  const currentUsername = currentUser && currentUser.username;
+  const currentUserId = currentUser && currentUser.id;
 
   let userCollections;
 
-  if (currentUsername) {
-    userCollections = collections.userCollections[currentUsername];
+  if (currentUserId) {
+    userCollections = collections.userCollections[String(currentUserId)];
   }
 
   return {
-    currentUsername,
+    currentUserId,
     isLoggedIn: !!currentUser,
     loadingUserCollections: userCollections ? userCollections.loading : false,
     collections: expandCollections(collections, userCollections),
@@ -160,8 +162,8 @@ export const mapStateToProps = (state: AppState) => {
 };
 
 export const extractId = (ownProps: InternalProps) => {
-  const { currentUsername } = ownProps;
-  return currentUsername || '';
+  const { currentUserId } = ownProps;
+  return currentUserId || '';
 };
 
 const CollectionList: React.ComponentType<Props> = compose(

--- a/src/amo/pages/CollectionList/index.js
+++ b/src/amo/pages/CollectionList/index.js
@@ -28,7 +28,7 @@ export type Props = {||};
 export type InternalProps = {|
   ...Props,
   collections: Array<CollectionType> | null,
-  currentUserId: number | null,
+  currentUserId: string | null,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   i18n: I18nType,
@@ -50,7 +50,7 @@ export class CollectionListBase extends React.Component<InternalProps> {
       dispatch(
         fetchUserCollections({
           errorHandlerId: errorHandler.id,
-          userId: String(currentUserId),
+          userId: currentUserId,
         }),
       );
     }
@@ -145,12 +145,12 @@ export const mapStateToProps = (state: AppState) => {
   const { collections, users } = state;
 
   const currentUser = getCurrentUser(users);
-  const currentUserId = currentUser && currentUser.id;
+  const currentUserId = currentUser && String(currentUser.id);
 
   let userCollections;
 
   if (currentUserId) {
-    userCollections = collections.userCollections[String(currentUserId)];
+    userCollections = collections.userCollections[currentUserId];
   }
 
   return {

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -1000,39 +1000,40 @@ export const convertFiltersToQueryParams = (filters: CollectionFilters) => {
 };
 
 type CollectionUrlParams = {|
-  authorUsername?: string,
+  authorId?: string,
   collection: CollectionType | null,
   collectionSlug?: string,
   _collectionUrl?: Function,
 |};
 
 export const collectionUrl = ({
-  authorUsername,
+  authorId,
   collection,
   collectionSlug,
 }: CollectionUrlParams): string => {
   let slug = collectionSlug;
-  let username = authorUsername;
+  let userId = authorId;
+
   if (collection) {
     slug = collection.slug;
-    username = collection.authorUsername;
+    userId = collection.authorId;
   }
   invariant(
-    slug && username,
-    'Either a collection or an authorUsername and collectionSlug are required.',
+    slug && userId,
+    'Either a collection or an authorId and collectionSlug are required.',
   );
 
-  return `/collections/${username}/${slug}/`;
+  return `/collections/${userId}/${slug}/`;
 };
 
 export const collectionEditUrl = ({
-  authorUsername,
+  authorId,
   collection,
   collectionSlug,
   _collectionUrl = collectionUrl,
 }: CollectionUrlParams): string => {
   return `${_collectionUrl({
-    authorUsername,
+    authorId,
     collection,
     collectionSlug,
   })}edit/`;

--- a/src/ui/components/UserCollection/index.js
+++ b/src/ui/components/UserCollection/index.js
@@ -11,7 +11,7 @@ import type { I18nType } from 'core/types/i18n';
 import './styles.scss';
 
 type Props = {|
-  authorUsername?: string,
+  authorId?: number,
   id: number,
   loading?: boolean,
   name?: string,
@@ -25,15 +25,7 @@ type InternalProps = {|
 |};
 
 export const UserCollectionBase = (props: InternalProps) => {
-  const {
-    authorUsername,
-    id,
-    loading,
-    name,
-    numberOfAddons,
-    slug,
-    i18n,
-  } = props;
+  const { authorId, id, loading, name, numberOfAddons, slug, i18n } = props;
 
   const linkProps = {};
   let numberText;
@@ -41,7 +33,7 @@ export const UserCollectionBase = (props: InternalProps) => {
   if (loading) {
     linkProps.href = '';
   } else {
-    invariant(authorUsername, 'authorUsername is required');
+    invariant(authorId, 'authorId is required');
     invariant(name, 'name is required');
     invariant(slug, 'slug is required');
     invariant(
@@ -49,7 +41,7 @@ export const UserCollectionBase = (props: InternalProps) => {
       'numberOfAddons must be a number',
     );
 
-    linkProps.to = `/collections/${authorUsername}/${slug}/`;
+    linkProps.to = `/collections/${authorId}/${slug}/`;
     numberText = i18n.sprintf(
       i18n.ngettext('%(total)s add-on', '%(total)s add-ons', numberOfAddons),
       { total: i18n.formatNumber(numberOfAddons) },

--- a/tests/unit/amo/components/TestCollectionManager.js
+++ b/tests/unit/amo/components/TestCollectionManager.js
@@ -36,7 +36,6 @@ describe(__filename, () => {
   let store;
   const apiHost = config.get('apiHost');
   const signedInUserId = 123;
-  const signedInUsername = 'user123';
   const lang = 'en-US';
 
   beforeEach(() => {
@@ -46,7 +45,6 @@ describe(__filename, () => {
       lang,
       store,
       userId: signedInUserId,
-      userProps: { username: signedInUsername },
     });
   });
 
@@ -131,13 +129,15 @@ describe(__filename, () => {
   it('can render an empty form for create', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const newLang = 'de';
-    const username = 'testUser';
-    const localStore = dispatchClientMetadata({ clientApp, lang: newLang })
-      .store;
+    const userId = 1001;
+    const { store: localStore } = dispatchClientMetadata({
+      clientApp,
+      lang: newLang,
+    });
     dispatchSignInActions({
       lang: newLang,
       store: localStore,
-      userProps: { username },
+      userId,
     });
 
     const root = render({
@@ -146,7 +146,7 @@ describe(__filename, () => {
       store: localStore,
     });
 
-    const expectedUrlPrefix = `${apiHost}/${newLang}/${clientApp}/collections/${username}/`;
+    const expectedUrlPrefix = `${apiHost}/${newLang}/${clientApp}/collections/${userId}/`;
     expect(root.find('#collectionName')).toHaveProp('value', '');
     expect(root.find('#collectionDescription')).toHaveProp('value', '');
     expect(root.find('#collectionSlug')).toHaveProp('value', '');
@@ -160,25 +160,26 @@ describe(__filename, () => {
   it('populates the edit form with collection data', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const newLang = 'de';
-    const username = 'testUser';
+    const userId = 1001;
     const localStore = dispatchClientMetadata({ clientApp, lang: newLang })
       .store;
     dispatchSignInActions({
       lang: newLang,
       store: localStore,
-      userProps: { username },
+      userId,
     });
     const collection = createInternalCollection({
       detail: createFakeCollectionDetail({
         name: 'OG name',
         description: 'OG description',
         slug: 'the-slug',
-        authorUsername: username,
+        authorId: userId,
       }),
     });
     const root = render({ collection, store: localStore });
 
-    const expectedUrlPrefix = `${apiHost}/${newLang}/${clientApp}/collections/${username}/`;
+    const expectedUrlPrefix = `${apiHost}/${newLang}/${clientApp}/collections/${userId}/`;
+
     expect(root.find('#collectionName')).toHaveProp('value', collection.name);
     expect(root.find('#collectionDescription')).toHaveProp(
       'value',
@@ -310,7 +311,7 @@ describe(__filename, () => {
         errorHandlerId: root.instance().props.errorHandler.id,
         name: { [lang]: name },
         slug,
-        userId: signedInUsername,
+        userId: String(signedInUserId),
       }),
     );
   });
@@ -347,7 +348,7 @@ describe(__filename, () => {
         includeAddonId: id,
         name: { [lang]: name },
         slug,
-        userId: signedInUsername,
+        userId: String(signedInUserId),
       }),
     );
   });
@@ -356,7 +357,7 @@ describe(__filename, () => {
     const filters = { page: '1' };
 
     const collection = createInternalCollection({
-      detail: createFakeCollectionDetail({ authorUsername: signedInUsername }),
+      detail: createFakeCollectionDetail({ authorId: signedInUserId }),
     });
     const dispatchSpy = sinon.spy(store, 'dispatch');
     const root = render({ collection, filters });
@@ -382,7 +383,7 @@ describe(__filename, () => {
         filters,
         name: { [lang]: name },
         slug,
-        userId: signedInUsername,
+        userId: String(signedInUserId),
       }),
     );
   });
@@ -534,7 +535,7 @@ describe(__filename, () => {
 
     const collection = createInternalCollection({
       detail: createFakeCollectionDetail({
-        authorUsername: signedInUsername,
+        authorId: signedInUserId,
         name,
         slug,
       }),
@@ -560,7 +561,7 @@ describe(__filename, () => {
         filters,
         name: { [lang]: name },
         slug,
-        userId: signedInUsername,
+        userId: String(signedInUserId),
       }),
     );
   });
@@ -627,7 +628,7 @@ describe(__filename, () => {
     const errorHandler = createStubErrorHandler();
     const filters = { page: '1' };
     const collection = createInternalCollection({
-      detail: createFakeCollectionDetail({ authorUsername: signedInUsername }),
+      detail: createFakeCollectionDetail({ authorId: signedInUserId }),
     });
 
     const dispatchSpy = sinon.spy(store, 'dispatch');
@@ -649,7 +650,7 @@ describe(__filename, () => {
         filters,
         name: { [lang]: collection.name },
         slug: collection.slug,
-        userId: signedInUsername,
+        userId: String(signedInUserId),
       }),
     );
   });

--- a/tests/unit/amo/components/TestCollectionSort.js
+++ b/tests/unit/amo/components/TestCollectionSort.js
@@ -69,7 +69,7 @@ describe(__filename, () => {
       `calls history.push with expected pathname and query when a sort is selected and editing is %s`,
       (editing) => {
         const slug = 'some-slug';
-        const username = 'some-username';
+        const userId = 123;
         const page = 2;
         const sort = COLLECTION_SORT_NAME;
         const clientApp = CLIENT_APP_FIREFOX;
@@ -77,7 +77,7 @@ describe(__filename, () => {
         const queryParams = { page, collection_sort: sort };
         const collection = createInternalCollection({
           detail: createFakeCollectionDetail({
-            authorUsername: username,
+            authorId: userId,
             slug,
           }),
           items: createFakeCollectionAddons(),
@@ -100,7 +100,7 @@ describe(__filename, () => {
         const select = root.find('.CollectionSort-select');
         select.simulate('change', fakeEvent);
 
-        const pathname = `/${lang}/${clientApp}/collections/${username}/${slug}/${
+        const pathname = `/${lang}/${clientApp}/collections/${userId}/${slug}/${
           editing ? 'edit/' : ''
         }`;
 

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -55,7 +55,7 @@ import {
 
 describe(__filename, () => {
   const defaultCollectionDetail = createFakeCollectionDetail();
-  const defaultUser = defaultCollectionDetail.author.username;
+  const defaultUserId = defaultCollectionDetail.author.id;
   const defaultSlug = defaultCollectionDetail.slug;
 
   const getProps = ({ ...otherProps } = {}) => ({
@@ -65,7 +65,7 @@ describe(__filename, () => {
     location: createFakeLocation(),
     match: {
       params: {
-        userId: defaultUser,
+        userId: String(defaultUserId),
         slug: defaultSlug,
       },
     },
@@ -221,7 +221,7 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const userId = 456;
+    const userId = '456';
     const params = { slug, userId };
 
     renderComponent({ errorHandler, match: { params }, store });
@@ -273,7 +273,7 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const userId = 567;
+    const userId = '567';
     const page = 123;
     const sort = COLLECTION_SORT_NAME;
 
@@ -334,7 +334,7 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const userId = 456;
+    const userId = '456';
 
     store.dispatch(
       fetchCurrentCollection({
@@ -356,7 +356,7 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const userId = 456;
+    const userId = '456';
 
     store.dispatch(
       fetchCurrentCollectionPage({
@@ -394,7 +394,7 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const slug = 'collection-slug';
-    const userId = 456;
+    const userId = '456';
     const page = 123;
     const sort = COLLECTION_SORT_NAME;
 
@@ -463,7 +463,7 @@ describe(__filename, () => {
       fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         filters: newFilters,
-        userId: defaultUser,
+        userId: String(defaultUserId),
         slug: defaultSlug,
       }),
     );
@@ -500,7 +500,7 @@ describe(__filename, () => {
       fetchCurrentCollectionPage({
         errorHandlerId: errorHandler.id,
         filters: newFilters,
-        userId: defaultUser,
+        userId: String(defaultUserId),
         slug: defaultSlug,
       }),
     );
@@ -524,7 +524,7 @@ describe(__filename, () => {
 
     const newParams = {
       slug: defaultSlug,
-      userId: 'another-user',
+      userId: '890',
     };
     wrapper.setProps({ match: { params: newParams } });
 
@@ -557,7 +557,7 @@ describe(__filename, () => {
 
     const newParams = {
       slug: 'some-other-collection-slug',
-      userId: defaultUser,
+      userId: String(defaultUserId),
     };
     wrapper.setProps({ match: { params: newParams } });
 
@@ -574,7 +574,7 @@ describe(__filename, () => {
 
   it('renders a collection', () => {
     const slug = 'some-slug';
-    const userId = 'some-username';
+    const userId = '1234';
     const page = 2;
     const sort = COLLECTION_SORT_NAME;
     const queryParams = { page, collection_sort: sort };
@@ -582,7 +582,7 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata();
 
     const detail = createFakeCollectionDetail({
-      authorUsername: userId,
+      authorId: userId,
       count: 10,
       slug,
     });
@@ -618,7 +618,7 @@ describe(__filename, () => {
     });
 
     const wrapper = renderComponent({
-      params: { userId: detail.author.username, slug: detail.slug },
+      params: { userId: detail.author.id, slug: detail.slug },
       store,
     });
 
@@ -633,7 +633,7 @@ describe(__filename, () => {
     const { detail, addons } = createCollectionWithTwoAddons();
 
     const wrapper = renderComponent({
-      params: { userId: detail.author.username, slug: detail.slug },
+      params: { userId: detail.author.id, slug: detail.slug },
       store,
     });
 
@@ -656,14 +656,14 @@ describe(__filename, () => {
 
   it('renders a collection with pagination', () => {
     const slug = 'some-slug';
-    const userId = 'some-username';
+    const userId = '123';
     const page = 2;
     const filters = { page, collection_sort: COLLECTION_SORT_NAME };
 
     const { store } = dispatchClientMetadata();
 
     const detail = createFakeCollectionDetail({
-      authorUsername: userId,
+      authorId: userId,
       count: 10,
       slug,
     });
@@ -730,12 +730,12 @@ describe(__filename, () => {
     const pageSize = 10;
     const slug = 'some-slug';
     const sort = COLLECTION_SORT_NAME;
-    const userId = 'some-username';
+    const userId = '1234567';
 
     const { store } = dispatchClientMetadata();
     const addons = createFakeCollectionAddons();
     const detail = createFakeCollectionDetail({
-      authorUsername: userId,
+      authorId: userId,
       slug,
     });
     const collection = createInternalCollection({
@@ -769,18 +769,17 @@ describe(__filename, () => {
   });
 
   it('renders a collection for editing', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const signedUserId = 11;
+    const { store } = dispatchSignInActions({ userId: signedUserId });
 
     const slug = 'some-slug';
-    const userId = 'some-username';
+    const userId = `${signedUserId + 123}`;
     const page = 2;
     const sort = COLLECTION_SORT_NAME;
 
     const addons = createFakeCollectionAddons();
     const detail = createFakeCollectionDetail({
-      authorId: authorUserId,
-      authorUsername: userId,
+      authorId: userId,
       count: 10,
       slug,
     });
@@ -858,7 +857,7 @@ describe(__filename, () => {
 
     const errorHandler = createStubErrorHandler();
     const { slug } = defaultCollectionDetail;
-    const userId = defaultUser;
+    const userId = String(defaultUserId);
 
     // User loads the collection page.
     _loadCurrentCollection({ store });
@@ -943,13 +942,13 @@ describe(__filename, () => {
   });
 
   it('renders a delete button when user is the collection owner', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     _loadCurrentCollection({
       store,
       detail: createFakeCollectionDetail({
-        authorId: authorUserId,
+        authorId,
       }),
     });
 
@@ -958,8 +957,8 @@ describe(__filename, () => {
   });
 
   it('does not render a delete button when user is not the collection owner', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     _loadCurrentCollection({
       store,
@@ -973,13 +972,13 @@ describe(__filename, () => {
   });
 
   it('passes the correct editing flag to AddonsCard when editing', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     _loadCurrentCollection({
       store,
       detail: createFakeCollectionDetail({
-        authorId: authorUserId,
+        authorId,
       }),
     });
 
@@ -989,17 +988,17 @@ describe(__filename, () => {
   });
 
   it('renders a CollectionAddAddon component when editing', () => {
-    const authorUserId = 11;
+    const authorId = 11;
     const page = 2;
     const sort = COLLECTION_SORT_NAME;
     const queryParams = { page, collection_sort: sort };
     const pageSize = DEFAULT_API_PAGE_SIZE;
     const filters = { collectionSort: sort, page };
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     const addons = createFakeCollectionAddons();
     const detail = createFakeCollectionDetail({
-      authorId: authorUserId,
+      authorId,
     });
     const collection = createInternalCollection({
       detail,
@@ -1057,13 +1056,13 @@ describe(__filename, () => {
   });
 
   it('does not update the page when removeAddon is called and there are still addons to show on the current page', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     const addons = createFakeCollectionAddons();
     const addonId = addons[0].addon.id;
     const detail = createFakeCollectionDetail({
-      authorId: authorUserId,
+      authorId,
       // This will simulate a few items on the 2nd page.
       count: DEFAULT_API_PAGE_SIZE + 2,
     });
@@ -1104,7 +1103,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        userId: detail.author.username,
+        userId: String(detail.author.id),
       }),
     );
     sinon.assert.callCount(fakeDispatch, 1);
@@ -1113,13 +1112,13 @@ describe(__filename, () => {
   });
 
   it("does not update the page when removeAddon is called and the current page isn't the last page", () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     const addons = createFakeCollectionAddons();
     const addonId = addons[0].addon.id;
     const detail = createFakeCollectionDetail({
-      authorId: authorUserId,
+      authorId,
       // This will simulate 1 item on the 3nd page.
       count: DEFAULT_API_PAGE_SIZE * 2 + 1,
     });
@@ -1160,7 +1159,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        userId: detail.author.username,
+        userId: String(detail.author.id),
       }),
     );
     sinon.assert.callCount(fakeDispatch, 1);
@@ -1169,13 +1168,13 @@ describe(__filename, () => {
   });
 
   it('updates the page when removeAddon removes the last addon from the current page', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     const addons = createFakeCollectionAddons();
     const addonId = addons[0].addon.id;
     const detail = createFakeCollectionDetail({
-      authorId: authorUserId,
+      authorId,
       // This will simulate only 1 item on the 2nd page.
       count: DEFAULT_API_PAGE_SIZE + 1,
     });
@@ -1217,7 +1216,7 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page: newPage, collectionSort: sort },
         slug: detail.slug,
-        userId: detail.author.username,
+        userId: String(detail.author.id),
       }),
     );
     sinon.assert.callCount(fakeDispatch, 1);
@@ -1232,19 +1231,16 @@ describe(__filename, () => {
   });
 
   it('dispatches deleteCollection when onDelete is called', () => {
-    const authorUserId = 11;
+    const authorId = 11;
     const slug = 'some-slug';
-    const userId = 'some-username';
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const { store } = dispatchSignInActions({ userId: authorId });
+
+    const detail = createFakeCollectionDetail({ authorId, slug });
 
     store.dispatch(
       loadCurrentCollection({
         addons: createFakeCollectionAddons(),
-        detail: createFakeCollectionDetail({
-          authorId: authorUserId,
-          authorUsername: userId,
-          slug,
-        }),
+        detail,
         pageSize: DEFAULT_API_PAGE_SIZE,
       }),
     );
@@ -1268,19 +1264,19 @@ describe(__filename, () => {
       deleteCollection({
         errorHandlerId: errorHandler.id,
         slug,
-        userId,
+        userId: String(detail.author.id),
       }),
     );
   });
 
   it('dispatches deleteCollectionAddonNotes when deleteNote is called', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     const addons = createFakeCollectionAddons();
     const addonId = addons[0].addon.id;
     const detail = createFakeCollectionDetail({
-      authorId: authorUserId,
+      authorId,
     });
     const errorHandler = createStubErrorHandler();
     const fakeDispatch = sinon.spy(store, 'dispatch');
@@ -1315,20 +1311,18 @@ describe(__filename, () => {
         errorHandlerId: errorHandler.id,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        userId: detail.author.username,
+        userId: String(detail.author.id),
       }),
     );
   });
 
   it('dispatches updateCollectionAddon when saveNote is called', () => {
-    const authorUserId = 11;
-    const { store } = dispatchSignInActions({ userId: authorUserId });
+    const authorId = 11;
+    const { store } = dispatchSignInActions({ userId: authorId });
 
     const addons = createFakeCollectionAddons();
     const addonId = addons[0].addon.id;
-    const detail = createFakeCollectionDetail({
-      authorId: authorUserId,
-    });
+    const detail = createFakeCollectionDetail({ authorId });
     const errorHandler = createStubErrorHandler();
     const fakeDispatch = sinon.spy(store, 'dispatch');
     const page = 123;
@@ -1363,21 +1357,25 @@ describe(__filename, () => {
         notes,
         filters: { page, collectionSort: sort },
         slug: detail.slug,
-        userId: detail.author.username,
+        userId: String(detail.author.id),
       }),
     );
   });
 
-  it(`sends a server redirect when username parameter case is not the same as the collection's author name`, () => {
+  it('sends a server redirect when userId parameter is not a numeric ID', () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const lang = 'fr';
+    const authorId = 123;
     const authorUsername = 'john';
 
     const { store } = dispatchClientMetadata({ clientApp, lang });
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     const collectionAddons = createFakeCollectionAddons();
-    const collectionDetail = createFakeCollectionDetail({ authorUsername });
+    const collectionDetail = createFakeCollectionDetail({
+      authorId,
+      authorUsername,
+    });
 
     _loadCurrentCollection({
       store,
@@ -1391,6 +1389,7 @@ describe(__filename, () => {
 
     const params = {
       slug: collection.slug,
+      // We use the `username` here.
       userId: authorUsername.toUpperCase(),
     };
     renderComponent({ match: { params }, store });
@@ -1399,7 +1398,7 @@ describe(__filename, () => {
       fakeDispatch,
       sendServerRedirect({
         status: 301,
-        url: `/${lang}/${clientApp}/collections/${collection.authorUsername}/${
+        url: `/${lang}/${clientApp}/collections/${collection.authorId}/${
           collection.slug
         }/`,
       }),
@@ -1430,6 +1429,7 @@ describe(__filename, () => {
 
     const params = {
       slug: slug.toUpperCase(),
+      // We use the `username` here.
       userId: collection.authorUsername,
     };
     renderComponent({ match: { params }, store });
@@ -1438,7 +1438,7 @@ describe(__filename, () => {
       fakeDispatch,
       sendServerRedirect({
         status: 301,
-        url: `/${lang}/${clientApp}/collections/${collection.authorUsername}/${
+        url: `/${lang}/${clientApp}/collections/${collection.authorId}/${
           collection.slug
         }/`,
       }),
@@ -1483,28 +1483,28 @@ describe(__filename, () => {
       const props = getProps({
         match: {
           params: {
-            userId: 'foo',
+            userId: '123',
             slug: 'collection-bar',
           },
         },
         location: createFakeLocation(),
       });
 
-      expect(extractId(props)).toEqual('foo/collection-bar/');
+      expect(extractId(props)).toEqual('123/collection-bar/');
     });
 
     it('adds the page as part of unique ID', () => {
       const props = getProps({
         match: {
           params: {
-            userId: 'foo',
+            userId: '123',
             slug: 'collection-bar',
           },
         },
         location: createFakeLocation({ query: { page: '124' } }),
       });
 
-      expect(extractId(props)).toEqual('foo/collection-bar/124');
+      expect(extractId(props)).toEqual('123/collection-bar/124');
     });
   });
 });

--- a/tests/unit/amo/pages/TestCollectionList.js
+++ b/tests/unit/amo/pages/TestCollectionList.js
@@ -40,8 +40,8 @@ describe(__filename, () => {
   };
 
   it('dispatches fetchUserCollections for a logged in user with no collections loaded yet', () => {
-    const username = 'some-username';
-    const { store } = dispatchSignInActions({ userProps: { username } });
+    const userId = 1234;
+    const { store } = dispatchSignInActions({ userId });
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     const errorHandler = createStubErrorHandler();
@@ -53,7 +53,7 @@ describe(__filename, () => {
       fakeDispatch,
       fetchUserCollections({
         errorHandlerId: errorHandler.id,
-        userId: username,
+        userId: String(userId),
       }),
     );
   });
@@ -68,8 +68,8 @@ describe(__filename, () => {
   });
 
   it('does not dispatch fetchUserCollections if collections are loading', () => {
-    const username = 'some-username';
-    const { store } = dispatchSignInActions({ userProps: { username } });
+    const userId = 1234;
+    const { store } = dispatchSignInActions({ userId });
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     const errorHandler = createStubErrorHandler();
@@ -77,7 +77,7 @@ describe(__filename, () => {
     store.dispatch(
       fetchUserCollections({
         errorHandlerId: errorHandler.id,
-        userId: username,
+        userId: String(userId),
       }),
     );
 
@@ -89,14 +89,14 @@ describe(__filename, () => {
   });
 
   it('does not dispatch fetchUserCollections if collections are loaded', () => {
-    const username = 'some-username';
-    const { store } = dispatchSignInActions({ userProps: { username } });
+    const userId = 1234;
+    const { store } = dispatchSignInActions({ userId });
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     store.dispatch(
       loadUserCollections({
         collections: [createFakeCollectionDetail()],
-        userId: username,
+        userId: String(userId),
       }),
     );
 
@@ -143,13 +143,13 @@ describe(__filename, () => {
   });
 
   it('renders placeholder text if the user has no collections', () => {
-    const username = 'some-username';
-    const { store } = dispatchSignInActions({ userProps: { username } });
+    const userId = 1234;
+    const { store } = dispatchSignInActions({ userId });
 
     store.dispatch(
       loadUserCollections({
         collections: [],
-        userId: username,
+        userId: String(userId),
       }),
     );
 
@@ -168,13 +168,13 @@ describe(__filename, () => {
   });
 
   it('renders loading UserCollection objects if collections are loading', () => {
-    const username = 'some-username';
-    const { store } = dispatchSignInActions({ userProps: { username } });
+    const userId = 1234;
+    const { store } = dispatchSignInActions({ userId });
 
     store.dispatch(
       fetchUserCollections({
         errorHandlerId: createStubErrorHandler().id,
-        userId: username,
+        userId: String(userId),
       }),
     );
 
@@ -193,29 +193,29 @@ describe(__filename, () => {
   });
 
   it('renders a list of collections', () => {
-    const username = 'some-username';
+    const userId = 1234;
     const collections = [
       createFakeCollectionDetail({
         addon_count: 1,
-        authorUsername: username,
+        authorId: userId,
         id: 1,
         name: 'collection1',
         slug: 'collection-1',
       }),
       createFakeCollectionDetail({
         addon_count: 2,
-        authorUsername: username,
+        authorId: userId,
         id: 2,
         name: 'collection2',
         slug: 'collection-2',
       }),
     ];
-    const { store } = dispatchSignInActions({ userProps: { username } });
+    const { store } = dispatchSignInActions({ userId });
 
     store.dispatch(
       loadUserCollections({
         collections,
-        userId: username,
+        userId: String(userId),
       }),
     );
 
@@ -225,9 +225,11 @@ describe(__filename, () => {
 
     const userCollections = root.find(UserCollection);
     expect(userCollections).toHaveLength(2);
+
     userCollections.forEach((collection, index) => {
       const expected = createInternalCollection({ detail: collections[index] });
-      expect(collection).toHaveProp('authorUsername', expected.authorUsername);
+
+      expect(collection).toHaveProp('authorId', expected.authorId);
       expect(collection).toHaveProp('id', expected.id);
       expect(collection).toHaveProp('name', expected.name);
       expect(collection).toHaveProp('numberOfAddons', expected.numberOfAddons);
@@ -236,13 +238,13 @@ describe(__filename, () => {
   });
 
   describe('errorHandler - extractId', () => {
-    it('returns a unique ID based on currentUsername', () => {
-      const currentUsername = 'some-username';
+    it('returns a unique ID based on currentUserId', () => {
+      const currentUserId = 456;
 
-      expect(extractId({ currentUsername })).toEqual(currentUsername);
+      expect(extractId({ currentUserId })).toEqual(currentUserId);
     });
 
-    it('returns a blank ID with no currentUsername', () => {
+    it('returns a blank ID with no currentUserId', () => {
       expect(extractId({})).toEqual('');
     });
   });

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -1088,44 +1088,44 @@ describe(__filename, () => {
 
   describe('collectionUrl', () => {
     it('returns a URL for a collection', () => {
-      const authorUsername = 'some-username';
+      const authorId = 123;
       const slug = 'some-slug';
       const collection = createInternalCollection({
-        detail: createFakeCollectionDetail({ authorUsername, slug }),
+        detail: createFakeCollectionDetail({ authorId, slug }),
       });
 
       expect(collectionUrl({ collection })).toEqual(
-        `/collections/${authorUsername}/${slug}/`,
+        `/collections/${authorId}/${slug}/`,
       );
     });
 
-    it('returns a URL for an authorUsername / collectionSlug', () => {
-      const authorUsername = 'some-username';
+    it('returns a URL for an authorId / collectionSlug', () => {
+      const authorId = 345;
       const slug = 'some-slug';
 
       expect(
         collectionUrl({
-          authorUsername,
+          authorId,
           collection: null,
           collectionSlug: slug,
         }),
-      ).toEqual(`/collections/${authorUsername}/${slug}/`);
+      ).toEqual(`/collections/${authorId}/${slug}/`);
     });
 
     it('returns a URL for the collection when all 3 params are passed', () => {
-      const authorUsername = 'some-username';
+      const authorId = 1;
       const slug = 'some-slug';
       const collection = createInternalCollection({
-        detail: createFakeCollectionDetail({ authorUsername, slug }),
+        detail: createFakeCollectionDetail({ authorId, slug }),
       });
 
       expect(
         collectionUrl({
-          authorUsername: 'a different username',
+          authorId: authorId + 1000,
           collection,
           collectionSlug: 'a-different-slug',
         }),
-      ).toEqual(`/collections/${authorUsername}/${slug}/`);
+      ).toEqual(`/collections/${authorId}/${slug}/`);
     });
   });
 
@@ -1133,7 +1133,7 @@ describe(__filename, () => {
     it('calls collectionUrl and appends `edit/` to it', () => {
       const _collectionUrl = sinon.spy(() => '/base/url/');
       const params = {
-        authorUsername: 'some-username',
+        authorId: 123,
         collection: null,
         collectionSlug: 'some-slug',
       };

--- a/tests/unit/ui/components/TestUserCollection.js
+++ b/tests/unit/ui/components/TestUserCollection.js
@@ -20,7 +20,7 @@ describe(__filename, () => {
 
   it('renders a collection', () => {
     const props = {
-      authorUsername: 'some-username',
+      authorId: 1234,
       id: 1,
       name: 'collection name',
       numberOfAddons: 5,
@@ -32,7 +32,7 @@ describe(__filename, () => {
     expect(root.find('.UserCollection')).toHaveLength(1);
     expect(root.find('.UserCollection-link')).toHaveProp(
       'to',
-      `/collections/${props.authorUsername}/${props.slug}/`,
+      `/collections/${props.authorId}/${props.slug}/`,
     );
     expect(root.find('.UserCollection-name').children()).toHaveText(props.name);
     expect(root.find('.UserCollection-number').children()).toHaveText(
@@ -42,7 +42,7 @@ describe(__filename, () => {
 
   it('renders singular text for a collection with 1 add-on', () => {
     const props = {
-      authorUsername: 'some-username',
+      authorId: 1234,
       id: 1,
       name: 'collection name',
       numberOfAddons: 1,


### PR DESCRIPTION
Fixes #6609

---

This PR updates the collection code to deal with user IDs instead of usernames. It handles the case when a collection is loaded by username and not user ID for backward compatibility.

I filed #7297 to fix the hardcoded collection URLs in the homepage.
