### PR TITLE
Fix width of site notices and error messages on home page

### DIFF
--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -15,6 +15,7 @@ import { sanitizeUserHTML } from 'core/utils';
 import LoadingText from 'ui/components/LoadingText';
 import type { PrimaryHeroShelfType } from 'amo/reducers/home';
 import type { AppState } from 'amo/store';
+import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
 
 import './styles.scss';
@@ -23,6 +24,7 @@ export const PRIMARY_HERO_CLICK_CATEGORY = 'AMO Primary Hero Clicks';
 export const PRIMARY_HERO_SRC = 'homepage-primary-hero';
 
 type Props = {|
+  errorHandler: ErrorHandlerType,
   shelfData?: PrimaryHeroShelfType,
 |};
 
@@ -78,6 +80,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
     const {
       _checkInternalURL,
       i18n,
+      errorHandler,
       shelfData,
       siteIsReadOnly,
       siteNotice,
@@ -151,6 +154,8 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           HeroRecommendation on the home page. All other pages in the app
           include it via the Page component. */}
           <AppBanner className="HeroRecommendation-banner" />
+
+          {errorHandler.renderErrorIfPresent()}
 
           <div className="HeroRecommendation-content">
             {featuredImage && (

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -21,6 +21,11 @@
   }
 }
 
+.HeroRecommendation .ErrorList {
+  padding: 24px;
+  padding-bottom: 0;
+}
+
 .HeroRecommendation-banner {
   padding-bottom: 0;
 }

--- a/src/amo/components/Page/index.js
+++ b/src/amo/components/Page/index.js
@@ -29,6 +29,10 @@ export const PageBase = ({
   isHomePage = false,
   location,
 }: InternalProps) => {
+  const enableFeatureHeroRecommendation = _config.get(
+    'enableFeatureHeroRecommendation',
+  );
+
   return (
     <div className="Page-amo">
       <InfoDialog />
@@ -39,13 +43,12 @@ export const PageBase = ({
         <div
           className={makeClassName('Page', {
             'Page-not-homepage': !isHomePage,
+            'Page-no-hero-promo': !enableFeatureHeroRecommendation,
           })}
         >
           {// Exclude the AppBanner from the home page if it will be
           // included via HeroRecommendation.
-          (!isHomePage || !_config.get('enableFeatureHeroRecommendation')) && (
-            <AppBanner />
-          )}
+          (!isHomePage || !enableFeatureHeroRecommendation) && <AppBanner />}
           {children}
         </div>
       </div>

--- a/src/amo/components/Page/styles.scss
+++ b/src/amo/components/Page/styles.scss
@@ -27,6 +27,6 @@
 
 // This ugly temporary hack fixes the padding for the error message on the
 // home page when there is no hero promo.
-.Page-no-hero-promo:not(.Page-not-homepage) .ErrorList {
-  padding: 0 24px;
-}
+// .Page-no-hero-promo:not(.Page-not-homepage) .ErrorList {
+//   padding: 0 24px;
+// }

--- a/src/amo/components/Page/styles.scss
+++ b/src/amo/components/Page/styles.scss
@@ -20,6 +20,13 @@
   margin: 0 auto;
 }
 
+.Page-no-hero-promo,
 .Page-not-homepage {
   max-width: $max-content-width;
+}
+
+// This ugly temporary hack fixes the padding for the error message on the
+// home page when there is no hero promo.
+.Page-no-hero-promo:not(.Page-not-homepage) .ErrorList {
+  padding: 0 24px;
 }

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -256,7 +256,9 @@ export class HomeBase extends React.Component {
 
           {(!_config.get('enableFeatureHeroRecommendation') ||
             clientApp === CLIENT_APP_ANDROID) &&
-            errorHandler.renderErrorIfPresent()}
+          errorHandler.hasError() ? (
+            <div className="Home-noHeroError">{errorHandler.renderError()}</div>
+          ) : null}
 
           {_config.get('enableFeatureHeroRecommendation') &&
           clientApp !== CLIENT_APP_ANDROID ? (

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -254,11 +254,14 @@ export class HomeBase extends React.Component {
             }}
           />
 
-          {errorHandler.renderErrorIfPresent()}
+          {(!_config.get('enableFeatureHeroRecommendation') ||
+            clientApp === CLIENT_APP_ANDROID) &&
+            errorHandler.renderErrorIfPresent()}
 
           {_config.get('enableFeatureHeroRecommendation') &&
           clientApp !== CLIENT_APP_ANDROID ? (
             <HeroRecommendation
+              errorHandler={errorHandler}
               shelfData={heroShelves && heroShelves.primary}
             />
           ) : null}

--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -148,3 +148,7 @@
     }
   }
 }
+
+.Home-noHeroError {
+  padding: 0 24px;
+}

--- a/stories/amo/HeroRecommendation.js
+++ b/stories/amo/HeroRecommendation.js
@@ -1,7 +1,12 @@
 /* @flow */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { createHeroShelves, fakeAddon, fakeI18n } from 'tests/unit/helpers';
+import {
+  createHeroShelves,
+  dispatchClientMetadata,
+  fakeAddon,
+  fakeI18n,
+} from 'tests/unit/helpers';
 
 import { HeroRecommendationBase } from 'amo/components/HeroRecommendation';
 import { createInternalHeroShelves } from 'amo/reducers/home';
