### PR TITLE
Ensure that storybook doesn't break again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,9 @@ jobs:
     - stage:
       <<: *node-prod
       env: COMMAND=prettier-ci
+    - stage:
+      <<: *node-prod
+      env: COMMAND=storybook-smoke-test
     # Run the functional tests.
     - stage:
       <<: *tox

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "storybook": "better-npm-run storybook",
     "storybook-build": "better-npm-run storybook-build",
     "storybook-deploy": "storybook-to-ghpages --script storybook-build",
+    "storybook-smoke-test": "better-npm-run storybook-smoke-test",
     "test-ci": "bin/config-check.js && NODE_APP_INSTANCE=amo npm run build-locales && NODE_APP_INSTANCE=disco npm run build-locales && better-npm-run test-ci && codecov",
     "test": "bin/config-check.js && better-npm-run jest --watch",
     "test-coverage": "bin/config-check.js && better-npm-run jest --coverage --watch",
@@ -166,6 +167,14 @@
     },
     "storybook-build": {
       "command": "build-storybook -c stories/setup",
+      "env": {
+        "NODE_PATH": "./:./src",
+        "NODE_ENV": "production",
+        "NODE_CONFIG_ENV": "prod"
+      }
+    },
+    "storybook-smoke-test": {
+      "command": "storybook-server -c stories/setup --smoke-test",
       "env": {
         "NODE_PATH": "./:./src",
         "NODE_ENV": "production",


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7491

I checked out the code before https://github.com/mozilla/addons-frontend/pull/7469 and verified that `yarn storybook-smoke-test` failed. It succeeds on master.