### PR TITLE
I-6827 Display reply button of a comment after deleting the reply

### DIFF
--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -97,6 +97,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
 
   componentDidUpdate(prevProps: InternalProps) {
     this.loadDataIfNeeded(prevProps);
+    this.dispatchFetchReviewPermissions();
   }
 
   loadDataIfNeeded(prevProps?: InternalProps) {
@@ -145,6 +146,13 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
   }
 
   componentDidMount() {
+    // Permissions are fetched in componentDidMount because siteUser
+    // is not reliable while server rendering.
+    // https://github.com/mozilla/addons-frontend/issues/6717
+    this.dispatchFetchReviewPermissions();
+  }
+
+  dispatchFetchReviewPermissions() {
     const {
       addon,
       checkingIfSiteUserCanReply,
@@ -161,9 +169,6 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
       !checkingIfSiteUserCanReply &&
       !errorHandler.hasError()
     ) {
-      // Permissions are fetched in componentDidMount because siteUser
-      // is not reliable while server rendering.
-      // https://github.com/mozilla/addons-frontend/issues/6717
       dispatch(
         fetchReviewPermissions({
           addonId: addon.id,

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -935,6 +935,29 @@ describe(__filename, () => {
       );
     });
 
+    it('dispatches fetchReviewPermissions on update', () => {
+      const addon = { ...fakeAddon };
+      const userId = 66432;
+
+      loadAddon(addon);
+      dispatchSignInActions({ store, userId });
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+
+      const root = render();
+      dispatchSpy.resetHistory();
+
+      root.setProps({ addon });
+
+      sinon.assert.calledWith(
+        dispatchSpy,
+        fetchReviewPermissions({
+          addonId: addon.id,
+          errorHandlerId: root.instance().props.errorHandler.id,
+          userId,
+        }),
+      );
+    });
+
     it('does not dispatch fetchReviewPermissions() when an error has occured', () => {
       const addon = { ...fakeAddon };
       const userId = 66432;


### PR DESCRIPTION
Fixes #6827 

The reply button is disappeared because `permissions` is undefined after the reply is deleted.
This situation only happens when the reply is featured, by clicking the time permalink.
This is because only the featured reply will be set to [byId](https://github.com/mozilla/addons-frontend/blob/master/src/amo/reducers/reviews.js#L705), it will then go into the `if` condition and set the permission to undefined. 

I then check the action after reload, it calls `fetchReviewPermissions`. Thus, I move `fetchReviewPermissions` from `componentDidMount` to `componentDidUpdate`.
But I am not sure it is a good solution, if you find out a better way, please comment.

![z4dmt4n47e](https://user-images.githubusercontent.com/6767433/51737839-96610700-20c8-11e9-935f-0b8101417256.gif)
