### PR TITLE
Temporarily ignore lodash prototype pollution

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -138,5 +138,11 @@ ignore:
     - node-pre-gyp > tar > chownr:
         reason: None given
         expires: '2019-02-13T08:53:31.604Z'
+  SNYK-JS-LODASH-450202:
+    - '*':
+        reason: >-
+          Affected functions are not used in our codebase (either directly or
+          indirectly)
+        expires: 2019-08-01T00:00:00.000Z
 patch: {}
 version: v1.13.5


### PR DESCRIPTION
I reviewed the use of the `defaultsDeep`, `mergeWith` and `merge` functions and they are not used in our code base. There are occurrences in the node modules but not in libs we are directly using (only build tools).