### PR TITLE
Recommended badges: replace spacer with a margin

### DIFF
--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -174,13 +174,10 @@ export class SearchResultBase extends React.Component<InternalProps> {
               addon &&
               addon.is_recommended &&
               clientApp !== CLIENT_APP_ANDROID ? (
-                <React.Fragment>
-                  <span className="SearchResult-recommendedBadgeSpacer" />
-                  <RecommendedBadge
-                    onClick={(e) => e.stopPropagation()}
-                    size="small"
-                  />
-                </React.Fragment>
+                <RecommendedBadge
+                  onClick={(e) => e.stopPropagation()}
+                  size="small"
+                />
               ) : null}
             </h2>
             {summary}

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -18,6 +18,9 @@ $icon-default-size: 32px;
 }
 
 .SearchResult-link {
+  // This margin gives the recommended badge some space.
+  @include margin-end(8px);
+
   text-decoration: none;
   word-wrap: anywhere;
 
@@ -32,9 +35,6 @@ $icon-default-size: 32px;
   &:hover {
     color: $link-color;
   }
-
-  // This margin gives the recommended badge some space.
-  @include margin-end(8px);
 }
 
 .SearchResult-result {

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -32,6 +32,9 @@ $icon-default-size: 32px;
   &:hover {
     color: $link-color;
   }
+
+  // This margin gives the recommended badge some space.
+  @include margin-end(8px);
 }
 
 .SearchResult-result {
@@ -133,22 +136,9 @@ $icon-default-size: 32px;
     margin-top: 6px;
   }
 
-  .SearchResult-recommendedBadgeSpacer {
-    display: none;
-  }
-
   @include respond-to(extraLarge) {
     flex-direction: row;
     margin-top: 0;
-
-    // Hold up! Before you get bummed about this spacer,
-    // consider how it's currently impossible to detect a flex
-    // wrapping event in CSS. The spacer exists to solve this
-    // wrapping problem: https://github.com/mozilla/addons-frontend/issues/8330
-    .SearchResult-recommendedBadgeSpacer {
-      display: inline-block;
-      width: 8px;
-    }
 
     .RecommendedBadge {
       margin-top: 0;


### PR DESCRIPTION
This fixes https://github.com/mozilla/addons-frontend/issues/8330 and reverts the previous attempt at a fix, too (https://github.com/mozilla/addons-frontend/pull/8335)

Before:

<img width="676" alt="Screenshot 2019-07-17 16 43 43" src="https://user-images.githubusercontent.com/55398/61413987-77427580-a8b2-11e9-9498-ef122cb3f4a6.png">

After:

<img width="784" alt="Screenshot 2019-07-23 15 46 50" src="https://user-images.githubusercontent.com/55398/61746513-7ce00580-ad61-11e9-9151-6ee560c3064b.png">
<img width="758" alt="Screenshot 2019-07-23 15 47 04" src="https://user-images.githubusercontent.com/55398/61746514-7d789c00-ad61-11e9-9a07-ee2a00586d59.png">
<img width="678" alt="Screenshot 2019-07-23 15 47 24" src="https://user-images.githubusercontent.com/55398/61746515-7d789c00-ad61-11e9-9ec7-f506b9d834c7.png">
<img width="680" alt="Screenshot 2019-07-23 15 47 47" src="https://user-images.githubusercontent.com/55398/61746517-7d789c00-ad61-11e9-8270-34ea989049fe.png">
<img width="394" alt="Screenshot 2019-07-23 15 48 06" src="https://user-images.githubusercontent.com/55398/61746518-7d789c00-ad61-11e9-86bb-198800d473ad.png">
<img width="740" alt="Screenshot 2019-07-23 15 48 52" src="https://user-images.githubusercontent.com/55398/61746519-7d789c00-ad61-11e9-985b-612ce8c24849.png">
<img width="643" alt="Screenshot 2019-07-23 15 49 16" src="https://user-images.githubusercontent.com/55398/61746520-7d789c00-ad61-11e9-98b6-9e0c1347254c.png">

