### PR TITLE
Use a spacer (I'm serious) to fix badge wrapping

### DIFF
--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -174,10 +174,13 @@ export class SearchResultBase extends React.Component<InternalProps> {
               addon &&
               addon.is_recommended &&
               clientApp !== CLIENT_APP_ANDROID ? (
-                <RecommendedBadge
-                  onClick={(e) => e.stopPropagation()}
-                  size="small"
-                />
+                <React.Fragment>
+                  <span className="SearchResult-recommendedBadgeSpacer" />
+                  <RecommendedBadge
+                    onClick={(e) => e.stopPropagation()}
+                    size="small"
+                  />
+                </React.Fragment>
               ) : null}
             </h2>
             {summary}

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -133,13 +133,24 @@ $icon-default-size: 32px;
     margin-top: 6px;
   }
 
+  .SearchResult-recommendedBadgeSpacer {
+    display: none;
+  }
+
   @include respond-to(extraLarge) {
     flex-direction: row;
     margin-top: 0;
 
-    .RecommendedBadge {
-      @include margin-start(8px);
+    // Hold up! Before you get bummed about this spacer,
+    // consider how it's currently impossible to detect a flex
+    // wrapping event in CSS. The spacer exists to solve this
+    // wrapping problem: https://github.com/mozilla/addons-frontend/issues/8330
+    .SearchResult-recommendedBadgeSpacer {
+      display: inline-block;
+      width: 8px;
+    }
 
+    .RecommendedBadge {
       margin-top: 0;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8330

![it_works](https://user-images.githubusercontent.com/55398/61414220-0cde0500-a8b3-11e9-88e0-04e3befd6411.gif)

🤷‍♂ 

Before:

<img width="676" alt="Screenshot 2019-07-17 16 43 43" src="https://user-images.githubusercontent.com/55398/61413987-77427580-a8b2-11e9-9498-ef122cb3f4a6.png">


After:

<img width="675" alt="Screenshot 2019-07-17 16 44 03" src="https://user-images.githubusercontent.com/55398/61413995-7d385680-a8b2-11e9-9281-e47b6725486a.png">
<img width="773" alt="Screenshot 2019-07-17 16 44 22" src="https://user-images.githubusercontent.com/55398/61413996-7d385680-a8b2-11e9-8685-37ec329b6332.png">
<img width="531" alt="Screenshot 2019-07-17 16 44 39" src="https://user-images.githubusercontent.com/55398/61413997-7d385680-a8b2-11e9-8d99-d80b31109fc5.png">
<img width="659" alt="Screenshot 2019-07-17 16 45 05" src="https://user-images.githubusercontent.com/55398/61413998-7d385680-a8b2-11e9-84f5-59d71d7af63b.png">
<img width="364" alt="Screenshot 2019-07-17 16 45 25" src="https://user-images.githubusercontent.com/55398/61413999-7d385680-a8b2-11e9-842e-2d671a524ea8.png">
<img width="652" alt="Screenshot 2019-07-17 16 45 59" src="https://user-images.githubusercontent.com/55398/61414001-7dd0ed00-a8b2-11e9-938a-44ad34ea3445.png">
