### PR TITLE
Wrap unbreaking words in add-on name in search results

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -19,6 +19,7 @@ $icon-default-size: 32px;
 
 .SearchResult-link {
   text-decoration: none;
+  word-wrap: anywhere;
 
   &,
   &:active,


### PR DESCRIPTION
Fixes #8254 

Note that the only css rule I could get to work is `word-wrap: anywhere;`, which seems odd as we use `word-wrap: break-word;` everywhere else, but for some reason that isn't working in this case. I'm not sure why.

Before:

![Screenshot 2019-07-04 13 17 23](https://user-images.githubusercontent.com/142755/60681682-341de680-9e5e-11e9-9560-3e83819356df.png)
![Screenshot 2019-07-04 13 15 38](https://user-images.githubusercontent.com/142755/60681694-3b44f480-9e5e-11e9-9722-1ed342d789a2.png)

After:

![Screenshot 2019-07-04 13 17 38](https://user-images.githubusercontent.com/142755/60681701-426c0280-9e5e-11e9-82f4-8d4b2f0924be.png)
![Screenshot 2019-07-04 13 15 18](https://user-images.githubusercontent.com/142755/60681706-45ff8980-9e5e-11e9-93d3-8713197759ed.png)

