### PR TITLE
Move PermissionsCard further up on addon page

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -503,15 +503,15 @@ export class AddonBase extends React.Component {
             )}
           </div>
 
-          <PermissionsCard version={currentVersion} />
-
           {this.renderRatingsCard()}
 
           <ContributeCard addon={addon} />
 
-          <AddAddonToCollection addon={addon} />
+          <PermissionsCard version={currentVersion} />
 
           <AddonMoreInfo addon={addon} />
+
+          <AddAddonToCollection addon={addon} />
 
           {this.renderVersionReleaseNotes()}
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -503,6 +503,8 @@ export class AddonBase extends React.Component {
             )}
           </div>
 
+          <PermissionsCard version={currentVersion} />
+
           {this.renderRatingsCard()}
 
           <ContributeCard addon={addon} />
@@ -510,8 +512,6 @@ export class AddonBase extends React.Component {
           <AddAddonToCollection addon={addon} />
 
           <AddonMoreInfo addon={addon} />
-
-          <PermissionsCard version={currentVersion} />
 
           {this.renderVersionReleaseNotes()}
 


### PR DESCRIPTION
Fixes #7624

This patch moves `<PermissionsCard />` further up on addon page.
Change works locally. Tests pass. I didn't add new tests - order of components was not tested previously.

Before:
![screenshot-2019-07-11 19_16_13](https://user-images.githubusercontent.com/3310268/61071067-70c68080-a410-11e9-8bf9-aeca84e01773.png)

After:
![screenshot-2019-07-11 19_15_02](https://user-images.githubusercontent.com/3310268/61071078-7623cb00-a410-11e9-96ac-56f46252bb43.png)