### PR TITLE
Make Primary Hero Shelf decoration load dynamically

### DIFF
--- a/src/amo/components/HeroRecommendation/decorations.js
+++ b/src/amo/components/HeroRecommendation/decorations.js
@@ -1,7 +1,7 @@
 /* @flow */
 import * as React from 'react';
 
-export const svg1 = (
+const svg1 = (
   <svg
     className="HeroRecommendation-decoration"
     xmlns="http://www.w3.org/2000/svg"
@@ -46,7 +46,7 @@ export const svg1 = (
   </svg>
 );
 
-export const svg2 = (
+const svg2 = (
   <svg
     className="HeroRecommendation-decoration"
     xmlns="http://www.w3.org/2000/svg"
@@ -91,6 +91,8 @@ export const svg2 = (
   </svg>
 );
 
-export const getDecoration = (randomizer: () => number = Math.random) => {
-  return randomizer() <= 0.5 ? svg1 : svg2;
+export const decorations = [svg1, svg2];
+
+export const getDecorationIndex = (randomizer: () => number = Math.random) => {
+  return Math.floor(randomizer() * decorations.length);
 };

--- a/src/amo/components/HeroRecommendation/decorations.js
+++ b/src/amo/components/HeroRecommendation/decorations.js
@@ -1,0 +1,96 @@
+/* @flow */
+import * as React from 'react';
+
+export const svg1 = (
+  <svg
+    className="HeroRecommendation-decoration"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 480 420"
+  >
+    <defs>
+      <linearGradient
+        id="background-noodle-1-a"
+        x1="37.554%"
+        x2="20.41%"
+        y1="51.425%"
+        y2="49.159%"
+      >
+        <stop offset="0%" stopColor="#592ACB" />
+        <stop offset="100%" stopColor="#312A65" />
+      </linearGradient>
+      <linearGradient
+        id="background-noodle-1-b"
+        x1="0%"
+        x2="100%"
+        y1="36.092%"
+        y2="36.092%"
+      >
+        <stop offset="0%" stopColor="#9059FF" />
+        <stop offset="100%" stopColor="#E31587" />
+      </linearGradient>
+    </defs>
+    <g fill="none" transform="matrix(-1 0 0 1 334 113)">
+      <path
+        fill="#312A65"
+        d="M334,307 L67,307 C119.112636,258.629663 161.220388,194.897267 187.226377,118.874319 C211.561794,47.736239 270.543021,3.04387234 334,0 L334,307 Z"
+      />
+      <path
+        fill="url(#background-noodle-1-a)"
+        d="M0,307 C17.5018261,297.066328 34.5740674,285.542356 51.0720591,272.398174 C121.246081,216.489776 216.932316,232.61482 271,307 L0,307 Z"
+      />
+      <path
+        fill="url(#background-noodle-1-b)"
+        d="M334,307 L114,307 C145.79039,282.134461 175.545243,252.742423 202.532663,218.864661 C237.964434,174.385973 285.119738,148.906295 334,143 L334,307 Z"
+      />
+    </g>
+  </svg>
+);
+
+export const svg2 = (
+  <svg
+    className="HeroRecommendation-decoration"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 480 420"
+  >
+    <defs>
+      <linearGradient
+        id="background-noodle-2-a"
+        x1="43.792%"
+        x2="35.24%"
+        y1="72.633%"
+        y2="36.647%"
+      >
+        <stop offset="0%" stopColor="#592ACB" />
+        <stop offset="100%" stopColor="#312A65" />
+      </linearGradient>
+      <linearGradient
+        id="background-noodle-2-b"
+        x1="0%"
+        x2="100%"
+        y1="36.092%"
+        y2="36.092%"
+      >
+        <stop offset="0%" stopColor="#9059FF" />
+        <stop offset="100%" stopColor="#E31587" />
+      </linearGradient>
+    </defs>
+    <g fill="none" transform="translate(0 8)">
+      <path
+        fill="#312A65"
+        d="M0,412 L0,128.75365 C31.0094766,238.211493 89.1811504,337.098969 169.23274,412 L0,412 Z"
+      />
+      <path
+        fill="url(#background-noodle-2-a)"
+        d="M0,412 L0,0 C15.5111978,74.0180542 43.5322127,146.095994 84.6678403,212.277121 C139.500279,300.495165 211.038639,367.631123 290.979914,412 L0,412 Z"
+      />
+      <path
+        fill="url(#background-noodle-2-b)"
+        d="M0,412 L0,259.885196 C22.4809046,291.225016 47.4133204,320.994453 74.7800083,348.850262 C97.4362756,371.909451 121.070413,392.95665 145.512407,412 L0,412 Z"
+      />
+    </g>
+  </svg>
+);
+
+export const getDecoration = (randomizer: () => number = Math.random) => {
+  return randomizer() <= 0.5 ? svg1 : svg2;
+};

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -14,6 +14,7 @@ import { addQueryParams, sanitizeUserHTML } from 'core/utils';
 import type { PrimaryHeroShelfType } from 'amo/reducers/home';
 import type { I18nType } from 'core/types/i18n';
 
+import { getDecoration } from './decorations';
 import './styles.scss';
 
 export const PRIMARY_HERO_CLICK_CATEGORY = 'AMO Primary Hero Clicks';
@@ -67,6 +68,8 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
     _tracking: tracking,
   };
 
+  decoration: React.Element<any>;
+
   makeCallToActionURL = () => {
     const { shelfData } = this.props;
     invariant(shelfData, 'The shelfData property is required');
@@ -94,73 +97,13 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
     });
   };
 
-  renderOverlayShape() {
-    const gradientA = 'HeroRecommendation-gradient-a';
-    const gradientB = 'HeroRecommendation-gradient-b';
-
-    return (
-      <svg
-        className="HeroRecommendation-overlayShape"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 334 307"
-      >
-        <defs>
-          <linearGradient
-            id={gradientA}
-            x1="37.554%"
-            x2="20.41%"
-            y1="51.425%"
-            y2="49.159%"
-          >
-            <stop
-              className="HeroRecommendation-gradientA-startColor"
-              offset="0%"
-            />
-            <stop
-              className="HeroRecommendation-gradientA-endColor"
-              offset="100%"
-            />
-          </linearGradient>
-          <linearGradient
-            id={gradientB}
-            x1="0%"
-            x2="100%"
-            y1="36.092%"
-            y2="36.092%"
-          >
-            <stop
-              className="HeroRecommendation-gradientB-startColor"
-              offset="0%"
-            />
-            <stop
-              className="HeroRecommendation-gradientB-endColor"
-              offset="100%"
-            />
-          </linearGradient>
-        </defs>
-        <g fill="none">
-          <path
-            className="HeroRecommendation-solidSwoosh"
-            d="M0 307h267c-52.113-48.37-94.22-112.103-120.226-188.126C122.438 47.736 63.457 3.044 0 0v307z"
-          />
-          <path
-            fill={`url(#${gradientA})`}
-            d="M0 307c17.502-9.934 34.574-21.458 51.072-34.602C121.246 216.49 216.932 232.615 271 307H0z"
-            transform="matrix(-1 0 0 1 334 0)"
-          />
-          <path
-            fill={`url(#${gradientB})`}
-            d="M334 307H114c31.79-24.866 61.545-54.258 88.533-88.135C237.964 174.386 285.12 148.906 334 143v164z"
-            transform="matrix(-1 0 0 1 334 0)"
-          />
-        </g>
-      </svg>
-    );
-  }
-
   render() {
     const { _isInternalURL, i18n, shelfData } = this.props;
     const { addon, description, external, featuredImage } = shelfData;
+
+    if (!this.decoration) {
+      this.decoration = getDecoration();
+    }
 
     const linkInsides = <span> {i18n.gettext('Get the extension')} </span>;
 
@@ -219,7 +162,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           />
           {link}
         </div>
-        {this.renderOverlayShape()}
+        {this.decoration}
       </section>
     );
   }

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -14,7 +14,7 @@ import { addQueryParams, sanitizeUserHTML } from 'core/utils';
 import type { PrimaryHeroShelfType } from 'amo/reducers/home';
 import type { I18nType } from 'core/types/i18n';
 
-import { getDecoration } from './decorations';
+import { decorations } from './decorations';
 import './styles.scss';
 
 export const PRIMARY_HERO_CLICK_CATEGORY = 'AMO Primary Hero Clicks';
@@ -68,8 +68,6 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
     _tracking: tracking,
   };
 
