### PR TITLE
Hide redundant rating titles from Accessibility

### DIFF
--- a/src/ui/components/Rating/index.js
+++ b/src/ui/components/Rating/index.js
@@ -140,6 +140,7 @@ export class RatingBase extends React.Component<InternalProps, StateType> {
         thisRating - rating > 0.25 && thisRating - rating <= 0.75;
 
       const props = {
+        'aria-hidden': readOnly,
         className: makeClassName('Rating-star', `Rating-rating-${thisRating}`, {
           'Rating-selected-star': isSelected,
           'Rating-half-star': halfStar,
@@ -225,6 +226,7 @@ export class RatingBase extends React.Component<InternalProps, StateType> {
 
     return (
       <div
+        aria-hidden="true"
         className={allClassNames}
         title={description}
         onMouseLeave={this.stopHovering}

--- a/tests/unit/ui/components/TestRating.js
+++ b/tests/unit/ui/components/TestRating.js
@@ -433,6 +433,11 @@ describe(__filename, () => {
       expect(star).toHaveProp('yellow');
       expect(star).toHaveProp('readOnly', true);
     });
+
+    it("hides multiple redundant title for accessibility when it's readOnly", () => {
+      const root = render({ readOnly: true });
+      expect(root).toHaveProp('aria-hidden', 'true');
+    });
   });
 
   describe('rating counts', () => {


### PR DESCRIPTION
Fixes #8829 

I have added `aria-hidden="true"` to all the six rating titles.