### PR TITLE
Connect `UsersUnsubscribe` component

### DIFF
--- a/src/amo/pages/UsersUnsubscribe/index.js
+++ b/src/amo/pages/UsersUnsubscribe/index.js
@@ -85,63 +85,67 @@ export class UsersUnsubscribeBase extends React.Component<InternalProps> {
           <title>{i18n.gettext('Unsubscribe')}</title>
         </Helmet>
 
-        {errorHandler.renderErrorIfPresent()}
-
-        <Card
-          header={
-            isUnsubscribed ? (
-              i18n.gettext('You are successfully unsubscribed!')
-            ) : (
-              <LoadingText />
-            )
-          }
-        >
-          {isUnsubscribed ? (
-            <p
-              className="UsersUnsubscribe-content-explanation"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={sanitizeHTML(
-                i18n.sprintf(
-                  // translators: a list of notifications will be displayed under this prompt.
-                  i18n.gettext(
-                    `The email address %(strongStart)s%(email)s%(strongEnd)s will
-                  no longer get messages when:`,
-                  ),
-                  {
-                    strongStart: '<strong>',
-                    strongEnd: '</strong>',
-                    email: base64url.decode(token),
-                  },
-                ),
-                ['strong'],
-              )}
-            />
-          ) : (
-            <p className="UsersUnsubscribe-content-explanation">
-              <LoadingText minWidth={40} />
-            </p>
-          )}
-
-          <blockquote className="UsersUnsubscribe-content-notification">
+        {errorHandler.hasError() ? (
+          errorHandler.renderError()
+        ) : (
+          <Card
+            header={
+              isUnsubscribed ? (
+                i18n.gettext('You are successfully unsubscribed!')
+              ) : (
+                <LoadingText />
+              )
+            }
+          >
             {isUnsubscribed ? (
-              getNotificationDescription(i18n, notificationName)
+              <p
+                className="UsersUnsubscribe-content-explanation"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={sanitizeHTML(
+                  i18n.sprintf(
+                    // translators: a list of notifications will be displayed under this prompt.
+                    i18n.gettext(
+                      `The email address %(strongStart)s%(email)s%(strongEnd)s
+                      will no longer get messages when:`,
+                    ),
+                    {
+                      strongStart: '<strong>',
+                      strongEnd: '</strong>',
+                      email: base64url.decode(token),
+                    },
+                  ),
+                  ['strong'],
+                )}
+              />
             ) : (
-              <LoadingText range={30} />
+              <p className="UsersUnsubscribe-content-explanation">
+                <LoadingText minWidth={40} />
+              </p>
             )}
-          </blockquote>
 
-          {isUnsubscribed ? (
-            <p className="UsersUnsubscribe-content-edit-profile">
-              {linkEditProfileParts.beforeLinkText}
-              <Link to="/users/edit">{linkEditProfileParts.innerLinkText}</Link>
-              {linkEditProfileParts.afterLinkText}
-            </p>
-          ) : (
-            <p className="UsersUnsubscribe-content-edit-profile">
-              <LoadingText />
-            </p>
-          )}
-        </Card>
+            <blockquote className="UsersUnsubscribe-content-notification">
+              {isUnsubscribed ? (
+                getNotificationDescription(i18n, notificationName)
+              ) : (
+                <LoadingText range={30} />
+              )}
+            </blockquote>
+
+            {isUnsubscribed ? (
+              <p className="UsersUnsubscribe-content-edit-profile">
+                {linkEditProfileParts.beforeLinkText}
+                <Link to="/users/edit">
+                  {linkEditProfileParts.innerLinkText}
+                </Link>
+                {linkEditProfileParts.afterLinkText}
+              </p>
+            ) : (
+              <p className="UsersUnsubscribe-content-edit-profile">
+                <LoadingText />
+              </p>
+            )}
+          </Card>
+        )}
       </div>
     );
   }

--- a/src/amo/pages/UsersUnsubscribe/index.js
+++ b/src/amo/pages/UsersUnsubscribe/index.js
@@ -3,18 +3,29 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { compose } from 'redux';
 import base64url from 'base64url';
+import { connect } from 'react-redux';
 
 import Link from 'amo/components/Link';
 import { getNotificationDescription } from 'amo/utils/notifications';
 import Card from 'ui/components/Card';
+import LoadingText from 'ui/components/LoadingText';
+import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
 import { getLocalizedTextWithLinkParts } from 'core/utils/i18n';
+import {
+  getUnsubscribeKey,
+  isUnsubscribedFor,
+  unsubscribeNotification,
+} from 'amo/reducers/users';
+import type { AppState } from 'amo/store';
+import type { DispatchFunc } from 'core/types/redux';
 import type {
   ReactRouterLocationType,
   ReactRouterMatchType,
 } from 'core/types/router';
 import type { I18nType } from 'core/types/i18n';
