### PR TITLE
Discrete styling for search results on small screens

### DIFF
--- a/src/amo/components/SearchContextCard/styles.scss
+++ b/src/amo/components/SearchContextCard/styles.scss
@@ -8,5 +8,4 @@
   @include respond-to(large) {
     font-size: $font-size-l;
   }
-
 }

--- a/src/amo/components/SearchContextCard/styles.scss
+++ b/src/amo/components/SearchContextCard/styles.scss
@@ -1,7 +1,12 @@
 @import '~amo/css/styles';
 
 .SearchContextCard-header {
-  font-size: $font-size-l;
+  font-size: $font-size-m;
+  font-weight: normal;
   margin: 0;
   word-wrap: break-word;
+
+  @include respond-to(large) {
+    font-size: $font-size-l;
+  }
 }

--- a/src/amo/components/SearchContextCard/styles.scss
+++ b/src/amo/components/SearchContextCard/styles.scss
@@ -2,11 +2,11 @@
 
 .SearchContextCard-header {
   font-size: $font-size-m;
-  font-weight: normal;
   margin: 0;
   word-wrap: break-word;
 
   @include respond-to(large) {
     font-size: $font-size-l;
   }
+
 }


### PR DESCRIPTION
Fixes #7530 

After:
![image](https://user-images.githubusercontent.com/22130317/52347359-bb019b00-2a47-11e9-9a87-bac48f140d42.png)

