### PR TITLE
Fix rating stars in edit mode on mobile

### DIFF
--- a/src/amo/components/AddonReviewManagerRating/styles.scss
+++ b/src/amo/components/AddonReviewManagerRating/styles.scss
@@ -1,4 +1,5 @@
 @import '~amo/css/styles';
+@import '~ui/components/Rating/styles';
 
 .AddonReviewManagerRating {
   display: flex;
@@ -9,6 +10,11 @@
     height: 36px;
     margin: 12px 0;
     width: 100%;
+
+    &.Rating--small .IconStar {
+      height: 75%;
+      width: 75%;
+    }
   }
 
   @include respond-to(large) {
@@ -20,6 +26,11 @@
       width: auto;
 
       @include margin-start(6px);
+
+      &.Rating--small .IconStar {
+        height: $icon-small;
+        width: $icon-small;
+      }
     }
   }
 }

--- a/src/ui/components/Rating/styles.scss
+++ b/src/ui/components/Rating/styles.scss
@@ -25,17 +25,6 @@ $icon-small: 13px;
         width: inherit;
       }
     }
-
-    &.Rating--editable {
-      .IconStar {
-        width: $icon-medium;
-
-        // stylelint-disable max-nesting-depth
-        @include respond-to(large) {
-          width: $icon-small;
-        }
-      }
-    }
   }
 
   // The width of large rating stars are controlled by the container.


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7581

Some screenshots of the components that this will apply to:

<img width="365" alt="screenshot 2019-02-13 16 59 12" src="https://user-images.githubusercontent.com/55398/52750491-079e2680-2fb2-11e9-8336-53a18785da47.png">
<img width="490" alt="screenshot 2019-02-13 17 00 13" src="https://user-images.githubusercontent.com/55398/52750492-079e2680-2fb2-11e9-86a1-edc66c4c4202.png">
<img width="362" alt="screenshot 2019-02-13 17 00 28" src="https://user-images.githubusercontent.com/55398/52750494-079e2680-2fb2-11e9-8e28-4d3c3771ba1c.png">
<img width="348" alt="screenshot 2019-02-13 17 00 53" src="https://user-images.githubusercontent.com/55398/52750495-0836bd00-2fb2-11e9-9804-af5583c83ed4.png">
<img width="560" alt="screenshot 2019-02-13 17 01 12" src="https://user-images.githubusercontent.com/55398/52750497-0836bd00-2fb2-11e9-9d6c-1e673219213a.png">
<img width="362" alt="screenshot 2019-02-13 17 01 29" src="https://user-images.githubusercontent.com/55398/52750498-0836bd00-2fb2-11e9-9780-d8700a71f9ca.png">


