### PR TITLE
See more links overlapping in mobile landscape 8737

### DIFF
--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -22,15 +22,9 @@
       top: 0;
 
       @include respond-to(large) {
-          [dir='ltr'] & {
-              padding-left:0;
-              left: 50%;
-          }
+        @include padding-start(0);
 
-          [dir='rtl'] & {
-              right:50%;
-              padding-right:0;
-          }
+        width: 50%;
       }
     }
 

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -20,6 +20,18 @@
       border: 0;
       position: absolute;
       top: 0;
+
+      @include respond-to(large) {
+          [dir='ltr'] & {
+              padding-left:0;
+              left: 50%;
+          }
+
+          [dir='rtl'] & {
+              right:50%;
+              padding-right:0;
+          }
+      }
     }
 
     ul.AddonsCard-list {

--- a/src/ui/components/Card/styles.scss
+++ b/src/ui/components/Card/styles.scss
@@ -66,6 +66,9 @@ $footer-padding: 10px;
     font-weight: normal;
     padding: $footer-padding;
     text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   a:focus {

--- a/src/ui/components/Card/styles.scss
+++ b/src/ui/components/Card/styles.scss
@@ -64,9 +64,9 @@ $footer-padding: 10px;
     color: $link-color;
     display: block;
     font-weight: normal;
+    overflow: hidden;
     padding: $footer-padding;
     text-decoration: none;
-    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }


### PR DESCRIPTION
Fixes #8737 

Limited the see-more to max 50% to avoid overlap and add ellipsis in case the text is too long.
This is my first PR here. Please let me know if you have any feedback.

Before
![image](https://user-images.githubusercontent.com/17780574/69796092-ad332700-11cd-11ea-98b5-2998e9bd4ec7.png)


After
![image](https://user-images.githubusercontent.com/17780574/69796144-c8059b80-11cd-11ea-9732-46a3ff153cb8.png)

