### PR TITLE
Do not render 'for Android' section when there is no link

### DIFF
--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -72,6 +72,35 @@ export class SectionLinksBase extends React.Component<InternalProps> {
       forBrowserNameText = i18n.gettext('for Android');
     }
 
+    const sectionsForBrowser = [];
+
+    if (clientApp !== CLIENT_APP_ANDROID) {
+      sectionsForBrowser.push(
+        <DropdownMenuItem key="dictionaries-and-language-packs">
+          <Link
+            className={makeClassName('SectionLinks-dropdownlink', {
+              'SectionLinks-dropdownlink--active':
+                viewContext === VIEW_CONTEXT_LANGUAGE_TOOLS,
+            })}
+            to="/language-tools/"
+          >
+            {i18n.gettext('Dictionaries & Language Packs')}
+          </Link>
+        </DropdownMenuItem>,
+      );
+    }
+
+    // See: https://github.com/mozilla/addons-frontend/issues/8680
+    if (!_config.get('enableFeatureRemoveSearchTools')) {
+      sectionsForBrowser.push(
+        <DropdownMenuItem key="search-tools">
+          <Link className="SectionLinks-dropdownlink" to="/search-tools/">
+            {i18n.gettext('Search Tools')}
+          </Link>
+        </DropdownMenuItem>,
+      );
+    }
+
     return (
       <ul className={makeClassName('SectionLinks', className)}>
         <li>
@@ -118,32 +147,12 @@ export class SectionLinksBase extends React.Component<InternalProps> {
             className="SectionLinks-link SectionLinks-dropdown"
             text={i18n.gettext('More…')}
           >
-            <DropdownMenuItem className="SectionLinks-subheader">
-              {forBrowserNameText}
-            </DropdownMenuItem>
-
-            {clientApp !== CLIENT_APP_ANDROID && (
-              <DropdownMenuItem>
-                <Link
-                  className={makeClassName('SectionLinks-dropdownlink', {
-                    'SectionLinks-dropdownlink--active':
-                      viewContext === VIEW_CONTEXT_LANGUAGE_TOOLS,
-                  })}
-                  to="/language-tools/"
-                >
-                  {i18n.gettext('Dictionaries & Language Packs')}
-                </Link>
+            {sectionsForBrowser.length > 0 && (
+              <DropdownMenuItem className="SectionLinks-subheader">
+                {forBrowserNameText}
               </DropdownMenuItem>
             )}
-
-            {// See: https://github.com/mozilla/addons-frontend/issues/8680
-            !_config.get('enableFeatureRemoveSearchTools') && (
-              <DropdownMenuItem>
-                <Link className="SectionLinks-dropdownlink" to="/search-tools/">
-                  {i18n.gettext('Search Tools')}
-                </Link>
-              </DropdownMenuItem>
-            )}
+            {sectionsForBrowser}
 
             <DropdownMenuItem className="SectionLinks-subheader">
               {i18n.gettext('Other Browser Sites')}

--- a/tests/unit/amo/components/TestSectionLinks.js
+++ b/tests/unit/amo/components/TestSectionLinks.js
@@ -99,6 +99,21 @@ describe(__filename, () => {
     ).toHaveLength(0);
   });
 
+  it('does not render the "for Android" section when there is no link for it', () => {
+    // There should be no "for Android" section because:
+    // 1. we browse the "android" version of the website
+    _store.dispatch(setClientApp(CLIENT_APP_ANDROID));
+    // 2. the "remove search tools" feature is enabled
+    const _config = getFakeConfig({ enableFeatureRemoveSearchTools: true });
+
+    const root = render({ _config });
+
+    expect(root.find('.SectionLinks-subheader')).toHaveLength(1);
+    expect(root.find('.SectionLinks-subheader').children()).not.toIncludeText(
+      'for Android',
+    );
+  });
+
   it('renders Explore active on homepage', () => {
     _store.dispatch(setViewContext(VIEW_CONTEXT_EXPLORE));
     const root = render();


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8940

---

Before:

![](https://user-images.githubusercontent.com/33448286/68946044-a6aeb380-07ba-11ea-83d5-b23f9420c3fb.png)

After:

![Screen Shot 2019-11-15 at 14 25 20](https://user-images.githubusercontent.com/217628/68947188-23d72a00-07b5-11ea-8ff9-cdd0a58df9bf.png)
