### PR TITLE
Prevent the primary hero image from changing its size on smalle…

### DIFF
--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -164,7 +164,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
 
           <div className="HeroRecommendation-content">
             {featuredImage && (
-              <div>
+              <div className="HeroRecommendation-image-container">
                 <img
                   className="HeroRecommendation-image"
                   alt=""

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -43,7 +43,7 @@
 
 .HeroRecommendation-info {
   display: flex;
-  flex: 1 1 0px;
+  flex: 1 1 0;
   flex-direction: column;
 
   @include respond-to(medium) {
@@ -62,7 +62,7 @@
 }
 
 .HeroRecommendation-image-container {
-  flex: 1 1 0px;
+  flex: 1 1 0;
 
   @include respond-to(extraLarge) {
     flex: 0 1 auto;

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -43,6 +43,7 @@
 
 .HeroRecommendation-info {
   display: flex;
+  flex: 1 1 0px;
   flex-direction: column;
 
   @include respond-to(medium) {
@@ -51,10 +52,20 @@
 
   @include respond-to(extraLarge) {
     @include margin-start(96px);
+
+    flex: 1;
   }
 
   @include respond-to(extraExtraLarge) {
     @include margin-start(132px);
+  }
+}
+
+.HeroRecommendation-image-container {
+  flex: 1 1 0px;
+
+  @include respond-to(extraLarge) {
+    flex: 0 1 auto;
   }
 }
 


### PR DESCRIPTION
Fixes #8949 

This causes the primary hero image to remain the same size, on smaller screens, regardless of the amount of text to the right of the image. 

Here are some samples showing the sizes of image with different amounts of text for different add-ons:

Before:

![Screen Shot 2019-12-03 at 11 20 18](https://user-images.githubusercontent.com/142755/70068988-ff55bd00-15be-11ea-81b0-0455fa4aea39.png)

![Screen Shot 2019-12-03 at 11 19 18](https://user-images.githubusercontent.com/142755/70069002-067ccb00-15bf-11ea-8b08-cbe26dbb924a.png)

![Screen Shot 2019-12-03 at 11 18 35](https://user-images.githubusercontent.com/142755/70069018-0d0b4280-15bf-11ea-81ef-e8451ebea899.png)

After:

![Screen Shot 2019-12-03 at 11 11 27](https://user-images.githubusercontent.com/142755/70068546-2cee3680-15be-11ea-8d2d-6f523d6cde21.png)

![Screen Shot 2019-12-03 at 11 11 06](https://user-images.githubusercontent.com/142755/70068556-32e41780-15be-11ea-921e-3f4c15db3423.png)

![Screen Shot 2019-12-03 at 11 11 44](https://user-images.githubusercontent.com/142755/70068523-219b0b00-15be-11ea-9efe-8d00f8be914b.png)
