### PR TITLE
I7301 - Indicating mandatory display name field

### DIFF
--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -414,7 +414,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     }
 
     return isEditingCurrentUser
-      ? i18n.gettext(`Tell users a bit more information about yourself. These
+      ? i18n.gettext(`Tell users a bit more information about yourself. Most
         fields are optional, but they'll help other users get to know you
         better.`)
       : i18n.sprintf(

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -584,7 +584,8 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 htmlFor="displayName"
                 title={i18n.gettext('This field is required')}
               >
-                {i18n.gettext('Display Name *')}
+                {// translators: the star is used to indicate a required field
+                i18n.gettext('Display Name *')}
               </label>
               <input
                 className="UserProfileEdit-displayName"

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -580,7 +580,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
               </p>
 
               <label className="UserProfileEdit--label" htmlFor="displayName">
-                {i18n.gettext('Display Name')}
+                {i18n.gettext('Display Name')} *
               </label>
               <input
                 className="UserProfileEdit-displayName"

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -419,7 +419,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
         better.`)
       : i18n.sprintf(
           i18n.gettext(`Tell users a bit more information about this user.
-            These fields are optional, but they'll help other users get to know
+            Most fields are optional, but they'll help other users get to know
             %(userName)s better.`),
           { userName: user.name },
         );
@@ -582,7 +582,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
               <label
                 className="UserProfileEdit--label"
                 htmlFor="displayName"
-                title={i18n.gettext('Required Field')}
+                title={i18n.gettext('This field is required')}
               >
                 {i18n.gettext('Display Name *')}
               </label>

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -579,8 +579,12 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                 {this.renderProfileAside()}
               </p>
 
-              <label className="UserProfileEdit--label" htmlFor="displayName">
-                {i18n.gettext('Display Name')} *
+              <label
+                className="UserProfileEdit--label"
+                htmlFor="displayName"
+                title={i18n.gettext('Required Field')}
+              >
+                {i18n.gettext('Display Name *')}
               </label>
               <input
                 className="UserProfileEdit-displayName"

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -422,6 +422,20 @@ describe(__filename, () => {
     );
   });
 
+  it('renders a displayName label with required filed notion', () => {
+    const displayName = 'the display name';
+    const root = renderUserProfileEdit({
+      userProps: defaultUserProps({
+        display_name: displayName,
+      }),
+    });
+
+    expect(root.find('[htmlFor="displayName"]')).toHaveLength(1);
+    expect(root.find('[htmlFor="displayName"]')).toHaveProp(
+      'title'
+    );
+  });
+
   it('renders a homepage input field', () => {
     const homepage = 'https://example.org';
     const root = renderUserProfileEdit({

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -420,19 +420,9 @@ describe(__filename, () => {
       'value',
       displayName,
     );
-  });
-
-  it('renders a displayName label with required filed notion', () => {
-    const displayName = 'the display name';
-    const root = renderUserProfileEdit({
-      userProps: defaultUserProps({
-        display_name: displayName,
-      }),
-    });
-
-    expect(root.find('[htmlFor="displayName"]')).toHaveLength(1);
     expect(root.find('[htmlFor="displayName"]')).toHaveProp(
-      'title'
+      'title',
+      'This field is required'
     );
   });
 
@@ -877,7 +867,7 @@ describe(__filename, () => {
     expect(root.find('.UserProfileEdit-notifications--help')).toHaveLength(0);
 
     expect(root.find('.UserProfileEdit-profile-aside')).toHaveText(oneLine`Tell
-      users a bit more information about this user. These fields are optional,
+      users a bit more information about this user. Most fields are optional,
       but they'll help other users get to know ${user.name} better.`);
 
     // We do not render this link when user is not the current logged-in user.

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -136,7 +136,7 @@ describe(__filename, () => {
       'Account',
     );
     expect(root.find('.UserProfileEdit-profile-aside')).toHaveText(oneLine`Tell
-      users a bit more information about yourself. These fields are optional,
+      users a bit more information about yourself. Most fields are optional,
       but they'll help other users get to know you better.`);
     expect(root.find({ htmlFor: 'biography' })).toHaveText(
       'Introduce yourself to the community if you like',


### PR DESCRIPTION
Fixes #7301 
Indicating mandatory display name field.
Put a mandatory sign `*` next to display name label, so as to make it look mandatory

**Before:**
<img width="284" alt="image" src="https://user-images.githubusercontent.com/5318732/51436315-21866b00-1c8b-11e9-8ebd-2835aef6173f.png">


**After:**
<img width="269" alt="image" src="https://user-images.githubusercontent.com/5318732/51436308-04ea3300-1c8b-11e9-9c8e-453137fe5f60.png">

Hope it works simply with a `*`