### PR TITLE
Handle unknown errors in addonManager.install()

### DIFF
--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -130,7 +130,8 @@ export function install(
       installObj.addEventListener('onInstallEnded', () => resolve());
       installObj.addEventListener('onInstallFailed', () => reject());
       log.info('Events to handle the installation initialized.');
-      installObj.install();
+      // See: https://github.com/mozilla/addons-frontend/issues/8633
+      installObj.install().catch(reject);
     });
   });
 }

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -197,6 +197,25 @@ describe(__filename, () => {
       );
     });
 
+    it('rejects if the install returns an error', () => {
+      const error = new Error('oops');
+      fakeInstallObj.install = sinon.spy(() => {
+        return Promise.reject(error);
+      });
+
+      return (
+        addonManager
+          .install(fakeInstallUrl, fakeCallback, {
+            _mozAddonManager: fakeMozAddonManager,
+            src: 'home',
+          })
+          // The second argument is the reject function.
+          .then(unexpectedSuccess, () => {
+            sinon.assert.calledOnce(fakeInstallObj.install);
+          })
+      );
+    });
+
     it('passes the installObj, the event and the id to the callback', async () => {
       const fakeEvent = { type: 'fakeEvent' };
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8633

---

It looks like `mozAddonManager` can reject. I don't know if that was the
case before or not, but here we go. By Making sure we catch errors and
call `reject`, it is not needed to handle the error. It is done in
`installAddon` (as a "fatal error"). Because we do not have a reason
attached to the error or even a message, we cannot really handle this
error differently.

In order to try it, you can setup a HTTPS env. The problem is that our
bundled certificates/key are expired so I suggest [mkcert](https://github.com/FiloSottile/mkcert) instead.

1. install the tool
2. run: `mkcert example.com`
3. run:

    ```
    mv example.com.pem bin/local-dev-server-certs/example.com.crt.pem
    mv example.com-key.pem bin/local-dev-server-certs/example.com.key.pem
    ```
4. edit the server code:

    ```diff
    diff --git a/src/core/server/base.js b/src/core/server/base.js
    index 9df7b0a62..831506991 100644
    --- a/src/core/server/base.js
    +++ b/src/core/server/base.js
    @@ -548,9 +548,6 @@ export function runServer({
                    cert: fs.readFileSync(
                    'bin/local-dev-server-certs/example.com.crt.pem',
                    ),
    -                ca: fs.readFileSync(
    -                  'bin/local-dev-server-certs/example.com.ca.crt.pem',
    -                ),
                    passphrase: '',
                };
                server = https.createServer(options, server);
    ```

5. start amo local dev with: `yarn amo:dev-https`