### PR TITLE
Highlight the addon title when focused

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -41,9 +41,16 @@ $icon-default-size: 32px;
     }
   }
 
+  &:focus,
   &:hover {
     .SearchResult-title {
       color: $link-color;
+    }
+  }
+
+  &:focus {
+    .SearchResult-title {
+      outline: 1px dotted $link-color;
     }
   }
 }


### PR DESCRIPTION
Fixes #9144 
I also added the dotted outline back (the same as the AMO stage shown in https://github.com/mozilla/addons-frontend/issues/9144#issue-561631860), but not exactly sure if we need that.

Sceenshot 
![image](https://user-images.githubusercontent.com/4984681/74112983-6f079b80-4b5e-11ea-91d1-dd54a53a3dad.png)
