### PR TITLE
Change logic for isHomePage to use `location` instead of `viewContext`

### DIFF
--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -29,11 +29,7 @@ import { logOutUser as logOutUserAction } from 'amo/reducers/users';
 import { addChangeListeners } from 'core/addonManager';
 import { setUserAgent as setUserAgentAction } from 'core/actions';
 import { setInstallState } from 'core/actions/installations';
-import {
-  CLIENT_APP_ANDROID,
-  VIEW_CONTEXT_HOME,
-  maximumSetTimeoutDelay,
-} from 'core/constants';
+import { CLIENT_APP_ANDROID, maximumSetTimeoutDelay } from 'core/constants';
 import DefaultErrorPage from 'core/components/ErrorPage';
 import InfoDialog from 'core/components/InfoDialog';
 import translate from 'core/i18n/translate';
@@ -49,8 +45,13 @@ interface MozNavigator extends Navigator {
   mozAddonManager?: Object;
 }
 
+export const isHomePage = (location: ReactRouterLocationType) => {
+  return location.pathname.split('/').filter(Boolean).length === 2;
+};
+
 type Props = {|
   _config: typeof config,
+  _isHomePage: typeof isHomePage,
   ErrorPage: typeof DefaultErrorPage,
   FooterComponent: typeof Footer,
   InfoDialogComponent: typeof InfoDialog,
@@ -62,7 +63,6 @@ type Props = {|
   clientApp: string,
   handleGlobalEvent: () => void,
   i18n: I18nType,
-  isHomePage: boolean,
   lang: string,
   location: ReactRouterLocationType,
   logOutUser: () => void,
@@ -78,6 +78,7 @@ export class AppBase extends React.Component<Props> {
 
   static defaultProps = {
     _config: config,
+    _isHomePage: isHomePage,
     ErrorPage: DefaultErrorPage,
     FooterComponent: Footer,
     InfoDialogComponent: InfoDialog,
@@ -188,13 +189,13 @@ export class AppBase extends React.Component<Props> {
   render() {
     const {
       _config,
+      _isHomePage,
       ErrorPage,
       FooterComponent,
       HeaderComponent,
       InfoDialogComponent,
       clientApp,
       i18n,
-      isHomePage,
       lang,
       location,
     } = this.props;
@@ -236,7 +237,7 @@ export class AppBase extends React.Component<Props> {
             <InfoDialogComponent />
 
             <HeaderComponent
-              isHomePage={isHomePage}
+              isHomePage={_isHomePage(location)}
               location={location}
               ref={(ref) => {
                 this.header = ref;
@@ -246,14 +247,14 @@ export class AppBase extends React.Component<Props> {
             <div className="App-content">
               <div
                 className={makeClassName(
-                  isHomePage
+                  _isHomePage(location)
                     ? 'App-content-wrapper-homepage'
                     : 'App-content-wrapper',
                 )}
               >
                 {// Exclude the AppBanner from the home page if it will be
                 // included via HeroRecommendation.
-                (!isHomePage ||
+                (!_isHomePage(location) ||
                   !_config.get('enableFeatureHeroRecommendation')) && (
                   <AppBanner />
                 )}
@@ -274,7 +275,6 @@ export class AppBase extends React.Component<Props> {
 export const mapStateToProps = (state: AppState) => ({
   authToken: state.api && state.api.token,
   clientApp: state.api.clientApp,
-  isHomePage: state.viewContext.context === VIEW_CONTEXT_HOME,
   lang: state.api.lang,
   userAgent: state.api.userAgent,
 });

--- a/src/amo/components/App/index.js
+++ b/src/amo/components/App/index.js
@@ -45,8 +45,12 @@ interface MozNavigator extends Navigator {
   mozAddonManager?: Object;
 }
 
+// This function assumed the home page will no more than two parts in its path,
+// whereas any page other than the home page will have more than two.
+// Every path in the app starts with /lang/application/ (e.g., /en-US/firefox/)
+// which is what this logic is based upon.
 export const isHomePage = (location: ReactRouterLocationType) => {
-  return location.pathname.split('/').filter(Boolean).length === 2;
+  return location.pathname.split('/').filter(Boolean).length <= 2;
 };
 
 type Props = {|

--- a/src/amo/reducers/viewContext.js
+++ b/src/amo/reducers/viewContext.js
@@ -1,7 +1,4 @@
 /* @flow */
-import config from 'config';
-import { LOCATION_CHANGE } from 'connected-react-router';
-
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_THEME,
@@ -32,22 +29,10 @@ export const initialState = { context: VIEW_CONTEXT_EXPLORE };
 export default function viewContext(
   state: ViewContextState = initialState,
   action: ViewContextActionType,
-  _config: typeof config = config,
 ) {
   switch (action.type) {
     case SET_VIEW_CONTEXT:
       return { ...state, context: action.payload.context };
-
-    // This is a hack to make sure that the viewContext does not remain
-    // VIEW_CONTEXT_HOME  when we leave the home page, because there is code
-    // in /components/App/index.js which uses this to determine if we are
-    // currently on the home page.
-    case LOCATION_CHANGE: {
-      if (!_config.get('server') && state.context === VIEW_CONTEXT_HOME) {
-        return initialState;
-      }
-      return state;
-    }
 
     default:
       return state;

--- a/tests/unit/amo/reducers/test_viewContext.js
+++ b/tests/unit/amo/reducers/test_viewContext.js
@@ -1,46 +1,10 @@
-import { LOCATION_CHANGE } from 'connected-react-router';
-
-import { setViewContext } from 'amo/actions/viewContext';
 import viewContext, { initialState } from 'amo/reducers/viewContext';
-import {
-  ADDON_TYPE_EXTENSION,
-  VIEW_CONTEXT_EXPLORE,
-  VIEW_CONTEXT_HOME,
-} from 'core/constants';
-import { getFakeConfig } from 'tests/unit/helpers';
+import { VIEW_CONTEXT_EXPLORE } from 'core/constants';
 
 describe(__filename, () => {
   it('defaults to explore', () => {
     const state = viewContext(initialState, {});
 
     expect(state).toEqual({ context: VIEW_CONTEXT_EXPLORE });
-  });
-
-  describe('LOCATION_CHANGE', () => {
-    it('resets the state on the client when the current viewContext is VIEW_CONTEXT_HOME', () => {
-      const _config = getFakeConfig({ server: false });
-
-      let state = viewContext(undefined, setViewContext(VIEW_CONTEXT_HOME));
-      expect(state.context).toEqual(VIEW_CONTEXT_HOME);
-
-      state = viewContext(state, { type: LOCATION_CHANGE }, _config);
-      expect(state).toEqual(initialState);
-    });
-
-    it('does not reset the state on the server', () => {
-      const _config = getFakeConfig({ server: true });
-      let state = viewContext(undefined, setViewContext(VIEW_CONTEXT_HOME));
-
-      state = viewContext(state, { type: LOCATION_CHANGE }, _config);
-      expect(state.context).toEqual(VIEW_CONTEXT_HOME);
-    });
-
-    it('does not reset the state when the current viewContext is not VIEW_CONTEXT_HOME', () => {
-      const _config = getFakeConfig({ server: false });
-      let state = viewContext(undefined, setViewContext(ADDON_TYPE_EXTENSION));
-
-      state = viewContext(state, { type: LOCATION_CHANGE }, _config);
-      expect(state.context).toEqual(ADDON_TYPE_EXTENSION);
-    });
   });
 });


### PR DESCRIPTION
Fixes #8703 

This is a fairly quick way to remove the hack introduced in https://github.com/mozilla/addons-frontend/commit/058cf22b66daf44e73e75fcea7b02ea1fe348f6a#diff-dfede40c05614c7530600e28abfe9bf5R41-R50. It switches the logic for determining the home page from using `viewContext` to using `location` instead, and it seems to be more accurate. It removes the need for the `viewContext` reducer hack, and it also addresses a glitch with the loading skeleton for the primary hero shelf.

We may still want to consider doing something different, but I think this is a good first step and would allow us to land all the changes for the new hero elements and enable them on prod.