### PR TITLE
Install the correct version when a specific version is set for installAddon

### DIFF
--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -222,7 +222,7 @@ type WithInstallHelpersProps = {|
   addon: AddonType | null,
   defaultInstallSource: string,
   location: ReactRouterLocationType,
-  version: AddonVersionType | null,
+  version?: AddonVersionType | null,
 |};
 
 type WithInstallHelpersInternalProps = {|

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -234,6 +234,7 @@ type WithInstallHelpersInternalProps = {|
   currentVersion: AddonVersionType | null,
   dispatch: DispatchFunc,
   userAgentInfo: UserAgentInfoType,
+  version: AddonVersionType | null,
 |};
 
 type EnableParams = {|
@@ -423,6 +424,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       dispatch,
       location,
       userAgentInfo,
+      version,
     } = this.props;
 
     if (!addon) {
@@ -430,13 +432,14 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       return Promise.resolve();
     }
 
-    if (!currentVersion) {
-      _log.debug('no currentVersion found, aborting install().');
+    const installVersion = version || currentVersion;
+    if (!installVersion) {
+      _log.debug('no version found, aborting install().');
       return Promise.resolve();
     }
 
     const { guid, name, type } = addon;
-    const { platformFiles } = currentVersion;
+    const { platformFiles } = installVersion;
 
     return new Promise((resolve) => {
       dispatch({ type: START_DOWNLOAD, payload: { guid } });
@@ -458,7 +461,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       .then((installURL) => {
         const hash =
           installURL &&
-          getFileHash({ addon, installURL, version: currentVersion });
+          getFileHash({ addon, installURL, version: installVersion });
 
         return _addonManager.install(
           installURL,

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -1398,7 +1398,7 @@ describe(__filename, () => {
         return install().then(() => {
           sinon.assert.calledWith(
             _log.debug,
-            'no version found, aborting install().',
+            'no currentVersion found, aborting install().',
           );
         });
       });


### PR DESCRIPTION
Fixes #7332 

Note that this only addresses the issue where the current version is installed no matter which button is clicked. It does not address the issue of the behaviour of all of the buttons (i.e., they all show install status, they all say "Remove" and they all say "Enable", in different scenarios). That may or may not be addressed via a separate issue.