### PR TITLE
Disable login/logout buttons

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -32,9 +32,10 @@ export class HeaderBase extends React.Component {
     handleLogOut: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
     isHomePage: PropTypes.bool.isRequired,
-    location: PropTypes.object.isRequired,
-    siteUser: PropTypes.object,
     isReviewer: PropTypes.bool.isRequired,
+    location: PropTypes.object.isRequired,
+    siteIsReadOnly: PropTypes.bool.isRequired,
+    siteUser: PropTypes.object,
   };
 
   static defaultProps = { _config: config };
@@ -52,6 +53,7 @@ export class HeaderBase extends React.Component {
       isHomePage,
       isReviewer,
       location,
+      siteIsReadOnly,
       siteUser,
     } = this.props;
 
@@ -190,7 +192,14 @@ export class HeaderBase extends React.Component {
                 <DropdownMenuItem
                   className="Header-logout-button"
                   detached
+                  disabled={siteIsReadOnly}
                   onClick={this.handleLogOut}
+                  title={
+                    siteIsReadOnly
+                      ? i18n.gettext(`This action is currently unavailable.
+                          Please reload the page in a moment.`)
+                      : null
+                  }
                 >
                   {i18n.gettext('Log out')}
                 </DropdownMenuItem>
@@ -213,8 +222,9 @@ export class HeaderBase extends React.Component {
 export const mapStateToProps = (state) => {
   return {
     api: state.api,
-    siteUser: getCurrentUser(state.users),
     isReviewer: hasAnyReviewerRelatedPermission(state),
+    siteIsReadOnly: state.site.readOnly,
+    siteUser: getCurrentUser(state.users),
   };
 };
 

--- a/src/core/components/AuthenticateButton/index.js
+++ b/src/core/components/AuthenticateButton/index.js
@@ -36,13 +36,18 @@ type Props = {|
   noIcon?: boolean,
 |};
 
-type InternalProps = {|
-  ...Props,
+type StateMappedProps = {|
   api: ApiState,
   handleLogIn: HandleLogInFunc,
+  siteIsReadOnly: boolean,
+  siteUser: UserType | null,
+|};
+
+type InternalProps = {|
+  ...Props,
+  ...StateMappedProps,
   i18n: I18nType,
   location: ReactRouterLocationType,
-  siteUser: UserType | null,
 |};
 
 export class AuthenticateButtonBase extends React.Component<InternalProps> {
@@ -73,12 +78,18 @@ export class AuthenticateButtonBase extends React.Component<InternalProps> {
       logInText,
       logOutText,
       noIcon,
+      siteIsReadOnly,
       siteUser,
     } = this.props;
 
     const buttonText = siteUser
       ? logOutText || i18n.gettext('Log out')
       : logInText || i18n.gettext('Register or Log in');
+
+    const title = siteIsReadOnly
+      ? i18n.gettext(`This action is currently unavailable. Please reload the
+        page in a moment.`)
+      : null;
 
     // The `href` is required because a <button> element with a :hover effect
     // and/or focus effect (that is not part of a form) that changes its
@@ -90,7 +101,9 @@ export class AuthenticateButtonBase extends React.Component<InternalProps> {
         href={`#${siteUser ? 'logout' : 'login'}`}
         buttonType={buttonType}
         className={className}
+        disabled={siteIsReadOnly}
         onClick={this.onClick}
+        title={title}
         micro
       >
         {noIcon ? null : <Icon name="user-dark" />}
@@ -99,12 +112,6 @@ export class AuthenticateButtonBase extends React.Component<InternalProps> {
     );
   }
 }
-
-type StateMappedProps = {|
-  api: ApiState,
-  handleLogIn: HandleLogInFunc,
-  siteUser: UserType | null,
-|};
 
 export const mapStateToProps = (
   state: AppState,
@@ -118,6 +125,7 @@ export const mapStateToProps = (
   return {
     api: state.api,
     handleLogIn: ownProps.handleLogIn || defaultHandleLogIn,
+    siteIsReadOnly: state.site.readOnly,
     siteUser: getCurrentUser(state.users),
   };
 };

--- a/src/ui/components/Button/index.js
+++ b/src/ui/components/Button/index.js
@@ -29,6 +29,7 @@ export type Props = {|
   noLink: boolean,
   onClick?: Function | null,
   puffy: boolean,
+  title?: string | null,
   // TODO: make a better Object type.
   to?: string | Object,
   target?: string,
@@ -101,7 +102,11 @@ export default class Button extends React.Component<Props> {
     };
 
     if (noLink) {
-      return <span className={getClassName()}>{children}</span>;
+      return (
+        <span className={getClassName()} title={rest.title}>
+          {children}
+        </span>
+      );
     }
 
     if (href || to) {

--- a/src/ui/components/DropdownMenuItem/index.js
+++ b/src/ui/components/DropdownMenuItem/index.js
@@ -10,14 +10,18 @@ type Props = {|
   children?: string | Link,
   className?: string,
   detached?: boolean,
+  disabled?: boolean,
   onClick?: Function,
+  title?: string | null,
 |};
 
 const DropdownMenuItem = ({
   children,
   className,
   onClick,
+  title,
   detached = false,
+  disabled = false,
 }: Props) => {
   const childIsComponent = typeof children === 'object';
   const _classNames = makeClassName(
@@ -26,6 +30,7 @@ const DropdownMenuItem = ({
       'DropdownMenuItem-section': !childIsComponent && !onClick,
       'DropdownMenuItem-link': childIsComponent || onClick,
       'DropdownMenuItem--detached': detached,
+      'DropdownMenuItem--disabled': disabled,
     },
     className,
   );
@@ -33,7 +38,12 @@ const DropdownMenuItem = ({
   return (
     <li className={_classNames}>
       {onClick ? (
-        <button onClick={onClick} type="button">
+        <button
+          disabled={disabled}
+          onClick={onClick}
+          title={title}
+          type="button"
+        >
           {children}
         </button>
       ) : (

--- a/src/ui/components/DropdownMenuItem/styles.scss
+++ b/src/ui/components/DropdownMenuItem/styles.scss
@@ -33,6 +33,13 @@
   margin-top: 8px;
 }
 
+.DropdownMenuItem--disabled {
+  &,
+  & button {
+    @include disabled();
+  }
+}
+
 .DropdownMenuItem {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/ui/components/DropdownMenuItem/styles.scss
+++ b/src/ui/components/DropdownMenuItem/styles.scss
@@ -37,6 +37,10 @@
   &,
   & button {
     @include disabled();
+
+    // We override the opacity because the default value in the `disabled()`
+    // mixin makes the text hard to read.
+    opacity: 0.8;
   }
 }
 

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -5,6 +5,7 @@ import Link from 'amo/components/Link';
 import { makeQueryStringWithUTM } from 'amo/utils';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import DropdownMenu from 'ui/components/DropdownMenu';
+import { loadSiteStatus } from 'core/reducers/site';
 import {
   createFakeEvent,
   createFakeLocation,
@@ -191,4 +192,27 @@ describe(__filename, () => {
       expect(wrapper.find('.Header')).toHaveClassName(expectedClassName);
     },
   );
+
+  it('disables the logout button when the site is in readonly mode', () => {
+    const { store } = dispatchSignInActions();
+    store.dispatch(loadSiteStatus({ readOnly: true, notice: null }));
+
+    const root = renderHeader({ store });
+
+    expect(root.find('.Header-logout-button')).toHaveProp('disabled', true);
+    expect(root.find('.Header-logout-button')).toHaveProp(
+      'title',
+      expect.stringContaining('currently unavailable'),
+    );
+  });
+
+  it('does not disable the logout button when the site is not in readonly mode', () => {
+    const { store } = dispatchSignInActions();
+    store.dispatch(loadSiteStatus({ readOnly: false, notice: null }));
+
+    const root = renderHeader({ store });
+
+    expect(root.find('.Header-logout-button')).toHaveProp('disabled', false);
+    expect(root.find('.Header-logout-button')).toHaveProp('title', null);
+  });
 });

--- a/tests/unit/core/components/TestAuthenticateButton.js
+++ b/tests/unit/core/components/TestAuthenticateButton.js
@@ -8,6 +8,7 @@ import AuthenticateButton, {
   createHandleLogOutFunction,
   mapStateToProps,
 } from 'core/components/AuthenticateButton';
+import { loadSiteStatus } from 'core/reducers/site';
 import {
   createContextWithFakeRouter,
   createFakeEvent,
@@ -155,6 +156,29 @@ describe(__filename, () => {
     sinon.assert.calledWith(handleLogOut, {
       api: store.getState().api,
     });
+  });
+
+  it('is disabled when the site is in readonly mode', () => {
+    const { store } = dispatchSignInActions();
+    store.dispatch(loadSiteStatus({ readOnly: true, notice: null }));
+
+    const root = render({ store });
+
+    expect(root).toHaveProp('disabled', true);
+    expect(root).toHaveProp(
+      'title',
+      expect.stringContaining('currently unavailable'),
+    );
+  });
+
+  it('is not disabled when the site is not in readonly mode', () => {
+    const { store } = dispatchSignInActions();
+    store.dispatch(loadSiteStatus({ readOnly: false, notice: null }));
+
+    const root = render({ store });
+
+    expect(root).toHaveProp('disabled', false);
+    expect(root).toHaveProp('title', null);
   });
 
   describe('createHandleLogOutFunction()', () => {

--- a/tests/unit/ui/components/TestButton.js
+++ b/tests/unit/ui/components/TestButton.js
@@ -124,4 +124,28 @@ describe(__filename, () => {
     expect(button.type()).toEqual('span');
     expect(button).toHaveClassName(className);
   });
+
+  it('renders a read only button with a title', () => {
+    const title = 'some title';
+    const button = render({ noLink: true, title });
+
+    expect(button.type()).toEqual('span');
+    expect(button).toHaveProp('title', title);
+  });
+
+  it('renders a link with a title', () => {
+    const title = 'some title';
+    const button = render({ href: '/', title });
+
+    expect(button.type()).toEqual(Link);
+    expect(button).toHaveProp('title', title);
+  });
+
+  it('renders a submit button with a title', () => {
+    const title = 'some title';
+    const button = render({ title });
+
+    expect(button.type()).toEqual('button');
+    expect(button).toHaveProp('title', title);
+  });
 });

--- a/tests/unit/ui/components/TestDropdownMenuItem.js
+++ b/tests/unit/ui/components/TestDropdownMenuItem.js
@@ -72,4 +72,27 @@ describe(__filename, () => {
     expect(item).toHaveClassName('DropdownMenuItem-section');
     expect(item).toHaveClassName('custom-class');
   });
+
+  it('can render a disabled button', () => {
+    const stub = sinon.stub();
+    const item = shallow(
+      <DropdownMenuItem onClick={stub} disabled>
+        A disabled button
+      </DropdownMenuItem>,
+    );
+
+    expect(item).toHaveClassName('DropdownMenuItem--disabled');
+  });
+
+  it('renders a button with a title', () => {
+    const stub = sinon.stub();
+    const title = 'some title';
+    const item = shallow(
+      <DropdownMenuItem onClick={stub} title={title}>
+        A button with title
+      </DropdownMenuItem>,
+    );
+
+    expect(item.find('button')).toHaveProp('title', title);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/7636

---

Given that we have a banner on every page, we can disable the login/logout buttons to avoid weird behaviors. Hopefully this is all we need. I could not think of any other buttons we'd need to "fix".

## Screenshots

Authenticate button:

<img width="1280" alt="Screen Shot 2019-10-14 at 20 47 59" src="https://user-images.githubusercontent.com/217628/66776313-5942dc00-eec6-11e9-89ba-f996f81a10c3.png">

Logout button/link in the dropdown:

<img width="320" alt="Screen Shot 2019-10-14 at 20 55 48" src="https://user-images.githubusercontent.com/217628/66776314-5942dc00-eec6-11e9-984d-c44dfc36ffc8.png">

![Screen Shot 2019-10-15 at 16 13 50](https://user-images.githubusercontent.com/217628/66839606-fa816f00-ef66-11e9-9df3-a040b9c884fd.png)

A login button in a page (+ HTML title):

![Screen Shot 2019-10-15 at 16 14 18](https://user-images.githubusercontent.com/217628/66839574-eb9abc80-ef66-11e9-8bfb-8f3bd8339387.png)

