### PR TITLE
Fix search result styles

### DIFF
--- a/src/amo/components/AddonRecommendations/styles.scss
+++ b/src/amo/components/AddonRecommendations/styles.scss
@@ -35,7 +35,7 @@
         }
       }
 
-      .SearchResult-link {
+      .SearchResult-wrapper {
         @include respond-to(large) {
           display: block;
           padding: 0;

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -35,7 +35,7 @@
         padding: 0;
       }
 
-      .SearchResult-link {
+      .SearchResult-wrapper {
         display: inline-block;
         height: 100%;
         padding: 12px 24px;
@@ -95,8 +95,8 @@
         // stylelint-enable max-nesting-depth
       }
 
-      .SearchResult-link:focus,
-      .SearchResult-link:hover {
+      .SearchResult-wrapper:focus,
+      .SearchResult-wrapper:hover {
         background-color: $grey-10;
         border-radius: $border-radius-default;
 

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -148,88 +148,91 @@ export class SearchResultBase extends React.Component<InternalProps> {
     }
 
     return (
-      <div className="SearchResult-result">
-        <div className={iconWrapperClassnames}>
-          {imageURL ? (
-            <img
-              className={makeClassName('SearchResult-icon', {
-                'SearchResult-icon--loading': !addon,
-              })}
-              src={imageURL}
-              alt={addon ? `${addon.name}` : ''}
-            />
-          ) : (
-            <p className="SearchResult-notheme">
-              {i18n.gettext('No theme preview available')}
-            </p>
-          )}
-        </div>
-
-        <div className="SearchResult-contents">
-          <h2 className="SearchResult-name">
-            {addonTitle}
-            {showRecommendedBadge &&
-            _config.get('enableFeatureRecommendedBadges') &&
-            addon &&
-            addon.is_recommended &&
-            clientApp !== CLIENT_APP_ANDROID ? (
-              <RecommendedBadge
-                onClick={(e) => e.stopPropagation()}
-                size="small"
+      <div className="SearchResult-wrapper">
+        <div className="SearchResult-result">
+          <div className={iconWrapperClassnames}>
+            {imageURL ? (
+              <img
+                className={makeClassName('SearchResult-icon', {
+                  'SearchResult-icon--loading': !addon,
+                })}
+                src={imageURL}
+                alt={addon ? `${addon.name}` : ''}
               />
-            ) : null}
-          </h2>
-          {summary}
+            ) : (
+              <p className="SearchResult-notheme">
+                {i18n.gettext('No theme preview available')}
+              </p>
+            )}
+          </div>
 
-          {showMetadata ? (
-            <div className="SearchResult-metadata">
-              <div className="SearchResult-rating">
-                <Rating
-                  rating={addon && addon.ratings ? addon.ratings.average : 0}
-                  readOnly
-                  styleSize="small"
+          <div className="SearchResult-contents">
+            <h2 className="SearchResult-name">
+              {addonTitle}
+              {showRecommendedBadge &&
+              _config.get('enableFeatureRecommendedBadges') &&
+              addon &&
+              addon.is_recommended &&
+              clientApp !== CLIENT_APP_ANDROID ? (
+                <RecommendedBadge
+                  onClick={(e) => e.stopPropagation()}
+                  size="small"
+                />
+              ) : null}
+            </h2>
+            {summary}
+
+            {showMetadata ? (
+              <div className="SearchResult-metadata">
+                <div className="SearchResult-rating">
+                  <Rating
+                    rating={addon && addon.ratings ? addon.ratings.average : 0}
+                    readOnly
+                    styleSize="small"
+                  />
+                </div>
+                {addonAuthors}
+              </div>
+            ) : null}
+
+            {addon && addon.notes && (
+              <div className="SearchResult-note">
+                <h4 className="SearchResult-note-header">
+                  <Icon name="comments-blue" />
+                  {i18n.gettext('Add-on note')}
+                </h4>
+                <p
+                  className="SearchResult-note-content"
+                  // eslint-disable-next-line react/no-danger
+                  dangerouslySetInnerHTML={sanitizeHTML(nl2br(addon.notes), [
+                    'br',
+                  ])}
                 />
               </div>
-              {addonAuthors}
-            </div>
+            )}
+          </div>
+
+          {!addon || (addon && addon.type !== ADDON_TYPE_OPENSEARCH) ? (
+            <h3 className="SearchResult-users SearchResult--meta-section">
+              <Icon className="SearchResult-users-icon" name="user-fill" />
+              <span className="SearchResult-users-text">
+                {averageDailyUsers !== null &&
+                averageDailyUsers !== undefined ? (
+                  i18n.sprintf(
+                    i18n.ngettext(
+                      '%(total)s user',
+                      '%(total)s users',
+                      averageDailyUsers,
+                    ),
+                    { total: i18n.formatNumber(averageDailyUsers) },
+                  )
+                ) : (
+                  <LoadingText width={90} />
+                )}
+              </span>
+            </h3>
           ) : null}
-
-          {addon && addon.notes && (
-            <div className="SearchResult-note">
-              <h4 className="SearchResult-note-header">
-                <Icon name="comments-blue" />
-                {i18n.gettext('Add-on note')}
-              </h4>
-              <p
-                className="SearchResult-note-content"
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={sanitizeHTML(nl2br(addon.notes), [
-                  'br',
-                ])}
-              />
-            </div>
-          )}
         </div>
-
-        {!addon || (addon && addon.type !== ADDON_TYPE_OPENSEARCH) ? (
-          <h3 className="SearchResult-users SearchResult--meta-section">
-            <Icon className="SearchResult-users-icon" name="user-fill" />
-            <span className="SearchResult-users-text">
-              {averageDailyUsers !== null && averageDailyUsers !== undefined ? (
-                i18n.sprintf(
-                  i18n.ngettext(
-                    '%(total)s user',
-                    '%(total)s users',
-                    averageDailyUsers,
-                  ),
-                  { total: i18n.formatNumber(averageDailyUsers) },
-                )
-              ) : (
-                <LoadingText width={90} />
-              )}
-            </span>
-          </h3>
-        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
Fixes #8154 

Note that this is a quick fix which simply replaces the `<a>` wrapper that was removed with a `<div>` wrapper. This works and seems to now render the site the same as what's on stage.

We may want to reevaluate how we're assigning these styles in a follow-up, as I'm not sure if we need this wrapper or if we could just assign the styles directly to the `SearchResult-result` `div`, but we need a fix to land in time for today's tag, so I think we should deal with that in a follow-up.

Before:

![Screenshot 2019-06-11 10 11 16](https://user-images.githubusercontent.com/142755/59279067-475bde80-8c31-11e9-8000-54f39ce39ad9.png)

![Screenshot 2019-06-11 10 12 06](https://user-images.githubusercontent.com/142755/59279144-6490ad00-8c31-11e9-9457-cd8cca7e1fa1.png)

After:

![Screenshot 2019-06-11 10 10 53](https://user-images.githubusercontent.com/142755/59279082-4e82ec80-8c31-11e9-9a40-0fb149ceec9b.png)

![Screenshot 2019-06-11 10 12 49](https://user-images.githubusercontent.com/142755/59279188-7b370400-8c31-11e9-91fa-fdef2acebfe5.png)
