### PR TITLE
Set a default name for license when name is `null`

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -113,13 +113,14 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       const linkProps = license.isCustom
         ? { to: `/addon/${addon.slug}/license/` }
         : { href: license.url, prependClientApp: false, prependLang: false };
+      const licenseName = license.name || i18n.gettext('Custom License');
 
       versionLicenseLink = license.url ? (
         <Link className="AddonMoreInfo-license-link" {...linkProps}>
-          {license.name}
+          {licenseName}
         </Link>
       ) : (
-        <span className="AddonMoreInfo-license-name">{license.name}</span>
+        <span className="AddonMoreInfo-license-name">{licenseName}</span>
       );
     }
 

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -239,6 +239,7 @@ describe(__filename, () => {
     const license = root.find('.AddonMoreInfo-license-name');
     expect(license).toHaveLength(1);
     expect(license.children()).toIncludeText('Custom License');
+    expect(root.find('.AddonMoreInfo-license-link')).toHaveLength(0);
   });
 
   it('renders the license info without a link if the url is null', () => {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -221,6 +221,26 @@ describe(__filename, () => {
     expect(link).toHaveProp('to', `/addon/${addon.slug}/license/`);
   });
 
+  it('renders a default name when the license name is null', () => {
+    _loadVersions({ license: { name: null, url: 'some-url' } });
+
+    const root = render({});
+
+    const license = root.find('.AddonMoreInfo-license-link');
+    expect(license).toHaveLength(1);
+    expect(license.children()).toIncludeText('Custom License');
+  });
+
+  it('renders a default name when the license name and url are null', () => {
+    _loadVersions({ license: { name: null, url: null } });
+
+    const root = render({});
+
+    const license = root.find('.AddonMoreInfo-license-name');
+    expect(license).toHaveLength(1);
+    expect(license.children()).toIncludeText('Custom License');
+  });
+
   it('renders the license info without a link if the url is null', () => {
     _loadVersions({ license: { name: 'justText', url: null } });
     const root = render({});


### PR DESCRIPTION
Fixes #7912

---

Before:

<img width="502" alt="Screen Shot 2019-04-25 at 12 09 38" src="https://user-images.githubusercontent.com/217628/56728462-1db72880-6753-11e9-85fe-f29d3bdaf8f0.png">

After:

<img width="506" alt="Screen Shot 2019-04-25 at 12 09 25" src="https://user-images.githubusercontent.com/217628/56728463-1db72880-6753-11e9-9392-b8e197e303fd.png">
