### PR TITLE
added word-break property to the AddAddonToCollection-added div

### DIFF
--- a/src/amo/components/AddAddonToCollection/styles.scss
+++ b/src/amo/components/AddAddonToCollection/styles.scss
@@ -4,4 +4,5 @@
 
 .AddAddonToCollection-added {
   margin-bottom: 10px;
+  word-break: break-all;
 }


### PR DESCRIPTION
fixes #4184
![unbrokentextissue](https://user-images.githubusercontent.com/15162247/68627875-29263300-049c-11ea-816c-9a60d700a345.png)

should we be limiting the length of a collection name too?