@@ -50,16 +55,15 @@ storiesOf('HeroRecommendation', module)
           },
           {
             title: 'with error',
-            sectionFn: () =>
-              render(
-                {},
-                {
-                  errorHandler: new ErrorHandler({
-                    id: 'some-id',
-                    capturedError: new Error('Some error'),
-                  }),
-                },
-              ),
+            sectionFn: () => {
+              const { store } = dispatchClientMetadata();
+              const errorHandler = new ErrorHandler({
+                dispatch: store.dispatch,
+                id: 'some-id',
+              });
+              errorHandler.handle(new Error('Some error'));
+              return render({}, { errorHandler });
+            },
           },
           {
             title: 'loading',

--- a/stories/amo/HeroRecommendation.js
+++ b/stories/amo/HeroRecommendation.js
@@ -5,11 +5,14 @@ import { createHeroShelves, fakeAddon, fakeI18n } from 'tests/unit/helpers';
 
 import { HeroRecommendationBase } from 'amo/components/HeroRecommendation';
 import { createInternalHeroShelves } from 'amo/reducers/home';
+import { ErrorHandler } from 'core/errorHandler';
 
 import Provider from '../setup/Provider';
 
 const render = (shelfProps = {}, moreProps = {}) => {
   const props = {
+    errorHandler: new ErrorHandler({ id: 'some-id' }),
+    i18n: fakeI18n({ includeJedSpy: false }),
     shelfData: createInternalHeroShelves(
       createHeroShelves({
         primaryProps: {
@@ -20,7 +23,6 @@ const render = (shelfProps = {}, moreProps = {}) => {
         },
       }),
     ).primary,
-    i18n: fakeI18n({ includeJedSpy: false }),
     siteIsReadOnly: false,
     siteNotice: null,
     ...moreProps,
@@ -45,6 +47,19 @@ storiesOf('HeroRecommendation', module)
           {
             title: 'without image',
             sectionFn: () => render({ featuredImage: null }),
+          },
+          {
+            title: 'with error',
+            sectionFn: () =>
+              render(
+                {},
+                {
+                  errorHandler: new ErrorHandler({
+                    id: 'some-id',
+                    capturedError: new Error('Some error'),
+                  }),
+                },
+              ),
           },
           {
             title: 'loading',

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -9,11 +9,13 @@ import HeroRecommendation, {
 import { createInternalHeroShelves } from 'amo/reducers/home';
 import { addParamsToHeroURL, getAddonURL } from 'amo/utils';
 import { loadSiteStatus } from 'core/reducers/site';
+import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
 import {
   createFakeEvent,
   createFakeTracking,
   createHeroShelves,
+  createStubErrorHandler,
   dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
@@ -29,6 +31,7 @@ describe(__filename, () => {
 
   const render = (moreProps = {}) => {
     const props = {
+      errorHandler: createStubErrorHandler(),
       i18n: fakeI18n(),
       store: dispatchClientMetadata().store,
       ...moreProps,
@@ -191,6 +194,13 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(AppBanner)).toHaveLength(1);
+  });
+
+  it('renders an error if present', () => {
+    const errorHandler = createStubErrorHandler(new Error('some error'));
+
+    const root = render({ errorHandler });
+    expect(root.find(ErrorList)).toHaveLength(1);
   });
 
   it.each([

--- a/tests/unit/amo/components/TestPage.js
+++ b/tests/unit/amo/components/TestPage.js
@@ -38,6 +38,22 @@ describe(__filename, () => {
     expect(root.find('.Page-not-homepage')).toHaveLength(0);
   });
 
+  it('assigns a className when there is no hero promo', () => {
+    const root = render({
+      _config: getFakeConfig({ enableFeatureHeroRecommendation: false }),
+    });
+
+    expect(root.find('.Page-no-hero-promo')).toHaveLength(1);
+  });
+
+  it('does not assign an extra className when there is a hero promo', () => {
+    const root = render({
+      _config: getFakeConfig({ enableFeatureHeroRecommendation: true }),
+    });
+
+    expect(root.find('.Page-no-hero-promo')).toHaveLength(0);
+  });
+
   it('renders an AppBanner if it is not the home page', () => {
     const root = render({ isHomePage: false });
 

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -35,7 +35,6 @@ import {
   VIEW_CONTEXT_HOME,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
-import ErrorList from 'ui/components/ErrorList';
 import {
   createAddonsApiResult,
   createFakeCollectionAddons,
@@ -426,7 +425,7 @@ describe(__filename, () => {
         errorHandler,
         store,
       });
-      expect(root.find(ErrorList)).toHaveLength(1);
+      expect(root.find('.Home-noHeroError')).toHaveLength(1);
     },
   );
 
@@ -443,7 +442,7 @@ describe(__filename, () => {
         errorHandler,
         store,
       });
-      expect(root.find(ErrorList)).toHaveLength(1);
+      expect(root.find('.Home-noHeroError')).toHaveLength(1);
     },
   );
 
@@ -456,7 +455,7 @@ describe(__filename, () => {
       errorHandler,
       store,
     });
-    expect(root.find(ErrorList)).toHaveLength(0);
+    expect(root.find('.Home-noHeroError')).toHaveLength(0);
   });
 
   describe('isFeaturedCollection', () => {


### PR DESCRIPTION
Fixes #8750 
Fixes #8756

Before (#8750):

![Screenshot 2019-10-10 09 37 15](https://user-images.githubusercontent.com/142755/66574181-c7437800-eb41-11e9-8505-accdff866c68.png)

After (#8750):

![Screenshot 2019-10-10 09 38 17](https://user-images.githubusercontent.com/142755/66574155-c01c6a00-eb41-11e9-81c3-d94098c2b592.png)

Before (#8756):

![Screenshot 2019-10-10 12 13 30](https://user-images.githubusercontent.com/142755/66587127-d2a19e00-eb57-11e9-8f02-d0ca0fd212d8.png)

After (#8756): 

![Screenshot 2019-10-10 15 04 27](https://user-images.githubusercontent.com/142755/66598651-75b1e200-eb6f-11e9-83f5-5c4af6c7b96d.png)
