### PR TITLE
Make the non-breaking space test less flaky

### DIFF
--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -130,17 +130,25 @@ describe(__filename, () => {
   });
 
   it('renders the user count', () => {
-    const root = render();
+    const root = render({ addon: { ...baseAddon, average_daily_users: 6233 } });
 
-    expect(root.find('.SearchResult-users')).toIncludeText('5,253 users');
+    expect(root.find('.SearchResult-users')).toIncludeText('6,233 users');
   });
 
   it('localises the user count', () => {
-    const root = render({ lang: 'fr' });
+    const root = render({
+      addon: { ...baseAddon, average_daily_users: 6233 },
+      lang: 'fr',
+    });
 
-    // `\u202F` is a narrow non-breaking space, see:
-    // https://www.fileformat.info/info/unicode/char/202f/index.htm
-    expect(root.find('.SearchResult-users-text')).toIncludeText('5\u202F253');
+    expect(
+      root
+        .find('.SearchResult-users-text')
+        .text()
+        // This handles `\u202F` which is a narrow non-breaking space, see:
+        // https://www.fileformat.info/info/unicode/char/202f/index.htm
+        .replace(/\s/g, ' '),
+    ).toContain('6 233');
   });
 
   it('renders the user count as singular', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -145,7 +145,9 @@ describe(__filename, () => {
       root
         .find('.SearchResult-users-text')
         .text()
-        // This handles `\u202F` which is a narrow non-breaking space, see:
+        // This regex handles `\u202F` which is a narrow,
+        // non-breaking space. The actual character varies between
+        // platform and Node.JS version. More info:
         // https://www.fileformat.info/info/unicode/char/202f/index.htm
         .replace(/\s/g, ' '),
     ).toContain('6 233');


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8379

I also updated the localization tests to rely on explicit input rather than implicit (default) input.