### PR TITLE
Fix overflow issue with long words on SearchResult-Link

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -22,6 +22,7 @@ $icon-default-size: 32px;
   @include margin-end(8px);
 
   text-decoration: none;
+  word-break: break-word;
   word-wrap: anywhere;
 
   &,


### PR DESCRIPTION
Fixes #8751 

### Before
<img width="922" alt="Screen Shot 2019-10-10 at 14 38 05" src="https://user-images.githubusercontent.com/31479458/66566376-721d5b80-eb6d-11e9-806d-50c87382d774.png">

### After
<img width="904" alt="Screen Shot 2019-10-10 at 14 45 27" src="https://user-images.githubusercontent.com/31479458/66566392-7ea1b400-eb6d-11e9-94da-f345102b583e.png">
