### PR TITLE
Update regex in `nl2br`

### DIFF
--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -102,7 +102,7 @@ export function sanitizeHTML(text, allowTags = [], _purify = purify) {
 
 // Convert new lines to HTML breaks.
 export function nl2br(text) {
-  return (text || '').replace(/(\r\n|\r|\n)(?!<.+?>)/g, '<br />');
+  return (text || '').replace(/(\r\n|\r|\n)(?!<\/?(li|ul|ol)>)/g, '<br />');
 }
 
 /*

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -364,17 +364,19 @@ describe(__filename, () => {
       expect(nl2br(null)).toEqual('');
     });
 
-    it('returns mixed content with <br/>', () => {
-      expect(nl2br('foo\nbar\n\n<b>bold</b>')).toEqual(
-        'foo<br />bar<br />\n<b>bold</b>',
-      );
-    });
-
-    it('preserves line breaks between tags', () => {
+    it('preserves line breaks between ul/li tags', () => {
       const htmlValue = '<ul>\n<li><strong></strong>\n</li>\n</ul>';
 
       expect(nl2br(htmlValue)).toEqual(
         '<ul>\n<li><strong></strong>\n</li>\n</ul>',
+      );
+    });
+
+    it('preserves line breaks between ol/li tags', () => {
+      const htmlValue = '<ol>\n<li><strong></strong>\n</li>\n</ol>';
+
+      expect(nl2br(htmlValue)).toEqual(
+        '<ol>\n<li><strong></strong>\n</li>\n</ol>',
       );
     });
 
@@ -389,6 +391,15 @@ describe(__filename, () => {
 
       expect(nl2br(htmlValue)).toEqual(
         'ul<br />li<strong>foo<br />bar</strong>',
+      );
+    });
+
+    it('converts line breaks between tags', () => {
+      const htmlValue =
+        '<strong>A title:</strong>\n<a href="something">A link</a>\nSome text';
+
+      expect(nl2br(htmlValue)).toEqual(
+        '<strong>A title:</strong><br /><a href="something">A link</a><br />Some text',
       );
     });
   });


### PR DESCRIPTION
Fixes #6129

---

## Screenshots

Using this content in the edit page of [my user in -dev](https://addons-dev.allizom.org/en-US/firefox/user/10641627/):

![screen shot 2019-01-10 at 16 42 04](https://user-images.githubusercontent.com/217628/50979430-b86a5f00-14f6-11e9-8c29-557290330d76.png)

### Before

![screen shot 2019-01-10 at 16 41 53](https://user-images.githubusercontent.com/217628/50979433-b86a5f00-14f6-11e9-8d37-82c382bf31b0.png)

### After

![screen shot 2019-01-10 at 16 41 57](https://user-images.githubusercontent.com/217628/50979432-b86a5f00-14f6-11e9-9ede-f1f48ce6e5cc.png)