### PR TITLE
Make the PR template easier to edit and understand

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
-    Thanks for opening a Pull Request (PR). Please read through
+    Thanks for opening a pull request (PR). Please read through
     these instructions to help us review and merge your change quicker.
 
-    Below, replace Fixes #ISSUE_NUMBER with the issue related to what
+    Replace ISSUE_NUMBER with the number of the issue related to what
     you're fixing followed by a description of your change. For example:
 
     Fixes #3588
@@ -15,15 +15,13 @@ Fixes #ISSUE_NUMBER
 Replace this sentence with a description of how your patch fixes the issue.
 
 <!--
-    Please read through this checklist to make sure your patch is ready
-    for review.
+    Read through this checklist to make sure your patch is ready for review.
 
-    - Add a PR description that summarizes your patch
+    - Add a PR title that summarizes your patch
     - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
     - Add tests to cover the changes added in this PR.
     - Check that the change works locally.
     - Add before and after screenshots (Only for changes that impact the UI).
-    - Delete anything that isn't relevant to your patch.
 
     Thanks for your contribution!
 -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,29 @@
-Thanks for opening a Pull Request (PR), here's a few guidelines as to what we need in your PR before we review it.
+<!--
+    Thanks for opening a Pull Request (PR). Please read through
+    these instructions to help us review and merge your change quicker.
 
-Please delete anything that isn't relevant to your patch.
+    Below, replace Fixes #ISSUE_NUMBER with the issue related to what
+    you're fixing followed by a description of your change. For example:
 
-- [ ] This PR relates to an existing open issue and there are no existing PRs open for the same issue.
-- [ ] Add `Fixes #ISSUENUM` at the top of your PR.
-- [ ] Add a description of the changes introduced in this PR.
-- [ ] The change has been successfully run locally.
-- [ ] Add tests to cover the changes added in this PR.
-- [ ] Add before and after screenshots (Only for changes that impact the UI).
+    Fixes #3588
 
-Once you have met the above requirements please replace this section with a `Fixes #ISSUENUM` linking to the issue fixed by this PR along with an explanation of the changes. Thanks for your contribution!
+    This patch adds a margin on the logout button to correct the layout.
+-->
+
+Fixes #ISSUE_NUMBER
+
+Replace this sentence with a description of how your patch fixes the issue.
+
+<!--
+    Please read through this checklist to make sure your patch is ready
+    for review.
+
+    - Add a PR description that summarizes your patch
+    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
+    - Add tests to cover the changes added in this PR.
+    - Check that the change works locally.
+    - Add before and after screenshots (Only for changes that impact the UI).
+    - Delete anything that isn't relevant to your patch.
+
+    Thanks for your contribution!
+-->


### PR DESCRIPTION
The last sentence of the old template explained how to finalize the PR but no one did that. This tells me that we should guide them towards the final state rather than explain how to do it. If someone doesn't read this new template at all, their PR description will at least look close to finalized.