### PR TITLE
Fix rating star alignment in mobile view

### DIFF
--- a/src/amo/components/AddonSummaryCard/styles.scss
+++ b/src/amo/components/AddonSummaryCard/styles.scss
@@ -1,6 +1,9 @@
 @import '~amo/css/styles';
 
 .AddonSummaryCard-overallRatingStars {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
   margin: 0 0 12px;
 
   @include respond-to(extraExtraLarge) {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8437

**Before** (in iPhone 6/7/8)

<img width="414" alt="Screenshot 2019-08-05 10 46 48" src="https://user-images.githubusercontent.com/55398/62477400-83fa1100-b76e-11e9-93fa-ed0d91a641bf.png">


**After**

<img width="414" alt="Screenshot 2019-08-05 10 47 08" src="https://user-images.githubusercontent.com/55398/62477405-878d9800-b76e-11e9-8a75-e4e5dcc85e56.png">
