### PR TITLE
Correct version history page capitalization

### DIFF
--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -123,8 +123,8 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
     if (addon && versions) {
       header = i18n.sprintf(
         i18n.ngettext(
-          '%(addonName)s Version history - %(total)s version',
-          '%(addonName)s Version history - %(total)s versions',
+          '%(addonName)s version history - %(total)s version',
+          '%(addonName)s version history - %(total)s versions',
           versions.length,
         ),
         {

--- a/tests/unit/amo/pages/TestAddonVersions.js
+++ b/tests/unit/amo/pages/TestAddonVersions.js
@@ -299,7 +299,7 @@ describe(__filename, () => {
     const slug = 'some-addon-slug';
     const addon = { ...fakeAddon, slug };
     const versions = [fakeVersion];
-    const expectedHeader = `${addon.name} Version history - ${
+    const expectedHeader = `${addon.name} version history - ${
       versions.length
     } version`;
 
@@ -321,7 +321,7 @@ describe(__filename, () => {
     const slug = 'some-addon-slug';
     const addon = { ...fakeAddon, slug };
     const versions = [fakeVersion, fakeVersion];
-    const expectedHeader = `${addon.name} Version history - ${
+    const expectedHeader = `${addon.name} version history - ${
       versions.length
     } versions`;
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7825

- [x] Add a description of the changes introduced in this PR.
- [x] The change has been successfully run locally.
- [x] Add tests to cover the changes added in this PR.
- [x] Add before and after screenshots (Only for changes that impact the UI).

Description:

This fixes a capitalization issue with the version history page.

Before:
![image](https://user-images.githubusercontent.com/27789806/55444894-544bba00-557e-11e9-9a45-e2fe58eda3de.png)
After:
![image](https://user-images.githubusercontent.com/27789806/55444897-5c0b5e80-557e-11e9-974c-7b413fbbec15.png)


