### PR TITLE
Fix theme shelves UI when loading

### DIFF
--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -24,6 +24,7 @@ type Props = {|
   className?: string,
   editing?: boolean,
   loading?: boolean,
+  useThemePlaceholder?: boolean,
   // When loading, this is the number of placeholders
   // that will be rendered.
   placeholderCount: number,
@@ -50,6 +51,7 @@ export default class AddonsCard extends React.Component<Props> {
     loading: false,
     placeholderCount: DEFAULT_API_PAGE_SIZE,
     showRecommendedBadge: true,
+    useThemePlaceholder: false,
   };
 
   render() {
@@ -64,6 +66,7 @@ export default class AddonsCard extends React.Component<Props> {
       removeAddon,
       saveNote,
       placeholderCount,
+      useThemePlaceholder,
       showMetadata,
       showRecommendedBadge,
       showSummary,
@@ -106,7 +109,12 @@ export default class AddonsCard extends React.Component<Props> {
       });
     } else if (loading) {
       for (let count = 0; count < placeholderCount; count++) {
-        addonElements.push(<SearchResult key={count} />);
+        addonElements.push(
+          <SearchResult
+            key={count}
+            useThemePlaceholder={useThemePlaceholder}
+          />,
+        );
       }
     }
 

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -70,6 +70,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
         type="horizontal"
         loading={loading}
         placeholderCount={count}
+        useThemePlaceholder={isTheme}
       />
     );
   }

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -39,6 +39,7 @@ type Props = {|
   showMetadata?: boolean,
   showRecommendedBadge?: boolean,
   showSummary?: boolean,
+  useThemePlaceholder?: boolean,
 |};
 
 type InternalProps = {|
@@ -58,6 +59,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
     showMetadata: true,
     showRecommendedBadge: true,
     showSummary: true,
+    useThemePlaceholder: false,
   };
 
   getAddonLink(
@@ -82,6 +84,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
       showMetadata,
       showRecommendedBadge,
       showSummary,
+      useThemePlaceholder,
     } = this.props;
 
     const averageDailyUsers = addon ? addon.average_daily_users : null;
