### PR TITLE
Use react-router for "all versions" link

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -164,7 +164,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
         <li>
           <Link
             className="AddonMoreInfo-version-history-link"
-            href={`/addon/${addon.slug}/versions/`}
+            to={`/addon/${addon.slug}/versions/`}
           >
             {i18n.gettext('See all versions')}
           </Link>

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -398,7 +398,7 @@ describe(__filename, () => {
 
     expect(history).toHaveProp('term', 'Version History');
     expect(history.find(Link)).toHaveProp(
-      'href',
+      'to',
       `/addon/${addon.slug}/versions/`,
     );
   });
@@ -414,7 +414,7 @@ describe(__filename, () => {
 
     expect(history).toHaveProp('term', 'Version History');
     expect(history.find(Link)).toHaveProp(
-      'href',
+      'to',
       `/addon/${addon.slug}/versions/`,
     );
   });
@@ -430,7 +430,7 @@ describe(__filename, () => {
 
     expect(history).toHaveProp('term', 'Version History');
     expect(history.find(Link)).toHaveProp(
-      'href',
+      'to',
       `/addon/${addon.slug}/versions/`,
     );
   });


### PR DESCRIPTION
Fixes #7352

---

This PR changes the link to "see all versions" of an add-on to use
client-side navigation and react-router.