### PR TITLE
Fixes #6242: Collapse text in long add-on reviews

### DIFF
--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -8,6 +8,7 @@ import translate from 'core/i18n/translate';
 import { nl2br, sanitizeHTML } from 'core/utils';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
+import ShowMoreCard from 'ui/components/ShowMoreCard';
 import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { I18nType } from 'core/types/i18n';
@@ -32,12 +33,14 @@ type InternalProps = {|
 function reviewBody({
   content,
   html,
+  id,
 }: {|
   content?: React.Node | string,
   html?: React.Node,
+  id: string,
 |}) {
   invariant(
-    content !== undefined || html !== undefined,
+    content !== undefined || html !== undefined || id !== undefined,
     'content or html is required',
   );
 
@@ -50,13 +53,15 @@ function reviewBody({
   }
 
   return (
-    <div
+    <ShowMoreCard
       className={makeClassName('UserReview-body', {
         // Add an extra class if the content is an empty string.
         'UserReview-emptyBody': !content && !html,
       })}
-      {...bodyAttr}
-    />
+      id={id}
+    >
+      <div {...bodyAttr} />
+    </ShowMoreCard>
   );
 }
 
@@ -72,15 +77,17 @@ export const UserReviewBase = (props: InternalProps) => {
     showRating = false,
   } = props;
 
-  let body = reviewBody({ content: <LoadingText /> });
+  const showMoreId = review && review.id ? `${review.id}` : 'loading-text';
+  let body = reviewBody({ content: <LoadingText />, id: showMoreId });
 
   if (review) {
     if (review.body) {
       body = reviewBody({
         html: sanitizeHTML(nl2br(review.body), ['br']),
+        id: showMoreId,
       });
     } else {
-      body = reviewBody({ content: '' });
+      body = reviewBody({ content: '', id: showMoreId });
     }
   }
 


### PR DESCRIPTION
Fixes #6242: Collapse text in long add-on reviews