### PR TITLE
Fix search API parameters

### DIFF
--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -2,9 +2,9 @@ import { oneLine } from 'common-tags';
 import defaultConfig from 'config';
 
 import {
+  ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
-  CLIENT_APP_FIREFOX,
 } from 'core/constants';
 import log from 'core/logger';
 
@@ -137,20 +137,15 @@ export const fixFiltersForAndroidThemes = ({ api, filters }) => {
     return newFilters;
   }
 
-  // TODO: This loads Firefox personas (lightweight themes) for Android
-  // until
-  // https:// github.com/mozilla/addons-frontend/issues/1723#issuecomment-278793546
-  // and https://github.com/mozilla/addons-server/issues/4766 are addressed.
-  // Essentially: right now there are no categories for the combo
-  // of "Android" + "Themes" but Firefox lightweight themes will work fine
-  // on mobile so we request "Firefox" + "Themes" for Android instead.
-  // Obviously we need to fix this on the API end so our requests aren't
-  // overridden, but for now this will work.
-  if (newFilters.addonType === ADDON_TYPE_THEME) {
-    log.info(oneLine`addonType: ${newFilters.addonType}/clientApp:
-      ${newFilters.clientApp} is not supported. Changing clientApp to
-      "${CLIENT_APP_FIREFOX}"`);
-    newFilters.clientApp = CLIENT_APP_FIREFOX;
+  // There are no categories containing LWT for Android, so we request ST only
+  // for Android, but only when there is a category set.
+  // See: https://github.com/mozilla/addons-frontend/issues/7459
+  if (
+    newFilters.category &&
+    newFilters.addonType &&
+    newFilters.addonType.includes(ADDON_TYPE_THEME)
+  ) {
+    newFilters.addonType = ADDON_TYPE_STATIC_THEME;
   }
 
   return newFilters;

--- a/tests/unit/core/api/test_search.js
+++ b/tests/unit/core/api/test_search.js
@@ -2,7 +2,6 @@
 import { search } from 'core/api/search';
 import {
   ADDON_TYPE_EXTENSION,
-  ADDON_TYPE_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
 } from 'core/constants';
@@ -178,25 +177,5 @@ describe(__filename, () => {
       expect(err.response.status).toEqual(401);
       expect(err.response.apiURL).toMatch('/api/v4/addons/search/');
     });
-  });
-
-  it('changes theme requests for android to firefox results', async () => {
-    mockWindow
-      .expects('fetch')
-      .withArgs(
-        urlWithTheseParams({
-          app: CLIENT_APP_FIREFOX,
-          type: ADDON_TYPE_THEME,
-        }),
-      )
-      .returns(mockResponse());
-
-    await _search({
-      filters: {
-        addonType: ADDON_TYPE_THEME,
-        clientApp: CLIENT_APP_ANDROID,
-      },
-    });
-    mockWindow.verify();
   });
 });

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -2,6 +2,7 @@ import { oneLine } from 'common-tags';
 
 import {
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
   ADDON_TYPE_THEMES_FILTER,
   CLIENT_APP_ANDROID,
@@ -210,18 +211,22 @@ describe(__filename, () => {
   });
 
   describe('fixFiltersForAndroidThemes', () => {
-    it('changes clientApp filter to `firefox` for Android themes', () => {
-      const filters = {
-        addonType: ADDON_TYPE_THEME,
-        clientApp: CLIENT_APP_ANDROID,
-      };
+    it.each([ADDON_TYPE_THEMES_FILTER, ADDON_TYPE_THEME])(
+      'changes the addonType filter to ADDON_TYPE_STATIC_THEME when addonType is "%s", clientApp is "Android" and there is a category defined',
+      (addonType) => {
+        const filters = {
+          addonType,
+          category: 'nature',
+          clientApp: CLIENT_APP_ANDROID,
+        };
 
-      const newFilters = fixFiltersForAndroidThemes({ filters });
-      expect(newFilters).toEqual({
-        ...filters,
-        clientApp: CLIENT_APP_FIREFOX,
-      });
-    });
+        const newFilters = fixFiltersForAndroidThemes({ filters });
+        expect(newFilters).toEqual({
+          ...filters,
+          addonType: ADDON_TYPE_STATIC_THEME,
+        });
+      },
+    );
 
     it('does not change clientApp filter for Android extensions', () => {
       const filters = {


### PR DESCRIPTION
Fixes mozilla/addons#12926

---

Before this patch and before the patch for mozilla/addons#12905, we were showing "LWT for Firefox Desktop" on Android. The patch for mozilla/addons#12905 removed part of this hack but not everything.

This patch changes the logic to only change the `addonType` filter when there is a category defined, because there is an incompatibility with the cagegory and the addonType filters for Android (no categories with LWT for Android). Since there are categories for ST on Android, we can use them.