### PR TITLE
Add API function to unsubscribe a user from a notification

### DIFF
--- a/src/amo/api/users.js
+++ b/src/amo/api/users.js
@@ -4,6 +4,7 @@ import invariant from 'invariant';
 import { callApi } from 'core/api';
 import type {
   ExternalUserType,
+  NotificationType,
   NotificationsType,
   NotificationsUpdateType,
   UserEditableFieldsType,
@@ -151,5 +152,31 @@ export function deleteUserAccount({
     endpoint: `accounts/account/${userId}`,
     method: 'DELETE',
     apiState: api,
+  });
+}
+
+export type UnsubscribeNotificationParams = {|
+  api: ApiState,
+  hash: string,
+  notification: string,
+  token: string,
+|};
+
+export function unsubscribeNotification({
+  api,
+  hash,
+  notification,
+  token,
+}: UnsubscribeNotificationParams): Promise<NotificationType> {
+  return callApi({
+    auth: false,
+    apiState: api,
+    endpoint: 'accounts/unsubscribe',
+    method: 'POST',
+    body: {
+      hash,
+      notification,
+      token,
+    },
   });
 }

--- a/tests/unit/amo/api/test_users.js
+++ b/tests/unit/amo/api/test_users.js
@@ -5,6 +5,7 @@ import {
   currentUserAccount,
   deleteUserAccount,
   deleteUserPicture,
+  unsubscribeNotification,
   updateUserAccount,
   updateUserNotifications,
   userAccount,
@@ -249,6 +250,39 @@ describe(__filename, () => {
         .returns(notificationsResponse);
 
       await updateUserNotifications(params);
+      mockApi.verify();
+    });
+  });
+
+  describe('unsubscribeNotification', () => {
+    it('unsubscribes a user from a notification', async () => {
+      const { state } = dispatchClientMetadata();
+      const hash = 'some-hash';
+      const token = 'some-token';
+      const notification = 'new_review';
+      const params = {
+        api: state.api,
+        hash,
+        notification,
+        token,
+      };
+
+      mockApi
+        .expects('callApi')
+        .withArgs({
+          apiState: params.api,
+          auth: false,
+          endpoint: `accounts/unsubscribe`,
+          method: 'POST',
+          body: {
+            hash,
+            notification,
+            token,
+          },
+        })
+        .returns(createApiResponse());
+
+      await unsubscribeNotification(params);
       mockApi.verify();
     });
   });


### PR DESCRIPTION
Fixes #7842

---

This patch only adds a new API function to reduce the diff of the patch needed for #7853.