### PR TITLE
Adjust font sizes, weights and spacing on hero elements

### DIFF
--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -68,7 +68,7 @@
   opacity: 0.5;
 
   @include respond-to(medium) {
-    font-size: $font-size-hero-description;
+    font-size: $font-size-hero-m;
   }
 
   @include respond-to(extraExtraLarge) {
@@ -96,7 +96,7 @@
   overflow-wrap: anywhere;
 
   @include respond-to(extraExtraLarge) {
-    font-size: 38px;
+    font-size: $font-size-hero-heading;
   }
 }
 
@@ -108,7 +108,7 @@
   margin: 18px 0 24px 0;
 
   @include respond-to(medium) {
-    font-size: 21px;
+    font-size: $font-size-hero-body;
   }
 
   @include respond-to(extraExtraLarge) {

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -59,6 +59,8 @@
 }
 
 .HeroRecommendation-recommended {
+  @include font-medium();
+
   font-size: $font-size-s;
   letter-spacing: 0.1em;
   line-height: 1.143;
@@ -66,7 +68,7 @@
   opacity: 0.5;
 
   @include respond-to(medium) {
-    font-size: $font-size-default;
+    font-size: $font-size-hero-description;
   }
 
   @include respond-to(extraExtraLarge) {
@@ -85,26 +87,28 @@
 }
 
 .HeroRecommendation-heading {
+  @include font-medium();
+
   color: $white;
   font-size: $font-size-l;
-  font-weight: normal;
   line-height: 1.188;
   margin: 14px 0 0 0;
   overflow-wrap: anywhere;
 
   @include respond-to(extraExtraLarge) {
-    font-size: $font-size-xl;
+    font-size: 38px;
   }
 }
 
 .HeroRecommendation-body {
+  @include font-light();
+
   font-size: $font-size-s;
-  font-weight: normal;
   line-height: 1.666;
-  margin: 24px 0;
+  margin: 18px 0 24px 0;
 
   @include respond-to(medium) {
-    font-size: $font-size-m;
+    font-size: 21px;
   }
 
   @include respond-to(extraExtraLarge) {

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -25,7 +25,9 @@
 }
 
 .SecondaryHero-message {
-  font-size: $font-size-m;
+  @include font-regular();
+
+  font-size: $font-size-hero-description;
   line-height: 1.5;
   margin-top: 0;
   padding: 0 10px 10px 10px;
@@ -36,8 +38,9 @@
 }
 
 .SecondaryHero-message-headline {
-  font-size: $font-size-l;
-  font-weight: normal;
+  @include font-medium();
+
+  font-size: 24px;
   line-height: 1.333;
   margin: 0;
   overflow-wrap: anywhere;
@@ -67,7 +70,7 @@
   display: flex;
   flex-direction: column;
   font-size: $font-size-hero-description;
-  line-height: 1.222;
+  line-height: 1.5;
   padding: $padding-page 0;
   padding-top: 0;
 
@@ -82,7 +85,7 @@
   width: 60px;
 
   @include respond-to(large) {
-    margin: 30px auto 36px auto;
+    margin: 30px auto 30px auto;
   }
 }
 

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -27,7 +27,7 @@
 .SecondaryHero-message {
   @include font-regular();
 
-  font-size: $font-size-hero-description;
+  font-size: $font-size-hero-m;
   line-height: 1.5;
   margin-top: 0;
   padding: 0 10px 10px 10px;
@@ -40,7 +40,7 @@
 .SecondaryHero-message-headline {
   @include font-medium();
 
-  font-size: 24px;
+  font-size: $font-size-hero-message-headline;
   line-height: 1.333;
   margin: 0;
   overflow-wrap: anywhere;
@@ -69,7 +69,7 @@
   border-radius: $border-radius-s;
   display: flex;
   flex-direction: column;
-  font-size: $font-size-hero-description;
+  font-size: $font-size-hero-m;
   line-height: 1.5;
   padding: $padding-page 0;
   padding-top: 0;

--- a/src/core/css/inc/vars.scss
+++ b/src/core/css/inc/vars.scss
@@ -31,7 +31,13 @@ $font-size-xl: 36px;
 $font-size-xxl: 42px;
 $font-size-form-header: 24px;
 $font-size-puffy-buttons: 15px;
-$font-size-hero-description: 18px;
+
+// Hero-specific font sizes
+// See https://github.com/mozilla/addons-frontend/issues/8837
+$font-size-hero-m: 18px;
+$font-size-hero-body: 21px;
+$font-size-hero-message-headline: 24px;
+$font-size-hero-heading: 38px;
 
 // Animation Variables
 $transition-short: 150ms;


### PR DESCRIPTION
Fixes #8837 

Note that I didn't create new variables in `core/css/inc/vars.scss` for all of the new font sizes because:

1. They are specific sizes currently just being used for these hero elements.
2. They don't necessarily conform with other common sizes on the site, but I believe it is intentional that the home page is starting to diverge from the rest of the site, and that we will eventually update the fonts on the rest of the site to be more in line with Skyline branding.

My thought is that when we undertake more branding work which affects fonts that we might at that time make things more consistent, at which point these sizes might also apply to other elements on the site.

Before:

![Screenshot 2019-11-06 09 06 51](https://user-images.githubusercontent.com/142755/68304950-cd5f4280-0074-11ea-881e-ce02b4b9ea67.png)

After:

![Screenshot 2019-11-06 09 00 43](https://user-images.githubusercontent.com/142755/68304967-d5b77d80-0074-11ea-8a1f-9d3d618aa881.png)