@@ -119,7 +122,9 @@ export class SearchResultBase extends React.Component<InternalProps> {
 
     // Sets classes to handle fallback if theme preview is not available.
     const iconWrapperClassnames = makeClassName('SearchResult-icon-wrapper', {
-      'SearchResult-icon-wrapper--no-theme-image': isTheme && imageURL === null,
+      'SearchResult-icon-wrapper--no-theme-image': addon
+        ? imageURL === null
+        : useThemePlaceholder,
     });
 
     let addonAuthors = null;
@@ -152,7 +157,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
       <div className="SearchResult-wrapper">
         <div className="SearchResult-result">
           <div className={iconWrapperClassnames}>
-            {imageURL ? (
+            {(addon && imageURL) || (!addon && !useThemePlaceholder) ? (
               <img
                 className={makeClassName('SearchResult-icon', {
                   'SearchResult-icon--loading': !addon,
@@ -249,11 +254,11 @@ export class SearchResultBase extends React.Component<InternalProps> {
   };
 
   render() {
-    const { addon } = this.props;
+    const { addon, useThemePlaceholder } = this.props;
 
     const result = this.renderResult();
     const resultClassnames = makeClassName('SearchResult', {
-      'SearchResult--theme': addon && isTheme(addon.type),
+      'SearchResult--theme': addon ? isTheme(addon.type) : useThemePlaceholder,
       'SearchResult--persona': addon && addon.type === ADDON_TYPE_THEME,
     });
 

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -64,13 +64,14 @@ $icon-default-size: 32px;
 .SearchResult-icon-wrapper--no-theme-image {
   align-items: center;
   background: #ccc;
-  color: $white;
+  color: $black;
   display: flex;
   font-size: 14px;
   font-weight: normal;
+  height: 100%;
   justify-content: center;
   text-align: center;
-  text-shadow: 0 0 1px $black;
+  text-shadow: 0 0 2px $white;
 }
 
 .SearchResult-icon {

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -98,6 +98,8 @@ describe(__filename, () => {
     expect(results).toHaveLength(DEFAULT_API_PAGE_SIZE);
     // Do a quick check to make sure these are rendered as placeholders.
     expect(results.at(0)).not.toHaveProp('addon');
+    // By default we do not want "theme" placeholders.
+    expect(results.at(0)).toHaveProp('useThemePlaceholder', false);
   });
 
   it('handles an empty set of addons', () => {
@@ -181,6 +183,18 @@ describe(__filename, () => {
     expect(root.find(SearchResult)).toHaveProp(
       'showRecommendedBadge',
       showRecommendedBadge,
+    );
+  });
+
+  it('passes the useThemePlaceholder to the SearchResult placeholders when loading', () => {
+    const useThemePlaceholder = true;
+
+    const root = render({ addons: null, loading: true, useThemePlaceholder });
+
+    const results = root.find(SearchResult);
+    expect(results.at(0)).toHaveProp(
+      'useThemePlaceholder',
+      useThemePlaceholder,
     );
   });
 });

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -162,4 +162,13 @@ describe(__filename, () => {
       linkString,
     );
   });
+
+  it.each([true, false])(
+    'sets useThemePlaceholder to the value of isTheme on the AddonsCard',
+    (isTheme) => {
+      const root = render({ isTheme });
+
+      expect(root.find(AddonsCard)).toHaveProp('useThemePlaceholder', isTheme);
+    },
+  );
 });

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -219,6 +219,12 @@ describe(__filename, () => {
     expect(root).toHaveClassName('SearchResult--theme');
   });
 
+  it('adds a theme-specific class when useThemePlaceholder is true and it is loading', () => {
+    const root = render({ addon: null, useThemePlaceholder: true });
+
+    expect(root).toHaveClassName('SearchResult--theme');
+  });
+
   it('does not render a theme image if the isAllowedOrigin is false', () => {
     const root = render({
       _isAllowedOrigin: sinon.stub().returns(false),
@@ -533,5 +539,74 @@ describe(__filename, () => {
     });
 
     expect(root.find(RecommendedBadge)).toHaveLength(0);
+  });
+
+  it('does not set an extra css class to the icon wrapper when there is a theme image', () => {
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        previews: [],
+        theme_data: {
+          previewURL:
+            'https://addons.cdn.mozilla.net/user-media/addons/334902/preview_large.jpg?1313374873',
+        },
+      }),
+    });
+
+    expect(root.find('.SearchResult-icon-wrapper')).toHaveLength(1);
+    expect(
+      root.find('.SearchResult-icon-wrapper--no-theme-image'),
+    ).toHaveLength(0);
+  });
+
+  it('sets an extra css class to the icon wrapper when there is no theme image', () => {
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        type: ADDON_TYPE_THEME,
+        previews: [],
+        theme_data: null,
+      }),
+    });
+
+    expect(root.find('.SearchResult-icon-wrapper')).toHaveLength(1);
+    expect(
+      root.find('.SearchResult-icon-wrapper--no-theme-image'),
+    ).toHaveLength(1);
+  });
+
+  it('sets an extra css class to the icon wrapper when there is no add-on and we want to use a theme placeholder', () => {
+    const root = render({ addon: null, useThemePlaceholder: true });
+
+    expect(root.find('.SearchResult-icon-wrapper')).toHaveLength(1);
+    expect(
+      root.find('.SearchResult-icon-wrapper--no-theme-image'),
+    ).toHaveLength(1);
+  });
+
+  it('does not set an extra css class to the icon wrapper when there is no add-on and we do not want to use a theme placeholder', () => {
+    const root = render({ addon: null, useThemePlaceholder: false });
+
+    expect(root.find('.SearchResult-icon-wrapper')).toHaveLength(1);
+    expect(
+      root.find('.SearchResult-icon-wrapper--no-theme-image'),
+    ).toHaveLength(0);
+  });
+
+  it('renders a "notheme" placeholder when there is no add-on and we want to use a theme placeholder', () => {
+    const root = render({ addon: null, useThemePlaceholder: true });
+
+    expect(root.find('.SearchResult-notheme')).toIncludeText(
+      'No theme preview available',
+    );
+  });
+
+  it('does not render a "notheme" placeholder when there is no add-on and we do not want to use a theme placeholder', () => {
+    const root = render({ addon: null, useThemePlaceholder: false });
+
+    expect(root.find('.SearchResult-notheme')).not.toIncludeText(
+      'No theme preview available',
+    );
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/3134

---

This is a small improvement to the loading state for theme pages. This patch will allow us to do the same thing for search results pages when we are sure that it will only contain themes (but that would be too much work here).

## Screenshots

![Screen Shot 2019-10-18 at 15 31 32](https://user-images.githubusercontent.com/217628/67098876-3f064800-f1bd-11e9-8ecb-7990fd9177b3.png)

I also improved the contrast of the "notheme" placeholder as seen below (text was white before):

![Screen Shot 2019-10-18 at 14 43 06](https://user-images.githubusercontent.com/217628/67098877-3f064800-f1bd-11e9-9adf-dc9dd2dda6fd.png)


## Gif

![2019-10-18 15 36 06](https://user-images.githubusercontent.com/217628/67098854-36ae0d00-f1bd-11e9-8861-181f5971b50d.gif)
