### PR TITLE
Create a function to append different query params to internal and external URLs

### DIFF
--- a/src/amo/utils/index.js
+++ b/src/amo/utils/index.js
@@ -1,5 +1,7 @@
 /* @flow */
 /* eslint camelcase: 0 */
+import url from 'url';
+
 import base62 from 'base62';
 import config from 'config';
 
@@ -47,4 +49,35 @@ export const getCanonicalURL = ({
   locationPathname: string,
 |}): string => {
   return `${_config.get('baseURL')}${locationPathname}`;
+};
+
+type QueryParams = { [key: string]: any };
+
+type MakeInternalExternalURLParams = {|
+  _config: typeof config,
+  urlString: string,
+  internalQueryParams?: QueryParams,
+  externalQueryParams?: QueryParams,
+|};
+
+export const makeInternalExternalURL = ({
+  _config = config,
+  externalQueryParams = {},
+  internalQueryParams = {},
+  urlString,
+}: MakeInternalExternalURLParams) => {
+  const baseURL = _config.get('baseURL');
+  const urlParts = url.parse(urlString, true);
+
+  const queryParams =
+    !urlParts.protocol || baseURL.includes(urlParts.host)
+      ? internalQueryParams
+      : externalQueryParams;
+
+  return url.format({
+    ...urlParts,
+    // Reset the search string so we can define a new one.
+    search: undefined,
+    query: { ...urlParts.query, ...queryParams },
+  });
 };

--- a/tests/unit/amo/utils/test_index.js
+++ b/tests/unit/amo/utils/test_index.js
@@ -1,4 +1,6 @@
-import { getCanonicalURL } from 'amo/utils';
+import url from 'url';
+
+import { getCanonicalURL, makeInternalExternalURL } from 'amo/utils';
 import { getFakeConfig } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -11,6 +13,213 @@ describe(__filename, () => {
       expect(getCanonicalURL({ _config, locationPathname })).toEqual(
         `${baseURL}${locationPathname}`,
       );
+    });
+  });
+
+  describe('makeInternalExternalURL', () => {
+    const baseURL = 'https://example.org';
+    const defaultConfig = getFakeConfig({ baseURL });
+    const initialQuery = { param1: 'param1' };
+    const pathname = '/path/name';
+
+    const _makeInternalExternalURL = ({
+      _config = defaultConfig,
+      externalQueryParams,
+      internalQueryParams,
+      urlString,
+    }) => {
+      return makeInternalExternalURL({
+        _config,
+        externalQueryParams,
+        internalQueryParams,
+        urlString,
+      });
+    };
+
+    it('adds internal query params to a relative URL', () => {
+      const internalQueryParams = { internalParam1: 'internalParam1' };
+      const urlString = url.format({ pathname, query: initialQuery });
+      const expectedURL = url.format({
+        pathname,
+        query: { ...initialQuery, ...internalQueryParams },
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          internalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('overrides internal query params for a relative URL', () => {
+      const originalQueryParams = { internalParam1: 'internalParam1' };
+      const internalQueryParams = { internalParam1: 'internalParam2' };
+      const urlString = url.format({ pathname, query: originalQueryParams });
+      const expectedURL = url.format({
+        pathname,
+        query: { ...originalQueryParams, ...internalQueryParams },
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          internalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('adds internal query params to an absolute URL for the host', () => {
+      const internalQueryParams = { internalParam1: 'internalParam1' };
+      const urlString = url.format({
+        ...url.parse(baseURL),
+        pathname,
+        query: initialQuery,
+      });
+      const expectedURL = url.format({
+        ...url.parse(baseURL),
+        pathname,
+        query: { ...initialQuery, ...internalQueryParams },
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          internalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('overrides internal query params for an absolute URL for the host', () => {
+      const originalQueryParams = { internalParam1: 'internalParam1' };
+      const internalQueryParams = { internalParam1: 'internalParam2' };
+      const urlString = url.format({
+        ...url.parse(baseURL),
+        pathname,
+        query: originalQueryParams,
+      });
+      const expectedURL = url.format({
+        ...url.parse(baseURL),
+        pathname,
+        query: { ...originalQueryParams, ...internalQueryParams },
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          internalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('does not add internal query params to an absolute URL for a different host', () => {
+      const internalQueryParams = { internalParam1: 'internalParam1' };
+      const siteBaseURL = 'https://example.org';
+      const newBaseURL = 'https://www.mozilla.org';
+
+      const urlString = url.format({
+        ...url.parse(newBaseURL),
+        pathname,
+        query: initialQuery,
+      });
+      const expectedURL = url.format({
+        ...url.parse(newBaseURL),
+        pathname,
+        query: initialQuery,
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          _config: getFakeConfig({ baseURL: siteBaseURL }),
+          internalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('adds external query params to an absolute URL for a different host', () => {
+      const externalQueryParams = { externalParam1: 'externalParam1' };
+      const siteBaseURL = 'https://example.org';
+      const newBaseURL = 'https://www.mozilla.org';
+
+      const urlString = url.format({
+        ...url.parse(newBaseURL),
+        pathname,
+        query: initialQuery,
+      });
+      const expectedURL = url.format({
+        ...url.parse(newBaseURL),
+        pathname,
+        query: { ...initialQuery, ...externalQueryParams },
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          _config: getFakeConfig({ baseURL: siteBaseURL }),
+          externalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('overrides external query params for an absolute URL for a different host', () => {
+      const originalQueryParams = { externalParam1: 'internalParam1' };
+      const externalQueryParams = { externalParam1: 'externalParam2' };
+      const siteBaseURL = 'https://example.org';
+      const newBaseURL = 'https://www.mozilla.org';
+
+      const urlString = url.format({
+        ...url.parse(newBaseURL),
+        pathname,
+        query: originalQueryParams,
+      });
+      const expectedURL = url.format({
+        ...url.parse(newBaseURL),
+        pathname,
+        query: { ...originalQueryParams, ...externalQueryParams },
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          _config: getFakeConfig({ baseURL: siteBaseURL }),
+          externalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('does not add external query params to a relative URL', () => {
+      const externalQueryParams = { externalParam1: 'externalParam1' };
+      const urlString = url.format({ pathname, query: initialQuery });
+      const expectedURL = url.format({ pathname, query: initialQuery });
+
+      expect(
+        _makeInternalExternalURL({
+          externalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
+    });
+
+    it('does not add external query params to an absolute URL for the host', () => {
+      const externalQueryParams = { externalParam1: 'externalParam1' };
+      const urlString = url.format({
+        ...url.parse(baseURL),
+        pathname,
+        query: initialQuery,
+      });
+      const expectedURL = url.format({
+        ...url.parse(baseURL),
+        pathname,
+        query: initialQuery,
+      });
+
+      expect(
+        _makeInternalExternalURL({
+          externalQueryParams,
+          urlString,
+        }),
+      ).toEqual(expectedURL);
     });
   });
 });


### PR DESCRIPTION
Fixes #8516 

The tests seem pretty repetitive, but I think it's important to be explicit about the data in each test so they can easily be reviewed and verified that they are testing the correct thing, so I'm not sure I can cut down on the repetitiveness with an extra helper.