### PR TITLE
Make wrapping category lists look more even

### DIFF
--- a/src/amo/components/Categories/styles.scss
+++ b/src/amo/components/Categories/styles.scss
@@ -13,7 +13,7 @@
 .Categories-list {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-evenly;
+  justify-content: center;
   list-style: none;
   margin: 0 auto;
   padding: 0;

--- a/src/amo/components/Categories/styles.scss
+++ b/src/amo/components/Categories/styles.scss
@@ -11,7 +11,9 @@
 }
 
 .Categories-list {
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
   list-style: none;
   margin: 0 auto;
   padding: 0;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8823

This is a simple fix to make the list wrapping a bit better.

**Before**

<details>
<summary>Screenshots</summary>

<img width="1591" alt="Screenshot 2019-10-24 09 19 05" src="https://user-images.githubusercontent.com/55398/67495913-3be9dc80-f641-11e9-8492-91ee36a30e60.png">
<img width="1349" alt="Screenshot 2019-10-24 09 19 34" src="https://user-images.githubusercontent.com/55398/67495914-3be9dc80-f641-11e9-8a28-73a3b560b483.png">


</details>

**After**


<details>
<summary>Screenshots</summary>

<img width="1539" alt="Screenshot 2019-10-24 09 42 54" src="https://user-images.githubusercontent.com/55398/67497515-b3207000-f643-11e9-8309-b60400b7e829.png">
<img width="1394" alt="Screenshot 2019-10-24 09 43 36" src="https://user-images.githubusercontent.com/55398/67497516-b3207000-f643-11e9-940a-f34c5d8db0d3.png">


</details>


Here are some more examples of wrapping scenarios with the new approach:


<details>
<summary>Screenshots</summary>

<img width="1244" alt="Screenshot 2019-10-24 09 43 49" src="https://user-images.githubusercontent.com/55398/67497543-bc114180-f643-11e9-8aba-b964193287e8.png">
<img width="1061" alt="Screenshot 2019-10-24 09 44 00" src="https://user-images.githubusercontent.com/55398/67497545-bc114180-f643-11e9-87d6-04bbac93a06d.png">
<img width="768" alt="Screenshot 2019-10-24 09 44 18" src="https://user-images.githubusercontent.com/55398/67497546-bc114180-f643-11e9-8732-8a20824f00d8.png">
<img width="617" alt="Screenshot 2019-10-24 09 44 34" src="https://user-images.githubusercontent.com/55398/67497547-bc114180-f643-11e9-941f-82307ca9844e.png">
<img width="1196" alt="Screenshot 2019-10-24 09 45 11" src="https://user-images.githubusercontent.com/55398/67497548-bc114180-f643-11e9-887b-96bf34280b2e.png">
<img width="1038" alt="Screenshot 2019-10-24 09 45 18" src="https://user-images.githubusercontent.com/55398/67497549-bca9d800-f643-11e9-95bd-3c2fc09a1f87.png">
<img width="881" alt="Screenshot 2019-10-24 09 45 24" src="https://user-images.githubusercontent.com/55398/67497550-bca9d800-f643-11e9-9001-d0fd0e42699b.png">
<img width="657" alt="Screenshot 2019-10-24 09 45 35" src="https://user-images.githubusercontent.com/55398/67497551-bca9d800-f643-11e9-902c-00734416f5db.png">



</details>