### PR TITLE
Improve padding on Secondary Hero message

### DIFF
--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -28,6 +28,11 @@
   font-size: $font-size-m;
   line-height: 1.5;
   margin-top: 0;
+  padding: 0 10px 10px 10px;
+
+  @include respond-to(large) {
+    padding: 0;
+  }
 }
 
 .SecondaryHero-message-headline {


### PR DESCRIPTION
Fixes #8720 

Before:

![Screen Shot 2019-10-22 at 12 57 39](https://user-images.githubusercontent.com/142755/67310866-89910880-f4cc-11e9-9012-03aed9759758.png)

After:

![Screen Shot 2019-10-22 at 12 57 24](https://user-images.githubusercontent.com/142755/67310879-9150ad00-f4cc-11e9-8055-bb9267477cae.png)
