### PR TITLE
Update footer links headers font-size

### DIFF
--- a/src/amo/components/Footer/styles.scss
+++ b/src/amo/components/Footer/styles.scss
@@ -61,6 +61,7 @@
 }
 
 .Footer-links-header {
+  font-size: 16px;
   margin: 40px 0 0;
 
   @include respond-to(large) {


### PR DESCRIPTION

Fixes #9197 

This PR fixes the issue #9197. Now all the footer links headers have the same font size. 

_Before:_

![Screenshot from 2020-03-06 02-38-48](https://user-images.githubusercontent.com/30138596/76025795-a433bd80-5f53-11ea-854f-6f1501868c60.png)

_After:_

![Screenshot from 2020-03-06 02-26-51](https://user-images.githubusercontent.com/30138596/76025804-a9910800-5f53-11ea-8330-98fcbb1d9f8c.png)


