### PR TITLE
Remove language picker ref

### DIFF
--- a/src/amo/components/Footer/index.js
+++ b/src/amo/components/Footer/index.js
@@ -211,11 +211,7 @@ export class FooterBase extends React.Component {
           />
 
           <div className="Footer-language-picker">
-            <LanguagePicker
-              ref={(ref) => {
-                this.languagePicker = ref;
-              }}
-            />
+            <LanguagePicker />
           </div>
         </div>
       </footer>


### PR DESCRIPTION


Fixes #8465 

`Footer` passes a ref to `LanguagePicker` which is a class component but it's wrapped in HOCs.
`this.languagePicker` is dead code so it is removed.

