### PR TITLE
do not test built-in discopane

### DIFF
--- a/tests/ui/tests/test_discopane.py
+++ b/tests/ui/tests/test_discopane.py
@@ -13,13 +13,6 @@ def incorrect_disco_url(firefox_options):
 
 
 @pytest.mark.nondestructive
-def test_discopane_error_loads(incorrect_disco_url, selenium, open_discopane):
-    """Test that the error alert shows."""
-    discovery_pane = open_discopane
-    assert discovery_pane.is_error_alert_displayed
-
-
-@pytest.mark.nondestructive
 def test_discopane_loads(discovery_pane):
     """Test that discovery pane loads."""
     assert discovery_pane.is_header_displayed


### PR DESCRIPTION
Fixes #9030

---

Although I am not sure why this test is failing precisely (I did not look at the latest FF changes), I think it does not make much sense to test the discopane built in FF. Before the FF discopane, we were loading an iframe. When this iframe was not present, we displayed a message. I think this is what this test case covers.