### PR TITLE
Removed "No Users" metadata entry for search tools(on add-on detail p…

### DIFF
--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -88,10 +88,6 @@ export class AddonMetaBase extends React.Component<InternalProps> {
           className="AddonMeta-overallRating"
           metadata={[
             {
-              content: userCount,
-              title: userTitle,
-            },
-            {
               content: reviewsContent,
               title: reviewsTitle,
             },


### PR DESCRIPTION
Fixes #7316 
![screenshot from 2019-01-19 01-48-39](https://user-images.githubusercontent.com/36242614/51427982-16e4bb00-1c24-11e9-8487-a7cc2693c2ea.png)
'No Users' is not displayed now


