### PR TITLE
Removed "No Users" metadata entry for search tools (on add-on detail …

### DIFF
--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -88,10 +88,6 @@ export class AddonMetaBase extends React.Component<InternalProps> {
           className="AddonMeta-overallRating"
           metadata={[
             {
-              content: userCount,
-              title: userTitle,
-            },
-            {
               content: reviewsContent,
               title: reviewsTitle,
             },

--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -35,20 +35,7 @@ export class AddonMetaBase extends React.Component<InternalProps> {
     }
     const addonRatingCount =
       addon && addon.ratings ? addon.ratings.count : null;
-    const averageDailyUsers = addon ? addon.average_daily_users : null;
     const roundedAverage = roundToOneDigit(averageRating || null);
-
-    let userCount = '';
-    let userTitle;
-    if (!addon) {
-      userCount = null;
-      userTitle = i18n.gettext('Users');
-    } else if (averageDailyUsers) {
-      userCount = i18n.formatNumber(averageDailyUsers);
-      userTitle = i18n.ngettext('User', 'Users', averageDailyUsers);
-    } else {
-      userTitle = i18n.gettext('No Users');
-    }
 
     let reviewCount = '';
     let reviewTitle;

--- a/tests/unit/amo/components/TestAddonMeta.js
+++ b/tests/unit/amo/components/TestAddonMeta.js
@@ -36,51 +36,6 @@ describe(__filename, () => {
     expect(root.find(MetadataCard)).toHaveLength(1);
   });
 
-  describe('average daily users', () => {
-    function getUserCount(root) {
-      return root.find(MetadataCard).prop('metadata')[0];
-    }
-
-    it('renders the user count', () => {
-      const root = render({
-        addon: createInternalAddon({ ...fakeAddon, average_daily_users: 2 }),
-      });
-
-      expect(getUserCount(root).content).toEqual('2');
-      expect(getUserCount(root).title).toEqual('Users');
-    });
-
-    it('renders one user', () => {
-      const root = render({
-        addon: createInternalAddon({ ...fakeAddon, average_daily_users: 1 }),
-      });
-
-      expect(getUserCount(root).content).toEqual('1');
-      expect(getUserCount(root).title).toEqual('User');
-    });
-
-    it('renders no users', () => {
-      const root = render({
-        addon: createInternalAddon({ ...fakeAddon, average_daily_users: 0 }),
-      });
-
-      expect(getUserCount(root).content).toEqual('');
-      expect(getUserCount(root).title).toEqual('No Users');
-    });
-
-    it('localizes the user count', () => {
-      const i18n = fakeI18n({ lang: 'de' });
-      const root = render({
-        addon: createInternalAddon({
-          ...fakeAddon,
-          average_daily_users: 1000,
-        }),
-        i18n,
-      });
-      expect(getUserCount(root).content).toMatch(/^1\.000/);
-    });
-  });
-
   describe('ratings', () => {
     function renderRatings(ratings = {}, otherProps = {}) {
       return render({


### PR DESCRIPTION
Fixes #7316 
Now the 'No Users' metadata is not displayed

![screenshot from 2019-01-19 01-48-39](https://user-images.githubusercontent.com/36242614/51430873-0560da80-1c47-11e9-956b-a6dc25cebac7.png)
