### PR TITLE
Warn AMO users when visiting the site with Fenix

### DIFF
--- a/src/amo/components/AddonCompatibilityError/index.js
+++ b/src/amo/components/AddonCompatibilityError/index.js
@@ -92,6 +92,11 @@ export class AddonCompatibilityErrorBase extends React.Component<InternalProps> 
       return null;
     }
 
+    if (reason === INCOMPATIBLE_FIREFOX_FENIX) {
+      // Do not display a message for Fenix, it is dealt with elsewhere.
+      return null;
+    }
+
     if (
       reason === INCOMPATIBLE_ANDROID_UNSUPPORTED &&
       clientApp === CLIENT_APP_FIREFOX
@@ -129,10 +134,6 @@ export class AddonCompatibilityErrorBase extends React.Component<InternalProps> 
     } else if (reason === INCOMPATIBLE_FIREFOX_FOR_IOS) {
       message = i18n.gettext(
         'Firefox for iOS does not currently support add-ons.',
-      );
-    } else if (reason === INCOMPATIBLE_FIREFOX_FENIX) {
-      message = i18n.gettext(
-        'Firefox Preview does not currently support add-ons.',
       );
     } else if (reason === INCOMPATIBLE_UNSUPPORTED_PLATFORM) {
       message = i18n.gettext('This add-on is not available on your platform.');

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -20,8 +20,8 @@ import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
-// TODO: Update this to the correct SUMO article.
-export const FENIX_LINK_DESTINATION = 'https://support.mozilla.org/kb/';
+export const FENIX_LINK_DESTINATION =
+  'https://support.mozilla.org/kb/add-compatibility-firefox-preview/';
 
 type Props = {|
   className?: string,
@@ -63,7 +63,7 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
       message = i18n.sprintf(
         this.props.fixFenixLinkMessage ||
           i18n.gettext(
-            `To find add-ons compatible with Firefox on Android,
+            `To find add-ons compatible with Firefox for Android,
                <a href="%(newLocation)s">click here</a>.`,
           ),
         { newLocation: FENIX_LINK_DESTINATION },

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -8,7 +8,10 @@ import { connect } from 'react-redux';
 import { CLIENT_APP_ANDROID } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
-import { correctedLocationForPlatform } from 'core/utils/compatibility';
+import {
+  correctedLocationForPlatform,
+  isFenix,
+} from 'core/utils/compatibility';
 import Notice, { warningInfoType } from 'ui/components/Notice';
 import type { AppState } from 'amo/store';
 import type { UserAgentInfoType } from 'core/reducers/api';
@@ -17,15 +20,20 @@ import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
+// TODO: Update this to the correct SUMO article.
+export const FENIX_LINK_DESTINATION = 'https://support.mozilla.org/kb/';
+
 type Props = {|
   className?: string,
   fixAndroidLinkMessage?: string,
   fixFirefoxLinkMessage?: string,
+  fixFenixLinkMessage?: string,
 |};
 
 type InternalProps = {|
   ...Props,
   _correctedLocationForPlatform: typeof correctedLocationForPlatform,
+  _isFenix: typeof isFenix,
   clientApp: string,
   i18n: I18nType,
   location: ReactRouterLocationType,
@@ -35,11 +43,13 @@ type InternalProps = {|
 export class WrongPlatformWarningBase extends React.Component<InternalProps> {
   static defaultProps = {
     _correctedLocationForPlatform: correctedLocationForPlatform,
+    _isFenix: isFenix,
   };
 
   render() {
     const {
       _correctedLocationForPlatform,
+      _isFenix,
       className,
       clientApp,
       i18n,
@@ -47,34 +57,47 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
       userAgentInfo,
     } = this.props;
 
-    const newLocation = _correctedLocationForPlatform({
-      clientApp,
-      location,
-      userAgentInfo,
-    });
+    let message;
 
-    if (!newLocation) {
-      return null;
-    }
+    if (_isFenix(userAgentInfo)) {
+      message = i18n.sprintf(
+        this.props.fixFenixLinkMessage ||
+          i18n.gettext(
+            `To find add-ons compatible with Firefox on Android,
+               <a href="%(newLocation)s">click here</a>.`,
+          ),
+        { newLocation: FENIX_LINK_DESTINATION },
+      );
+    } else {
+      const newLocation = _correctedLocationForPlatform({
+        clientApp,
+        location,
+        userAgentInfo,
+      });
 
-    const fixAndroidLinkMessage =
-      this.props.fixAndroidLinkMessage ||
-      i18n.gettext(
-        `To find add-ons compatible with Firefox on Android,
+      if (!newLocation) {
+        return null;
+      }
+
+      const fixAndroidLinkMessage =
+        this.props.fixAndroidLinkMessage ||
+        i18n.gettext(
+          `To find add-ons compatible with Firefox on Android,
                <a href="%(newLocation)s">visit our mobile site</a>.`,
-      );
+        );
 
-    const fixFirefoxLinkMessage =
-      this.props.fixFirefoxLinkMessage ||
-      i18n.gettext(
-        `To find add-ons compatible with Firefox on desktop,
+      const fixFirefoxLinkMessage =
+        this.props.fixFirefoxLinkMessage ||
+        i18n.gettext(
+          `To find add-ons compatible with Firefox on desktop,
                <a href="%(newLocation)s">visit our desktop site</a>.`,
-      );
+        );
 
-    const message =
-      clientApp === CLIENT_APP_ANDROID
-        ? i18n.sprintf(fixFirefoxLinkMessage, { newLocation })
-        : i18n.sprintf(fixAndroidLinkMessage, { newLocation });
+      message =
+        clientApp === CLIENT_APP_ANDROID
+          ? i18n.sprintf(fixFirefoxLinkMessage, { newLocation })
+          : i18n.sprintf(fixAndroidLinkMessage, { newLocation });
+    }
 
     return (
       <div className={makeClassName('WrongPlatformWarning', className)}>

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -63,7 +63,7 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
       message = i18n.sprintf(
         this.props.fixFenixLinkMessage ||
           i18n.gettext(
-            `To find add-ons compatible with Firefox for Android,
+            `To learn about add-ons compatible with Firefox for Android,
                <a href="%(newLocation)s">click here</a>.`,
           ),
         { newLocation: FENIX_LINK_DESTINATION },

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -488,7 +488,7 @@ export class AddonBase extends React.Component {
                 )}
                 fixFenixLinkMessage={i18n.gettext(
                   `This add-on is not compatible with Firefox for Android.
-                    <a href="%(newLocation)s">Browse compatible add-ons</a>.`,
+                    <a href="%(newLocation)s">Learn more</a>.`,
                 )}
               />
               {addon && <InstallWarning addon={addon} />}

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -486,6 +486,10 @@ export class AddonBase extends React.Component {
                   `This listing is not intended for this platform.
                     <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
                 )}
+                fixFenixLinkMessage={i18n.gettext(
+                  `This add-on is not compatible with Firefox for Android.
+                    <a href="%(newLocation)s">Browse compatible add-ons</a>.`,
+                )}
               />
               {addon && <InstallWarning addon={addon} />}
             </Card>

--- a/tests/unit/amo/components/TestAddonCompatibilityError.js
+++ b/tests/unit/amo/components/TestAddonCompatibilityError.js
@@ -255,19 +255,14 @@ describe(__filename, () => {
     ).toContain('Firefox for iOS does not currently support add-ons.');
   });
 
-  it('renders a notice for Fenix users', () => {
+  it('renders nothing if the browser is Fenix', () => {
     const _getClientCompatibility = makeGetClientCompatibilityIncompatible({
       reason: INCOMPATIBLE_FIREFOX_FENIX,
     });
 
     const root = render({ _getClientCompatibility });
 
-    expect(
-      root
-        .find('.AddonCompatibilityError')
-        .childAt(0)
-        .html(),
-    ).toContain('Firefox Preview does not currently support add-ons.');
+    expect(root.find('.AddonCompatibilityError')).toHaveLength(0);
   });
 
   it('renders a notice for browsers that do not support OpenSearch', () => {

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import UAParser from 'ua-parser-js';
 
 import WrongPlatformWarning, {
+  FENIX_LINK_DESTINATION,
   WrongPlatformWarningBase,
 } from 'amo/components/WrongPlatformWarning';
 import { CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX } from 'core/constants';
@@ -16,10 +17,12 @@ import {
 
 describe(__filename, () => {
   let _correctedLocationForPlatform;
+  let _isFenix;
   let store;
 
   beforeEach(() => {
     _correctedLocationForPlatform = sinon.stub();
+    _isFenix = sinon.stub();
     store = dispatchClientMetadata().store;
   });
 
@@ -34,6 +37,7 @@ describe(__filename, () => {
   const render = ({ location = createFakeLocation(), ...customProps } = {}) => {
     const props = {
       _correctedLocationForPlatform,
+      _isFenix,
       i18n: fakeI18n(),
       store,
       ...customProps,
@@ -48,8 +52,9 @@ describe(__filename, () => {
     );
   };
 
-  it('returns nothing if no location correction is required', () => {
+  it('returns nothing if not Fenix and no location correction is required', () => {
     _correctedLocationForPlatform.returns(null);
+    _isFenix.returns(false);
     const root = render();
 
     expect(root.find('.WrongPlatformWarning')).toHaveLength(0);
@@ -64,7 +69,32 @@ describe(__filename, () => {
     expect(root).toHaveClassName(className);
   });
 
-  it('calls _correctedLocationForPlatform with clientApp, location and userAgentInfo', () => {
+  it('calls _isFenix to check for Fenix user agent', () => {
+    const clientApp = CLIENT_APP_ANDROID;
+    const userAgent = userAgentsByPlatform.mac.firefox57;
+    const parsedUserAgent = UAParser(userAgent);
+    _dispatchClientMetadata({ clientApp, userAgent });
+
+    render();
+
+    sinon.assert.calledWith(
+      _isFenix,
+      sinon.match({
+        browser: sinon.match(parsedUserAgent.browser),
+        os: sinon.match(parsedUserAgent.os),
+      }),
+    );
+  });
+
+  it('does not call _correctedLocationForPlatform when user agent is Fenix', () => {
+    _isFenix.returns(true);
+    render();
+
+    sinon.assert.notCalled(_correctedLocationForPlatform);
+  });
+
+  it('calls _correctedLocationForPlatform with clientApp, location and userAgentInfo when not Fenix', () => {
+    _isFenix.returns(false);
     const clientApp = CLIENT_APP_ANDROID;
     const userAgent = userAgentsByPlatform.mac.firefox57;
     const parsedUserAgent = UAParser(userAgent);
@@ -101,10 +131,11 @@ describe(__filename, () => {
       ],
     ],
   ])(
-    'generates the expected message when clientApp is %s',
+    'generates the expected message when clientApp is %s and not Fenix',
     (clientApp, expectedText) => {
       const newLocation = '/some/location/';
       _correctedLocationForPlatform.returns(newLocation);
+      _isFenix.returns(false);
       _dispatchClientMetadata({ clientApp });
       const root = render();
 
@@ -120,22 +151,64 @@ describe(__filename, () => {
   );
 
   it.each([CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX])(
-    'can display a custom message when clientApp is %s',
+    'can display a custom message when clientApp is %s and not Fenix',
     (clientApp) => {
       const newLocation = '/some/location/';
       _correctedLocationForPlatform.returns(newLocation);
+      _isFenix.returns(false);
       _dispatchClientMetadata({ clientApp });
-      const fixAndroidLinkMessage =
-        'A message to show when clientApp is firefox';
-      const fixFirefoxLinkMessage =
-        'A message to show when clientApp is android';
+      const androidMessageText = 'A message to show when clientApp is firefox';
+      const androidLinkText = 'click here for Android';
+      const firefoxMessageText = 'A message to show when clientApp is android';
+      const firefoxLinkText = 'click here for Firefox';
+      const fixAndroidLinkMessage = `${androidMessageText}<a href="%(newLocation)s">${androidLinkText}</a>.`;
+      const fixFirefoxLinkMessage = `${firefoxMessageText}<a href="%(newLocation)s">${firefoxLinkText}</a>.`;
       const root = render({ fixAndroidLinkMessage, fixFirefoxLinkMessage });
 
       expect(root.find('.WrongPlatformWarning-message').html()).toContain(
         clientApp === CLIENT_APP_ANDROID
-          ? fixFirefoxLinkMessage
-          : fixAndroidLinkMessage,
+          ? firefoxMessageText
+          : androidMessageText,
+      );
+      expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+        clientApp === CLIENT_APP_ANDROID ? firefoxLinkText : androidLinkText,
+      );
+      expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+        `<a href="${newLocation}">`,
       );
     },
   );
+
+  it('generates the expected message when user agent is Fenix', () => {
+    _isFenix.returns(true);
+    const root = render();
+
+    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+      'To find add-ons compatible with Firefox on Android,',
+    );
+    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+      'click here',
+    );
+    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+      `<a href="${FENIX_LINK_DESTINATION}">`,
+    );
+  });
+
+  it('can display a custom message when user agent is Fenix', () => {
+    _isFenix.returns(true);
+    const messageText = 'A custom message.';
+    const linkText = 'click here';
+    const fixFenixLinkMessage = `${messageText}<a href="%(newLocation)s">${linkText}</a>.`;
+    const root = render({ fixFenixLinkMessage });
+
+    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+      messageText,
+    );
+    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+      linkText,
+    );
+    expect(root.find('.WrongPlatformWarning-message').html()).toContain(
+      `<a href="${FENIX_LINK_DESTINATION}">`,
+    );
+  });
 });

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -184,7 +184,7 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find('.WrongPlatformWarning-message').html()).toContain(
-      'To find add-ons compatible with Firefox for Android,',
+      'To learn about add-ons compatible with Firefox for Android,',
     );
     expect(root.find('.WrongPlatformWarning-message').html()).toContain(
       'click here',

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -184,7 +184,7 @@ describe(__filename, () => {
     const root = render();
 
     expect(root.find('.WrongPlatformWarning-message').html()).toContain(
-      'To find add-ons compatible with Firefox on Android,',
+      'To find add-ons compatible with Firefox for Android,',
     );
     expect(root.find('.WrongPlatformWarning-message').html()).toContain(
       'click here',


### PR DESCRIPTION
Fixes #9068 

This PR introduces a few changes:

1. The `AddonCompatibilityError`, which is the red warning near the top of the add-on detail card, will no longer be displayed when a user visits the site with Fenix. This is because that warning is being replaced by the `WrongPlatformWarning`. Before screenshot:

![Screenshot 2020-01-13 12 09 58](https://user-images.githubusercontent.com/142755/72276329-acc7e180-35fd-11ea-9227-87b160a90961.png)

2. When visiting the site with Fenix, the `WrongPlatformWarning` will be displayed with a message. This will either be displayed under the install button (on the add-on detail page):

![Screenshot 2020-01-13 12 07 39](https://user-images.githubusercontent.com/142755/72276219-74280800-35fd-11ea-9cd7-a805e8ef19fd.png)

or at the top of the screen:

![Screenshot 2020-01-13 12 08 00](https://user-images.githubusercontent.com/142755/72276239-8144f700-35fd-11ea-9668-a886dbd7530c.png)

3. Similar to 2, above, the standard `WrongPlatformWarning`, which displays a warning if you visit the `/android` site with desktop, or the `/firefox` site with Android, will *not* be displayed for Fenix users, as it will be replaced by the new `WrongPlatformWarning` as described in 2, above.
