### PR TITLE
replacing the profile url with "Homepage" (#4916)

### DIFF
--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -35,7 +35,7 @@ import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import { sendServerRedirect } from 'core/reducers/redirectTo';
-import { removeProtocolFromURL, sanitizeUserHTML } from 'core/utils';
+import { sanitizeUserHTML } from 'core/utils';
 import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
 import CardList from 'ui/components/CardList';

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -355,7 +355,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                   term={i18n.gettext('Homepage')}
                 >
                   <a href={user.homepage}>
-                    {removeProtocolFromURL(user.homepage)}
+                    {i18n.gettext('Homepage')}
                   </a>
                 </Definition>
               ) : null}

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -266,7 +266,7 @@ describe(__filename, () => {
 
     expect(root.find('.UserProfile-homepage')).toHaveLength(1);
     expect(root.find('.UserProfile-homepage').children()).toHaveText(
-      'hamsterdance.com/',
+      'Homepage',
     );
   });
 


### PR DESCRIPTION
Fixes #4916 

Profile homepage ref now looks like this.
<img width="411" alt="Bildschirmfoto 2019-05-18 um 16 37 07" src="https://user-images.githubusercontent.com/6454853/57971223-70b78080-798b-11e9-9580-9379c61bc01a.png">

Kept the lightgray 'Homepage' label, as discussed in #4916