### PR TITLE
Stop searching for lightweight themes to prevent an API error

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -51,7 +51,7 @@ export const ADDON_TYPE_OPENSEARCH = 'search';
 export const ADDON_TYPE_STATIC_THEME = 'statictheme';
 export const ADDON_TYPE_THEME = 'persona';
 export const ADDON_TYPE_THEMES = [ADDON_TYPE_STATIC_THEME, ADDON_TYPE_THEME];
-export const ADDON_TYPE_THEMES_FILTER = ADDON_TYPE_THEMES.join(',');
+export const ADDON_TYPE_THEMES_FILTER = ADDON_TYPE_STATIC_THEME;
 // TODO: Remove ADDON_TYPE_COMPLETE_THEME once we don't support complete
 // themes.
 export const ADDON_TYPE_COMPLETE_THEME = 'theme';

--- a/tests/unit/amo/components/TestAddonsByAuthorsCard.js
+++ b/tests/unit/amo/components/TestAddonsByAuthorsCard.js
@@ -467,20 +467,12 @@ describe(__filename, () => {
   it('should display at most numberOfAddons themes', () => {
     const numberOfAddons = 3;
     const root = renderAddonsWithType({
-      addonType: ADDON_TYPE_THEME,
+      addonType: ADDON_TYPE_STATIC_THEME,
       multipleAuthors: false,
       numberOfAddons,
     });
 
     expect(root.find(AddonsCard).props().addons).toHaveLength(numberOfAddons);
-  });
-
-  it('should add a theme class if it is a lightweight theme', () => {
-    const root = renderAddonsWithType({
-      addonType: ADDON_TYPE_THEME,
-    });
-
-    expect(root).toHaveClassName('AddonsByAuthorsCard--theme');
   });
 
   it('should add a theme class if it is a static theme', () => {
@@ -641,18 +633,6 @@ describe(__filename, () => {
     );
   });
 
-  it('shows extensions in header for a lightweight theme', () => {
-    const root = renderAddonsWithType({
-      addonType: ADDON_TYPE_THEME,
-      multipleAuthors: false,
-    });
-
-    expect(root.find(AddonsCard)).toHaveProp(
-      'header',
-      `More themes by ${fakeAuthor.name}`,
-    );
-  });
-
   it('shows extensions in header for a static theme', () => {
     const root = renderAddonsWithType({
       addonType: ADDON_TYPE_STATIC_THEME,
@@ -662,19 +642,6 @@ describe(__filename, () => {
     expect(root.find(AddonsCard)).toHaveProp(
       'header',
       `More themes by ${fakeAuthor.name}`,
-    );
-  });
-
-  it('shows extensions in header for a lightweight theme without More text', () => {
-    const root = renderAddonsWithType({
-      addonType: ADDON_TYPE_THEME,
-      showMore: false,
-      multipleAuthors: false,
-    });
-
-    expect(root.find(AddonsCard)).toHaveProp(
-      'header',
-      `Themes by ${fakeAuthor.name}`,
     );
   });
 
@@ -691,18 +658,6 @@ describe(__filename, () => {
     );
   });
 
-  it('shows extensions in header for a lightweight theme with multiple authors', () => {
-    const root = renderAddonsWithType({
-      addonType: ADDON_TYPE_THEME,
-      multipleAuthors: true,
-    });
-
-    expect(root.find(AddonsCard)).toHaveProp(
-      'header',
-      'More themes by these artists',
-    );
-  });
-
   it('shows extensions in header for a static theme with multiple authors', () => {
     const root = renderAddonsWithType({
       addonType: ADDON_TYPE_STATIC_THEME,
@@ -712,19 +667,6 @@ describe(__filename, () => {
     expect(root.find(AddonsCard)).toHaveProp(
       'header',
       'More themes by these artists',
-    );
-  });
-
-  it('shows extensions in header for a lightweight theme with multiple authors and without More text ', () => {
-    const root = renderAddonsWithType({
-      addonType: ADDON_TYPE_THEME,
-      showMore: false,
-      multipleAuthors: true,
-    });
-
-    expect(root.find(AddonsCard)).toHaveProp(
-      'header',
-      'Themes by these artists',
     );
   });
 

--- a/tests/unit/amo/reducers/test_addonsByAuthors.js
+++ b/tests/unit/amo/reducers/test_addonsByAuthors.js
@@ -737,33 +737,6 @@ describe(__filename, () => {
       ]);
     });
 
-    it("returns lightweight themes when filtering for authors' themes", () => {
-      const addons = fakeExternalAddons({ type: ADDON_TYPE_THEME });
-
-      const authorIds = [
-        fakeAuthorOne.id,
-        fakeAuthorTwo.id,
-        fakeAuthorThree.id,
-      ];
-      const state = reducer(
-        undefined,
-        loadAddonsByAuthors({
-          addons: Object.values(addons),
-          addonType: ADDON_TYPE_THEME,
-          authorIds,
-          count: Object.values(addons).length,
-          pageSize: THEMES_BY_AUTHORS_PAGE_SIZE,
-        }),
-      );
-
-      expect(getAddonsForAuthorIds(state, authorIds, ADDON_TYPE_THEME)).toEqual(
-        [
-          createInternalAddon(addons.firstAddon),
-          createInternalAddon(addons.secondAddon),
-        ],
-      );
-    });
-
     it("returns static themes when filtering for authors' themes ", () => {
       const addons = fakeExternalAddons({ type: ADDON_TYPE_STATIC_THEME });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7584

I was able to reproduce the bug locally before fixing it.

I don't really know what I'm doing here TBH. Lightweight themes have been removed entirely, correct? I deleted some tests which were only related to lightweight themes. Each one had a complimentary test using a static theme and those are still passing.