### PR TITLE
Enable abuse reporting via Firefox for static themes

### DIFF
--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { ADDON_TYPE_EXTENSION } from 'core/constants';
+import { ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
@@ -93,10 +93,7 @@ export class ReportAbuseButtonBase extends React.Component<InternalProps> {
       // localized descriptions only for these two kind of addons), and so
       // currently it is going to refuse to create an abuse report panel for
       // langpacks, dictionaries and search tools.
-      //
-      // Static themes should be supported but there is a bug in FF, see:
-      // https://github.com/mozilla/addons-frontend/issues/8762#issuecomment-553430081
-      [ADDON_TYPE_EXTENSION].includes(addon.type)
+      [ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME].includes(addon.type)
     ) {
       dispatch(initiateAddonAbuseReportViaFirefox({ addon }));
       return;

--- a/tests/unit/amo/components/TestReportAbuseButton.js
+++ b/tests/unit/amo/components/TestReportAbuseButton.js
@@ -143,7 +143,7 @@ describe(__filename, () => {
     expect(root.find('.ReportAbuseButton--is-expanded')).toHaveLength(1);
   });
 
-  it.each([ADDON_TYPE_EXTENSION])(
+  it.each([ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME])(
     'initiates an abuse report via Firefox when the "report" button is clicked if supported and add-on type is %s',
     (addonType) => {
       const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);
@@ -167,12 +167,7 @@ describe(__filename, () => {
     },
   );
 
-  it.each([
-    ADDON_TYPE_DICT,
-    ADDON_TYPE_LANG,
-    ADDON_TYPE_OPENSEARCH,
-    ADDON_TYPE_STATIC_THEME,
-  ])(
+  it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG, ADDON_TYPE_OPENSEARCH])(
     'does not initiate an abuse report via Firefox when add-on type is %s',
     (addonType) => {
       const _hasAbuseReportPanelEnabled = sinon.stub().returns(true);


### PR DESCRIPTION
Fixes #8931 