### PR TITLE
Update recommended badge colors

### DIFF
--- a/src/ui/components/RecommendedBadge/styles.scss
+++ b/src/ui/components/RecommendedBadge/styles.scss
@@ -1,7 +1,7 @@
 @import '~ui/css/styles';
 
-$recommended-text-color: $orange-70;
-$recommended-hover-color: $orange-50;
+$recommended-text-color: $orange-50;
+$recommended-hover-color: $orange-60;
 
 .RecommendedBadge {
   align-items: center;
@@ -54,4 +54,8 @@ $recommended-hover-color: $orange-50;
   padding-bottom: 4px;
   padding-top: 2px;
   width: 22px;
+}
+
+.RecommendedBadge-label {
+  color: $orange-80;
 }


### PR DESCRIPTION
Fixes #7986 

Default:

<img width="191" alt="Screenshot 2019-05-09 13 10 08" src="https://user-images.githubusercontent.com/142755/57472574-cb4e2f80-725b-11e9-9aa5-13f023a5ade2.png">

Hovered:

<img width="183" alt="Screenshot 2019-05-09 13 10 46" src="https://user-images.githubusercontent.com/142755/57472619-e456e080-725b-11e9-8caa-687cb51429dc.png">
