### PR TITLE
Add gnupg in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN buildDeps=' \
     ' && \
     # `apt-transport-https` is required to use https deb repositories
     apt-get update -y && \
-    apt-get install -y --no-install-recommends apt-transport-https && \
+    apt-get install -y --no-install-recommends gnupg ca-certificates apt-transport-https && \
     # configure Yarn repository, see: https://yarnpkg.com/en/docs/install#linux-tab
     apt-key add /etc/pki/yarnpkg.gpg.key && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \


### PR DESCRIPTION
Fixes #9074 

---

This patch re-adds two dependencies we need to be able to install Yarn in our Docker images. It needs both dependencies, adding `gnupg` only leads to the following error:

```
Failed to fetch https://dl.yarnpkg.com/debian/dists/stable/main/binary-amd64/Packages
```

Both dependencies were present before the update on the base image so I assume this patch only brings the old behavior back. At least it works..