### PR TITLE
Use FF abuse report panel for extensions and static themes only

### DIFF
--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import { ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -81,13 +82,23 @@ export class ReportAbuseButtonBase extends React.Component<InternalProps> {
   };
 
   onReportButtonClick = async (event: SyntheticEvent<any>) => {
+    const { _hasAbuseReportPanelEnabled, addon, dispatch } = this.props;
+
     event.preventDefault();
 
-    const { _hasAbuseReportPanelEnabled, addon, dispatch } = this.props;
-    if (_hasAbuseReportPanelEnabled()) {
+    if (
+      _hasAbuseReportPanelEnabled() &&
+      // The integrated abuse report panel currently support only extension and
+      // themes (e.g. we do only have abuse categories and related localized
+      // descriptions only for these two kind of addons), and so currently it
+      // is going to refuse to create an abuse report panel for langpacks,
+      // dictionaries and search tools.
+      [ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME].includes(addon.type)
+    ) {
       dispatch(initiateAddonAbuseReportViaFirefox({ addon }));
       return;
     }
+
     dispatch(showAddonAbuseReportUI({ addon }));
   };
 

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -88,11 +88,11 @@ export class ReportAbuseButtonBase extends React.Component<InternalProps> {
 
     if (
       _hasAbuseReportPanelEnabled() &&
-      // The integrated abuse report panel currently support only extension and
-      // themes (e.g. we do only have abuse categories and related localized
-      // descriptions only for these two kind of addons), and so currently it
-      // is going to refuse to create an abuse report panel for langpacks,
-      // dictionaries and search tools.
+      // The integrated abuse report panel currently supports only extensions
+      // and themes (e.g. we do only have abuse categories and related
+      // localized descriptions only for these two kind of addons), and so
+      // currently it is going to refuse to create an abuse report panel for
+      // langpacks, dictionaries and search tools.
       //
       // Static themes should be supported but there is a bug in FF, see:
       // https://github.com/mozilla/addons-frontend/issues/8762#issuecomment-553430081

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -93,7 +93,10 @@ export class ReportAbuseButtonBase extends React.Component<InternalProps> {
       // descriptions only for these two kind of addons), and so currently it
       // is going to refuse to create an abuse report panel for langpacks,
       // dictionaries and search tools.
-      [ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME].includes(addon.type)
+      //
+      // Static themes should be supported but there is a bug in FF, see:
+      // https://github.com/mozilla/addons-frontend/issues/8762#issuecomment-553430081
+      [ADDON_TYPE_EXTENSION].includes(addon.type)
     ) {
       dispatch(initiateAddonAbuseReportViaFirefox({ addon }));
       return;

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME } from 'core/constants';
+import { ADDON_TYPE_EXTENSION } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import translate from 'core/i18n/translate';

--- a/tests/unit/amo/components/TestReportAbuseButton.js
+++ b/tests/unit/amo/components/TestReportAbuseButton.js
@@ -144,7 +144,7 @@ describe(__filename, () => {
   });
 
   it.each([ADDON_TYPE_EXTENSION])(
-    'initiates an abuse report via Firefox when the "report" button is clicked if supported and add-on is %s',
+    'initiates an abuse report via Firefox when the "report" button is clicked if supported and add-on type is %s',
     (addonType) => {
       const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);
       const addon = createInternalAddon({ ...fakeAddon, type: addonType });
@@ -173,11 +173,10 @@ describe(__filename, () => {
     ADDON_TYPE_OPENSEARCH,
     ADDON_TYPE_STATIC_THEME,
   ])(
-    'does not initiate an abuse report via Firefox when add-on is %s',
+    'does not initiate an abuse report via Firefox when add-on type is %s',
     (addonType) => {
       const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);
       const addon = createInternalAddon({ ...fakeAddon, type: addonType });
-      const fakeEvent = createFakeEvent();
       const { store } = dispatchClientMetadata();
       const dispatchSpy = sinon.spy(store, 'dispatch');
 
@@ -186,7 +185,7 @@ describe(__filename, () => {
         addon,
         store,
       });
-      root.find(Button).simulate('click', fakeEvent);
+      root.find(Button).simulate('click', createFakeEvent());
 
       sinon.assert.calledWith(dispatchSpy, showAddonAbuseReportUI({ addon }));
     },

--- a/tests/unit/amo/components/TestReportAbuseButton.js
+++ b/tests/unit/amo/components/TestReportAbuseButton.js
@@ -5,6 +5,13 @@ import ReportAbuseButton, {
 } from 'amo/components/ReportAbuseButton';
 import { setError } from 'core/actions/errors';
 import {
+  ADDON_TYPE_DICT,
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_LANG,
+  ADDON_TYPE_OPENSEARCH,
+  ADDON_TYPE_STATIC_THEME,
+} from 'core/constants';
+import {
   initiateAddonAbuseReportViaFirefox,
   loadAddonAbuseReport,
   sendAddonAbuseReport,
@@ -14,6 +21,7 @@ import {
 import Button from 'ui/components/Button';
 import ErrorList from 'ui/components/ErrorList';
 import DismissibleTextForm from 'ui/components/DismissibleTextForm';
+import { createInternalAddon } from 'core/reducers/addons';
 import {
   createFakeAddonAbuseReport,
   createFakeEvent,
@@ -27,7 +35,7 @@ import {
 describe(__filename, () => {
   const defaultRenderProps = {
     _hasAbuseReportPanelEnabled: sinon.stub(),
-    addon: { ...fakeAddon, slug: 'my-addon' },
+    addon: createInternalAddon({ ...fakeAddon, slug: 'my-addon' }),
     errorHandler: createStubErrorHandler(),
     i18n: fakeI18n(),
     store: dispatchClientMetadata().store,
@@ -135,26 +143,49 @@ describe(__filename, () => {
     expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(1);
   });
 
-  it('initiates an abuse report via Firefox when the "report" button is clicked if supported', () => {
-    const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);
-    const addon = fakeAddon;
-    const fakeEvent = createFakeEvent();
-    const { store } = dispatchClientMetadata();
-    const dispatchSpy = sinon.spy(store, 'dispatch');
-    const root = renderShallow({
-      _hasAbuseReportPanelEnabled,
-      addon,
-      store,
-    });
+  it.each([ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME])(
+    'initiates an abuse report via Firefox when the "report" button is clicked if supported and add-on is %s',
+    (addonType) => {
+      const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);
+      const addon = createInternalAddon({ ...fakeAddon, type: addonType });
+      const fakeEvent = createFakeEvent();
+      const { store } = dispatchClientMetadata();
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+      const root = renderShallow({
+        _hasAbuseReportPanelEnabled,
+        addon,
+        store,
+      });
 
-    root.find(Button).simulate('click', fakeEvent);
+      root.find(Button).simulate('click', fakeEvent);
 
-    sinon.assert.called(fakeEvent.preventDefault);
-    sinon.assert.calledWith(
-      dispatchSpy,
-      initiateAddonAbuseReportViaFirefox({ addon }),
-    );
-  });
+      sinon.assert.called(fakeEvent.preventDefault);
+      sinon.assert.calledWith(
+        dispatchSpy,
+        initiateAddonAbuseReportViaFirefox({ addon }),
+      );
+    },
+  );
+
+  it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG, ADDON_TYPE_OPENSEARCH])(
+    'does not initiate an abuse report via Firefox when add-on is %s',
+    (addonType) => {
+      const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);
+      const addon = createInternalAddon({ ...fakeAddon, type: addonType });
+      const fakeEvent = createFakeEvent();
+      const { store } = dispatchClientMetadata();
+      const dispatchSpy = sinon.spy(store, 'dispatch');
+
+      const root = renderShallow({
+        _hasAbuseReportPanelEnabled,
+        addon,
+        store,
+      });
+      root.find(Button).simulate('click', fakeEvent);
+
+      sinon.assert.calledWith(dispatchSpy, showAddonAbuseReportUI({ addon }));
+    },
+  );
 
   it('shows a success message and hides the button if report was sent', () => {
     const addon = { ...fakeAddon, slug: 'bank-machine-skimmer' };

--- a/tests/unit/amo/components/TestReportAbuseButton.js
+++ b/tests/unit/amo/components/TestReportAbuseButton.js
@@ -143,7 +143,7 @@ describe(__filename, () => {
     expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(1);
   });
 
-  it.each([ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME])(
+  it.each([ADDON_TYPE_EXTENSION])(
     'initiates an abuse report via Firefox when the "report" button is clicked if supported and add-on is %s',
     (addonType) => {
       const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);
@@ -167,7 +167,12 @@ describe(__filename, () => {
     },
   );
 
-  it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG, ADDON_TYPE_OPENSEARCH])(
+  it.each([
+    ADDON_TYPE_DICT,
+    ADDON_TYPE_LANG,
+    ADDON_TYPE_OPENSEARCH,
+    ADDON_TYPE_STATIC_THEME,
+  ])(
     'does not initiate an abuse report via Firefox when add-on is %s',
     (addonType) => {
       const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8929

---

This would be a good candidate for cherry-picking.