+import type { ErrorHandlerType } from 'core/errorHandler';
 
 import './styles.scss';
 
@@ -32,12 +43,33 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
+  dispatch: DispatchFunc,
+  errorHandler: ErrorHandlerType,
   i18n: I18nType,
+  isUnsubscribed: boolean,
 |};
 
 export class UsersUnsubscribeBase extends React.Component<InternalProps> {
+  constructor(props: InternalProps) {
+    super(props);
+
+    const { dispatch, errorHandler, match, isUnsubscribed } = props;
+    const { hash, notificationName, token } = match.params;
+
+    if (isUnsubscribed === undefined) {
+      dispatch(
+        unsubscribeNotification({
+          errorHandlerId: errorHandler.id,
+          hash,
+          notification: notificationName,
+          token,
+        }),
+      );
+    }
+  }
+
   render() {
-    const { i18n, match } = this.props;
+    const { errorHandler, i18n, isUnsubscribed, match } = this.props;
     const { token, notificationName } = match.params;
 
     const linkEditProfileParts = getLocalizedTextWithLinkParts({
@@ -53,43 +85,92 @@ export class UsersUnsubscribeBase extends React.Component<InternalProps> {
           <title>{i18n.gettext('Unsubscribe')}</title>
         </Helmet>
 
-        <Card header={i18n.gettext('You are successfully unsubscribed!')}>
-          <p
-            className="UsersUnsubscribe-content-explanation"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={sanitizeHTML(
-              i18n.sprintf(
-                // translators: a list of notifications will be displayed under this prompt.
-                i18n.gettext(
-                  `The email address %(strongStart)s%(email)s%(strongEnd)s will
+        {errorHandler.renderErrorIfPresent()}
+
+        <Card
+          header={
+            isUnsubscribed ? (
+              i18n.gettext('You are successfully unsubscribed!')
+            ) : (
+              <LoadingText />
+            )
+          }
+        >
+          {isUnsubscribed ? (
+            <p
+              className="UsersUnsubscribe-content-explanation"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={sanitizeHTML(
+                i18n.sprintf(
+                  // translators: a list of notifications will be displayed under this prompt.
+                  i18n.gettext(
+                    `The email address %(strongStart)s%(email)s%(strongEnd)s will
                   no longer get messages when:`,
+                  ),
+                  {
+                    strongStart: '<strong>',
+                    strongEnd: '</strong>',
+                    email: base64url.decode(token),
+                  },
                 ),
-                {
-                  strongStart: '<strong>',
-                  strongEnd: '</strong>',
-                  email: base64url.decode(token),
-                },
-              ),
-              ['strong'],
-            )}
-          />
+                ['strong'],
+              )}
+            />
+          ) : (
+            <p className="UsersUnsubscribe-content-explanation">
+              <LoadingText minWidth={40} />
+            </p>
+          )}
+
           <blockquote className="UsersUnsubscribe-content-notification">
-            {getNotificationDescription(i18n, notificationName)}
+            {isUnsubscribed ? (
+              getNotificationDescription(i18n, notificationName)
+            ) : (
+              <LoadingText range={30} />
+            )}
           </blockquote>
 
-          <p className="UsersUnsubscribe-content-edit-profile">
-            {linkEditProfileParts.beforeLinkText}
-            <Link to="/users/edit">{linkEditProfileParts.innerLinkText}</Link>
-            {linkEditProfileParts.afterLinkText}
-          </p>
+          {isUnsubscribed ? (
+            <p className="UsersUnsubscribe-content-edit-profile">
+              {linkEditProfileParts.beforeLinkText}
+              <Link to="/users/edit">{linkEditProfileParts.innerLinkText}</Link>
+              {linkEditProfileParts.afterLinkText}
+            </p>
+          ) : (
+            <p className="UsersUnsubscribe-content-edit-profile">
+              <LoadingText />
+            </p>
+          )}
         </Card>
       </div>
     );
   }
 }
 
-const UsersUnsubscribe: React.ComponentType<Props> = compose(translate())(
-  UsersUnsubscribeBase,
-);
+export const extractId = (ownProps: Props) => {
+  const { match } = ownProps;
+  const { hash, notificationName, token } = match.params;
+
+  return getUnsubscribeKey({ hash, notification: notificationName, token });
+};
+
+const mapStateToProps = (state: AppState, ownProps: Props) => {
+  const { hash, notificationName, token } = ownProps.match.params;
+
+  return {
+    isUnsubscribed: isUnsubscribedFor(
+      state.users,
+      hash,
+      notificationName,
+      token,
+    ),
+  };
+};
+
+const UsersUnsubscribe: React.ComponentType<Props> = compose(
+  connect(mapStateToProps),
+  translate(),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
+)(UsersUnsubscribeBase);
 
 export default UsersUnsubscribe;

--- a/tests/unit/amo/pages/TestUsersUnsubscribe.js
+++ b/tests/unit/amo/pages/TestUsersUnsubscribe.js
@@ -1,12 +1,26 @@
 import * as React from 'react';
 import base64url from 'base64url';
 
+import {
+  abortUnsubscribeNotification,
+  finishUnsubscribeNotification,
+  getUnsubscribeKey,
+  unsubscribeNotification,
+} from 'amo/reducers/users';
 import UsersUnsubscribe, {
   UsersUnsubscribeBase,
+  extractId,
 } from 'amo/pages/UsersUnsubscribe';
 import Card from 'ui/components/Card';
+import LoadingText from 'ui/components/LoadingText';
 import { getNotificationDescription } from 'amo/utils/notifications';
-import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+import { ErrorHandler } from 'core/errorHandler';
+import ErrorList from 'ui/components/ErrorList';
+import {
+  dispatchClientMetadata,
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
 
 describe(__filename, () => {
   const getParams = (overrides = {}) => {
@@ -21,22 +35,49 @@ describe(__filename, () => {
   const render = ({
     i18n = fakeI18n(),
     params = getParams(),
+    store = dispatchClientMetadata().store,
     ...props
   } = {}) => {
     return shallowUntilTarget(
-      <UsersUnsubscribe i18n={i18n} match={{ params }} {...props} />,
+      <UsersUnsubscribe
+        i18n={i18n}
+        match={{ params }}
+        store={store}
+        {...props}
+      />,
       UsersUnsubscribeBase,
     );
   };
 
-  it('renders correctly', () => {
+  const _finishUnsubscribeNotification = (store, overrides = {}) => {
+    const params = getParams(overrides);
+
+    store.dispatch(
+      finishUnsubscribeNotification({
+        hash: params.hash,
+        notification: params.notificationName,
+        token: params.token,
+      }),
+    );
+  };
+
+  it('renders loading indicators when the user is not unsubscribed yet', () => {
     const root = render();
 
     expect(root.find(Card)).toHaveLength(1);
-    expect(root.find(Card)).toHaveProp(
-      'header',
-      'You are successfully unsubscribed!',
-    );
+    expect(root.find(Card)).toHaveProp('header', <LoadingText />);
+
+    expect(
+      root.find('.UsersUnsubscribe-content-explanation').find(LoadingText),
+    ).toHaveLength(1);
+
+    expect(
+      root.find('.UsersUnsubscribe-content-notification').find(LoadingText),
+    ).toHaveLength(1);
+
+    expect(
+      root.find('.UsersUnsubscribe-content-edit-profile').find(LoadingText),
+    ).toHaveLength(1);
   });
 
   it('renders an HTML title', () => {
@@ -46,43 +87,126 @@ describe(__filename, () => {
     expect(root.find('title')).toHaveText('Unsubscribe');
   });
 
-  it('decodes the token to reveal the email of the user', () => {
-    const email = 'some@email.example.org';
-    const params = getParams({ token: base64url.encode(email) });
+  it('dispatches unsubscribeNotification on mount', () => {
+    const params = getParams();
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
 
-    const root = render({ params });
+    const root = render({ params, store });
 
-    expect(root.find('.UsersUnsubscribe-content-explanation').html()).toContain(
-      `The email address <strong>${email}</strong> will`,
+    sinon.assert.calledWith(
+      dispatchSpy,
+      unsubscribeNotification({
+        errorHandlerId: root.instance().props.errorHandler.id,
+        hash: params.hash,
+        notification: params.notificationName,
+        token: params.token,
+      }),
     );
   });
 
-  it('renders a description of the unsubscribed notification', () => {
-    const notificationName = 'announcements';
-    const params = getParams({ notificationName });
-
-    const root = render({ params });
-
-    expect(root.find('.UsersUnsubscribe-content-notification')).toHaveText(
-      getNotificationDescription(fakeI18n(), notificationName),
+  it('does not dispatch unsubscribeNotification if the operation has been aborted', () => {
+    const params = getParams();
+    const { store } = dispatchClientMetadata();
+    store.dispatch(
+      abortUnsubscribeNotification({
+        hash: params.hash,
+        notification: params.notificationName,
+        token: params.token,
+      }),
     );
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    render({ params, store });
+
+    sinon.assert.notCalled(dispatchSpy);
   });
 
-  it('renders a link to edit the user profile', () => {
-    const root = render();
+  it('does not dispatch unsubscribeNotification if already dispatched', () => {
+    const params = getParams();
+    const { store } = dispatchClientMetadata();
+    _finishUnsubscribeNotification(store, params);
+    const dispatchSpy = sinon.spy(store, 'dispatch');
 
-    expect(
-      root.find('.UsersUnsubscribe-content-edit-profile').childAt(0),
-    ).toHaveText('You can edit your notification settings by ');
-    // The second child is a `Link`.
-    expect(
-      root.find('.UsersUnsubscribe-content-edit-profile').childAt(1),
-    ).toHaveProp('to', '/users/edit');
-    expect(
-      root.find('.UsersUnsubscribe-content-edit-profile').childAt(1),
-    ).toHaveProp('children', 'editing your profile');
-    expect(
-      root.find('.UsersUnsubscribe-content-edit-profile').childAt(2),
-    ).toHaveText('.');
+    render({ params, store });
+
+    sinon.assert.notCalled(dispatchSpy);
+  });
+
+  it('renders errors', () => {
+    const { store } = dispatchClientMetadata();
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: store.dispatch,
+    });
+    errorHandler.handle(new Error('unexpected error'));
+
+    const root = render({ errorHandler, store });
+
+    expect(root.find(ErrorList)).toHaveLength(1);
+  });
+
+  describe('when user is successfully unsubscribed', () => {
+    it('decodes the token to reveal the email of the user', () => {
+      const email = 'some@email.example.org';
+      const params = getParams({ token: base64url.encode(email) });
+      const { store } = dispatchClientMetadata();
+      _finishUnsubscribeNotification(store, params);
+
+      const root = render({ params, store });
+
+      expect(
+        root.find('.UsersUnsubscribe-content-explanation').html(),
+      ).toContain(`The email address <strong>${email}</strong> will`);
+    });
+
+    it('renders a description of the unsubscribed notification', () => {
+      const notificationName = 'announcements';
+      const params = getParams({ notificationName });
+      const { store } = dispatchClientMetadata();
+      _finishUnsubscribeNotification(store, params);
+
+      const root = render({ params, store });
+
+      expect(root.find('.UsersUnsubscribe-content-notification')).toHaveText(
+        getNotificationDescription(fakeI18n(), notificationName),
+      );
+    });
+
+    it('renders a link to edit the user profile', () => {
+      const { store } = dispatchClientMetadata();
+      _finishUnsubscribeNotification(store);
+
+      const root = render({ store });
+
+      expect(
+        root.find('.UsersUnsubscribe-content-edit-profile').childAt(0),
+      ).toHaveText('You can edit your notification settings by ');
+      // The second child is a `Link`.
+      expect(
+        root.find('.UsersUnsubscribe-content-edit-profile').childAt(1),
+      ).toHaveProp('to', '/users/edit');
+      expect(
+        root.find('.UsersUnsubscribe-content-edit-profile').childAt(1),
+      ).toHaveProp('children', 'editing your profile');
+      expect(
+        root.find('.UsersUnsubscribe-content-edit-profile').childAt(2),
+      ).toHaveText('.');
+    });
+  });
+
+  describe('extractId', () => {
+    it('returns a unique ID using getUnsubscribeKey()', () => {
+      const params = getParams();
+      const ownProps = { match: { params } };
+
+      expect(extractId(ownProps)).toEqual(
+        getUnsubscribeKey({
+          hash: params.hash,
+          notification: params.notificationName,
+          token: params.token,
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #7656
~~⚠️ depends on #7855~~

---

**Only the last commit is relevant.**

This is the last iteration to ship a new unsubscribe page.

## Screenshots

Happy path:

![Screen Shot 2019-04-08 at 14 22 04](https://user-images.githubusercontent.com/217628/55723580-b470af00-5a09-11e9-9097-76246c141fb4.png)

Loading state:

![Screen Shot 2019-04-08 at 14 23 12](https://user-images.githubusercontent.com/217628/55723657-de29d600-5a09-11e9-9d84-94e55627dec6.png)

Token is invalid:

![Screen Shot 2019-04-08 at 14 21 16](https://user-images.githubusercontent.com/217628/55723540-9a36d100-5a09-11e9-8b3f-d76113ac2cc3.png)

Hash is invalid:

![Screen Shot 2019-04-08 at 14 21 51](https://user-images.githubusercontent.com/217628/55723567-ac187400-5a09-11e9-90ba-a6e4affa0201.png)

Notification name is invalid:

![Screen Shot 2019-04-08 at 14 25 00](https://user-images.githubusercontent.com/217628/55723757-20531780-5a0a-11e9-9131-b43f9e10c38f.png)
