### PR TITLE
Right-click on the extension card area opens the extension page in a new tab

### DIFF
--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -38,9 +38,7 @@
       .SearchResult-wrapper {
         display: inline-block;
         height: 100%;
-        outline: none;
         padding: 12px 24px;
-        text-decoration: none;
         transition: background-color $transition-short ease-in-out;
         width: 100%;
       }

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -38,7 +38,9 @@
       .SearchResult-wrapper {
         display: inline-block;
         height: 100%;
+        outline: none;
         padding: 12px 24px;
+        text-decoration: none;
         transition: background-color $transition-short ease-in-out;
         width: 100%;
       }
@@ -95,7 +97,6 @@
         // stylelint-enable max-nesting-depth
       }
 
-      .SearchResult-wrapper:focus,
       .SearchResult-wrapper:hover {
         background-color: $grey-10;
         border-radius: $border-radius-default;

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -125,7 +125,9 @@ export class SearchResultBase extends React.Component<InternalProps> {
 
     return (
       <Link
-        href={addon ? this.getAddonLink(addon, addonInstallSource) : '#'}
+        {...(addon
+          ? { to: this.getAddonLink(addon, addonInstallSource) }
+          : { href: '#' })}
         className="SearchResult-wrapper"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -72,7 +72,6 @@ export class SearchResultBase extends React.Component<InternalProps> {
       showRecommendedBadge,
       showSummary,
       useThemePlaceholder,
-      history,
     } = this.props;
 
     const averageDailyUsers = addon ? addon.average_daily_users : null;
@@ -126,11 +125,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
 
     return (
       <Link
-        to={
-          addon
-            ? this.getAddonLink(addon, addonInstallSource)
-            : history.location.pathname
-        }
+        href={addon ? this.getAddonLink(addon, addonInstallSource) : '#'}
         className="SearchResult-wrapper"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -72,6 +72,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
       showRecommendedBadge,
       showSummary,
       useThemePlaceholder,
+      history,
     } = this.props;
 
     const averageDailyUsers = addon ? addon.average_daily_users : null;
@@ -83,15 +84,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
     let addonTitle = <LoadingText />;
 
     if (addon) {
-      addonTitle = (
-        <Link
-          className="SearchResult-link"
-          to={this.getAddonLink(addon, addonInstallSource)}
-          onClick={(e) => e.stopPropagation()}
-        >
-          {addon.name}
-        </Link>
-      );
+      addonTitle = <span className="SearchResult-title">{addon.name}</span>;
     }
 
     if (addon && addon.type === ADDON_TYPE_STATIC_THEME) {
@@ -132,7 +125,15 @@ export class SearchResultBase extends React.Component<InternalProps> {
     }
 
     return (
-      <div className="SearchResult-wrapper">
+      <Link
+        to={
+          addon
+            ? this.getAddonLink(addon, addonInstallSource)
+            : history.location.pathname
+        }
+        className="SearchResult-wrapper"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="SearchResult-result">
           <div className={iconWrapperClassnames}>
             {(addon && imageURL) || (!addon && !useThemePlaceholder) ? (
@@ -216,19 +217,9 @@ export class SearchResultBase extends React.Component<InternalProps> {
             </h3>
           ) : null}
         </div>
-      </div>
+      </Link>
     );
   }
-
-  onClickResult = () => {
-    const { addon, addonInstallSource, clientApp, history, lang } = this.props;
-
-    if (addon) {
-      history.push(
-        `/${lang}/${clientApp}${this.getAddonLink(addon, addonInstallSource)}`,
-      );
-    }
-  };
 
   render() {
     const { addon, useThemePlaceholder } = this.props;
@@ -245,9 +236,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
       // added an actual link to the h2 tag.
       // eslint-disable-next-line max-len
       // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
-      <li onClick={this.onClickResult} className={resultClassnames}>
-        {result}
-      </li>
+      <li className={resultClassnames}>{result}</li>
     );
   }
 }

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -7,6 +7,11 @@ $icon-default-size: 32px;
 .SearchResult {
   list-style-type: none;
   margin: 0 0 1px;
+
+  .SearchResult-wrapper {
+    outline: none;
+    text-decoration: none;
+  }
 }
 
 .SearchResult-title {

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -7,34 +7,14 @@ $icon-default-size: 32px;
 .SearchResult {
   list-style-type: none;
   margin: 0 0 1px;
-
-  &:hover {
-    cursor: pointer;
-
-    .SearchResult-link {
-      color: $link-color;
-    }
-  }
 }
 
-.SearchResult-link {
+.SearchResult-title {
   // This margin gives the recommended badge some space.
   @include margin-end(8px);
 
   text-decoration: none;
   word-wrap: anywhere;
-
-  &,
-  &:active,
-  &:link,
-  &:visited {
-    color: $text-color-default;
-  }
-
-  &:focus,
-  &:hover {
-    color: $link-color;
-  }
 }
 
 .SearchResult-result {
@@ -44,6 +24,23 @@ $icon-default-size: 32px;
   max-width: $theme-width-default;
   padding: 0;
   width: 100%;
+}
+
+.SearchResult-wrapper {
+  &,
+  &:active,
+  &:link,
+  &:visited {
+    .SearchResult-title {
+      color: $text-color-default;
+    }
+  }
+
+  &:hover {
+    .SearchResult-title {
+      color: $link-color;
+    }
+  }
 }
 
 .SearchResult-icon-wrapper {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -79,18 +79,14 @@ describe(__filename, () => {
       'to',
       getAddonURL(slug),
     );
-    expect(root.find('.SearchResult-wrapper')).not.toHaveProp('href', '#');
+    expect(root.find('.SearchResult-wrapper')).not.toHaveProp('href');
   });
 
   it('links the card to do nothing when addon is null', () => {
-    const slug = 'some-addon-slug';
     const root = render({ addon: null });
 
     expect(root.find('.SearchResult-wrapper')).toHaveProp('href', '#');
-    expect(root.find('.SearchResult-wrapper')).not.toHaveProp(
-      'to',
-      getAddonURL(slug),
-    );
+    expect(root.find('.SearchResult-wrapper')).not.toHaveProp('to');
   });
 
   it('stops propagation when clicking on the card', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -79,12 +79,18 @@ describe(__filename, () => {
       'to',
       getAddonURL(slug),
     );
+    expect(root.find('.SearchResult-wrapper')).not.toHaveProp('href', '#');
   });
 
   it('links the card to do nothing when addon is null', () => {
+    const slug = 'some-addon-slug';
     const root = render({ addon: null });
 
     expect(root.find('.SearchResult-wrapper')).toHaveProp('href', '#');
+    expect(root.find('.SearchResult-wrapper')).not.toHaveProp(
+      'to',
+      getAddonURL(slug),
+    );
   });
 
   it('stops propagation when clicking on the card', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -76,7 +76,7 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find('.SearchResult-wrapper')).toHaveProp(
-      'href',
+      'to',
       getAddonURL(slug),
     );
   });
@@ -102,7 +102,7 @@ describe(__filename, () => {
     const root = render({ addonInstallSource });
 
     const link = root.find('.SearchResult-wrapper');
-    expect(url.parse(link.prop('href'), true).query).toMatchObject({
+    expect(url.parse(link.prop('to'), true).query).toMatchObject({
       src: addonInstallSource,
     });
   });

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -76,9 +76,15 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find('.SearchResult-wrapper')).toHaveProp(
-      'to',
+      'href',
       getAddonURL(slug),
     );
+  });
+
+  it('links the card to do nothing when addon is null', () => {
+    const root = render({ addon: null });
+
+    expect(root.find('.SearchResult-wrapper')).toHaveProp('href', '#');
   });
 
   it('stops propagation when clicking on the card', () => {
@@ -96,7 +102,7 @@ describe(__filename, () => {
     const root = render({ addonInstallSource });
 
     const link = root.find('.SearchResult-wrapper');
-    expect(url.parse(link.prop('to'), true).query).toMatchObject({
+    expect(url.parse(link.prop('href'), true).query).toMatchObject({
       src: addonInstallSource,
     });
   });

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -64,35 +64,38 @@ describe(__filename, () => {
   it('renders the heading', () => {
     const root = render();
 
-    expect(root.find('.SearchResult-link').children()).toIncludeText(
+    expect(root.find('.SearchResult-title').children()).toIncludeText(
       'A search result',
     );
   });
 
-  it('links the heading to the detail page', () => {
+  it('links the card to the detail page', () => {
     const slug = 'some-addon-slug';
     const addon = createInternalAddon({ ...fakeAddon, slug });
 
     const root = render({ addon });
 
-    expect(root.find('.SearchResult-link')).toHaveProp('to', getAddonURL(slug));
+    expect(root.find('.SearchResult-wrapper')).toHaveProp(
+      'to',
+      getAddonURL(slug),
+    );
   });
 
-  it('stops propagation when clicking on the add-on name', () => {
+  it('stops propagation when clicking on the card', () => {
     const root = render();
 
     const clickEvent = createFakeEvent();
-    root.find('.SearchResult-link').simulate('click', clickEvent);
+    root.find('.SearchResult-wrapper').simulate('click', clickEvent);
 
     sinon.assert.called(clickEvent.stopPropagation);
   });
 
-  it('links the heading to the detail page with a source', () => {
+  it('links the card to the detail page with a source', () => {
     const addonInstallSource = 'home-page-featured';
 
     const root = render({ addonInstallSource });
 
-    const link = root.find('.SearchResult-link');
+    const link = root.find('.SearchResult-wrapper');
     expect(url.parse(link.prop('to'), true).query).toMatchObject({
       src: addonInstallSource,
     });
@@ -151,25 +154,6 @@ describe(__filename, () => {
     });
 
     expect(root.find('.SearchResult-users')).toIncludeText('1 user');
-  });
-
-  it('links the li element to the detail page', () => {
-    const slug = 'some-addon-slug';
-    const addon = createInternalAddon({ ...fakeAddon, slug });
-    const clientApp = CLIENT_APP_FIREFOX;
-    const lang = 'fr';
-    const history = createFakeHistory();
-    const { store } = dispatchClientMetadata({ clientApp, lang });
-
-    const root = render({ addon, history, store });
-
-    const onClick = root.find('.SearchResult').prop('onClick');
-    onClick();
-
-    sinon.assert.calledWith(
-      history.push,
-      `/${lang}/${clientApp}${getAddonURL(slug)}`,
-    );
   });
 
   it('renders the star ratings', () => {


### PR DESCRIPTION
Fixes #8724 

Changes inside:

1. Remove Link tag from the title.

2. Change extension-title className from `SearchResult-link` to `SearchResult-title`.

3. Replace className `SearchResult-wrapper` element `div` to `Link` tag.

4.Remove onClick Function on `li` element.

5.Update test cases.
