### PR TITLE
Fix #5081, ToolTip display in CollectionManager

### DIFF
--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -274,14 +274,16 @@ export class CollectionManagerBase extends React.Component<
             title={collectionUrlPrefix}
             className="CollectionManager-slug-url-hint"
           >
-            {/*
-              &lrm; (left-to-right mark) is an invisible control
-              character. It's added to prevent the bi-directional
-              trailing slash character (in the URL) from getting
-              reversed when using direction: rtl.
-            */}
-            {collectionUrlPrefix}
-            &lrm;
+            <div className="CollectionManager-slug-url-prefix">
+              {/*
+                &lrm; (left-to-right mark) is an invisible control
+                character. It's added to prevent the bi-directional
+                trailing slash character (in the URL) from getting
+                reversed when using direction: rtl.
+              */}
+              {collectionUrlPrefix}
+              &lrm;
+            </div>
           </div>
           <input
             onChange={this.onTextInput}

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -47,13 +47,17 @@
   border-radius: $border-radius-xs 0 0 $border-radius-xs;
   // Disregarding text direction is intentional.
   border-right: none;
+  direction: ltr;
+  padding: 4px;
+  white-space: nowrap;
+  width: auto;
+}
+
+.CollectionManager-slug-url-prefix {
   // Switch the direction so that the ellipsis truncates from the left.
   direction: rtl;
   overflow: hidden;
-  padding: 4px;
   text-overflow: ellipsis;
-  white-space: nowrap;
-  width: auto;
 }
 
 .CollectionManager-footer {


### PR DESCRIPTION
Fixes #5081

I added extra `<div></div>`  and changed styles to make html text had `direction:rtl` while tooltip text has `direction:ltr`.


Before:
![image](https://user-images.githubusercontent.com/4984681/50378763-c105fe80-05f6-11e9-8ea4-fc41f916b6a2.png)

After:
![image](https://user-images.githubusercontent.com/4984681/50378764-ca8f6680-05f6-11e9-81b4-486d7ae7c3e6.png)
