### PR TITLE
Add basic UsersUnsubscribe page

### DIFF
--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -28,6 +28,7 @@ import SearchPage from 'amo/pages/SearchPage';
 import ServerError from 'amo/components/ErrorPage/ServerError';
 import UserProfile from 'amo/pages/UserProfile';
 import UserProfileEdit from 'amo/pages/UserProfileEdit';
+import UsersUnsubscribe from 'amo/pages/UsersUnsubscribe';
 import SimulateAsyncError from 'core/pages/error-simulation/SimulateAsyncError';
 import SimulateClientError from 'core/pages/error-simulation/SimulateClientError';
 import SimulateSyncError from 'core/pages/error-simulation/SimulateSyncError';
@@ -203,6 +204,12 @@ const Routes = ({ _config = config }: Props = {}) => (
       exact
       path="/:lang/:application/:visibleAddonType(extensions|themes)/"
       component={LandingPage}
+    />
+
+    <Route
+      exact
+      path="/:lang/:application/users/unsubscribe/:token/:hash/:notificationName/"
+      component={UsersUnsubscribe}
     />
 
     <Route component={NotFound} />

--- a/src/amo/components/UserProfileEditNotifications/index.js
+++ b/src/amo/components/UserProfileEditNotifications/index.js
@@ -4,6 +4,7 @@ import { oneLine } from 'common-tags';
 import * as React from 'react';
 import { compose } from 'redux';
 
+import { getNotificationDescription } from 'amo/utils/notifications';
 import log from 'core/logger';
 import translate from 'core/i18n/translate';
 import LoadingText from 'ui/components/LoadingText';
@@ -11,32 +12,6 @@ import type { UserType } from 'amo/reducers/users';
 import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
-
-export const getLabelText = (i18n: I18nType, name: string): string | null => {
-  switch (name) {
-    case 'announcements':
-      return i18n.gettext(`stay up-to-date with news and events relevant to
-        add-on developers (including the about:addons newsletter)`);
-    case 'individual_contact':
-      return i18n.gettext(`Mozilla needs to contact me about my individual
-        add-on`);
-    case 'new_features':
-      return i18n.gettext('new add-ons or Firefox features are available');
-    case 'new_review':
-      return i18n.gettext('someone writes a review of my add-on');
-    case 'reply':
-      return i18n.gettext('an add-on developer replies to my review');
-    case 'reviewer_reviewed':
-      return i18n.gettext('my add-on is reviewed by a reviewer');
-    case 'upgrade_fail':
-      return i18n.gettext(`my add-on's compatibility cannot be upgraded`);
-    case 'upgrade_success':
-      return i18n.gettext(`my add-on's compatibility is upgraded successfully`);
-    default:
-  }
-
-  return null;
-};
 
 type CreateNotificationParams = {|
   enabled: boolean,
@@ -116,7 +91,7 @@ export const UserProfileEditNotificationsBase = ({
     notifications = user.notifications.map((notification) =>
       createNotification({
         ...notification,
-        label: getLabelText(i18n, notification.name),
+        label: getNotificationDescription(i18n, notification.name),
         onChange,
       }),
     );

--- a/src/amo/pages/UsersUnsubscribe/index.js
+++ b/src/amo/pages/UsersUnsubscribe/index.js
@@ -1,0 +1,94 @@
+/* @flow */
+import * as React from 'react';
+import Helmet from 'react-helmet';
+import { compose } from 'redux';
+import base64url from 'base64url';
+
+import Link from 'amo/components/Link';
+import { getNotificationDescription } from 'amo/utils/notifications';
+import Card from 'ui/components/Card';
+import translate from 'core/i18n/translate';
+import { sanitizeHTML } from 'core/utils';
+import { getLocalizedTextWithLinkParts } from 'core/utils/i18n';
+import type {
+  ReactRouterLocationType,
+  ReactRouterMatchType,
+} from 'core/types/router';
+import type { I18nType } from 'core/types/i18n';
+
+import './styles.scss';
+
+type Props = {|
+  location: ReactRouterLocationType,
+  match: {|
+    ...ReactRouterMatchType,
+    params: {|
+      hash: string,
+      token: string,
+      notificationName: string,
+    |},
+  |},
+|};
+
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
+|};
+
+export class UsersUnsubscribeBase extends React.Component<InternalProps> {
+  render() {
+    const { i18n, match } = this.props;
+    const { token, notificationName } = match.params;
+
+    const linkEditProfileParts = getLocalizedTextWithLinkParts({
+      i18n,
+      text: i18n.gettext(
+        'You can edit your notification settings by %(linkStart)sediting your profile%(linkEnd)s.',
+      ),
+    });
+
+    return (
+      <div className="UsersUnsubscribe">
+        <Helmet>
+          <title>{i18n.gettext('Unsubscribe')}</title>
+        </Helmet>
+
+        <Card header={i18n.gettext('You are successfully unsubscribed!')}>
+          <p
+            className="UsersUnsubscribe-content-explanation"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={sanitizeHTML(
+              i18n.sprintf(
+                i18n.gettext(
+                  `The email address %(strongStart)s%(email)s%(strongEnd)s will
+                  no longer get messages when:`,
+                ),
+                {
+                  strongStart: '<strong>',
+                  strongEnd: '</strong>',
+                  email: base64url.decode(token),
+                },
+              ),
+              ['strong'],
+            )}
+          />
+          <blockquote className="UsersUnsubscribe-content-notification">
+            {getNotificationDescription(i18n, notificationName)}
+          </blockquote>
+
+          <p className="UsersUnsubscribe-content-edit-profile">
+            {linkEditProfileParts.beforeLinkText}
+            <Link to="/users/edit">{linkEditProfileParts.innerLinkText}</Link>
+            {linkEditProfileParts.afterLinkText}
+          </p>
+        </Card>
+      </div>
+    );
+  }
+}
+
+const UsersUnsubscribe: React.ComponentType<Props> = compose(translate())(
+  UsersUnsubscribeBase,
+);
+
+export default UsersUnsubscribe;

--- a/src/amo/pages/UsersUnsubscribe/index.js
+++ b/src/amo/pages/UsersUnsubscribe/index.js
@@ -59,6 +59,7 @@ export class UsersUnsubscribeBase extends React.Component<InternalProps> {
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={sanitizeHTML(
               i18n.sprintf(
+                // translators: a list of notifications will be displayed under this prompt.
                 i18n.gettext(
                   `The email address %(strongStart)s%(email)s%(strongEnd)s will
                   no longer get messages when:`,

--- a/src/amo/pages/UsersUnsubscribe/styles.scss
+++ b/src/amo/pages/UsersUnsubscribe/styles.scss
@@ -1,0 +1,19 @@
+@import '~amo/css/styles';
+
+.UsersUnsubscribe {
+  @include page-padding();
+
+  .UsersUnsubscribe-content-explanation,
+  .UsersUnsubscribe-content-edit-profile,
+  .UsersUnsubscribe-content-notification {
+    font-size: $font-size-default;
+  }
+
+  .UsersUnsubscribe-content-notification {
+    font-style: italic;
+  }
+
+  .UsersUnsubscribe-content-edit-profile {
+    margin-top: 36px;
+  }
+}

--- a/src/amo/utils/notifications.js
+++ b/src/amo/utils/notifications.js
@@ -1,0 +1,31 @@
+/* @flow */
+import type { I18nType } from 'core/types/i18n';
+
+export const getNotificationDescription = (
+  i18n: I18nType,
+  name: string,
+): string | null => {
+  switch (name) {
+    case 'announcements':
+      return i18n.gettext(`stay up-to-date with news and events relevant to
+        add-on developers (including the about:addons newsletter)`);
+    case 'individual_contact':
+      return i18n.gettext(`Mozilla needs to contact me about my individual
+        add-on`);
+    case 'new_features':
+      return i18n.gettext('new add-ons or Firefox features are available');
+    case 'new_review':
+      return i18n.gettext('someone writes a review of my add-on');
+    case 'reply':
+      return i18n.gettext('an add-on developer replies to my review');
+    case 'reviewer_reviewed':
+      return i18n.gettext('my add-on is reviewed by a reviewer');
+    case 'upgrade_fail':
+      return i18n.gettext(`my add-on's compatibility cannot be upgraded`);
+    case 'upgrade_success':
+      return i18n.gettext(`my add-on's compatibility is upgraded successfully`);
+    default:
+  }
+
+  return null;
+};

--- a/src/amo/utils/notifications.js
+++ b/src/amo/utils/notifications.js
@@ -25,7 +25,6 @@ export const getNotificationDescription = (
     case 'upgrade_success':
       return i18n.gettext(`my add-on's compatibility is upgraded successfully`);
     default:
+      return null;
   }
-
-  return null;
 };

--- a/tests/unit/amo/components/TestRoutes.js
+++ b/tests/unit/amo/components/TestRoutes.js
@@ -16,7 +16,7 @@ describe(__filename, () => {
   it('renders the routes for the amo app', () => {
     const root = render();
 
-    expect(root.find(Route)).toHaveLength(33);
+    expect(root.find(Route)).toExist();
   });
 
   describe('path = /:lang/:application/401/', () => {

--- a/tests/unit/amo/components/TestRoutes.js
+++ b/tests/unit/amo/components/TestRoutes.js
@@ -16,7 +16,7 @@ describe(__filename, () => {
   it('renders the routes for the amo app', () => {
     const root = render();
 
-    expect(root.find(Route)).toHaveLength(32);
+    expect(root.find(Route)).toHaveLength(33);
   });
 
   describe('path = /:lang/:application/401/', () => {

--- a/tests/unit/amo/components/TestUserProfileEditNotifications.js
+++ b/tests/unit/amo/components/TestUserProfileEditNotifications.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
+import { getNotificationDescription } from 'amo/utils/notifications';
 import UserProfileEditNotifications, {
-  getLabelText,
   UserProfileEditNotificationsBase,
 } from 'amo/components/UserProfileEditNotifications';
 import { getCurrentUser, loadUserNotifications } from 'amo/reducers/users';
@@ -88,7 +88,9 @@ describe(__filename, () => {
       expect(input).toHaveProp('onChange', onChange);
 
       const label = input.parent();
-      expect(label.shallow()).toHaveText(getLabelText(i18n, notification.name));
+      expect(label.shallow()).toHaveText(
+        getNotificationDescription(i18n, notification.name),
+      );
 
       const p = input.closest('p');
       expect(p).toHaveClassName('UserProfileEditNotification');

--- a/tests/unit/amo/pages/TestUsersUnsubscribe.js
+++ b/tests/unit/amo/pages/TestUsersUnsubscribe.js
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import base64url from 'base64url';
+
+import UsersUnsubscribe, {
+  UsersUnsubscribeBase,
+} from 'amo/pages/UsersUnsubscribe';
+import Card from 'ui/components/Card';
+import { getNotificationDescription } from 'amo/utils/notifications';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  const getParams = (overrides = {}) => {
+    return {
+      hash: 'some-hash',
+      token: base64url.encode('email@example.org'),
+      notificationName: 'new_review',
+      ...overrides,
+    };
+  };
+
+  const render = ({
+    i18n = fakeI18n(),
+    params = getParams(),
+    ...props
+  } = {}) => {
+    return shallowUntilTarget(
+      <UsersUnsubscribe i18n={i18n} match={{ params }} {...props} />,
+      UsersUnsubscribeBase,
+    );
+  };
+
+  it('renders correctly', () => {
+    const root = render();
+
+    expect(root.find(Card)).toHaveLength(1);
+    expect(root.find(Card)).toHaveProp(
+      'header',
+      'You are successfully unsubscribed!',
+    );
+  });
+
+  it('renders an HTML title', () => {
+    const root = render();
+
+    expect(root.find('title')).toHaveLength(1);
+    expect(root.find('title')).toHaveText('Unsubscribe');
+  });
+
+  it('decodes the token to reveal the email of the user', () => {
+    const email = 'some@email.example.org';
+    const params = getParams({ token: base64url.encode(email) });
+
+    const root = render({ params });
+
+    expect(root.find('.UsersUnsubscribe-content-explanation').html()).toContain(
+      `The email address <strong>${email}</strong> will`,
+    );
+  });
+
+  it('renders a description of the unsubscribed notification', () => {
+    const notificationName = 'announcements';
+    const params = getParams({ notificationName });
+
+    const root = render({ params });
+
+    expect(root.find('.UsersUnsubscribe-content-notification')).toHaveText(
+      getNotificationDescription(fakeI18n(), notificationName),
+    );
+  });
+
+  it('renders a link to edit the user profile', () => {
+    const root = render();
+
+    expect(
+      root.find('.UsersUnsubscribe-content-edit-profile').childAt(0),
+    ).toHaveText('You can edit your notification settings by ');
+    // The second child is a `Link`.
+    expect(
+      root.find('.UsersUnsubscribe-content-edit-profile').childAt(1),
+    ).toHaveProp('to', '/users/edit');
+    expect(
+      root.find('.UsersUnsubscribe-content-edit-profile').childAt(1),
+    ).toHaveProp('children', 'editing your profile');
+    expect(
+      root.find('.UsersUnsubscribe-content-edit-profile').childAt(2),
+    ).toHaveText('.');
+  });
+});


### PR DESCRIPTION
Fixes #7840

---

This patch adds a new `UsersUnsubscribe` page component. It won't be enabled in -dev because the route is redirected to addons-server at the nginx level. This patch supports #7656. It does NOT perform any action yet.

Being logged in or out does not matter because we'll use the hash/token in the URL. That's why the two screenshots thereafter are the same. The UI is similar to the old one but I did not add two links to edit the notification settings/profile. It's the same page, so I added a sentence that explains what a user can do after having landed to this page. That's what I'd expect when landing to this page. 

## Screenshots

User is logged in:

![Screen Shot 2019-04-05 at 16 24 27](https://user-images.githubusercontent.com/217628/55635396-d88d7f80-57c0-11e9-8dbd-2c5cc9c9e588.png)

User is not logged in:

![Screen Shot 2019-04-05 at 16 24 24](https://user-images.githubusercontent.com/217628/55635397-d88d7f80-57c0-11e9-86d5-b587f470ddec.png)
