### PR TITLE
Create loading skeleton for hero shelves

### DIFF
--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -161,9 +161,9 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
             )}
             <div className="HeroRecommendation-info">
               <div className="HeroRecommendation-recommended">
-                {/* translators: If uppercase does not work in your locale, change it */}
-                {/*  to lowercase. This is used as a secondary heading. */}
                 {shelfData ? (
+                  // translators: If uppercase does not work in your locale,
+                  // change it to lowercase. This is used as a secondary heading.
                   i18n.gettext('RECOMMENDED')
                 ) : (
                   <LoadingText width={20} />

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -135,16 +135,6 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
       gradientsClassName = `HeroRecommendation--loading`;
     }
 
-    const recommended = shelfData ? (
-      <div className="HeroRecommendation-recommended">
-        {/* translators: If uppercase does not work in your locale, change it */}
-        {/*  to lowercase. This is used as a secondary heading. */}
-        {i18n.gettext('RECOMMENDED')}
-      </div>
-    ) : (
-      <LoadingText width={20} />
-    );
-
     return (
       <section
         className={makeClassName(
@@ -171,16 +161,17 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
             )}
             <div className="HeroRecommendation-info">
               <div className="HeroRecommendation-recommended">
-                {recommended}
+                {/* translators: If uppercase does not work in your locale, change it */}
+                {/*  to lowercase. This is used as a secondary heading. */}
+                {shelfData ? (
+                  i18n.gettext('RECOMMENDED')
+                ) : (
+                  <LoadingText width={20} />
+                )}
               </div>
-              {heading ? (
-                <h2 className="HeroRecommendation-heading">{heading}</h2>
-              ) : (
-                <LoadingText
-                  className="HeroRecommendation-heading"
-                  width={50}
-                />
-              )}
+              <h2 className="HeroRecommendation-heading">
+                {heading || <LoadingText width={60} />}
+              </h2>
               {description ? (
                 <div
                   className="HeroRecommendation-body"
@@ -188,7 +179,13 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
                   dangerouslySetInnerHTML={sanitizeUserHTML(description)}
                 />
               ) : (
-                <LoadingText className="HeroRecommendation-body" width={100} />
+                <div className="HeroRecommendation-body">
+                  <>
+                    <LoadingText width={100} />
+                    <br />
+                    <LoadingText width={80} />
+                  </>
+                </div>
               )}
               {link}
             </div>

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -2,6 +2,7 @@
 import makeClassName from 'classnames';
 import invariant from 'invariant';
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import AppBanner from 'amo/components/AppBanner';
@@ -11,7 +12,9 @@ import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import tracking from 'core/tracking';
 import { sanitizeUserHTML } from 'core/utils';
+import LoadingText from 'ui/components/LoadingText';
 import type { PrimaryHeroShelfType } from 'amo/reducers/home';
+import type { AppState } from 'amo/store';
 import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
@@ -20,11 +23,17 @@ export const PRIMARY_HERO_CLICK_CATEGORY = 'AMO Primary Hero Clicks';
 export const PRIMARY_HERO_SRC = 'homepage-primary-hero';
 
 type Props = {|
-  shelfData: PrimaryHeroShelfType,
+  shelfData?: PrimaryHeroShelfType,
+|};
+
+type MappedProps = {|
+  siteIsReadOnly: boolean,
+  siteNotice: string | null,
 |};
 
 type InternalProps = {|
   ...Props,
+  ...MappedProps,
   i18n: I18nType,
   _checkInternalURL: typeof checkInternalURL,
   _tracking: typeof tracking,
@@ -66,58 +75,86 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
   };
 
   render() {
-    const { _checkInternalURL, i18n, shelfData } = this.props;
-    const { addon, description, external, gradient, featuredImage } = shelfData;
+    const {
+      _checkInternalURL,
+      i18n,
+      shelfData,
+      siteIsReadOnly,
+      siteNotice,
+    } = this.props;
+    const { addon, description, external, featuredImage, gradient } =
+      shelfData || {};
 
-    const linkInsides = <span> {i18n.gettext('Get the extension')} </span>;
-
+    let gradientsClassName;
     let heading;
     let link;
 
-    const linkProps = _checkInternalURL({
-      urlString: this.makeCallToActionURL(),
-    }).isInternal
-      ? {}
-      : { rel: 'noopener noreferrer', target: '_blank' };
+    const heightClassName =
+      siteIsReadOnly || siteNotice
+        ? 'HeroRecommendation--height-with-notice'
+        : 'HeroRecommendation--height-without-notice';
 
-    if (addon) {
-      heading = addon.name;
-      link = (
-        <Link
-          className="HeroRecommendation-link"
-          onClick={this.onHeroClick}
-          to={this.makeCallToActionURL()}
-        >
-          {linkInsides}
-        </Link>
+    if (shelfData) {
+      gradientsClassName = `HeroRecommendation-${gradient.start}-${gradient.end}`;
+      log.info(
+        `className ${gradientsClassName} generated from the API response. This should match a selector in styles.scss`,
       );
-    } else if (external) {
-      heading = external.name;
-      link = (
-        <a
-          className="HeroRecommendation-link"
-          href={this.makeCallToActionURL()}
-          onClick={this.onHeroClick}
-          {...linkProps}
-        >
-          {linkInsides}
-        </a>
-      );
+
+      const linkInsides = <span> {i18n.gettext('Get the extension')} </span>;
+      const linkProps = _checkInternalURL({
+        urlString: this.makeCallToActionURL(),
+      }).isInternal
+        ? {}
+        : { rel: 'noopener noreferrer', target: '_blank' };
+
+      if (addon) {
+        heading = addon.name;
+        link = (
+          <Link
+            className="HeroRecommendation-link"
+            onClick={this.onHeroClick}
+            to={this.makeCallToActionURL()}
+          >
+            {linkInsides}
+          </Link>
+        );
+      } else if (external) {
+        heading = external.name;
+        link = (
+          <a
+            className="HeroRecommendation-link"
+            href={this.makeCallToActionURL()}
+            onClick={this.onHeroClick}
+            {...linkProps}
+          >
+            {linkInsides}
+          </a>
+        );
+      }
+    } else {
+      gradientsClassName = `HeroRecommendation--loading`;
     }
 
-    // translators: If uppercase does not work in your locale, change it to lowercase.
-    // This is used as a secondary heading.
-    const recommended = i18n.gettext('RECOMMENDED');
-    const gradientsClassName = `HeroRecommendation-${gradient.start}-${gradient.end}`;
-    log.info(
-      `className ${gradientsClassName} generated from the API response. This should match a selector in styles.scss`,
+    const recommended = shelfData ? (
+      <div className="HeroRecommendation-recommended">
+        {/* translators: If uppercase does not work in your locale, change it */}
+        {/*  to lowercase. This is used as a secondary heading. */}
+        {i18n.gettext('RECOMMENDED')}
+      </div>
+    ) : (
+      <LoadingText width={20} />
     );
 
     return (
       <section
-        className={makeClassName('HeroRecommendation', gradientsClassName, {
-          'HeroRecommendation--no-image': !featuredImage,
-        })}
+        className={makeClassName(
+          'HeroRecommendation',
+          gradientsClassName,
+          heightClassName,
+          {
+            'HeroRecommendation--no-image': !featuredImage,
+          },
+        )}
       >
         <div className="HeroRecommendation-wrapper">
           <AppBanner className="HeroRecommendation-banner" />
@@ -136,12 +173,23 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
               <div className="HeroRecommendation-recommended">
                 {recommended}
               </div>
-              <h2 className="HeroRecommendation-heading">{heading}</h2>
-              <div
-                className="HeroRecommendation-body"
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={sanitizeUserHTML(description)}
-              />
+              {heading ? (
+                <h2 className="HeroRecommendation-heading">{heading}</h2>
+              ) : (
+                <LoadingText
+                  className="HeroRecommendation-heading"
+                  width={50}
+                />
+              )}
+              {description ? (
+                <div
+                  className="HeroRecommendation-body"
+                  // eslint-disable-next-line react/no-danger
+                  dangerouslySetInnerHTML={sanitizeUserHTML(description)}
+                />
+              ) : (
+                <LoadingText className="HeroRecommendation-body" width={100} />
+              )}
               {link}
             </div>
           </div>
@@ -151,8 +199,16 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
   }
 }
 
-const HeroRecommendation: React.ComponentType<Props> = compose(translate())(
-  HeroRecommendationBase,
-);
+const mapStateToProps = (state: AppState): MappedProps => {
+  return {
+    siteIsReadOnly: state.site.readOnly,
+    siteNotice: state.site.notice,
+  };
+};
+
+const HeroRecommendation: React.ComponentType<Props> = compose(
+  connect(mapStateToProps),
+  translate(),
+)(HeroRecommendationBase);
 
 export default HeroRecommendation;

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -3,6 +3,29 @@
 .HeroRecommendation-wrapper {
   margin: 0 auto;
   max-width: $max-content-width;
+
+.HeroRecommendation--height-with-notice {
+  min-height: 300px;
+
+  @include respond-to(medium) {
+    min-height: 324px;
+  }
+
+  @include respond-to(extraExtraLarge) {
+    min-height: 432px;
+  }
+}
+
+.HeroRecommendation--height-without-notice {
+  min-height: 252px;
+
+  @include respond-to(medium) {
+    min-height: 268px;
+  }
+
+  @include respond-to(extraExtraLarge) {
+    min-height: 376px;
+  }
 }
 
 .HeroRecommendation-banner {
@@ -168,4 +191,8 @@
 
 .HeroRecommendation-color-ink-80-color-violet-70 {
   @include gradientStyle($color-ink-80, $color-violet-70);
+}
+
+.HeroRecommendation--loading {
+  @include gradientStyle($color-ink-80, $background-grey);
 }

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -3,29 +3,14 @@
 .HeroRecommendation-wrapper {
   margin: 0 auto;
   max-width: $max-content-width;
+}
 
 .HeroRecommendation--height-with-notice {
-  min-height: 300px;
-
-  @include respond-to(medium) {
-    min-height: 324px;
-  }
-
-  @include respond-to(extraExtraLarge) {
-    min-height: 452px;
-  }
+  min-height: 452px;
 }
 
 .HeroRecommendation--height-without-notice {
-  min-height: 252px;
-
-  @include respond-to(medium) {
-    min-height: 268px;
-  }
-
-  @include respond-to(extraExtraLarge) {
-    min-height: 376px;
-  }
+  min-height: 376px;
 }
 
 .HeroRecommendation-banner {
@@ -67,6 +52,16 @@
 
   @include respond-to(extraExtraLarge) {
     margin-top: 16px;
+  }
+}
+
+.HeroRecommendation-body,
+.HeroRecommendation-heading,
+.HeroRecommendation-recommended {
+  width: 100%;
+
+  .LoadingText {
+    height: 1em;
   }
 }
 
@@ -194,5 +189,5 @@
 }
 
 .HeroRecommendation--loading {
-  @include gradientStyle($color-ink-80, $background-grey);
+  @include gradientStyle($color-ink-80, $color-blue-70);
 }

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -12,7 +12,7 @@
   }
 
   @include respond-to(extraExtraLarge) {
-    min-height: 432px;
+    min-height: 452px;
   }
 }
 

--- a/src/amo/components/SecondaryHero/index.js
+++ b/src/amo/components/SecondaryHero/index.js
@@ -71,7 +71,7 @@ export const SecondaryHeroBase = ({
             src={module.icon}
           />
         ) : (
-          <LoadingText className="SecondaryHero-module-icon" width={40} />
+          <div className="SecondaryHero-module-icon" />
         )}
         <div className="SecondaryHero-module-description">
           {module.description || <LoadingText width={60} />}
@@ -99,10 +99,22 @@ export const SecondaryHeroBase = ({
     <section className="SecondaryHero">
       <div className="SecondaryHero-message">
         <h2 className="SecondaryHero-message-headline">
-          {headline || <LoadingText width={60} />}
+          {headline || (
+            <>
+              <LoadingText width={70} />
+              <br />
+              <LoadingText width={50} />
+            </>
+          )}
         </h2>
         <div className="SecondaryHero-message-description">
-          {description || <LoadingText width={70} />}
+          {description || (
+            <>
+              <LoadingText width={80} />
+              <br />
+              <LoadingText width={60} />
+            </>
+          )}
         </div>
         {cta && (
           <Link className="SecondaryHero-message-link" {...getLinkProps(cta)}>
@@ -111,7 +123,7 @@ export const SecondaryHeroBase = ({
         )}
         {!headline && (
           <div className="SecondaryHero-message-link">
-            <LoadingText width={40} />
+            <LoadingText width={50} />
           </div>
         )}
       </div>

--- a/src/amo/components/SecondaryHero/index.js
+++ b/src/amo/components/SecondaryHero/index.js
@@ -1,10 +1,10 @@
 /* @flow */
-import invariant from 'invariant';
 import * as React from 'react';
 
 import Link from 'amo/components/Link';
 import { addParamsToHeroURL, checkInternalURL } from 'amo/utils';
 import tracking from 'core/tracking';
+import LoadingText from 'ui/components/LoadingText';
 import type {
   HeroCallToActionType,
   SecondaryHeroShelfType,
@@ -15,7 +15,7 @@ import './styles.scss';
 export const SECONDARY_HERO_CLICK_CATEGORY = 'AMO Secondary Hero Clicks';
 export const SECONDARY_HERO_SRC = 'homepage-secondary-hero';
 
-type Props = {| shelfData: SecondaryHeroShelfType |};
+type Props = {| shelfData?: SecondaryHeroShelfType |};
 
 type InternalProps = {|
   ...Props,
@@ -32,11 +32,8 @@ export const SecondaryHeroBase = ({
   _tracking = tracking,
   shelfData,
 }: InternalProps) => {
-  const { headline, description, cta, modules } = shelfData;
-
-  invariant(headline, 'The headline property is required');
-  invariant(description, 'The description property is required');
-  invariant(modules, 'The modules property is required');
+  const { headline, description, cta } = shelfData || {};
+  const modules = (shelfData && shelfData.modules) || Array(3).fill({});
 
   const onHeroClick = (event: SyntheticEvent<HTMLAnchorElement>) => {
     _tracking.sendEvent({
@@ -67,14 +64,22 @@ export const SecondaryHeroBase = ({
   modules.forEach((module) => {
     renderedModules.push(
       <div className="SecondaryHero-module" key={module.description}>
-        <img
-          alt={module.description}
-          className="SecondaryHero-module-icon"
-          src={module.icon}
-        />
-        <div className="SecondaryHero-module-description">
-          {module.description}
-        </div>
+        {module.icon ? (
+          <img
+            alt={module.description}
+            className="SecondaryHero-module-icon"
+            src={module.icon}
+          />
+        ) : (
+          <LoadingText className="SecondaryHero-module-icon" width={50} />
+        )}
+        {module.description ? (
+          <div className="SecondaryHero-module-description">
+            {module.description}
+          </div>
+        ) : (
+          <LoadingText width={100} />
+        )}
         {module.cta && (
           <Link
             className="SecondaryHero-module-link"
@@ -92,8 +97,12 @@ export const SecondaryHeroBase = ({
   return (
     <section className="SecondaryHero">
       <div className="SecondaryHero-message">
-        <h2 className="SecondaryHero-message-headline">{headline}</h2>
-        <div className="SecondaryHero-message-description">{description}</div>
+        <h2 className="SecondaryHero-message-headline">
+          {headline || <LoadingText width={50} />}
+        </h2>
+        <div className="SecondaryHero-message-description">
+          {description || <LoadingText width={100} />}
+        </div>
         {cta && (
           <Link className="SecondaryHero-message-link" {...getLinkProps(cta)}>
             <span className="SecondaryHero-message-linkText">{cta.text}</span>

--- a/src/amo/components/SecondaryHero/index.js
+++ b/src/amo/components/SecondaryHero/index.js
@@ -71,15 +71,11 @@ export const SecondaryHeroBase = ({
             src={module.icon}
           />
         ) : (
-          <LoadingText className="SecondaryHero-module-icon" width={50} />
+          <LoadingText className="SecondaryHero-module-icon" width={40} />
         )}
-        {module.description ? (
-          <div className="SecondaryHero-module-description">
-            {module.description}
-          </div>
-        ) : (
-          <LoadingText width={100} />
-        )}
+        <div className="SecondaryHero-module-description">
+          {module.description || <LoadingText width={60} />}
+        </div>
         {module.cta && (
           <Link
             className="SecondaryHero-module-link"
@@ -90,6 +86,11 @@ export const SecondaryHeroBase = ({
             </span>
           </Link>
         )}
+        {!module.description && (
+          <div className="SecondaryHero-module-link">
+            <LoadingText width={50} />
+          </div>
+        )}
       </div>,
     );
   });
@@ -98,15 +99,20 @@ export const SecondaryHeroBase = ({
     <section className="SecondaryHero">
       <div className="SecondaryHero-message">
         <h2 className="SecondaryHero-message-headline">
-          {headline || <LoadingText width={50} />}
+          {headline || <LoadingText width={60} />}
         </h2>
         <div className="SecondaryHero-message-description">
-          {description || <LoadingText width={100} />}
+          {description || <LoadingText width={70} />}
         </div>
         {cta && (
           <Link className="SecondaryHero-message-link" {...getLinkProps(cta)}>
             <span className="SecondaryHero-message-linkText">{cta.text}</span>
           </Link>
+        )}
+        {!headline && (
+          <div className="SecondaryHero-message-link">
+            <LoadingText width={40} />
+          </div>
         )}
       </div>
       {renderedModules}

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -5,12 +5,22 @@
   display: grid;
   grid-gap: $padding-page;
   grid-template-columns: auto;
+  min-height: 568px;
   padding: $padding-page 0 0 0;
+
+  @include respond-to(medium) {
+    min-height: 628px;
+  }
 
   @include respond-to(large) {
     grid-gap: 32px;
     grid-template-columns: repeat(4, 1fr);
+    min-height: 340px;
     padding: 48px 0 24px 0;
+  }
+
+  @include respond-to(extraLarge) {
+    min-height: 296px;
   }
 }
 

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -35,6 +35,10 @@
   font-weight: normal;
   line-height: 1.333;
   margin: 0;
+
+  .LoadingText {
+    height: 1em;
+  }
 }
 
 .SecondaryHero-message-description {
@@ -42,6 +46,10 @@
 
   @include respond-to(large) {
     padding: 8px 0 24px 0;
+  }
+
+  .LoadingText {
+    height: 1em;
   }
 }
 
@@ -88,6 +96,17 @@
   }
 }
 
-.SecondaryHero-module-description {
+.SecondaryHero-message-link,
+.SecondaryHero-module-description,
+.SecondaryHero-module-link {
+  width: 100%;
+
+  .LoadingText {
+    height: 1em;
+  }
+}
+
+.SecondaryHero-module-description,
+.SecondaryHero-module-link {
   text-align: center;
 }

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -253,16 +253,14 @@ export class HomeBase extends React.Component {
         {errorHandler.renderErrorIfPresent()}
 
         {_config.get('enableFeatureHeroRecommendation') &&
-        clientApp !== CLIENT_APP_ANDROID &&
-        heroShelves ? (
-          <HeroRecommendation shelfData={heroShelves.primary} />
+        clientApp !== CLIENT_APP_ANDROID ? (
+          <HeroRecommendation shelfData={heroShelves && heroShelves.primary} />
         ) : null}
 
         <div className="Home-content">
           {_config.get('enableFeatureHeroRecommendation') &&
-          clientApp !== CLIENT_APP_ANDROID &&
-          heroShelves ? (
-            <SecondaryHero shelfData={heroShelves.secondary} />
+          clientApp !== CLIENT_APP_ANDROID ? (
+            <SecondaryHero shelfData={heroShelves && heroShelves.secondary} />
           ) : null}
 
           {!_config.get('enableFeatureHeroRecommendation') ||

--- a/stories/amo/HeroRecommendation.js
+++ b/stories/amo/HeroRecommendation.js
@@ -21,6 +21,8 @@ const render = (shelfProps = {}, moreProps = {}) => {
       }),
     ).primary,
     i18n: fakeI18n({ includeJedSpy: false }),
+    siteIsReadOnly: false,
+    siteNotice: null,
     ...moreProps,
   };
   return <HeroRecommendationBase {...props} />;
@@ -43,6 +45,10 @@ storiesOf('HeroRecommendation', module)
           {
             title: 'without image',
             sectionFn: () => render({ featuredImage: null }),
+          },
+          {
+            title: 'loading',
+            sectionFn: () => render({}, { shelfData: undefined }),
           },
         ],
       },

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -222,7 +222,7 @@ describe(__filename, () => {
     const root = render();
 
     expect(root).toHaveClassName('HeroRecommendation--loading');
-    expect(root.find(LoadingText)).toHaveLength(3);
+    expect(root.find(LoadingText)).toHaveLength(4);
   });
 
   describe('makeCallToActionURL', () => {

--- a/tests/unit/amo/components/TestSecondaryHero.js
+++ b/tests/unit/amo/components/TestSecondaryHero.js
@@ -110,7 +110,7 @@ describe(__filename, () => {
   it('renders in a loading state', () => {
     const root = render();
 
-    expect(root.find(LoadingText)).toHaveLength(8);
+    expect(root.find(LoadingText)).toHaveLength(11);
   });
 
   describe('modules', () => {

--- a/tests/unit/amo/components/TestSecondaryHero.js
+++ b/tests/unit/amo/components/TestSecondaryHero.js
@@ -7,6 +7,7 @@ import SecondaryHero, {
 } from 'amo/components/SecondaryHero';
 import { createInternalHeroShelves } from 'amo/reducers/home';
 import { addParamsToHeroURL } from 'amo/utils';
+import LoadingText from 'ui/components/LoadingText';
 import {
   createFakeEvent,
   createFakeTracking,
@@ -21,11 +22,7 @@ describe(__filename, () => {
     ).secondary;
   };
 
-  const render = (moreProps = {}) => {
-    const props = {
-      shelfData: createShelfData(),
-      ...moreProps,
-    };
+  const render = (props = {}) => {
     return shallow(<SecondaryHero {...props} />);
   };
 
@@ -108,6 +105,12 @@ describe(__filename, () => {
       category: SECONDARY_HERO_CLICK_CATEGORY,
     });
     sinon.assert.calledOnce(_tracking.sendEvent);
+  });
+
+  it('renders in a loading state', () => {
+    const root = render();
+
+    expect(root.find(LoadingText)).toHaveLength(8);
   });
 
   describe('modules', () => {

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -574,7 +574,7 @@ describe(__filename, () => {
       expect(root.find(HomeHeroGuides)).toHaveLength(0);
     });
 
-    it('does not render if heroShelves are not loaded', () => {
+    it('renders even if heroShelves are not loaded', () => {
       const { store } = dispatchClientMetadata({
         clientApp: CLIENT_APP_FIREFOX,
       });
@@ -584,8 +584,8 @@ describe(__filename, () => {
         store,
       });
 
-      expect(root.find(HeroRecommendation)).toHaveLength(0);
-      expect(root.find(SecondaryHero)).toHaveLength(0);
+      expect(root.find(HeroRecommendation)).toHaveLength(1);
+      expect(root.find(SecondaryHero)).toHaveLength(1);
     });
 
     it('does not render when enabled on Android', () => {


### PR DESCRIPTION
~~Depends on #8662~~

Fixes #8619 

This is my first take at solving this issue. It basically works, but as discussed in the front-end meeting, it's virtually impossible to make sure the `min-height` always works, because sometimes the content can make the hero bigger, and at the same time we don't want to make the standard `min-height` too big or the hero will take up an unnecessary amount of space. I came up with the numbers in this PR by taking what looked to me that an average amount of content for a hero (both the Primary and Secondary) and then observing the sizes at different viewport sizes.

The positioning of the `LoadingText` elements are not very exact, but I'm not sure how important that is. I think it's more important to try to get the overall sizes of the elements as close as possible to avoid jumpiness. If there are some tricks I can use to get the `LoadingText` elements positioned closer to where the eventual elements will be, I'd be happy to give that a try.
