### PR TITLE
Re-fetch home data when clientApp changes

### DIFF
--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -92,13 +92,21 @@ export class HomeBase extends React.Component {
   constructor(props) {
     super(props);
 
+    this.loadDataIfNeeded();
+  }
+
+  componentDidUpdate() {
+    this.loadDataIfNeeded();
+  }
+
+  loadDataIfNeeded() {
     const {
       dispatch,
       errorHandler,
       includeFeaturedThemes,
       includeTrendingExtensions,
       resultsLoaded,
-    } = props;
+    } = this.props;
 
     dispatch(setViewContext(VIEW_CONTEXT_HOME));
 

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -5,9 +5,11 @@ import {
   LANDING_PAGE_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
+import { SET_CLIENT_APP } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
-import type { AddonType, ExternalAddonType } from 'core/types/addons';
 import { isTheme } from 'core/utils';
+import type { AddonType, ExternalAddonType } from 'core/types/addons';
+import type { SetClientAppAction } from 'core/actions';
 
 export const FETCH_HOME_ADDONS: 'FETCH_HOME_ADDONS' = 'FETCH_HOME_ADDONS';
 export const LOAD_HOME_ADDONS: 'LOAD_HOME_ADDONS' = 'LOAD_HOME_ADDONS';
@@ -87,7 +89,7 @@ export const loadHomeAddons = ({
   };
 };
 
-type Action = FetchHomeAddonsAction | LoadHomeAddonsAction;
+type Action = FetchHomeAddonsAction | LoadHomeAddonsAction | SetClientAppAction;
 
 const createInternalAddons = (
   response: ApiAddonsResponse,
@@ -100,6 +102,9 @@ const reducer = (
   action: Action,
 ): HomeState => {
   switch (action.type) {
+    case SET_CLIENT_APP:
+      return initialState;
+
     case FETCH_HOME_ADDONS:
       return {
         ...state,

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -319,6 +319,38 @@ describe(__filename, () => {
     );
   });
 
+  it('dispatches an action to fetch the add-ons to display on update', () => {
+    const includeFeaturedThemes = false;
+    const includeTrendingExtensions = false;
+    const errorHandler = createStubErrorHandler();
+    const { store } = dispatchClientMetadata();
+
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+
+    const root = render({
+      errorHandler,
+      includeFeaturedThemes,
+      includeTrendingExtensions,
+      store,
+    });
+    fakeDispatch.resetHistory();
+
+    // We simulate an update to trigger `componentDidUpdate()`.
+    root.setProps();
+
+    sinon.assert.callCount(fakeDispatch, 2);
+    sinon.assert.calledWith(fakeDispatch, setViewContext(VIEW_CONTEXT_HOME));
+    sinon.assert.calledWith(
+      fakeDispatch,
+      fetchHomeAddons({
+        errorHandlerId: errorHandler.id,
+        collectionsToFetch: FEATURED_COLLECTIONS,
+        includeFeaturedThemes,
+        includeTrendingExtensions,
+      }),
+    );
+  });
+
   it('does not display a collection shelf if there is no collection in state', () => {
     const { store } = dispatchClientMetadata();
 

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -322,13 +322,11 @@ describe(__filename, () => {
   it('dispatches an action to fetch the add-ons to display on update', () => {
     const includeFeaturedThemes = false;
     const includeTrendingExtensions = false;
-    const errorHandler = createStubErrorHandler();
     const { store } = dispatchClientMetadata();
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
 
     const root = render({
-      errorHandler,
       includeFeaturedThemes,
       includeTrendingExtensions,
       store,
@@ -343,7 +341,7 @@ describe(__filename, () => {
     sinon.assert.calledWith(
       fakeDispatch,
       fetchHomeAddons({
-        errorHandlerId: errorHandler.id,
+        errorHandlerId: root.instance().props.errorHandler.id,
         collectionsToFetch: FEATURED_COLLECTIONS,
         includeFeaturedThemes,
         includeTrendingExtensions,

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -8,7 +8,8 @@ import homeReducer, {
   loadHomeAddons,
 } from 'amo/reducers/home';
 import { createInternalAddon } from 'core/reducers/addons';
-import { ADDON_TYPE_THEME } from 'core/constants';
+import { ADDON_TYPE_THEME, CLIENT_APP_FIREFOX } from 'core/constants';
+import { setClientApp } from 'core/actions';
 import {
   createAddonsApiResult,
   createFakeCollectionAddon,
@@ -188,6 +189,25 @@ describe(__filename, () => {
       );
 
       expect(state.resultsLoaded).toEqual(false);
+    });
+
+    it('resets the state when clientApp changes', () => {
+      const { store } = dispatchClientMetadata();
+
+      _loadHomeAddons({
+        store,
+        collections: [
+          createFakeCollectionAddonsListResponse({
+            addons: Array(10).fill(createFakeCollectionAddon()),
+          }),
+        ],
+      });
+
+      const prevState = store.getState().home;
+      expect(prevState.collections).toHaveLength(1);
+
+      const state = homeReducer(prevState, setClientApp(CLIENT_APP_FIREFOX));
+      expect(state).toEqual(initialState);
     });
   });
 });


### PR DESCRIPTION
Fixes #6650

---

This PR changes the `home` reducer and `Home` component to re-fetch the
homepage data when the `clientApp` changes.