### PR TITLE
Handle query params correctly for client app urls with no trailing slash

### DIFF
--- a/tests/unit/core/middleware/test_prefixMiddleware.js
+++ b/tests/unit/core/middleware/test_prefixMiddleware.js
@@ -229,6 +229,27 @@ describe(__filename, () => {
     sinon.assert.called(fakeRes.redirect);
   });
 
+  it('should not redirect for locale + app urls missing a trailing slash with query params', () => {
+    const fakeReq = {
+      originalUrl: '/en-US/android?foo=1',
+      headers: {},
+    };
+    prefixMiddleware(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    expect(fakeRes.locals.lang).toEqual('en-US');
+    expect(fakeRes.locals.clientApp).toEqual('android');
+    sinon.assert.notCalled(fakeRes.redirect);
+    sinon.assert.called(fakeNext);
+  });
+
+  it('should redirect for app url missing a trailing slash with query params', () => {
+    const fakeReq = {
+      originalUrl: '/android?foo=2',
+      headers: {},
+    };
+    prefixMiddleware(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/en-US/android?foo=2');
+  });
+
   it('should not mangle a query string for a redirect', () => {
     const fakeReq = {
       originalUrl: '/foo/bar?test=1&bar=2',

--- a/tests/unit/core/middleware/test_prefixMiddleware.js
+++ b/tests/unit/core/middleware/test_prefixMiddleware.js
@@ -250,6 +250,15 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeRes.redirect, 301, '/en-US/android?foo=2');
   });
 
+  it('should redirect for locale url missing a trailing slash with query params', () => {
+    const fakeReq = {
+      originalUrl: '/en-US?foo=3',
+      headers: {},
+    };
+    prefixMiddleware(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
+    sinon.assert.calledWith(fakeRes.redirect, 301, '/en-US/firefox?foo=3');
+  });
+
   it('should not mangle a query string for a redirect', () => {
     const fakeReq = {
       originalUrl: '/foo/bar?test=1&bar=2',


### PR DESCRIPTION
Fixes #8059

From local testing (to exercise both the prefix and the trailing slash middleware) this results in the following:

`/android?foo=1` => `/en-US/android/?foo=1`
`/en-US/android?foo=1` => `/en-US/android/?foo=1`
`/en-US?foo=1` => `/en-US/firefox/?foo=1`