### PR TITLE
Fix heading overflow in disco pane

### DIFF
--- a/src/disco/components/Addon/styles.scss
+++ b/src/disco/components/Addon/styles.scss
@@ -78,6 +78,7 @@ $addon-padding: 20px;
     font-weight: medium;
     line-height: 1.2;
     margin: 0;
+    word-break: break-all;
 
     a:link,
     a:visited,


### PR DESCRIPTION
Fixes  #7502

---

Before:

![screen shot 2019-01-28 at 17 39 20](https://user-images.githubusercontent.com/217628/51851201-b5a7a080-2323-11e9-9557-db7a99c8fbf4.png)

After:

![screen shot 2019-01-28 at 17 38 50](https://user-images.githubusercontent.com/217628/51851202-b5a7a080-2323-11e9-8b6b-9878da60b641.png)
