### PR TITLE
replacing the profile url with "Homepage" (#4916)

### DIFF
--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -355,7 +355,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                   term={i18n.gettext('Homepage')}
                 >
                   <a href={user.homepage}>
-                    {removeProtocolFromURL(user.homepage)}
+                    {i18n.gettext('Homepage')}
                   </a>
                 </Definition>
               ) : null}


### PR DESCRIPTION
Fixes #4916 

Profile homepage ref now looks like this.
<img width="411" alt="Bildschirmfoto 2019-05-18 um 16 37 07" src="https://user-images.githubusercontent.com/6454853/57971223-70b78080-798b-11e9-9580-9379c61bc01a.png">

Kept the lightgray 'Homepage' label, as discussed in #4916