### PR TITLE
Fixes #3900: Add file size info to addon's "More Info" section

### DIFF
--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -12,6 +12,7 @@ import {
   STATS_VIEW,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
+import { formatFilesize } from 'core/i18n/utils';
 import {
   dispatchClientMetadata,
   dispatchSignInActions,
@@ -186,17 +187,20 @@ describe(__filename, () => {
   });
 
   it('renders file size of an add-on', () => {
+    const size = 10;
     _loadVersions({
       files: [
         {
           ...fakePlatformFile,
-          size: 10,
+          size,
         },
       ],
     });
     const root = render({});
 
-    expect(root.find('.AddonMoreInfo-filesize').children()).toHaveText('10 B');
+    expect(root.find('.AddonMoreInfo-filesize').children()).toHaveText(
+      formatFilesize({ size, i18n: fakeI18n() }),
+    );
   });
 
   it('renders a non-custom license and link', () => {

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -19,6 +19,7 @@ import {
   fakeI18n,
   fakeTheme,
   fakeVersion,
+  fakePlatformFile,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import LoadingText from 'ui/components/LoadingText';
@@ -182,6 +183,20 @@ describe(__filename, () => {
     const root = render({});
 
     expect(root.find('.AddonMoreInfo-version').children()).toHaveText('2.0.1');
+  });
+
+  it('renders file size of an add-on', () => {
+    _loadVersions({
+      files: [
+        {
+          ...fakePlatformFile,
+          size: 10,
+        },
+      ],
+    });
+    const root = render({});
+
+    expect(root.find('.AddonMoreInfo-filesize').children()).toHaveText('10 B');
   });
 
   it('renders a non-custom license and link', () => {


### PR DESCRIPTION
Fixes #3900 

This patch adds file size information to "More Info" section on addon's page.

Before:

<img width="410" alt="Screenshot 2019-06-29 at 14 37 54" src="https://user-images.githubusercontent.com/974035/60384360-0b23dd00-9a7d-11e9-8f1f-dd643777a853.png"> 

After:

<img width="414" alt="Screenshot 2019-06-29 at 14 36 42" src="https://user-images.githubusercontent.com/974035/60384362-0fe89100-9a7d-11e9-812d-908ecef1b4dd.png">

### Approach and changes

- [x] updated `AddonMoreInfo` component with `versionInfo` prop
- [x] using `getVersionInfo` reducer for this purpose similarly to `AddonVersionCard` component [which is already capable](https://github.com/mozilla/addons-frontend/blob/master/src/amo/components/AddonVersionCard/index.js#L204-L211) of displaying such data
- [x] added relevant test case into `TestAddonMoreInfo` to cover the change
