### PR TITLE
I7205 style tweak for non firefox button

### DIFF
--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -65,6 +65,10 @@
     @include respond-to(medium) {
       flex: 0 0 180px;
     }
+
+    .GetFirefoxButton {
+      padding: 0 12px;
+    }
   }
 
   .GetFirefoxButton {


### PR DESCRIPTION
fixes #7205 

## Before
![Alt text](https://monosnap.com/image/Qcje1oWGU2MJUMK9r08oND8xdSzM4R.png)

## After
![Alt text](https://monosnap.com/image/eRinKgOOQ9l7lDmz4J7YtNhX6IpYO3.png)


I played with this for a bit and the only way I could make it show only 2 lines across the different browsers was with this approach. It does it break it differently (than what was seen on chrome) but hopefully this is okay.