### PR TITLE
add collapse text in long add-on reviews

### DIFF
--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -44,6 +44,13 @@ const initialUIState: UIStateType = {
 export class ShowMoreCardBase extends React.Component<InternalProps> {
   contents: HTMLElement | null;
 
+  componentDidMount() {
+    const { uiState } = this.props;
+    if (!uiState.readMoreExpanded) {
+      this.truncateToMaxHeight(this.contents);
+    }
+  }
+
   componentDidUpdate(prevProps: InternalProps) {
     const { children: prevChildren } = prevProps;
     const { children, uiState } = this.props;

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -11,6 +11,7 @@ import LoadingText from 'ui/components/LoadingText';
 import UserRating from 'ui/components/UserRating';
 import type { UserReviewType } from 'amo/actions/reviews';
 import type { I18nType } from 'core/types/i18n';
+import ShowMoreCard from 'ui/components/ShowMoreCard';
 
 import './styles.scss';
 
@@ -27,22 +28,24 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
+  id: String,
 |};
 
 function reviewBody({
   content,
   html,
+  id,
 }: {|
   content?: React.Node | string,
   html?: React.Node,
+  id: string,
 |}) {
   invariant(
-    content !== undefined || html !== undefined,
-    'content or html is required',
+    content !== undefined || html !== undefined || id !== undefined,
+    'content or html or id is required',
   );
 
   const bodyAttr = {};
-
   if (content) {
     bodyAttr.children = content;
   } else {
@@ -50,13 +53,15 @@ function reviewBody({
   }
 
   return (
-    <div
+    <ShowMoreCard
+      id={id}
       className={makeClassName('UserReview-body', {
         // Add an extra class if the content is an empty string.
         'UserReview-emptyBody': !content && !html,
       })}
-      {...bodyAttr}
-    />
+    >
+      <div {...bodyAttr} />
+    </ShowMoreCard>
   );
 }
 
@@ -72,15 +77,17 @@ export const UserReviewBase = (props: InternalProps) => {
     showRating = false,
   } = props;
 
-  let body = reviewBody({ content: <LoadingText /> });
+  const showMoreCardId = review && review.id ? `${review.id}` : 'loading-text';
+  let body = reviewBody({ content: <LoadingText />, id: showMoreCardId });
 
   if (review) {
     if (review.body) {
       body = reviewBody({
         html: sanitizeHTML(nl2br(review.body), ['br']),
+        id: showMoreCardId,
       });
     } else {
-      body = reviewBody({ content: '' });
+      body = reviewBody({ content: '', id: showMoreCardId });
     }
   }
 

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -76,7 +76,8 @@ export const UserReviewBase = (props: InternalProps) => {
     showRating = false,
   } = props;
 
-  const showMoreCardId = review && review.id ? String(review.id) : 'loading-text';
+  const showMoreCardId =
+    review && review.id ? String(review.id) : 'loading-text';
   let body = reviewBody({ content: <LoadingText />, id: showMoreCardId });
 
   if (review) {

--- a/src/ui/components/UserReview/index.js
+++ b/src/ui/components/UserReview/index.js
@@ -28,7 +28,6 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
-  id: String,
 |};
 
 function reviewBody({
@@ -77,7 +76,7 @@ export const UserReviewBase = (props: InternalProps) => {
     showRating = false,
   } = props;
 
-  const showMoreCardId = review && review.id ? `${review.id}` : 'loading-text';
+  const showMoreCardId = review && review.id ? String(review.id) : 'loading-text';
   let body = reviewBody({ content: <LoadingText />, id: showMoreCardId });
 
   if (review) {

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -21,6 +21,10 @@
     background: transparent;
     padding: 0;
   }
+
+  .Card.ShowMoreCard.UserReview-body.UserReview-emptyBody {
+    margin: 0;
+  }
 }
 
 .UserReview-review-header {
@@ -28,13 +32,13 @@
   padding: 0;
 }
 
-.UserReview-body {
+.UserReview-body.ShowMoreCard {
   font-size: $font-size-default;
-  margin: 0 !important;
+  margin: 0 ;
   word-wrap: break-word;
 
   &:not(.UserReview-emptyBody) {
-    margin: 4px 0 6px !important;
+    margin: 4px 0 6px 
   }
 }
 

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -22,7 +22,7 @@
     padding: 0;
   }
 
-  .Card.ShowMoreCard.UserReview-body.UserReview-emptyBody {
+  .ShowMoreCard.UserReview-emptyBody {
     margin: 0;
   }
 }

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -34,11 +34,11 @@
 
 .UserReview-body.ShowMoreCard {
   font-size: $font-size-default;
-  margin: 0 ;
+  margin: 0;
   word-wrap: break-word;
 
   &:not(.UserReview-emptyBody) {
-    margin: 4px 0 6px 
+    margin: 4px 0 6px;
   }
 }
 

--- a/src/ui/components/UserReview/styles.scss
+++ b/src/ui/components/UserReview/styles.scss
@@ -16,6 +16,11 @@
   .TooltipMenu {
     width: fit-content;
   }
+
+  .Card-contents {
+    background: transparent;
+    padding: 0;
+  }
 }
 
 .UserReview-review-header {
@@ -25,10 +30,11 @@
 
 .UserReview-body {
   font-size: $font-size-default;
+  margin: 0 !important;
   word-wrap: break-word;
 
   &:not(.UserReview-emptyBody) {
-    margin: 4px 0 6px;
+    margin: 4px 0 6px !important;
   }
 }
 

--- a/tests/unit/ui/components/TestShowMoreCard.js
+++ b/tests/unit/ui/components/TestShowMoreCard.js
@@ -24,11 +24,16 @@ describe(__filename, () => {
     };
   };
 
-  function render({ children = 'some text', ...otherProps } = {}) {
+  function render({
+    children = 'some text',
+    shallowOptions,
+    ...otherProps
+  } = {}) {
     const props = getProps(otherProps);
     return shallowUntilTarget(
       <ShowMoreCard {...props}>{children}</ShowMoreCard>,
       ShowMoreCardBase,
+      { shallowOptions },
     );
   }
 
@@ -54,10 +59,27 @@ describe(__filename, () => {
     expect(root).toHaveClassName('ShowMoreCard--expanded');
   });
 
-  it('is expanded by default', () => {
+  it('is expanded by default if content is not too long', () => {
     const root = render();
 
     expect(root).toHaveClassName('ShowMoreCard--expanded');
+  });
+
+  it('is truncate by default if content is too long', () => {
+    const { store } = dispatchClientMetadata();
+
+    const root = render({
+      store,
+      shallowOptions: { disableLifecycleMethods: true },
+    });
+
+    root.instance().contents = { clientHeight: MAX_HEIGHT + 1 };
+
+    root.instance().componentDidMount();
+
+    applyUIStateChanges({ root, store });
+
+    expect(root).not.toHaveClassName('ShowMoreCard--expanded');
   });
 
   it('truncates the contents if they are too long', () => {

--- a/tests/unit/ui/components/TestShowMoreCard.js
+++ b/tests/unit/ui/components/TestShowMoreCard.js
@@ -65,7 +65,7 @@ describe(__filename, () => {
     expect(root).toHaveClassName('ShowMoreCard--expanded');
   });
 
-  it('is truncate by default if content is too long', () => {
+  it('is truncates by default if content is too long', () => {
     const { store } = dispatchClientMetadata();
 
     const root = render({

--- a/tests/unit/ui/components/TestShowMoreCard.js
+++ b/tests/unit/ui/components/TestShowMoreCard.js
@@ -65,7 +65,7 @@ describe(__filename, () => {
     expect(root).toHaveClassName('ShowMoreCard--expanded');
   });
 
-  it('is truncates by default if content is too long', () => {
+  it('is truncated by default if content is too long', () => {
     const { store } = dispatchClientMetadata();
 
     const root = render({

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -49,11 +49,7 @@ describe(__filename, () => {
     });
     const root = render({ review, showRating: true });
 
-    expect(
-      root
-        .find('.UserReview-body div')
-        .html(),
-    ).toContain(fakeReview.body);
+    expect(root.find('.UserReview-body div').html()).toContain(fakeReview.body);
 
     const rating = root.find(UserRating);
     expect(rating).toHaveProp('readOnly', true);
@@ -83,9 +79,7 @@ describe(__filename, () => {
       review: _setReview({ ...fakeReview, body: undefined }),
     });
 
-    expect(
-      root.find('.UserReview-body div'),
-    ).toHaveText('');
+    expect(root.find('.UserReview-body div')).toHaveText('');
   });
 
   it('adds UserReview-emptyBody for an empty body', () => {

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -49,7 +49,12 @@ describe(__filename, () => {
     });
     const root = render({ review, showRating: true });
 
-    expect(root.find('.UserReview-body div').html()).toContain(fakeReview.body);
+    expect(
+      root
+        .find('.UserReview-body')
+        .children()
+        .html(),
+    ).toContain(fakeReview.body);
 
     const rating = root.find(UserRating);
     expect(rating).toHaveProp('readOnly', true);
@@ -68,7 +73,8 @@ describe(__filename, () => {
 
     expect(
       root
-        .find('.UserReview-body div')
+        .find('.UserReview-body')
+        .children()
         .render()
         .find('br'),
     ).toHaveLength(1);
@@ -79,7 +85,7 @@ describe(__filename, () => {
       review: _setReview({ ...fakeReview, body: undefined }),
     });
 
-    expect(root.find('.UserReview-body div')).toHaveText('');
+    expect(root.find('.UserReview-body').children()).toHaveText('');
   });
 
   it('adds UserReview-emptyBody for an empty body', () => {

--- a/tests/unit/ui/components/TestUserReview.js
+++ b/tests/unit/ui/components/TestUserReview.js
@@ -1,8 +1,5 @@
 import * as React from 'react';
-import { Provider } from 'react-redux';
-import { mount } from 'enzyme';
 
-import I18nProvider from 'core/i18n/Provider';
 import { createInternalReview, setReview } from 'amo/actions/reviews';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';
@@ -33,23 +30,6 @@ describe(__filename, () => {
     return shallowUntilTarget(<UserReview {...props} />, UserReviewBase);
   };
 
-  const renderAndMount = (otherProps = {}) => {
-    const props = {
-      byLine: null,
-      i18n: fakeI18n(),
-      review: fakeReview,
-      ...otherProps,
-    };
-
-    return mount(
-      <Provider store={store}>
-        <I18nProvider i18n={props.i18n}>
-          <UserReview {...props} />
-        </I18nProvider>
-      </Provider>,
-    );
-  };
-
   const _setReview = (externalReview) => {
     store.dispatch(setReview(externalReview));
     return createInternalReview(externalReview);
@@ -67,11 +47,11 @@ describe(__filename, () => {
       id: 1,
       rating: 2,
     });
-    const root = renderAndMount({ review, showRating: true });
+    const root = render({ review, showRating: true });
 
     expect(
       root
-        .find('.UserReview-body .ShowMoreCard .ShowMoreCard-contents div')
+        .find('.UserReview-body div')
         .html(),
     ).toContain(fakeReview.body);
 
@@ -86,25 +66,25 @@ describe(__filename, () => {
       ...fakeReview,
       body: "It's awesome \n isn't it?",
     };
-    const root = renderAndMount({
+    const root = render({
       review: _setReview(fakeReviewWithNewLine),
     });
 
     expect(
       root
-        .find('.UserReview-body .ShowMoreCard .ShowMoreCard-contents div')
+        .find('.UserReview-body div')
         .render()
         .find('br'),
     ).toHaveLength(1);
   });
 
   it('does not render an empty review body', () => {
-    const root = renderAndMount({
+    const root = render({
       review: _setReview({ ...fakeReview, body: undefined }),
     });
 
     expect(
-      root.find('.UserReview-body .ShowMoreCard .ShowMoreCard-contents div'),
+      root.find('.UserReview-body div'),
     ).toHaveText('');
   });
 


### PR DESCRIPTION
Fixes #6242 

Replace`div` with `ShowMoreCard` inside `UserReview`.




 Before:

     <div
      className={makeClassName('UserReview-body', {
        // Add an extra class if the content is an empty string.
        'UserReview-emptyBody': !content && !html,
      })}
    >
      {...bodyAttr}
    </div>


 After:

     <ShowMoreCard
      id={id}
      className={makeClassName('UserReview-body', {
        // Add an extra class if the content is an empty string.
        'UserReview-emptyBody': !content && !html,
      })}
    >
      <div {...bodyAttr} />
    </ShowMoreCard>