### PR TITLE
Add Triqui (trs), update name for ca-valencia

### DIFF
--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -81,7 +81,7 @@ export const unfilteredLanguages = {
   },
   'ca-valencia': {
     English: 'Catalan (Valencian)',
-    native: 'catal\u00e0 (valenci\u00e0)',
+    native: 'Catal\u00e0 (Valenci\u00e0)',
   },
   cak: {
     English: 'Kaqchikel',
@@ -579,6 +579,10 @@ export const unfilteredLanguages = {
     English: 'Turkish',
     native: 'T\u00fcrk\u00e7e',
   },
+  trs: {
+    English: 'Triqui',
+    native: 'N\u00e1nj n\u00ef\'\u00efn',
+  },  
   ts: {
     English: 'Tsonga',
     native: 'Xitsonga',

--- a/src/core/languages.js
+++ b/src/core/languages.js
@@ -581,8 +581,8 @@ export const unfilteredLanguages = {
   },
   trs: {
     English: 'Triqui',
-    native: 'N\u00e1nj n\u00ef\'\u00efn',
-  },  
+    native: "N\u00e1nj n\u00ef'\u00efn",
+  },
   ts: {
     English: 'Tsonga',
     native: 'Xitsonga',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8613

---

We're in the process of adding trs and ca-valencia to Firefox 71, we need trs added in order to show the language pack on the page.

The decode name is `Nánj nï'ïn`.