### PR TITLE
Bring back primary hero loading indicators

### DIFF
--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -164,7 +164,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
 
           <div className="HeroRecommendation-content">
             {featuredImage && (
-              <div>
+              <div className="HeroRecommendation-image-wrapper">
                 <img
                   className="HeroRecommendation-image"
                   alt=""

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -164,7 +164,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
 
           <div className="HeroRecommendation-content">
             {featuredImage && (
-              <div className="HeroRecommendation-image-container">
+              <div>
                 <img
                   className="HeroRecommendation-image"
                   alt=""

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -41,12 +41,24 @@
   }
 }
 
+.HeroRecommendation-image-wrapper {
+  @include respond-to(medium) {
+    flex: 40%;
+  }
+
+  @include respond-to(extraExtraLarge) {
+    flex: initial;
+  }
+}
+
 .HeroRecommendation-info {
   display: flex;
   flex-direction: column;
 
   @include respond-to(medium) {
     @include margin-start(24px);
+
+    flex: 60%;
   }
 
   @include respond-to(extraLarge) {
@@ -55,6 +67,8 @@
 
   @include respond-to(extraExtraLarge) {
     @include margin-start(132px);
+
+    flex: initial;
   }
 }
 

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -43,7 +43,6 @@
 
 .HeroRecommendation-info {
   display: flex;
-  flex: 1 1 0;
   flex-direction: column;
 
   @include respond-to(medium) {
@@ -52,20 +51,10 @@
 
   @include respond-to(extraLarge) {
     @include margin-start(96px);
-
-    flex: 1;
   }
 
   @include respond-to(extraExtraLarge) {
     @include margin-start(132px);
-  }
-}
-
-.HeroRecommendation-image-container {
-  flex: 1 1 0;
-
-  @include respond-to(extraLarge) {
-    flex: 0 1 auto;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9034 (maybe)

---

I had to re-read https://github.com/mozilla/addons-frontend/issues/8949 to
understand the previous changes, which I reverted because it was hard to
follow. I tried something without really believing in it (the `max-width`
thingy) but it seems to fix both issues so maybe that's what we want? WDYT?