### PR TITLE
Upgrade to node v10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:10-slim
 
 # Install node_modules into a different directory to avoid npm/npm#9863.
 RUN mkdir -p /srv/node
@@ -12,6 +12,8 @@ COPY docker/etc/pki/yarnpkg.gpg.key /etc/pki/yarnpkg.gpg.key
 RUN buildDeps=' \
     git \
     yarn \
+    python \
+    build-essential \
     ' && \
     # `apt-transport-https` is required to use https deb repositories
     apt-get update -y && \


### PR DESCRIPTION
Fixes #7418

---

- [X] Add a description of the changes introduced in this PR.
- [X] The change has been successfully run locally.

As discussed in the weekly, this upgrades node to v10.

Need to add python and build-essential packages or the `yarn install --pure-lockfile`
fails while trying to invoke `detect-libc prebuild-install || node-gyp rebuild`.

