### PR TITLE
Fix display issue with Recommended Badge on Guides pages

### DIFF
--- a/src/amo/components/GuidesAddonCard/index.js
+++ b/src/amo/components/GuidesAddonCard/index.js
@@ -68,7 +68,7 @@ export class GuidesAddonCardBase extends React.Component<InternalProps> {
                   )}
                 </div>
               </div>
-              <div className="GuidesAddonCard-content-button">
+              <div className="GuidesAddonCard-content-description-button">
                 <p className="GuidesAddonCard-content-description">
                   {this.props.addonCustomText}
                 </p>

--- a/src/amo/components/GuidesAddonCard/index.js
+++ b/src/amo/components/GuidesAddonCard/index.js
@@ -68,18 +68,20 @@ export class GuidesAddonCardBase extends React.Component<InternalProps> {
                   )}
                 </div>
               </div>
-              <p className="GuidesAddonCard-content-description">
-                {this.props.addonCustomText}
-              </p>
+              <div className="GuidesAddonCard-content-button">
+                <p className="GuidesAddonCard-content-description">
+                  {this.props.addonCustomText}
+                </p>
+                {addon && (
+                  <InstallButtonWrapper
+                    addon={addon}
+                    defaultInstallSource={INSTALL_SOURCE_GUIDES_PAGE}
+                    getFirefoxButtonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+                    puffy={false}
+                  />
+                )}
+              </div>
             </div>
-            {addon && (
-              <InstallButtonWrapper
-                addon={addon}
-                defaultInstallSource={INSTALL_SOURCE_GUIDES_PAGE}
-                getFirefoxButtonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
-                puffy={false}
-              />
-            )}
           </div>
         </div>
       </Card>

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -33,7 +33,7 @@
   }
 
   .GuidesAddonCard-content-header-title,
-  .GuidesAddonCard-content-button {
+  .GuidesAddonCard-content-description-button {
     width: 100%;
 
     @include respond-to(medium) {
@@ -43,7 +43,7 @@
     }
   }
 
-  .GuidesAddonCard-content-button {
+  .GuidesAddonCard-content-description-button {
     margin: 8px 0 10px;
   }
 

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -44,9 +44,7 @@
   }
 
   .GuidesAddonCard-content-button {
-    .InstallButtonWrapper {
-      padding-bottom: 8px;
-    }
+    margin: 8px 0 10px;
   }
 
   .GuidesAddonCard-content-header-title {
@@ -149,6 +147,6 @@
   line-height: 1.4;
 
   @include respond-to(medium) {
-    margin: 8px 16px;
+    margin: 0 16px;
   }
 }

--- a/src/amo/components/GuidesAddonCard/styles.scss
+++ b/src/amo/components/GuidesAddonCard/styles.scss
@@ -32,13 +32,24 @@
     }
   }
 
-  .GuidesAddonCard-content-header-title {
+  .GuidesAddonCard-content-header-title,
+  .GuidesAddonCard-content-button {
     width: 100%;
 
     @include respond-to(medium) {
+      align-items: center;
       display: flex;
+      justify-content: space-between;
     }
+  }
 
+  .GuidesAddonCard-content-button {
+    .InstallButtonWrapper {
+      padding-bottom: 8px;
+    }
+  }
+
+  .GuidesAddonCard-content-header-title {
     .GuidesAddonCard-content-header-authors {
       width: auto;
     }
@@ -82,6 +93,10 @@
   }
 }
 
+.GuidesAddonCard-content-text {
+  width: 100%;
+}
+
 .GuidesAddonCard-content {
   display: flex;
   flex-wrap: wrap;
@@ -123,7 +138,7 @@
 
 .GuidesAddonCard-content-header-title {
   @include respond-to(medium) {
-    margin: 0 16px;
+    @include margin-start(16px);
   }
 }
 


### PR DESCRIPTION
Fixes #8284 

I got this working pretty much exactly how I wanted, with one exception. When the description of the add-on is only on one line, the Install Button looks too close to the bottom of the card (to me, anyway). That's because it is center aligned with the description. To fix this I added some padding to the bottom of the button, which gives it a decent amount of space in this scenario, but it does mean that when there is more than one line of add-on description, the button is not 100% center aligned with the description, but is above center by a very small amount. The longer the description, the less of a difference this makes. 

Perhaps there's something else I can do to fix this without affecting the centering of the button for longer descriptions?

Here's an example of the problem, without the padding that I added:

![Screenshot 2019-07-15 14 08 51](https://user-images.githubusercontent.com/142755/61238183-2263fb00-a70a-11e9-8874-b8b2d790602b.png)

and here's how it looks with the padding:

![Screenshot 2019-07-15 14 10 32](https://user-images.githubusercontent.com/142755/61238302-5d662e80-a70a-11e9-93bf-0095d9656bc8.png)
