### PR TITLE
Recommendation disco UI

### DIFF
--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -118,7 +118,7 @@ export class AddonRecommendationsBase extends React.Component<Props> {
 
     if (!recommendations) {
       log.debug(
-        'No recommandations, hiding the AddonRecommendations component.',
+        'No recommendations, hiding the AddonRecommendations component.',
       );
       return null;
     }

--- a/src/disco/components/App/index.js
+++ b/src/disco/components/App/index.js
@@ -33,8 +33,8 @@ export class AppBase extends React.Component {
   render() {
     const { ErrorPage, browserVersion, i18n } = this.props;
 
-    const classes = makeClassName('disco-pane', {
-      'padding-compensation': parseInt(browserVersion, 10) < 50,
+    const classes = makeClassName('App', {
+      'App--padding-compensation': parseInt(browserVersion, 10) < 50,
     });
 
     return (

--- a/src/disco/components/App/styles.scss
+++ b/src/disco/components/App/styles.scss
@@ -18,39 +18,19 @@ img {
   box-sizing: content-box;
 }
 
-// Special class to apply compensation
-// for the padding applied by xul in FF < 50.
-.padding-compensation {
-  @include padding-end(68px);
-}
-
-header {
-  margin: 0 0 20px;
-  padding: 20px 0 0;
-
-  h1 {
-    color: $primary-font-color;
-    display: block;
-    font-size: 30px;
-    font-weight: 400;
-    line-height: 1.1;
-    margin: 0 0 20px;
-  }
+.App {
+  box-sizing: content-box;
+  max-width: 680px;
+  min-width: 260px;
+  padding: 10px 20px 20px;
 
   @include respond-to(large) {
-    background: inherit;
-    border-bottom: 1px solid $header-border-color;
-    margin: 0 0 40px;
-    padding: 0 0 40px;
-
-    h1 {
-      font-size: 20px;
-      line-height: 1.5;
-    }
+    padding-top: 50px;
   }
 }
 
-.amo-link {
-  margin: 30px 0;
-  text-align: center;
+// Special class to apply compensation
+// for the padding applied by xul in FF < 50.
+.App--padding-compensation {
+  @include padding-end(68px);
 }

--- a/src/disco/pages/DiscoPane/styles.scss
+++ b/src/disco/pages/DiscoPane/styles.scss
@@ -1,25 +1,55 @@
 @import '~disco/css/styles';
 
-.disco-pane {
-  box-sizing: content-box;
-  max-width: 680px;
-  min-width: 260px;
-  padding: 10px 20px 20px;
+.DiscoPane-header {
+  margin: 0 0 20px;
+  padding: 20px 0 0;
+
+  h1 {
+    color: $primary-font-color;
+    display: block;
+    font-size: 30px;
+    font-weight: 400;
+    line-height: 1.1;
+    margin: 0 0 20px;
+  }
 
   @include respond-to(large) {
-    padding-top: 50px;
+    background: inherit;
+    border-bottom: 1px solid $header-border-color;
+    margin: 0 0 40px;
+    padding: 0 0 40px;
+
+    h1 {
+      font-size: 20px;
+      line-height: 1.5;
+    }
   }
 }
 
-.disco-content {
+.DiscoPane-notice-recommendations {
+  .Notice-content {
+    display: flex;
+
+    .Notice-button.Button {
+      margin: auto;
+      width: 180px;
+    }
+  }
+}
+
+.DiscoPane-header-intro {
   color: $header-copy-font-color;
   font-size: 16px;
   line-height: 1.5;
-  max-width: 620px;
   width: 100%;
 
   &:last-child {
     display: block;
     margin-bottom: 0;
   }
+}
+
+.DiscoPane-amo-link {
+  margin: 30px 0;
+  text-align: center;
 }

--- a/src/disco/reducers/discoResults.js
+++ b/src/disco/reducers/discoResults.js
@@ -29,10 +29,12 @@ export type DiscoResultsType = Array<DiscoResultType>;
 
 export type DiscoResultsState = {|
   results: DiscoResultsType,
+  hasRecommendations: boolean,
 |};
 
 export const initialState: DiscoResultsState = {
   results: [],
+  hasRecommendations: false,
 };
 
 type GetDiscoResultsParams = {|
@@ -110,11 +112,15 @@ export default function discoResults(
 ): DiscoResultsState {
   switch (action.type) {
     case LOAD_DISCO_RESULTS: {
-      const { results } = action.payload;
+      const results = action.payload.results.map(createInternalResult);
+      const hasRecommendations = results.some(
+        (result) => result.isRecommendation === true,
+      );
 
       return {
         ...state,
-        results: results.map(createInternalResult),
+        results,
+        hasRecommendations,
       };
     }
     default:

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -131,7 +131,7 @@ export class NoticeBase extends React.Component<InternalProps> {
       <div className={finalClass}>
         <div className="Notice-icon" />
         <div className="Notice-column">
-          <div>
+          <div className="Notice-content">
             <p className="Notice-text">{children}</p>
             {actionButton}
           </div>

--- a/tests/ui/pages/discopane.py
+++ b/tests/ui/pages/discopane.py
@@ -7,13 +7,13 @@ from selenium.webdriver.common.by import By
 class DiscoveryPane(Page):
     """Contain the locators and actions relating to the discovery pane."""
 
-    _root_locator = (By.CLASS_NAME, 'disco-pane')
+    _root_locator = (By.CLASS_NAME, 'App')
     _extensions_locator = (By.CLASS_NAME, 'extension')
     _discopane_error_alert_locator = (
         By.CSS_SELECTOR, '#discover-error .alert')
-    _discopane_header_locator = (By.CLASS_NAME, 'disco-header')
+    _discopane_header_locator = (By.CLASS_NAME, 'DiscoPane-header')
     _discovery_list_item_locator = (By.ID, 'category-discover')
-    _see_more_btn_locator = (By.CLASS_NAME, 'amo-link')
+    _see_more_btn_locator = (By.CLASS_NAME, 'DiscoPane-amo-link')
     _themes_locator = (By.CLASS_NAME, 'theme')
 
     def _wait_for_page_to_load(self):

--- a/tests/unit/disco/components/TestApp.js
+++ b/tests/unit/disco/components/TestApp.js
@@ -42,8 +42,8 @@ describe(__filename, () => {
     });
   }
 
-  const renderDiscoPane = (props = {}) => {
-    return render(props).find('.disco-pane');
+  const renderApp = (props = {}) => {
+    return render(props).find('.App');
   };
 
   describe('App', () => {
@@ -51,7 +51,7 @@ describe(__filename, () => {
       const root = render();
       expect(root).toHaveLength(1);
       expect(root).toHaveProp('code', 200);
-      expect(root.find('.disco-pane')).toHaveLength(1);
+      expect(root.find('.App')).toHaveLength(1);
     });
 
     it('renders a ErrorPage', () => {
@@ -75,28 +75,28 @@ describe(__filename, () => {
     });
 
     it('renders padding compensation class for FF < 50', () => {
-      const root = renderDiscoPane({ browserVersion: '49.0' });
-      expect(root).toHaveClassName('padding-compensation');
+      const root = renderApp({ browserVersion: '49.0' });
+      expect(root).toHaveClassName('App--padding-compensation');
     });
 
     it('does not render padding compensation class for a bogus value', () => {
-      const root = renderDiscoPane({ browserVersion: 'whatever' });
-      expect(root).not.toHaveClassName('padding-compensation');
+      const root = renderApp({ browserVersion: 'whatever' });
+      expect(root).not.toHaveClassName('App--padding-compensation');
     });
 
     it('does not render padding compensation class for a undefined value', () => {
-      const root = renderDiscoPane({ browserVersion: undefined });
-      expect(root).not.toHaveClassName('padding-compensation');
+      const root = renderApp({ browserVersion: undefined });
+      expect(root).not.toHaveClassName('App--padding-compensation');
     });
 
     it('does not render padding compensation class for FF == 50', () => {
-      const root = renderDiscoPane({ browserVersion: '50.0' });
-      expect(root).not.toHaveClassName('padding-compensation');
+      const root = renderApp({ browserVersion: '50.0' });
+      expect(root).not.toHaveClassName('App--padding-compensation');
     });
 
     it('does not render padding compensation class for FF > 50', () => {
-      const root = renderDiscoPane({ browserVersion: '52.0a1' });
-      expect(root).not.toHaveClassName('padding-compensation');
+      const root = renderApp({ browserVersion: '52.0a1' });
+      expect(root).not.toHaveClassName('App--padding-compensation');
     });
 
     it('renders a response with a 200 status', () => {

--- a/tests/unit/disco/reducers/test_discoResults.js
+++ b/tests/unit/disco/reducers/test_discoResults.js
@@ -25,6 +25,7 @@ describe(__filename, () => {
         ...fakeDiscoAddon,
         guid: '@guid1',
       },
+      is_recommendation: false,
     });
     const result2 = createDiscoResult({
       heading: 'Discovery Addon 2',
@@ -33,15 +34,51 @@ describe(__filename, () => {
         ...fakeDiscoAddon,
         guid: '@guid2',
       },
+      is_recommendation: false,
     });
 
     const { results } = createFetchDiscoveryResult([result1, result2]);
 
     const state = discoResults(undefined, loadDiscoResults({ results }));
 
-    expect(state).toEqual({
+    expect(state).toMatchObject({
       results: [createInternalResult(result1), createInternalResult(result2)],
     });
+    expect(state.hasRecommendations).toEqual(false);
+  });
+
+  it('sets `hasRecommendations` to `true` when at least one results comes from the recommandation service', () => {
+    const { results } = createFetchDiscoveryResult([
+      createDiscoResult({
+        addon: { ...fakeDiscoAddon, guid: '@guid1' },
+        is_recommendation: false,
+      }),
+      createDiscoResult({
+        addon: { ...fakeDiscoAddon, guid: '@guid2' },
+        is_recommendation: true,
+      }),
+      createDiscoResult({
+        addon: { ...fakeDiscoAddon, guid: '@guid3' },
+        is_recommendation: false,
+      }),
+    ]);
+
+    const state = discoResults(undefined, loadDiscoResults({ results }));
+
+    expect(state.hasRecommendations).toEqual(true);
+  });
+
+  it('sets `hasRecommendations` to `false` when there is no recommended results', () => {
+    const { results } = createFetchDiscoveryResult([
+      createDiscoResult({
+        addon: { ...fakeDiscoAddon, guid: '@guid1' },
+        is_recommendation: false,
+      }),
+    ]);
+
+    const state = discoResults(undefined, loadDiscoResults({ results }));
+
+    expect(state.hasRecommendations).toEqual(false);
   });
 
   describe('createInternalResult', () => {

--- a/tests/unit/disco/reducers/test_discoResults.js
+++ b/tests/unit/disco/reducers/test_discoResults.js
@@ -47,7 +47,7 @@ describe(__filename, () => {
     expect(state.hasRecommendations).toEqual(false);
   });
 
-  it('sets `hasRecommendations` to `true` when at least one results comes from the recommandation service', () => {
+  it('sets `hasRecommendations` to `true` when at least one results comes from the recommendation service', () => {
     const { results } = createFetchDiscoveryResult([
       createDiscoResult({
         addon: { ...fakeDiscoAddon, guid: '@guid1' },


### PR DESCRIPTION
Fixes #7494 

---

This PR mainly adds a `Notice` component to the Disco Pane when there are "recommended results" listed, i.e. **some** of the API results come from the recommendation service (TAAR) and not from the static curated content.

Because following the CSS was tricky, I also refactored some of the CSS in the disco app by:

- moving CSS code to the right file
- renaming some CSS class names

## Screenshots

When there are no recommended results, there is no notice:

![screen shot 2019-01-28 at 11 40 07](https://user-images.githubusercontent.com/217628/51831136-b32c5300-22f1-11e9-8d59-a363abbc8ee1.png)

But when there is at least one recommended result, a notice is displayed with a parametrized "learn more" link:

![screen shot 2019-01-28 at 11 39 56](https://user-images.githubusercontent.com/217628/51831138-b32c5300-22f1-11e9-9a40-fab16a608086.png)
