### PR TITLE
New A/B test for non-recommended warning

### DIFF
--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -31,4 +31,8 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  experiments: {
+    installButtonWarning: true,
+  },
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -31,4 +31,8 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  experiments: {
+    installButtonWarning: true,
+  },
 };

--- a/src/amo/components/InstallWarning/index.js
+++ b/src/amo/components/InstallWarning/index.js
@@ -2,6 +2,7 @@
 import makeClassName from 'classnames';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import type { AppState } from 'amo/store';
@@ -9,12 +10,16 @@ import { ADDON_TYPE_EXTENSION, CLIENT_APP_FIREFOX } from 'core/constants';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
 import tracking from 'core/tracking';
-import { isFirefox } from 'core/utils/compatibility';
-import { withExperiment } from 'core/withExperiment';
-import Notice from 'ui/components/Notice';
+import {
+  correctedLocationForPlatform,
+  isFirefox,
+} from 'core/utils/compatibility';
+import { NOT_IN_EXPERIMENT, withExperiment } from 'core/withExperiment';
+import Notice, { genericWarningType, warningType } from 'ui/components/Notice';
 import type { UserAgentInfoType } from 'core/reducers/api';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
+import type { ReactRouterLocationType } from 'core/types/router';
 import type { WithExperimentInjectedProps } from 'core/withExperiment';
 
 import './styles.scss';
@@ -26,12 +31,14 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   ...WithExperimentInjectedProps,
+  _correctedLocationForPlatform: typeof correctedLocationForPlatform,
   _couldShowWarning?: () => boolean,
   _log: typeof log,
   _tracking: typeof tracking,
   clientApp: string,
   className?: string,
   i18n: I18nType,
+  location: ReactRouterLocationType,
   userAgentInfo: UserAgentInfoType,
 |};
 
@@ -43,29 +50,48 @@ export const EXPERIMENT_ID = 'installButtonWarning';
 // We use dimension6 because that is a custom GA dimension added for this
 // particular experiment.
 export const INSTALL_WARNING_EXPERIMENT_DIMENSION = 'dimension6';
-export const VARIANT_INCLUDE_WARNING = 'includeWarning';
+export const VARIANT_INCLUDE_WARNING_CURRENT = 'includeWarning-current';
+export const VARIANT_INCLUDE_WARNING_PROPOSED = 'includeWarning-proposed';
 export const VARIANT_EXCLUDE_WARNING = 'excludeWarning';
