### PR TITLE
Fixes #8066: Add twitter meta tags to head

### DIFF
--- a/src/amo/components/AddonHead/index.js
+++ b/src/amo/components/AddonHead/index.js
@@ -169,6 +169,7 @@ export class AddonHeadBase extends React.Component<InternalProps> {
           image={image}
           lastModified={addon.last_updated}
           title={this.getPageTitle()}
+          withTwitterMeta={addon.type === ADDON_TYPE_EXTENSION}
         />
 
         <HeadLinks />

--- a/src/amo/components/HeadMetaTags/index.js
+++ b/src/amo/components/HeadMetaTags/index.js
@@ -117,7 +117,7 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
 
   renderTwitter() {
     const tags = [
-      <meta key="twitter:site" name="twitter:site" content="@firefox" />,
+      <meta key="twitter:site" name="twitter:site" content="@mozamo" />,
       <meta
         key="twitter:card"
         name="twitter:card"

--- a/src/amo/components/HeadMetaTags/index.js
+++ b/src/amo/components/HeadMetaTags/index.js
@@ -115,6 +115,41 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
     return tags;
   }
 
+  renderTwitter() {
+    const { description } = this.props;
+
+    const tags = [
+      <meta key="twitter:site" name="twitter:site" content="@firefox" />,
+      <meta
+        key="twitter:card"
+        name="twitter:card"
+        content="summary_large_image"
+      />,
+      <meta
+        key="twitter:title"
+        name="twitter:title"
+        content={this.getTitle()}
+      />,
+      <meta
+        key="twitter:image:src"
+        name="twitter:image:src"
+        content={this.getImage()}
+      />,
+    ];
+
+    if (description) {
+      tags.push(
+        <meta
+          key="twitter:description"
+          name="twitter:description"
+          content={description}
+        />,
+      );
+    }
+
+    return tags;
+  }
+
   render() {
     const { date, description, lastModified } = this.props;
 
@@ -124,6 +159,7 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
         {date && <meta name="date" content={date} />}
         {lastModified && <meta name="last-modified" content={lastModified} />}
         {this.renderOpenGraph()}
+        {this.renderTwitter()}
       </Helmet>
     );
   }

--- a/src/amo/components/HeadMetaTags/index.js
+++ b/src/amo/components/HeadMetaTags/index.js
@@ -21,6 +21,7 @@ export type Props = {|
   lastModified?: Date | null,
   queryString?: string,
   title?: string | null,
+  withTwitterMeta?: boolean,
 |};
 
 type InternalProps = {|
@@ -36,6 +37,7 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
   static defaultProps = {
     _config: config,
     appendDefaultTitle: true,
+    withTwitterMeta: false,
   };
 
   getImage() {
@@ -116,6 +118,10 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
   }
 
   renderTwitter() {
+    if (!this.props.withTwitterMeta) {
+      return null;
+    }
+
     const tags = [
       <meta key="twitter:site" name="twitter:site" content="@mozamo" />,
       <meta

--- a/src/amo/components/HeadMetaTags/index.js
+++ b/src/amo/components/HeadMetaTags/index.js
@@ -116,8 +116,6 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
   }
 
   renderTwitter() {
-    const { description } = this.props;
-
     const tags = [
       <meta key="twitter:site" name="twitter:site" content="@firefox" />,
       <meta
@@ -125,27 +123,7 @@ export class HeadMetaTagsBase extends React.PureComponent<InternalProps> {
         name="twitter:card"
         content="summary_large_image"
       />,
-      <meta
-        key="twitter:title"
-        name="twitter:title"
-        content={this.getTitle()}
-      />,
-      <meta
-        key="twitter:image:src"
-        name="twitter:image:src"
-        content={this.getImage()}
-      />,
     ];
-
-    if (description) {
-      tags.push(
-        <meta
-          key="twitter:description"
-          name="twitter:description"
-          content={description}
-        />,
-      );
-    }
 
     return tags;
   }

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -237,6 +237,7 @@ export class HomeBase extends React.Component {
           description={i18n.gettext(`Download Firefox extensions and themes.
             They’re like apps for your browser. They can block annoying ads,
             protect passwords, change browser appearance, and more.`)}
+          withTwitterMeta
         />
 
         <HeadLinks />

--- a/tests/unit/amo/components/TestAddonHead.js
+++ b/tests/unit/amo/components/TestAddonHead.js
@@ -115,6 +115,7 @@ describe(__filename, () => {
       'title',
       `${addon.name} – Get this Extension for 🦊 Firefox Android (${lang})`,
     );
+    expect(root.find(HeadMetaTags)).toHaveProp('withTwitterMeta', true);
   });
 
   it('passes the preview URL as `image` to the HeadMetaTags component when add-on is a lightweight theme', () => {
@@ -125,6 +126,8 @@ describe(__filename, () => {
       'image',
       addon.themeData.previewURL,
     );
+    // This prop is only true for ADDON_TYPE_EXTENSION.
+    expect(root.find(HeadMetaTags)).toHaveProp('withTwitterMeta', false);
   });
 
   it('renders JSON linked data', () => {

--- a/tests/unit/amo/components/TestHeadMetaTags.js
+++ b/tests/unit/amo/components/TestHeadMetaTags.js
@@ -194,8 +194,16 @@ describe(__filename, () => {
     },
   );
 
-  it('renders Twitter meta tags', () => {
+  it('does not render Twitter meta tags by default', () => {
     const root = render();
+
+    ['twitter:site', 'twitter:card'].forEach((name) => {
+      expect(root.find(`meta[name="${name}"]`)).toHaveLength(0);
+    });
+  });
+
+  it('renders Twitter meta tags when withTwitterMeta is true', () => {
+    const root = render({ withTwitterMeta: true });
 
     [
       ['twitter:site', '@mozamo'],

--- a/tests/unit/amo/components/TestHeadMetaTags.js
+++ b/tests/unit/amo/components/TestHeadMetaTags.js
@@ -198,7 +198,7 @@ describe(__filename, () => {
     const root = render();
 
     [
-      ['twitter:site', '@firefox'],
+      ['twitter:site', '@mozamo'],
       ['twitter:card', 'summary_large_image'],
     ].forEach(([name, expectedValue]) => {
       expect(root.find(`meta[name="${name}"]`)).toHaveProp(

--- a/tests/unit/amo/components/TestHeadMetaTags.js
+++ b/tests/unit/amo/components/TestHeadMetaTags.js
@@ -195,22 +195,9 @@ describe(__filename, () => {
   );
 
   it('renders Twitter meta tags', () => {
-    const baseURL = 'https://example.org';
-    const _config = getFakeConfig({ baseURL });
-
-    const description = 'page desc';
-    const image = 'https://example.com/image.png';
-    const title = 'page title';
-
-    const lang = 'de';
-    const pathname = '/bar';
-    const { store } = dispatchClientMetadata({ lang, pathname });
-
-    const root = render({ _config, description, image, title, store });
+    const root = render();
 
     [
-      ['twitter:description', description],
-      ['twitter:image:src', image],
       ['twitter:site', '@firefox'],
       ['twitter:card', 'summary_large_image'],
     ].forEach(([name, expectedValue]) => {
@@ -219,79 +206,5 @@ describe(__filename, () => {
         expectedValue,
       );
     });
-
-    expect(root.find(`meta[name="twitter:title"]`)).toHaveLength(1);
-    expect(root.find(`meta[name="twitter:title"]`).prop('content')).toContain(
-      title,
-    );
   });
-
-  it('renders a default image in "twitter:image:src" meta tag when image is null', () => {
-    const root = render({ image: null });
-
-    expect(root.find(`meta[name="twitter:image:src"]`)).toHaveProp(
-      'content',
-      'default-og-image.png',
-    );
-  });
-
-  it('renders a default image in "twitter:image:src" meta tag when image is not defined', () => {
-    const root = render({ image: undefined });
-
-    expect(root.find(`meta[name="twitter:image:src"]`)).toHaveProp(
-      'content',
-      'default-og-image.png',
-    );
-  });
-
-  it('does not render a "twitter:description" meta tag when description is null', () => {
-    const root = render({ description: null });
-
-    expect(root.find(`meta[name="twitter:description"]`)).toHaveLength(0);
-  });
-
-  it('does not render a "twitter:description" meta tag when description is not defined', () => {
-    const root = render({ description: undefined });
-
-    expect(root.find(`meta[name="twitter:description"]`)).toHaveLength(0);
-  });
-
-  it('does not append the default title in the "twitter:title" meta tag when `appendDefaultTitle` is `false`', () => {
-    const title = 'some title';
-
-    const root = render({ title, appendDefaultTitle: false });
-
-    expect(root.find(`meta[name="twitter:title"]`).prop('content')).toEqual(
-      title,
-    );
-  });
-
-  it.each([CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX])(
-    'appends a default %s title in the "twitter:title" meta tag when title is supplied',
-    (clientApp) => {
-      const title = 'some title';
-      const lang = 'de';
-      const { store } = dispatchClientMetadata({ clientApp, lang });
-
-      const root = render({ store, title });
-
-      expect(root.find(`meta[name="twitter:title"]`).prop('content')).toMatch(
-        new RegExp(`^${title} – Add-ons for Firefox( Android)? \\(${lang}\\)$`),
-      );
-    },
-  );
-
-  it.each([CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX])(
-    'uses the default %s title in the "twitter:title" meta tag when title is not supplied',
-    (clientApp) => {
-      const lang = 'de';
-      const { store } = dispatchClientMetadata({ clientApp, lang });
-
-      const root = render({ store, title: null });
-
-      expect(root.find(`meta[name="twitter:title"]`).prop('content')).toMatch(
-        new RegExp(`^Add-ons for Firefox( Android)? \\(${lang}\\)$`),
-      );
-    },
-  );
 });


### PR DESCRIPTION
Fixes #8066

This patch adds missed Twitter meta tags into html head.

## Details

According to ["Twitter Cards and Open Graph"](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started.html) documentation -
> When the Twitter card processor looks for tags on a page, it first checks for the Twitter-specific property, and if not present, falls back to the supported Open Graph property. This allows for both to be defined on the page independently, and minimizes the amount of duplicate markup required to describe content and experience.

Also this line from ["Overview of all Twitter Card Tags"](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup) explains the current behavior -

> If an og:type, og:title and og:description exist in the markup but twitter:card is absent, then a summary card may be rendered.

So in order to have a card that looks like the one mentioned in this comment -https://github.com/mozilla/addons/issues/1055#issuecomment-494547261, it's enough to add `twitter:card` meta tag which was done in this PR.
