### PR TITLE
Remove use of componentWillReceiveProps() in UserProfileEdit

### DIFF
--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -140,12 +140,12 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     }
   }
 
-  componentWillReceiveProps(props: Props) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
     const {
       isUpdating: wasUpdating,
       user: oldUser,
       userId: oldUserId,
-    } = this.props;
+    } = prevProps;
 
     const {
       clientApp,
@@ -157,7 +157,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       lang,
       user: newUser,
       userId: newUserId,
-    } = props;
+    } = this.props;
 
     if (oldUserId !== newUserId) {
       if (!newUser && newUserId) {
@@ -178,6 +178,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
         );
       }
 
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         ...this.getFormValues(newUser),
         pictureData: null,
@@ -189,6 +190,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       newUser &&
       !newUser.picture_url
     ) {
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         picture: null,
         pictureData: null,
@@ -199,9 +201,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     if (wasUpdating && !isUpdating && !errorHandler.hasError()) {
       history.push(`/${lang}/${clientApp}/user/${newUserId}/`);
     }
-  }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
     if (
       (!prevProps.errorHandler.hasError() &&
         this.props.errorHandler.hasError()) ||


### PR DESCRIPTION
Fixes #6769 

---

This is similar to [other](https://github.com/mozilla/addons-frontend/issues/6770) [patches](https://github.com/mozilla/addons-frontend/issues/6771).

It is needed to [upgrade Enzyme to 3.9.0](https://github.com/mozilla/addons-frontend/pull/7606) which, in turn, should allow us to use `getDerivedStateFromProps()` in this component to get rid of the `setState` calls in `componentDidUpdate()` (there is [a known Enzyme issue about that](https://github.com/airbnb/enzyme/issues/2020)).

It is not recommended to use `setState` in `componentDidUpdate()` but it is possible. The only potential problem is infinite loops but we have enough guards in place to avoid that, so I don't think we'll run into issues. That being said, once this patch lands and we upgrade to Enzyme 3.9.0, I'll try to rewrite the logic with `getDerivedStateFromProps()` (cf. https://github.com/mozilla/addons-frontend/issues/7875).