### PR TITLE
Increase padding for site notices

### DIFF
--- a/src/amo/components/AppBanner/styles.scss
+++ b/src/amo/components/AppBanner/styles.scss
@@ -2,10 +2,6 @@
 
 .AppBanner {
   padding: $padding-page;
-  // Split the top padding in half so that we can put optional content
-  // in there when needed.
-  padding-bottom: $padding-page / 2;
-  padding-top: $padding-page / 2;
 
   & > *:not(:last-child) {
     margin-bottom: $padding-page / 2;


### PR DESCRIPTION
Fixes #8827 

This addresses the issue, but I'm not sure if it is the correct fix. It undoes a change that was introduced in https://github.com/mozilla/addons-frontend/commit/8058cd3152d223fe0e1285f5054a565142cd083e, and I'm not sure exactly what the purpose of that code was, or if it is still needed. It was added by @kumar303, so maybe be can comment on it.

Before:

![Screen Shot 2019-11-12 at 13 39 42](https://user-images.githubusercontent.com/142755/68700413-dfe4ea80-0552-11ea-9792-b558fe0c5a56.png)

After:

![Screen Shot 2019-11-12 at 13 39 28](https://user-images.githubusercontent.com/142755/68700426-e5423500-0552-11ea-9f95-d098995192a7.png)
