### PR TITLE
Use an isomorphic lib for FormData

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "@babel/polyfill": "7.4.3",
     "@loadable/component": "5.6.1",
     "@loadable/server": "5.6.1",
+    "@willdurand/isomorphic-formdata": "1.2.0",
     "base62": "2.0.1",
     "base64url": "3.0.1",
     "better-npm-run": "0.1.1",

--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -1,5 +1,6 @@
 /* @flow */
 import invariant from 'invariant';
+import FormData from '@willdurand/isomorphic-formdata';
 
 import { callApi } from 'core/api';
 import type {

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -2,6 +2,7 @@
 /* global fetch */
 import url from 'url';
 
+import FormData from '@willdurand/isomorphic-formdata';
 import utf8 from 'utf8';
 import { oneLine } from 'common-tags';
 import config from 'config';

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -1,4 +1,5 @@
 import deepEqual from 'deep-eql';
+import FormData from '@willdurand/isomorphic-formdata';
 
 import * as api from 'core/api';
 import {

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -1,6 +1,7 @@
 /* global window */
 import querystring from 'querystring';
 
+import FormData from '@willdurand/isomorphic-formdata';
 import config from 'config';
 import utf8 from 'utf8';
 
@@ -35,6 +36,10 @@ describe(__filename, () => {
   });
 
   describe('core.callApi', () => {
+    it('uses a browser implementation of FormData', () => {
+      expect(FormData).toEqual(window.FormData);
+    });
+
     it('does not use remote host for api calls', () => {
       expect(apiHost).toEqual('http://if-you-see-this-host-file-a-bug');
     });

--- a/tests/unit/core/api/test_index_node.js
+++ b/tests/unit/core/api/test_index_node.js
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+import FormData from '@willdurand/isomorphic-formdata';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import FormDataNode from 'formdata-node';
+
+describe(__filename, () => {
+  describe('core.callApi', () => {
+    it('uses a server implementation of FormData', () => {
+      expect(FormData).toEqual(FormDataNode);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1056,6 +1056,14 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.54.tgz#39ebb42723fe7ca4b3e1b00e967e80138d47cadf"
+  integrity sha1-Oeu0JyP+fKSz4bAOln6AE41Hyt8=
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/runtime@7.3.1":
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
@@ -1500,6 +1508,28 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@octetstream/eslint-config@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@octetstream/eslint-config/-/eslint-config-3.0.0.tgz#3239f94790a04e92948f04b0c317bbfffc38b586"
+  integrity sha512-VX8gZ6h9PNKrWb+N9AoWM2DA+eVBAqAL0OLHwLjh+iwLrICQRFYzJDxxHIpD7rN413PCppr2vp6cy8UGdZGd+A==
+  dependencies:
+    babel-eslint "^9.0.0"
+    eslint-config-airbnb-base "^13.1.0"
+    eslint-plugin-import "^2.14.0"
+    eslint-plugin-promise "^4.0.0"
+
+"@octetstream/invariant@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@octetstream/invariant/-/invariant-1.2.0.tgz#731ae22545a13093f834a6166d4c3fcf505e0abe"
+  integrity sha512-H8dGu44EiXMOU6dv82RiEtLPzi/Q0nmjuPsyznL6VN3KSWEdZI7be2sUO1m7HlWkgD/qSSwt076hBkCgOl9jgw==
+  dependencies:
+    sprintf-js "1.1.2"
+
+"@octetstream/promisify@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@octetstream/promisify/-/promisify-2.0.2.tgz#29ac3bd7aefba646db670227f895d812c1a19615"
+  integrity sha512-7XHoRB61hxsz8lBQrjC1tq/3OEIgpvGWg6DKAdwi7WRzruwkmsdwmOoUXbU4Dtd4RSOMDwed0SkP3y8UlMt1Bg==
 
 "@reach/router@^1.2.1":
   version "1.2.1"
@@ -2513,6 +2543,13 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@willdurand/isomorphic-formdata@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@willdurand/isomorphic-formdata/-/isomorphic-formdata-1.2.0.tgz#2391957a6f70b5cb99285a7cb53d7599c6b30e7e"
+  integrity sha512-vY0Ptxbxhvqve6EmeXgM/ac5LCJgbASLPAO4fSIhOcMw10s9YbFmLpuhYGLkxUM9px4+q+PyCV0rcCq4zmpLUQ==
+  dependencies:
+    formdata-node "^1.5.2"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -3133,9 +3170,20 @@ babel-eslint@^10.0.1:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
+babel-eslint@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-9.0.0.tgz#7d9445f81ed9f60aff38115f838970df9f2b6220"
+  integrity sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
 "babel-gettext-extractor@github:mozilla/babel-gettext-extractor#babel-7":
   version "4.0.0"
-  uid "78ff104e669edb731e979e36fbf4fe261a569924"
   resolved "https://codeload.github.com/mozilla/babel-gettext-extractor/tar.gz/78ff104e669edb731e979e36fbf4fe261a569924"
   dependencies:
     "@babel/core" "^7.0.0"
@@ -6015,7 +6063,7 @@ eslint-plugin-amo@^1.9.1:
     requireindex "~1.1.0"
     string-natural-compare "^2.0.2"
 
-eslint-plugin-import@2.16.0:
+eslint-plugin-import@2.16.0, eslint-plugin-import@^2.14.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz#97ac3e75d0791c4fac0e15ef388510217be7f66f"
   integrity sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==
@@ -6811,6 +6859,17 @@ format@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formdata-node@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-1.5.2.tgz#6450771c2c1dd6ba1ed4f7303a2564b0c8730db1"
+  integrity sha512-tmXmPazQ+nl6XV6KQmnXshwq1oDAF/Vgs1Ig/k4QZiJWHWhv9V9DVJqFKs4Iu5BZRxXyVqjBxzc1l/2xYPGB6g==
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.54"
+    "@octetstream/invariant" "1.2.0"
+    mime-types "2.1.22"
+    nanoid "2.0.1"
+    promise-fs "2.1.0"
 
 formidable@^1.2.0:
   version "1.2.1"
@@ -10032,7 +10091,7 @@ mime-db@~1.38.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
   integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
 
-mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
+mime-types@2.1.22, mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.22"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
   integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
@@ -10329,6 +10388,11 @@ nano-time@1.0.0:
   integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
   dependencies:
     big-integer "^1.6.16"
+
+nanoid@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.0.1.tgz#deb55cac196e3f138071911dabbc3726eb048864"
+  integrity sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -12115,6 +12179,14 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-fs@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/promise-fs/-/promise-fs-2.1.0.tgz#497f7c7143e4ca9d418ab1f6ba76fe30a06cde24"
+  integrity sha512-Wl6Y+dSQnw1cJjXdMbXABoH2fRXC3G3KjQHH32qPT6UYyDrh9Iouj/rvI+KKJiVFwQ1/3KiPe1dybp6cHYvUag==
+  dependencies:
+    "@octetstream/eslint-config" "3.0.0"
+    "@octetstream/promisify" "2.0.2"
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -14467,6 +14539,11 @@ split2@^3.0.0:
   integrity sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==
   dependencies:
     readable-stream "^3.0.0"
+
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Fixes #7843

---

This patch fixes an issue with `FormData` being not defined on the server. The fact that it still works without having to change any test case is a good sign. I added two smoke tests to make sure we use the right `FormData` in each context.