### PR TITLE
Fix site banner and error messages on Android home page

### DIFF
--- a/src/amo/components/Page/index.js
+++ b/src/amo/components/Page/index.js
@@ -2,12 +2,16 @@
 import makeClassName from 'classnames';
 import config from 'config';
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { compose } from 'redux';
 
 import AppBanner from 'amo/components/AppBanner';
 import Footer from 'amo/components/Footer';
 import Header from 'amo/components/Header';
 import InfoDialog from 'core/components/InfoDialog';
+import { CLIENT_APP_ANDROID } from 'core/constants';
+import type { AppState } from 'amo/store';
 import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
@@ -20,12 +24,14 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   _config: typeof config,
+  clientApp: string,
   location: ReactRouterLocationType,
 |};
 
 export const PageBase = ({
   _config = config,
   children,
+  clientApp,
   isHomePage = false,
   location,
 }: InternalProps) => {
@@ -43,12 +49,17 @@ export const PageBase = ({
         <div
           className={makeClassName('Page', {
             'Page-not-homepage': !isHomePage,
-            'Page-no-hero-promo': !enableFeatureHeroRecommendation,
+            'Page-no-hero-promo':
+              !enableFeatureHeroRecommendation ||
+              clientApp === CLIENT_APP_ANDROID,
           })}
         >
           {// Exclude the AppBanner from the home page if it will be
-          // included via HeroRecommendation.
-          (!isHomePage || !enableFeatureHeroRecommendation) && <AppBanner />}
+          // included via HeroRecommendation, but include it on the Android
+          // home page.
+          (!isHomePage ||
+            !enableFeatureHeroRecommendation ||
+            clientApp === CLIENT_APP_ANDROID) && <AppBanner />}
           {children}
         </div>
       </div>
@@ -58,6 +69,15 @@ export const PageBase = ({
   );
 };
 
-const Page: React.ComponentType<Props> = withRouter(PageBase);
+export const mapStateToProps = (state: AppState) => {
+  return {
+    clientApp: state.api.clientApp,
+  };
+};
+
+const Page: React.ComponentType<Props> = compose(
+  withRouter,
+  connect(mapStateToProps),
+)(PageBase);
 
 export default Page;

--- a/tests/unit/amo/components/TestPage.js
+++ b/tests/unit/amo/components/TestPage.js
@@ -3,15 +3,21 @@ import * as React from 'react';
 import Page, { PageBase } from 'amo/components/Page';
 import AppBanner from 'amo/components/AppBanner';
 import Header from 'amo/components/Header';
+import { CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX } from 'core/constants';
 import {
   createContextWithFakeRouter,
+  dispatchClientMetadata,
   getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   const render = (props = {}) => {
-    const allProps = { children: <div>Some content</div>, ...props };
+    const allProps = {
+      children: <div>Some content</div>,
+      store: dispatchClientMetadata().store,
+      ...props,
+    };
 
     return shallowUntilTarget(<Page {...allProps} />, PageBase, {
       shallowOptions: createContextWithFakeRouter(),
@@ -47,11 +53,24 @@ describe(__filename, () => {
   });
 
   it('does not assign an extra className when there is a hero promo', () => {
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
     const root = render({
       _config: getFakeConfig({ enableFeatureHeroRecommendation: true }),
+      store,
     });
 
     expect(root.find('.Page-no-hero-promo')).toHaveLength(0);
+  });
+
+  it('assigns a className when there is a hero promo and it is also the Android home page', () => {
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID });
+
+    const root = render({
+      _config: getFakeConfig({ enableFeatureHeroRecommendation: true }),
+      store,
+    });
+
+    expect(root.find('.Page-no-hero-promo')).toHaveLength(1);
   });
 
   it('renders an AppBanner if it is not the home page', () => {
@@ -70,12 +89,25 @@ describe(__filename, () => {
   });
 
   it('does not render an AppBanner if it is the home page and enableFeatureHeroRecommendation is true', () => {
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
     const root = render({
       _config: getFakeConfig({ enableFeatureHeroRecommendation: true }),
       isHomePage: true,
+      store,
     });
 
     expect(root.find(AppBanner)).toHaveLength(0);
+  });
+
+  it('renders an AppBanner if it is the home page and enableFeatureHeroRecommendation is true on Android', () => {
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID });
+    const root = render({
+      _config: getFakeConfig({ enableFeatureHeroRecommendation: true }),
+      isHomePage: true,
+      store,
+    });
+
+    expect(root.find(AppBanner)).toHaveLength(1);
   });
 
   it('renders children', () => {


### PR DESCRIPTION
~~Depends on #8753~~
Fixes #8757 

I could easily combine this into the patch for #8753 if that would be preferred.

Before:

![Screenshot 2019-10-10 15 14 37](https://user-images.githubusercontent.com/142755/66599229-b8c08500-eb70-11e9-9149-079261503f42.png)

After:

![Screenshot 2019-10-10 17 18 23](https://user-images.githubusercontent.com/142755/66608317-478acd00-eb84-11e9-8666-ccc4fb1c019b.png)
