### PR TITLE
Fix category colors

### DIFF
--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -163,6 +163,8 @@ export class CategoriesBase extends React.Component<InternalProps> {
               return (
                 <li className="Categories-item" key={name}>
                   <Button
+                    // `12` is the number of colors declared in
+                    // "$category-colors".
                     className={`Categories-link
                       Categories--category-color-${(index % 12) + 1}`}
                     to={categoryResultsLinkTo({ addonType, slug })}

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -9,7 +9,7 @@ import { setViewContext } from 'amo/actions/viewContext';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import { fetchCategories } from 'core/reducers/categories';
-import { getCategoryResultsQuery, getCategoryColor } from 'core/utils';
+import { getCategoryResultsQuery } from 'core/utils';
 import Button from 'ui/components/Button';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
@@ -153,7 +153,7 @@ export class CategoriesBase extends React.Component<InternalProps> {
           </div>
         ) : (
           <ul className="Categories-list">
-            {categories.map((category) => {
+            {categories.map((category, index) => {
               // Flow cannot figure out CategoryType in this case.
               // See https://github.com/facebook/flow/issues/2174
               // and https://github.com/facebook/flow/issues/2221
@@ -164,7 +164,7 @@ export class CategoriesBase extends React.Component<InternalProps> {
                 <li className="Categories-item" key={name}>
                   <Button
                     className={`Categories-link
-                      Categories--category-color-${getCategoryColor(category)}`}
+                      Categories--category-color-${(index % 12) + 1}`}
                     to={categoryResultsLinkTo({ addonType, slug })}
                   >
                     {name}

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -273,19 +273,6 @@ export const ERROR_ADDON_DISABLED_BY_ADMIN = 'ERROR_ADDON_DISABLED_BY_ADMIN';
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Maximum_delay_value
 export const maximumSetTimeoutDelay = 2147483647;
 
-// Category Color Numbers
-// These are used to define the number of colors used to add accent color to a
-// category background header/link. Most have 12, but certain add-on types
-// can have their own color set with a different max number.
-export const CATEGORY_COLORS = {
-  [ADDON_TYPE_DICT]: 12,
-  [ADDON_TYPE_EXTENSION]: 10,
-  [ADDON_TYPE_LANG]: 12,
-  [ADDON_TYPE_OPENSEARCH]: 12,
-  [ADDON_TYPE_STATIC_THEME]: 12,
-  [ADDON_TYPE_THEME]: 12,
-};
-
 // Can access the website admin interface index page. Inner pages may require
 // other/additional permissions.
 export const ADMIN_TOOLS_VIEW = 'AdminTools:View';

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -12,7 +12,6 @@ import {
   ADDON_TYPE_THEME,
   ADDON_TYPE_THEMES,
   API_ADDON_TYPES_MAPPING,
-  CATEGORY_COLORS,
   OS_ALL,
   OS_ANDROID,
   OS_LINUX,
@@ -243,32 +242,6 @@ export function trimAndAddProtocolToUrl(urlToCheck) {
     urlToReturn = `http://${urlToReturn}`;
   }
   return urlToReturn;
-}
-
-export function getCategoryColor(category) {
-  if (!category) {
-    throw new Error('category is required.');
-  }
-
-  const maxColors = CATEGORY_COLORS[category.type];
-
-  if (!maxColors) {
-    throw new Error(
-      `addonType "${category.type}" not found in CATEGORY_COLORS.`,
-    );
-  }
-
-  if (category.id > maxColors) {
-    const color = parseInt(category.id / maxColors, 10);
-
-    if (color > maxColors) {
-      return maxColors;
-    }
-
-    return color;
-  }
-
-  return category.id;
 }
 
 export function addonHasVersionHistory(addon) {

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -38,8 +38,8 @@ $header-text-not-active-color: transparentize($white, 0.5);
 // Category Colors
 // There are currently 12 colors and this number must be kept in sync with
 // `src/amo/components/Categories/index.js`.
-$category-colors: $teal-80, $green-70, $red-70, $magenta-70, $blue-70,
-  $orange-70, $teal-90, $yellow-80, $purple-70, $green-90, $ink-70, $purple-90;
+$category-colors: $teal-70, $red-60, $magenta-60, $orange-60, $blue-50,
+  $green-70, $magenta-70, $red-50, $purple-40, $orange-70, $blue-60, $yellow-70;
 
 // Fonts
 $font-size-s: 12px;

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -36,6 +36,8 @@ $header-accent-color: $link-color;
 $header-text-not-active-color: transparentize($white, 0.5);
 
 // Category Colors
+// There are currently 12 colors and this number must be kept in sync with
+// `src/amo/components/Categories/index.js`.
 $category-colors: $teal-70, $red-50, $magenta-60, $blue-50, $orange-70,
   $green-60, $teal-60, $orange-70, $purple-60, $green-70, $blue-60, $orange-50;
 

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -38,8 +38,8 @@ $header-text-not-active-color: transparentize($white, 0.5);
 // Category Colors
 // There are currently 12 colors and this number must be kept in sync with
 // `src/amo/components/Categories/index.js`.
-$category-colors: $teal-70, $red-50, $magenta-60, $blue-50, $orange-70,
-  $green-60, $teal-60, $orange-70, $purple-60, $green-70, $blue-60, $orange-50;
+$category-colors: $teal-80, $green-70, $red-70, $magenta-70, $blue-70,
+  $orange-70, $teal-90, $yellow-80, $purple-70, $green-90, $ink-70, $purple-90;
 
 // Fonts
 $font-size-s: 12px;

--- a/src/ui/css/vars.scss
+++ b/src/ui/css/vars.scss
@@ -36,8 +36,8 @@ $header-accent-color: $link-color;
 $header-text-not-active-color: transparentize($white, 0.5);
 
 // Category Colors
-$category-colors: #fa5252, #e64980, #be4bdb, #7950f2, #4c6ef5, #228ae6, #15aabf,
-  #12b886, #40c057, #82c91e, #fab005, #fd7e14;
+$category-colors: $teal-70, $red-50, $magenta-60, $blue-50, $orange-70,
+  $green-60, $teal-60, $orange-70, $purple-60, $green-70, $blue-60, $orange-50;
 
 // Fonts
 $font-size-s: 12px;

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -306,42 +306,34 @@ describe(__filename, () => {
 
   it('renders a class name with a color for each category', () => {
     const categoriesResponse = {
-      // Generate 13 categories. We use 13 ordered letters because the reducer
-      // sorts the categories by name (alphabetically). By doing this here, we
-      // ensure a consistent output, which we need to make sure the 1st and
-      // 13rd categories have the correct CSS class names...
-      results: 'abcdefghijklm'.split('').map((letter, index) => ({
-        ...fakeCategory,
-        application: CLIENT_APP_ANDROID,
-        id: index + 1,
-        name: `category ${letter}`,
-        slug: `category-${letter}`,
-        type: ADDON_TYPE_EXTENSION,
-      })),
+      // Generate 13 categories.
+      results: Array(13)
+        .fill()
+        .map((_, index) => ({
+          ...fakeCategory,
+          application: CLIENT_APP_ANDROID,
+          id: index,
+          name: `category ${index}`,
+          slug: `category-${index}`,
+          type: ADDON_TYPE_EXTENSION,
+        })),
     };
     store.dispatch(loadCategories(categoriesResponse));
 
     const root = render();
 
     expect(root.find('.Categories-link')).toHaveLength(13);
-    // There are 2 `color-1` class names because we only have 12 category
-    // colors. We loop over these 12 colors to give a color to each category.
-    expect(root.find('.Categories--category-color-1')).toHaveLength(2);
     // The first `color-1` should be set on the 1st category.
-    expect(root.find('.Categories--category-color-1').at(0)).toHaveProp(
-      'children',
-      'category a',
+    expect(root.find('.Categories-link').at(0)).toHaveClassName(
+      'Categories--category-color-1',
     );
-    // The first `color-1` should be set on the 13rd category.
-    expect(root.find('.Categories--category-color-1').at(1)).toHaveProp(
-      'children',
-      'category m',
+    // The `color-12` should be set on the 12th category.
+    expect(root.find('.Categories-link').at(11)).toHaveClassName(
+      'Categories--category-color-12',
     );
-    // Quick check for the 12nd category.
-    expect(root.find('.Categories--category-color-12')).toHaveLength(1);
-    expect(root.find('.Categories--category-color-12')).toHaveProp(
-      'children',
-      'category l',
+    // The second `color-1` should be set on the 13th category.
+    expect(root.find('.Categories-link').at(12)).toHaveClassName(
+      'Categories--category-color-1',
     );
   });
 

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -304,6 +304,47 @@ describe(__filename, () => {
     expect(root.find(ErrorList)).toHaveLength(1);
   });
 
+  it('renders a class name with a color for each category', () => {
+    const categoriesResponse = {
+      // Generate 13 categories. We use 13 ordered letters because the reducer
+      // sorts the categories by name (alphabetically). By doing this here, we
+      // ensure a consistent output, which we need to make sure the 1st and
+      // 13rd categories have the correct CSS class names...
+      results: 'abcdefghijklm'.split('').map((letter, index) => ({
+        ...fakeCategory,
+        application: CLIENT_APP_ANDROID,
+        id: index + 1,
+        name: `category ${letter}`,
+        slug: `category-${letter}`,
+        type: ADDON_TYPE_EXTENSION,
+      })),
+    };
+    store.dispatch(loadCategories(categoriesResponse));
+
+    const root = render();
+
+    expect(root.find('.Categories-link')).toHaveLength(13);
+    // There are 2 `color-1` class names because we only have 12 category
+    // colors. We loop over these 12 colors to give a color to each category.
+    expect(root.find('.Categories--category-color-1')).toHaveLength(2);
+    // The first `color-1` should be set on the 1st category.
+    expect(root.find('.Categories--category-color-1').at(0)).toHaveProp(
+      'children',
+      'category a',
+    );
+    // The first `color-1` should be set on the 13rd category.
+    expect(root.find('.Categories--category-color-1').at(1)).toHaveProp(
+      'children',
+      'category m',
+    );
+    // Quick check for the 12nd category.
+    expect(root.find('.Categories--category-color-12')).toHaveLength(1);
+    expect(root.find('.Categories--category-color-12')).toHaveProp(
+      'children',
+      'category l',
+    );
+  });
+
   describe('categoryResultsLinkTo', () => {
     const addonType = ADDON_TYPE_EXTENSION;
     const slug = 'some-slug';

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -10,7 +10,6 @@ import {
   ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_STATIC_THEME,
   ADDON_TYPE_THEME,
-  CATEGORY_COLORS,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
   SEARCH_SORT_POPULAR,
@@ -20,7 +19,6 @@ import {
   OS_LINUX,
   OS_MAC,
   OS_WINDOWS,
-  validAddonTypes,
 } from 'core/constants';
 import {
   addQueryParams,
@@ -31,7 +29,6 @@ import {
   convertBoolean,
   decodeHtmlEntities,
   findFileForPlatform,
-  getCategoryColor,
   getCategoryResultsQuery,
   getClientApp,
   getClientConfig,
@@ -536,52 +533,6 @@ describe(__filename, () => {
       expect(trimAndAddProtocolToUrl('https://test.com')).toEqual(
         'https://test.com',
       );
-    });
-  });
-
-  describe('getCategoryColor', () => {
-    it('throws if category is false-y', () => {
-      expect(() => {
-        getCategoryColor(null);
-      }).toThrowError('category is required');
-    });
-
-    it('all valid addonTypes are in CATEGORY_COLORS', () => {
-      expect(() => {
-        validAddonTypes.forEach((addonType) => {
-          const category = { id: 2, type: addonType };
-
-          getCategoryColor(category);
-        });
-      }).not.toThrowError('not found in CATEGORY_COLORS');
-    });
-
-    it('throws on unrecognised addonType', () => {
-      expect(() => {
-        getCategoryColor({ id: 5, type: 'NOT_A_REAL_TYPE' });
-      }).toThrowError(
-        'addonType "NOT_A_REAL_TYPE" not found in CATEGORY_COLORS',
-      );
-    });
-
-    it('deals with high category IDs', () => {
-      for (let i = 750; i < 800; i++) {
-        const category = { id: i, type: ADDON_TYPE_THEME };
-        const categoryColor = getCategoryColor(category);
-
-        expect(categoryColor).toBeLessThanOrEqual(
-          CATEGORY_COLORS[ADDON_TYPE_THEME],
-        );
-        expect(categoryColor).toBeLessThanOrEqual(12);
-        expect(categoryColor).toBeGreaterThanOrEqual(1);
-      }
-    });
-
-    it('has a different number of colors for different addonTypes', () => {
-      const category = { id: 11, type: ADDON_TYPE_EXTENSION };
-      const categoryColor = getCategoryColor(category);
-
-      expect(categoryColor).toEqual(1);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8180

---

Now that we are only using colors for the buttons, we don't need the complicated function to return a color. We can simply have 12 fixed colors and iterate over them.

Colors are now Photon colors.

## Screenshots

### firefox/themes

Before:

![Screen Shot 2019-10-23 at 15 55 32](https://user-images.githubusercontent.com/217628/67400181-92a5d680-f5ad-11e9-9353-bfc83bf92ef9.png)

After:

![Screen Shot 2019-10-23 at 16 15 39](https://user-images.githubusercontent.com/217628/67402121-65a6f300-f5b0-11e9-914b-c23f41f64fde.png)

### android/themes

Before:

![Screen Shot 2019-10-23 at 15 56 20](https://user-images.githubusercontent.com/217628/67400253-aea97800-f5ad-11e9-8efc-b60ad4c4bfd6.png)

After:

![Screen Shot 2019-10-23 at 16 16 51](https://user-images.githubusercontent.com/217628/67402204-8a02cf80-f5b0-11e9-9652-787226e54c21.png)


### android/extensions

Before:

![Screen Shot 2019-10-23 at 15 56 05](https://user-images.githubusercontent.com/217628/67400230-a5201000-f5ad-11e9-9333-9d46490558b2.png)

After:

![Screen Shot 2019-10-23 at 16 16 33](https://user-images.githubusercontent.com/217628/67402190-840cee80-f5b0-11e9-9bef-8b3aff4cea7e.png)


### firefox/extensions

Before:

![Screen Shot 2019-10-23 at 15 54 31](https://user-images.githubusercontent.com/217628/67400075-7144ea80-f5ad-11e9-88fb-06a48d1e9c3e.png)

After:

![Screen Shot 2019-10-23 at 16 15 28](https://user-images.githubusercontent.com/217628/67402160-78212c80-f5b0-11e9-8c0e-dc27bb297079.png)

### "All categories pages"

![Screen Shot 2019-10-23 at 16 26 12](https://user-images.githubusercontent.com/217628/67403210-e61a2380-f5b1-11e9-9c15-38cd193824a3.png)
![Screen Shot 2019-10-23 at 16 26 04](https://user-images.githubusercontent.com/217628/67403212-e61a2380-f5b1-11e9-9593-5ad1e7ee0a50.png)
