### PR TITLE
Change extension workshop urls when running dev

### DIFF
--- a/bin/.gitattributes
+++ b/bin/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/bin/.gitattributes
+++ b/bin/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -31,5 +31,5 @@ module.exports = {
     },
   },
 
-  extensionWorkshopUrl: 'https://extensionworkshop.allizom.org',
+  extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -30,5 +30,5 @@ module.exports = {
     },
   },
 
-  extensionWorkshopUrl: 'https://extensionworkshop.allizom.org',
+  extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
 };


### PR DESCRIPTION
Fix #7830

---

## Description

When running `yarn dev:amo`, the link to extension workshop in footer now point at ttps://extensionworkshop-dev.allizom.org.
Please note the url is not available :cry: 

~I've also added `.gitattribute` file to force LF end of lines on checkout. Developers with `auto.crlf=true` in their global git configuration. One cannot run the app with CLRF in script files.~

## Screenshot

![image](https://user-images.githubusercontent.com/186268/55667633-09bc8d00-585f-11e9-8236-e0a085f9cc58.png)




