### PR TITLE
Fixes #7646: Text in the 'Log in to rate extension' button is center …

### DIFF
--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -12,6 +12,7 @@
   left: 50%;
   padding: 2px 16px;
   position: absolute;
+  text-align: center;
   top: 50%;
   transform: translate(-50%, -50%);
   width: 100%;


### PR DESCRIPTION
Fixes #7646: Text in the 'Log in to rate extension' button is in center