### PR TITLE
Add `src` query param to related links in add-on detail pages

### DIFF
--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 import * as React from 'react';
 import { compose } from 'redux';
+import { withRouter } from 'react-router-dom';
 
 import Link from 'amo/components/Link';
 import { reviewListURL } from 'amo/reducers/reviews';
@@ -11,6 +12,7 @@ import MetadataCard from 'ui/components/MetadataCard';
 import Rating from 'ui/components/Rating';
 import RatingsByStar from 'amo/components/RatingsByStar';
 import type { I18nType } from 'core/types/i18n';
+import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
@@ -21,6 +23,7 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
+  location: ReactRouterLocationType,
 |};
 
 export const roundToOneDigit = (value: number | null): number => {
@@ -29,7 +32,8 @@ export const roundToOneDigit = (value: number | null): number => {
 
 export class AddonMetaBase extends React.Component<InternalProps> {
   render() {
-    const { addon, i18n } = this.props;
+    const { addon, i18n, location } = this.props;
+
     let averageRating;
     if (addon) {
       averageRating = addon.ratings ? addon.ratings.average : null;
@@ -66,7 +70,9 @@ export class AddonMetaBase extends React.Component<InternalProps> {
     }
 
     const reviewsLink =
-      addon && reviewCount ? reviewListURL({ addonSlug: addon.slug }) : null;
+      addon && reviewCount
+        ? reviewListURL({ addonSlug: addon.slug, src: location.query.src })
+        : null;
 
     const reviewsContent = reviewsLink ? (
       <Link className="AddonMeta-reviews-content-link" to={reviewsLink}>
@@ -134,8 +140,9 @@ export class AddonMetaBase extends React.Component<InternalProps> {
   }
 }
 
-const AddonMeta: React.ComponentType<Props> = compose(translate())(
-  AddonMetaBase,
-);
+const AddonMeta: React.ComponentType<Props> = compose(
+  withRouter,
+  translate(),
+)(AddonMetaBase);
 
 export default AddonMeta;

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -105,7 +105,9 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       statsLink = (
         <Link
           className="AddonMoreInfo-stats-link"
-          href={`/addon/${addon.slug}/statistics/`}
+          href={addQueryParams(`/addon/${addon.slug}/statistics/`, {
+            src: location.query.src,
+          })}
         >
           {i18n.gettext('Visit stats dashboard')}
         </Link>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { withRouter } from 'react-router-dom';
 
 import AddonAdminLinks from 'amo/components/AddonAdminLinks';
 import Link from 'amo/components/Link';
@@ -18,9 +19,11 @@ import {
 import Card from 'ui/components/Card';
 import DefinitionList, { Definition } from 'ui/components/DefinitionList';
 import LoadingText from 'ui/components/LoadingText';
+import { addQueryParams } from 'core/utils';
 import type { AppState } from 'amo/store';
 import type { AddonVersionType, VersionInfoType } from 'core/reducers/versions';
 import type { I18nType } from 'core/types/i18n';
+import type { ReactRouterLocationType } from 'core/types/router';
 
 type Props = {|
   addon: AddonType | null,
@@ -30,20 +33,21 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   hasStatsPermission: boolean,
-  i18n: I18nType,
   userId: number | null,
   currentVersion: AddonVersionType | null,
   versionInfo: VersionInfoType | null,
+  location: ReactRouterLocationType,
 |};
 
 export class AddonMoreInfoBase extends React.Component<InternalProps> {
   listContent() {
     const {
       addon,
+      currentVersion,
       hasStatsPermission,
       i18n,
+      location,
       userId,
-      currentVersion,
       versionInfo,
     } = this.props;
 
@@ -153,7 +157,9 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       privacyPolicyLink: addon.has_privacy_policy ? (
         <Link
           className="AddonMoreInfo-privacy-policy-link"
-          to={`/addon/${addon.slug}/privacy/`}
+          to={addQueryParams(`/addon/${addon.slug}/privacy/`, {
+            src: location.query.src,
+          })}
         >
           {i18n.gettext('Read the privacy policy for this add-on')}
         </Link>
@@ -161,7 +167,9 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       eulaLink: addon.has_eula ? (
         <Link
           className="AddonMoreInfo-eula-link"
-          to={`/addon/${addon.slug}/eula/`}
+          to={addQueryParams(`/addon/${addon.slug}/eula/`, {
+            src: location.query.src,
+          })}
         >
           {i18n.gettext('Read the license agreement for this add-on')}
         </Link>
@@ -170,7 +178,9 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
         <li>
           <Link
             className="AddonMoreInfo-version-history-link"
-            to={`/addon/${addon.slug}/versions/`}
+            to={addQueryParams(`/addon/${addon.slug}/versions/`, {
+              src: location.query.src,
+            })}
           >
             {i18n.gettext('See all versions')}
           </Link>
@@ -321,6 +331,7 @@ export const mapStateToProps = (state: AppState, ownProps: Props) => {
 };
 
 const AddonMoreInfo: React.ComponentType<Props> = compose(
+  withRouter,
   translate(),
   connect(mapStateToProps),
 )(AddonMoreInfoBase);

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -19,7 +19,7 @@ import {
 import Card from 'ui/components/Card';
 import DefinitionList, { Definition } from 'ui/components/DefinitionList';
 import LoadingText from 'ui/components/LoadingText';
-import { addQueryParams } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 import type { AppState } from 'amo/store';
 import type { AddonVersionType, VersionInfoType } from 'core/reducers/versions';
 import type { I18nType } from 'core/types/i18n';

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -4,6 +4,7 @@ import invariant from 'invariant';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { withRouter } from 'react-router-dom';
 
 import Link from 'amo/components/Link';
 import AddonReviewManager from 'amo/components/AddonReviewManager';
@@ -41,6 +42,7 @@ import type { AddonType } from 'core/types/addons';
 import type { DispatchFunc } from 'core/types/redux';
 import type { OnSubmitParams } from 'ui/components/DismissibleTextForm';
 import type { I18nType } from 'core/types/i18n';
+import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
@@ -74,6 +76,7 @@ type InternalProps = {|
   siteUser: UserType | null,
   siteUserCanManageReplies: boolean,
   submittingReply: boolean,
+  location: ReactRouterLocationType,
 |};
 
 export class AddonReviewCardBase extends React.Component<InternalProps> {
@@ -330,6 +333,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       errorHandler,
       flaggable,
       i18n,
+      location,
       replyingToReview,
       review,
       shortByLine,
@@ -388,6 +392,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
                   to={reviewListURL({
                     addonSlug: String(slugForReviewLink),
                     id: review.id,
+                    src: location.query.src,
                   })}
                 >
                   {text}
@@ -585,6 +590,7 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
 }
 
 const AddonReviewCard: React.ComponentType<Props> = compose(
+  withRouter,
   connect(mapStateToProps),
   withErrorHandler({ name: 'AddonReviewCard' }),
   translate(),

--- a/src/amo/components/AddonSummaryCard/index.js
+++ b/src/amo/components/AddonSummaryCard/index.js
@@ -1,12 +1,14 @@
 /* @flow */
 import * as React from 'react';
 import { compose } from 'redux';
+import { withRouter } from 'react-router-dom';
 
 import AddonTitle from 'amo/components/AddonTitle';
 import Link from 'amo/components/Link';
 import RatingsByStar from 'amo/components/RatingsByStar';
 import translate from 'core/i18n/translate';
 import { getAddonIconUrl } from 'core/imageUtils';
+import { addQueryParams } from 'core/utils';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';
@@ -14,6 +16,7 @@ import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 import { roundToOneDigit } from 'amo/components/AddonMeta';
 import { getAddonURL } from 'amo/utils';
+import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
@@ -25,14 +28,18 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
+  location: ReactRouterLocationType,
 |};
 
 export const AddonSummaryCardBase = ({
   addon,
   headerText,
   i18n,
+  location,
 }: InternalProps) => {
-  const addonUrl = addon ? getAddonURL(addon.slug) : '';
+  const addonUrl = addon
+    ? addQueryParams(getAddonURL(addon.slug), { src: location.query.src })
+    : '';
   const iconUrl = getAddonIconUrl(addon);
   const iconImage = (
     <img
@@ -49,7 +56,9 @@ export const AddonSummaryCardBase = ({
       </div>
       <div className="AddonSummaryCard-header-text">
         <h1 className="visually-hidden">{headerText}</h1>
-        <AddonTitle addon={addon} linkToAddon />
+        {/* We override the add-on URL so that it contains the `src` parameter
+        (if provided) but only in this case.  */}
+        <AddonTitle addon={addon} linkToAddon linkTo={addonUrl} />
       </div>
     </div>
   );
@@ -86,8 +95,9 @@ export const AddonSummaryCardBase = ({
   );
 };
 
-const AddonSummaryCard: React.ComponentType<Props> = compose(translate())(
-  AddonSummaryCardBase,
-);
+const AddonSummaryCard: React.ComponentType<Props> = compose(
+  withRouter,
+  translate(),
+)(AddonSummaryCardBase);
 
 export default AddonSummaryCard;

--- a/src/amo/components/AddonSummaryCard/index.js
+++ b/src/amo/components/AddonSummaryCard/index.js
@@ -58,7 +58,7 @@ export const AddonSummaryCardBase = ({
         <h1 className="visually-hidden">{headerText}</h1>
         {/* We override the add-on URL so that it contains the `src` parameter
         (if provided) but only in this case.  */}
-        <AddonTitle addon={addon} linkToAddon linkTo={addonUrl} />
+        <AddonTitle addon={addon} linkToAddon linkSource={location.query.src} />
       </div>
     </div>
   );

--- a/src/amo/components/AddonSummaryCard/index.js
+++ b/src/amo/components/AddonSummaryCard/index.js
@@ -56,8 +56,6 @@ export const AddonSummaryCardBase = ({
       </div>
       <div className="AddonSummaryCard-header-text">
         <h1 className="visually-hidden">{headerText}</h1>
-        {/* We override the add-on URL so that it contains the `src` parameter
-        (if provided) but only in this case.  */}
         <AddonTitle addon={addon} linkToAddon linkSource={location.query.src} />
       </div>
     </div>

--- a/src/amo/components/AddonSummaryCard/index.js
+++ b/src/amo/components/AddonSummaryCard/index.js
@@ -8,7 +8,7 @@ import Link from 'amo/components/Link';
 import RatingsByStar from 'amo/components/RatingsByStar';
 import translate from 'core/i18n/translate';
 import { getAddonIconUrl } from 'core/imageUtils';
-import { addQueryParams } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
 import Rating from 'ui/components/Rating';

--- a/src/amo/components/AddonTitle/index.js
+++ b/src/amo/components/AddonTitle/index.js
@@ -18,6 +18,7 @@ type Props = {|
   as?: string,
   addon: AddonType | null,
   linkToAddon?: boolean,
+  linkTo?: string,
 |};
 
 type InternalProps = {|
@@ -32,6 +33,7 @@ export const AddonTitleBase = ({
   i18n,
   isRTL,
   linkToAddon = false,
+  linkTo,
 }: InternalProps) => {
   const authors = [];
 
@@ -64,7 +66,7 @@ export const AddonTitleBase = ({
       {addon ? (
         <>
           {linkToAddon ? (
-            <Link to={getAddonURL(addon.slug)}>{addon.name}</Link>
+            <Link to={linkTo || getAddonURL(addon.slug)}>{addon.name}</Link>
           ) : (
             addon.name
           )}

--- a/src/amo/components/AddonTitle/index.js
+++ b/src/amo/components/AddonTitle/index.js
@@ -8,6 +8,7 @@ import { getAddonURL } from 'amo/utils';
 import translate from 'core/i18n/translate';
 import { isRtlLang } from 'core/i18n/utils';
 import LoadingText from 'ui/components/LoadingText';
+import { addQueryParams } from 'core/utils/url';
 import type { AppState } from 'amo/store';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
@@ -18,7 +19,7 @@ type Props = {|
   as?: string,
   addon: AddonType | null,
   linkToAddon?: boolean,
-  linkTo?: string,
+  linkSource?: string,
 |};
 
 type InternalProps = {|
@@ -33,7 +34,7 @@ export const AddonTitleBase = ({
   i18n,
   isRTL,
   linkToAddon = false,
-  linkTo,
+  linkSource,
 }: InternalProps) => {
   const authors = [];
 
@@ -66,7 +67,11 @@ export const AddonTitleBase = ({
       {addon ? (
         <>
           {linkToAddon ? (
-            <Link to={linkTo || getAddonURL(addon.slug)}>{addon.name}</Link>
+            <Link
+              to={addQueryParams(getAddonURL(addon.slug), { src: linkSource })}
+            >
+              {addon.name}
+            </Link>
           ) : (
             addon.name
           )}

--- a/src/amo/components/LanguagePicker/index.js
+++ b/src/amo/components/LanguagePicker/index.js
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 
 import languages from 'core/languages';
 import translate from 'core/i18n/translate';
-import { addQueryParams } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 
 import './styles.scss';
 

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -4,6 +4,7 @@ import invariant from 'invariant';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { withRouter } from 'react-router-dom';
 
 import Link from 'amo/components/Link';
 import { fetchGroupedRatings } from 'amo/actions/reviews';
@@ -12,7 +13,6 @@ import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import LoadingText from 'ui/components/LoadingText';
 import IconStar from 'ui/components/IconStar';
-import { withRouter } from 'react-router-dom';
 import type { GroupedRatingsType } from 'amo/api/reviews';
 import type { AppState } from 'amo/store';
 import type { AddonType } from 'core/types/addons';

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -12,12 +12,14 @@ import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import LoadingText from 'ui/components/LoadingText';
 import IconStar from 'ui/components/IconStar';
+import { withRouter } from 'react-router-dom';
 import type { GroupedRatingsType } from 'amo/api/reviews';
 import type { AppState } from 'amo/store';
 import type { AddonType } from 'core/types/addons';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
+import type { ReactRouterLocationType } from 'core/types/router';
 
 import './styles.scss';
 
@@ -31,6 +33,7 @@ type InternalProps = {|
   errorHandler: ErrorHandlerType,
   groupedRatings?: GroupedRatingsType,
   i18n: I18nType,
+  location: ReactRouterLocationType,
 |};
 
 export class RatingsByStarBase extends React.Component<InternalProps> {
@@ -84,7 +87,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
   }
 
   render() {
-    const { addon, errorHandler, i18n, groupedRatings } = this.props;
+    const { addon, errorHandler, i18n, groupedRatings, location } = this.props;
     const loading = (!addon || !groupedRatings) && !errorHandler.hasError();
 
     const linkTitles = {
@@ -114,6 +117,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
                   to={reviewListURL({
                     addonSlug: addon.slug,
                     score: star,
+                    src: location.query.src,
                   })}
                 >
                   {text}
@@ -182,6 +186,7 @@ export const extractId = (props: Props) => {
 };
 
 const RatingsByStar: React.ComponentType<Props> = compose(
+  withRouter,
   translate(),
   connect(mapStateToProps),
   withFixedErrorHandler({ fileName: __filename, extractId }),

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -13,7 +13,8 @@ import {
   CLIENT_APP_ANDROID,
   ADDON_TYPE_STATIC_THEME,
 } from 'core/constants';
-import { addQueryParams, nl2br, sanitizeHTML } from 'core/utils';
+import { nl2br, sanitizeHTML } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
 import Icon from 'ui/components/Icon';
 import LoadingText from 'ui/components/LoadingText';

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -225,7 +225,7 @@ export class AddonBase extends React.Component {
       content = (
         <Link
           className="Addon-all-reviews-link"
-          to={reviewListURL({ addonSlug: addon.slug })}
+          to={reviewListURL({ addonSlug: addon.slug, src: location.query.src })}
         >
           {linkText}
         </Link>
@@ -489,7 +489,7 @@ export class AddonBase extends React.Component {
                     <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
                 )}
                 fixFenixLinkMessage={i18n.gettext(
-                  `Not available on Firefox for Android. You can use this add-on with Firefox for Desktop. 
+                  `Not available on Firefox for Android. You can use this add-on with Firefox for Desktop.
                     Learn more about <a href="%(newLocation)s">add-ons for Android</a>.`,
                 )}
               />

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -202,7 +202,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
   }
 
   onSelectOption = (event: ElementEvent<HTMLSelectElement>) => {
-    const { addon, clientApp, history, lang } = this.props;
+    const { addon, clientApp, history, lang, location } = this.props;
     invariant(addon, 'addon is required');
 
     event.preventDefault();
@@ -211,6 +211,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     const listURL = reviewListURL({
       addonSlug: addon.slug,
       score: value === SHOW_ALL_REVIEWS ? undefined : value,
+      src: location.query.src,
     });
 
     history.push(`/${lang || ''}/${clientApp || ''}${listURL}`);
@@ -327,6 +328,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
           pathname={reviewListURL({
             addonSlug: addon.slug,
             score: location.query.score,
+            src: location.query.src,
           })}
           perPage={Number(pageSize)}
         />

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -32,6 +32,7 @@ import {
   UPDATE_RATING_COUNTS,
   createInternalReview,
 } from 'amo/actions/reviews';
+import { addQueryParams } from 'core/utils/url';
 import type {
   BeginDeleteAddonReviewAction,
   CancelDeleteAddonReviewAction,
@@ -77,23 +78,9 @@ export function reviewListURL({
   src?: string,
 |}) {
   invariant(addonSlug, 'addonSlug is required');
-  let path = `/addon/${addonSlug}/reviews/${id ? `${id}/` : ''}`;
+  const path = `/addon/${addonSlug}/reviews/${id ? `${id}/` : ''}`;
 
-  const queryParams = [];
-
-  if (score) {
-    queryParams.push(`score=${score}`);
-  }
-
-  if (src) {
-    queryParams.push(`src=${src}`);
-  }
-
-  if (queryParams.length) {
-    path = `${path}?${queryParams.join('&')}`;
-  }
-
-  return path;
+  return addQueryParams(path, { src, score });
 }
 
 type ReviewsById = {

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -69,16 +69,30 @@ export function reviewListURL({
   addonSlug,
   id,
   score,
+  src,
 }: {|
   addonSlug: string,
   id?: number,
   score?: number | string,
+  src?: string,
 |}) {
   invariant(addonSlug, 'addonSlug is required');
   let path = `/addon/${addonSlug}/reviews/${id ? `${id}/` : ''}`;
+
+  const queryParams = [];
+
   if (score) {
-    path = `${path}?score=${score}`;
+    queryParams.push(`score=${score}`);
   }
+
+  if (src) {
+    queryParams.push(`src=${src}`);
+  }
+
+  if (queryParams.length) {
+    path = `${path}?${queryParams.join('&')}`;
+  }
+
   return path;
 }
 

--- a/src/amo/utils/index.js
+++ b/src/amo/utils/index.js
@@ -6,7 +6,7 @@ import base62 from 'base62';
 import config from 'config';
 
 import { makeQueryString } from 'core/api';
-import { addQueryParams } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 
 /*
  * Return a base62 object that encodes/decodes just like how Django does it

--- a/src/core/addonManager.js
+++ b/src/core/addonManager.js
@@ -14,7 +14,7 @@ import {
   SET_ENABLE_NOT_AVAILABLE,
   ADDON_TYPE_STATIC_THEME,
 } from 'core/constants';
-import { addQueryParams } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 
 // This is the representation of an add-on in Firefox.
 type FirefoxAddon = {|
@@ -135,7 +135,7 @@ type OptionalInstallParams = {|
 |};
 
 export function install(
-  _url: string | void,
+  _url: string,
   eventCallback: Function,
   {
     _log = log,

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -14,7 +14,7 @@ import {
   addVersionCompatibilityToFilters,
   convertFiltersToQueryParams,
 } from 'core/searchUtils';
-import { addQueryParams } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { ApiState } from 'core/reducers/api';
 import type { LocalizedString, PaginatedApiResponse } from 'core/types/api';

--- a/src/core/components/SurveyNotice/index.js
+++ b/src/core/components/SurveyNotice/index.js
@@ -14,7 +14,7 @@ import {
   SURVEY_CATEGORY,
 } from 'core/constants';
 import tracking from 'core/tracking';
-import { addQueryParams } from 'core/utils';
+import { addQueryParams } from 'core/utils/url';
 import Notice from 'ui/components/Notice';
 import type { ReactRouterLocationType } from 'core/types/router';
 import type { I18nType } from 'core/types/i18n';

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -420,12 +420,18 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       resolve(installURL);
     })
       .then((installURL) => {
-        const hash =
-          installURL &&
-          getFileHash({ addon, installURL, version: currentVersion });
+        if (!installURL) {
+          throw new Error('installURL is invalid (empty or undefined)');
+        }
+
+        const hash = getFileHash({
+          addon,
+          installURL,
+          version: currentVersion,
+        });
 
         return _addonManager.install(
-          installURL,
+          installURL || '',
           makeProgressHandler({
             _tracking,
             dispatch,

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -5,7 +5,7 @@ import {
   UNLOAD_ADDON_REVIEWS,
   UPDATE_RATING_COUNTS,
 } from 'amo/actions/reviews';
-import { removeUndefinedProps } from 'core/utils/addons';
+import { removeUndefinedProps } from 'core/utils/url';
 import type {
   UnloadAddonReviewsAction,
   UpdateRatingCountsAction,

--- a/src/core/utils/addons.js
+++ b/src/core/utils/addons.js
@@ -12,6 +12,7 @@ import {
 } from 'core/constants';
 import log from 'core/logger';
 import { getPreviewImage } from 'core/imageUtils';
+import { removeUndefinedProps } from 'core/utils/url';
 import type { AddonVersionType } from 'core/reducers/versions';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
@@ -70,16 +71,6 @@ export const getFileHash = ({
 
   return undefined;
 };
-
-export function removeUndefinedProps(object: Object): Object {
-  const newObject = {};
-  Object.keys(object).forEach((key) => {
-    if (typeof object[key] !== 'undefined') {
-      newObject[key] = object[key];
-    }
-  });
-  return newObject;
-}
 
 export const getAddonJsonLinkedData = ({
   addon,

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -48,7 +48,6 @@ import {
   USER_AGENT_OS_WINDOWS,
 } from 'core/reducers/api';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
-import { removeUndefinedProps } from 'core/utils';
 
 export function getClientConfig(_config) {
   const clientConfig = {};
@@ -156,20 +155,6 @@ export function isAllowedOrigin(
   }
 
   return allowedOrigins.includes(`${parsedURL.protocol}//${parsedURL.host}`);
-}
-
-/*
- * Returns a new URL with query params appended to `urlString`.
- *
- * `urlString` can be a relative or absolute URL.
- */
-export function addQueryParams(urlString, queryParams = {}) {
-  const urlObj = url.parse(urlString, true);
-  // Clear search, since query object will only be used if search
-  // property doesn't exist.
-  urlObj.search = undefined;
-  urlObj.query = removeUndefinedProps({ ...urlObj.query, ...queryParams });
-  return url.format(urlObj);
 }
 
 export function apiAddonTypeIsValid(addonType) {

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -48,6 +48,7 @@ import {
   USER_AGENT_OS_WINDOWS,
 } from 'core/reducers/api';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
+import { removeUndefinedProps } from 'core/utils';
 
 export function getClientConfig(_config) {
   const clientConfig = {};
@@ -167,7 +168,7 @@ export function addQueryParams(urlString, queryParams = {}) {
   // Clear search, since query object will only be used if search
   // property doesn't exist.
   urlObj.search = undefined;
-  urlObj.query = { ...urlObj.query, ...queryParams };
+  urlObj.query = removeUndefinedProps({ ...urlObj.query, ...queryParams });
   return url.format(urlObj);
 }
 

--- a/src/core/utils/url.js
+++ b/src/core/utils/url.js
@@ -1,0 +1,21 @@
+/* @flow */
+import url from 'url';
+
+import { removeUndefinedProps } from 'core/utils/addons';
+
+/**
+ * Returns a new URL with query params appended to `urlString`.
+ *
+ * Note: undefined query parameters will be omitted.
+ */
+export function addQueryParams(
+  urlString: string,
+  queryParams: { [key: string]: ?string | number } = {},
+): string {
+  const urlObj = url.parse(urlString, true);
+  // Clear search, since query object will only be used if search property
+  // doesn't exist.
+  urlObj.search = undefined;
+  urlObj.query = removeUndefinedProps({ ...urlObj.query, ...queryParams });
+  return url.format(urlObj);
+}

--- a/src/core/utils/url.js
+++ b/src/core/utils/url.js
@@ -1,7 +1,19 @@
 /* @flow */
 import url from 'url';
 
-import { removeUndefinedProps } from 'core/utils/addons';
+// TODO: move this function in `index.js` if possible. It was moved from
+// `core/utils/addons` to here in order to avoid a weird import error, but it
+// does not really belong to `core/utils/addons` or `core/utils/url` either. It
+// should be put in `core/utils/index` once the file is converted to Flow.
+export function removeUndefinedProps(object: Object): Object {
+  const newObject = {};
+  Object.keys(object).forEach((key) => {
+    if (typeof object[key] !== 'undefined') {
+      newObject[key] = object[key];
+    }
+  });
+  return newObject;
+}
 
 /**
  * Returns a new URL with query params appended to `urlString`.

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -447,6 +447,36 @@ describe(__filename, () => {
     expect(statsLink).toHaveProp('href', '/addon/coolio/statistics/');
   });
 
+  it('adds a `src` query parameter to the stats link if available in the location', () => {
+    const src = 'some-src';
+    const authorUserId = 11;
+    const addon = createInternalAddon({
+      ...fakeAddon,
+      slug: 'coolio',
+      authors: [
+        {
+          ...fakeAddon.authors[0],
+          id: authorUserId,
+          name: 'tofumatt',
+          picture_url: 'http://cdn.a.m.o/myphoto.jpg',
+          url: 'http://a.m.o/en-GB/firefox/user/tofumatt/',
+          username: 'tofumatt',
+        },
+      ],
+    });
+    const root = render({
+      addon,
+      store: dispatchSignInActions({ userId: authorUserId }).store,
+      location: createFakeLocation({ query: { src } }),
+    });
+
+    const statsLink = root.find('.AddonMoreInfo-stats-link');
+    expect(statsLink).toHaveProp(
+      'href',
+      `/addon/coolio/statistics/?src=${src}`,
+    );
+  });
+
   it('links to stats if user has STATS_VIEW permission', () => {
     const addon = createInternalAddon({
       ...fakeAddon,

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1088,6 +1088,7 @@ describe(__filename, () => {
         reviewListURL({ addonSlug: slug, id: review.id, src }),
       );
     });
+
     it('uses the addonId for the byLine link when the reviewAddon has an empty slug', () => {
       // See https://github.com/mozilla/addons-frontend/issues/7322 for
       // the reason this test was added.

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -25,7 +25,9 @@ import { ALL_SUPER_POWERS } from 'core/constants';
 import { ErrorHandler } from 'core/errorHandler';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
+  createContextWithFakeRouter,
   createFakeEvent,
+  createFakeLocation,
   createStubErrorHandler,
   dispatchClientMetadata,
   dispatchSignInActions,
@@ -54,7 +56,7 @@ describe(__filename, () => {
     store = dispatchClientMetadata().store;
   });
 
-  const render = (customProps = {}) => {
+  const render = ({ location, ...customProps } = {}) => {
     const props = {
       addon: createInternalAddon(fakeAddon),
       i18n: fakeI18n(),
@@ -65,6 +67,9 @@ describe(__filename, () => {
     return shallowUntilTarget(
       <AddonReviewCard {...props} />,
       AddonReviewCardBase,
+      {
+        shallowOptions: createContextWithFakeRouter({ location }),
+      },
     );
   };
 
@@ -1065,6 +1070,24 @@ describe(__filename, () => {
       });
     });
 
+    it('adds a `src` query parameter to the link in the byLine if available in the location', () => {
+      const slug = 'some-slug';
+      const review = signInAndDispatchSavedReview({
+        externalReview: { ...fakeReview, addon: { ...fakeReview.addon, slug } },
+      });
+      const src = 'some-src';
+
+      const root = render({
+        review,
+        store,
+        location: createFakeLocation({ query: { src } }),
+      });
+
+      expect(renderByLine(root).find(Link)).toHaveProp(
+        'to',
+        reviewListURL({ addonSlug: slug, id: review.id, src }),
+      );
+    });
     it('uses the addonId for the byLine link when the reviewAddon has an empty slug', () => {
       // See https://github.com/mozilla/addons-frontend/issues/7322 for
       // the reason this test was added.

--- a/tests/unit/amo/components/TestAddonTitle.js
+++ b/tests/unit/amo/components/TestAddonTitle.js
@@ -196,4 +196,16 @@ describe(__filename, () => {
     expect(root.find('h1')).toHaveLength(0);
     expect(root.find('span.AddonTitle')).toHaveLength(1);
   });
+
+  it('accepts a linkSource prop to append to the add-on URL', () => {
+    const linkSource = 'some-src';
+    const addon = createInternalAddon(fakeAddon);
+
+    const root = render({ addon, linkToAddon: true, linkSource });
+
+    expect(root.find(Link).at(0)).toHaveProp(
+      'to',
+      `${getAddonURL(addon.slug)}?src=${linkSource}`,
+    );
+  });
 });

--- a/tests/unit/amo/components/TestRatingsByStar.js
+++ b/tests/unit/amo/components/TestRatingsByStar.js
@@ -11,6 +11,7 @@ import { ErrorHandler } from 'core/errorHandler';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
   createContextWithFakeRouter,
+  createFakeLocation,
   dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
@@ -34,11 +35,11 @@ describe(__filename, () => {
     return { addon, i18n: fakeI18n(), store, ...customProps };
   };
 
-  const render = (customProps = {}) => {
+  const render = ({ location, ...customProps } = {}) => {
     const props = getProps(customProps);
 
     return shallowUntilTarget(<RatingsByStar {...props} />, RatingsByStarBase, {
-      shallowOptions: createContextWithFakeRouter(),
+      shallowOptions: createContextWithFakeRouter({ location }),
     });
   };
 
@@ -200,6 +201,37 @@ describe(__filename, () => {
     validateLink(counts.at(2), '3', 'Read all three-star reviews');
     validateLink(counts.at(3), '2', 'Read all two-star reviews');
     validateLink(counts.at(4), '1', 'Read all one-star reviews');
+  });
+
+  it('adds a `src` query parameter to the review links when available in the location', () => {
+    const src = 'some-src';
+    const grouping = {
+      5: 964,
+      4: 821,
+      3: 543,
+      2: 22,
+      1: 0,
+    };
+    const addon = addonForGrouping(grouping);
+    store.dispatch(setGroupedRatings({ addonId: addon.id, grouping }));
+    const root = render({
+      addon,
+      location: createFakeLocation({ query: { src } }),
+    });
+    const counts = root.find('.RatingsByStar-count').find(Link);
+
+    function validateLink(link, score) {
+      expect(link).toHaveProp(
+        'to',
+        reviewListURL({ addonSlug: addon.slug, score, src }),
+      );
+    }
+
+    validateLink(counts.at(0), '5');
+    validateLink(counts.at(1), '4');
+    validateLink(counts.at(2), '3');
+    validateLink(counts.at(3), '2');
+    validateLink(counts.at(4), '1');
   });
 
   it('renders IconStar', () => {

--- a/tests/unit/amo/components/TestRatingsByStar.js
+++ b/tests/unit/amo/components/TestRatingsByStar.js
@@ -10,6 +10,7 @@ import { reviewListURL } from 'amo/reducers/reviews';
 import { ErrorHandler } from 'core/errorHandler';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
+  createContextWithFakeRouter,
   dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
@@ -36,7 +37,9 @@ describe(__filename, () => {
   const render = (customProps = {}) => {
     const props = getProps(customProps);
 
-    return shallowUntilTarget(<RatingsByStar {...props} />, RatingsByStarBase);
+    return shallowUntilTarget(<RatingsByStar {...props} />, RatingsByStarBase, {
+      shallowOptions: createContextWithFakeRouter(),
+    });
   };
 
   const addonForGrouping = (grouping, addonParams = {}) => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -1147,6 +1147,21 @@ describe(__filename, () => {
       expect(link).toHaveLength(1);
       expect(link).toHaveProp('to', reviewListURL({ addonSlug }));
     });
+
+    it('adds a `src` query parameter to the all reviews link when available in the location', () => {
+      const src = 'some-src';
+      const location = createFakeLocation({ query: { src } });
+      const addonSlug = 'adblock-plus';
+      const card = readReviewsCard({
+        addonSlug,
+        ratingsCount: 2,
+        location,
+      });
+
+      const link = allReviewsLink(card);
+
+      expect(link).toHaveProp('to', reviewListURL({ addonSlug, src }));
+    });
   });
 
   describe('version release notes', () => {

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -836,6 +836,26 @@ describe(__filename, () => {
         expect(paginator).toHaveProp('pathname', reviewListURL({ addonSlug }));
       });
 
+      it('adds a `src` query parameter to the reviews URL when available in the location', () => {
+        const src = 'some-src';
+        const location = createFakeLocation({ query: { src } });
+        const addonSlug = 'adblock-plus';
+        const addon = { ...fakeAddon, id: 8765, slug: addonSlug };
+        loadAddon(addon);
+        const root = renderWithPagination({
+          addon,
+          params: { addonSlug },
+          location,
+        });
+
+        const paginator = renderFooter(root);
+
+        expect(paginator).toHaveProp(
+          'pathname',
+          reviewListURL({ addonSlug, src }),
+        );
+      });
+
       it('configures a paginator with the right Link', () => {
         const root = renderWithPagination();
 

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -1904,5 +1904,22 @@ describe(__filename, () => {
         `/addon/${addonSlug}/reviews/${id}/?score=${score}`,
       );
     });
+
+    it('returns a URL with a src query parameter', () => {
+      const addonSlug = 'adblock-plus';
+      const src = 'some-src';
+      expect(reviewListURL({ addonSlug, src })).toEqual(
+        `/addon/${addonSlug}/reviews/?src=${src}`,
+      );
+    });
+
+    it('returns a URL with score and src in the query string', () => {
+      const addonSlug = 'adblock-plus';
+      const score = 5;
+      const src = 'some-src';
+      expect(reviewListURL({ addonSlug, score, src })).toEqual(
+        `/addon/${addonSlug}/reviews/?src=${src}&score=${score}`,
+      );
+    });
   });
 });

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -1151,7 +1151,7 @@ describe(__filename, () => {
         });
       });
 
-      it('passes an undefined hash when installURL is not found', () => {
+      it('rejects when installURL is not found', () => {
         _loadVersions({
           store,
           versionProps: {
@@ -1164,20 +1164,23 @@ describe(__filename, () => {
           },
         });
 
+        const addon = createInternalAddon(fakeAddon);
         const fakeAddonManager = getFakeAddonManagerWrapper();
-        const { root } = renderWithInstallHelpers({
+        const { root, dispatch } = renderWithInstallHelpers({
           _addonManager: fakeAddonManager,
-          defaultInstallSource,
+          addon,
           store,
         });
         const { install } = root.instance().props;
 
         return install().then(() => {
+          sinon.assert.notCalled(fakeAddonManager.install);
           sinon.assert.calledWith(
-            fakeAddonManager.install,
-            undefined,
-            sinon.match.func,
-            { defaultInstallSource, hash: undefined },
+            dispatch,
+            setInstallError({
+              guid: addon.guid,
+              error: FATAL_INSTALL_ERROR,
+            }),
           );
         });
       });

--- a/tests/unit/core/utils/test_addons.js
+++ b/tests/unit/core/utils/test_addons.js
@@ -16,7 +16,6 @@ import {
   getAddonJsonLinkedData,
   getErrorMessage,
   getFileHash,
-  removeUndefinedProps,
 } from 'core/utils/addons';
 
 describe(__filename, () => {
@@ -190,28 +189,6 @@ describe(__filename, () => {
       expect(
         getAddonJsonLinkedData({ addon, ratingThreshold: 4 }),
       ).not.toHaveProperty('aggregateRating');
-    });
-  });
-
-  describe('removeUndefinedProps', () => {
-    it('removes undefined properties', () => {
-      expect(removeUndefinedProps({ thing: undefined })).toEqual({});
-    });
-
-    it('preserves falsy properties', () => {
-      expect(removeUndefinedProps({ thing: false })).toEqual({ thing: false });
-    });
-
-    it('preserves other properties', () => {
-      expect(removeUndefinedProps({ thing: 'thing' })).toEqual({
-        thing: 'thing',
-      });
-    });
-
-    it('does not modify the original object', () => {
-      const example = { thing: undefined };
-      removeUndefinedProps(example);
-      expect(example).toEqual({ thing: undefined });
     });
   });
 });

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -1,5 +1,3 @@
-import url from 'url';
-
 import config from 'config';
 import UAParser from 'ua-parser-js';
 
@@ -20,7 +18,6 @@ import {
   OS_WINDOWS,
 } from 'core/constants';
 import {
-  addQueryParams,
   addQueryParamsToHistory,
   addonHasVersionHistory,
   apiAddonType,
@@ -412,52 +409,6 @@ describe(__filename, () => {
       expect(isAllowedOrigin('https://foo.com', { allowedOrigins })).toEqual(
         true,
       );
-    });
-  });
-
-  describe('addQueryParams', () => {
-    it('adds a query param to a plain url', () => {
-      const output = addQueryParams('http://whatever.com/', { foo: 'bar' });
-      expect(url.parse(output, true).query).toEqual({ foo: 'bar' });
-    });
-
-    it('adds more than one query param to a plain url', () => {
-      const output = addQueryParams('http://whatever.com/', {
-        foo: 'bar',
-        test: 1,
-      });
-      expect(url.parse(output, true).query).toEqual({ foo: 'bar', test: '1' });
-    });
-
-    it('overrides an existing parameter', () => {
-      const output = addQueryParams('http://whatever.com/?foo=1', {
-        foo: 'bar',
-      });
-      expect(url.parse(output, true).query).toEqual({ foo: 'bar' });
-    });
-
-    it('overrides multiple existing parameters', () => {
-      const output = addQueryParams('http://whatever.com/?foo=1&bar=2', {
-        foo: 'bar',
-        bar: 'baz',
-      });
-      expect(url.parse(output, true).query).toEqual({ foo: 'bar', bar: 'baz' });
-    });
-
-    it('leaves other params intact', () => {
-      const output = addQueryParams('http://whatever.com/?foo=1&bar=2', {
-        bar: 'updated',
-      });
-      expect(url.parse(output, true).query).toEqual({
-        foo: '1',
-        bar: 'updated',
-      });
-    });
-
-    it('handles relative URLs', () => {
-      const output = addQueryParams('/relative/path/?one=1', { two: '2' });
-      expect(output).toMatch(/^\/relative\/path\//);
-      expect(url.parse(output, true).query).toEqual({ one: '1', two: '2' });
     });
   });
 

--- a/tests/unit/core/utils/test_url.js
+++ b/tests/unit/core/utils/test_url.js
@@ -1,0 +1,58 @@
+import url from 'url';
+
+import { addQueryParams } from 'core/utils/url';
+
+describe(__filename, () => {
+  describe('addQueryParams', () => {
+    it('adds a query param to a plain url', () => {
+      const output = addQueryParams('http://whatever.com/', { foo: 'bar' });
+      expect(url.parse(output, true).query).toEqual({ foo: 'bar' });
+    });
+
+    it('adds more than one query param to a plain url', () => {
+      const output = addQueryParams('http://whatever.com/', {
+        foo: 'bar',
+        test: 1,
+      });
+      expect(url.parse(output, true).query).toEqual({ foo: 'bar', test: '1' });
+    });
+
+    it('overrides an existing parameter', () => {
+      const output = addQueryParams('http://whatever.com/?foo=1', {
+        foo: 'bar',
+      });
+      expect(url.parse(output, true).query).toEqual({ foo: 'bar' });
+    });
+
+    it('overrides multiple existing parameters', () => {
+      const output = addQueryParams('http://whatever.com/?foo=1&bar=2', {
+        foo: 'bar',
+        bar: 'baz',
+      });
+      expect(url.parse(output, true).query).toEqual({ foo: 'bar', bar: 'baz' });
+    });
+
+    it('leaves other params intact', () => {
+      const output = addQueryParams('http://whatever.com/?foo=1&bar=2', {
+        bar: 'updated',
+      });
+      expect(url.parse(output, true).query).toEqual({
+        foo: '1',
+        bar: 'updated',
+      });
+    });
+
+    it('handles relative URLs', () => {
+      const output = addQueryParams('/relative/path/?one=1', { two: '2' });
+      expect(output).toMatch(/^\/relative\/path\//);
+      expect(url.parse(output, true).query).toEqual({ one: '1', two: '2' });
+    });
+
+    it('removes undefined query parameters', () => {
+      const output = addQueryParams('http://whatever.com/', {
+        bar: undefined,
+      });
+      expect(url.parse(output, true).query).toEqual({});
+    });
+  });
+});

--- a/tests/unit/core/utils/test_url.js
+++ b/tests/unit/core/utils/test_url.js
@@ -1,8 +1,30 @@
 import url from 'url';
 
-import { addQueryParams } from 'core/utils/url';
+import { addQueryParams, removeUndefinedProps } from 'core/utils/url';
 
 describe(__filename, () => {
+  describe('removeUndefinedProps', () => {
+    it('removes undefined properties', () => {
+      expect(removeUndefinedProps({ thing: undefined })).toEqual({});
+    });
+
+    it('preserves falsy properties', () => {
+      expect(removeUndefinedProps({ thing: false })).toEqual({ thing: false });
+    });
+
+    it('preserves other properties', () => {
+      expect(removeUndefinedProps({ thing: 'thing' })).toEqual({
+        thing: 'thing',
+      });
+    });
+
+    it('does not modify the original object', () => {
+      const example = { thing: undefined };
+      removeUndefinedProps(example);
+      expect(example).toEqual({ thing: undefined });
+    });
+  });
+
   describe('addQueryParams', () => {
     it('adds a query param to a plain url', () => {
       const output = addQueryParams('http://whatever.com/', { foo: 'bar' });


### PR DESCRIPTION
Fixes #9054

---

I had to move the `addQueryParams()` function to a different file to:

- keep Flow annotations
- avoid circular dependency errors

It should work as intended for:

- all review links
- all versions
- eula pages
- privacy policy pages