### PR TITLE
Warn AMO users when visiting wrong platform site

### DIFF
--- a/src/amo/components/ErrorPage/NotAuthorized/index.js
+++ b/src/amo/components/ErrorPage/NotAuthorized/index.js
@@ -33,7 +33,7 @@ export class NotAuthorizedBase extends React.Component<Props> {
     /* eslint-disable react/no-danger */
     return (
       <NestedStatus code={401}>
-        <Page>
+        <Page showWrongPlatformWarning={false}>
           <Card
             className="ErrorPage NotAuthorized"
             header={i18n.gettext('Not Authorized')}

--- a/src/amo/components/ErrorPage/NotFound/index.js
+++ b/src/amo/components/ErrorPage/NotFound/index.js
@@ -64,7 +64,7 @@ export class NotFoundBase extends React.Component<InternalProps> {
 
     return (
       <NestedStatus code={404}>
-        <Page>
+        <Page showWrongPlatformWarning={false}>
           <Card
             className="ErrorPage NotFound"
             header={i18n.gettext('Oops! We can’t find that page')}

--- a/src/amo/components/ErrorPage/ServerError/index.js
+++ b/src/amo/components/ErrorPage/ServerError/index.js
@@ -28,7 +28,7 @@ export class ServerErrorBase extends React.Component {
     /* eslint-disable react/no-danger */
     return (
       <NestedStatus code={500}>
-        <Page>
+        <Page showWrongPlatformWarning={false}>
           <Card
             className="ErrorPage ServerError"
             header={i18n.gettext('Server Error')}

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -7,6 +7,7 @@ import { compose } from 'redux';
 
 import AppBanner from 'amo/components/AppBanner';
 import Link from 'amo/components/Link';
+import WrongPlatformWarning from 'amo/components/WrongPlatformWarning';
 import { addParamsToHeroURL, checkInternalURL, getAddonURL } from 'amo/utils';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
@@ -154,6 +155,10 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           HeroRecommendation on the home page. All other pages in the app
           include it via the Page component. */}
           <AppBanner className="HeroRecommendation-banner" />
+          {/* The WrongPlatformWarning is included here as it wants to live
+          inside the HeroRecommendation on the home page. Most other pages in
+          the app include it via the Page component. */}
+          <WrongPlatformWarning className="HeroRecommendation-WrongPlatformWarning" />
 
           {errorHandler.renderErrorIfPresent()}
 

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -218,3 +218,7 @@
 .HeroRecommendation--loading {
   @include gradientStyle($color-ink-80, $color-blue-70);
 }
+
+.HeroRecommendation-WrongPlatformWarning {
+  margin-top: 12px;
+}

--- a/src/amo/components/Page/index.js
+++ b/src/amo/components/Page/index.js
@@ -9,6 +9,7 @@ import { compose } from 'redux';
 import AppBanner from 'amo/components/AppBanner';
 import Footer from 'amo/components/Footer';
 import Header from 'amo/components/Header';
+import WrongPlatformWarning from 'amo/components/WrongPlatformWarning';
 import InfoDialog from 'core/components/InfoDialog';
 import { CLIENT_APP_ANDROID } from 'core/constants';
 import type { AppState } from 'amo/store';
@@ -19,6 +20,7 @@ import './styles.scss';
 type Props = {|
   children: React.Node,
   isHomePage?: boolean,
+  showWrongPlatformWarning?: boolean,
 |};
 
 type InternalProps = {|
@@ -34,6 +36,7 @@ export const PageBase = ({
   clientApp,
   isHomePage = false,
   location,
+  showWrongPlatformWarning = true,
 }: InternalProps) => {
   const enableFeatureHeroRecommendation = _config.get(
     'enableFeatureHeroRecommendation',
@@ -60,6 +63,13 @@ export const PageBase = ({
           (!isHomePage ||
             !enableFeatureHeroRecommendation ||
             clientApp === CLIENT_APP_ANDROID) && <AppBanner />}
+          {// Exclude the WrongPlatformWarning from the home page if it will be
+          // included via HeroRecommendation or if showWrongPlatformWarning is
+          // false, but include it on the Android home page.
+          (!isHomePage ||
+            !enableFeatureHeroRecommendation ||
+            clientApp === CLIENT_APP_ANDROID) &&
+            showWrongPlatformWarning && <WrongPlatformWarning />}
           {children}
         </div>
       </div>

--- a/src/amo/components/Page/index.js
+++ b/src/amo/components/Page/index.js
@@ -63,13 +63,7 @@ export const PageBase = ({
           (!isHomePage ||
             !enableFeatureHeroRecommendation ||
             clientApp === CLIENT_APP_ANDROID) && <AppBanner />}
-          {// Exclude the WrongPlatformWarning from the home page if it will be
-          // included via HeroRecommendation or if showWrongPlatformWarning is
-          // false, but include it on the Android home page.
-          (!isHomePage ||
-            !enableFeatureHeroRecommendation ||
-            clientApp === CLIENT_APP_ANDROID) &&
-            showWrongPlatformWarning && <WrongPlatformWarning />}
+          {showWrongPlatformWarning && <WrongPlatformWarning />}
           {children}
         </div>
       </div>

--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -192,7 +192,7 @@ const Routes = ({ _config = config }: Props = {}) => (
       exact
       path="/:lang/:application/simulate-async-error/"
       component={() => (
-        <Page>
+        <Page showWrongPlatformWarning={false}>
           <SimulateAsyncError />
         </Page>
       )}
@@ -201,7 +201,7 @@ const Routes = ({ _config = config }: Props = {}) => (
       exact
       path="/:lang/:application/simulate-sync-error/"
       component={() => (
-        <Page>
+        <Page showWrongPlatformWarning={false}>
           <SimulateSyncError />
         </Page>
       )}
@@ -210,7 +210,7 @@ const Routes = ({ _config = config }: Props = {}) => (
       exact
       path="/:lang/:application/simulate-client-error/"
       component={() => (
-        <Page>
+        <Page showWrongPlatformWarning={false}>
           <SimulateClientError />
         </Page>
       )}

--- a/src/amo/components/StaticPage/index.js
+++ b/src/amo/components/StaticPage/index.js
@@ -19,7 +19,7 @@ const StaticPage = (props: Props) => {
   const { title, metaDescription, children } = props;
 
   return (
-    <Page>
+    <Page showWrongPlatformWarning={false}>
       <Card className="StaticPage" header={title}>
         <Helmet>
           <title>{title}</title>

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -1,0 +1,131 @@
+/* @flow */
+import makeClassName from 'classnames';
+import { withRouter } from 'react-router-dom';
+import * as React from 'react';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+
+import { CLIENT_APP_ANDROID } from 'core/constants';
+import translate from 'core/i18n/translate';
+import { sanitizeHTML } from 'core/utils';
+import { correctedLocationForPlatform } from 'core/utils/compatibility';
+import Notice from 'ui/components/Notice';
+import type { AppState } from 'amo/store';
+import type { UserAgentInfoType } from 'core/reducers/api';
+import type { I18nType } from 'core/types/i18n';
+import type { ReactRouterLocationType } from 'core/types/router';
+
+import './styles.scss';
+
+type Props = {|
+  className?: string,
+  forAddonDetailPage?: boolean,
+|};
+
+type InternalProps = {|
+  ...Props,
+  _correctedLocationForPlatform: typeof correctedLocationForPlatform,
+  clientApp: string,
+  i18n: I18nType,
+  location: ReactRouterLocationType,
+  userAgentInfo: UserAgentInfoType,
+|};
+
+export class WrongPlatformWarningBase extends React.Component<InternalProps> {
+  static defaultProps = {
+    _correctedLocationForPlatform: correctedLocationForPlatform,
+    forAddonDetailPage: false,
+  };
+
+  render() {
+    const {
+      _correctedLocationForPlatform,
+      className,
+      clientApp,
+      forAddonDetailPage,
+      i18n,
+      location,
+      userAgentInfo,
+    } = this.props;
+
+    const newLocation = _correctedLocationForPlatform({
+      clientApp,
+      location,
+      userAgentInfo,
+    });
+
+    if (!newLocation) {
+      return null;
+    }
+
+    let message;
+
+    if (forAddonDetailPage) {
+      message =
+        clientApp === CLIENT_APP_ANDROID
+          ? i18n.sprintf(
+              i18n.gettext(
+                `This add-on is not compatible with this platform.
+               <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
+              ),
+              { newLocation },
+            )
+          : i18n.sprintf(
+              i18n.gettext(
+                `This add-on is not compatible with this platform.
+               <a href="%(newLocation)s">Browse add-ons for Firefox on Android</a>.`,
+              ),
+              { newLocation },
+            );
+    } else {
+      message =
+        clientApp === CLIENT_APP_ANDROID
+          ? i18n.sprintf(
+              i18n.gettext(
+                `To find add-ons compatible with Firefox on desktop,
+               <a href="%(newLocation)s">visit our desktop site</a>.`,
+              ),
+              { newLocation },
+            )
+          : i18n.sprintf(
+              i18n.gettext(
+                `To find add-ons compatible with Firefox on Android,
+               <a href="%(newLocation)s">visit our mobile site</a>.`,
+              ),
+              { newLocation },
+            );
+    }
+
+    return (
+      <div className={makeClassName('WrongPlatformWarning', className)}>
+        <Notice
+          className="WrongPlatformWarning-Notice"
+          dismissible
+          id="WrongPlatformWarning-Notice"
+          type="warning"
+        >
+          <span
+            className="WrongPlatformWarning-message"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={sanitizeHTML(message, ['a'])}
+          />
+        </Notice>
+      </div>
+    );
+  }
+}
+
+export function mapStateToProps(state: AppState) {
+  return {
+    clientApp: state.api.clientApp,
+    userAgentInfo: state.api.userAgentInfo,
+  };
+}
+
+const WrongPlatformWarning: React.ComponentType<Props> = compose(
+  withRouter,
+  connect(mapStateToProps),
+  translate(),
+)(WrongPlatformWarningBase);
+
+export default WrongPlatformWarning;

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -9,7 +9,7 @@ import { CLIENT_APP_ANDROID } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
 import { correctedLocationForPlatform } from 'core/utils/compatibility';
-import Notice from 'ui/components/Notice';
+import Notice, { warningInfoType } from 'ui/components/Notice';
 import type { AppState } from 'amo/store';
 import type { UserAgentInfoType } from 'core/reducers/api';
 import type { I18nType } from 'core/types/i18n';
@@ -99,10 +99,9 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
     return (
       <div className={makeClassName('WrongPlatformWarning', className)}>
         <Notice
-          className="WrongPlatformWarning-Notice"
           dismissible
           id="WrongPlatformWarning-Notice"
-          type="warning"
+          type={warningInfoType}
         >
           <span
             className="WrongPlatformWarning-message"

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -19,7 +19,8 @@ import './styles.scss';
 
 type Props = {|
   className?: string,
-  forAddonDetailPage?: boolean,
+  fixAndroidLinkMessage?: string,
+  fixFirefoxLinkMessage?: string,
 |};
 
 type InternalProps = {|
@@ -34,7 +35,6 @@ type InternalProps = {|
 export class WrongPlatformWarningBase extends React.Component<InternalProps> {
   static defaultProps = {
     _correctedLocationForPlatform: correctedLocationForPlatform,
-    forAddonDetailPage: false,
   };
 
   render() {
@@ -42,7 +42,6 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
       _correctedLocationForPlatform,
       className,
       clientApp,
-      forAddonDetailPage,
       i18n,
       location,
       userAgentInfo,
@@ -58,43 +57,24 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
       return null;
     }
 
-    let message;
-
-    if (forAddonDetailPage) {
-      message =
-        clientApp === CLIENT_APP_ANDROID
-          ? i18n.sprintf(
-              i18n.gettext(
-                `This add-on is not compatible with this platform.
-               <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
-              ),
-              { newLocation },
-            )
-          : i18n.sprintf(
-              i18n.gettext(
-                `This add-on is not compatible with this platform.
-               <a href="%(newLocation)s">Browse add-ons for Firefox on Android</a>.`,
-              ),
-              { newLocation },
-            );
-    } else {
-      message =
-        clientApp === CLIENT_APP_ANDROID
-          ? i18n.sprintf(
-              i18n.gettext(
-                `To find add-ons compatible with Firefox on desktop,
-               <a href="%(newLocation)s">visit our desktop site</a>.`,
-              ),
-              { newLocation },
-            )
-          : i18n.sprintf(
-              i18n.gettext(
-                `To find add-ons compatible with Firefox on Android,
+    const fixAndroidLinkMessage =
+      this.props.fixAndroidLinkMessage ||
+      i18n.gettext(
+        `To find add-ons compatible with Firefox on Android,
                <a href="%(newLocation)s">visit our mobile site</a>.`,
-              ),
-              { newLocation },
-            );
-    }
+      );
+
+    const fixFirefoxLinkMessage =
+      this.props.fixFirefoxLinkMessage ||
+      i18n.gettext(
+        `To find add-ons compatible with Firefox on desktop,
+               <a href="%(newLocation)s">visit our desktop site</a>.`,
+      );
+
+    const message =
+      clientApp === CLIENT_APP_ANDROID
+        ? i18n.sprintf(fixFirefoxLinkMessage, { newLocation })
+        : i18n.sprintf(fixAndroidLinkMessage, { newLocation });
 
     return (
       <div className={makeClassName('WrongPlatformWarning', className)}>

--- a/src/amo/components/WrongPlatformWarning/styles.scss
+++ b/src/amo/components/WrongPlatformWarning/styles.scss
@@ -1,0 +1,26 @@
+@import '~amo/css/styles';
+
+.WrongPlatformWarning {
+  margin: 0 0 12px 0;
+  padding-left: $padding-page;
+  padding-right: $padding-page;
+
+  @include respond-to(large) {
+    padding-left: $padding-page-l;
+    padding-right: $padding-page-l;
+  }
+}
+
+.Addon .WrongPlatformWarning {
+  margin: 12px 0 0 0;
+  padding-left: 0;
+  padding-right: 0;
+
+  @include respond-to(medium) {
+    margin-top: 0;
+  }
+}
+
+.HeroRecommendation-WrongPlatformWarning {
+  margin-top: 12px;
+}

--- a/src/amo/components/WrongPlatformWarning/styles.scss
+++ b/src/amo/components/WrongPlatformWarning/styles.scss
@@ -10,17 +10,3 @@
     padding-right: $padding-page-l;
   }
 }
-
-.Addon .WrongPlatformWarning {
-  margin: 12px 0 0 0;
-  padding-left: 0;
-  padding-right: 0;
-
-  @include respond-to(medium) {
-    margin-top: 0;
-  }
-}
-
-.HeroRecommendation-WrongPlatformWarning {
-  margin-top: 12px;
-}

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -27,6 +27,7 @@ import PermissionsCard from 'amo/components/PermissionsCard';
 import DefaultRatingManager from 'amo/components/RatingManager';
 import ScreenShots from 'amo/components/ScreenShots';
 import Link from 'amo/components/Link';
+import WrongPlatformWarning from 'amo/components/WrongPlatformWarning';
 import { getAddonsForSlug } from 'amo/reducers/addonsByAuthors';
 import { reviewListURL } from 'amo/reducers/reviews';
 import { getAddonURL } from 'amo/utils';
@@ -428,7 +429,7 @@ export class AddonBase extends React.Component {
       : 0;
 
     return (
-      <Page>
+      <Page showWrongPlatformWarning={false}>
         <div
           className={makeClassName('Addon', `Addon-${addonType}`, {
             'Addon-theme': isThemeType,
@@ -481,6 +482,7 @@ export class AddonBase extends React.Component {
                   {i18n.gettext('Extension Metadata')}
                 </h2>
               </header>
+              <WrongPlatformWarning forAddonDetailPage />
               {addon && <InstallWarning addon={addon} />}
             </Card>
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -482,7 +482,17 @@ export class AddonBase extends React.Component {
                   {i18n.gettext('Extension Metadata')}
                 </h2>
               </header>
-              <WrongPlatformWarning forAddonDetailPage />
+              <WrongPlatformWarning
+                className="Addon-WrongPlatformWarning"
+                fixAndroidLinkMessage={i18n.gettext(
+                  `This add-on is not compatible with this platform.
+                    <a href="%(newLocation)s">Browse add-ons for Firefox on Android</a>.`,
+                )}
+                fixFirefoxLinkMessage={i18n.gettext(
+                  `This add-on is not compatible with this platform.
+                    <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
+                )}
+              />
               {addon && <InstallWarning addon={addon} />}
             </Card>
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -485,11 +485,11 @@ export class AddonBase extends React.Component {
               <WrongPlatformWarning
                 className="Addon-WrongPlatformWarning"
                 fixAndroidLinkMessage={i18n.gettext(
-                  `This add-on is not compatible with this platform.
+                  `This listing is not intended for this platform.
                     <a href="%(newLocation)s">Browse add-ons for Firefox on Android</a>.`,
                 )}
                 fixFirefoxLinkMessage={i18n.gettext(
-                  `This add-on is not compatible with this platform.
+                  `This listing is not intended for this platform.
                     <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
                 )}
               />

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -177,3 +177,13 @@
   //   display: none;
   // }
 }
+
+.Addon .WrongPlatformWarning {
+  margin: 12px 0 0 0;
+  padding-left: 0;
+  padding-right: 0;
+
+  @include respond-to(medium) {
+    margin-top: 0;
+  }
+}

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -178,7 +178,7 @@
   // }
 }
 
-.Addon .WrongPlatformWarning {
+.Addon-WrongPlatformWarning {
   margin: 12px 0 0 0;
   padding-left: 0;
   padding-right: 0;

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -228,8 +228,12 @@ export class HomeBase extends React.Component {
       return null;
     };
 
+    const showHero =
+      _config.get('enableFeatureHeroRecommendation') &&
+      clientApp !== CLIENT_APP_ANDROID;
+
     return (
-      <Page isHomePage>
+      <Page isHomePage showWrongPlatformWarning={!showHero}>
         <div className="Home">
           <HeadMetaTags
             description={i18n.gettext(`Download Firefox extensions and themes.

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -228,12 +228,12 @@ export class HomeBase extends React.Component {
       return null;
     };
 
-    const showHero =
+    const showHeroPromo =
       _config.get('enableFeatureHeroRecommendation') &&
       clientApp !== CLIENT_APP_ANDROID;
 
     return (
-      <Page isHomePage showWrongPlatformWarning={!showHero}>
+      <Page isHomePage showWrongPlatformWarning={!showHeroPromo}>
         <div className="Home">
           <HeadMetaTags
             description={i18n.gettext(`Download Firefox extensions and themes.
@@ -252,14 +252,11 @@ export class HomeBase extends React.Component {
             }}
           />
 
-          {(!_config.get('enableFeatureHeroRecommendation') ||
-            clientApp === CLIENT_APP_ANDROID) &&
-          errorHandler.hasError() ? (
+          {!showHeroPromo && errorHandler.hasError() ? (
             <div className="Home-noHeroError">{errorHandler.renderError()}</div>
           ) : null}
 
-          {_config.get('enableFeatureHeroRecommendation') &&
-          clientApp !== CLIENT_APP_ANDROID ? (
+          {showHeroPromo ? (
             <HeroRecommendation
               errorHandler={errorHandler}
               shelfData={heroShelves && heroShelves.primary}
@@ -267,15 +264,11 @@ export class HomeBase extends React.Component {
           ) : null}
 
           <div className="Home-content">
-            {_config.get('enableFeatureHeroRecommendation') &&
-            clientApp !== CLIENT_APP_ANDROID ? (
+            {showHeroPromo ? (
               <SecondaryHero shelfData={heroShelves && heroShelves.secondary} />
             ) : null}
 
-            {!_config.get('enableFeatureHeroRecommendation') ||
-            clientApp === CLIENT_APP_ANDROID ? (
-              <HomeHeroGuides />
-            ) : null}
+            {!showHeroPromo ? <HomeHeroGuides /> : null}
 
             <LandingAddonsCard
               addonInstallSource={INSTALL_SOURCE_FEATURED}

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -309,5 +309,3 @@ export const LTR = 'ltr';
 
 export const AMO_REQUEST_ID_HEADER = 'amo-request-id';
 export const DISCO_TAAR_CLIENT_ID_HEADER = 'moz-client-id';
-
-export const USER_AGENT_BROWSER_FIREFOX = 'Firefox';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -309,3 +309,5 @@ export const LTR = 'ltr';
 
 export const AMO_REQUEST_ID_HEADER = 'amo-request-id';
 export const DISCO_TAAR_CLIENT_ID_HEADER = 'moz-client-id';
+
+export const USER_AGENT_BROWSER_FIREFOX = 'Firefox';

--- a/src/core/reducers/api.js
+++ b/src/core/reducers/api.js
@@ -19,6 +19,7 @@ import type {
 } from 'core/actions/index';
 import type { Exact } from 'core/types/util';
 
+export const USER_AGENT_BROWSER_FIREFOX = 'Firefox';
 export const USER_AGENT_OS_ANDROID: 'Android' = 'Android';
 export const USER_AGENT_OS_BSD_DRAGONFLY: 'DragonFly' = 'DragonFly';
 export const USER_AGENT_OS_BSD_FREEBSD: 'FreeBSD' = 'FreeBSD';

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -4,7 +4,11 @@ import { oneLine } from 'common-tags';
 import invariant from 'invariant';
 import mozCompare from 'mozilla-version-comparator';
 
-import { USER_AGENT_OS_ANDROID } from 'core/reducers/api';
+import {
+  USER_AGENT_BROWSER_FIREFOX,
+  USER_AGENT_OS_ANDROID,
+  USER_AGENT_OS_IOS,
+} from 'core/reducers/api';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
@@ -18,7 +22,6 @@ import {
   INCOMPATIBLE_OVER_MAX_VERSION,
   INCOMPATIBLE_UNDER_MIN_VERSION,
   INCOMPATIBLE_UNSUPPORTED_PLATFORM,
-  USER_AGENT_BROWSER_FIREFOX,
 } from 'core/constants';
 import { findInstallURL } from 'core/installAddon';
 import log from 'core/logger';
@@ -317,17 +320,20 @@ export const correctedLocationForPlatform = ({
 
   const { browser, os } = userAgentInfo;
 
-  let newLocation = null;
+  let currentClientApp;
+  let newClientApp;
+
+  if (os.name === USER_AGENT_OS_IOS) {
+    return null;
+  }
 
   if (
     os.name === USER_AGENT_OS_ANDROID &&
     browser.name === USER_AGENT_BROWSER_FIREFOX &&
     clientApp === CLIENT_APP_FIREFOX
   ) {
-    newLocation = location.pathname.replace(
-      CLIENT_APP_FIREFOX,
-      CLIENT_APP_ANDROID,
-    );
+    currentClientApp = CLIENT_APP_FIREFOX;
+    newClientApp = CLIENT_APP_ANDROID;
   }
 
   if (
@@ -335,11 +341,13 @@ export const correctedLocationForPlatform = ({
     browser.name === USER_AGENT_BROWSER_FIREFOX &&
     clientApp === CLIENT_APP_ANDROID
   ) {
-    newLocation = location.pathname.replace(
-      CLIENT_APP_ANDROID,
-      CLIENT_APP_FIREFOX,
-    );
+    currentClientApp = CLIENT_APP_ANDROID;
+    newClientApp = CLIENT_APP_FIREFOX;
   }
 
-  return newLocation && `${newLocation}${location.search}`;
+  return currentClientApp && newClientApp
+    ? `${location.pathname.replace(currentClientApp, newClientApp)}${
+        location.search
+      }`
+    : null;
 };

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -16,6 +16,7 @@ export const errorType: 'error' = 'error';
 export const genericType: 'generic' = 'generic';
 export const firefoxRequiredType: 'firefox' = 'firefox';
 export const successType: 'success' = 'success';
+export const warningInfoType: 'warningInfo' = 'warningInfo';
 export const warningType: 'warning' = 'warning';
 
 const validTypes = [
@@ -23,6 +24,7 @@ const validTypes = [
   genericType,
   firefoxRequiredType,
   successType,
+  warningInfoType,
   warningType,
 ];
 
@@ -35,6 +37,7 @@ export type NoticeType =
   | typeof firefoxRequiredType
   | typeof genericType
   | typeof successType
+  | typeof warningInfoType
   | typeof warningType;
 
 type Props = {|

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -185,7 +185,8 @@
   );
 }
 
-.Notice-warning {
+.Notice-warning,
+.Notice-warningInfo {
   @include notice_type(
     $button-background-color: $yellow-60,
     $button-background-active-color: $yellow-80,
@@ -207,6 +208,6 @@
   background-image: url('./img/firefox.svg');
 }
 
-.WrongPlatformWarning-Notice .Notice-icon {
+.Notice-warningInfo .Notice-icon {
   background-image: url('./img/generic-info-mark.svg');
 }

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -206,3 +206,7 @@
 .Notice-firefox .Notice-icon {
   background-image: url('./img/firefox.svg');
 }
+
+.WrongPlatformWarning-Notice .Notice-icon {
+  background-image: url('./img/generic-info-mark.svg');
+}

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -1,0 +1,153 @@
+import * as React from 'react';
+import UAParser from 'ua-parser-js';
+
+import WrongPlatformWarning, {
+  WrongPlatformWarningBase,
+} from 'amo/components/WrongPlatformWarning';
+import { CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX } from 'core/constants';
+import {
+  createContextWithFakeRouter,
+  createFakeLocation,
+  dispatchClientMetadata,
+  fakeI18n,
+  shallowUntilTarget,
+  userAgentsByPlatform,
+} from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  let _correctedLocationForPlatform;
+  let store;
+
+  beforeEach(() => {
+    _correctedLocationForPlatform = sinon.stub();
+    store = dispatchClientMetadata().store;
+  });
+
+  const _dispatchClientMetadata = (params = {}) => {
+    return dispatchClientMetadata({
+      store,
+      userAgent: userAgentsByPlatform.mac.firefox57,
+      ...params,
+    });
+  };
+
+  const render = ({ location = createFakeLocation(), ...customProps } = {}) => {
+    const props = {
+      _correctedLocationForPlatform,
+      i18n: fakeI18n(),
+      store,
+      ...customProps,
+    };
+
+    return shallowUntilTarget(
+      <WrongPlatformWarning {...props} />,
+      WrongPlatformWarningBase,
+      {
+        shallowOptions: createContextWithFakeRouter({ location }),
+      },
+    );
+  };
+
+  it('returns nothing if no location correction is required', () => {
+    _correctedLocationForPlatform.returns(null);
+    const root = render();
+
+    expect(root.find('.WrongPlatformWarning')).toHaveLength(0);
+  });
+
+  it('can add a custom className', () => {
+    _correctedLocationForPlatform.returns('/some/location/');
+    const className = 'some-class-name';
+    const root = render({ className });
+
+    expect(root).toHaveClassName('WrongPlatformWarning');
+    expect(root).toHaveClassName(className);
+  });
+
+  it('calls _correctedLocationForPlatform with clientApp, location and userAgentInfo', () => {
+    const clientApp = CLIENT_APP_ANDROID;
+    const userAgent = userAgentsByPlatform.mac.firefox57;
+    const parsedUserAgent = UAParser(userAgent);
+    _dispatchClientMetadata({ clientApp, userAgent });
+
+    const pathname = '/some/path/';
+    const location = createFakeLocation({ pathname });
+
+    render({ location });
+
+    sinon.assert.calledWith(_correctedLocationForPlatform, {
+      clientApp,
+      location,
+      userAgentInfo: sinon.match({
+        browser: sinon.match(parsedUserAgent.browser),
+        os: sinon.match(parsedUserAgent.os),
+      }),
+    });
+  });
+
+  // This is the test config for the four possible states of the message, the format is:
+  // [clientApp, forAddonDetailPage, [array of expected message text]
+  const messageTestData = [
+    [
+      CLIENT_APP_ANDROID,
+      false,
+      [
+        'To find add-ons compatible with Firefox on desktop',
+        'visit our desktop site',
+      ],
+    ],
+    [
+      CLIENT_APP_FIREFOX,
+      false,
+      [
+        'To find add-ons compatible with Firefox on Android',
+        'visit our mobile site',
+      ],
+    ],
+    [
+      CLIENT_APP_ANDROID,
+      true,
+      [
+        'This add-on is not compatible with this platform',
+        'Browse add-ons for Firefox on desktop',
+      ],
+    ],
+    [
+      CLIENT_APP_FIREFOX,
+      true,
+      [
+        'This add-on is not compatible with this platform',
+        'Browse add-ons for Firefox on Android',
+      ],
+    ],
+  ];
+
+  it.each(messageTestData)(
+    'generates the expected message when clientApp is %s and forAddonDetailPage is %s',
+    (clientApp, forAddonDetailPage, expectedText) => {
+      const newLocation = '/some/location/';
+      _correctedLocationForPlatform.returns(newLocation);
+      _dispatchClientMetadata({ clientApp });
+      const root = render({ forAddonDetailPage });
+
+      for (const text of expectedText) {
+        expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+          text,
+        );
+      }
+      expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+        `<a href="${newLocation}">`,
+      );
+    },
+  );
+
+  it('defaults forAddonDetailPage to `false`', () => {
+    _correctedLocationForPlatform.returns('/some/location/');
+    _dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID });
+    const root = render();
+
+    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+      'To find add-ons compatible with Firefox on desktop',
+    );
+  });
+});

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -85,12 +85,9 @@ describe(__filename, () => {
     });
   });
 
-  // This is the test config for the four possible states of the message, the format is:
-  // [clientApp, forAddonDetailPage, [array of expected message text]
-  const messageTestData = [
+  it.each([
     [
       CLIENT_APP_ANDROID,
-      false,
       [
         'To find add-ons compatible with Firefox on desktop',
         'visit our desktop site',
@@ -98,37 +95,18 @@ describe(__filename, () => {
     ],
     [
       CLIENT_APP_FIREFOX,
-      false,
       [
         'To find add-ons compatible with Firefox on Android',
         'visit our mobile site',
       ],
     ],
-    [
-      CLIENT_APP_ANDROID,
-      true,
-      [
-        'This add-on is not compatible with this platform',
-        'Browse add-ons for Firefox on desktop',
-      ],
-    ],
-    [
-      CLIENT_APP_FIREFOX,
-      true,
-      [
-        'This add-on is not compatible with this platform',
-        'Browse add-ons for Firefox on Android',
-      ],
-    ],
-  ];
-
-  it.each(messageTestData)(
-    'generates the expected message when clientApp is %s and forAddonDetailPage is %s',
-    (clientApp, forAddonDetailPage, expectedText) => {
+  ])(
+    'generates the expected message when clientApp is %s',
+    (clientApp, expectedText) => {
       const newLocation = '/some/location/';
       _correctedLocationForPlatform.returns(newLocation);
       _dispatchClientMetadata({ clientApp });
-      const root = render({ forAddonDetailPage });
+      const root = render();
 
       for (const text of expectedText) {
         expect(root.find('.WrongPlatformWarning-message').html()).toContain(
@@ -141,13 +119,23 @@ describe(__filename, () => {
     },
   );
 
-  it('defaults forAddonDetailPage to `false`', () => {
-    _correctedLocationForPlatform.returns('/some/location/');
-    _dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID });
-    const root = render();
+  it.each([CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX])(
+    'can display a custom message when clientApp is %s',
+    (clientApp) => {
+      const newLocation = '/some/location/';
+      _correctedLocationForPlatform.returns(newLocation);
+      _dispatchClientMetadata({ clientApp });
+      const fixAndroidLinkMessage =
+        'A message to show when clientApp is firefox';
+      const fixFirefoxLinkMessage =
+        'A message to show when clientApp is android';
+      const root = render({ fixAndroidLinkMessage, fixFirefoxLinkMessage });
 
-    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
-      'To find add-ons compatible with Firefox on desktop',
-    );
-  });
+      expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+        clientApp === CLIENT_APP_ANDROID
+          ? fixFirefoxLinkMessage
+          : fixAndroidLinkMessage,
+      );
+    },
+  );
 });

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -22,6 +22,7 @@ import InstallWarning from 'amo/components/InstallWarning';
 import RatingManager, {
   RatingManagerWithI18n,
 } from 'amo/components/RatingManager';
+import WrongPlatformWarning from 'amo/components/WrongPlatformWarning';
 import { reviewListURL } from 'amo/reducers/reviews';
 import { getAddonURL } from 'amo/utils';
 import { createInternalVersion } from 'core/reducers/versions';
@@ -241,6 +242,13 @@ describe(__filename, () => {
   it('renders an AddonHead component', () => {
     const root = shallowRender();
     expect(root.find(AddonHead)).toHaveLength(1);
+  });
+
+  it('renders a WrongPlatformWarning component', () => {
+    const root = shallowRender();
+    expect(root.find(WrongPlatformWarning)).toHaveLength(1);
+    expect(root.find(WrongPlatformWarning)).toHaveProp('fixAndroidLinkMessage');
+    expect(root.find(WrongPlatformWarning)).toHaveProp('fixFirefoxLinkMessage');
   });
 
   it('renders without an add-on', () => {

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -971,6 +971,21 @@ describe(__filename, () => {
       );
     });
 
+    it('maintains the word `android` in a slug for an add-on when switching platforms', () => {
+      const pathname = `/en-US/${CLIENT_APP_ANDROID}/addon/awesome-android-extension/`;
+
+      expect(
+        _correctedLocationForPlatform({
+          clientApp: CLIENT_APP_ANDROID,
+          location: createFakeLocation({ pathname }),
+          userAgentInfo: {
+            browser: { name: USER_AGENT_BROWSER_FIREFOX },
+            os: { name: USER_AGENT_OS_MAC },
+          },
+        }),
+      ).toEqual('/en-US/firefox/addon/awesome-android-extension/');
+    });
+
     it('returns a link with `CLIENT_APP_FIREFOX` replaced with `CLIENT_APP_ANDROID` when on Firefox for Android', () => {
       const pathname = `/en-US/${CLIENT_APP_FIREFOX}/addon/slug/`;
       const search = '?src=featured';
@@ -987,6 +1002,21 @@ describe(__filename, () => {
       ).toEqual(
         `${pathname.replace(CLIENT_APP_FIREFOX, CLIENT_APP_ANDROID)}${search}`,
       );
+    });
+
+    it('maintains the word `firefox` in a slug for an add-on when switching platforms', () => {
+      const pathname = `/en-US/${CLIENT_APP_FIREFOX}/addon/awesome-firefox-extension/`;
+
+      expect(
+        _correctedLocationForPlatform({
+          clientApp: CLIENT_APP_FIREFOX,
+          location: createFakeLocation({ pathname }),
+          userAgentInfo: {
+            browser: { name: USER_AGENT_BROWSER_FIREFOX },
+            os: { name: USER_AGENT_OS_ANDROID },
+          },
+        }),
+      ).toEqual('/en-US/android/addon/awesome-firefox-extension/');
     });
 
     it('returns null if clientApp is `CLIENT_APP_FIREFOX` on desktop', () => {

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -1,6 +1,5 @@
 import UAParser from 'ua-parser-js';
 
-import { USER_AGENT_OS_ANDROID, USER_AGENT_OS_MAC } from 'core/reducers/api';
 import {
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_THEME,
@@ -19,7 +18,6 @@ import {
   OS_LINUX,
   OS_MAC,
   OS_WINDOWS,
-  USER_AGENT_BROWSER_FIREFOX,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -961,14 +959,9 @@ describe(__filename, () => {
         _correctedLocationForPlatform({
           clientApp: CLIENT_APP_ANDROID,
           location: createFakeLocation({ pathname, search }),
-          userAgentInfo: {
-            browser: { name: USER_AGENT_BROWSER_FIREFOX },
-            os: { name: USER_AGENT_OS_MAC },
-          },
+          userAgentInfo: UAParser(userAgentsByPlatform.mac.firefox69),
         }),
-      ).toEqual(
-        `${pathname.replace(CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX)}${search}`,
-      );
+      ).toEqual(`/en-US/${CLIENT_APP_FIREFOX}/addon/slug/${search}`);
     });
 
     it('maintains the word `android` in a slug for an add-on when switching platforms', () => {
@@ -978,12 +971,11 @@ describe(__filename, () => {
         _correctedLocationForPlatform({
           clientApp: CLIENT_APP_ANDROID,
           location: createFakeLocation({ pathname }),
-          userAgentInfo: {
-            browser: { name: USER_AGENT_BROWSER_FIREFOX },
-            os: { name: USER_AGENT_OS_MAC },
-          },
+          userAgentInfo: UAParser(userAgentsByPlatform.mac.firefox69),
         }),
-      ).toEqual('/en-US/firefox/addon/awesome-android-extension/');
+      ).toEqual(
+        `/en-US/${CLIENT_APP_FIREFOX}/addon/awesome-android-extension/`,
+      );
     });
 
     it('returns a link with `CLIENT_APP_FIREFOX` replaced with `CLIENT_APP_ANDROID` when on Firefox for Android', () => {
@@ -994,14 +986,9 @@ describe(__filename, () => {
         _correctedLocationForPlatform({
           clientApp: CLIENT_APP_FIREFOX,
           location: createFakeLocation({ pathname, search }),
-          userAgentInfo: {
-            browser: { name: USER_AGENT_BROWSER_FIREFOX },
-            os: { name: USER_AGENT_OS_ANDROID },
-          },
+          userAgentInfo: UAParser(userAgentsByPlatform.android.firefox40Mobile),
         }),
-      ).toEqual(
-        `${pathname.replace(CLIENT_APP_FIREFOX, CLIENT_APP_ANDROID)}${search}`,
-      );
+      ).toEqual(`/en-US/${CLIENT_APP_ANDROID}/addon/slug/${search}`);
     });
 
     it('maintains the word `firefox` in a slug for an add-on when switching platforms', () => {
@@ -1011,22 +998,18 @@ describe(__filename, () => {
         _correctedLocationForPlatform({
           clientApp: CLIENT_APP_FIREFOX,
           location: createFakeLocation({ pathname }),
-          userAgentInfo: {
-            browser: { name: USER_AGENT_BROWSER_FIREFOX },
-            os: { name: USER_AGENT_OS_ANDROID },
-          },
+          userAgentInfo: UAParser(userAgentsByPlatform.android.firefox40Mobile),
         }),
-      ).toEqual('/en-US/android/addon/awesome-firefox-extension/');
+      ).toEqual(
+        `/en-US/${CLIENT_APP_ANDROID}/addon/awesome-firefox-extension/`,
+      );
     });
 
     it('returns null if clientApp is `CLIENT_APP_FIREFOX` on desktop', () => {
       expect(
         _correctedLocationForPlatform({
           clientApp: CLIENT_APP_FIREFOX,
-          userAgentInfo: {
-            browser: { name: USER_AGENT_BROWSER_FIREFOX },
-            os: { name: USER_AGENT_OS_MAC },
-          },
+          userAgentInfo: UAParser(userAgentsByPlatform.mac.firefox69),
         }),
       ).toEqual(null);
     });
@@ -1035,10 +1018,7 @@ describe(__filename, () => {
       expect(
         _correctedLocationForPlatform({
           clientApp: CLIENT_APP_ANDROID,
-          userAgentInfo: {
-            browser: { name: USER_AGENT_BROWSER_FIREFOX },
-            os: { name: USER_AGENT_OS_ANDROID },
-          },
+          userAgentInfo: UAParser(userAgentsByPlatform.android.firefox40Mobile),
         }),
       ).toEqual(null);
     });
@@ -1049,10 +1029,7 @@ describe(__filename, () => {
         expect(
           _correctedLocationForPlatform({
             clientApp,
-            userAgentInfo: {
-              browser: { name: 'Chrome' },
-              os: { name: USER_AGENT_OS_MAC },
-            },
+            userAgentInfo: UAParser(userAgentsByPlatform.mac.chrome41),
           }),
         ).toEqual(null);
       },
@@ -1064,10 +1041,19 @@ describe(__filename, () => {
         expect(
           _correctedLocationForPlatform({
             clientApp,
-            userAgentInfo: {
-              browser: { name: 'Chrome' },
-              os: { name: USER_AGENT_OS_ANDROID },
-            },
+            userAgentInfo: UAParser(userAgents.chromeAndroid[0]),
+          }),
+        ).toEqual(null);
+      },
+    );
+
+    it.each([CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX])(
+      'returns null for clientApp %s on Firefox for iOS',
+      (clientApp) => {
+        expect(
+          _correctedLocationForPlatform({
+            clientApp,
+            userAgentInfo: UAParser(userAgentsByPlatform.ios.firefox1iPhone),
           }),
         ).toEqual(null);
       },


### PR DESCRIPTION
Fixes #8701 

Screenshots:

<details>
<summary>When mistakenly on /android/</summary>

![Screenshot 2019-10-21 12 19 28](https://user-images.githubusercontent.com/142755/67223606-95fa6000-f3fd-11e9-971b-a319bda1e92c.png)
![Screenshot 2019-10-21 12 19 47](https://user-images.githubusercontent.com/142755/67223590-90047f00-f3fd-11e9-93ff-a6e0a1c397ce.png)
![Screenshot 2019-10-21 12 20 03](https://user-images.githubusercontent.com/142755/67223585-8b3fcb00-f3fd-11e9-85e7-528e9fede1f1.png)

</details>

<details>
<summary>When mistakenly on /firefox/</summary>

![Screen Shot 2019-10-21 at 12 21 33](https://user-images.githubusercontent.com/142755/67223754-d8bc3800-f3fd-11e9-9c5f-a5c19490ff14.png)
![Screen Shot 2019-10-21 at 12 21 47](https://user-images.githubusercontent.com/142755/67223761-dbb72880-f3fd-11e9-9889-e337cc1acae4.png)
![Screen Shot 2019-10-21 at 12 22 13](https://user-images.githubusercontent.com/142755/67223768-df4aaf80-f3fd-11e9-9af8-adf9ba08bc7d.png)

</details>
