### PR TITLE
Do not indefinitely reload homepage collections on 403

### DIFF
--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -54,7 +54,7 @@ export function* fetchHomeAddons({
         oneLine`Home collection: ${collection.userId}/${collection.slug}
           failed to load: ${error}`,
       );
-      if (error.response && [401, 404].includes(error.response.status)) {
+      if (error.response && [401, 403, 404].includes(error.response.status)) {
         // The collection was not found or is marked private.
         collections.push(null);
       } else {

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -279,7 +279,7 @@ describe(__filename, () => {
       expect(expectedAction).toEqual(loadAction);
     });
 
-    it.each([401, 404])(
+    it.each([401, 403, 404])(
       'loads a null for a collection that returns a %i',
       async (status) => {
         const error = createApiError({ response: { status } });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8294

---

To ease the review, you can edit `src/amo/pages/Home/index.js` and
change the `userId` to `10641627` as shown below. I made a private
collection with the `password-maangers` slug. Be sure to be logged in
and you should see that the collection is hidden with the patch and
everything is broken without it.

```diff
diff --git a/src/amo/pages/Home/index.js b/src/amo/pages/Home/index.js
index 9e2b538f8..d317fec64 100644
--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -34,7 +34,7 @@ export const MOZILLA_USER_ID = config.get('mozillaUserId');

 export const FEATURED_COLLECTIONS = [
   { slug: 'privacy-matters', userId: MOZILLA_USER_ID },
-  { slug: 'password-managers', userId: MOZILLA_USER_ID },
+  { slug: 'password-managers', userId: 10641627 }, // MOZILLA_USER_ID },
 ];

 export const isFeaturedCollection = (
```