### PR TITLE
Fixes #7579: Choose Language Select BG is always White

### DIFF
--- a/src/amo/components/Footer/styles.scss
+++ b/src/amo/components/Footer/styles.scss
@@ -150,6 +150,7 @@
   }
 
   .LanguagePicker-selector {
+    background-color: $white;
     color: $black;
     display: inline-block;
   }


### PR DESCRIPTION
Fixes #7579: Choose Language Select BG is always White
![image](https://user-images.githubusercontent.com/10033914/53335779-65236300-3922-11e9-8b14-efc282aea9a8.png)
