### PR TITLE
Fix test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ _aliases:
   - &node-next
     # This is the next NodeJS version we will support.
     language: node_js
-    node_js: '11'
+    node_js: '12'
     before_install: npm install -g yarn
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,6 @@ script: FORCE_COLOR=0 yarn $COMMAND
 # See: https://github.com/mozilla/addons-frontend/issues/3034
 install: yarn install --pure-lockfile
 
-matrix:
-  allow_failures:
-    - node_js: '11'
-
 jobs:
   include:
     # Test the build process.

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -100,9 +100,9 @@ describe(__filename, () => {
   it('localises the user count', () => {
     const root = render({ lang: 'fr' });
 
-    // `\xa0` is a non-breaking space.
-    // See: https://github.com/airbnb/enzyme/issues/1349
-    expect(root.find('.SearchResult-users-text')).toIncludeText('5\xa0253');
+    // `\u202F` is a narrow non-breaking space, see:
+    // https://www.fileformat.info/info/unicode/char/202f/index.htm
+    expect(root.find('.SearchResult-users-text')).toIncludeText('5\u202F253');
   });
 
   it('renders the user count as singular', () => {

--- a/tests/unit/core/i18n/test_utils.js
+++ b/tests/unit/core/i18n/test_utils.js
@@ -490,7 +490,10 @@ describe(__filename, () => {
       const i18n = utils.makeI18n({}, 'fr', FakeJed, { _Intl: {} });
       const toLocaleStringSpy = sinon.spy(Number.prototype, 'toLocaleString');
       const number = 12345;
-      expect(i18n.formatNumber(number)).toEqual('12 345');
+
+      // `\u202F` is a narrow non-breaking space, see:
+      // https://www.fileformat.info/info/unicode/char/202f/index.htm
+      expect(i18n.formatNumber(number)).toEqual('12\u202F345');
       sinon.assert.calledWith(toLocaleStringSpy, 'fr');
       sinon.assert.notCalled(numberFormatSpy);
     });


### PR DESCRIPTION
Fixes #8100

---

- Use a narrow space (`\u202F`) in the expected formatted strings.
- Upgrade to Node 12 because Node 11 was set before Node 12 was available (and Node LTS are only even numbers)