### PR TITLE
Display only 3 themes for all home page shelves that include themes

### DIFF
--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -11,6 +11,8 @@ import {
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import type { AddonType } from 'core/types/addons';
 
+import './styles.scss';
+
 type Props = {|
   addonInstallSource?: string,
   addons?: Array<AddonType> | null,
@@ -59,7 +61,9 @@ export default class LandingAddonsCard extends React.Component<Props> {
       <AddonsCard
         addonInstallSource={addonInstallSource}
         addons={addons}
-        className={makeClassName('LandingAddonsCard', className)}
+        className={makeClassName('LandingAddonsCard', className, {
+          'LandingAddonsCard-Themes': isTheme,
+        })}
         footerLink={footerLinkHtml}
         header={header}
         showRecommendedBadge={false}

--- a/src/amo/components/LandingAddonsCard/styles.scss
+++ b/src/amo/components/LandingAddonsCard/styles.scss
@@ -1,0 +1,7 @@
+.LandingAddonsCard-Themes {
+  .Card-contents {
+    .AddonsCard-list {
+      grid-template-columns: repeat(3, 33%);
+    }
+  }
+}

--- a/src/amo/components/LandingAddonsCard/styles.scss
+++ b/src/amo/components/LandingAddonsCard/styles.scss
@@ -1,7 +1,3 @@
-.LandingAddonsCard-Themes {
-  .Card-contents {
-    .AddonsCard-list {
-      grid-template-columns: repeat(3, 33%);
-    }
-  }
+.LandingAddonsCard-Themes .Card-contents .AddonsCard-list {
+  grid-template-columns: repeat(3, auto);
 }

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -283,6 +283,7 @@ export class HomeBase extends React.Component {
               sort: SEARCH_SORT_POPULAR,
             },
           }}
+          isTheme
           loading={loading}
         />
 

--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -4,14 +4,6 @@
   @include page-padding();
 }
 
-.Home-RecommendedThemes {
-  .Card-contents {
-    .AddonsCard-list {
-      grid-template-columns: repeat(3, 33%);
-    }
-  }
-}
-
 .Home-SubjectShelf {
   .Card-header {
     display: block;

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -98,7 +98,7 @@ export function* fetchHomeAddons({
     api: state.api,
     filters: {
       addonType: getAddonTypeFilter(ADDON_TYPE_THEME),
-      page_size: String(LANDING_PAGE_EXTENSION_COUNT),
+      page_size: String(LANDING_PAGE_THEME_COUNT),
       sort: SEARCH_SORT_POPULAR,
     },
   };

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -146,7 +146,7 @@ describe(__filename, () => {
           .withArgs({
             ...baseArgs,
             filters: {
-              page_size: String(LANDING_PAGE_EXTENSION_COUNT),
+              page_size: String(LANDING_PAGE_THEME_COUNT),
               addonType: getAddonTypeFilter(ADDON_TYPE_THEME),
               sort: SEARCH_SORT_POPULAR,
             },


### PR DESCRIPTION
Fixes #8278 

This fixes the issue, but it's causing a css problem that I can't seem to track down. I've compared the style rules using Firefox's dev tools for all of the elements that make up both the Recommended Themes shelf (which looks fine) and the Popular Themes shelf (which is way too high) and they all seem identical. I could use some help debugging this css issue.

![Screenshot 2019-07-09 09 30 21](https://user-images.githubusercontent.com/142755/60891901-31d7d580-a22c-11e9-8d83-332ca30d4a30.png)
