### PR TITLE
Fix the link to photos-music-videos from the Guides page

### DIFF
--- a/src/amo/pages/Guides/index.js
+++ b/src/amo/pages/Guides/index.js
@@ -1,4 +1,6 @@
 /* @flow */
+import querystring from 'querystring';
+
 import Helmet from 'react-helmet';
 import * as React from 'react';
 import { compose } from 'redux';
@@ -9,12 +11,13 @@ import Link from 'amo/components/Link';
 import NotFound from 'amo/components/ErrorPage/NotFound';
 import HeadLinks from 'amo/components/HeadLinks';
 import { fetchGuidesAddons, getGUIDsBySlug } from 'amo/reducers/guides';
-import { CLIENT_APP_ANDROID } from 'core/constants';
+import { ADDON_TYPE_EXTENSION, CLIENT_APP_ANDROID } from 'core/constants';
 import { getAddonByGUID } from 'core/reducers/addons';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import { replaceStringsWithJSX } from 'core/i18n/utils';
+import { getCategoryResultsQuery } from 'core/utils';
 import Icon from 'ui/components/Icon';
 import type { AddonType } from 'core/types/addons';
 import type { AppState } from 'amo/store';
@@ -244,8 +247,12 @@ export const getSections = ({
           exploreMore: i18n.gettext(
             'Explore among thousands of %(linkStart)sphoto, music & video extensions%(linkEnd)s.',
           ),
-          exploreUrl:
-            '/search/?category=photos-music-videos&sort=recommended%2Cusers&type=extension',
+          exploreUrl: `/search/?${querystring.stringify(
+            getCategoryResultsQuery({
+              addonType: ADDON_TYPE_EXTENSION,
+              slug: 'photos-music-videos',
+            }),
+          )}`,
         },
       ];
     default:

--- a/src/amo/pages/Guides/index.js
+++ b/src/amo/pages/Guides/index.js
@@ -244,7 +244,8 @@ export const getSections = ({
           exploreMore: i18n.gettext(
             'Explore among thousands of %(linkStart)sphoto, music & video extensions%(linkEnd)s.',
           ),
-          exploreUrl: '/extensions/photos-music-videos/',
+          exploreUrl:
+            '/search/?category=photos-music-videos&sort=recommended%2Cusers&type=extension',
         },
       ];
     default:


### PR DESCRIPTION
Fixes #8131 

Note that I thought about using [`categoryResultsLinkTo`](https://github.com/mozilla/addons-frontend/blob/6dcf336e0834d98499a7ce837b37d4d3373211d7/src/amo/components/Categories/index.js#L59-L70) to build the link, but `exploreUrl` in the Guides page expects a string, which it uses in a couple of places, whereas `categoryResultsLinkTo` returns an object which we'd have to unpack and manipulate. Seeing as this page is always going to be manually edited whenever changes are required, and all the other values of `exploreUrl` are strings, I kept it simple and just included an explicit link.
