### PR TITLE
Remove text shadow for collection action buttons

### DIFF
--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -10,12 +10,6 @@ $icon-size: 32px;
   }
 }
 
-.EditableCollectionAddon {
-  .Button {
-    text-shadow: none;
-  }
-}
-
 .EditableCollectionAddon-buttons,
 .EditableCollectionAddon-details {
   align-items: center;

--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -10,6 +10,12 @@ $icon-size: 32px;
   }
 }
 
+.EditableCollectionAddon {
+  .Button {
+    text-shadow: none;
+  }
+}
+
 .EditableCollectionAddon-buttons,
 .EditableCollectionAddon-details {
   align-items: center;

--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -78,11 +78,12 @@ $default-font-size: 13px;
         padding-top: 1px;
       }
 
-      // Small text is difficult to read against the bright Photon colors.
-      // This isn't (yet) part of the spec but @tofumatt added it because
-      // he thinks it improves accessibility.
-      // See: https://github.com/FirefoxUX/photon/issues/264
-      text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
+      // Small text is difficult to read against the bright Photon colors
+      // since it is blurry
+      // This isn't (yet) part of the spec but added this because
+      // it improves accessibility.
+      // https://github.com/FirefoxUX/photon/issues/264#issuecomment-364927535
+      letter-spacing: 0.01rem;
     }
   }
 

--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -78,10 +78,10 @@ $default-font-size: 13px;
         padding-top: 1px;
       }
 
-      // Small text is difficult to read against the bright Photon colors
-      // since it is blurry. This isn't (yet) part of the spec but added
-      // this because it improves accessibility.
-      // See: https://github.com/FirefoxUX/photon/issues/264#issuecomment-364927535
+      // Small text is difficult to read against the bright Photon colors since
+      // it is blurry. This isn't (yet) part of the spec but added this because
+      // it improves accessibility. See:
+      // https://github.com/FirefoxUX/photon/issues/264#issuecomment-364927535
       letter-spacing: 0.01rem;
     }
   }

--- a/src/ui/components/Button/styles.scss
+++ b/src/ui/components/Button/styles.scss
@@ -79,10 +79,9 @@ $default-font-size: 13px;
       }
 
       // Small text is difficult to read against the bright Photon colors
-      // since it is blurry
-      // This isn't (yet) part of the spec but added this because
-      // it improves accessibility.
-      // https://github.com/FirefoxUX/photon/issues/264#issuecomment-364927535
+      // since it is blurry. This isn't (yet) part of the spec but added
+      // this because it improves accessibility.
+      // See: https://github.com/FirefoxUX/photon/issues/264#issuecomment-364927535
       letter-spacing: 0.01rem;
     }
   }


### PR DESCRIPTION
Fixes #5575 

### Screenshot
![Screenshot 2019-06-03 at 9 53 22 PM](https://user-images.githubusercontent.com/9111111/58830454-a2e30680-864a-11e9-97a8-01067cad61f8.png)

Updated style for buttons to remove `text-shadow` for `Buttons` on CollectionEdit.
