### PR TITLE
Allow some HTML tags in SiteNotices

### DIFF
--- a/src/core/components/SiteNotices/index.js
+++ b/src/core/components/SiteNotices/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import { sanitizeUserHTML } from 'core/utils';
 import translate from 'core/i18n/translate';
 import Notice from 'ui/components/Notice';
 import type { I18nType } from 'core/types/i18n';
@@ -32,7 +33,10 @@ export class SiteNoticesBase extends React.Component<InternalProps> {
     if (siteNotice) {
       notices.push(
         <Notice className="SiteNotices" id="amo-site-notice" type="warning">
-          {siteNotice}
+          <div
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={sanitizeUserHTML(siteNotice)}
+          />
         </Notice>,
       );
     }

--- a/tests/unit/core/components/TestSiteNotices.js
+++ b/tests/unit/core/components/TestSiteNotices.js
@@ -38,7 +38,27 @@ describe(__filename, () => {
 
     expect(root.find(Notice)).toHaveLength(1);
     expect(root.find(Notice)).toHaveProp('id', 'amo-site-notice');
-    expect(root.find(Notice)).toHaveProp('children', notice);
+    expect(
+      root
+        .find(Notice)
+        .find('div')
+        .html(),
+    ).toContain(notice);
+  });
+
+  it('renders a site notice with HTML tags', () => {
+    const notice = 'more info <a href="https://example.org">here</a>';
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadSiteStatus({ readOnly: false, notice }));
+
+    const root = render({ store });
+
+    expect(
+      root
+        .find(Notice)
+        .find('div')
+        .html(),
+    ).toContain(notice);
   });
 
   it('renders nothing when the site is not in read only mode and there is no site notice configured', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8599

---

Before:

![Screen Shot 2019-09-17 at 10 27 52](https://user-images.githubusercontent.com/217628/65024870-ecbfd600-d935-11e9-81c0-c0110a72c321.png)

After:

![Screen Shot 2019-09-17 at 10 27 45](https://user-images.githubusercontent.com/217628/65024831-e03b7d80-d935-11e9-8dcf-6f310fc2aa5b.png)
