### PR TITLE
Added tooltips to Extension Workshop and DevHub header links

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -92,6 +92,7 @@ export class HeaderBase extends React.Component {
             prependClientApp={false}
             prependLang={false}
             target="_blank"
+            title={i18n.gettext('Learn how to create extensions and themes')}
           >
             {i18n.gettext('Extension Workshop')}
           </Link>
@@ -101,6 +102,7 @@ export class HeaderBase extends React.Component {
             external
             prependClientApp={false}
             target="_blank"
+            title={i18n.gettext('Submit and manage extensions and themes')}
           >
             {i18n.gettext('Developer Hub')}
           </Link>


### PR DESCRIPTION
Fixes [#7831](https://github.com/mozilla/addons-frontend/issues/7831)

 Add tooltips to the Extension Workshop and DevHub header links:
   - Extension Workshop: "Learn how to create extensions and themes"
   - Developer Hub: "Submit and manage extensions and themes"

<img width="1440" alt="tooltipAddons" src="https://user-images.githubusercontent.com/16367007/55775406-2b886080-5a67-11e9-8527-18019d181bd0.png">
