### PR TITLE
Change the colors for the themes shelf on homepage

### DIFF
--- a/src/amo/components/Categories/styles.scss
+++ b/src/amo/components/Categories/styles.scss
@@ -47,6 +47,8 @@
   text-decoration: none;
 }
 
+// There are currently 12 colors and this number must be kept in sync with
+// `$category-colors` in `src/ui/css/vars.scss`.
 @for $i from 1 through 12 {
   .Categories--category-color-#{$i} {
     background: nth($category-colors, $i);

--- a/src/amo/components/CategoryIcon/styles.scss
+++ b/src/amo/components/CategoryIcon/styles.scss
@@ -22,6 +22,8 @@ $default-icon-size: 64px;
   }
 }
 
+// There are currently 12 colors and this number must be kept in sync with
+// `$category-colors` in `src/ui/css/vars.scss`.
 @for $i from 1 through 12 {
   .CategoryIcon-#{$i} {
     background-color: nth($category-colors, $i);

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -135,32 +135,32 @@ export class HomeBase extends React.Component {
     const { i18n } = this.props;
     const curatedThemes = [
       {
-        color: 8,
+        color: 1,
         slug: 'abstract',
         title: i18n.gettext('Abstract'),
       },
       {
-        color: 8,
+        color: 2,
         slug: 'nature',
         title: i18n.gettext('Nature'),
       },
       {
-        color: 10,
+        color: 3,
         slug: 'film-and-tv',
         title: i18n.gettext('Film & TV'),
       },
       {
-        color: 8,
+        color: 4,
         slug: 'scenery',
         title: i18n.gettext('Scenery'),
       },
       {
-        color: 10,
+        color: 5,
         slug: 'music',
         title: i18n.gettext('Music'),
       },
       {
-        color: 9,
+        color: 6,
         slug: 'seasonal',
         title: i18n.gettext('Seasonal'),
       },


### PR DESCRIPTION
fixes https://github.com/mozilla/addons-frontend/issues/8835

---

I updated each `color` attribute instead of using the `index` because I
did not want to introduce a complicated logic to make sure we only use
one of the 12 allowed colors (with `% 12`).

I don't think I precisely reused the colors in the landing pages either.
Does it really matter now that we don't have dedicated pages?

## Screenshots

Before:

![](https://user-images.githubusercontent.com/33448286/67571585-fc081f80-f73c-11e9-89a4-33b79d992fa2.png)

After:

![Screen Shot 2019-10-25 at 18 20 33](https://user-images.githubusercontent.com/217628/67587428-26190c00-f754-11e9-809c-01a648936416.png)