### PR TITLE
Replace homepage text with the user's homepage URL

### DIFF
--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -354,7 +354,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                   className="UserProfile-homepage"
                   term={i18n.gettext('Homepage')}
                 >
-                  <a href={user.homepage}>{i18n.gettext('Homepage')}</a>
+                  <a href={user.homepage}>{user.homepage}</a>
                 </Definition>
               ) : null}
               {user && user.location ? (

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -266,7 +266,7 @@ describe(__filename, () => {
 
     expect(root.find('.UserProfile-homepage')).toHaveLength(1);
     expect(root.find('.UserProfile-homepage').children()).toHaveText(
-      'Homepage',
+      'http://hamsterdance.com/',
     );
   });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7039523/59973443-a12fa300-9565-11e9-92fe-97e921fcafe9.png)

In the above screenshot, you can notice the text 'Homepage' twice - as the heading and as the content (the URL). Is there any reason why we are not displaying the URL?

This PR removes the redundant homepage text and renders the link instead. 

What do you think about this change? 

![image](https://user-images.githubusercontent.com/7039523/59973436-91b05a00-9565-11e9-9df3-7c9c8117c9cd.png)

