### PR TITLE
Add Bengali (bn) to list of languages

### DIFF
--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -59,6 +59,10 @@ export const unfilteredLanguages = {
     English: 'Bengali (India)',
     native: '\u09ac\u09be\u0982\u09b2\u09be (\u09ad\u09be\u09b0\u09a4)',
   },
+  'bn': {
+    English: 'Bengali',
+    native: '\u09ac\u09be\u0982\u09b2\u09be',
+  },  
   br: {
     English: 'Breton',
     native: 'Brezhoneg',

--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -59,10 +59,10 @@ export const unfilteredLanguages = {
     English: 'Bengali (India)',
     native: '\u09ac\u09be\u0982\u09b2\u09be (\u09ad\u09be\u09b0\u09a4)',
   },
-  'bn': {
+  bn: {
     English: 'Bengali',
     native: '\u09ac\u09be\u0982\u09b2\u09be',
-  },  
+  },
   br: {
     English: 'Breton',
     native: 'Brezhoneg',


### PR DESCRIPTION
We need to support Bengali (bn) from 68. 
https://addons.mozilla.org/it/firefox/addon/bengali-language-pack/

Without the language listed here, the language pack won't be available in 
https://addons.mozilla.org/firefox/language-tools/