### PR TITLE
Layout fixes for Primary Hero element on mobile

### DIFF
--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -39,7 +39,6 @@
 .HeroRecommendation-info {
   display: flex;
   flex-direction: column;
-  min-width: 0;
 
   @include respond-to(medium) {
     @include margin-start(24px);

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -28,6 +28,7 @@
 .HeroRecommendation-content {
   color: $white;
   display: flex;
+  min-width: 0;
   padding: 24px;
 
   @include respond-to(extraExtraLarge) {
@@ -36,7 +37,13 @@
 }
 
 .HeroRecommendation-info {
-  @include margin-start(24px);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+
+  @include respond-to(medium) {
+    @include margin-start(24px);
+  }
 
   @include respond-to(extraLarge) {
     @include margin-start(96px);
@@ -149,7 +156,8 @@
   display: inline-block;
   font-size: $font-size-m;
   line-height: 1.25;
-  padding: 12px 48px;
+  padding: 12px 24px;
+  text-align: center;
   // The theme styles will add a hover effect.
   transition: background-color $transition-medium ease-in-out;
   white-space: nowrap;
@@ -161,6 +169,10 @@
   &:visited {
     color: $white;
     text-decoration: none;
+  }
+
+  @include respond-to(medium) {
+    padding: 12px 48px;
   }
 }
 


### PR DESCRIPTION
Fixes #8742 

Before, with image (however image is hidden):

![Screen Shot 2019-10-09 at 14 42 09](https://user-images.githubusercontent.com/142755/66510831-d1af3480-eaa3-11e9-9f30-75303f8477ff.png)

After, with image:

![Screen Shot 2019-10-09 at 14 41 20](https://user-images.githubusercontent.com/142755/66510843-d83dac00-eaa3-11e9-8bc6-3d0e974fa021.png)


Before, no image:

![Screen Shot 2019-10-09 at 14 42 40](https://user-images.githubusercontent.com/142755/66510817-cc51ea00-eaa3-11e9-9cea-bc344b31c815.png)

After, no image:

![Screen Shot 2019-10-09 at 14 42 55](https://user-images.githubusercontent.com/142755/66510798-c0febe80-eaa3-11e9-8302-33411923e4c6.png)





