### PR TITLE
Show all search results by default

### DIFF
--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -11,7 +11,7 @@ import NotFound from 'amo/components/ErrorPage/NotFound';
 import SearchContextCard from 'amo/components/SearchContextCard';
 import SearchFilters from 'amo/components/SearchFilters';
 import SearchResults from 'amo/components/SearchResults';
-import { resetSearch, searchStart } from 'core/reducers/search';
+import { searchStart } from 'core/reducers/search';
 import Paginate from 'core/components/Paginate';
 import {
   ADDON_TYPE_EXTENSION,
@@ -24,10 +24,7 @@ import {
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
-import {
-  convertFiltersToQueryParams,
-  hasSearchFilters,
-} from 'core/searchUtils';
+import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { AppState } from 'amo/store';
 import type { SearchFilters as SearchFiltersType } from 'core/api/search';
 import type { ErrorHandler as ErrorHandlerType } from 'core/errorHandler';
@@ -51,7 +48,7 @@ type InternalProps = {|
   count: number,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
-  filtersUsedForResults: SearchFiltersType,
+  filtersUsedForResults: SearchFiltersType | null,
   i18n: I18nType,
   loading: boolean,
   pageSize: string,
@@ -87,25 +84,24 @@ export class SearchBase extends React.Component<InternalProps> {
 
   dispatchSearch({
     newFilters = {},
-    oldFilters = {},
-  }: {| newFilters: SearchFiltersType, oldFilters: SearchFiltersType |} = {}) {
+    oldFilters,
+  }: {|
+    newFilters: SearchFiltersType,
+    oldFilters: ?SearchFiltersType,
+  |} = {}) {
     const { context, dispatch, errorHandler } = this.props;
     const { addonType } = newFilters;
 
     if (!deepEqual(oldFilters, newFilters)) {
-      if (hasSearchFilters(newFilters)) {
-        dispatch(
-          searchStart({
-            errorHandlerId: errorHandler.id,
-            filters: newFilters,
-          }),
-        );
+      dispatch(
+        searchStart({
+          errorHandlerId: errorHandler.id,
+          filters: newFilters,
+        }),
+      );
 
-        if (addonType) {
-          dispatch(setViewContext(addonType));
-        }
-      } else {
-        dispatch(resetSearch());
+      if (addonType) {
+        dispatch(setViewContext(addonType));
       }
     }
 

--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -196,7 +196,7 @@ export class SearchContextCardBase extends React.Component<InternalProps> {
 
 export function mapStateToProps(state: AppState) {
   const { search } = state;
-  const { filters = {} } = search;
+  const { filters } = search;
 
   let currentCategory;
   let categoryName = null;
@@ -218,7 +218,11 @@ export function mapStateToProps(state: AppState) {
       const appTypes = categoriesState[clientApp];
 
       if (appTypes) {
-        if (filters.addonType && typeof filters.addonType === 'string') {
+        if (
+          filters &&
+          filters.addonType &&
+          typeof filters.addonType === 'string'
+        ) {
           // eslint-disable-next-line prefer-destructuring
           let addonType = filters.addonType;
           if (addonType === ADDON_TYPE_THEMES_FILTER) {
@@ -239,7 +243,7 @@ export function mapStateToProps(state: AppState) {
     hasCategory: !!currentCategory,
     categoryName,
     count: search.count || 0,
-    filters,
+    filters: filters || {},
     loadingSearch: search.loading,
   };
 }

--- a/src/amo/components/SearchResults/index.js
+++ b/src/amo/components/SearchResults/index.js
@@ -6,7 +6,6 @@ import AddonsCard from 'amo/components/AddonsCard';
 import Paginate from 'core/components/Paginate';
 import { INSTALL_SOURCE_FEATURED, INSTALL_SOURCE_SEARCH } from 'core/constants';
 import translate from 'core/i18n/translate';
-import { hasSearchFilters } from 'core/searchUtils';
 import type { SearchFilters } from 'core/api/search';
 import type { AddonType, CollectionAddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
@@ -42,7 +41,7 @@ export class SearchResultsBase extends React.Component<InternalProps> {
       loadingMessage = (
         <div className="visually-hidden">{i18n.gettext('Searching…')}</div>
       );
-    } else if (count === 0 && hasSearchFilters(filters)) {
+    } else if (count === 0) {
       if (query) {
         messageText = i18n.sprintf(
           i18n.gettext('No results were found for "%(query)s".'),
@@ -53,10 +52,6 @@ export class SearchResultsBase extends React.Component<InternalProps> {
         // "no extensions" found that match your search or something.
         messageText = i18n.gettext('No results were found.');
       }
-    } else if (!hasSearchFilters(filters)) {
-      messageText = i18n.gettext(
-        'Please enter a search term to search Firefox Add-ons.',
-      );
     }
 
     const addonInstallSource = filters.featured
@@ -68,7 +63,7 @@ export class SearchResultsBase extends React.Component<InternalProps> {
         {loadingMessage}
         <AddonsCard
           addonInstallSource={addonInstallSource}
-          addons={hasSearchFilters(filters) ? results : null}
+          addons={results}
           footer={paginator}
           header={i18n.gettext('Search results')}
           loading={loading}

--- a/src/core/reducers/search.js
+++ b/src/core/reducers/search.js
@@ -13,11 +13,10 @@ export const SEARCH_STARTED: 'SEARCH_STARTED' = 'SEARCH_STARTED';
 export const SEARCH_LOADED: 'SEARCH_LOADED' = 'SEARCH_LOADED';
 
 const SEARCH_ABORTED: 'SEARCH_ABORTED' = 'SEARCH_ABORTED';
-const SEARCH_RESET: 'SEARCH_RESET' = 'SEARCH_RESET';
 
 export type SearchState = {|
   count: number,
-  filters: SearchFilters | {},
+  filters: SearchFilters | {} | null,
   loading: boolean,
   pageSize: string | null,
   results: Array<AddonType | CollectionAddonType>,
@@ -25,7 +24,7 @@ export type SearchState = {|
 
 export const initialState: SearchState = {
   count: 0,
-  filters: {},
+  filters: null,
   loading: false,
   pageSize: null,
   results: [],
@@ -37,14 +36,6 @@ type AbortSearchAction = {|
 
 export const abortSearch = (): AbortSearchAction => {
   return { type: SEARCH_ABORTED };
-};
-
-type ResetSearchAction = {|
-  type: typeof SEARCH_RESET,
-|};
-
-export const resetSearch = (): ResetSearchAction => {
-  return { type: SEARCH_RESET };
 };
 
 type SearchStartParams = {|
@@ -94,11 +85,7 @@ export function searchLoad({
   };
 }
 
-type Action =
-  | AbortSearchAction
-  | ResetSearchAction
-  | SearchStartAction
-  | SearchLoadAction;
+type Action = AbortSearchAction | SearchStartAction | SearchLoadAction;
 
 export default function search(
   state: SearchState = initialState,
@@ -134,8 +121,6 @@ export default function search(
         loading: false,
         results: [],
       };
-    case SEARCH_RESET:
-      return initialState;
     default:
       return state;
   }

--- a/src/core/reducers/search.js
+++ b/src/core/reducers/search.js
@@ -16,7 +16,7 @@ const SEARCH_ABORTED: 'SEARCH_ABORTED' = 'SEARCH_ABORTED';
 
 export type SearchState = {|
   count: number,
-  filters: SearchFilters | {} | null,
+  filters: SearchFilters | null,
   loading: boolean,
   pageSize: string | null,
   results: Array<AddonType | CollectionAddonType>,

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -114,15 +114,6 @@ export function convertOSToFilterValue(name) {
   return undefined;
 }
 
-export function hasSearchFilters(filters) {
-  const filtersSubset = { ...filters };
-  delete filtersSubset.clientApp;
-  delete filtersSubset.lang;
-  delete filtersSubset.page;
-  delete filtersSubset.page_size;
-  return filtersSubset && !!Object.keys(filtersSubset).length;
-}
-
 export const fixFiltersForAndroidThemes = ({ api, filters }) => {
   const newFilters = { ...filters };
 

--- a/tests/unit/amo/components/TestSearch.js
+++ b/tests/unit/amo/components/TestSearch.js
@@ -22,7 +22,7 @@ import {
 } from 'core/constants';
 import { DEFAULT_API_PAGE_SIZE, createApiError } from 'core/api';
 import { ErrorHandler } from 'core/errorHandler';
-import { resetSearch, searchStart } from 'core/reducers/search';
+import { searchStart } from 'core/reducers/search';
 import ErrorList from 'ui/components/ErrorList';
 import {
   createStubErrorHandler,
@@ -147,12 +147,18 @@ describe(__filename, () => {
     );
   });
 
-  it('dispatches a SEARCH_RESET when filters become empty', () => {
+  it('dispatches a search when filters become empty', () => {
     const root = render({ filters: { query: 'foo' } });
 
     root.setProps({ filters: {} });
 
-    sinon.assert.calledWith(props.dispatch, resetSearch());
+    sinon.assert.calledWith(
+      props.dispatch,
+      searchStart({
+        errorHandlerId: props.errorHandler.id,
+        filters: {},
+      }),
+    );
   });
 
   it('sets the viewContext to the addonType if addonType exists', () => {

--- a/tests/unit/amo/components/TestSearchResults.js
+++ b/tests/unit/amo/components/TestSearchResults.js
@@ -26,14 +26,6 @@ describe(__filename, () => {
     );
   }
 
-  it('renders empty search results container', () => {
-    const root = render();
-
-    expect(root.find('.SearchResults-message')).toHaveText(
-      'Please enter a search term to search Firefox Add-ons.',
-    );
-  });
-
   it('renders no results when searched but nothing is found', () => {
     const root = render({
       count: 0,
@@ -45,15 +37,6 @@ describe(__filename, () => {
     expect(root.find('.SearchResults-message')).toHaveText(
       'No results were found.',
     );
-  });
-
-  it('renders error when no search params exist', () => {
-    const root = render({ filters: {} });
-
-    expect(root.find('.SearchResults-message')).toHaveText(
-      'Please enter a search term to search Firefox Add-ons.',
-    );
-    expect(root.find(AddonsCard)).toHaveProp('addons', null);
   });
 
   it('renders error when no results and valid query', () => {

--- a/tests/unit/core/reducers/test_search.js
+++ b/tests/unit/core/reducers/test_search.js
@@ -2,16 +2,15 @@ import { createInternalAddon } from 'core/reducers/addons';
 import search, {
   abortSearch,
   initialState,
-  resetSearch,
   searchLoad,
   searchStart,
 } from 'core/reducers/search';
 import { fakeAddon } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  it('defaults to an set of filters', () => {
+  it('defaults to no filters', () => {
     const { filters } = search(undefined, { type: 'unrelated' });
-    expect(filters).toEqual({});
+    expect(filters).toEqual(null);
   });
 
   it('defaults to not loading', () => {
@@ -95,22 +94,6 @@ describe(__filename, () => {
       const { results } = getNextState();
 
       expect(results).toEqual(response.results.map(createInternalAddon));
-    });
-  });
-
-  describe('SEARCH_RESET', () => {
-    it('resets the state to its initial state', () => {
-      const state = search(
-        initialState,
-        searchStart({
-          errorHandlerId: 'foo',
-          filters: { query: 'foo' },
-        }),
-      );
-      expect(state).not.toEqual(initialState);
-
-      const newState = search(state, resetSearch());
-      expect(newState).toEqual(initialState);
     });
   });
 });


### PR DESCRIPTION
Fixes #6117

---

We do not reset filters anymore and we show all the results coming from the API, with or without filters.

In order to make sure a fresh call to `/search/` shows all the results, I changed the initial state from `filters: {}` to `filters: null` so that we call the API the very first time only.