### PR TITLE
Make sure mozAddonManager uses the right src query parameter

### DIFF
--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -1,4 +1,6 @@
 /* @flow */
+import urllib from 'url';
+
 /* global window */
 import log from 'core/logger';
 import {
@@ -129,7 +131,7 @@ type OptionalInstallParams = {|
   _log?: typeof log,
   hash?: string | null,
   onIgnoredRejection?: () => void,
-  src: string,
+  defaultInstallSource: string,
 |};
 
 export function install(
@@ -140,9 +142,14 @@ export function install(
     _mozAddonManager = window.navigator.mozAddonManager,
     hash,
     onIgnoredRejection = () => {},
-    src,
+    defaultInstallSource,
   }: OptionalInstallParams = {},
 ) {
+  const parseQuery = true;
+  const urlParts = _url && urllib.parse(_url, parseQuery);
+  const srcInInstallURL = urlParts && urlParts.query && urlParts.query.src;
+  const src = srcInInstallURL || defaultInstallSource;
+
   if (src === undefined) {
     return Promise.reject(new Error('No src for add-on install'));
   }

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -433,7 +433,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
             name,
             type,
           }),
-          { src: defaultInstallSource, hash },
+          { defaultInstallSource, hash },
         );
       })
       .then(() => {

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -209,10 +209,40 @@ describe(__filename, () => {
   });
 
   describe('install()', () => {
+    // See: https://github.com/mozilla/addons-frontend/issues/9202
+    it('uses the `src` query parameter in the URL when provided', async () => {
+      const url = 'http://example.com/path/to/file.xpi?src=src-in-install-url';
+
+      await addonManager.install(url, fakeCallback, {
+        _mozAddonManager: fakeMozAddonManager,
+        defaultInstallSource: 'default-src',
+      });
+
+      sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
+        url,
+        hash: undefined,
+      });
+    });
+
+    it('uses the default install source when the URL does not have a `src` query parameter', async () => {
+      const url = 'http://example.com/path/to/file.xpi';
+      const defaultInstallSource = 'default-src';
+
+      await addonManager.install(url, fakeCallback, {
+        _mozAddonManager: fakeMozAddonManager,
+        defaultInstallSource,
+      });
+
+      sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
+        url: `${url}?src=${defaultInstallSource}`,
+        hash: undefined,
+      });
+    });
+
     it('should call mozAddonManager.createInstall() with url', async () => {
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        src: 'home',
+        defaultInstallSource: 'home',
       });
 
       sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
@@ -226,7 +256,7 @@ describe(__filename, () => {
 
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        src: 'home',
+        defaultInstallSource: 'home',
         hash,
       });
 
@@ -239,7 +269,7 @@ describe(__filename, () => {
     it('should call installObj.addEventListener to setup events', async () => {
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        src: 'home',
+        defaultInstallSource: 'home',
       });
 
       // It registers an extra onInstallFailed and onInstallEnded listener.
@@ -252,7 +282,7 @@ describe(__filename, () => {
     it('should call installObj.install()', async () => {
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        src: 'home',
+        defaultInstallSource: 'home',
       });
 
       sinon.assert.called(fakeInstallObj.install);
@@ -267,7 +297,7 @@ describe(__filename, () => {
         addonManager
           .install(fakeInstallUrl, fakeCallback, {
             _mozAddonManager: fakeMozAddonManager,
-            src: 'home',
+            defaultInstallSource: 'home',
           })
           // The second argument is the reject function.
           .then(unexpectedSuccess, () => {
@@ -292,7 +322,7 @@ describe(__filename, () => {
         _log,
         _mozAddonManager: fakeMozAddonManager,
         onIgnoredRejection: () => finishInstall(),
-        src: 'home',
+        defaultInstallSource: 'home',
       });
 
       await installToFinish;
@@ -304,7 +334,7 @@ describe(__filename, () => {
 
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        src: 'home',
+        defaultInstallSource: 'home',
       });
 
       fakeInstallObj.onDownloadProgressListener(fakeEvent);

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -1098,7 +1098,7 @@ describe(__filename, () => {
             fakeAddonManager.install,
             `${installURL}?src=${defaultInstallSource}`,
             sinon.match.func,
-            { src: defaultInstallSource, hash },
+            { defaultInstallSource, hash },
           );
         });
       });
@@ -1146,7 +1146,7 @@ describe(__filename, () => {
             fakeAddonManager.install,
             `${versionInstallURL}?src=${defaultInstallSource}`,
             sinon.match.func,
-            { src: defaultInstallSource, hash: versionHash },
+            { defaultInstallSource, hash: versionHash },
           );
         });
       });
@@ -1177,7 +1177,7 @@ describe(__filename, () => {
             fakeAddonManager.install,
             undefined,
             sinon.match.func,
-            { src: defaultInstallSource, hash: undefined },
+            { defaultInstallSource, hash: undefined },
           );
         });
       });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9202

---

It turns out that the `mozAddonManager` never used the `src` query parameter passed in the install URL. Instead, it was always overriding it with the default install source. This patch changes that so that we pass the correct install URL with the right `src` value to the `mozAddonManager`.