### PR TITLE
Work around layout bug for hero promo SVG

### DIFF
--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -3,6 +3,10 @@
 .HeroRecommendation {
   color: $white;
   display: flex;
+  // This works around a layout bug in Firefox.
+  // It is currently unfixed as of 70.0 (Nightly).
+  // https://github.com/mozilla/addons-frontend/issues/8426
+  overflow: auto;
   padding: 24px;
   position: relative;
 


### PR DESCRIPTION
This fixes https://github.com/mozilla/addons-frontend/issues/8426 with a workaround.

**Before** (the SVG shape overlaps its container just slightly at the bottom):

<img width="926" alt="Screenshot 2019-08-01 11 38 56" src="https://user-images.githubusercontent.com/55398/62311386-54d35f00-b451-11e9-93dc-40dc68f7fe08.png">


**After**:

<img width="926" alt="Screenshot 2019-08-01 11 39 23" src="https://user-images.githubusercontent.com/55398/62311402-5a30a980-b451-11e9-87b4-772054abef81.png">
