### PR TITLE
Fix UI glitch on SiteNotices by adding a new sanitize function

### DIFF
--- a/src/core/components/SiteNotices/index.js
+++ b/src/core/components/SiteNotices/index.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { sanitizeUserHTML } from 'core/utils';
+import { sanitizeHTML, nl2br } from 'core/utils';
 import translate from 'core/i18n/translate';
 import Notice from 'ui/components/Notice';
 import type { I18nType } from 'core/types/i18n';
@@ -24,6 +24,15 @@ type InternalProps = {|
   i18n: I18nType,
 |};
 
+// This is needed because of https://github.com/mozilla/addons-frontend/issues/8616
+//
+// We cannot use `sanitizeUserHTML()` on a `<span />`, which is required to
+// avoid the UI glitch so we configure our own sanitize function to make sure
+// it is safe to use `<span />`.
+const sanitizeNoticeHTML = (text: string): string => {
+  return sanitizeHTML(nl2br(text), ['a', 'b', 'br', 'em', 'i', 'strong']);
+};
+
 export class SiteNoticesBase extends React.Component<InternalProps> {
   render() {
     const { i18n, siteIsReadOnly, siteNotice } = this.props;
@@ -33,9 +42,9 @@ export class SiteNoticesBase extends React.Component<InternalProps> {
     if (siteNotice) {
       notices.push(
         <Notice className="SiteNotices" id="amo-site-notice" type="warning">
-          <div
+          <span
             // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={sanitizeUserHTML(siteNotice)}
+            dangerouslySetInnerHTML={sanitizeNoticeHTML(siteNotice)}
           />
         </Notice>,
       );

--- a/tests/unit/core/components/TestSiteNotices.js
+++ b/tests/unit/core/components/TestSiteNotices.js
@@ -41,7 +41,7 @@ describe(__filename, () => {
     expect(
       root
         .find(Notice)
-        .find('div')
+        .find('span')
         .html(),
     ).toContain(notice);
   });
@@ -56,7 +56,7 @@ describe(__filename, () => {
     expect(
       root
         .find(Notice)
-        .find('div')
+        .find('span')
         .html(),
     ).toContain(notice);
   });


### PR DESCRIPTION
Fixes #8616

---

We need to use a new sanitize function so that we can use a `<span />`.

We have an [ESLint rule](https://github.com/mozilla/eslint-plugin-amo#dangerously-set-inner-html) to prevent the use of `sanitizeUserHTML()` with a tag that is not `<div />`.

`<span />` should only have [phrasing content](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content) as children, which is why we need a new sanitize function. `<a />` is allowed "if it contains only phrasing content", which should be fine here.