### PR TITLE
Do not disable the "Report Abuse" button while reporting abuse…

### DIFF
--- a/src/core/reducers/abuse.js
+++ b/src/core/reducers/abuse.js
@@ -191,7 +191,6 @@ export default function abuseReducer(
         loading: false,
       };
     }
-    case INITIATE_ADDON_ABUSE_REPORT_VIA_FIREFOX:
     case SEND_ADDON_ABUSE_REPORT:
       return { ...state, loading: true };
     case SHOW_ADDON_ABUSE_REPORT_UI: {

--- a/tests/unit/amo/components/TestReportAbuseButton.js
+++ b/tests/unit/amo/components/TestReportAbuseButton.js
@@ -220,7 +220,8 @@ describe(__filename, () => {
     expect(root.find('button.ReportAbuseButton-send-report')).toHaveLength(0);
   });
 
-  it('disables the "Report this add-on for abuse" button if a report is in progress', () => {
+  it('does not disable the "Report this add-on for abuse" button if a report is in progress', () => {
+    // See https://github.com/mozilla/addons-frontend/issues/9086.
     const { store } = dispatchClientMetadata();
 
     store.dispatch(initiateAddonAbuseReportViaFirefox({ addon: fakeAddon }));
@@ -228,7 +229,7 @@ describe(__filename, () => {
 
     expect(root.find('.ReportAbuseButton-show-more')).toHaveProp(
       'disabled',
-      true,
+      false,
     );
   });
 

--- a/tests/unit/core/reducers/test_abuse.js
+++ b/tests/unit/core/reducers/test_abuse.js
@@ -172,16 +172,14 @@ describe(__filename, () => {
   });
 
   describe('initiateAddonAbuseReportViaFirefox', () => {
-    it('sets the loading state to true', () => {
+    it('does not set the loading state to true', () => {
+      // See https://github.com/mozilla/addons-frontend/issues/9086.
       const state = abuseReducer(
         initialState,
         initiateAddonAbuseReportViaFirefox({ addon: fakeAddon }),
       );
 
-      expect(state).toEqual({
-        ...initialState,
-        loading: true,
-      });
+      expect(state).toEqual(initialState);
     });
   });
 


### PR DESCRIPTION
Fixes #9086 

The issue describes why this patch is needed, and what it does in detail, but to summarize, this patch will cause the "Report Abuse" button to *not* become disabled when an abuse report is initiated via the built-in Firefox API.