+export const EXPERIMENT_VARIANTS = [
+  { id: VARIANT_INCLUDE_WARNING_CURRENT, percentage: 0.2 },
+  { id: VARIANT_INCLUDE_WARNING_PROPOSED, percentage: 0.2 },
+  { id: VARIANT_EXCLUDE_WARNING, percentage: 0.2 },
+  { id: NOT_IN_EXPERIMENT, percentage: 0.4 },
+];
 const WARNING_LINK_DESTINATION =
   'https://support.mozilla.org/kb/recommended-extensions-program#w_what-are-the-risks-of-installing-non-recommended-extensions';
 
 export class InstallWarningBase extends React.Component<InternalProps> {
   static defaultProps = {
+    _correctedLocationForPlatform: correctedLocationForPlatform,
     _log: log,
     _tracking: tracking,
   };
 
   couldShowWarning = () => {
     const {
+      _correctedLocationForPlatform,
       _couldShowWarning,
       addon,
       clientApp,
       isExperimentEnabled,
       isUserInExperiment,
+      location,
       userAgentInfo,
     } = this.props;
+
+    // Do not show this warning if we are also going to show a WrongPlatformWarning.
+    const correctedLocation = _correctedLocationForPlatform({
+      clientApp,
+      location,
+      userAgentInfo,
+    });
+
     return _couldShowWarning
       ? _couldShowWarning()
-      : isFirefox({ userAgentInfo }) &&
+      : !correctedLocation &&
+          isFirefox({ userAgentInfo }) &&
           clientApp === CLIENT_APP_FIREFOX &&
           addon.type === ADDON_TYPE_EXTENSION &&
           !addon.is_recommended &&
@@ -116,17 +142,31 @@ export class InstallWarningBase extends React.Component<InternalProps> {
   render() {
     const { className, i18n, variant } = this.props;
 
-    if (this.couldShowWarning() && variant === VARIANT_INCLUDE_WARNING) {
+    if (
+      this.couldShowWarning() &&
+      [
+        VARIANT_INCLUDE_WARNING_CURRENT,
+        VARIANT_INCLUDE_WARNING_PROPOSED,
+      ].includes(variant)
+    ) {
       return (
         <Notice
           actionHref={WARNING_LINK_DESTINATION}
           actionTarget="_blank"
           actionText={i18n.gettext('Learn more')}
           className={makeClassName('InstallWarning', className)}
-          type="warning"
+          type={
+            variant === VARIANT_INCLUDE_WARNING_CURRENT
+              ? warningType
+              : genericWarningType
+          }
         >
-          {i18n.gettext(`This extension isn’t monitored by Mozilla. Make sure you trust the
-            extension before you install it.`)}
+          {variant === VARIANT_INCLUDE_WARNING_CURRENT
+            ? i18n.gettext(`This extension isn’t monitored by Mozilla. Make sure you trust the
+            extension before you install it.`)
+            : i18n.gettext(
+                `This is not a Recommended Extension. Make sure you trust it before installing.`,
+              )}
         </Notice>
       );
     }
@@ -142,14 +182,12 @@ export const mapStateToProps = (state: AppState) => {
 };
 
 const InstallWarning: React.ComponentType<Props> = compose(
+  withRouter,
   connect(mapStateToProps),
   translate(),
   withExperiment({
     id: EXPERIMENT_ID,
-    variants: [
-      { id: VARIANT_INCLUDE_WARNING, percentage: 0.5 },
-      { id: VARIANT_EXCLUDE_WARNING, percentage: 0.5 },
-    ],
+    variants: EXPERIMENT_VARIANTS,
   }),
 )(InstallWarningBase);
 

--- a/src/amo/components/InstallWarning/index.js
+++ b/src/amo/components/InstallWarning/index.js
@@ -53,12 +53,15 @@ export const INSTALL_WARNING_EXPERIMENT_DIMENSION = 'dimension6';
 export const VARIANT_INCLUDE_WARNING_CURRENT = 'includeWarning-current';
 export const VARIANT_INCLUDE_WARNING_PROPOSED = 'includeWarning-proposed';
 export const VARIANT_EXCLUDE_WARNING = 'excludeWarning';
-export const EXPERIMENT_VARIANTS = [
-  { id: VARIANT_INCLUDE_WARNING_CURRENT, percentage: 0.2 },
-  { id: VARIANT_INCLUDE_WARNING_PROPOSED, percentage: 0.2 },
-  { id: VARIANT_EXCLUDE_WARNING, percentage: 0.2 },
-  { id: NOT_IN_EXPERIMENT, percentage: 0.4 },
-];
+export const EXPERIMENT_CONFIG = {
+  id: EXPERIMENT_ID,
+  variants: [
+    { id: VARIANT_INCLUDE_WARNING_CURRENT, percentage: 0.2 },
+    { id: VARIANT_INCLUDE_WARNING_PROPOSED, percentage: 0.2 },
+    { id: VARIANT_EXCLUDE_WARNING, percentage: 0.2 },
+    { id: NOT_IN_EXPERIMENT, percentage: 0.4 },
+  ],
+};
 const WARNING_LINK_DESTINATION =
   'https://support.mozilla.org/kb/recommended-extensions-program#w_what-are-the-risks-of-installing-non-recommended-extensions';
 
@@ -185,10 +188,7 @@ const InstallWarning: React.ComponentType<Props> = compose(
   withRouter,
   connect(mapStateToProps),
   translate(),
-  withExperiment({
-    id: EXPERIMENT_ID,
-    variants: EXPERIMENT_VARIANTS,
-  }),
+  withExperiment(EXPERIMENT_CONFIG),
 )(InstallWarningBase);
 
 export default InstallWarning;

--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -11,8 +11,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import {
   EXPERIMENT_CATEGORY_CLICK,
-  EXPERIMENT_ID,
-  EXPERIMENT_VARIANTS,
+  EXPERIMENT_CONFIG,
 } from 'amo/components/InstallWarning';
 import {
   ADDON_TYPE_EXTENSION,
@@ -396,10 +395,7 @@ const AMInstallButton: React.ComponentType<Props> = compose(
   withRouter,
   connect(mapStateToProps),
   translate(),
-  withExperiment({
-    id: EXPERIMENT_ID,
-    variants: EXPERIMENT_VARIANTS,
-  }),
+  withExperiment(EXPERIMENT_CONFIG),
 )(AMInstallButtonBase);
 
 export default AMInstallButton;

--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -12,8 +12,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import {
   EXPERIMENT_CATEGORY_CLICK,
   EXPERIMENT_ID,
-  VARIANT_INCLUDE_WARNING,
-  VARIANT_EXCLUDE_WARNING,
+  EXPERIMENT_VARIANTS,
 } from 'amo/components/InstallWarning';
 import {
   ADDON_TYPE_EXTENSION,
@@ -399,10 +398,7 @@ const AMInstallButton: React.ComponentType<Props> = compose(
   translate(),
   withExperiment({
     id: EXPERIMENT_ID,
-    variants: [
-      { id: VARIANT_INCLUDE_WARNING, percentage: 0.5 },
-      { id: VARIANT_EXCLUDE_WARNING, percentage: 0.5 },
-    ],
+    variants: EXPERIMENT_VARIANTS,
   }),
 )(AMInstallButtonBase);
 

--- a/src/ui/components/Notice/index.js
+++ b/src/ui/components/Notice/index.js
@@ -14,6 +14,7 @@ import './styles.scss';
 
 export const errorType: 'error' = 'error';
 export const genericType: 'generic' = 'generic';
+export const genericWarningType: 'genericWarning' = 'genericWarning';
 export const firefoxRequiredType: 'firefox' = 'firefox';
 export const successType: 'success' = 'success';
 export const warningInfoType: 'warningInfo' = 'warningInfo';
@@ -22,6 +23,7 @@ export const warningType: 'warning' = 'warning';
 const validTypes = [
   errorType,
   genericType,
+  genericWarningType,
   firefoxRequiredType,
   successType,
   warningInfoType,
@@ -36,6 +38,7 @@ export type NoticeType =
   | typeof errorType
   | typeof firefoxRequiredType
   | typeof genericType
+  | typeof genericWarningType
   | typeof successType
   | typeof warningInfoType
   | typeof warningType;

--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -147,7 +147,8 @@
   );
 }
 
-.Notice-generic {
+.Notice-generic,
+.Notice-genericWarning {
   @include notice_type(
     $button-background-color: $grey-90-a10,
     $button-background-active-color: $grey-90-a30,
@@ -210,4 +211,9 @@
 
 .Notice-warningInfo .Notice-icon {
   background-image: url('./img/generic-info-mark.svg');
+}
+
+.Notice-genericWarning .Notice-icon {
+  background-image: url('./img/warning.svg');
+  background-size: cover;
 }

--- a/tests/unit/amo/components/TestInstallWarning.js
+++ b/tests/unit/amo/components/TestInstallWarning.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import UAParser from 'ua-parser-js';
 
 import InstallWarning, {
   EXPERIMENT_CATEGORY_DISPLAY,
   EXPERIMENT_ID,
   INSTALL_WARNING_EXPERIMENT_DIMENSION,
-  VARIANT_INCLUDE_WARNING,
+  VARIANT_INCLUDE_WARNING_CURRENT,
+  VARIANT_INCLUDE_WARNING_PROPOSED,
   VARIANT_EXCLUDE_WARNING,
   InstallWarningBase,
 } from 'amo/components/InstallWarning';
@@ -17,6 +19,8 @@ import {
 import { createInternalAddon } from 'core/reducers/addons';
 import { NOT_IN_EXPERIMENT } from 'core/withExperiment';
 import {
+  createContextWithFakeRouter,
+  createFakeLocation,
   createFakeTracking,
   dispatchClientMetadata,
   fakeAddon,
@@ -25,7 +29,7 @@ import {
   shallowUntilTarget,
   userAgentsByPlatform,
 } from 'tests/unit/helpers';
-import Notice from 'ui/components/Notice';
+import Notice, { genericWarningType, warningType } from 'ui/components/Notice';
 
 describe(__filename, () => {
   let store;
@@ -37,18 +41,24 @@ describe(__filename, () => {
     }).store;
   });
 
-  const render = (props = {}) => {
+  const render = ({ location = createFakeLocation(), ...customProps } = {}) => {
+    const props = {
+      _correctedLocationForPlatform: sinon.stub().returns(null),
+      addon: createInternalAddon(fakeAddon),
+      i18n: fakeI18n(),
+      isExperimentEnabled: true,
+      isUserInExperiment: true,
+      store,
+      variant: VARIANT_INCLUDE_WARNING_CURRENT,
+      ...customProps,
+    };
+
     return shallowUntilTarget(
-      <InstallWarning
-        addon={createInternalAddon(fakeAddon)}
-        i18n={fakeI18n()}
-        isExperimentEnabled
-        isUserInExperiment
-        store={store}
-        variant={VARIANT_INCLUDE_WARNING}
-        {...props}
-      />,
+      <InstallWarning {...props} />,
       InstallWarningBase,
+      {
+        shallowOptions: createContextWithFakeRouter({ location }),
+      },
     );
   };
 
@@ -141,11 +151,43 @@ describe(__filename, () => {
 
       expect(component.instance().couldShowWarning()).toEqual(false);
     });
+
+    it('returns false if the WrongPlatformWarning would be shown', () => {
+      const _correctedLocationForPlatform = sinon.stub().returns('/some/path/');
+
+      const component = renderWithWarning({ _correctedLocationForPlatform });
+
+      expect(component.instance().couldShowWarning()).toEqual(false);
+    });
+
+    it('calls _correctedLocationForPlatform with clientApp, location and userAgentInfo', () => {
+      const clientApp = CLIENT_APP_ANDROID;
+      const userAgent = userAgentsByPlatform.mac.firefox57;
+      const parsedUserAgent = UAParser(userAgent);
+      const location = createFakeLocation();
+      const _correctedLocationForPlatform = sinon.spy();
+
+      dispatchClientMetadata({
+        store,
+        userAgent,
+      });
+
+      renderWithWarning({ _correctedLocationForPlatform, location, store });
+
+      sinon.assert.calledWith(_correctedLocationForPlatform, {
+        clientApp,
+        location,
+        userAgentInfo: sinon.match({
+          browser: sinon.match(parsedUserAgent.browser),
+          os: sinon.match(parsedUserAgent.os),
+        }),
+      });
+    });
   });
 
   it('sets a dimension on mount if a variant exists', () => {
     const _tracking = createFakeTracking();
-    const variant = VARIANT_INCLUDE_WARNING;
+    const variant = VARIANT_INCLUDE_WARNING_CURRENT;
 
     render({ _tracking, variant });
 
@@ -186,7 +228,7 @@ describe(__filename, () => {
     const _tracking = createFakeTracking();
     dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID, store });
 
-    render({ _tracking, store, variant: VARIANT_INCLUDE_WARNING });
+    render({ _tracking, store, variant: VARIANT_INCLUDE_WARNING_CURRENT });
 
     sinon.assert.notCalled(_tracking.setDimension);
   });
@@ -206,74 +248,104 @@ describe(__filename, () => {
       _tracking.sendEvent.resetHistory();
     });
 
-    describe('VARIANT_INCLUDE_WARNING', () => {
-      const variant = VARIANT_INCLUDE_WARNING;
+    it('sends the event on mount if couldShowWarning is true and a variant exists', () => {
+      const _couldShowWarning = sinon.stub().returns(true);
+      const addon = createInternalAddon(fakeAddon);
+      const variant = VARIANT_INCLUDE_WARNING_CURRENT;
 
-      it('sends the event on mount if couldShowWarning is true and a variant exists', () => {
-        const _couldShowWarning = sinon.stub().returns(true);
-        const addon = createInternalAddon(fakeAddon);
-
-        render({
-          _couldShowWarning,
-          _tracking,
-          addon,
-          variant,
-        });
-
-        sinon.assert.calledWith(_tracking.sendEvent, {
-          action: variant,
-          category: EXPERIMENT_CATEGORY_DISPLAY,
-          label: addon.name,
-        });
+      render({
+        _couldShowWarning,
+        _tracking,
+        addon,
+        variant,
       });
 
-      it('does not send the event on mount if couldShowWarning is false', () => {
-        const _couldShowWarning = sinon.stub().returns(false);
+      sinon.assert.calledWith(_tracking.sendEvent, {
+        action: variant,
+        category: EXPERIMENT_CATEGORY_DISPLAY,
+        label: addon.name,
+      });
+    });
 
-        render({ _couldShowWarning, _tracking, variant });
+    it('does not send the event on mount if couldShowWarning is false', () => {
+      const _couldShowWarning = sinon.stub().returns(false);
 
-        sinon.assert.notCalled(_tracking.sendEvent);
+      render({
+        _couldShowWarning,
+        _tracking,
+        variant: VARIANT_INCLUDE_WARNING_CURRENT,
       });
 
-      it('does not send the event on mount if a variant is not set', () => {
-        const _couldShowWarning = sinon.stub().returns(true);
+      sinon.assert.notCalled(_tracking.sendEvent);
+    });
 
-        render({ _couldShowWarning, _tracking, variant: undefined });
+    it('does not send the event on mount if a variant is not set', () => {
+      const _couldShowWarning = sinon.stub().returns(true);
 
-        sinon.assert.notCalled(_tracking.sendEvent);
-      });
+      render({ _couldShowWarning, _tracking, variant: undefined });
+
+      sinon.assert.notCalled(_tracking.sendEvent);
     });
   });
 
-  it('displays a warning if couldShowWarning is true and the user is in the included cohort', () => {
-    const _couldShowWarning = sinon.stub().returns(true);
+  it.each([VARIANT_INCLUDE_WARNING_CURRENT, VARIANT_INCLUDE_WARNING_PROPOSED])(
+    'displays a warning if couldShowWarning is true and the user is in the %s branch',
+    (variant) => {
+      const _couldShowWarning = sinon.stub().returns(true);
 
-    const root = render({
-      _couldShowWarning,
-      variant: VARIANT_INCLUDE_WARNING,
-    });
-    expect(root.find(Notice)).toHaveLength(1);
-  });
+      const root = render({
+        _couldShowWarning,
+        variant,
+      });
+      expect(root.find(Notice)).toHaveLength(1);
+    },
+  );
 
   it('does not display a warning if couldShowWarning is false', () => {
     const _couldShowWarning = sinon.stub().returns(false);
 
     const root = render({
       _couldShowWarning,
-      variant: VARIANT_INCLUDE_WARNING,
+      variant: VARIANT_INCLUDE_WARNING_CURRENT,
     });
     expect(root.find(Notice)).toHaveLength(0);
   });
 
-  describe('VARIANT_EXCLUDE_WARNING', () => {
-    it('does not display a warning if the user is in the excluded cohort', () => {
-      const _couldShowWarning = sinon.stub().returns(true);
+  it('does not display a warning if the user is in the excluded cohort', () => {
+    const _couldShowWarning = sinon.stub().returns(true);
 
-      const root = render({
-        _couldShowWarning,
-        variant: VARIANT_EXCLUDE_WARNING,
-      });
-      expect(root.find(Notice)).toHaveLength(0);
+    const root = render({
+      _couldShowWarning,
+      variant: VARIANT_EXCLUDE_WARNING,
     });
+    expect(root.find(Notice)).toHaveLength(0);
+  });
+
+  it('sets the expected notice type and message for VARIANT_INCLUDE_WARNING_CURRENT', () => {
+    const _couldShowWarning = sinon.stub().returns(true);
+
+    const root = render({
+      _couldShowWarning,
+      variant: VARIANT_INCLUDE_WARNING_CURRENT,
+    });
+    expect(root.find(Notice)).toHaveProp('type', warningType);
+    expect(root.find(Notice)).toHaveProp(
+      'children',
+      `This extension isn’t monitored by Mozilla. Make sure you trust the extension before you install it.`,
+    );
+  });
+
+  it('sets the expected notice type and message for VARIANT_INCLUDE_WARNING_PROPOSED', () => {
+    const _couldShowWarning = sinon.stub().returns(true);
+
+    const root = render({
+      _couldShowWarning,
+      variant: VARIANT_INCLUDE_WARNING_PROPOSED,
+    });
+    expect(root.find(Notice)).toHaveProp('type', genericWarningType);
+    expect(root.find(Notice)).toHaveProp(
+      'children',
+      `This is not a Recommended Extension. Make sure you trust it before installing.`,
+    );
   });
 });

--- a/tests/unit/amo/components/TestInstallWarning.js
+++ b/tests/unit/amo/components/TestInstallWarning.js
@@ -62,6 +62,24 @@ describe(__filename, () => {
     );
   };
 
+  // This is an add-on that would cause a warning to be displayed.
+  const addonThatWouldShowWarning = {
+    ...fakeAddon,
+    is_recommended: false,
+    type: ADDON_TYPE_EXTENSION,
+  };
+
+  // This will render the component with values needed to allow
+  // the warning to be displayed.
+  const renderWithWarning = (props = {}) => {
+    return render({
+      addon: createInternalAddon(addonThatWouldShowWarning),
+      isExperimentEnabled: true,
+      isUserInExperiment: true,
+      ...props,
+    });
+  };
+
   it('can be customized with a class name', () => {
     const className = 'ExampleClass';
     const root = render({ className });
@@ -70,23 +88,6 @@ describe(__filename, () => {
   });
 
   describe('couldShowWarning', () => {
-    const addonThatWouldShowWarning = {
-      ...fakeAddon,
-      is_recommended: false,
-      type: ADDON_TYPE_EXTENSION,
-    };
-
-    // This will render the component with values needed to allow
-    // couldShowWarning to be true.
-    const renderWithWarning = (props = {}) => {
-      return render({
-        addon: createInternalAddon(addonThatWouldShowWarning),
-        isExperimentEnabled: true,
-        isUserInExperiment: true,
-        ...props,
-      });
-    };
-
     // This is a test for the happy path, but also serves as a sanity test for
     // renderWithWarning returning the happy path.
     it('returns true if the experiment is enabled, the userAgent and clientApp are both Firefox, and the add-on is an extension and is not recommended', () => {
@@ -168,6 +169,7 @@ describe(__filename, () => {
       const _correctedLocationForPlatform = sinon.spy();
 
       dispatchClientMetadata({
+        clientApp,
         store,
         userAgent,
       });
@@ -322,10 +324,7 @@ describe(__filename, () => {
   });
 
   it('sets the expected notice type and message for VARIANT_INCLUDE_WARNING_CURRENT', () => {
-    const _couldShowWarning = sinon.stub().returns(true);
-
-    const root = render({
-      _couldShowWarning,
+    const root = renderWithWarning({
       variant: VARIANT_INCLUDE_WARNING_CURRENT,
     });
     expect(root.find(Notice)).toHaveProp('type', warningType);
@@ -336,10 +335,7 @@ describe(__filename, () => {
   });
 
   it('sets the expected notice type and message for VARIANT_INCLUDE_WARNING_PROPOSED', () => {
-    const _couldShowWarning = sinon.stub().returns(true);
-
-    const root = render({
-      _couldShowWarning,
+    const root = renderWithWarning({
       variant: VARIANT_INCLUDE_WARNING_PROPOSED,
     });
     expect(root.find(Notice)).toHaveProp('type', genericWarningType);

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -6,7 +6,7 @@ import AMInstallButton, {
 } from 'core/components/AMInstallButton';
 import {
   EXPERIMENT_CATEGORY_CLICK,
-  VARIANT_INCLUDE_WARNING,
+  VARIANT_INCLUDE_WARNING_CURRENT,
 } from 'amo/components/InstallWarning';
 import {
   ADDON_TYPE_OPENSEARCH,
@@ -359,7 +359,7 @@ describe(__filename, () => {
   it('sends a tracking event for the install warning test when installing an extension', async () => {
     const _tracking = createFakeTracking();
     const addon = createInternalAddon({ ...fakeAddon, is_recommended: true });
-    const variant = VARIANT_INCLUDE_WARNING;
+    const variant = VARIANT_INCLUDE_WARNING_CURRENT;
 
     const root = render({
       _tracking,
@@ -386,7 +386,7 @@ describe(__filename, () => {
   it('sends the expected category for a tracking event for a non-recommended extension', async () => {
     const _tracking = createFakeTracking();
     const addon = createInternalAddon({ ...fakeAddon, is_recommended: false });
-    const variant = VARIANT_INCLUDE_WARNING;
+    const variant = VARIANT_INCLUDE_WARNING_CURRENT;
 
     const root = render({
       _tracking,
@@ -418,7 +418,7 @@ describe(__filename, () => {
       _tracking,
       addon,
       isExperimentEnabled: false,
-      variant: VARIANT_INCLUDE_WARNING,
+      variant: VARIANT_INCLUDE_WARNING_CURRENT,
     });
 
     const event = createFakeEvent();
@@ -458,7 +458,7 @@ describe(__filename, () => {
       addon,
       isExperimentEnabled: true,
       isUserInExperiment: false,
-      variant: VARIANT_INCLUDE_WARNING,
+      variant: VARIANT_INCLUDE_WARNING_CURRENT,
     });
 
     const event = createFakeEvent();
@@ -478,7 +478,7 @@ describe(__filename, () => {
       _tracking,
       addon: createInternalAddon(themeAddon),
       isExperimentEnabled: true,
-      variant: VARIANT_INCLUDE_WARNING,
+      variant: VARIANT_INCLUDE_WARNING_CURRENT,
     });
 
     const event = createFakeEvent();

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -356,16 +356,23 @@ describe(__filename, () => {
     sinon.assert.calledOnce(event.stopPropagation);
   });
 
+  const renderWithExperimentEnabled = (props = {}) => {
+    return render({
+      addon: createInternalAddon(fakeAddon),
+      isExperimentEnabled: true,
+      isUserInExperiment: true,
+      ...props,
+    });
+  };
+
   it('sends a tracking event for the install warning test when installing an extension', async () => {
     const _tracking = createFakeTracking();
     const addon = createInternalAddon({ ...fakeAddon, is_recommended: true });
     const variant = VARIANT_INCLUDE_WARNING_CURRENT;
 
-    const root = render({
+    const root = renderWithExperimentEnabled({
       _tracking,
       addon,
-      isExperimentEnabled: true,
-      isUserInExperiment: true,
       variant,
     });
 
@@ -388,11 +395,9 @@ describe(__filename, () => {
     const addon = createInternalAddon({ ...fakeAddon, is_recommended: false });
     const variant = VARIANT_INCLUDE_WARNING_CURRENT;
 
-    const root = render({
+    const root = renderWithExperimentEnabled({
       _tracking,
       addon,
-      isExperimentEnabled: true,
-      isUserInExperiment: true,
       variant,
     });
 
@@ -412,11 +417,9 @@ describe(__filename, () => {
 
   it('does not send a tracking event for the install warning test if the experiment is disabled', async () => {
     const _tracking = createFakeTracking();
-    const addon = createInternalAddon({ ...fakeAddon, is_recommended: false });
 
     const root = render({
       _tracking,
-      addon,
       isExperimentEnabled: false,
       variant: VARIANT_INCLUDE_WARNING_CURRENT,
     });
@@ -432,11 +435,9 @@ describe(__filename, () => {
 
   it('does not send a tracking event for the install warning test if there is no variant', async () => {
     const _tracking = createFakeTracking();
-    const addon = createInternalAddon({ ...fakeAddon, is_recommended: false });
 
-    const root = render({
+    const root = renderWithExperimentEnabled({
       _tracking,
-      addon,
       isExperimentEnabled: true,
     });
 
@@ -451,11 +452,9 @@ describe(__filename, () => {
 
   it('does not send a tracking event for the install warning test if the user is not in the experiment', async () => {
     const _tracking = createFakeTracking();
-    const addon = createInternalAddon({ ...fakeAddon, is_recommended: false });
 
     const root = render({
       _tracking,
-      addon,
       isExperimentEnabled: true,
       isUserInExperiment: false,
       variant: VARIANT_INCLUDE_WARNING_CURRENT,
@@ -472,13 +471,10 @@ describe(__filename, () => {
 
   it('does not send a tracking event for the install warning test for a theme', async () => {
     const _tracking = createFakeTracking();
-    const themeAddon = { ...fakeAddon, type: ADDON_TYPE_STATIC_THEME };
 
-    const root = render({
+    const root = renderWithExperimentEnabled({
       _tracking,
-      addon: createInternalAddon(themeAddon),
-      isExperimentEnabled: true,
-      variant: VARIANT_INCLUDE_WARNING_CURRENT,
+      addon: createInternalAddon(fakeTheme),
     });
 
     const event = createFakeEvent();
@@ -492,12 +488,9 @@ describe(__filename, () => {
 
   it('does not send a tracking event for the install warning test when clientApp is Android', async () => {
     const _tracking = createFakeTracking();
-    const addon = createInternalAddon({ ...fakeAddon, is_recommended: false });
 
-    const root = render({
+    const root = renderWithExperimentEnabled({
       _tracking,
-      addon,
-      isExperimentEnabled: true,
       store: dispatchClientMetadata({
         clientApp: CLIENT_APP_ANDROID,
       }).store,


### PR DESCRIPTION
Fixes #8760 
~~Depends on #8869~~

Screenshots:

<details>
<summary>For users who will see the "old" warning:</summary>

![Screenshot 2019-11-04 12 08 34](https://user-images.githubusercontent.com/142755/68141835-46875a00-fefc-11e9-8fde-66b78148ea23.png)

</details>

<details>
<summary>For users who will see the "new" warning:</summary>

![Screenshot 2019-11-04 12 09 16](https://user-images.githubusercontent.com/142755/68141787-33748a00-fefc-11e9-86c7-c25ed266c3f3.png)

</details>

<details>
<summary>When the "wrong platform warning" would be displayed:</summary>

![Screenshot 2019-11-04 12 09 02](https://user-images.githubusercontent.com/142755/68141915-6e76bd80-fefc-11e9-867b-fd2683814c0e.png)

</details>


