### PR TITLE
Store reviews data with a score

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -169,7 +169,7 @@ type FetchReviewsParams = {|
   addonSlug: string,
   errorHandlerId: string,
   page?: string,
-  score?: string,
+  score: string | null,
 |};
 
 export type FetchReviewsAction = {|
@@ -178,7 +178,7 @@ export type FetchReviewsAction = {|
     addonSlug: string,
     errorHandlerId: string,
     page: string,
-    score: string | void,
+    score: string | null,
   |},
 |};
 
@@ -440,6 +440,7 @@ type SetAddonReviewsParams = {|
   pageSize: string,
   reviewCount: number,
   reviews: Array<ExternalReviewType>,
+  score: string | null,
 |};
 
 export type SetAddonReviewsAction = {|
@@ -452,11 +453,13 @@ export const setAddonReviews = ({
   pageSize,
   reviewCount,
   reviews,
+  score,
 }: SetAddonReviewsParams): SetAddonReviewsAction => {
   invariant(addonSlug, 'addonSlug is required');
   invariant(pageSize, 'pageSize is required');
   invariant(typeof reviewCount === 'number', 'reviewCount is required');
   invariant(Array.isArray(reviews), 'reviews is required and must be an array');
+  invariant(typeof score !== 'undefined', 'score is required');
 
   return {
     type: SET_ADDON_REVIEWS,
@@ -465,6 +468,7 @@ export const setAddonReviews = ({
       pageSize,
       reviewCount,
       reviews,
+      score,
     },
   };
 };

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -18,6 +18,7 @@ import {
   reviewListURL,
   reviewsAreLoading,
   selectReviewPermissions,
+  selectReviews,
 } from 'amo/reducers/reviews';
 import { getCurrentUser } from 'amo/reducers/users';
 import {
@@ -380,7 +381,11 @@ export function mapStateToProps(
 ): $Shape<InternalProps> {
   const { addonSlug } = ownProps.match.params;
   const addon = getAddonBySlug(state, addonSlug);
-  const reviewData = state.reviews.byAddon[addonSlug];
+  const reviewData = selectReviews({
+    reviewsState: state.reviews,
+    addonSlug,
+    score: ownProps.location.query.score || null,
+  });
 
   const siteUser = getCurrentUser(state.users);
   let checkingIfSiteUserCanReply = false;

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -138,7 +138,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
           addonSlug,
           errorHandlerId: errorHandler.id,
           page: this.getCurrentPage(location),
-          score: location.query.score,
+          score: location.query.score || null,
         }),
       );
     }

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -98,7 +98,10 @@ type ReviewsData = {|
 |};
 
 type ReviewsByAddon = {
-  [slug: string]: ?StoredReviewsData,
+  [slug: string]: {|
+    data: StoredReviewsData,
+    score: string | null,
+  |} | void,
 };
 
 type ReviewsByUserId = {
@@ -162,6 +165,25 @@ export const initialState: ReviewsState = {
   loadingForSlug: {},
 };
 
+export function selectReviews({
+  reviewsState,
+  addonSlug,
+  score,
+}: {|
+  addonSlug: string,
+  reviewsState: ReviewsState,
+  score?: string | null,
+|}): StoredReviewsData | null {
+  const reviewData = reviewsState.byAddon[addonSlug];
+  if (!reviewData) {
+    return null;
+  }
+  if (score && reviewData.score !== score) {
+    return null;
+  }
+  return reviewData.data;
+}
+
 export function createGroupedRatings(
   grouping: $Shape<GroupedRatingsType> = {},
 ): GroupedRatingsType {
@@ -211,7 +233,7 @@ export const expandReviewObjects = ({
   reviews,
 }: {|
   state: ReviewsState,
-  reviews: Array<number>,
+  reviews: $PropertyType<StoredReviewsData, 'reviews'>,
 |}): Array<UserReviewType> => {
   return reviews.map((id) => {
     const review = selectReview(state, id);
@@ -363,7 +385,7 @@ export const addReviewToState = ({
     : {
         ...state.byAddon,
         // For any newly entered rating object *or* when upgrading a
-        // rating to a review, rest the review list to trigger a
+        // rating to a review, reset the review list to trigger a
         // re-fetch from the server.
         [review.reviewAddon.slug]: undefined,
       };
@@ -583,9 +605,12 @@ export default function reviewsReducer(
         byAddon: {
           ...state.byAddon,
           [payload.addonSlug]: {
-            pageSize: payload.pageSize,
-            reviewCount: payload.reviewCount,
-            reviews: reviews.map((review) => review.id),
+            data: {
+              pageSize: payload.pageSize,
+              reviewCount: payload.reviewCount,
+              reviews: reviews.map((review) => review.id),
+            },
+            score: payload.score,
           },
         },
         loadingForSlug: {

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -172,13 +172,17 @@ export function selectReviews({
 }: {|
   addonSlug: string,
   reviewsState: ReviewsState,
-  score?: string | null,
+  score: string | null,
 |}): StoredReviewsData | null {
+  invariant(reviewsState, 'reviewsState is required');
+  invariant(addonSlug, 'addonSlug is required');
+  invariant(score !== undefined, 'score is required');
+
   const reviewData = reviewsState.byAddon[addonSlug];
   if (!reviewData) {
     return null;
   }
-  if (score && reviewData.score !== score) {
+  if (reviewData.score !== score) {
     return null;
   }
   return reviewData.data;

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -96,7 +96,7 @@ function* fetchReviews({
       addon: addonSlug,
       apiState: state.api,
       page,
-      score,
+      score: score || undefined,
     };
 
     const response: GetReviewsApiResponse = yield call(getReviews, params);
@@ -107,6 +107,7 @@ function* fetchReviews({
         pageSize: response.page_size,
         reviewCount: response.count,
         reviews: response.results,
+        score,
       }),
     );
   } catch (error) {

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -90,12 +90,15 @@ describe(__filename, () => {
   const _setAddonReviews = ({
     addon = fakeAddon,
     reviews = [{ ...fakeReview, id: 1 }],
+    ...params
   } = {}) => {
     const action = setAddonReviews({
       addonSlug: addon.slug,
       pageSize: DEFAULT_API_PAGE_SIZE,
       reviewCount: reviews.length,
       reviews,
+      score: null,
+      ...params,
     });
     store.dispatch(action);
   };
@@ -427,6 +430,32 @@ describe(__filename, () => {
           addonSlug,
           errorHandlerId: errorHandler.id,
           page: 3,
+        }),
+      );
+    });
+
+    it('fetches reviews when the score changes', () => {
+      const addonSlug = fakeAddon.slug;
+      loadAddon(fakeAddon);
+      _setAddonReviews({
+        addonSlug,
+        reviews: [fakeReview],
+        score: '4',
+      });
+      const dispatch = sinon.spy(store, 'dispatch');
+
+      const root = render({
+        location: createFakeLocation({ query: { score: '5' } }),
+        params: { addonSlug },
+      });
+
+      sinon.assert.calledWith(
+        dispatch,
+        fetchReviews({
+          addonSlug,
+          errorHandlerId: root.instance().props.errorHandler.id,
+          page: '1',
+          score: '5',
         }),
       );
     });

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -87,6 +87,14 @@ describe(__filename, () => {
     store.dispatch(loadAddonResults({ addons: [addon] }));
   };
 
+  const _fetchReviews = (params = {}) => {
+    return fetchReviews({
+      page: '1',
+      score: null,
+      ...params,
+    });
+  };
+
   const _setAddonReviews = ({
     addon = fakeAddon,
     reviews = [{ ...fakeReview, id: 1 }],
@@ -278,7 +286,7 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug: addon.slug,
           errorHandlerId: errorHandler.id,
         }),
@@ -290,7 +298,7 @@ describe(__filename, () => {
       const errorHandler = createStubErrorHandler();
       loadAddon(addon);
       store.dispatch(
-        fetchReviews({
+        _fetchReviews({
           addonSlug: addon.slug,
           errorHandlerId: errorHandler.id,
         }),
@@ -305,7 +313,7 @@ describe(__filename, () => {
 
       sinon.assert.neverCalledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug: addon.slug,
           errorHandlerId: errorHandler.id,
         }),
@@ -333,7 +341,7 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug: addon.slug,
           errorHandlerId: errorHandler.id,
         }),
@@ -355,7 +363,7 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug,
           errorHandlerId: errorHandler.id,
           page,
@@ -386,6 +394,27 @@ describe(__filename, () => {
       );
     });
 
+    it('fetches with null scores when empty', () => {
+      const addon = { ...fakeAddon };
+      loadAddon(addon);
+      const dispatch = sinon.stub(store, 'dispatch');
+
+      const root = render({
+        // Set up a location where ?score= is not present in the URL.
+        location: createFakeLocation({ query: {} }),
+        params: { addonSlug: addon.slug },
+      });
+
+      sinon.assert.calledWith(
+        dispatch,
+        _fetchReviews({
+          addonSlug: addon.slug,
+          errorHandlerId: root.instance().props.errorHandler.id,
+          score: null,
+        }),
+      );
+    });
+
     it('dispatches fetchReviews with an invalid page variable', () => {
       // We intentionally pass invalid pages to the API to get a 404 response.
       const dispatch = sinon.stub(store, 'dispatch');
@@ -401,7 +430,7 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug,
           errorHandlerId: errorHandler.id,
           page,
@@ -416,20 +445,20 @@ describe(__filename, () => {
 
       const root = render({
         errorHandler,
-        location: createFakeLocation({ query: { page: 2 } }),
+        location: createFakeLocation({ query: { page: '2' } }),
         params: { addonSlug },
       });
       dispatch.resetHistory();
       root.setProps({
-        location: createFakeLocation({ query: { page: 3 } }),
+        location: createFakeLocation({ query: { page: '3' } }),
       });
 
       sinon.assert.calledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug,
           errorHandlerId: errorHandler.id,
-          page: 3,
+          page: '3',
         }),
       );
     });
@@ -451,10 +480,9 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug,
           errorHandlerId: root.instance().props.errorHandler.id,
-          page: '1',
           score: '5',
         }),
       );

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -394,7 +394,7 @@ describe(__filename, () => {
       );
     });
 
-    it('fetches with null scores when empty', () => {
+    it('fetches with a null score when score is not in URL', () => {
       const addon = { ...fakeAddon };
       loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -103,6 +103,13 @@ describe(__filename, () => {
     });
   }
 
+  function _selectReviews(params = {}) {
+    return selectReviews({
+      score: null,
+      ...params,
+    });
+  }
+
   it('defaults to an empty object', () => {
     expect(reviewsReducer(undefined, { type: 'SOME_OTHER_ACTION' })).toEqual(
       initialState,
@@ -278,7 +285,7 @@ describe(__filename, () => {
         reviews: [review1, review2],
       });
       const state = reviewsReducer(undefined, action);
-      const storedReviews = selectReviews({
+      const storedReviews = _selectReviews({
         reviewsState: state,
         addonSlug: fakeAddon.slug,
       }).reviews;
@@ -312,13 +319,13 @@ describe(__filename, () => {
 
       const reviewsState = state;
       expect(
-        selectReviews({ reviewsState, addonSlug: addon1.slug }).reviews[0],
+        _selectReviews({ reviewsState, addonSlug: addon1.slug }).reviews[0],
       ).toEqual(review1.id);
       expect(
-        selectReviews({ reviewsState, addonSlug: addon2.slug }).reviews[0],
+        _selectReviews({ reviewsState, addonSlug: addon2.slug }).reviews[0],
       ).toEqual(review2.id);
       expect(
-        selectReviews({ reviewsState, addonSlug: addon2.slug }).reviews[1],
+        _selectReviews({ reviewsState, addonSlug: addon2.slug }).reviews[1],
       ).toEqual(review3.id);
     });
 
@@ -352,10 +359,10 @@ describe(__filename, () => {
 
       const reviewsState = newState;
       expect(
-        selectReviews({ reviewsState, addonSlug: 'slug1' }).reviewCount,
+        _selectReviews({ reviewsState, addonSlug: 'slug1' }).reviewCount,
       ).toEqual(1);
       expect(
-        selectReviews({ reviewsState, addonSlug: 'slug2' }).reviewCount,
+        _selectReviews({ reviewsState, addonSlug: 'slug2' }).reviewCount,
       ).toEqual(2);
     });
 
@@ -470,9 +477,9 @@ describe(__filename, () => {
 
       // Verify that data has been loaded for the reviewId.
       expect(state.byId[reviewId].reviewAddon.id).toEqual(addonId);
-      expect(selectReviews({ reviewsState: state, addonSlug }).reviews).toEqual(
-        [reviewId],
-      );
+      expect(
+        _selectReviews({ reviewsState: state, addonSlug }).reviews,
+      ).toEqual([reviewId]);
       expect(state.byUserId[userId].reviews).toEqual([reviewId]);
       expect(state.groupedRatings[addonId]).toEqual(grouping);
       expect(state.view[reviewId].someFlag).toEqual(true);
@@ -565,7 +572,7 @@ describe(__filename, () => {
       // Verify that the unrelated data has been loaded for the reviewId.
       expect(state.byId[reviewId2].reviewAddon.id).toEqual(addonId2);
       expect(
-        selectReviews({ reviewsState: state, addonSlug: addonSlug2 }).reviews,
+        _selectReviews({ reviewsState: state, addonSlug: addonSlug2 }).reviews,
       ).toEqual([reviewId2]);
       expect(state.byUserId[userId2].reviews).toEqual([reviewId2]);
       expect(state.groupedRatings[addonId2]).toEqual(grouping);
@@ -576,7 +583,7 @@ describe(__filename, () => {
       // Verify that the unrelated data has not been unloaded.
       expect(state.byId[reviewId2].reviewAddon.id).toEqual(addonId2);
       expect(
-        selectReviews({ reviewsState: state, addonSlug: addonSlug2 }).reviews,
+        _selectReviews({ reviewsState: state, addonSlug: addonSlug2 }).reviews,
       ).toEqual([reviewId2]);
       expect(state.byUserId[userId2].reviews).toEqual([reviewId2]);
       expect(state.groupedRatings[addonId2]).toEqual(grouping);
@@ -594,7 +601,7 @@ describe(__filename, () => {
       });
       const state = reviewsReducer(undefined, action);
 
-      const reviewsData = selectReviews({
+      const reviewsData = _selectReviews({
         reviewsState: state,
         addonSlug: fakeAddon.slug,
       });
@@ -632,7 +639,11 @@ describe(__filename, () => {
       });
       const reviewsState = reviewsReducer(undefined, action);
 
-      const data = selectReviews({ reviewsState, addonSlug: fakeAddon.slug });
+      const data = selectReviews({
+        reviewsState,
+        addonSlug: fakeAddon.slug,
+        score: null,
+      });
       expect(data.reviews).toEqual([review1.id, review2.id]);
       expect(data.pageSize).toEqual(pageSize);
       expect(data.reviewCount).toEqual(reviewCount);
@@ -645,7 +656,11 @@ describe(__filename, () => {
       });
       const reviewsState = reviewsReducer(undefined, action);
 
-      const data = selectReviews({ reviewsState, addonSlug: 'slug2' });
+      const data = selectReviews({
+        reviewsState,
+        addonSlug: 'slug2',
+        score: null,
+      });
       expect(data).toEqual(null);
     });
 

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -82,6 +82,7 @@ describe(__filename, () => {
         fetchReviews({
           errorHandlerId: errorHandler.id,
           addonSlug: fakeAddon.slug,
+          score: null,
           ...params,
         }),
       );
@@ -116,6 +117,7 @@ describe(__filename, () => {
           pageSize: DEFAULT_API_PAGE_SIZE,
           reviewCount: 1,
           reviews,
+          score: null,
         }),
       );
     });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7206 by adding `score` as a dimension to the stored reviews data.

I discovered a new bug while working on this one: https://github.com/mozilla/addons-frontend/issues/7376 It will be fixed in a follow-up patch.