### PR TITLE
Do not enter a fetch loop on error

### DIFF
--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -66,6 +66,11 @@ export class RatingManagerBase extends React.Component<InternalProps> {
   componentDidMount() {
     const { addon, dispatch, errorHandler, userId, userReview } = this.props;
 
+    if (errorHandler.hasError()) {
+      log.warn('Not loading data because of an error');
+      return;
+    }
+
     if (userId && userReview === undefined) {
       log.debug(`Loading a saved rating (if it exists) for user ${userId}`);
       dispatch(
@@ -263,7 +268,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
   }
 }
 
-const mapStateToProps = (state: AppState, ownProps: Props) => {
+export const mapStateToProps = (state: AppState, ownProps: Props) => {
   const userId = state.users.currentUserID;
   let userReview;
   if (userId && ownProps.addon) {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -109,8 +109,12 @@ function renderProps({
   };
 }
 
-function renderAsDOMNode(...args) {
-  const { store, i18n, ...props } = renderProps(...args);
+function renderAsDOMNode(customProps) {
+  const { store, i18n, ...props } = renderProps({
+    // Use the real RatingManager since we're doing a full mount.
+    RatingManager,
+    ...customProps,
+  });
   props.i18n = i18n;
 
   const history = addQueryParamsToHistory({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8450

This isn't the first one we've had to fix. D'oh. I have a feeling hooks would make it easier to write a wrapper around our loaders to automatically prevent execution on error. We need some kind of abstraction like that but it's not really possible with `componentDidMount()`.