### PR TITLE
Store page as part of review listing data

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -437,6 +437,7 @@ export const setInternalReview = (
 
 type SetAddonReviewsParams = {|
   addonSlug: string,
+  page: string,
   pageSize: string,
   reviewCount: number,
   reviews: Array<ExternalReviewType>,
@@ -450,12 +451,14 @@ export type SetAddonReviewsAction = {|
 
 export const setAddonReviews = ({
   addonSlug,
+  page,
   pageSize,
   reviewCount,
   reviews,
   score,
 }: SetAddonReviewsParams): SetAddonReviewsAction => {
   invariant(addonSlug, 'addonSlug is required');
+  invariant(page, 'page is required');
   invariant(pageSize, 'pageSize is required');
   invariant(typeof reviewCount === 'number', 'reviewCount is required');
   invariant(Array.isArray(reviews), 'reviews is required and must be an array');
@@ -465,6 +468,7 @@ export const setAddonReviews = ({
     type: SET_ADDON_REVIEWS,
     payload: {
       addonSlug,
+      page,
       pageSize,
       reviewCount,
       reviews,

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -129,14 +129,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       dispatch(setViewContext(addon.type));
     }
 
-    let locationChanged = false;
-    if (prevProps && prevProps.location) {
-      if (prevProps.location !== location) {
-        locationChanged = true;
-      }
-    }
-
-    if (!areReviewsLoading && (!reviews || locationChanged)) {
+    if (!areReviewsLoading && !reviews) {
       dispatch(
         fetchReviews({
           addonSlug,

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -51,6 +51,10 @@ import Notice from 'ui/components/Notice';
 
 import './styles.scss';
 
+function getCurrentPage(location: ReactRouterLocationType) {
+  return location.query.page || '1';
+}
+
 type Props = {|
   location: ReactRouterLocationType,
   match: {|
@@ -137,7 +141,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
         fetchReviews({
           addonSlug,
           errorHandlerId: errorHandler.id,
-          page: this.getCurrentPage(location),
+          page: getCurrentPage(location),
           score: location.query.score || null,
         }),
       );
@@ -180,10 +184,6 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       throw new Error('cannot access addonURL() with a falsey addon property');
     }
     return `/addon/${addon.slug}/`;
-  }
-
-  getCurrentPage(location: ReactRouterLocationType) {
-    return location.query.page || '1';
   }
 
   getPageDescription() {
@@ -305,7 +305,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
         <Paginate
           LinkComponent={Link}
           count={reviewCount}
-          currentPage={this.getCurrentPage(location)}
+          currentPage={getCurrentPage(location)}
           pathname={reviewListURL({
             addonSlug: addon.slug,
             score: location.query.score,
@@ -382,6 +382,7 @@ export function mapStateToProps(
   const { addonSlug } = ownProps.match.params;
   const addon = getAddonBySlug(state, addonSlug);
   const reviewData = selectReviews({
+    page: getCurrentPage(ownProps.location),
     reviewsState: state.reviews,
     addonSlug,
     score: ownProps.location.query.score || null,

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -183,10 +183,7 @@ export function selectReviews({
   invariant(score !== undefined, 'score is required');
 
   const reviewData = reviewsState.byAddon[addonSlug];
-  if (!reviewData) {
-    return null;
-  }
-  if (reviewData.score !== score || reviewData.page !== page) {
+  if (!reviewData || reviewData.score !== score || reviewData.page !== page) {
     return null;
   }
   return reviewData.data;

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -100,6 +100,7 @@ type ReviewsData = {|
 type ReviewsByAddon = {
   [slug: string]: {|
     data: StoredReviewsData,
+    page: string,
     score: string | null,
   |} | void,
 };
@@ -168,21 +169,24 @@ export const initialState: ReviewsState = {
 export function selectReviews({
   reviewsState,
   addonSlug,
+  page,
   score,
 }: {|
   addonSlug: string,
+  page: string,
   reviewsState: ReviewsState,
   score: string | null,
 |}): StoredReviewsData | null {
-  invariant(reviewsState, 'reviewsState is required');
   invariant(addonSlug, 'addonSlug is required');
+  invariant(page, 'page is required');
+  invariant(reviewsState, 'reviewsState is required');
   invariant(score !== undefined, 'score is required');
 
   const reviewData = reviewsState.byAddon[addonSlug];
   if (!reviewData) {
     return null;
   }
-  if (reviewData.score !== score) {
+  if (reviewData.score !== score || reviewData.page !== page) {
     return null;
   }
   return reviewData.data;
@@ -614,6 +618,7 @@ export default function reviewsReducer(
               reviewCount: payload.reviewCount,
               reviews: reviews.map((review) => review.id),
             },
+            page: payload.page,
             score: payload.score,
           },
         },

--- a/src/amo/sagas/reviews.js
+++ b/src/amo/sagas/reviews.js
@@ -104,6 +104,7 @@ function* fetchReviews({
     yield put(
       setAddonReviews({
         addonSlug,
+        page: page || '1',
         pageSize: response.page_size,
         reviewCount: response.count,
         reviews: response.results,

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -490,31 +490,6 @@ describe(__filename, () => {
       );
     });
 
-    it('fetches reviews when the score changes', () => {
-      const addonSlug = fakeAddon.slug;
-      loadAddon(fakeAddon);
-      _setAddonReviews({
-        addonSlug,
-        reviews: [fakeReview],
-        score: '4',
-      });
-      const dispatch = sinon.spy(store, 'dispatch');
-
-      const root = render({
-        location: createFakeLocation({ query: { score: '5' } }),
-        params: { addonSlug },
-      });
-
-      sinon.assert.calledWith(
-        dispatch,
-        _fetchReviews({
-          addonSlug,
-          errorHandlerId: root.instance().props.errorHandler.id,
-          score: '5',
-        }),
-      );
-    });
-
     it('does not fetch an addon if there is an error', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
       const dispatch = sinon.stub(store, 'dispatch');

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -488,6 +488,32 @@ describe(__filename, () => {
       );
     });
 
+    it('fetches reviews when the score changes', () => {
+      const addonSlug = fakeAddon.slug;
+      loadAddon(fakeAddon);
+      _setAddonReviews({
+        addonSlug,
+        reviews: [fakeReview],
+        score: '4',
+      });
+      const dispatch = sinon.spy(store, 'dispatch');
+
+      const root = render({
+        location: createFakeLocation({ query: { score: '5' } }),
+        params: { addonSlug },
+      });
+
+      sinon.assert.calledWith(
+        dispatch,
+        fetchReviews({
+          addonSlug,
+          errorHandlerId: root.instance().props.errorHandler.id,
+          page: '1',
+          score: '5',
+        }),
+      );
+    });
+
     it('does not fetch an addon if there is an error', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
       const dispatch = sinon.stub(store, 'dispatch');

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -356,7 +356,6 @@ describe(__filename, () => {
       const page = '2';
 
       render({
-        reviews: null,
         errorHandler,
         location: createFakeLocation({ query: { page } }),
         params: { addonSlug },
@@ -368,6 +367,33 @@ describe(__filename, () => {
           addonSlug,
           errorHandlerId: errorHandler.id,
           page,
+        }),
+      );
+    });
+
+    it('fetches reviews when the page changes', () => {
+      const addonSlug = fakeAddon.slug;
+      loadAddon(fakeAddon);
+      // Set up loaded data for a different page.
+      _setAddonReviews({
+        addonSlug,
+        page: '3',
+        reviews: [fakeReview],
+      });
+      const dispatch = sinon.spy(store, 'dispatch');
+
+      const page = '2';
+      const root = render({
+        location: createFakeLocation({ query: { page } }),
+        params: { addonSlug },
+      });
+
+      sinon.assert.calledWith(
+        dispatch,
+        _fetchReviews({
+          addonSlug,
+          page,
+          errorHandlerId: root.instance().props.errorHandler.id,
         }),
       );
     });
@@ -439,32 +465,6 @@ describe(__filename, () => {
       );
     });
 
-    // TODO: delete these tests
-    it('fetches reviews when the page location changes', () => {
-      const dispatch = sinon.stub(store, 'dispatch');
-      const errorHandler = createStubErrorHandler();
-      const addonSlug = fakeAddon.slug;
-
-      const root = render({
-        errorHandler,
-        location: createFakeLocation({ query: { page: '2' } }),
-        params: { addonSlug },
-      });
-      dispatch.resetHistory();
-      root.setProps({
-        location: createFakeLocation({ query: { page: '3' } }),
-      });
-
-      sinon.assert.calledWith(
-        dispatch,
-        _fetchReviews({
-          addonSlug,
-          errorHandlerId: errorHandler.id,
-          page: '3',
-        }),
-      );
-    });
-
     it('fetches reviews when the score changes', () => {
       const addonSlug = fakeAddon.slug;
       loadAddon(fakeAddon);
@@ -511,32 +511,6 @@ describe(__filename, () => {
           addonSlug,
           errorHandlerId: root.instance().props.errorHandler.id,
           score: '5',
-        }),
-      );
-    });
-
-    it('fetches reviews when the page changes', () => {
-      const addonSlug = fakeAddon.slug;
-      loadAddon(fakeAddon);
-      _setAddonReviews({
-        addonSlug,
-        page: '3',
-        reviews: [fakeReview],
-      });
-      const dispatch = sinon.spy(store, 'dispatch');
-
-      const page = '2';
-      const root = render({
-        location: createFakeLocation({ query: { page } }),
-        params: { addonSlug },
-      });
-
-      sinon.assert.calledWith(
-        dispatch,
-        _fetchReviews({
-          addonSlug,
-          page,
-          errorHandlerId: root.instance().props.errorHandler.id,
         }),
       );
     });

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -505,10 +505,9 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(
         dispatch,
-        fetchReviews({
+        _fetchReviews({
           addonSlug,
           errorHandlerId: root.instance().props.errorHandler.id,
-          page: '1',
           score: '5',
         }),
       );

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -85,6 +85,7 @@ describe(__filename, () => {
   } = {}) {
     return setAddonReviews({
       addonSlug: fakeAddon.slug,
+      page: '1',
       pageSize: DEFAULT_API_PAGE_SIZE,
       reviews,
       reviewCount: reviews.length,
@@ -105,6 +106,7 @@ describe(__filename, () => {
 
   function _selectReviews(params = {}) {
     return selectReviews({
+      page: '1',
       score: null,
       ...params,
     });
@@ -388,6 +390,18 @@ describe(__filename, () => {
 
       expect(state.byAddon[fakeAddon.slug].score).toEqual(null);
     });
+
+    it('stores the page', () => {
+      const page = '4';
+      const action = _setAddonReviews({
+        addonSlug: fakeAddon.slug,
+        page,
+        reviews: [{ ...fakeReview, id: 1 }],
+      });
+      const state = reviewsReducer(undefined, action);
+
+      expect(state.byAddon[fakeAddon.slug].page).toEqual(page);
+    });
   });
 
   describe('unloadAddonReviews', () => {
@@ -629,20 +643,22 @@ describe(__filename, () => {
     it('selects reviews by slug', () => {
       const review1 = { ...fakeReview, id: 1 };
       const review2 = { ...fakeReview, id: 2 };
+      const page = '1';
       const pageSize = 13;
       const reviewCount = 2;
       const action = _setAddonReviews({
         addonSlug: fakeAddon.slug,
+        page,
         pageSize,
         reviews: [review1, review2],
         reviewCount,
       });
       const reviewsState = reviewsReducer(undefined, action);
 
-      const data = selectReviews({
+      const data = _selectReviews({
         reviewsState,
         addonSlug: fakeAddon.slug,
-        score: null,
+        page,
       });
       expect(data.reviews).toEqual([review1.id, review2.id]);
       expect(data.pageSize).toEqual(pageSize);
@@ -656,10 +672,9 @@ describe(__filename, () => {
       });
       const reviewsState = reviewsReducer(undefined, action);
 
-      const data = selectReviews({
+      const data = _selectReviews({
         reviewsState,
         addonSlug: 'slug2',
-        score: null,
       });
       expect(data).toEqual(null);
     });
@@ -673,10 +688,26 @@ describe(__filename, () => {
       });
       const reviewsState = reviewsReducer(undefined, action);
 
-      const data = selectReviews({
+      const data = _selectReviews({
         reviewsState,
         addonSlug: fakeAddon.slug,
         score: '3',
+      });
+      expect(data).toEqual(null);
+    });
+
+    it('only selects reviews with a matching page', () => {
+      const action = _setAddonReviews({
+        addonSlug: fakeAddon.slug,
+        page: '2',
+        reviews: [{ ...fakeReview, id: 1 }],
+      });
+      const reviewsState = reviewsReducer(undefined, action);
+
+      const data = _selectReviews({
+        addonSlug: fakeAddon.slug,
+        page: '6',
+        reviewsState,
       });
       expect(data).toEqual(null);
     });

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -114,6 +114,7 @@ describe(__filename, () => {
       expect(action).toEqual(
         setAddonReviews({
           addonSlug: fakeAddon.slug,
+          page: '1',
           pageSize: DEFAULT_API_PAGE_SIZE,
           reviewCount: 1,
           reviews,


### PR DESCRIPTION
~~⚠️  Depends on https://github.com/mozilla/addons-frontend/pull/7374~~

<hr>

This patch fixes https://github.com/mozilla/addons-frontend/issues/7376 by adding `page` to the reducer data. Because this implements more natural pagination, it also magically fixes https://github.com/mozilla/addons-frontend/issues/3759