### PR TITLE
add ShowMoreCard component to collapse long reviews

### DIFF
--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -8,6 +8,7 @@ import translate from 'core/i18n/translate';
 import { nl2br, sanitizeHTML } from 'core/utils';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
+import ShowMoreCard from 'ui/components/ShowMoreCard';
 import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { I18nType } from 'core/types/i18n';
@@ -32,12 +33,14 @@ type InternalProps = {|
 function reviewBody({
   content,
   html,
+  id,
 }: {|
   content?: React.Node | string,
   html?: React.Node,
+  id: string,
 |}) {
   invariant(
-    content !== undefined || html !== undefined,
+    content !== undefined || html !== undefined || id !== undefined,
     'content or html is required',
   );
 
@@ -50,13 +53,15 @@ function reviewBody({
   }
 
   return (
-    <div
+    <ShowMoreCard
       className={makeClassName('UserReview-body', {
         // Add an extra class if the content is an empty string.
         'UserReview-emptyBody': !content && !html,
       })}
-      {...bodyAttr}
-    />
+      id={id}
+    >
+      <div {...bodyAttr} />
+    </ShowMoreCard>
   );
 }
 
@@ -72,15 +77,17 @@ export const UserReviewBase = (props: InternalProps) => {
     showRating = false,
   } = props;
 
-  let body = reviewBody({ content: <LoadingText /> });
+  const showMoreId = review && review.id ? `${review.id}` : '0';
+  let body = reviewBody({ content: <LoadingText />, id: showMoreId });
 
   if (review) {
     if (review.body) {
       body = reviewBody({
         html: sanitizeHTML(nl2br(review.body), ['br']),
+        id: showMoreId,
       });
     } else {
-      body = reviewBody({ content: '' });
+      body = reviewBody({ content: '', id: showMoreId });
     }
   }
 


### PR DESCRIPTION
Fixes #6242, so that long text in add-on reviews gets collapsed and becomes expandable by clicking a 'read more' link (see image for example of problem in the original issue).

This PR modifies the code in the `reviewBody()` function to use the `ShowMoreCard` for reviews that exceed a certain line height.

After editing or submitting a review that exceeds maximum height, the review renders and behaves as follows:  
  
![show_more_card](https://user-images.githubusercontent.com/26360553/49330854-6aab2000-f562-11e8-832c-d9da9bf5ec83.gif)  
  
When user navigates to 'Read all reviews' page, long reviews are truncated with expandable read more link:  
  
![review_list](https://user-images.githubusercontent.com/26360553/49330876-e86f2b80-f562-11e8-9441-a76f74abfa70.gif)

Trying to solve some environment problem related to `jest`, but in the meantime if someone can provide some direction regarding testing, that'd be much appreciated :)