### PR TITLE
Fix NotFound component so that it handles localized strings with 2 li…

### DIFF
--- a/tests/unit/amo/components/ErrorPage/TestNotFound.js
+++ b/tests/unit/amo/components/ErrorPage/TestNotFound.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { oneLine } from 'common-tags';
 
 import NotFound, { NotFoundBase } from 'amo/components/ErrorPage/NotFound';
 import Link from 'amo/components/Link';
@@ -52,5 +53,35 @@ describe(__filename, () => {
     expect(landingLinks).toHaveLength(2);
     expect(landingLinks.at(0)).toHaveProp('to', '/extensions/');
     expect(landingLinks.at(1)).toHaveProp('to', '/themes/');
+  });
+
+  it('handles a localized string with links inverted', () => {
+    const localizedString = oneLine`Try visiting the page later, as the theme
+      or extension may become available again. Alternatively, you may be able
+      to find what you’re looking for in one of the available
+      %(secondLinkStart)sthemes%(secondLinkEnd)s or
+      %(linkStart)sextensions%(linkEnd)s.`;
+
+    const i18n = fakeI18n();
+    // We override the `gettext` function to inject a localized string with the
+    // two links inverted. This was the issue in
+    // https://github.com/mozilla/addons-frontend/issues/7597.
+    i18n.gettext = (string) => {
+      if (string.startsWith('Try visiting')) {
+        return localizedString;
+      }
+
+      return string;
+    };
+
+    // It should not crash.
+    const root = render({ i18n });
+    const landingLinks = root
+      .find('.ErrorPage-paragraph-with-links')
+      .at(1)
+      .find(Link);
+    expect(landingLinks).toHaveLength(2);
+    expect(landingLinks.at(0)).toHaveProp('to', '/themes/');
+    expect(landingLinks.at(1)).toHaveProp('to', '/extensions/');
   });
 });


### PR DESCRIPTION
Fixes #7597

---

This patch fixes the root cause of #7597 by inspecting the localized string.

You can see it in action by applying this patch and restarting the AMO app locally:

```diff
diff --git a/locale/pt_BR/LC_MESSAGES/amo.po b/locale/pt_BR/LC_MESSAGES/amo.po
index ae8e04f8e..b06ac54c0 100644
--- a/locale/pt_BR/LC_MESSAGES/amo.po
+++ b/locale/pt_BR/LC_MESSAGES/amo.po
@@ -852,8 +852,8 @@ msgid ""
 msgstr ""
 "Tente visitar a página mais tarde, já que o tema ou extensão pode estar "
 "disponível novamente. Como alternativa, você pode conseguir encontrar o que "
-"estava procurando em um dos %(linkStart)sextensões%(linkEnd)s ou "
-"%(secondLinkStart)stemas%(secondLinkEnd)s disponíveis."
+"estava procurando em um dos %(secondLinkStart)stemas%(secondLinkEnd)s ou "
+"%(linkStart)sextensões%(linkEnd)s disponíveis."
 
 #: src/amo/components/ErrorPage/NotFound/index.js:60
 msgid "Oops! We can’t find that page"
```

Then browse: http://localhost:3000/pt-BR/firefox/addon/video-downloadhelperrr/?src=featured

You should see a 404 page and the two links, inverted yet valid and no errors:

![screen shot 2019-02-22 at 16 15 39](https://user-images.githubusercontent.com/217628/53251823-d57d7a80-36bd-11e9-88bb-8604d6250611.png)
