### PR TITLE
Update file-loader to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "eslint-config-amo": "^1.14.0",
     "eslint-plugin-amo": "^1.9.1",
     "eslint-plugin-promise": "^4.0.0",
-    "file-loader": "^5.0.0",
+    "file-loader": "^5.0.2",
     "flow-bin": "^0.110.0",
     "glob": "^7.1.1",
     "html-webpack-plugin": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6250,10 +6250,10 @@ file-loader@^3.0.1:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
-file-loader@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-5.0.0.tgz#4342ecdf64a3375d330e6464534745dab4252023"
-  integrity sha512-dWYcWE80fLMw9VO7yBtDQ0Ai6VvsB/z/NdifU57Ap77Xg+h0QcM12cPdXPySv+fxgD6frlZ+xnVaklib2UJJkg==
+file-loader@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-5.0.2.tgz#7f3d8b4ac85a5e8df61338cfec95d7405f971caa"
+  integrity sha512-QMiQ+WBkGLejKe81HU8SZ9PovsU/5uaLo0JdTCEXOYv7i7jfAjHZi1tcwp9tSASJPOmmHZtbdCervFmXMH/Dcg==
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"


### PR DESCRIPTION
This is needed as the `esModule` option has been introduced in version 5.0.2 (5.0.0 used `esModules`).