### PR TITLE
Create a helper to identify Fenix

### DIFF
--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -89,6 +89,22 @@ export const isFirefox = ({
   return userAgentInfo.browser.name === 'Firefox';
 };
 
+export const isFenix = (userAgentInfo: UserAgentInfoType): boolean => {
+  // If the userAgent is false there was likely a programming error.
+  invariant(userAgentInfo, 'userAgentInfo is required');
+
+  const { browser, os } = userAgentInfo;
+
+  if (
+    isFirefox({ userAgentInfo }) &&
+    os.name === USER_AGENT_OS_ANDROID &&
+    mozCompare(browser.version, '69.0') >= 0
+  ) {
+    return true;
+  }
+  return false;
+};
+
 export type IsCompatibleWithUserAgentParams = {|
   _findInstallURL?: typeof findInstallURL,
   _log?: typeof log,
@@ -140,10 +156,7 @@ export function isCompatibleWithUserAgent({
   // Fenix does not support add-ons (yet?).
   // See: https://github.com/mozilla-mobile/fenix/issues/1134
   // See also: https://github.com/mozilla/addons-frontend/issues/7963
-  if (
-    os.name === USER_AGENT_OS_ANDROID &&
-    mozCompare(browser.version, '69.0') >= 0
-  ) {
+  if (isFenix(userAgentInfo)) {
     return { compatible: false, reason: INCOMPATIBLE_FIREFOX_FENIX };
   }
 

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -27,6 +27,7 @@ import {
   getCompatibleVersions,
   getClientCompatibility,
   isCompatibleWithUserAgent,
+  isFenix,
   isFirefox,
   isQuantumCompatible,
   correctedLocationForPlatform,
@@ -1081,5 +1082,55 @@ describe(__filename, () => {
         ).toEqual(null);
       },
     );
+  });
+
+  describe('isFenix', () => {
+    it('returns true for Firefox Fenix', () => {
+      userAgents.fenix.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(true);
+      });
+    });
+
+    it('returns false for Android/webkit', () => {
+      userAgents.androidWebkit.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(false);
+      });
+    });
+
+    it('returns false for Chrome Android', () => {
+      userAgents.chromeAndroid.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(false);
+      });
+    });
+
+    it('returns false for Chrome desktop', () => {
+      userAgents.chrome.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(false);
+      });
+    });
+
+    it('returns false for Firefox desktop', () => {
+      userAgents.firefox.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(false);
+      });
+    });
+
+    it('returns false for Firefox Android', () => {
+      userAgents.firefoxAndroid.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(false);
+      });
+    });
+
+    it('returns false for Firefox OS', () => {
+      userAgents.firefoxOS.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(false);
+      });
+    });
+
+    it('returns false for Firefox iOS', () => {
+      userAgents.firefoxIOS.forEach((userAgent) => {
+        expect(isFenix(UAParser(userAgent))).toEqual(false);
+      });
+    });
   });
 });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -683,6 +683,8 @@ export const userAgentsByPlatform = {
       Gecko/40.0 Firefox/40.0`,
     firefox40Tablet: oneLine`Mozilla/5.0 (Android; Tablet; rv:40.0)
       Gecko/40.0 Firefox/40.0`,
+    firefox68: oneLine`Mozilla/5.0 (Android 9; Mobile; rv:68.0) Gecko/68.0
+      Firefox/68.0`,
   },
   fenix: {
     firefox69: oneLine`Mozilla/5.0 (Android 9; Mobile; rv:69.0) Gecko/69.0


### PR DESCRIPTION
Fixes #9069 

This introduces a helper that identifies Fenix, based on an OS of Android, browser of Firefox, and version of 69 or higher.

It also replaces the logic that previously existed inside `isCompatibleWithUserAgent` with a call to the new `isFenix` function.