### PR TITLE
Support wildcards in `hasPermission()`

### DIFF
--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -467,7 +467,22 @@ export const hasPermission = (state: AppState, permission: string): boolean => {
     return true;
   }
 
-  return permissions.includes(permission);
+  // Match exact permissions.
+  if (permissions.includes(permission)) {
+    return true;
+  }
+
+  // See: https://github.com/mozilla/addons-frontend/issues/8575
+  const appsWithAllPermissions = permissions
+    // Only consider permissions with wildcards.
+    .filter((perm) => perm.endsWith(':*'))
+    // Return the permission "app".
+    // See: https://github.com/mozilla/addons-server/blob/3a15aafb703349923ee2eb9a9f7b527ba9b16c03/src/olympia/constants/permissions.py#L4
+    .map((perm) => perm.replace(':*', ''));
+
+  const app = permission.split(':')[0];
+
+  return appsWithAllPermissions.includes(app);
 };
 
 export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -22,14 +22,12 @@ import reducer, {
 } from 'amo/reducers/users';
 import {
   ADDONS_CONTENTREVIEW,
-  ADDONS_EDIT,
   ADDONS_POSTREVIEW,
   ADDONS_REVIEW,
   ADMIN_TOOLS_VIEW,
   ALL_SUPER_POWERS,
   STATS_VIEW,
   THEMES_REVIEW,
-  USERS_EDIT,
 } from 'core/constants';
 import {
   createUserAccountResponse,
@@ -319,21 +317,21 @@ describe(__filename, () => {
       const permissions = ['Addons:*'];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
-      expect(hasPermission(state, ADDONS_EDIT)).toEqual(true);
+      expect(hasPermission(state, 'Addons:Edit')).toEqual(true);
     });
 
     it('returns `false` when user does not have a broad permission', () => {
-      const permissions = [ADDONS_REVIEW];
+      const permissions = ['Addons:Review'];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
-      expect(hasPermission(state, ADDONS_EDIT)).toEqual(false);
+      expect(hasPermission(state, 'Addons:Edit')).toEqual(false);
     });
 
     it('returns `false` when user has a broad permission but app is different', () => {
       const permissions = ['Addons:*'];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
-      expect(hasPermission(state, USERS_EDIT)).toEqual(false);
+      expect(hasPermission(state, 'Users:Edit')).toEqual(false);
     });
   });
 

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -21,13 +21,15 @@ import reducer, {
   updateUserAccount,
 } from 'amo/reducers/users';
 import {
-  ADDONS_POSTREVIEW,
   ADDONS_CONTENTREVIEW,
+  ADDONS_EDIT,
+  ADDONS_POSTREVIEW,
   ADDONS_REVIEW,
-  ALL_SUPER_POWERS,
   ADMIN_TOOLS_VIEW,
+  ALL_SUPER_POWERS,
   STATS_VIEW,
   THEMES_REVIEW,
+  USERS_EDIT,
 } from 'core/constants';
 import {
   createUserAccountResponse,
@@ -311,6 +313,27 @@ describe(__filename, () => {
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasPermission(state, THEMES_REVIEW)).toEqual(true);
+    });
+
+    it('returns `true` when user has a broad permission', () => {
+      const permissions = ['Addons:*'];
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
+
+      expect(hasPermission(state, ADDONS_EDIT)).toEqual(true);
+    });
+
+    it('returns `false` when user does not have a broad permission', () => {
+      const permissions = [ADDONS_REVIEW];
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
+
+      expect(hasPermission(state, ADDONS_EDIT)).toEqual(false);
+    });
+
+    it('returns `false` when user has a broad permission but app is different', () => {
+      const permissions = ['Addons:*'];
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
+
+      expect(hasPermission(state, USERS_EDIT)).toEqual(false);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8575