### PR TITLE
Different layout for primary hero based on primary image

### DIFF
--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -114,15 +114,19 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
 
     return (
       <section
-        className={makeClassName('HeroRecommendation', gradientsClassName)}
+        className={makeClassName('HeroRecommendation', gradientsClassName, {
+          'HeroRecommendation--no-image': !featuredImage,
+        })}
       >
-        <div>
-          <img
-            className="HeroRecommendation-image"
-            alt=""
-            src={featuredImage}
-          />
-        </div>
+        {featuredImage && (
+          <div>
+            <img
+              className="HeroRecommendation-image"
+              alt=""
+              src={featuredImage}
+            />
+          </div>
+        )}
         <div className="HeroRecommendation-info">
           <div className="HeroRecommendation-recommended">{recommended}</div>
           <h2 className="HeroRecommendation-heading">{heading}</h2>

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -24,6 +24,22 @@
   }
 }
 
+.HeroRecommendation--no-image {
+  justify-content: center;
+
+  @include respond-to(extraExtraLarge) {
+    @include padding-start(36px);
+  }
+
+  .HeroRecommendation-info {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+
+    @include margin-start(0);
+  }
+}
+
 .HeroRecommendation-image {
   height: 0;
   visibility: hidden;

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -20,39 +20,7 @@
   }
 
   @include respond-to(extraExtraLarge) {
-    @include margin-start(136px);
-  }
-}
-
-.HeroRecommendation--no-image {
-  justify-content: center;
-
-  @include respond-to(extraExtraLarge) {
-    @include padding-start(36px);
-  }
-
-  .HeroRecommendation-info {
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-
-    @include margin-start(0);
-  }
-}
-
-.HeroRecommendation-image {
-  height: 0;
-  visibility: hidden;
-  width: 0;
-
-  @include respond-to(medium) {
-    height: auto;
-    visibility: visible;
-    width: 100%;
-  }
-
-  @include respond-to(extraExtraLarge) {
-    width: 480px;
+    @include margin-start(132px);
   }
 }
 
@@ -97,6 +65,48 @@
 
   @include respond-to(extraExtraLarge) {
     margin-bottom: 84px;
+  }
+}
+
+.HeroRecommendation--no-image {
+  justify-content: center;
+
+  @include respond-to(extraExtraLarge) {
+    @include padding-start(36px);
+  }
+
+  .HeroRecommendation-info {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+
+    @include respond-to(large) {
+      width: 576px;
+    }
+  }
+
+  .HeroRecommendation-recommended,
+  .HeroRecommendation-heading,
+  .HeroRecommendation-body,
+  .HeroRecommendation-link {
+    text-align: center;
+  }
+}
+
+.HeroRecommendation-image {
+  height: 0;
+  visibility: hidden;
+  width: 0;
+
+  @include respond-to(medium) {
+    height: auto;
+    visibility: visible;
+    width: 100%;
+  }
+
+  @include respond-to(extraExtraLarge) {
+    width: 480px;
   }
 }
 

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -37,7 +37,7 @@ type HeroGradientType = {|
 
 type BaseExternalPrimaryHeroShelfType = {|
   gradient: HeroGradientType,
-  featured_image: string,
+  featured_image: string | null,
   description: string | null,
 |};
 
@@ -59,7 +59,7 @@ export type ExternalPrimaryHeroShelfType =
 
 type BasePrimaryHeroShelfType = {|
   gradient: HeroGradientType,
-  featuredImage: string,
+  featuredImage: string | null,
   description: string | null,
 |};
 

--- a/stories/amo/HeroRecommendation.js
+++ b/stories/amo/HeroRecommendation.js
@@ -8,15 +8,15 @@ import { createInternalHeroShelves } from 'amo/reducers/home';
 
 import Provider from '../setup/Provider';
 
-const render = (moreProps = {}) => {
+const render = (shelfProps = {}, moreProps = {}) => {
   const props = {
     shelfData: createInternalHeroShelves(
       createHeroShelves({
         primaryProps: {
           addon: { ...fakeAddon, name: 'Forest Preserve Nougat (beta)' },
-          description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-      sed do eiusmod tempor incididunt ut labore et dolore magna
-      aliqua. Sed augue lacus viverra vitae.`,
+          description:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse eget rutrum mi. Mauris eleifend sapien ut metus varius, nec vulputate nunc rutrum. Maecenas porttitor tincidunt egestas. Nullam sed massa in.',
+          ...shelfProps,
         },
       }),
     ).primary,
@@ -32,6 +32,19 @@ storiesOf('HeroRecommendation', module)
       <Provider story={story()} />
     </div>
   ))
-  .add('default', () => {
-    return render();
+  .addWithChapters('all variants', {
+    chapters: [
+      {
+        sections: [
+          {
+            title: 'with image',
+            sectionFn: () => render(),
+          },
+          {
+            title: 'wihout image',
+            sectionFn: () => render({ featuredImage: null }),
+          },
+        ],
+      },
+    ],
   });

--- a/stories/amo/HeroRecommendation.js
+++ b/stories/amo/HeroRecommendation.js
@@ -41,7 +41,7 @@ storiesOf('HeroRecommendation', module)
             sectionFn: () => render(),
           },
           {
-            title: 'wihout image',
+            title: 'without image',
             sectionFn: () => render({ featuredImage: null }),
           },
         ],

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -117,16 +117,27 @@ describe(__filename, () => {
     });
   });
 
-  it('renders an image', () => {
+  it('renders with an image', () => {
     const featuredImage = 'https://mozilla.org/featured.png';
     const shelfData = createShelfData({ addon: fakeAddon, featuredImage });
 
     const root = render({ shelfData });
 
+    expect(root).not.toHaveClassName('HeroRecommendation--no-image');
     expect(root.find('.HeroRecommendation-image')).toHaveProp(
       'src',
       featuredImage,
     );
+  });
+
+  it('renders without an image', () => {
+    const featuredImage = null;
+    const shelfData = createShelfData({ addon: fakeAddon, featuredImage });
+
+    const root = render({ shelfData });
+
+    expect(root).toHaveClassName('HeroRecommendation--no-image');
+    expect(root.find('.HeroRecommendation-image')).toHaveLength(0);
   });
 
   it('assigns a className based on the gradient', () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -287,7 +287,7 @@ export const createPrimaryHeroShelf = ({
   description = 'Primary shelf description',
   external = undefined,
   featuredImage = 'https://addons-dev-cdn.allizom.org/static/img/hero/featured/teamaddons.jpg',
-  gradient = { start: '000000', end: 'FFFFFF' },
+  gradient = { start: 'color-ink-80', end: 'color-blue-70' },
 } = {}) => {
   return {
     addon,


### PR DESCRIPTION
~~Depends on #8615~~

Fixes #8629 

With and without image screenshots, from Storybook:

![Screenshot 2019-09-23 11 17 32](https://user-images.githubusercontent.com/142755/65438608-c3022580-ddf3-11e9-8304-a970433dd9de.png)
