### PR TITLE
Revert "Update dependency react-textarea-autosize to v7.1.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "react-super-responsive-table": "5.1.1",
-    "react-textarea-autosize": "7.1.1",
+    "react-textarea-autosize": "7.1.0",
     "react-transition-group": "4.3.0",
     "redux": "4.0.4",
     "redux-logger": "3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13240,15 +13240,7 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.6.3:
     react-is "^16.8.6"
     scheduler "^0.17.0"
 
-react-textarea-autosize@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.1.tgz#66ff1b7d6e1ab759fdf35f09e60bdd0e15d8e143"
-  integrity sha512-dVDVXlUm5uUgWyZAL4gaxJiDb2xCWM/qk6Rl2ixXPSKNsngKhvAj3KbDS9mnQn/qIZSYVD+/iuZT/eQWmNjBLw==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    prop-types "^15.6.0"
-
-react-textarea-autosize@^7.1.0:
+react-textarea-autosize@7.1.0, react-textarea-autosize@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.1.0.tgz#3132cb77e65d94417558d37c0bfe415a5afd3445"
   integrity sha512-c2FlR/fP0qbxmlrW96SdrbgP/v0XZMTupqB90zybvmDVDutytUgPl7beU35klwcTeMepUIQEpQUn3P3bdshGPg==


### PR DESCRIPTION
Reverts mozilla/addons-frontend#8856

Reverting this temporarily because of https://github.com/andreypopp/react-textarea-autosize/issues/253

This breaks the webpack build and thus breaks local development on addons-server