### PR TITLE
Update smoke tests to use requests instead of seleium.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,6 @@ jobs:
             cat /etc/hosts
       - run:
           name: Test Image
-          environment:
-            MOZ_HEADLESS: 1
           command: |
             sudo sysctl -w vm.max_map_count=262144
             ./tests/smoke/setup_docker.sh
@@ -122,8 +120,6 @@ jobs:
             cat /etc/hosts
       - run:
           name: Test Image
-          environment:
-            MOZ_HEADLESS: 1
           command: |
             sudo sysctl -w vm.max_map_count=262144
             ./tests/smoke/setup_docker.sh

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -4,7 +4,7 @@ A simple smoke test suite for the addons-frontend docker image.
 
 ### Prerequisites
 
-Python 3 is recommended but the tests can run on Python 2. You must have `tox` installed either way.
+Python 3 is recommended but the tests can run on Python 2. You must have `tox`, `docker` and `docker-compose` installed as well.
 
 You should also stop any services that may be using the port `3000`. You will also need to add `olympia.test` to your `/etc/hosts` in line with `127.0.0.1`.
 

--- a/tests/smoke/setup_docker.sh
+++ b/tests/smoke/setup_docker.sh
@@ -12,5 +12,3 @@ docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.fu
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml exec web make setup-ui-tests
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml stop nginx
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml up -d
-# Pull and run selenium firefox docker image
-docker run -p 4444:4444 --detach selenium/standalone-firefox

--- a/tests/smoke/setup_docker.sh
+++ b/tests/smoke/setup_docker.sh
@@ -12,3 +12,5 @@ docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.fu
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml exec web make setup-ui-tests
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml stop nginx
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml up -d
+# Pull and run selenium firefox docker image
+docker run --net "host" --detach selenium/standalone-firefox

--- a/tests/smoke/setup_docker.sh
+++ b/tests/smoke/setup_docker.sh
@@ -13,4 +13,4 @@ docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.fu
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml stop nginx
 docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml up -d
 # Pull and run selenium firefox docker image
-docker run --net "host" --detach selenium/standalone-firefox
+docker run -p 4444:4444 --detach selenium/standalone-firefox

--- a/tests/smoke/test_homepage.py
+++ b/tests/smoke/test_homepage.py
@@ -1,6 +1,5 @@
 """Smoke tests for addons-frontend docker image."""
 
-import pytest
 import requests
 
 

--- a/tests/smoke/test_homepage.py
+++ b/tests/smoke/test_homepage.py
@@ -1,18 +1,10 @@
 """Smoke tests for addons-frontend docker image."""
 
 import pytest
+import requests
 
 
-@pytest.fixture
-def firefox_options(firefox_options):
-    """Set up Firefox options."""
-    firefox_options.add_argument("-headless")
-    firefox_options.add_argument('-foreground')
-    return firefox_options
-
-
-@pytest.mark.nondestructive
-def test_hidden_comment_is_found(base_url, selenium):
+def test_hidden_comment_is_found(base_url):
     """Test hidden element is found."""
-    selenium.get(base_url)
-    assert "<!-- Godzilla of browsers -->" in selenium.page_source
+    r = requests.get(base_url)
+    assert "<!-- Godzilla of browsers -->" in r.text

--- a/tests/ui/docker-compose.functional-tests.yml
+++ b/tests/ui/docker-compose.functional-tests.yml
@@ -5,5 +5,6 @@ version: "2.3"
 
 services:
   addons-frontend:
-    image: addons-frontend:latest
+    image: addons-frontend
+    build: ../.
     # This should build a local image if it isn't built already.

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
   pytest-base-url
   pytest-selenium
   pytest-rerunfailures
-commands = pytest --driver Firefox --base-url http://olympia.test --verify-base-url --reruns 1 tests/smoke/test_homepage.py {posargs}
+commands = pytest --driver Remote --capability browserName firefox --base-url http://olympia.test --verify-base-url --reruns 1 tests/smoke/test_homepage.py {posargs}
 
 [testenv:flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,10 @@ commands = pytest --driver Firefox tests/ui/tests/test_discopane.py {posargs}
 basepython = python3.7
 passenv = PYTEST_ADDOPTS
 deps = 
-  pytest-base-url
-  requests
-  pytest-rerunfailures
+  pytest>=5.0.1
+  pytest-base-url>=1.4.1
+  requests>=2.22.0
+  pytest-rerunfailures>=7.0
 commands = pytest --base-url http://olympia.test --verify-base-url --reruns 1 tests/smoke/test_homepage.py {posargs}
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,12 @@ commands = pytest --driver Firefox tests/ui/tests/test_discopane.py {posargs}
 
 [testenv:smoke-tests]
 basepython = python3.7
-recreate = true
-passenv = DISPLAY MOZ_HEADLESS PYTEST_ADDOPTS
+passenv = PYTEST_ADDOPTS
 deps = 
   pytest-base-url
-  pytest-selenium
+  requests
   pytest-rerunfailures
-commands = pytest --driver Remote --capability browserName firefox --base-url http://olympia.test --verify-base-url --reruns 1 tests/smoke/test_homepage.py {posargs}
+commands = pytest --base-url http://olympia.test --verify-base-url --reruns 1 tests/smoke/test_homepage.py {posargs}
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
More fixes for the smoke test suite. This adds a selenium-firefox docker image that the tests can run in.