### PR TITLE
handled error when recommendation service down

### DIFF
--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -85,7 +85,7 @@ export class AddonRecommendationsBase extends React.Component<Props> {
     if (newRecommendations && oldRecommendations !== newRecommendations) {
       const { fallbackReason, loading, outcome } = newRecommendations;
 
-      if (loading) {
+      if (loading || this.props.errorHandler.hasError()) {
         return;
       }
 
@@ -114,9 +114,9 @@ export class AddonRecommendationsBase extends React.Component<Props> {
   }
 
   render() {
-    const { className, i18n, recommendations } = this.props;
+    const { className, i18n, recommendations, errorHandler } = this.props;
 
-    if (!recommendations) {
+    if (!recommendations || errorHandler.hasError()) {
       log.debug(
         'No recommendations, hiding the AddonRecommendations component.',
       );

--- a/src/amo/components/AddonRecommendations/index.js
+++ b/src/amo/components/AddonRecommendations/index.js
@@ -71,6 +71,7 @@ export class AddonRecommendationsBase extends React.Component<Props> {
       addon: newAddon,
       recommendations: newRecommendations,
       tracking,
+      errorHandler,
     } = this.props;
 
     // Fetch recommendations when the add-on changes.
@@ -85,7 +86,7 @@ export class AddonRecommendationsBase extends React.Component<Props> {
     if (newRecommendations && oldRecommendations !== newRecommendations) {
       const { fallbackReason, loading, outcome } = newRecommendations;
 
-      if (loading || this.props.errorHandler.hasError()) {
+      if (loading || errorHandler.hasError()) {
         return;
       }
 
@@ -116,9 +117,16 @@ export class AddonRecommendationsBase extends React.Component<Props> {
   render() {
     const { className, i18n, recommendations, errorHandler } = this.props;
 
-    if (!recommendations || errorHandler.hasError()) {
+    if (!recommendations) {
       log.debug(
         'No recommendations, hiding the AddonRecommendations component.',
+      );
+      return null;
+    }
+
+    if (errorHandler.hasError()) {
+      log.debug(
+        'Error in fetching recommendations, hiding the AddonRecommendations component.',
       );
       return null;
     }

--- a/tests/unit/amo/components/TestAddonRecommendations.js
+++ b/tests/unit/amo/components/TestAddonRecommendations.js
@@ -26,6 +26,7 @@ import {
   fakeRecommendations,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
+import { ErrorHandler } from 'core/errorHandler';
 import LoadingText from 'ui/components/LoadingText';
 
 describe(__filename, () => {
@@ -74,6 +75,18 @@ describe(__filename, () => {
 
   it('renders nothing without an addon', () => {
     const root = render({ addon: null });
+    expect(root).not.toHaveClassName('AddonRecommendations');
+  });
+
+  it('renders nothing if there is an error', () => {
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: store.dispatch,
+    });
+    errorHandler.handle(new Error('some unexpected error'));
+    store.dispatch(doLoadRecommendations({}));
+
+    const root = render({ errorHandler });
     expect(root).not.toHaveClassName('AddonRecommendations');
   });
 
@@ -279,6 +292,19 @@ describe(__filename, () => {
         loading: true,
       },
     });
+
+    sinon.assert.notCalled(fakeTracking.sendEvent);
+  });
+
+  it('should not send a GA ping when there an error', () => {
+    const errorHandler = new ErrorHandler({
+      id: 'some-id',
+      dispatch: store.dispatch,
+    });
+    errorHandler.handle(new Error('some unexpected error'));
+    const root = render({ tracking: fakeTracking });
+
+    root.setProps({ errorHandler });
 
     sinon.assert.notCalled(fakeTracking.sendEvent);
   });


### PR DESCRIPTION
Fixes #6001

Changes inside?

1. In `ComponentDidUpdate` check, if there is an error then return.
2. In `render` check, if there is an error then render nothing.