### PR TITLE
Issue #8632, Change link color

### DIFF
--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -64,7 +64,7 @@
   margin: 0;
   padding: 4px 0;
 
-  a:link {color: $android-link-color}
+  a:link { color: $android-link-color; }
 
   .Notice-light & {
     padding: 0;

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -64,7 +64,9 @@
   margin: 0;
   padding: 4px 0;
 
-  a:link { color: $android-link-color; }
+  a:link {
+    color: $android-link-color;
+  }
 
   .Notice-light & {
     padding: 0;

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -64,10 +64,6 @@
   margin: 0;
   padding: 4px 0;
 
-  a:link {
-    color: $android-link-color;
-  }
-
   .Notice-light & {
     padding: 0;
   }
@@ -135,13 +131,7 @@
   }
 
   background-color: $notice-background-color;
-
-  &,
-  :link,
-  :hover,
-  :active {
-    color: $notice-link-color;
-  }
+  color: $notice-link-color;
 }
 
 .Notice-error {

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -64,6 +64,10 @@
   margin: 0;
   padding: 4px 0;
 
+  a:link {
+    color: #551a8b;
+  }
+  
   .Notice-light & {
     padding: 0;
   }

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -64,10 +64,8 @@
   margin: 0;
   padding: 4px 0;
 
-  a:link {
-    color: #551a8b;
-  }
-  
+  a:link {color: $android-link-color}
+
   .Notice-light & {
     padding: 0;
   }

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -9,7 +9,6 @@ $header-search-color: #36395b;
 $action-base-color: #329af0;
 $action-hover-color: #72c3fc;
 $action-active-color: #1c7cd6;
-$android-link-color: #551a8b;
 $cancel-base-color: $grey-50;
 $cancel-hover-color: $grey-40;
 $cancel-active-color: $grey-50;

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -9,6 +9,7 @@ $header-search-color: #36395b;
 $action-base-color: #329af0;
 $action-hover-color: #72c3fc;
 $action-active-color: #1c7cd6;
+$android-link-color: #551a8b;
 $cancel-base-color: $grey-50;
 $cancel-hover-color: $grey-40;
 $cancel-active-color: $grey-50;


### PR DESCRIPTION
fixes #8632

@willdurand I ran it locally and both desktop and android links are black. The links change color when they are clicked and you return the page once again. If you clear the browsing data, the color is back to black. Located class Notice-text, and change the link color.