### PR TITLE
I6376: show focus rectangles rectangles at home page

### DIFF
--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -65,7 +65,6 @@
   flex-flow: column wrap;
   justify-content: space-between;
   margin: 0 auto;
-  overflow: auto;
   padding: 0;
   width: 100%;
 


### PR DESCRIPTION
Fixes #6376

`.Home-SubjectShelf-list` should ideally never have overflow, so `overflow:auto` is kinda removable. `overflow: auto` causes this issue, adding 1px to top and bottom would have also helped, but I preferred removing `overflow`