### PR TITLE
Fix reply to a review does not load after deletion

### DIFF
--- a/src/amo/components/FeaturedAddonReview/index.js
+++ b/src/amo/components/FeaturedAddonReview/index.js
@@ -89,6 +89,7 @@ export class FeaturedAddonReviewBase extends React.Component<InternalProps> {
       : null;
 
     const featuredReviewCard =
+      !featuredReview &&
       errorHandler.hasError() &&
       errorHandler.capturedError.responseStatusCode === 404 ? (
         <NestedStatus code={404}>

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -547,14 +547,18 @@ export default function reviewsReducer(
         throw new Error(oneLine`Cannot store reply to review ID
           ${reviewId} because it does not exist`);
       }
+      const reviewReply = action.payload.reply;
+      const replyData = createInternalReview(action.payload.reply);
+
       return {
         ...state,
         byId: {
           ...state.byId,
           [review.id]: {
             ...review,
-            reply: createInternalReview(action.payload.reply),
+            reply: replyData,
           },
+          [reviewReply.id]: replyData,
         },
       };
     }

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -225,6 +225,7 @@ describe(__filename, () => {
     expect(newState.byId[review.id].body).toEqual('Original review body');
     expect(newState.byId[review.id].reply.body).toEqual('A developer reply');
     expect(newState.byId[review.id].reply).toEqual(createInternalReview(reply));
+    expect(newState.byId[reply.id]).toEqual(createInternalReview(reply));
   });
 
   it('cannot store a reply to a non-existant review', () => {


### PR DESCRIPTION
Fixes #6447

#### Description
Clicking the timestamp permalink of a reply, it will become a featured review.
Delete it and then reply to the same review, the featured review should not be not found.