### PR TITLE
Make url clickable in add-on notes I7444

### DIFF
--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -164,7 +164,7 @@ export class EditableCollectionAddonBase extends React.Component<InternalProps> 
                   onSubmit={this.onSaveNote}
                   placeholder={i18n.gettext('Add a comment about this add-on.')}
                   submitButtonText={i18n.gettext('Save')}
-                  text={addon.notes || null}
+                  text={sanitizeHTML(addon.notes || '').__html}
                 />
               </React.Fragment>
             ) : (
@@ -174,7 +174,7 @@ export class EditableCollectionAddonBase extends React.Component<InternalProps> 
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={sanitizeHTML(
                     nl2br(addon.notes || ''),
-                    ['br'],
+                    ['br', 'a'],
                   )}
                 />
                 <div className="EditableCollectionAddon-notes-buttons">

--- a/tests/unit/amo/components/TestEditableCollectionAddon.js
+++ b/tests/unit/amo/components/TestEditableCollectionAddon.js
@@ -215,12 +215,34 @@ describe(__filename, () => {
         'Add a comment about this add-on.',
       );
       expect(notesForm).toHaveProp('submitButtonText', 'Save');
-      expect(notesForm).toHaveProp('text', null);
+      expect(notesForm).toHaveProp('text', '');
 
       // The read-only portion should not be shown.
       expect(
         root.find('.EditableCollectionAddon-notes-read-only'),
       ).toHaveLength(0);
+    });
+
+    it('renders clickable URL in notes', () => {
+      const notes = `<a href="url">http://www.w3schools.com</a>`;
+      const root = render({ notes });
+
+      expect(root.find('.EditableCollectionAddon-notes-content')).toHaveHTML(
+        `<span class="EditableCollectionAddon-notes-content"> ${notes}</span>`,
+      );
+    });
+
+    it('does not show <a> tag in DismissibleTextForm when editing notes', () => {
+      const { store } = dispatchClientMetadata();
+      const url = 'http://w3schools.com';
+      const notes = `<a href="to somewhere">${url}</a>`;
+      const root = render({ notes, store });
+      root
+        .find('.EditableCollectionAddon-notes-edit-button')
+        .simulate('click', createFakeEvent());
+      applyUIStateChanges({ root, store });
+
+      expect(root.find(DismissibleTextForm)).toHaveProp('text', url);
     });
 
     it('changes UI state when the leave a note button is clicked', () => {


### PR DESCRIPTION
Fixes #7444 
After
![fix_notes_link](https://user-images.githubusercontent.com/4984681/51644139-5107d280-1f2c-11e9-892e-fd05bd0ae304.gif)