-  decoration: React.Element<any>;
-
   makeCallToActionURL = () => {
     const { shelfData } = this.props;
     invariant(shelfData, 'The shelfData property is required');
@@ -99,11 +97,13 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
 
   render() {
     const { _isInternalURL, i18n, shelfData } = this.props;
-    const { addon, description, external, featuredImage } = shelfData;
-
-    if (!this.decoration) {
-      this.decoration = getDecoration();
-    }
+    const {
+      addon,
+      decorationIndex,
+      description,
+      external,
+      featuredImage,
+    } = shelfData;
 
     const linkInsides = <span> {i18n.gettext('Get the extension')} </span>;
 
@@ -162,7 +162,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           />
           {link}
         </div>
-        {this.decoration}
+        {decorations[decorationIndex]}
       </section>
     );
   }

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -29,15 +29,15 @@
   }
 }
 
-$overlayShapeZIndex: 1;
+$decorationZIndex: 1;
 
-.HeroRecommendation-overlayShape {
+.HeroRecommendation-decoration {
   bottom: 0;
   height: 70%;
   left: 0;
   max-height: 307px;
   position: absolute;
-  z-index: $overlayShapeZIndex;
+  z-index: $decorationZIndex;
 
   [dir='rtl'] & {
     left: auto;
@@ -130,45 +130,20 @@ $overlayShapeZIndex: 1;
 .HeroRecommendation-body,
 .HeroRecommendation-link {
   position: relative;
-  z-index: $overlayShapeZIndex + 1;
+  z-index: $decorationZIndex + 1;
 }
 
 .HeroRecommendation-purple {
   $heroPurple1: #20123a;
   $heroPurple2: #712290;
-  $heroPurple3: #592acb;
-  $heroPurple4: #312a65;
-  $heroPurple5: #9059ff;
-  $heroPurple6: #e31587;
-  $heroPurple7: #312a65;
 
   background-image: linear-gradient($heroPurple1, $heroPurple2);
-
-  .HeroRecommendation-gradientA-startColor {
-    stop-color: $heroPurple3;
-  }
-
-  .HeroRecommendation-gradientA-endColor {
-    stop-color: $heroPurple4;
-  }
-
-  .HeroRecommendation-gradientB-startColor {
-    stop-color: $heroPurple5;
-  }
-
-  .HeroRecommendation-gradientB-endColor {
-    stop-color: $heroPurple6;
-  }
-
-  .HeroRecommendation-solidSwoosh {
-    fill: $heroPurple7;
-  }
 
   .HeroRecommendation-link {
     &,
     &:hover,
     &:active {
-      // Fill the background on small screens in case the overlayShape
+      // Fill the background on small screens in case the decoration
       // overlaps the button. Also, fill the background when hovering.
       background-color: $heroPurple2;
     }

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -3,6 +3,7 @@ import config from 'config';
 import { LOCATION_CHANGE } from 'connected-react-router';
 import invariant from 'invariant';
 
+import { getDecorationIndex } from 'amo/components/HeroRecommendation/decorations';
 import {
   LANDING_PAGE_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
@@ -56,6 +57,7 @@ export type ExternalPrimaryHeroShelfType =
   | ExternalPrimaryHeroShelfWithExternalType;
 
 type BasePrimaryHeroShelfType = {|
+  decorationIndex: number,
   gradient: HeroGradientType,
   featuredImage: string,
   description: string | null,
@@ -200,6 +202,7 @@ const createInternalAddons = (
 
 export const createInternalHeroShelves = (
   heroShelves: ExternalHeroShelvesType,
+  randomizer: () => number = Math.random,
 ): HeroShelvesType => {
   const { primary, secondary } = heroShelves;
 
@@ -211,6 +214,7 @@ export const createInternalHeroShelves = (
   let shelves;
 
   const basePrimaryShelf = {
+    decorationIndex: getDecorationIndex(randomizer),
     gradient: primary.gradient,
     featuredImage: primary.featured_image,
     description: primary.description,

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -8,11 +8,7 @@ import HeroRecommendation, {
   addParamsToHeroURL,
   HeroRecommendationBase,
 } from 'amo/components/HeroRecommendation';
-import {
-  getDecoration,
-  svg1,
-  svg2,
-} from 'amo/components/HeroRecommendation/decorations';
+import { getDecorationIndex } from 'amo/components/HeroRecommendation/decorations';
 import { createInternalHeroShelves } from 'amo/reducers/home';
 import { getAddonURL } from 'amo/utils';
 import {
@@ -339,12 +335,12 @@ describe(__filename, () => {
     );
   });
 
-  describe('getDecoration', () => {
-    it.each([[0.4, svg1], [0.6, svg2]])(
-      'retuns the expected svg file for %s',
-      (randomNumber, expectedSvg) => {
+  describe('getDecorationIndex', () => {
+    it.each([[0.4, 0], [0.6, 1]])(
+      'retuns the expected index for %s',
+      (randomNumber, expectedIndex) => {
         const randomizer = () => randomNumber;
-        expect(getDecoration(randomizer)).toEqual(expectedSvg);
+        expect(getDecorationIndex(randomizer)).toEqual(expectedIndex);
       },
     );
   });

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -8,6 +8,11 @@ import HeroRecommendation, {
   addParamsToHeroURL,
   HeroRecommendationBase,
 } from 'amo/components/HeroRecommendation';
+import {
+  getDecoration,
+  svg1,
+  svg2,
+} from 'amo/components/HeroRecommendation/decorations';
 import { createInternalHeroShelves } from 'amo/reducers/home';
 import { getAddonURL } from 'amo/utils';
 import {
@@ -133,6 +138,12 @@ describe(__filename, () => {
       'src',
       featuredImage,
     );
+  });
+
+  it('renders a decoration', () => {
+    const root = render();
+
+    expect(root.find('.HeroRecommendation-decoration')).toHaveLength(1);
   });
 
   it('renders a body', () => {
@@ -324,6 +335,16 @@ describe(__filename, () => {
           category: PRIMARY_HERO_CLICK_CATEGORY,
         });
         sinon.assert.calledOnce(_tracking.sendEvent);
+      },
+    );
+  });
+
+  describe('getDecoration', () => {
+    it.each([[0.4, svg1], [0.6, svg2]])(
+      'retuns the expected svg file for %s',
+      (randomNumber, expectedSvg) => {
+        const randomizer = () => randomNumber;
+        expect(getDecoration(randomizer)).toEqual(expectedSvg);
       },
     );
   });

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -322,6 +322,7 @@ describe(__filename, () => {
       expect(createInternalHeroShelves(heroShelves)).toEqual({
         primary: {
           addon: createInternalAddon(addon),
+          decorationIndex: heroShelves.primary.decorationIndex,
           description: heroShelves.primary.description,
           external: undefined,
           featuredImage: heroShelves.primary.featured_image,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -284,6 +284,7 @@ export const fakePrimaryHeroShelfExternal = Object.freeze({
 
 export const createPrimaryHeroShelf = ({
   addon = undefined,
+  decorationIndex = 1,
   description = 'Primary shelf description',
   external = undefined,
   featuredImage = 'https://addons-dev-cdn.allizom.org/static/img/hero/featured/teamaddons.jpg',
@@ -291,6 +292,7 @@ export const createPrimaryHeroShelf = ({
 } = {}) => {
   return {
     addon,
+    decorationIndex,
     description,
     external,
     featured_image: featuredImage,


### PR DESCRIPTION
Fixes #8248 

There is one problem with this implementation: When loading the home page for the first time (from the server), it can start with one decoration, and then change to a different one. I had hoped that introducing the local property for `decoration` and only calling the function to populate it once would solve this issue, but it does not. Any advice on how to best address that would be appreciated.