### PR TITLE
Only use the first instance of multiple query parameters

### DIFF
--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -96,9 +96,15 @@ export function convertFiltersToQueryParams(filters) {
 
 export function convertQueryParamsToFilters(params) {
   return Object.keys(paramsToFilter).reduce((object, key) => {
-    const paramValue = Array.isArray(params[key])
-      ? params[key][0]
-      : params[key];
+    let paramValue = params[key];
+
+    // The param value could be an array if the param appeared on the URL
+    // multiple times. In that case just use the first instance.
+    if (Array.isArray(params[key])) {
+      log.info(`${key} param was provided multiple times: ${paramValue}`);
+      paramValue = params[key][0];
+    }
+
     if (typeof paramValue !== 'undefined' && paramValue !== '') {
       return { ...object, [paramsToFilter[key]]: paramValue };
     }

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -96,8 +96,11 @@ export function convertFiltersToQueryParams(filters) {
 
 export function convertQueryParamsToFilters(params) {
   return Object.keys(paramsToFilter).reduce((object, key) => {
-    if (typeof params[key] !== 'undefined' && params[key] !== '') {
-      return { ...object, [paramsToFilter[key]]: params[key] };
+    const paramValue = Array.isArray(params[key])
+      ? params[key][0]
+      : params[key];
+    if (typeof paramValue !== 'undefined' && paramValue !== '') {
+      return { ...object, [paramsToFilter[key]]: paramValue };
     }
     return object;
   }, {});

--- a/tests/unit/core/test_searchUtils.js
+++ b/tests/unit/core/test_searchUtils.js
@@ -166,6 +166,18 @@ describe(__filename, () => {
         tag: 'firefox57',
       });
     });
+
+    it('uses the first instance of multiple query params', () => {
+      const filters = convertQueryParamsToFilters({
+        appversion: ['57.0', '58.0'],
+        page: ['4', '5', '6'],
+      });
+
+      expect(filters).toEqual({
+        compatibleWithVersion: '57.0',
+        page: '4',
+      });
+    });
   });
 
   describe('convertOSToFilterValue', () => {


### PR DESCRIPTION
Fixes #8177 

Note that this error is triggered by having multiple `sort` query parameters, which results in `filters.sort` being an array rather than a string.

We discussed this in IRC and we cannot really properly support multiple instances of query parameters for a number of reasons including:
- The APIs do not support it (they take the last instance of multiple params passed)
- Our UI generally does not support it (for things like search params, where we only allow the user to choose a single value)

My solution to this is to just take the first instance of multiple query params and use that. There is no reason for a user to expect to be able to manually add multiple instances of a query param to the URL and expect the application to be smart enough to know what to do with them.