### PR TITLE
Remove the main access points to the search tools behind a flag

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -119,6 +119,7 @@ module.exports = {
     'enableDevTools',
     'enableFeatureDiscoTaar',
     'enableFeatureExperienceSurvey',
+    'enableFeatureRemoveSearchTools',
     'enableRequestID',
     'enableStrictMode',
     'experiments',
@@ -371,6 +372,9 @@ module.exports = {
 
   enableFeatureExperienceSurvey: false,
   dismissedExperienceSurveyCookieName: 'dismissedExperienceSurvey',
+
+  // See: https://github.com/mozilla/addons-frontend/issues/8680
+  enableFeatureRemoveSearchTools: false,
 
   // The withExperiment HOC relies on this config to enable/disable A/B
   // experiments.

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -32,6 +32,8 @@ module.exports = {
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
 
+  enableFeatureRemoveSearchTools: true,
+
   experiments: {
     installButtonWarning2: true,
   },

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -32,6 +32,8 @@ module.exports = {
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
 
+  enableFeatureRemoveSearchTools: true,
+
   experiments: {
     installButtonWarning2: true,
   },

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
+import config from 'config';
 
 import {
   ADDON_TYPE_EXTENSION,
@@ -34,12 +35,17 @@ const sortSelectName = paramsToFilter.sort;
 
 export class SearchFiltersBase extends React.Component {
   static propTypes = {
+    _config: PropTypes.object.isRequired,
     clientApp: PropTypes.string.isRequired,
     filters: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     i18n: PropTypes.object.isRequired,
     lang: PropTypes.string.isRequired,
     pathname: PropTypes.string.isRequired,
+  };
+
+  static defaultProps = {
+    _config: config,
   };
 
   onSelectElementChange = (event) => {
@@ -123,17 +129,27 @@ export class SearchFiltersBase extends React.Component {
   }
 
   addonTypeOptions() {
-    const { i18n } = this.props;
+    const { _config, i18n } = this.props;
 
-    return [
+    const options = [
       { children: i18n.gettext('All'), value: NO_FILTER },
       { children: i18n.gettext('Extension'), value: ADDON_TYPE_EXTENSION },
-      { children: i18n.gettext('Search Tool'), value: ADDON_TYPE_OPENSEARCH },
-      {
-        children: i18n.gettext('Theme'),
-        value: ADDON_TYPE_STATIC_THEME,
-      },
     ];
+
+    // See: https://github.com/mozilla/addons-frontend/issues/8680
+    if (!_config.get('enableFeatureRemoveSearchTools')) {
+      options.push({
+        children: i18n.gettext('Search Tool'),
+        value: ADDON_TYPE_OPENSEARCH,
+      });
+    }
+
+    options.push({
+      children: i18n.gettext('Theme'),
+      value: ADDON_TYPE_STATIC_THEME,
+    });
+
+    return options;
   }
 
   operatingSystemOptions() {

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -137,7 +137,7 @@ export class SectionLinksBase extends React.Component<InternalProps> {
             )}
 
             {// See: https://github.com/mozilla/addons-frontend/issues/8680
-            _config.get('enableFeatureRemoveSearchTools') !== true && (
+            !_config.get('enableFeatureRemoveSearchTools') && (
               <DropdownMenuItem>
                 <Link className="SectionLinks-dropdownlink" to="/search-tools/">
                   {i18n.gettext('Search Tools')}

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import config from 'config';
 
 import Link from 'amo/components/Link';
 import { setClientApp } from 'core/actions';
@@ -37,7 +38,16 @@ type Props = {|
   viewContext: ViewContextType,
 |};
 
-export class SectionLinksBase extends React.Component<Props> {
+type InternalProps = {
+  ...Props,
+  _config: typeof config,
+};
+
+export class SectionLinksBase extends React.Component<InternalProps> {
+  static defaultProps = {
+    _config: config,
+  };
+
   setClientApp = (event: Object) => {
     event.preventDefault();
 
@@ -50,7 +60,7 @@ export class SectionLinksBase extends React.Component<Props> {
   };
 
   render() {
-    const { className, clientApp, i18n, viewContext } = this.props;
+    const { _config, className, clientApp, i18n, viewContext } = this.props;
     const isExploring = [VIEW_CONTEXT_EXPLORE, VIEW_CONTEXT_HOME].includes(
       viewContext,
     );
@@ -111,6 +121,7 @@ export class SectionLinksBase extends React.Component<Props> {
             <DropdownMenuItem className="SectionLinks-subheader">
               {forBrowserNameText}
             </DropdownMenuItem>
+
             {clientApp !== CLIENT_APP_ANDROID && (
               <DropdownMenuItem>
                 <Link
@@ -124,11 +135,15 @@ export class SectionLinksBase extends React.Component<Props> {
                 </Link>
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem>
-              <Link className="SectionLinks-dropdownlink" to="/search-tools/">
-                {i18n.gettext('Search Tools')}
-              </Link>
-            </DropdownMenuItem>
+
+            {// See: https://github.com/mozilla/addons-frontend/issues/8680
+            _config.get('enableFeatureRemoveSearchTools') !== true && (
+              <DropdownMenuItem>
+                <Link className="SectionLinks-dropdownlink" to="/search-tools/">
+                  {i18n.gettext('Search Tools')}
+                </Link>
+              </DropdownMenuItem>
+            )}
 
             <DropdownMenuItem className="SectionLinks-subheader">
               {i18n.gettext('Other Browser Sites')}

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -2,16 +2,27 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import config from 'config';
 
 import Search from 'amo/components/Search';
 import HeadLinks from 'amo/components/HeadLinks';
 import HeadMetaTags from 'amo/components/HeadMetaTags';
 import Page from 'amo/components/Page';
-import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_TOP_RATED } from 'core/constants';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_OPENSEARCH,
+  SEARCH_SORT_POPULAR,
+  SEARCH_SORT_RECOMMENDED,
+  SEARCH_SORT_TOP_RATED,
+} from 'core/constants';
 import translate from 'core/i18n/translate';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
-import type { SearchFilters } from 'amo/components/AutoSearchInput';
+import { makeQueryString } from 'core/api';
+import { sendServerRedirect } from 'core/reducers/redirectTo';
+import type { AppState } from 'amo/store';
+import type { DispatchFunc } from 'core/types/redux';
 import type { I18nType } from 'core/types/i18n';
+import type { SearchFilters } from 'amo/components/AutoSearchInput';
 
 type Props = {|
   filters: SearchFilters,
@@ -19,10 +30,40 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
+  _config: typeof config,
+  clientApp: string,
+  dispatch: DispatchFunc,
   i18n: I18nType,
+  lang: string,
 |};
 
 export class SearchToolsBase extends React.Component<InternalProps> {
+  static defaultProps = {
+    _config: config,
+  };
+
+  constructor(props: InternalProps) {
+    super(props);
+
+    // See: https://github.com/mozilla/addons-frontend/issues/8679
+    if (props._config.get('enableFeatureRemoveSearchTools')) {
+      const { clientApp, dispatch, lang } = props;
+
+      const queryString = makeQueryString({
+        category: 'search-tools',
+        sort: `${SEARCH_SORT_RECOMMENDED},${SEARCH_SORT_POPULAR}`,
+        type: ADDON_TYPE_EXTENSION,
+      });
+
+      dispatch(
+        sendServerRedirect({
+          status: 301,
+          url: `/${lang}/${clientApp}/search/${queryString}`,
+        }),
+      );
+    }
+  }
+
   render() {
     const { filters, i18n } = this.props;
 
@@ -47,13 +88,17 @@ export class SearchToolsBase extends React.Component<InternalProps> {
   }
 }
 
-export function mapStateToProps() {
+export function mapStateToProps(state: AppState) {
   const filters = {
     addonType: ADDON_TYPE_OPENSEARCH,
     sort: SEARCH_SORT_TOP_RATED,
   };
 
-  return { filters };
+  return {
+    filters,
+    clientApp: state.api.clientApp,
+    lang: state.api.lang,
+  };
 }
 
 const SearchTools: React.ComponentType<Props> = compose(

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -11,14 +11,13 @@ import Page from 'amo/components/Page';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_OPENSEARCH,
-  SEARCH_SORT_POPULAR,
-  SEARCH_SORT_RECOMMENDED,
   SEARCH_SORT_TOP_RATED,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import { makeQueryString } from 'core/api';
 import { sendServerRedirect } from 'core/reducers/redirectTo';
+import { getCategoryResultsQuery } from 'core/utils';
 import type { AppState } from 'amo/store';
 import type { DispatchFunc } from 'core/types/redux';
 import type { I18nType } from 'core/types/i18n';
@@ -49,11 +48,12 @@ export class SearchToolsBase extends React.Component<InternalProps> {
     if (props._config.get('enableFeatureRemoveSearchTools')) {
       const { clientApp, dispatch, lang } = props;
 
-      const queryString = makeQueryString({
-        category: 'search-tools',
-        sort: `${SEARCH_SORT_RECOMMENDED},${SEARCH_SORT_POPULAR}`,
-        type: ADDON_TYPE_EXTENSION,
-      });
+      const queryString = makeQueryString(
+        getCategoryResultsQuery({
+          addonType: ADDON_TYPE_EXTENSION,
+          slug: 'search-tools',
+        }),
+      );
 
       dispatch(
         sendServerRedirect({

--- a/tests/unit/amo/components/TestSearchFilters.js
+++ b/tests/unit/amo/components/TestSearchFilters.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import SearchFilters, { SearchFiltersBase } from 'amo/components/SearchFilters';
 import {
   ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_OPENSEARCH,
   ADDON_TYPE_STATIC_THEME,
   OS_LINUX,
   SEARCH_SORT_RANDOM,
@@ -21,6 +22,7 @@ import {
   createStubErrorHandler,
   dispatchClientMetadata,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 
@@ -429,7 +431,7 @@ describe(__filename, () => {
     expect(root.find('.SearchFilters-AddonType')).toHaveLength(0);
   });
 
-  it('sets themes filters shelf with the ADDON_TYPE_STATIC_THEME filter', () => {
+  it('renders a theme option', () => {
     const root = render();
     const selectFilters = root.find(Select);
 
@@ -438,5 +440,31 @@ describe(__filename, () => {
       .children()
       .map((option) => option.props().value);
     expect(optionValues).toContain(ADDON_TYPE_STATIC_THEME);
+  });
+
+  it('renders a search tools option', () => {
+    const _config = getFakeConfig({ enableFeatureRemoveSearchTools: false });
+
+    const root = render({ _config });
+
+    const selectFilters = root.find(Select);
+    const optionValues = selectFilters
+      .find('#SearchFilters-AddonType')
+      .children()
+      .map((option) => option.props().value);
+    expect(optionValues).toContain(ADDON_TYPE_OPENSEARCH);
+  });
+
+  it('does not render a search tools option when the feature flag is active', () => {
+    const _config = getFakeConfig({ enableFeatureRemoveSearchTools: true });
+
+    const root = render({ _config });
+
+    const selectFilters = root.find(Select);
+    const optionValues = selectFilters
+      .find('#SearchFilters-AddonType')
+      .children()
+      .map((option) => option.props().value);
+    expect(optionValues).not.toContain(ADDON_TYPE_OPENSEARCH);
   });
 });

--- a/tests/unit/amo/components/TestSectionLinks.js
+++ b/tests/unit/amo/components/TestSectionLinks.js
@@ -18,6 +18,7 @@ import {
   createFakeHistory,
   dispatchClientMetadata,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import DropdownMenu from 'ui/components/DropdownMenu';
@@ -75,13 +76,27 @@ describe(__filename, () => {
   });
 
   it('renders a link to the Search Tools page', () => {
-    const root = render({ viewContext: ADDON_TYPE_EXTENSION });
+    const _config = getFakeConfig({ enableFeatureRemoveSearchTools: false });
+
+    const root = render({ _config, viewContext: ADDON_TYPE_EXTENSION });
 
     expect(
       root.find('.SectionLinks-dropdownlink').findWhere((element) => {
         return element.prop('to') === '/search-tools/';
       }),
     ).toHaveProp('children', 'Search Tools');
+  });
+
+  it('does not render a link to the Search Tools page when feature flag is active', () => {
+    const _config = getFakeConfig({ enableFeatureRemoveSearchTools: true });
+
+    const root = render({ _config, viewContext: ADDON_TYPE_EXTENSION });
+
+    expect(
+      root.find('.SectionLinks-dropdownlink').findWhere((element) => {
+        return element.prop('to') === '/search-tools/';
+      }),
+    ).toHaveLength(0);
   });
 
   it('renders Explore active on homepage', () => {

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -5,9 +5,11 @@ import Search from 'amo/components/Search';
 import HeadLinks from 'amo/components/HeadLinks';
 import HeadMetaTags from 'amo/components/HeadMetaTags';
 import { ADDON_TYPE_OPENSEARCH, SEARCH_SORT_TOP_RATED } from 'core/constants';
+import { sendServerRedirect } from 'core/reducers/redirectTo';
 import {
   dispatchClientMetadata,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 
@@ -52,5 +54,44 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find(HeadLinks)).toHaveLength(1);
+  });
+
+  describe('enableFeatureRemoveSearchTools = true', () => {
+    const renderWithoutSearchTools = (props = {}) => {
+      const _config = getFakeConfig({ enableFeatureRemoveSearchTools: true });
+
+      return render({ _config, ...props });
+    };
+
+    it('sends a server redirect', () => {
+      const fakeDispatch = sinon.spy(store, 'dispatch');
+
+      renderWithoutSearchTools();
+
+      sinon.assert.calledWith(
+        fakeDispatch,
+        sendServerRedirect({
+          status: 301,
+          url: sinon.match('/en-US/android/search/?category=search-tools'),
+        }),
+      );
+      sinon.assert.callCount(fakeDispatch, 1);
+    });
+  });
+
+  describe('enableFeatureRemoveSearchTools = false', () => {
+    const renderWithSearchTools = (props = {}) => {
+      const _config = getFakeConfig({ enableFeatureRemoveSearchTools: false });
+
+      return render({ _config, ...props });
+    };
+
+    it('does not send a server redirect', () => {
+      const fakeDispatch = sinon.spy(store, 'dispatch');
+
+      renderWithSearchTools();
+
+      sinon.assert.notCalled(fakeDispatch);
+    });
   });
 });

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -57,16 +57,11 @@ describe(__filename, () => {
   });
 
   describe('enableFeatureRemoveSearchTools = true', () => {
-    const renderWithoutSearchTools = (props = {}) => {
-      const _config = getFakeConfig({ enableFeatureRemoveSearchTools: true });
-
-      return render({ _config, ...props });
-    };
-
     it('sends a server redirect', () => {
+      const _config = getFakeConfig({ enableFeatureRemoveSearchTools: true });
       const fakeDispatch = sinon.spy(store, 'dispatch');
 
-      renderWithoutSearchTools();
+      render({ _config });
 
       sinon.assert.calledWith(
         fakeDispatch,
@@ -80,16 +75,11 @@ describe(__filename, () => {
   });
 
   describe('enableFeatureRemoveSearchTools = false', () => {
-    const renderWithSearchTools = (props = {}) => {
-      const _config = getFakeConfig({ enableFeatureRemoveSearchTools: false });
-
-      return render({ _config, ...props });
-    };
-
     it('does not send a server redirect', () => {
+      const _config = getFakeConfig({ enableFeatureRemoveSearchTools: false });
       const fakeDispatch = sinon.spy(store, 'dispatch');
 
-      renderWithSearchTools();
+      render({ _config });
 
       sinon.assert.notCalled(fakeDispatch);
     });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8679
Fixes https://github.com/mozilla/addons-frontend/issues/8680

---

This patch adds a new feature flag to remove the main access points to the search tools. It also adds a server redirect to handle requests to `/search-tools/`. The `/search-engines/` is handled at the [nginx level](https://github.com/mozilla-services/cloudops-deployment/blob/be40e0b13a1c2a9d4322027e8955647a74753e8e/projects/amo/puppet/modules/amo_proxy/templates/nginx.addons.conf.erb#L382-L385).

The feature flag is active for local dev and -dev for QA.