### PR TITLE
Fix list padding in release notes I7732

### DIFF
--- a/src/amo/pages/AddonVersions/styles.scss
+++ b/src/amo/pages/AddonVersions/styles.scss
@@ -24,6 +24,13 @@
         }
       }
     }
+
+    .AddonVersionCard-releaseNotes ul {
+      li {
+        list-style-position: inside;
+        padding: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fix #7732 

I cannot find addon release notes with `ul` tag for test. So I only manually add `ul` into `<div class="AddonVersionCard-releaseNotes"></div>` and it looks ok.

![image](https://user-images.githubusercontent.com/4984681/54838685-2952a200-4d04-11e9-9045-58510be25381.png)

