### PR TITLE
Dotted Line Border Will not show up on Android & Desktop

### DIFF
--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -22,6 +22,9 @@
     // Restore default outline for webkit.
     outline: auto 5px -webkit-focus-ring-color;
   }
+  &:not(.focus-visible) {
+    outline: none;
+  }
 
   .DropdownMenu-button-text {
     @include font-regular();

--- a/src/ui/components/DropdownMenu/styles.scss
+++ b/src/ui/components/DropdownMenu/styles.scss
@@ -22,6 +22,7 @@
     // Restore default outline for webkit.
     outline: auto 5px -webkit-focus-ring-color;
   }
+
   &:not(.focus-visible) {
     outline: none;
   }


### PR DESCRIPTION
Fixes #7389: Dotted Line Border Will not show up on Android & Desktop

Bugs Remaining:
1. Pressing Ctrl brings up the Dotted Line on Dropdown Menu
2. Dev Hub still showing dotted Line(Need Help in this)