### PR TITLE
Fix inconsistencies between the All Versions page and the mocks

### DIFF
--- a/src/amo/components/AddonVersionCard/index.js
+++ b/src/amo/components/AddonVersionCard/index.js
@@ -112,20 +112,20 @@ export const AddonVersionCardBase = (props: InternalProps) => {
         });
 
         licenseSection = (
-          <div className="AddonVersionCard-license">
+          <p className="AddonVersionCard-license">
             {licenseLinkParts.beforeLinkText}
             <Link {...licenseLinkParams}>{licenseLinkParts.innerLinkText}</Link>
             {licenseLinkParts.afterLinkText}
-          </div>
+          </p>
         );
       } else {
         licenseSection = (
-          <div className="AddonVersionCard-license">
+          <p className="AddonVersionCard-license">
             {i18n.sprintf(
               i18n.gettext('Source code released under %(licenseName)s'),
               otherVars,
             )}
-          </div>
+          </p>
         );
       }
     }

--- a/src/amo/components/AddonVersionCard/styles.scss
+++ b/src/amo/components/AddonVersionCard/styles.scss
@@ -1,7 +1,9 @@
 @import '~amo/css/styles';
 
 .AddonVersionCard {
-  display: flex;
+  @include respond-to(large) {
+    display: flex;
+  }
 
   .InstallButtonWrapper {
     align-self: center;
@@ -9,16 +11,33 @@
 }
 
 .AddonVersionCard-header {
-  @include font-bold();
+  @include font-regular();
   @include text-align-start();
 
-  font-size: $font-size-default;
+  font-size: 24px;
+}
+
+.AddonVersionCard-version {
+  @include font-medium();
+
+  color: $link-color;
+  font-size: $font-size-m;
+}
+
+.AddonVersionCard-fileInfo,
+.AddonVersionCard-compatibility {
+  color: $grey-50;
 }
 
 .AddonVersionCard-releaseNotes {
+  font-size: $font-size-default;
   margin-top: $padding-page;
 
   @include respond-to(medium) {
     margin-top: $padding-page-l;
   }
+}
+
+.AddonVersionCard-license {
+  color: $grey-50;
 }

--- a/src/amo/components/AddonVersionCard/styles.scss
+++ b/src/amo/components/AddonVersionCard/styles.scss
@@ -14,7 +14,7 @@
   @include font-regular();
   @include text-align-start();
 
-  font-size: 24px;
+  font-size: $font-size-form-header;
 }
 
 .AddonVersionCard-version {

--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -166,7 +166,7 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
             header={header || <LoadingText />}
           >
             <ul>
-              <li className="AddonVersions-warning">
+              <li>
                 <Notice type="warning">
                   <p className="AddonVersions-warning-text">
                     {i18n.gettext(

--- a/src/amo/pages/AddonVersions/styles.scss
+++ b/src/amo/pages/AddonVersions/styles.scss
@@ -12,15 +12,16 @@
   .CardList ul {
     li {
       margin-bottom: 0;
-    }
-
-    .AddonVersions-warning {
-      padding: $padding-page;
       padding-bottom: 0;
 
+      &:last-of-type {
+        padding-bottom: $padding-page;
+      }
+
       @include respond-to(large) {
-        padding: $padding-page-l;
-        padding-bottom: 0;
+        &:last-of-type {
+          padding-bottom: $padding-page-l;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #7245 
Also fixes #7350

I believe this fixes all of the items mentioned in #7245.

Before (desktop):

![screenshot 2019-01-11 11 28 46](https://user-images.githubusercontent.com/142755/51046563-65df8000-1594-11e9-89b3-4ea334811388.png)

After (desktop):

![screenshot 2019-01-11 11 29 18](https://user-images.githubusercontent.com/142755/51047300-274ac500-1596-11e9-940f-8e1101f54898.png)

Before (mobile): 

![screenshot 2019-01-11 11 28 17](https://user-images.githubusercontent.com/142755/51047427-70027e00-1596-11e9-9d15-6469d3e0ca07.png)

After (mobile):

![screenshot 2019-01-11 11 27 02](https://user-images.githubusercontent.com/142755/51047338-3893d180-1596-11e9-9d80-39511e870abe.png)
