### PR TITLE
Fix site banner alignment with no-image primary hero

### DIFF
--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -115,10 +115,6 @@
 .HeroRecommendation--no-image {
   justify-content: center;
 
-  @include respond-to(extraExtraLarge) {
-    @include padding-start(36px);
-  }
-
   .HeroRecommendation-info {
     align-items: center;
     display: flex;


### PR DESCRIPTION
Fixes #8886 

Before: 

![Screenshot 2019-11-05 11 50 38](https://user-images.githubusercontent.com/142755/68227995-a6483880-ffc2-11e9-92a4-7ad2b361bad0.png)

After:

![Screenshot 2019-11-05 11 50 04](https://user-images.githubusercontent.com/142755/68228017-afd1a080-ffc2-11e9-8f64-03a5bb9ece37.png)
