### PR TITLE
fixing position of add to FF button to center at version page

### DIFF
--- a/src/amo/components/AddonVersionCard/styles.scss
+++ b/src/amo/components/AddonVersionCard/styles.scss
@@ -4,7 +4,7 @@
   display: flex;
 
   .InstallButtonWrapper {
-    align-self: start;
+    align-self: center;
   }
 }
 


### PR DESCRIPTION
Fixes #7333 

After:
![image](https://user-images.githubusercontent.com/22130317/50884502-13298b00-1411-11e9-92d1-97b7b233990f.png)
