### PR TITLE
Rename unidentified license to Custom License in AddonVersionCard

### DIFF
--- a/src/amo/components/AddonVersionCard/index.js
+++ b/src/amo/components/AddonVersionCard/index.js
@@ -111,7 +111,7 @@ export const AddonVersionCardBase = (props: InternalProps) => {
               },
             )
           : i18n.gettext(
-              'Source code released under %(linkStart)san unidentified license%(linkEnd)s',
+              'Source code released under %(linkStart)sCustom License%(linkEnd)s',
             );
 
         const licenseLink = replaceStringsWithJSX({

--- a/tests/unit/amo/components/TestAddonVersionCard.js
+++ b/tests/unit/amo/components/TestAddonVersionCard.js
@@ -227,7 +227,7 @@ describe(__filename, () => {
     });
 
     const license = root.find('.AddonVersionCard-license');
-    expect(license.childAt(1).children()).toHaveText('an unidentified license');
+    expect(license.childAt(1).children()).toHaveText('Custom License');
   });
 
   it('renders a link to a non-custom license', () => {


### PR DESCRIPTION
Fixes #7913 
Rename unidentified license to Custom License in `AddonVersionCard`.
Also, I find the translation doesn't work properly, so I change the condition a little bit.
Please check if it is appropriate.

Before: 
![image](https://user-images.githubusercontent.com/6767433/56588790-06771e80-661f-11e9-86f6-cf0596933ac1.png)

After
![image](https://user-images.githubusercontent.com/6767433/56588848-20b0fc80-661f-11e9-80a4-f7171e43dff9.png)