### PR TITLE
Workaround bug in svgo causing glitchy stars

### DIFF
--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -61,7 +61,24 @@ export default {
           },
         },
       }),
-      new OptimizeCssAssetsPlugin(),
+      new OptimizeCssAssetsPlugin({
+        cssProcessorPluginOptions: {
+          preset: [
+            'default',
+            {
+              svgo: {
+                plugins: [
+                  {
+                    // There is a bug in this optimization.
+                    // See https://github.com/mozilla/addons-frontend/issues/7191
+                    convertPathData: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }),
     ],
   },
   plugins: [


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7191 by disabling one of our SVG optimizations.

I couldn't figure out how to apply SVG optimizations to `yarn amo:dev` so I was testing with a [production build](https://github.com/mozilla/addons-frontend/#building-and-running-services) which allowed me to reproduce the bug.

Here are the stars before my patch:

<img width="511" alt="screenshot 2019-01-15 10 57 28" src="https://user-images.githubusercontent.com/55398/51196848-989bb800-18b5-11e9-928a-70a0a005f658.png">


Here are the stars after:

<img width="507" alt="screenshot 2019-01-15 11 00 40" src="https://user-images.githubusercontent.com/55398/51196854-9c2f3f00-18b5-11e9-9188-caba04a2e08b.png">
