### PR TITLE
Add circleci config for more memory in containers.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ jobs:
     working_directory: ~/addons-frontend
     machine:
       image: ubuntu-1604:201903-01
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The integration-test job runs out of memory, this should help with that.