### PR TITLE
Redirect user to a specified location after creating their prof…

### DIFF
--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -200,10 +200,6 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       });
     }
 
-    const redirectToUserProfile = () => {
-      history.push(`/${lang}/${clientApp}/user/${newUserId}/`);
-    };
-
     if (wasUpdating && !isUpdating && !errorHandler.hasError()) {
       let toPath = location.query.to;
       if (toPath && typeof toPath === 'string' && !toPath.startsWith('//')) {
@@ -217,7 +213,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
           log.warn(`Error redirecting to location: ${toPath}: ${error}`);
         }
       }
-      redirectToUserProfile();
+      history.push(`/${lang}/${clientApp}/user/${newUserId}/`);
     }
 
     if (

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -206,19 +206,18 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
     if (wasUpdating && !isUpdating && !errorHandler.hasError()) {
       let toPath = location.query.to;
-      if (toPath) {
+      if (toPath && typeof toPath === 'string' && !toPath.startsWith('//')) {
         if (!toPath.startsWith('/')) {
           toPath = `/${toPath}`;
         }
         try {
           history.push(toPath);
+          return;
         } catch (error) {
-          log.warn(`Error redirecting to location: ${toPath}`);
-          redirectToUserProfile();
+          log.warn(`Error redirecting to location: ${toPath}: ${error}`);
         }
-      } else {
-        redirectToUserProfile();
       }
+      redirectToUserProfile();
     }
 
     if (

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -200,14 +200,25 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       });
     }
 
-    if (wasUpdating && !isUpdating && !errorHandler.hasError()) {
-      let newPath =
-        location.query.to || `/${lang}/${clientApp}/user/${newUserId}/`;
-      if (!newPath.startsWith('/')) {
-        newPath = `/${newPath}`;
-      }
+    const redirectToUserProfile = () => {
+      history.push(`/${lang}/${clientApp}/user/${newUserId}/`);
+    };
 
-      history.push(newPath);
+    if (wasUpdating && !isUpdating && !errorHandler.hasError()) {
+      let toPath = location.query.to;
+      if (toPath) {
+        if (!toPath.startsWith('/')) {
+          toPath = `/${toPath}`;
+        }
+        try {
+          history.push(toPath);
+        } catch (error) {
+          log.warn(`Error redirecting to location: ${toPath}`);
+          redirectToUserProfile();
+        }
+      } else {
+        redirectToUserProfile();
+      }
     }
 
     if (
@@ -795,14 +806,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
                     puffy
                     type="submit"
                   >
-                    {/* eslint-disable-next-line no-nested-ternary */}
-                    {isEditingCurrentUser
-                      ? isUpdating
-                        ? i18n.gettext('Updating your profile…')
-                        : i18n.gettext('Update My Profile')
-                      : isUpdating
-                      ? i18n.gettext('Updating profile…')
-                      : i18n.gettext('Update Profile')}
+                    {submitButtonText}
                   </Button>
                   <Button
                     buttonType="neutral"

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -47,6 +47,7 @@ import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
 import type {
   ReactRouterHistoryType,
+  ReactRouterLocationType,
   ReactRouterMatchType,
 } from 'core/types/router';
 
@@ -55,7 +56,6 @@ import './styles.scss';
 type Props = {|
   _window: typeof window | Object,
   clientApp: string,
-  history: ReactRouterHistoryType,
   currentUser: UserType | null,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
@@ -66,6 +66,7 @@ type Props = {|
   isReviewer: boolean,
   isUpdating: boolean,
   lang: string,
+  location: ReactRouterLocationType,
   // `match` is used in `mapStateToProps()`
   // eslint-disable-next-line react/no-unused-prop-types
   match: {|
@@ -151,6 +152,7 @@ export class UserProfileEditBase extends React.Component<Props, State> {
       i18n,
       isUpdating,
       lang,
+      location,
       user: newUser,
       userId: newUserId,
     } = this.props;
@@ -199,7 +201,13 @@ export class UserProfileEditBase extends React.Component<Props, State> {
     }
 
     if (wasUpdating && !isUpdating && !errorHandler.hasError()) {
-      history.push(`/${lang}/${clientApp}/user/${newUserId}/`);
+      let newPath =
+        location.query.to || `/${lang}/${clientApp}/user/${newUserId}/`;
+      if (!newPath.startsWith('/')) {
+        newPath = `/${newPath}`;
+      }
+
+      history.push(newPath);
     }
 
     if (
@@ -490,6 +498,21 @@ export class UserProfileEditBase extends React.Component<Props, State> {
 
       if (user && !hasEditPermission) {
         return <NotFound />;
+      }
+    }
+
+    let submitButtonText = isUpdating
+      ? i18n.gettext('Creating your profile…')
+      : i18n.gettext('Create My Profile');
+    if (user && user.display_name) {
+      if (isEditingCurrentUser) {
+        submitButtonText = isUpdating
+          ? i18n.gettext('Updating your profile…')
+          : i18n.gettext('Update My Profile');
+      } else {
+        submitButtonText = isUpdating
+          ? i18n.gettext('Updating profile…')
+          : i18n.gettext('Update Profile');
       }
     }
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1042,7 +1042,7 @@ export const createFakeHistory = ({ location = createFakeLocation() } = {}) => {
     location,
     goBack: sinon.spy(),
     listen: sinon.spy(),
-    push: sinon.spy(),
+    push: sinon.stub(),
   };
 };
 


### PR DESCRIPTION
Fixes #8666 

This patch introduces two changes:

1. If there is a `to` URL parameter when visiting the Edit User Profile page, then after the user saves their profile they will be directed to the URL contained in that parameter.
2. If the user is creating their profile for the first time, which is identified by that fact that their `display_name` is empty, the button text changes from `Update` to `Create`.