### PR TITLE
Log page views for client-side navigation

### DIFF
--- a/src/core/tracking.js
+++ b/src/core/tracking.js
@@ -200,7 +200,8 @@ export class Tracking {
   }
 
   pageView(data: Object = {}) {
-    this._ga('send', 'pageview', data);
+    // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/pages#pageview_fields
+    this._ga('send', { hitType: 'pageview', ...data });
     this.log('pageView', JSON.stringify(data));
   }
 

--- a/tests/unit/core/client/test_base.js
+++ b/tests/unit/core/client/test_base.js
@@ -2,7 +2,7 @@ import createAmoStore from 'amo/store';
 import { setRequestId } from 'core/actions';
 import createClient from 'core/client/base';
 import { getSentryRelease } from 'core/utils/sentry';
-import { getFakeConfig } from 'tests/unit/helpers';
+import { getFakeConfig, createFakeTracking } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('createClient()', () => {
@@ -117,6 +117,17 @@ describe(__filename, () => {
 
       sinon.assert.notCalled(_RavenJs.config);
       sinon.assert.notCalled(_RavenJs.setTagsContext);
+    });
+
+    it('updates the tracking page on location change', async () => {
+      const _tracking = createFakeTracking();
+      const { history } = await _createClient({ _tracking });
+      const pathname = '/foo';
+
+      history.push({ pathname });
+
+      sinon.assert.calledWith(_tracking.setPage, pathname);
+      sinon.assert.calledWith(_tracking.pageView, { title: '' });
     });
   });
 });

--- a/tests/unit/core/test_tracking.js
+++ b/tests/unit/core/test_tracking.js
@@ -184,8 +184,13 @@ describe(__filename, () => {
         dimension1: 'whatever',
         dimension2: 'whatever2',
       };
+
       tracking.pageView(data);
-      sinon.assert.calledWith(window.ga, 'send', 'pageview', data);
+
+      sinon.assert.calledWith(window.ga, 'send', {
+        hitType: 'pageview',
+        ...data,
+      });
     });
 
     it('should set a custom dimension when requested', () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1205,8 +1205,10 @@ export function fakeCookies(overrides = {}) {
 
 export const createFakeTracking = (overrides = {}) => {
   return {
+    pageView: sinon.stub(),
     sendEvent: sinon.stub(),
     setDimension: sinon.stub(),
+    setPage: sinon.stub(),
     ...overrides,
   };
 };


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8647

---

I don't know if we need more but it seems to work locally for me so.. I
looked at various options and it looks like `history.listen()` is both
simple and functional.