### PR TITLE
Fixes #6773: Keeping the edit page open after the page is refreshed

### DIFF
--- a/src/amo/components/CollectionDetails/index.js
+++ b/src/amo/components/CollectionDetails/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import type { AppState } from 'amo/store';
 
 import {
   beginEditingCollectionDetails,
@@ -20,6 +21,7 @@ import type {
 } from 'amo/reducers/collections';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
+import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
@@ -35,6 +37,7 @@ type InternalProps = {|
   ...Props,
   dispatch: DispatchFunc,
   i18n: I18nType,
+  location: ReactRouterLocationType,
 |};
 
 export class CollectionDetailsBase extends React.Component<InternalProps> {
@@ -46,6 +49,13 @@ export class CollectionDetailsBase extends React.Component<InternalProps> {
 
     dispatch(beginEditingCollectionDetails());
   };
+
+  componentDidMount() {
+    const { dispatch, location } = this.props;
+    if (location.pathname.indexOf('edit') >= 1) {
+      dispatch(beginEditingCollectionDetails());
+    }
+  }
 
   render() {
     const {
@@ -131,9 +141,15 @@ export class CollectionDetailsBase extends React.Component<InternalProps> {
   }
 }
 
+const mapStateToProps = (state: AppState) => {
+  return {
+    location: state.router.location,
+  };
+};
+
 const CollectionDetails: React.ComponentType<Props> = compose(
   translate(),
-  connect(),
+  connect(mapStateToProps),
 )(CollectionDetailsBase);
 
 export default CollectionDetails;

--- a/src/amo/components/CollectionDetails/index.js
+++ b/src/amo/components/CollectionDetails/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+
 import type { AppState } from 'amo/store';
 
 import {

--- a/src/amo/components/CollectionDetails/index.js
+++ b/src/amo/components/CollectionDetails/index.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import type { AppState } from 'amo/store';
-
 import {
   beginEditingCollectionDetails,
   collectionEditUrl,

--- a/src/amo/components/CollectionManager/index.js
+++ b/src/amo/components/CollectionManager/index.js
@@ -11,6 +11,7 @@ import {
   createCollection,
   finishEditingCollectionDetails,
   updateCollection,
+  collectionUrl,
 } from 'amo/reducers/collections';
 import { getCurrentUser } from 'amo/reducers/users';
 import { withFixedErrorHandler } from 'core/errorHandler';
@@ -98,7 +99,15 @@ export class CollectionManagerBase extends React.Component<
   }
 
   onCancel = (event: SyntheticEvent<HTMLButtonElement>) => {
-    const { clientApp, creating, dispatch, history, siteLang } = this.props;
+    const {
+      clientApp,
+      creating,
+      collection,
+      location,
+      dispatch,
+      history,
+      siteLang,
+    } = this.props;
 
     if (creating) {
       if (siteLang) {
@@ -110,6 +119,13 @@ export class CollectionManagerBase extends React.Component<
 
     event.preventDefault();
     event.stopPropagation();
+    if (location.pathname.indexOf('edit') >= 1) {
+      if (siteLang) {
+        history.push(
+          `/${siteLang}/${clientApp}${collectionUrl({ collection })}`,
+        );
+      }
+    }
 
     dispatch(finishEditingCollectionDetails());
   };


### PR DESCRIPTION
Fixes #6773: Keeping the edit page open after the page is refreshed