### PR TITLE
Show rating-only reviews to avoid confusing counts

### DIFF
--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -35,8 +35,6 @@ export class AddonMetaBase extends React.Component<InternalProps> {
     }
     const addonRatingCount =
       addon && addon.ratings ? addon.ratings.count : null;
-    const addonReviewCount =
-      addon && addon.ratings ? addon.ratings.text_count : null;
     const averageDailyUsers = addon ? addon.average_daily_users : null;
     const roundedAverage = roundToOneDigit(averageRating || null);
 
@@ -57,9 +55,9 @@ export class AddonMetaBase extends React.Component<InternalProps> {
     if (!addon) {
       reviewCount = null;
       reviewTitle = i18n.gettext('Reviews');
-    } else if (addonReviewCount) {
-      reviewCount = i18n.formatNumber(addonReviewCount);
-      reviewTitle = i18n.ngettext('Review', 'Reviews', addonReviewCount);
+    } else if (addonRatingCount) {
+      reviewCount = i18n.formatNumber(addonRatingCount);
+      reviewTitle = i18n.ngettext('Review', 'Reviews', addonRatingCount);
     } else {
       reviewTitle = i18n.gettext('No Reviews');
     }

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -431,6 +431,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
         !replyingToReview &&
         !review.reply &&
         !this.isReply() &&
+        !this.isRatingOnly() &&
         siteUserCanManageReplies &&
         siteUser &&
         review.userId !== siteUser.id ? (
@@ -444,8 +445,10 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           </a>
         ) : null}
 
