### PR TITLE
Fixes #7655: Enter doesn't do anything after the hover over suggestion

### DIFF
--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -254,6 +254,11 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
       return;
     }
 
+    if(event.keyCode == 13){
+      // Because of issue #7655
+      return;
+    }
+
     this.setState({ autocompleteIsOpen: false, searchValue: '' });
     this.props.onSuggestionSelected(suggestion);
   };

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -254,7 +254,7 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
       return;
     }
 
-    if(event.keyCode == 13){
+    if (event.keyCode === 13) {
       // Because of issue #7655
       return;
     }


### PR DESCRIPTION
Fixes #7655: Enter doesn't do anything after the hover over suggestion