### PR TITLE
Fix the "Get the extension" button in the primary hero shelf

### DIFF
--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -165,6 +165,7 @@
   // The theme styles will add a hover effect.
   transition: background-color $transition-medium ease-in-out;
   white-space: nowrap;
+  width: fit-content;
 
   &,
   &:active,


### PR DESCRIPTION
Fixes #8775 

Before:

![Screenshot 2019-10-15 14 38 32](https://user-images.githubusercontent.com/142755/66859649-b340b180-ef59-11e9-8e9d-7372c59a5970.png)

After:

![Screenshot 2019-10-15 14 38 08](https://user-images.githubusercontent.com/142755/66859662-bcca1980-ef59-11e9-9d63-b8d7a59e1ed4.png)