-        {/* Do not render the "flag" button for reviews made by the current user */}
-        {flaggable && review && (!siteUser || siteUser.id !== review.userId) ? (
+        {flaggable &&
+        !this.isRatingOnly() &&
+        review &&
+        (!siteUser || siteUser.id !== review.userId) ? (
           <FlagReviewMenu
             isDeveloperReply={this.isReply()}
             openerClass="AddonReviewCard-control"

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -204,8 +204,8 @@ export class AddonBase extends React.Component {
       );
     }
 
-    if (addon && addon.ratings.text_count) {
-      const count = addon.ratings.text_count;
+    if (addon && addon.ratings.count) {
+      const { count } = addon.ratings;
       const linkText = i18n.sprintf(
         i18n.ngettext(
           'Read %(count)s review',

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -204,7 +204,9 @@ export class AddonBase extends React.Component {
       );
     }
 
-    if (addon && addon.ratings.count) {
+    if (!addon) {
+      content = <LoadingText width={100} />;
+    } else if (addon.ratings && addon.ratings.count) {
       const { count } = addon.ratings;
       const linkText = i18n.sprintf(
         i18n.ngettext(
@@ -224,8 +226,6 @@ export class AddonBase extends React.Component {
           {linkText}
         </Link>
       );
-    } else if (!addon) {
-      content = <LoadingText width={100} />;
     } else {
       content = i18n.gettext('No reviews yet');
     }

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -274,11 +274,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     const reviewCountHTML =
       reviewCount !== null ? (
         i18n.sprintf(
-          i18n.ngettext(
-            '%(total)s review for this add-on',
-            '%(total)s reviews for this add-on',
-            reviewCount,
-          ),
+          i18n.ngettext('%(total)s review', '%(total)s reviews', reviewCount),
           {
             total: i18n.formatNumber(reviewCount),
           },
@@ -288,7 +284,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       );
 
     const addonReviewCount =
-      addon && addon.ratings ? addon.ratings.text_count : null;
+      addon && addon.ratings ? addon.ratings.count : null;
     let placeholderCount = addonReviewCount || 4;
     if (placeholderCount > DEFAULT_API_PAGE_SIZE) {
       placeholderCount = DEFAULT_API_PAGE_SIZE;
@@ -367,7 +363,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
           ) : (
             <Card>
               <p className="AddonReviewList-noReviews">
-                {i18n.gettext('No reviews')}
+                {i18n.gettext('There are no reviews')}
               </p>
             </Card>
           )}

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -95,8 +95,6 @@ function* fetchReviews({
     const params: GetReviewsParams = {
       addon: addonSlug,
       apiState: state.api,
-      // Hide star-only ratings (reviews that do not have a body).
-      filter: 'without_empty_body',
       page,
       score,
     };

--- a/tests/unit/amo/components/TestAddonMeta.js
+++ b/tests/unit/amo/components/TestAddonMeta.js
@@ -123,10 +123,11 @@ describe(__filename, () => {
 
     it('renders a count of multiple reviews', () => {
       const slug = 'some-slug';
+      const ratingsCount = 5;
       const root = render({
         addon: createInternalAddon({
           ...fakeAddon,
-          ratings: { count: 10, text_count: 5 },
+          ratings: { text_count: 3, count: ratingsCount },
           slug,
         }),
       });
@@ -140,11 +141,11 @@ describe(__filename, () => {
       expect(reviewTitleLink.children()).toHaveText('Reviews');
 
       expect(reviewCountLink).toHaveProp('to', listURL);
-      expect(reviewCountLink.children()).toHaveText('5');
+      expect(reviewCountLink.children()).toHaveText(ratingsCount.toString());
     });
 
     it('renders a count of one review', () => {
-      const root = renderRatings({ text_count: 1 });
+      const root = renderRatings({ count: 1 });
 
       expect(
         getReviewCount(root)
@@ -160,7 +161,7 @@ describe(__filename, () => {
 
     it('localizes review count', () => {
       const i18n = fakeI18n({ lang: 'de' });
-      const root = renderRatings({ text_count: 1000 }, { i18n });
+      const root = renderRatings({ count: 1000 }, { i18n });
 
       expect(
         getReviewCount(root)

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1134,7 +1134,7 @@ describe(__filename, () => {
         slug: addonSlug,
         ratings: {
           ...fakeAddon.ratings,
-          text_count: ratingsCount,
+          count: ratingsCount,
         },
       };
 

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -131,7 +131,7 @@ describe(__filename, () => {
         ...fakeAddon,
         ratings: {
           ...fakeAddon.ratings,
-          text_count: 0,
+          count: 0,
         },
       };
       const addon = createInternalAddon(externalAddon);
@@ -148,12 +148,12 @@ describe(__filename, () => {
     });
 
     it('displays the same number of placeholders as there are reviews for an addon', () => {
-      const reviewCount = 10;
+      const reviewCount = 6;
       const externalAddon = {
         ...fakeAddon,
         ratings: {
           ...fakeAddon.ratings,
-          text_count: reviewCount,
+          count: reviewCount,
         },
       };
       const addon = createInternalAddon(externalAddon);
@@ -174,7 +174,7 @@ describe(__filename, () => {
         ...fakeAddon,
         ratings: {
           ...fakeAddon.ratings,
-          text_count: DEFAULT_API_PAGE_SIZE + 1,
+          count: DEFAULT_API_PAGE_SIZE + 1,
         },
       };
 
@@ -684,8 +684,8 @@ describe(__filename, () => {
         ...fakeAddon,
         ratings: {
           ...fakeAddon.ratings,
-          // This is the total of all reviews.
-          text_count: 200,
+          // This is the total of all ratings and reviews.
+          count: 200,
         },
       };
       loadAddon(addon);
@@ -697,9 +697,7 @@ describe(__filename, () => {
 
       const cardList = root.find('.AddonReviewList-reviews-listing');
       expect(cardList).toHaveProp('header');
-      expect(cardList.prop('header')).toContain(
-        `${reviewCount} reviews for this add-on`,
-      );
+      expect(cardList.prop('header')).toContain(`${reviewCount} reviews`);
     });
 
     describe('with pagination', () => {

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -95,7 +95,6 @@ describe(__filename, () => {
         .withArgs({
           addon: fakeAddon.slug,
           apiState,
-          filter: 'without_empty_body',
           page: '1',
           score: undefined,
         })


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7200

**Before**

<img width="916" alt="screenshot 2018-12-13 09 55 47" src="https://user-images.githubusercontent.com/55398/49950562-a37dba00-febd-11e8-97d5-a081c6ac632c.png">

**After**

<img width="917" alt="screenshot 2018-12-13 09 56 07" src="https://user-images.githubusercontent.com/55398/49950571-a8db0480-febd-11e8-9688-d0f0e7815996.png">

<hr>

This new approach will always show rating-only reviews which will make the number of ratings always match the number of results.

Here are a few other changes:
* On the add-on detail page, The metadata count in the star breakdown of "reviews" now includes a count of ratings. This should make the number less confusing as it will now add up to the number of stars.
* The add-on detail page has a link to the review list saying *Read N reviews* where *N* now includes the number of ratings, too. This is because the review list will also show ratings. This will clear up confusion when an add-on has star ratings but no written reviews.
