### PR TITLE
Default the expiry date for cookies created by withExperiment to 30 days

### DIFF
--- a/src/core/withExperiment.js
+++ b/src/core/withExperiment.js
@@ -8,7 +8,10 @@ import log from 'core/logger';
 import tracking from 'core/tracking';
 import { getDisplayName } from 'core/utils';
 
-export const DEFAULT_COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30 days in seconds
+// This value defaults to 30 days in seconds. This value should not be changed
+// unless directed to do so by a requirements change.
+// See https://github.com/mozilla/addons-frontend/issues/8515
+export const DEFAULT_COOKIE_MAX_AGE = 30 * 24 * 60 * 60;
 export const EXPERIMENT_ENROLLMENT_CATEGORY = 'AMO Experiment Enrollment -';
 export const NOT_IN_EXPERIMENT = 'notInExperiment';
 

--- a/src/core/withExperiment.js
+++ b/src/core/withExperiment.js
@@ -8,6 +8,7 @@ import log from 'core/logger';
 import tracking from 'core/tracking';
 import { getDisplayName } from 'core/utils';
 
+export const DEFAULT_COOKIE_MAX_AGE = 30 * 24 * 60 * 60; // 30 days in seconds
 export const EXPERIMENT_ENROLLMENT_CATEGORY = 'AMO Experiment Enrollment -';
 export const NOT_IN_EXPERIMENT = 'notInExperiment';
 
@@ -17,6 +18,7 @@ export type WithExperimentInjectedProps = {|
 |};
 
 type CookieConfig = {|
+  maxAge?: number,
   path?: string,
 |};
 
@@ -36,7 +38,10 @@ type withExperimentInternalProps = {|
   randomizer: () => number,
 |};
 
-const defaultCookieConfig: CookieConfig = { path: '/' };
+export const defaultCookieConfig: CookieConfig = {
+  maxAge: DEFAULT_COOKIE_MAX_AGE,
+  path: '/',
+};
 
 export const withExperiment = ({
   _tracking = tracking,

--- a/tests/unit/core/test_withExperiment.js
+++ b/tests/unit/core/test_withExperiment.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import {
   EXPERIMENT_ENROLLMENT_CATEGORY,
+  defaultCookieConfig,
   withExperiment,
 } from 'core/withExperiment';
 import {
@@ -94,6 +95,7 @@ describe(__filename, () => {
       cookies.set,
       `${id}Experiment`,
       root.instance().experimentCookie,
+      defaultCookieConfig,
     );
   });
 


### PR DESCRIPTION
Fixes #8515 

This makes the default expiry date of a cookie created via `withExperiment` 30 days in the future (2592000 seconds, to be exact). This can be overridden for a particular experiment by passing a `cookieConfig` property into the call to `withExperiment`, which can then specify a different expiry date.
