### PR TITLE
Default experiment cookies to secure cookies

### DIFF
--- a/src/core/withExperiment.js
+++ b/src/core/withExperiment.js
@@ -62,6 +62,7 @@ export type WithExperimentInjectedProps = {|
 type CookieConfig = {|
   maxAge?: number,
   path?: string,
+  secure?: boolean,
 |};
 
 type ExperimentVariant = {|
@@ -114,6 +115,7 @@ type withExperimentInternalProps = {|
 export const defaultCookieConfig: CookieConfig = {
   maxAge: DEFAULT_COOKIE_MAX_AGE,
   path: '/',
+  secure: true,
 };
 
 export const withExperiment = ({

--- a/src/core/withExperiment.js
+++ b/src/core/withExperiment.js
@@ -59,6 +59,7 @@ export type WithExperimentInjectedProps = {|
   variant: string | null,
 |};
 
+// https://github.com/reactivestack/cookies/tree/f9beead40a6bebac475d9bf17c1da55418d26751/packages/react-cookie#setcookiename-value-options
 type CookieConfig = {|
   maxAge?: number,
   path?: string,
@@ -115,6 +116,7 @@ type withExperimentInternalProps = {|
 export const defaultCookieConfig: CookieConfig = {
   maxAge: DEFAULT_COOKIE_MAX_AGE,
   path: '/',
+  // See https://github.com/mozilla/addons-frontend/issues/8957
   secure: true,
 };
 


### PR DESCRIPTION
Fixes #8957 by making the cookie secure. @psiinon is going to whitelist the cookie to allow it to remain non-httpOnly.