### PR TITLE
Fix Dropdown mouse click

### DIFF
--- a/src/ui/components/DropdownMenu/index.js
+++ b/src/ui/components/DropdownMenu/index.js
@@ -18,23 +18,17 @@ type Props = {|
 
 type State = {|
   buttonIsActive: boolean,
-  setByHover: boolean,
 |};
 
 export class DropdownMenuBase extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    this.state = { buttonIsActive: false, setByHover: false };
+    this.state = { buttonIsActive: false };
   }
 
   handleOnClick = (event: SyntheticEvent<any>) => {
     event.preventDefault();
-
-    if (this.state.setByHover) {
-      this.setState({ setByHover: false });
-      return;
-    }
 
     this.setState((previousState) => ({
       buttonIsActive: !previousState.buttonIsActive,
@@ -47,20 +41,20 @@ export class DropdownMenuBase extends React.Component<Props, State> {
     if (event.target && event.target.tagName === 'A') {
       log.debug(oneLine`Setting state of DropdownMenu to buttonIsActive to
         false, because a link inside the menu was clicked.`);
-      this.setState({ buttonIsActive: false, setByHover: false });
+      this.setState({ buttonIsActive: false });
     }
   };
 
   handleClickOutside = () => {
-    this.setState({ buttonIsActive: false, setByHover: false });
+    this.setState({ buttonIsActive: false });
   };
 
   handleOnMouseEnter = () => {
-    this.setState({ buttonIsActive: true, setByHover: true });
+    this.setState({ buttonIsActive: true });
   };
 
   handleOnMouseLeave = () => {
-    this.setState({ buttonIsActive: false, setByHover: false });
+    this.setState({ buttonIsActive: false });
   };
 
   render() {

--- a/tests/unit/ui/components/TestDropdownMenu.js
+++ b/tests/unit/ui/components/TestDropdownMenu.js
@@ -116,39 +116,6 @@ describe(__filename, () => {
     expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
   });
 
-  it('allows the user to hover then click without dismissing the menu', () => {
-    const root = mount(<DropdownMenu text="Menu" />);
-    const getMenu = () => root.find('.DropdownMenu');
-
-    // User hovers on the menu.
-    getMenu().simulate('mouseEnter', createFakeEvent());
-    expect(getMenu()).toHaveClassName('DropdownMenu--active');
-
-    // User clicks the menu's main button once, which should not hide it.
-    getMenu()
-      .find('.DropdownMenu-button')
-      .simulate('click', createFakeEvent());
-    expect(getMenu()).toHaveClassName('DropdownMenu--active');
-  });
-
-  it('allows the user to hover, then dismiss the menu with a click', () => {
-    const root = mount(<DropdownMenu text="Menu" />);
-    const getMenu = () => root.find('.DropdownMenu');
-
-    // User hovers on the menu.
-    getMenu().simulate('mouseEnter', createFakeEvent());
-    expect(getMenu()).toHaveClassName('DropdownMenu--active');
-
-    // User clicks the menu's main button twice, which will dismiss it.
-    getMenu()
-      .find('.DropdownMenu-button')
-      .simulate('click', createFakeEvent());
-    getMenu()
-      .find('.DropdownMenu-button')
-      .simulate('click', createFakeEvent());
-    expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
-  });
-
   it('optionally takes a class name', () => {
     const menu = renderComponent(
       <DropdownMenu text="Menu" className="my-class" />,


### PR DESCRIPTION
Fixes #8424 

Replace this sentence with a description of how your patch fixes the issue.

The handleClick function is checking if the element is in hover state or not. If it's in hover state and clicked then it set hover state to be `false` and return. Then we again clicked then it then it's checking that state is `false` then drop down state change and hide. That's the reason every time the mouse enters the element and has to clicked twice to close the dropdown.

```
 if (this.state.setByHover) {
      this.setState({ setByHover: false });
      return;
    }
```

Just by removing this if condition dropdown works as expected.