### PR TITLE
Fix themes on homepage

### DIFF
--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -54,21 +54,25 @@ export const getFeaturedCollectionsMetadata = (i18n) => {
     {
       footerText: i18n.gettext('See more video extensions'),
       header: i18n.gettext('Extensions for enhancing video'),
+      isTheme: false,
       ...FEATURED_COLLECTIONS[0],
     },
     {
       footerText: i18n.gettext('See more spring themes'),
       header: i18n.gettext('Spring themes'),
+      isTheme: true,
       ...FEATURED_COLLECTIONS[1],
     },
     {
       footerText: i18n.gettext('See more Wikipedia boosters'),
       header: i18n.gettext('Wikipedia boosters'),
+      isTheme: false,
       ...FEATURED_COLLECTIONS[2],
     },
     {
       footerText: i18n.gettext('See more tab extensions'),
       header: i18n.gettext('Change up your tabs'),
+      isTheme: false,
       ...FEATURED_COLLECTIONS[3],
     },
   ];

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -459,4 +459,36 @@ describe(__filename, () => {
 
     expect(root.find(HeadLinks)).toHaveLength(1);
   });
+
+  describe('getFeaturedCollectionsMetadata', () => {
+    it('exposes a `footerText` prop', () => {
+      const metadata = getFeaturedCollectionsMetadata(fakeI18n());
+
+      expect(metadata[0]).toHaveProperty('footerText');
+    });
+
+    it('exposes a `header` prop', () => {
+      const metadata = getFeaturedCollectionsMetadata(fakeI18n());
+
+      expect(metadata[0]).toHaveProperty('header');
+    });
+
+    it('exposes a `slug` prop', () => {
+      const metadata = getFeaturedCollectionsMetadata(fakeI18n());
+
+      expect(metadata[0]).toHaveProperty('slug');
+    });
+
+    it('exposes a `userId` prop', () => {
+      const metadata = getFeaturedCollectionsMetadata(fakeI18n());
+
+      expect(metadata[0]).toHaveProperty('userId');
+    });
+
+    it('exposes a `isTheme` prop', () => {
+      const metadata = getFeaturedCollectionsMetadata(fakeI18n());
+
+      expect(metadata[0]).toHaveProperty('isTheme');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #7746

---

It turns out that `isTheme` was more useful than expected 😓 

## Screenshots

Before:

![Screen Shot 2019-03-21 at 18 32 39](https://user-images.githubusercontent.com/217628/54772480-b82dc480-4c07-11e9-8090-faac130271f1.png)


After:

![Screen Shot 2019-03-21 at 18 32 25](https://user-images.githubusercontent.com/217628/54772470-b2d07a00-4c07-11e9-820e-3a35139c9a89.png)

