### PR TITLE
Added new line under Get Involved

### DIFF
--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -131,11 +131,13 @@ export class AboutBase extends React.Component<Props> {
                 // eslint-disable-next-line react/no-danger
                 dangerouslySetInnerHTML={sanitizeHTML(
                   i18n.sprintf(
-                    i18n.gettext(`Want to interact with addons.mozilla.org (AMO)
-                    programmatically? Check out the
-                    %(startAddonsServerDocumentation)sAdd-ons Servers documentation %(endAddonsServerDocumentation)s
-                    for details about the APIs used by AMO and the
-                    %(startAddonsManager)sAdd-ons Manager%(endAddonsManager)s.`),
+                    i18n.gettext(`Want to interact with addons.mozilla.org
+                      (AMO) programmatically? Check out the
+                      %(startAddonsServerDocumentation)sAdd-ons Servers
+                      documentation%(endAddonsServerDocumentation)s for details
+                      about the APIs used by AMO and the
+                      %(startAddonsManager)sAdd-ons
+                      Manager%(endAddonsManager)s.`),
                     {
                       startAddonsServerDocumentation:
                         '<a href="https://addons-server.readthedocs.io/en/latest/index.html">',

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -132,9 +132,9 @@ export class AboutBase extends React.Component<Props> {
                 dangerouslySetInnerHTML={sanitizeHTML(
                   i18n.sprintf(
                     i18n.gettext(`Want to interact with addons.mozilla.org (AMO)
-                    programmatically? Check out the documentation for the
+                    programmatically? Check out the
                     %(startAddonsServerDocumentation)sAdd-ons Servers documentation %(endAddonsServerDocumentation)s
-                    for details about the AMO APIs, the APIs used by the
+                    for details about the APIs used by AMO and the
                     %(startAddonsManager)sAdd-ons Manager%(endAddonsManager)s.`),
                     {
                       startAddonsServerDocumentation:

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -186,7 +186,7 @@ export class AboutBase extends React.Component<Props> {
               dangerouslySetInnerHTML={sanitizeHTML(
                 i18n.sprintf(
                   i18n.gettext(
-                    `To see more ways you can contribute to the add-on community, please visit our %(startLink)swiki%(endLink)s`,
+                    `To see more ways you can contribute to the add-on community, please visit our %(startLink)swiki%(endLink)s.`,
                   ),
                   {
                     startLink:

--- a/src/amo/pages/StaticPages/About/index.js
+++ b/src/amo/pages/StaticPages/About/index.js
@@ -127,6 +127,27 @@ export class AboutBase extends React.Component<Props> {
                   ['a'],
                 )}
               />
+              <li
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={sanitizeHTML(
+                  i18n.sprintf(
+                    i18n.gettext(`Want to interact with addons.mozilla.org (AMO)
+                    programmatically? Check out the documentation for the
+                    %(startAddonsServerDocumentation)sAdd-ons Servers documentation %(endAddonsServerDocumentation)s
+                    for details about the AMO APIs, the APIs used by the
+                    %(startAddonsManager)sAdd-ons Manager%(endAddonsManager)s.`),
+                    {
+                      startAddonsServerDocumentation:
+                        '<a href="https://addons-server.readthedocs.io/en/latest/index.html">',
+                      endAddonsServerDocumentation: '</a>',
+                      startAddonsManager:
+                        '<a href="https://blog.mozilla.org/firefox/add-ons-manager/">',
+                      endAddonsManager: '</a>',
+                    },
+                  ),
+                  ['a'],
+                )}
+              />
             </ul>
             <p>
               {i18n.gettext(


### PR DESCRIPTION
Fixes #7838

---

Under Get Involved, Added new line :

Want to interact with addons.mozilla.org (AMO) programmatically? Check out the documentation for the Add-ons Servers documentation for details about the AMO APIs, the APIs used by the Add-ons Manager.
