### PR TITLE
Fixes #7580: Replaced break-all with break-word

### DIFF
--- a/src/disco/components/Addon/styles.scss
+++ b/src/disco/components/Addon/styles.scss
@@ -20,7 +20,7 @@ $addon-padding: 20px;
     color: $header-copy-font-color;
     font-size: 12px;
     margin: 0.75em 0;
-    word-break: break-all;
+    word-break: break-word;
 
     a:link,
     a:visited,

--- a/src/disco/components/Addon/styles.scss
+++ b/src/disco/components/Addon/styles.scss
@@ -79,7 +79,7 @@ $addon-padding: 20px;
     font-weight: medium;
     line-height: 1.2;
     margin: 0;
-    word-break: break-all;
+    word-break: break-word;
 
     a:link,
     a:visited,


### PR DESCRIPTION
Fixes #7580 
Replaced break-all with break-word in src/disco/components/Addon/styles.scss file at L23