### PR TITLE
I6486 removing style to left align disco pane

### DIFF
--- a/src/disco/pages/DiscoPane/styles.scss
+++ b/src/disco/pages/DiscoPane/styles.scss
@@ -2,7 +2,6 @@
 
 .disco-pane {
   box-sizing: content-box;
-  margin: 0 auto;
   max-width: 680px;
   min-width: 260px;
   padding: 10px 20px 20px;


### PR DESCRIPTION
fixes #6486 

## BEFORE
![Alt text](https://monosnap.com/image/6mQt2CmeycDGIkgNGFBfzCVPaPJpKG.png)

## AFTER 
![Alt text](https://monosnap.com/image/zRWNuW08wetULSn4yGE7gN4W542A3G.png)