### PR TITLE
Show recommended badge on details page

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -119,6 +119,7 @@ module.exports = {
     'enableDevTools',
     'enableFeatureDiscoTaar',
     'enableFeatureExperienceSurvey',
+    'enableFeatureRecommendedBadges',
     'enableRequestID',
     'enableStrictMode',
     'experiments',
@@ -368,6 +369,8 @@ module.exports = {
 
   enableFeatureExperienceSurvey: false,
   dismissedExperienceSurveyCookieName: 'dismissedExperienceSurvey',
+
+  enableFeatureRecommendedBadges: false,
 
   // The withExperiment HOC relies on this config to enable/disable A/B
   // experiments.

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -32,4 +32,6 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  enableFeatureRecommendedBadges: true,
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -31,4 +31,6 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  enableFeatureRecommendedBadges: true,
 };

--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import config from 'config';
 import * as React from 'react';
 import { compose } from 'redux';
 
@@ -10,6 +11,7 @@ import {
 import translate from 'core/i18n/translate';
 import { isQuantumCompatible } from 'core/utils/compatibility';
 import Badge from 'ui/components/Badge';
+import RecommendedBadge from 'ui/components/RecommendedBadge';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 
@@ -17,61 +19,76 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType,
+|};
+
+type InternalProps = {|
+  ...Props,
+  _config: typeof config,
   i18n: I18nType,
 |};
 
-export const AddonBadgesBase = (props: Props) => {
-  const { addon, i18n } = props;
-
-  if (!addon) {
-    return null;
-  }
-
-  const getFeaturedText = (addonType: string) => {
-    switch (addonType) {
-      case ADDON_TYPE_EXTENSION:
-        return i18n.gettext('Featured Extension');
-      case ADDON_TYPE_STATIC_THEME:
-      case ADDON_TYPE_THEME:
-        return i18n.gettext('Featured Theme');
-      default:
-        return i18n.gettext('Featured Add-on');
-    }
+export class AddonBadgesBase extends React.Component<InternalProps> {
+  static defaultProps = {
+    _config: config,
   };
 
-  const isIncompatible =
-    addon.type === ADDON_TYPE_EXTENSION &&
-    isQuantumCompatible({ addon }) === false;
+  render() {
+    const { _config, addon, i18n } = this.props;
 
-  return (
-    <div className="AddonBadges">
-      {addon.is_featured ? (
-        <Badge type="featured" label={getFeaturedText(addon.type)} />
-      ) : null}
-      {addon.isRestartRequired ? (
-        <Badge
-          type="restart-required"
-          label={i18n.gettext('Restart Required')}
-        />
-      ) : null}
-      {addon.is_experimental ? (
-        <Badge type="experimental" label={i18n.gettext('Experimental')} />
-      ) : null}
-      {isIncompatible ? (
-        <Badge
-          type="not-compatible"
-          label={i18n.gettext('Not compatible with Firefox Quantum')}
-        />
-      ) : null}
-      {addon.requires_payment ? (
-        <Badge
-          type="requires-payment"
-          label={i18n.gettext('Some features may require payment')}
-        />
-      ) : null}
-    </div>
-  );
-};
+    if (!addon) {
+      return null;
+    }
+
+    const getFeaturedText = (addonType: string) => {
+      switch (addonType) {
+        case ADDON_TYPE_EXTENSION:
+          return i18n.gettext('Featured Extension');
+        case ADDON_TYPE_STATIC_THEME:
+        case ADDON_TYPE_THEME:
+          return i18n.gettext('Featured Theme');
+        default:
+          return i18n.gettext('Featured Add-on');
+      }
+    };
+
+    const isIncompatible =
+      addon.type === ADDON_TYPE_EXTENSION &&
+      isQuantumCompatible({ addon }) === false;
+
+    return (
+      <div className="AddonBadges">
+        {_config.get('enableFeatureRecommendedBadges') &&
+        addon.is_recommended ? (
+          <RecommendedBadge />
+        ) : null}
+        {addon.is_featured ? (
+          <Badge type="featured" label={getFeaturedText(addon.type)} />
+        ) : null}
+        {addon.isRestartRequired ? (
+          <Badge
+            type="restart-required"
+            label={i18n.gettext('Restart Required')}
+          />
+        ) : null}
+        {addon.is_experimental ? (
+          <Badge type="experimental" label={i18n.gettext('Experimental')} />
+        ) : null}
+        {isIncompatible ? (
+          <Badge
+            type="not-compatible"
+            label={i18n.gettext('Not compatible with Firefox Quantum')}
+          />
+        ) : null}
+        {addon.requires_payment ? (
+          <Badge
+            type="requires-payment"
+            label={i18n.gettext('Some features may require payment')}
+          />
+        ) : null}
+      </div>
+    );
+  }
+}
 
 const AddonBadges: React.ComponentType<Props> = compose(translate())(
   AddonBadgesBase,

--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -59,6 +59,11 @@ export class AddonBadgesBase extends React.Component<InternalProps> {
       addon.type === ADDON_TYPE_EXTENSION &&
       isQuantumCompatible({ addon }) === false;
 
+    const showFeaturedBadge =
+      addon.is_featured &&
+      (!_config.get('enableFeatureRecommendedBadges') ||
+        addon.type !== ADDON_TYPE_EXTENSION);
+
     return (
       <div className="AddonBadges">
         {_config.get('enableFeatureRecommendedBadges') &&
@@ -66,7 +71,7 @@ export class AddonBadgesBase extends React.Component<InternalProps> {
         clientApp !== CLIENT_APP_ANDROID ? (
           <RecommendedBadge />
         ) : null}
-        {addon.is_featured ? (
+        {showFeaturedBadge ? (
           <Badge type="featured" label={getFeaturedText(addon.type)} />
         ) : null}
         {addon.isRestartRequired ? (

--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -1,17 +1,20 @@
 /* @flow */
 import config from 'config';
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { isQuantumCompatible } from 'core/utils/compatibility';
 import Badge from 'ui/components/Badge';
 import RecommendedBadge from 'ui/components/RecommendedBadge';
+import type { AppState } from 'amo/store';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 
@@ -24,6 +27,7 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   _config: typeof config,
+  clientApp: string,
   i18n: I18nType,
 |};
 
@@ -33,7 +37,7 @@ export class AddonBadgesBase extends React.Component<InternalProps> {
   };
 
   render() {
-    const { _config, addon, i18n } = this.props;
+    const { _config, addon, clientApp, i18n } = this.props;
 
     if (!addon) {
       return null;
@@ -58,7 +62,8 @@ export class AddonBadgesBase extends React.Component<InternalProps> {
     return (
       <div className="AddonBadges">
         {_config.get('enableFeatureRecommendedBadges') &&
-        addon.is_recommended ? (
+        addon.is_recommended &&
+        clientApp !== CLIENT_APP_ANDROID ? (
           <RecommendedBadge />
         ) : null}
         {addon.is_featured ? (
@@ -90,8 +95,15 @@ export class AddonBadgesBase extends React.Component<InternalProps> {
   }
 }
 
-const AddonBadges: React.ComponentType<Props> = compose(translate())(
-  AddonBadgesBase,
-);
+export const mapStateToProps = (state: AppState) => {
+  return {
+    clientApp: state.api.clientApp,
+  };
+};
+
+const AddonBadges: React.ComponentType<Props> = compose(
+  connect(mapStateToProps),
+  translate(),
+)(AddonBadgesBase);
 
 export default AddonBadges;

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -210,6 +210,7 @@ export function createInternalAddon(
     is_disabled: apiAddon.is_disabled,
     is_experimental: apiAddon.is_experimental,
     is_featured: apiAddon.is_featured,
+    is_recommended: apiAddon.is_recommended,
     is_source_public: apiAddon.is_source_public,
     last_updated: apiAddon.last_updated,
     latest_unlisted_version: apiAddon.latest_unlisted_version,

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -92,6 +92,7 @@ export type ExternalAddonType = {|
   is_disabled?: boolean,
   is_experimental?: boolean,
   is_featured?: boolean,
+  is_recommended?: boolean,
   is_source_public?: boolean,
   last_updated: Date | null,
   latest_unlisted_version?: ?ExternalAddonVersionType,

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -6,11 +6,13 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
+  CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
   createFakeAddon,
+  dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
   getFakeConfig,
@@ -26,6 +28,7 @@ describe(__filename, () => {
         enableFeatureRecommendedBadges: false,
       }),
       i18n: fakeI18n(),
+      store: dispatchClientMetadata().store,
       ...props,
     };
 
@@ -48,6 +51,10 @@ describe(__filename, () => {
   });
 
   it('displays a badge when the addon is recommended', () => {
+    const { store } = dispatchClientMetadata({
+      clientApp: CLIENT_APP_FIREFOX,
+    });
+
     const addon = createInternalAddon({
       ...fakeAddon,
       is_recommended: true,
@@ -58,9 +65,31 @@ describe(__filename, () => {
         enableFeatureRecommendedBadges: true,
       }),
       addon,
+      store,
     });
 
     expect(root.find(RecommendedBadge)).toHaveLength(1);
+  });
+
+  it('does not display a recommended badge on Android', () => {
+    const { store } = dispatchClientMetadata({
+      clientApp: CLIENT_APP_ANDROID,
+    });
+
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_recommended: true,
+      type: ADDON_TYPE_EXTENSION,
+    });
+    const root = shallowRender({
+      _config: getFakeConfig({
+        enableFeatureRecommendedBadges: true,
+      }),
+      addon,
+      store,
+    });
+
+    expect(root.find(RecommendedBadge)).toHaveLength(0);
   });
 
   it('does not display a recommended badge when the feature is disabled', () => {

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -108,16 +108,53 @@ describe(__filename, () => {
     expect(root.find(RecommendedBadge)).toHaveLength(0);
   });
 
-  it('displays a badge when the addon is featured', () => {
+  it('displays a badge for an extension when the addon is featured and the recommended feature is off', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
       is_featured: true,
       type: ADDON_TYPE_EXTENSION,
     });
-    const root = shallowRender({ addon });
+    const root = shallowRender({
+      _config: getFakeConfig({
+        enableFeatureRecommendedBadges: false,
+      }),
+      addon,
+    });
 
     expect(root.find(Badge)).toHaveProp('type', 'featured');
     expect(root.find(Badge)).toHaveProp('label', 'Featured Extension');
+  });
+
+  it('displays a badge for a theme when the addon is featured and the recommended feature is on', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_featured: true,
+      type: ADDON_TYPE_THEME,
+    });
+    const root = shallowRender({
+      _config: getFakeConfig({
+        enableFeatureRecommendedBadges: true,
+      }),
+      addon,
+    });
+
+    expect(root.find(Badge)).toHaveProp('type', 'featured');
+  });
+
+  it('does not display a badge for an extension when the addon is featured and the recommended feature is on', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_featured: true,
+      type: ADDON_TYPE_EXTENSION,
+    });
+    const root = shallowRender({
+      _config: getFakeConfig({
+        enableFeatureRecommendedBadges: true,
+      }),
+      addon,
+    });
+
+    expect(root.find(Badge)).toHaveLength(0);
   });
 
   it('adds a different badge label when a "theme" addon is featured', () => {

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -13,13 +13,18 @@ import {
   createFakeAddon,
   fakeAddon,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import Badge from 'ui/components/Badge';
+import RecommendedBadge from 'ui/components/RecommendedBadge';
 
 describe(__filename, () => {
   function shallowRender(props) {
     const allProps = {
+      _config: getFakeConfig({
+        enableFeatureRecommendedBadges: false,
+      }),
       i18n: fakeI18n(),
       ...props,
     };
@@ -40,6 +45,38 @@ describe(__filename, () => {
     const root = shallowRender({ addon });
 
     expect(root.find(Badge)).toHaveLength(0);
+  });
+
+  it('displays a badge when the addon is recommended', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_recommended: true,
+      type: ADDON_TYPE_EXTENSION,
+    });
+    const root = shallowRender({
+      _config: getFakeConfig({
+        enableFeatureRecommendedBadges: true,
+      }),
+      addon,
+    });
+
+    expect(root.find(RecommendedBadge)).toHaveLength(1);
+  });
+
+  it('does not display a recommended badge when the feature is disabled', () => {
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      is_recommended: true,
+      type: ADDON_TYPE_EXTENSION,
+    });
+    const root = shallowRender({
+      _config: getFakeConfig({
+        enableFeatureRecommendedBadges: false,
+      }),
+      addon,
+    });
+
+    expect(root.find(RecommendedBadge)).toHaveLength(0);
   });
 
   it('displays a badge when the addon is featured', () => {

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -28,7 +28,7 @@ describe(__filename, () => {
         enableFeatureRecommendedBadges: false,
       }),
       i18n: fakeI18n(),
-      store: dispatchClientMetadata().store,
+      store: dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX }).store,
       ...props,
     };
 
@@ -50,11 +50,7 @@ describe(__filename, () => {
     expect(root.find(Badge)).toHaveLength(0);
   });
 
-  it('displays a badge when the addon is recommended', () => {
-    const { store } = dispatchClientMetadata({
-      clientApp: CLIENT_APP_FIREFOX,
-    });
-
+  it('displays a recommended badge when the addon is recommended', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
       is_recommended: true,
@@ -65,7 +61,6 @@ describe(__filename, () => {
         enableFeatureRecommendedBadges: true,
       }),
       addon,
-      store,
     });
 
     expect(root.find(RecommendedBadge)).toHaveLength(1);
@@ -108,7 +103,7 @@ describe(__filename, () => {
     expect(root.find(RecommendedBadge)).toHaveLength(0);
   });
 
-  it('displays a badge for an extension when the addon is featured and the recommended feature is off', () => {
+  it('displays a featured badge for an extension when the addon is featured and the recommended feature is off', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
       is_featured: true,
@@ -125,7 +120,7 @@ describe(__filename, () => {
     expect(root.find(Badge)).toHaveProp('label', 'Featured Extension');
   });
 
-  it('displays a badge for a theme when the addon is featured and the recommended feature is on', () => {
+  it('displays a featured badge for a theme when the addon is featured and the recommended feature is on', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
       is_featured: true,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -124,6 +124,7 @@ export const fakeAddon = Object.freeze({
   is_disabled: false,
   is_experimental: false,
   is_featured: false,
+  is_recommended: false,
   is_source_public: true,
   last_updated: '2018-11-22T10:09:01Z',
   name: 'Chill Out',


### PR DESCRIPTION
~~Depends on #7958~~

Fixes #7794 

Large screen:

![Screenshot 2019-05-02 15 47 05](https://user-images.githubusercontent.com/142755/57102479-94bf6480-6cf1-11e9-9d00-e1be803e750b.png)

Small screen:

![Screenshot 2019-05-02 15 48 00](https://user-images.githubusercontent.com/142755/57102526-b0c30600-6cf1-11e9-8515-da1c6a54c647.png)

I know there are some issues with the small screen, but I think I'll be able to address them once I have the correct icon.

@jvillalobos & @brassy- Do we want the Recommended badge to appear lower down on the small version of the screen, as it does in my screenshot above? I've simply put it above all the other badges on both the large and small screens. But maybe we want this new Recommended badge to show up in the upper right-hand corner even on smaller screens?
