### PR TITLE
I6507 updating preview size

### DIFF
--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -13,11 +13,7 @@ import {
   nl2br,
   sanitizeHTML,
 } from 'core/utils';
-import {
-  getAddonIconUrl,
-  getPreviewImage,
-  getPreviewIndexBySize,
-} from 'core/imageUtils';
+import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
@@ -63,9 +59,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
     let imageURL = iconURL;
 
     if (addon && isTheme(addon.type)) {
-      const previewIndex = getPreviewIndexBySize(addon);
-
-      let themeURL = getPreviewImage(addon, { index: previewIndex });
+      let themeURL = getPreviewImage(addon, { useStandardSize: true });
 
       if (!themeURL && addon && addon.type === ADDON_TYPE_THEME) {
         themeURL =

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -13,7 +13,11 @@ import {
   nl2br,
   sanitizeHTML,
 } from 'core/utils';
-import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
+import {
+  getAddonIconUrl,
+  getPreviewImage,
+  getPreviewIndexBySize,
+} from 'core/imageUtils';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
@@ -59,10 +63,9 @@ export class SearchResultBase extends React.Component<InternalProps> {
     let imageURL = iconURL;
 
     if (addon && isTheme(addon.type)) {
-      // Since only newly created static themes will have more than one preview
-      // we will set up a fallback for now.
-      let themeURL =
-        getPreviewImage(addon, { index: 1 }) || getPreviewImage(addon);
+      const previewIndex = getPreviewIndexBySize(addon);
+
+      let themeURL = getPreviewImage(addon, { index: previewIndex });
 
       if (!themeURL && addon && addon.type === ADDON_TYPE_THEME) {
         themeURL =

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -59,7 +59,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
     let imageURL = iconURL;
 
     if (addon && isTheme(addon.type)) {
-      let themeURL = getPreviewImage(addon, { useStandardSize: true });
+      let themeURL = getPreviewImage(addon);
 
       if (!themeURL && addon && addon.type === ADDON_TYPE_THEME) {
         themeURL =

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -18,6 +18,7 @@ $icon-default-size: 32px;
   display: flex;
   flex-flow: row wrap;
   margin: 0;
+  max-width: $theme-width-default;
   padding: 0;
   width: 100%;
 }

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -159,7 +159,7 @@ export class AddonBase extends React.Component {
     const { addon, i18n } = this.props;
 
     if (addon && isTheme(addon.type)) {
-      return <ThemeImage addon={addon} roundedCorners useStandardSize />;
+      return <ThemeImage addon={addon} roundedCorners />;
     }
 
     const label = addon

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -46,7 +46,7 @@ import {
   INSTALL_SOURCE_DETAIL_PAGE,
 } from 'core/constants';
 import { isTheme, nl2br, sanitizeHTML, sanitizeUserHTML } from 'core/utils';
-import { getAddonIconUrl, getPreviewIndexBySize } from 'core/imageUtils';
+import { getAddonIconUrl } from 'core/imageUtils';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import Card from 'ui/components/Card';
@@ -159,13 +159,7 @@ export class AddonBase extends React.Component {
     const { addon, i18n } = this.props;
 
     if (addon && isTheme(addon.type)) {
-      return (
-        <ThemeImage
-          addon={addon}
-          index={getPreviewIndexBySize(addon)}
-          roundedCorners
-        />
-      );
+      return <ThemeImage addon={addon} roundedCorners useStandardSize />;
     }
 
     const label = addon

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -46,7 +46,7 @@ import {
   INSTALL_SOURCE_DETAIL_PAGE,
 } from 'core/constants';
 import { isTheme, nl2br, sanitizeHTML, sanitizeUserHTML } from 'core/utils';
-import { getAddonIconUrl } from 'core/imageUtils';
+import { getAddonIconUrl, getPreviewIndexBySize } from 'core/imageUtils';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import Card from 'ui/components/Card';
@@ -159,7 +159,13 @@ export class AddonBase extends React.Component {
     const { addon, i18n } = this.props;
 
     if (addon && isTheme(addon.type)) {
-      return <ThemeImage addon={addon} roundedCorners />;
+      return (
+        <ThemeImage
+          addon={addon}
+          index={getPreviewIndexBySize(addon)}
+          roundedCorners
+        />
+      );
     }
 
     const label = addon

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -52,7 +52,7 @@ $max-modal-width: 768px;
 
 // Theme image dimensions
 $theme-height-default: 92px;
-$theme-width-default: 680px;
+$theme-width-default: 720px;
 
 // Lightweight images are slightly different
 $theme-height-legacy: 100px;

--- a/src/core/imageUtils.js
+++ b/src/core/imageUtils.js
@@ -7,21 +7,33 @@ export function getAddonIconUrl(addon) {
     : fallbackIcon;
 }
 
-export const getPreviewImage = (addon, { index = 0, full = true } = {}) => {
-  const preview = addon.previews.length && addon.previews[index];
-  if (preview) {
-    const previewSize = full ? 'image_url' : 'thumbnail_url';
-    return preview[previewSize] && isAllowedOrigin(preview[previewSize])
-      ? preview[previewSize]
-      : null;
+export const getPreviewImage = (
+  addon,
+  { index = 0, full = true, useStandardSize = false } = {},
+) => {
+  if (!addon.previews.length) {
+    return null;
   }
-  return null;
-};
 
-export const getPreviewIndexBySize = (addon, size = 720) => {
-  const imageIndex =
-    addon.previews &&
-    addon.previews.findIndex((preview) => preview.image_size[0] === size);
+  let imageIndex = index;
 
-  return imageIndex !== -1 ? imageIndex : undefined;
+  if (useStandardSize) {
+    // 720 is now the standard width for previews.
+    const width = 720;
+    imageIndex =
+      // The preview.image_size[0] is the image width.
+      addon.previews.findIndex((preview) => preview.image_size[0] === width);
+
+    // This is a fallback for older themes that do not have this size generated.
+    if (imageIndex < 0) {
+      imageIndex = 0;
+    }
+  }
+
+  const preview = addon.previews[imageIndex];
+
+  const previewSize = full ? 'image_url' : 'thumbnail_url';
+  return preview[previewSize] && isAllowedOrigin(preview[previewSize])
+    ? preview[previewSize]
+    : null;
 };

--- a/src/core/imageUtils.js
+++ b/src/core/imageUtils.js
@@ -17,3 +17,11 @@ export const getPreviewImage = (addon, { index = 0, full = true } = {}) => {
   }
   return null;
 };
+
+export const getPreviewIndexBySize = (addon, size = 720) => {
+  const imageIndex =
+    addon.previews &&
+    addon.previews.findIndex((preview) => preview.image_size[0] === size);
+
+  return imageIndex !== -1 ? imageIndex : undefined;
+};

--- a/src/core/imageUtils.js
+++ b/src/core/imageUtils.js
@@ -9,13 +9,13 @@ export function getAddonIconUrl(addon) {
 
 export const getPreviewImage = (
   addon,
-  { index = 0, full = true, useStandardSize = false } = {},
+  { full = true, useStandardSize = true } = {},
 ) => {
   if (!addon.previews.length) {
     return null;
   }
 
-  let imageIndex = index;
+  let imageIndex = 0;
 
   if (useStandardSize) {
     // 720 is now the standard width for previews.
@@ -23,11 +23,11 @@ export const getPreviewImage = (
     imageIndex =
       // The preview.image_size[0] is the image width.
       addon.previews.findIndex((preview) => preview.image_size[0] === width);
+  }
 
-    // This is a fallback for older themes that do not have this size generated.
-    if (imageIndex < 0) {
-      imageIndex = 0;
-    }
+  // This is a fallback for older themes that do not have this size generated.
+  if (imageIndex < 0) {
+    imageIndex = 0;
   }
 
   const preview = addon.previews[imageIndex];

--- a/src/core/imageUtils.js
+++ b/src/core/imageUtils.js
@@ -18,6 +18,10 @@ export const getPreviewImage = (
   let imageIndex = 0;
 
   if (useStandardSize) {
+    if (!full) {
+      throw new Error("Currently there is no 'standard' thumbnail size");
+    }
+
     // 720 is now the standard width for previews.
     const width = 720;
     imageIndex =

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -126,7 +126,7 @@ export class AddonBase extends React.Component<InternalProps> {
       };
     }
 
-    const themeImage = <ThemeImage addon={addon} />;
+    const themeImage = <ThemeImage addon={addon} useStandardSize />;
 
     return hasAddonManager ? (
       <a {...imageLinkProps}>{themeImage}</a>

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -126,7 +126,7 @@ export class AddonBase extends React.Component<InternalProps> {
       };
     }
 
-    const themeImage = <ThemeImage addon={addon} />;
+    const themeImage = <ThemeImage addon={addon} useStandardSize={false} />;
 
     return hasAddonManager ? (
       <a {...imageLinkProps}>{themeImage}</a>

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -126,7 +126,7 @@ export class AddonBase extends React.Component<InternalProps> {
       };
     }
 
-    const themeImage = <ThemeImage addon={addon} useStandardSize />;
+    const themeImage = <ThemeImage addon={addon} />;
 
     return hasAddonManager ? (
       <a {...imageLinkProps}>{themeImage}</a>

--- a/src/ui/components/ThemeImage/index.js
+++ b/src/ui/components/ThemeImage/index.js
@@ -14,6 +14,7 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType | null,
+  index?: number,
   roundedCorners?: boolean,
 |};
 
@@ -26,13 +27,14 @@ export const ThemeImageBase = ({
   addon,
   i18n,
   roundedCorners = false,
+  index = 0,
 }: InternalProps) => {
   if (addon && isTheme(addon.type)) {
     const label = i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
       title: addon.name,
     });
 
-    let previewURL = getPreviewImage(addon);
+    let previewURL = getPreviewImage(addon, { index });
     if (!previewURL && addon.type === ADDON_TYPE_THEME) {
       invariant(addon.themeData, 'themeData is required');
 

--- a/src/ui/components/ThemeImage/index.js
+++ b/src/ui/components/ThemeImage/index.js
@@ -16,6 +16,7 @@ type Props = {|
   addon: AddonType | null,
   index?: number,
   roundedCorners?: boolean,
+  useStandardSize?: boolean,
 |};
 
 type InternalProps = {|
@@ -26,15 +27,16 @@ type InternalProps = {|
 export const ThemeImageBase = ({
   addon,
   i18n,
-  roundedCorners = false,
   index = 0,
+  roundedCorners = false,
+  useStandardSize = false,
 }: InternalProps) => {
   if (addon && isTheme(addon.type)) {
     const label = i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
       title: addon.name,
     });
 
-    let previewURL = getPreviewImage(addon, { index });
+    let previewURL = getPreviewImage(addon, { useStandardSize, index });
     if (!previewURL && addon.type === ADDON_TYPE_THEME) {
       invariant(addon.themeData, 'themeData is required');
 

--- a/src/ui/components/ThemeImage/index.js
+++ b/src/ui/components/ThemeImage/index.js
@@ -14,7 +14,6 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType | null,
-  index?: number,
   roundedCorners?: boolean,
   useStandardSize?: boolean,
 |};
@@ -27,16 +26,15 @@ type InternalProps = {|
 export const ThemeImageBase = ({
   addon,
   i18n,
-  index = 0,
   roundedCorners = false,
-  useStandardSize = false,
+  useStandardSize = true,
 }: InternalProps) => {
   if (addon && isTheme(addon.type)) {
     const label = i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
       title: addon.name,
     });
 
-    let previewURL = getPreviewImage(addon, { useStandardSize, index });
+    let previewURL = getPreviewImage(addon, { useStandardSize });
     if (!previewURL && addon.type === ADDON_TYPE_THEME) {
       invariant(addon.themeData, 'themeData is required');
 

--- a/tests/unit/core/test_imageUtils.js
+++ b/tests/unit/core/test_imageUtils.js
@@ -45,21 +45,6 @@ describe(__filename, () => {
       expect(image).toEqual(fullImage);
     });
 
-    it('returns the thumb image from the previews array', () => {
-      const thumbImage = `${config.get('amoCDN')}/full/12345.png`;
-      const addon = createInternalAddon({
-        previews: [
-          {
-            ...fakePreview,
-            thumbnail_url: thumbImage,
-          },
-        ],
-      });
-
-      const image = getPreviewImage(addon, { full: false });
-      expect(image).toEqual(thumbImage);
-    });
-
     it('returns null if the previews array is empty', () => {
       const addon = createInternalAddon({
         previews: [],
@@ -131,6 +116,24 @@ describe(__filename, () => {
       expect(image).toEqual(image300);
     });
 
+    it('returns the thumb image from the previews array when full and useStandardSize are false', () => {
+      const thumbImage = `${config.get('amoCDN')}/full/12345.png`;
+      const addon = createInternalAddon({
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url: thumbImage,
+          },
+        ],
+      });
+
+      const image = getPreviewImage(addon, {
+        full: false,
+        useStandardSize: false,
+      });
+      expect(image).toEqual(thumbImage);
+    });
+
     it('uses the first preview image when useStandardSize is true but the 720 size is not present', () => {
       const image300 = `${config.get('amoCDN')}/full/12345.png`;
       const addon = createInternalAddon({
@@ -149,6 +152,14 @@ describe(__filename, () => {
 
       const image = getPreviewImage(addon, { useStandardSize: true });
       expect(image).toEqual(image300);
+    });
+
+    it('returns an error if useStandardSize is true but full is false', () => {
+      const addon = createInternalAddon(fakeAddon);
+
+      expect(() => {
+        getPreviewImage(addon, { full: false });
+      }).toThrowError(/Currently there is no 'standard' thumbnail size/);
     });
   });
 });

--- a/tests/unit/core/test_imageUtils.js
+++ b/tests/unit/core/test_imageUtils.js
@@ -154,11 +154,11 @@ describe(__filename, () => {
       expect(image).toEqual(image300);
     });
 
-    it('returns an error if useStandardSize is true but full is false', () => {
+    it('throws an error if useStandardSize is true and full is false', () => {
       const addon = createInternalAddon(fakeAddon);
 
       expect(() => {
-        getPreviewImage(addon, { full: false });
+        getPreviewImage(addon, { full: false, useStandardSize: true });
       }).toThrowError(/Currently there is no 'standard' thumbnail size/);
     });
   });

--- a/tests/unit/core/test_imageUtils.js
+++ b/tests/unit/core/test_imageUtils.js
@@ -1,10 +1,6 @@
 import config from 'config';
 
-import {
-  getAddonIconUrl,
-  getPreviewImage,
-  getPreviewIndexBySize,
-} from 'core/imageUtils';
+import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon, fakePreview } from 'tests/unit/helpers';
 import fallbackIcon from 'amo/img/icons/default-64.png';
@@ -105,42 +101,9 @@ describe(__filename, () => {
       const image = getPreviewImage(addon);
       expect(image).toEqual(null);
     });
-  });
 
-  describe('getPreviewIndexBySize', () => {
-    it('finds the correct preview index by size', () => {
-      const size = 450;
-      const addon = createInternalAddon({
-        previews: [
-          {
-            ...fakePreview,
-            image_size: [400, 300],
-          },
-          {
-            ...fakePreview,
-            image_size: [size, 300],
-          },
-        ],
-      });
-      const imageIndex = getPreviewIndexBySize(addon, size);
-      expect(imageIndex).toEqual(1);
-    });
-
-    it('returns undefined if the size is not found', () => {
-      const size = 600;
-      const addon = createInternalAddon({
-        previews: [
-          {
-            ...fakePreview,
-            image_size: [200, 100],
-          },
-        ],
-      });
-      const imageIndex = getPreviewIndexBySize(addon, size);
-      expect(imageIndex).toEqual(undefined);
-    });
-
-    it('uses 720 size as the default size if not size is not provided', () => {
+    it('uses the standard preview size (720) if the useStandardSize prop is passed', () => {
+      const image720 = `${config.get('amoCDN')}/full/12345.png`;
       const addon = createInternalAddon({
         previews: [
           {
@@ -154,11 +117,33 @@ describe(__filename, () => {
           {
             ...fakePreview,
             image_size: [720, 520],
+            image_url: image720,
           },
         ],
       });
-      const imageIndex = getPreviewIndexBySize(addon);
-      expect(imageIndex).toEqual(2);
+
+      const image = getPreviewImage(addon, { useStandardSize: true });
+      expect(image).toEqual(image720);
+    });
+
+    it('returns the first preview image if the useStandardSize prop is passed but the 720 size is not present', () => {
+      const image300 = `${config.get('amoCDN')}/full/12345.png`;
+      const addon = createInternalAddon({
+        previews: [
+          {
+            ...fakePreview,
+            image_size: [300, 200],
+            image_url: image300,
+          },
+          {
+            ...fakePreview,
+            image_size: [500, 300],
+          },
+        ],
+      });
+
+      const image = getPreviewImage(addon, { useStandardSize: true });
+      expect(image).toEqual(image300);
     });
   });
 });

--- a/tests/unit/core/test_imageUtils.js
+++ b/tests/unit/core/test_imageUtils.js
@@ -1,6 +1,10 @@
 import config from 'config';
 
-import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
+import {
+  getAddonIconUrl,
+  getPreviewImage,
+  getPreviewIndexBySize,
+} from 'core/imageUtils';
 import { createInternalAddon } from 'core/reducers/addons';
 import { fakeAddon, fakePreview } from 'tests/unit/helpers';
 import fallbackIcon from 'amo/img/icons/default-64.png';
@@ -100,6 +104,61 @@ describe(__filename, () => {
 
       const image = getPreviewImage(addon);
       expect(image).toEqual(null);
+    });
+  });
+
+  describe('getPreviewIndexBySize', () => {
+    it('finds the correct preview index by size', () => {
+      const size = 450;
+      const addon = createInternalAddon({
+        previews: [
+          {
+            ...fakePreview,
+            image_size: [400, 300],
+          },
+          {
+            ...fakePreview,
+            image_size: [size, 300],
+          },
+        ],
+      });
+      const imageIndex = getPreviewIndexBySize(addon, size);
+      expect(imageIndex).toEqual(1);
+    });
+
+    it('returns undefined if the size is not found', () => {
+      const size = 600;
+      const addon = createInternalAddon({
+        previews: [
+          {
+            ...fakePreview,
+            image_size: [200, 100],
+          },
+        ],
+      });
+      const imageIndex = getPreviewIndexBySize(addon, size);
+      expect(imageIndex).toEqual(undefined);
+    });
+
+    it('uses 720 size as the default size if not size is not provided', () => {
+      const addon = createInternalAddon({
+        previews: [
+          {
+            ...fakePreview,
+            image_size: [300, 200],
+          },
+          {
+            ...fakePreview,
+            image_size: [500, 300],
+          },
+          {
+            ...fakePreview,
+            image_size: [720, 520],
+          },
+        ],
+      });
+      const imageIndex = getPreviewIndexBySize(addon);
+      expect(imageIndex).toEqual(2);
     });
   });
 });

--- a/tests/unit/core/test_imageUtils.js
+++ b/tests/unit/core/test_imageUtils.js
@@ -45,25 +45,6 @@ describe(__filename, () => {
       expect(image).toEqual(fullImage);
     });
 
-    it('returns the full image from index 1 in the previews array', () => {
-      const fullImage = `${config.get('amoCDN')}/full/12345.png`;
-      const addon = createInternalAddon({
-        previews: [
-          {
-            ...fakePreview,
-            image_url: `${config.get('amoCDN')}/image.not.used.here.png`,
-          },
-          {
-            ...fakePreview,
-            image_url: fullImage,
-          },
-        ],
-      });
-
-      const image = getPreviewImage(addon, { index: 1 });
-      expect(image).toEqual(fullImage);
-    });
-
     it('returns the thumb image from the previews array', () => {
       const thumbImage = `${config.get('amoCDN')}/full/12345.png`;
       const addon = createInternalAddon({
@@ -102,7 +83,7 @@ describe(__filename, () => {
       expect(image).toEqual(null);
     });
 
-    it('uses the standard preview size (720) if the useStandardSize prop is passed', () => {
+    it('uses the standard preview size (720) when useStandardSize is true', () => {
       const image720 = `${config.get('amoCDN')}/full/12345.png`;
       const addon = createInternalAddon({
         previews: [
@@ -126,7 +107,31 @@ describe(__filename, () => {
       expect(image).toEqual(image720);
     });
 
-    it('returns the first preview image if the useStandardSize prop is passed but the 720 size is not present', () => {
+    it('uses the first preview image when useStandardSize is false', () => {
+      const image300 = `${config.get('amoCDN')}/full/12345.png`;
+      const addon = createInternalAddon({
+        previews: [
+          {
+            ...fakePreview,
+            image_size: [300, 200],
+            image_url: image300,
+          },
+          {
+            ...fakePreview,
+            image_size: [500, 300],
+          },
+          {
+            ...fakePreview,
+            image_size: [720, 520],
+          },
+        ],
+      });
+
+      const image = getPreviewImage(addon, { useStandardSize: false });
+      expect(image).toEqual(image300);
+    });
+
+    it('uses the first preview image when useStandardSize is true but the 720 size is not present', () => {
       const image300 = `${config.get('amoCDN')}/full/12345.png`;
       const addon = createInternalAddon({
         previews: [

--- a/tests/unit/disco/components/TestAddon.js
+++ b/tests/unit/disco/components/TestAddon.js
@@ -495,6 +495,7 @@ describe(__filename, () => {
       const root = renderStaticTheme();
 
       expect(root.find(ThemeImage)).toHaveLength(1);
+      expect(root.find(ThemeImage)).toHaveProp('useStandardSize', false);
     });
 
     it("calls install and enable helper functions when clicking on the static theme's header image", async () => {

--- a/tests/unit/ui/components/TestThemeImage.js
+++ b/tests/unit/ui/components/TestThemeImage.js
@@ -103,7 +103,6 @@ describe(__filename, () => {
   });
 
   it('passes useStandardSize to display a preview with 720 width', () => {
-    const fullImage600 = `${config.get('amoCDN')}/full/600.png`;
     const fullImage720 = `${config.get('amoCDN')}/full/720.png`;
     const addon = createInternalAddon({
       ...fakeTheme,
@@ -112,7 +111,6 @@ describe(__filename, () => {
         {
           ...fakePreview,
           image_size: [600, 500],
-          image_url: fullImage600,
         },
         {
           ...fakePreview,
@@ -126,16 +124,12 @@ describe(__filename, () => {
     expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage720);
   });
 
-  it('passes index when it wants to specify a certain preview image', () => {
+  it('passes useStandardSize as false to display the first preview image', () => {
     const fullImage600 = `${config.get('amoCDN')}/full/600.png`;
     const addon = createInternalAddon({
       ...fakeTheme,
       type: ADDON_TYPE_STATIC_THEME,
       previews: [
-        {
-          ...fakePreview,
-          image_size: [500, 500],
-        },
         {
           ...fakePreview,
           image_size: [600, 500],
@@ -147,7 +141,7 @@ describe(__filename, () => {
         },
       ],
     });
-    const root = render({ addon, index: 1 });
+    const root = render({ addon, useStandardSize: false });
 
     expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage600);
   });

--- a/tests/unit/ui/components/TestThemeImage.js
+++ b/tests/unit/ui/components/TestThemeImage.js
@@ -102,7 +102,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes index if provided', () => {
+  it('passes useStandardSize to display a preview with 720 width', () => {
     const fullImage600 = `${config.get('amoCDN')}/full/600.png`;
     const fullImage720 = `${config.get('amoCDN')}/full/720.png`;
     const addon = createInternalAddon({
@@ -121,18 +121,21 @@ describe(__filename, () => {
         },
       ],
     });
-    const root = render({ addon, index: 1 });
+    const root = render({ addon, useStandardSize: true });
 
     expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage720);
   });
 
-  it('uses the default index if the index prop is not provided', () => {
+  it('passes index when it wants to specify a certain preview image', () => {
     const fullImage600 = `${config.get('amoCDN')}/full/600.png`;
-    const fullImage720 = `${config.get('amoCDN')}/full/720.png`;
     const addon = createInternalAddon({
       ...fakeTheme,
       type: ADDON_TYPE_STATIC_THEME,
       previews: [
+        {
+          ...fakePreview,
+          image_size: [500, 500],
+        },
         {
           ...fakePreview,
           image_size: [600, 500],
@@ -141,11 +144,10 @@ describe(__filename, () => {
         {
           ...fakePreview,
           image_size: [720, 500],
-          image_url: fullImage720,
         },
       ],
     });
-    const root = render({ addon });
+    const root = render({ addon, index: 1 });
 
     expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage600);
   });

--- a/tests/unit/ui/components/TestThemeImage.js
+++ b/tests/unit/ui/components/TestThemeImage.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import config from 'config';
 
 import {
   ADDON_TYPE_EXTENSION,
@@ -10,6 +11,7 @@ import ThemeImage, { ThemeImageBase } from 'ui/components/ThemeImage';
 import {
   fakeAddon,
   fakeI18n,
+  fakePreview,
   fakeTheme,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
@@ -98,5 +100,53 @@ describe(__filename, () => {
     expect(root.find('.ThemeImage')).toHaveClassName(
       'ThemeImage--rounded-corners',
     );
+  });
+
+  it('passes index if provided', () => {
+    const fullImage600 = `${config.get('amoCDN')}/full/600.png`;
+    const fullImage720 = `${config.get('amoCDN')}/full/720.png`;
+    const addon = createInternalAddon({
+      ...fakeTheme,
+      type: ADDON_TYPE_STATIC_THEME,
+      previews: [
+        {
+          ...fakePreview,
+          image_size: [600, 500],
+          image_url: fullImage600,
+        },
+        {
+          ...fakePreview,
+          image_size: [720, 500],
+          image_url: fullImage720,
+        },
+      ],
+    });
+    const root = render({ addon, index: 1 });
+
+    expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage720);
+  });
+
+  it('uses the default index if the index prop is not provided', () => {
+    const fullImage600 = `${config.get('amoCDN')}/full/600.png`;
+    const fullImage720 = `${config.get('amoCDN')}/full/720.png`;
+    const addon = createInternalAddon({
+      ...fakeTheme,
+      type: ADDON_TYPE_STATIC_THEME,
+      previews: [
+        {
+          ...fakePreview,
+          image_size: [600, 500],
+          image_url: fullImage600,
+        },
+        {
+          ...fakePreview,
+          image_size: [720, 500],
+          image_url: fullImage720,
+        },
+      ],
+    });
+    const root = render({ addon });
+
+    expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage600);
   });
 });


### PR DESCRIPTION
fixes #6507

This updates the header in the product detail and search results. 

Note: I created a method so it would be more dynamic since there is [discussion](https://github.com/mozilla/addons-server/issues/9419#issuecomment-424329033) of removing the other previews sizes.

some static themes (eg: eco theme) don't have the 720 sizes so it should default to using the first image in the previews array

EDIT
NOTE: I do have a follow up question to see if we should be updating this on disco too: See https://github.com/mozilla/addons-frontend/issues/6507#issuecomment-460373429

maybe that could be a follow up issue tho?
