### PR TITLE
Fix overflow issue with long words on Secondary Hero

### DIFF
--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -43,8 +43,8 @@
 }
 
 .SecondaryHero-message-description {
-  padding: $padding-page 0;
   overflow-wrap: anywhere;
+  padding: $padding-page 0;
 
   @include respond-to(large) {
     padding: 8px 0 24px 0;
@@ -101,8 +101,8 @@
 .SecondaryHero-message-link,
 .SecondaryHero-module-description,
 .SecondaryHero-module-link {
-  width: 100%;
   overflow-wrap: anywhere;
+  width: 100%;
 
   .LoadingText {
     height: 1em;

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -35,6 +35,7 @@
   font-weight: normal;
   line-height: 1.333;
   margin: 0;
+  word-break: break-word;
 
   .LoadingText {
     height: 1em;
@@ -43,6 +44,7 @@
 
 .SecondaryHero-message-description {
   padding: $padding-page 0;
+  word-break: break-word;
 
   @include respond-to(large) {
     padding: 8px 0 24px 0;
@@ -100,6 +102,7 @@
 .SecondaryHero-module-description,
 .SecondaryHero-module-link {
   width: 100%;
+  word-break: break-word;
 
   .LoadingText {
     height: 1em;

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -35,7 +35,7 @@
   font-weight: normal;
   line-height: 1.333;
   margin: 0;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 
   .LoadingText {
     height: 1em;
@@ -44,7 +44,7 @@
 
 .SecondaryHero-message-description {
   padding: $padding-page 0;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 
   @include respond-to(large) {
     padding: 8px 0 24px 0;
@@ -102,7 +102,7 @@
 .SecondaryHero-module-description,
 .SecondaryHero-module-link {
   width: 100%;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 
   .LoadingText {
     height: 1em;


### PR DESCRIPTION
Fixes #8740 

Before:

![Screen Shot 2019-10-09 at 15 03 43](https://user-images.githubusercontent.com/142755/66512082-37042500-eaa6-11e9-88a0-e64e2014b01d.png)


After:

![Screen Shot 2019-10-09 at 15 04 01](https://user-images.githubusercontent.com/142755/66512089-3e2b3300-eaa6-11e9-8d65-45ec10e4c8a1.png)
