### PR TITLE
Change integration-test job to only run specific tests.

### DIFF
--- a/tests/ui/run-functional-tests.sh
+++ b/tests/ui/run-functional-tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+export PYTEST_ADDOPTS=-k "test_home or test_search" -n 4 --reruns 1
 set -x
 sudo sysctl -w vm.max_map_count=262144
 sudo apt-get update -qqy && sudo apt-get -qqy install uuid

--- a/tests/ui/run-functional-tests.sh
+++ b/tests/ui/run-functional-tests.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env sh
-export PYTEST_ADDOPTS=-k "test_home or test_search" -n 4 --reruns 1
 set -x
 sudo sysctl -w vm.max_map_count=262144
+# Install UUID for fxa email accounts
 sudo apt-get update -qqy && sudo apt-get -qqy install uuid
+# Only run homepage and search tests
+export PYTEST_ADDOPTS=-k "test_home or test_search" -n 4 --reruns 1
 export UITEST_FXA_EMAIL=uitest-$(uuid)@restmail.net
 git clone --depth 1 https://github.com/mozilla/addons-server.git
 docker-compose -f addons-server/docker-compose.yml -f addons-server/tests/ui/docker-compose.selenium.yml -f tests/ui/docker-compose.functional-tests.yml pull --quiet
 docker-compose -f addons-server/docker-compose.yml -f addons-server/tests/ui/docker-compose.selenium.yml -f tests/ui/docker-compose.functional-tests.yml up -d --build
+# Wait for server to start
 until docker-compose -f addons-server/docker-compose.yml -f addons-server/tests/ui/docker-compose.selenium.yml -f tests/ui/docker-compose.functional-tests.yml images | grep "addons-server_addons-frontend_1" ;
     do printf "."; sleep 1
 done


### PR DESCRIPTION
This disables the devhub and install tests within this repo. See https://github.com/mozilla/addons-server/issues/11691 for more details.

Fixes #8323 
