### PR TITLE
Add new reviewer permissions

### DIFF
--- a/src/amo/components/AddonAdminLinks/index.js
+++ b/src/amo/components/AddonAdminLinks/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import {
-  ADDONS_CONTENTREVIEW,
+  ADDONS_CONTENT_REVIEW,
   ADDONS_EDIT,
   ADDONS_POST_REVIEW,
   ADMIN_TOOLS_VIEW,
@@ -158,7 +158,7 @@ export const mapStateToProps = (state: AppState) => {
   return {
     hasAdminPermission: hasPermission(state, ADMIN_TOOLS_VIEW),
     hasCodeReviewPermission: hasPermission(state, ADDONS_POST_REVIEW),
-    hasContentReviewPermission: hasPermission(state, ADDONS_CONTENTREVIEW),
+    hasContentReviewPermission: hasPermission(state, ADDONS_CONTENT_REVIEW),
     hasEditPermission: hasPermission(state, ADDONS_EDIT),
     hasThemeReviewPermission: hasPermission(state, THEMES_REVIEW),
   };

--- a/src/amo/components/AddonAdminLinks/index.js
+++ b/src/amo/components/AddonAdminLinks/index.js
@@ -6,7 +6,7 @@ import { compose } from 'redux';
 import {
   ADDONS_CONTENTREVIEW,
   ADDONS_EDIT,
-  ADDONS_POSTREVIEW,
+  ADDONS_POST_REVIEW,
   ADMIN_TOOLS_VIEW,
   THEMES_REVIEW,
   ADDON_TYPE_STATIC_THEME,
@@ -157,7 +157,7 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
 export const mapStateToProps = (state: AppState) => {
   return {
     hasAdminPermission: hasPermission(state, ADMIN_TOOLS_VIEW),
-    hasCodeReviewPermission: hasPermission(state, ADDONS_POSTREVIEW),
+    hasCodeReviewPermission: hasPermission(state, ADDONS_POST_REVIEW),
     hasContentReviewPermission: hasPermission(state, ADDONS_CONTENTREVIEW),
     hasEditPermission: hasPermission(state, ADDONS_EDIT),
     hasThemeReviewPermission: hasPermission(state, THEMES_REVIEW),

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -7,7 +7,7 @@ import {
   ADDONS_POST_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
   ADDONS_REVIEW,
-  ADDONS_REVIEWUNLISTED,
+  ADDONS_REVIEW_UNLISTED,
   ALL_SUPER_POWERS,
   RATINGS_MODERATE,
   REVIEWER_TOOLS_VIEW,
@@ -511,7 +511,7 @@ export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {
     permissions.includes(ADDONS_POST_REVIEW) ||
     permissions.includes(ADDONS_RECOMMENDED_REVIEW) ||
     permissions.includes(ADDONS_REVIEW) ||
-    permissions.includes(ADDONS_REVIEWUNLISTED) ||
+    permissions.includes(ADDONS_REVIEW_UNLISTED) ||
     permissions.includes(RATINGS_MODERATE) ||
     permissions.includes(REVIEWER_TOOLS_VIEW) ||
     permissions.includes(THEMES_REVIEW)

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -4,7 +4,7 @@ import invariant from 'invariant';
 import {
   ADDONS_CONTENTREVIEW,
   ADDONS_EDIT,
-  ADDONS_POSTREVIEW,
+  ADDONS_POST_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
   ADDONS_REVIEW,
   ADDONS_REVIEWUNLISTED,
@@ -508,7 +508,7 @@ export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {
   return (
     permissions.includes(ADDONS_CONTENTREVIEW) ||
     permissions.includes(ADDONS_EDIT) ||
-    permissions.includes(ADDONS_POSTREVIEW) ||
+    permissions.includes(ADDONS_POST_REVIEW) ||
     permissions.includes(ADDONS_RECOMMENDED_REVIEW) ||
     permissions.includes(ADDONS_REVIEW) ||
     permissions.includes(ADDONS_REVIEWUNLISTED) ||

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -5,10 +5,12 @@ import {
   ADDONS_CONTENTREVIEW,
   ADDONS_EDIT,
   ADDONS_POSTREVIEW,
+  ADDONS_RECOMMENDED_REVIEW,
   ADDONS_REVIEW,
   ADDONS_REVIEWUNLISTED,
   ALL_SUPER_POWERS,
   RATINGS_MODERATE,
+  REVIEWER_TOOLS_VIEW,
   THEMES_REVIEW,
 } from 'core/constants';
 import type { AppState } from 'amo/store';
@@ -504,13 +506,15 @@ export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {
   }
 
   return (
-    permissions.includes(ADDONS_POSTREVIEW) ||
     permissions.includes(ADDONS_CONTENTREVIEW) ||
+    permissions.includes(ADDONS_EDIT) ||
+    permissions.includes(ADDONS_POSTREVIEW) ||
+    permissions.includes(ADDONS_RECOMMENDED_REVIEW) ||
     permissions.includes(ADDONS_REVIEW) ||
-    permissions.includes(RATINGS_MODERATE) ||
-    permissions.includes(THEMES_REVIEW) ||
     permissions.includes(ADDONS_REVIEWUNLISTED) ||
-    permissions.includes(ADDONS_EDIT)
+    permissions.includes(RATINGS_MODERATE) ||
+    permissions.includes(REVIEWER_TOOLS_VIEW) ||
+    permissions.includes(THEMES_REVIEW)
   );
 };
 

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -11,6 +11,7 @@ import {
   ALL_SUPER_POWERS,
   RATINGS_MODERATE,
   REVIEWER_TOOLS_VIEW,
+  STATIC_THEMES_REVIEW,
   THEMES_REVIEW,
 } from 'core/constants';
 import type { AppState } from 'amo/store';
@@ -514,6 +515,7 @@ export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {
     permissions.includes(ADDONS_REVIEW_UNLISTED) ||
     permissions.includes(RATINGS_MODERATE) ||
     permissions.includes(REVIEWER_TOOLS_VIEW) ||
+    permissions.includes(STATIC_THEMES_REVIEW) ||
     permissions.includes(THEMES_REVIEW)
   );
 };

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -2,7 +2,7 @@
 import invariant from 'invariant';
 
 import {
-  ADDONS_CONTENTREVIEW,
+  ADDONS_CONTENT_REVIEW,
   ADDONS_EDIT,
   ADDONS_POST_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
@@ -506,7 +506,7 @@ export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {
   }
 
   return (
-    permissions.includes(ADDONS_CONTENTREVIEW) ||
+    permissions.includes(ADDONS_CONTENT_REVIEW) ||
     permissions.includes(ADDONS_EDIT) ||
     permissions.includes(ADDONS_POST_REVIEW) ||
     permissions.includes(ADDONS_RECOMMENDED_REVIEW) ||

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -288,7 +288,7 @@ export const ADDONS_POST_REVIEW = 'Addons:PostReview';
 // Can approve add-ons content.
 export const ADDONS_CONTENT_REVIEW = 'Addons:ContentReview';
 // Can review unlisted add-ons.
-export const ADDONS_REVIEWUNLISTED = 'Addons:ReviewUnlisted';
+export const ADDONS_REVIEW_UNLISTED = 'Addons:ReviewUnlisted';
 // Can moderate user ratings on add-ons.
 export const RATINGS_MODERATE = 'Ratings:Moderate';
 // Can edit user accounts.

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -286,7 +286,7 @@ export const FEATURED_THEMES_COLLECTION_SLUG = 'featured-personas';
 // Can confirm approval of automatically approved add-ons.
 export const ADDONS_POST_REVIEW = 'Addons:PostReview';
 // Can approve add-ons content.
-export const ADDONS_CONTENTREVIEW = 'Addons:ContentReview';
+export const ADDONS_CONTENT_REVIEW = 'Addons:ContentReview';
 // Can review unlisted add-ons.
 export const ADDONS_REVIEWUNLISTED = 'Addons:ReviewUnlisted';
 // Can moderate user ratings on add-ons.

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -297,6 +297,10 @@ export const USERS_EDIT = 'Users:Edit';
 export const ADMIN_TOOLS = 'Admin:Tools';
 // Super powers. It means absolutely all permissions.
 export const ALL_SUPER_POWERS = '*:*';
+// Can view only the reviewer tools.
+export const REVIEWER_TOOLS_VIEW = 'ReviewerTools:View';
+// Can review recommend(ed|able) add-ons.
+export const ADDONS_RECOMMENDED_REVIEW = 'Addons:RecommendedReview';
 
 export const RTL = 'rtl';
 export const LTR = 'ltr';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -284,7 +284,7 @@ export const FEATURED_THEMES_COLLECTION_EDIT = 'Collections:Contribute';
 // The slug for the special Featured Themes collection.
 export const FEATURED_THEMES_COLLECTION_SLUG = 'featured-personas';
 // Can confirm approval of automatically approved add-ons.
-export const ADDONS_POSTREVIEW = 'Addons:PostReview';
+export const ADDONS_POST_REVIEW = 'Addons:PostReview';
 // Can approve add-ons content.
 export const ADDONS_CONTENTREVIEW = 'Addons:ContentReview';
 // Can review unlisted add-ons.

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -301,6 +301,8 @@ export const ALL_SUPER_POWERS = '*:*';
 export const REVIEWER_TOOLS_VIEW = 'ReviewerTools:View';
 // Can review recommend(ed|able) add-ons.
 export const ADDONS_RECOMMENDED_REVIEW = 'Addons:RecommendedReview';
+// Can review a static theme.
+export const STATIC_THEMES_REVIEW = 'Addons:ThemeReview';
 
 export const RTL = 'rtl';
 export const LTR = 'ltr';

--- a/tests/unit/amo/components/TestAddonAdminLinks.js
+++ b/tests/unit/amo/components/TestAddonAdminLinks.js
@@ -6,7 +6,7 @@ import AddonAdminLinks, {
 import {
   ADDONS_CONTENTREVIEW,
   ADDONS_EDIT,
-  ADDONS_POSTREVIEW,
+  ADDONS_POST_REVIEW,
   ADDON_TYPE_STATIC_THEME,
   ADMIN_TOOLS_VIEW,
   THEMES_REVIEW,
@@ -165,7 +165,7 @@ describe(__filename, () => {
   });
 
   it('shows a code review link for an extension if the user has permission', () => {
-    const root = renderWithPermissions({ permissions: ADDONS_POSTREVIEW });
+    const root = renderWithPermissions({ permissions: ADDONS_POST_REVIEW });
 
     expect(root.find('.AddonAdminLinks-codeReview-link')).toHaveProp(
       'href',

--- a/tests/unit/amo/components/TestAddonAdminLinks.js
+++ b/tests/unit/amo/components/TestAddonAdminLinks.js
@@ -4,7 +4,7 @@ import AddonAdminLinks, {
   AddonAdminLinksBase,
 } from 'amo/components/AddonAdminLinks';
 import {
-  ADDONS_CONTENTREVIEW,
+  ADDONS_CONTENT_REVIEW,
   ADDONS_EDIT,
   ADDONS_POST_REVIEW,
   ADDON_TYPE_STATIC_THEME,
@@ -137,7 +137,7 @@ describe(__filename, () => {
   );
 
   it('shows a content review link if the user has permission', () => {
-    const root = renderWithPermissions({ permissions: ADDONS_CONTENTREVIEW });
+    const root = renderWithPermissions({ permissions: ADDONS_CONTENT_REVIEW });
 
     expect(root.find('.AddonAdminLinks-contentReview-link')).toHaveProp(
       'href',
@@ -157,7 +157,7 @@ describe(__filename, () => {
       addon: createInternalAddon({
         ...fakeTheme,
       }),
-      permissions: [ADDONS_CONTENTREVIEW, ADDONS_EDIT],
+      permissions: [ADDONS_CONTENT_REVIEW, ADDONS_EDIT],
     });
 
     expect(root.find('.AddonAdminLinks')).toHaveLength(1);

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -25,7 +25,7 @@ import {
 } from 'amo/reducers/users';
 import { createApiError } from 'core/api';
 import {
-  ADDONS_POSTREVIEW,
+  ADDONS_POST_REVIEW,
   CLIENT_APP_FIREFOX,
   USERS_EDIT,
 } from 'core/constants';
@@ -440,7 +440,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({
       userProps: defaultUserProps({
         reviewer_name: reviewerName,
-        permissions: [ADDONS_POSTREVIEW],
+        permissions: [ADDONS_POST_REVIEW],
       }),
     });
 
@@ -573,7 +573,7 @@ describe(__filename, () => {
 
     const root = renderUserProfileEdit({
       userProps: defaultUserProps({
-        permissions: [ADDONS_POSTREVIEW],
+        permissions: [ADDONS_POST_REVIEW],
         reviewer_name: '', // The API would return a value !== undefined for a reviewer.
       }),
     });
@@ -628,7 +628,7 @@ describe(__filename, () => {
 
   it('dispatches updateUserAccount action with all fields on submit for reviewers', () => {
     const { params, store } = signInUserWithProps({
-      permissions: [ADDONS_POSTREVIEW],
+      permissions: [ADDONS_POST_REVIEW],
       reviewer_name: 'My Reviewer Name',
     });
     const dispatchSpy = sinon.spy(store, 'dispatch');

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -24,6 +24,8 @@ import {
   ADDONS_CONTENTREVIEW,
   ADDONS_POSTREVIEW,
   ADDONS_REVIEW,
+  ADDONS_RECOMMENDED_REVIEW,
+  REVIEWER_TOOLS_VIEW,
   ADMIN_TOOLS_VIEW,
   ALL_SUPER_POWERS,
   STATS_VIEW,
@@ -352,6 +354,20 @@ describe(__filename, () => {
 
     it('returns `true` when user has ADDONS_REVIEW', () => {
       const permissions = [ADDONS_REVIEW];
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
+
+      expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
+    });
+
+    it('returns `true` when user has ADDONS_RECOMMENDED_REVIEW', () => {
+      const permissions = [ADDONS_RECOMMENDED_REVIEW];
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
+
+      expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
+    });
+
+    it('returns `true` when user has REVIEWER_TOOLS_VIEW', () => {
+      const permissions = [REVIEWER_TOOLS_VIEW];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -23,11 +23,12 @@ import reducer, {
 import {
   ADDONS_CONTENT_REVIEW,
   ADDONS_POST_REVIEW,
-  ADDONS_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
-  REVIEWER_TOOLS_VIEW,
+  ADDONS_REVIEW,
   ADMIN_TOOLS_VIEW,
   ALL_SUPER_POWERS,
+  REVIEWER_TOOLS_VIEW,
+  STATIC_THEMES_REVIEW,
   STATS_VIEW,
   THEMES_REVIEW,
 } from 'core/constants';
@@ -354,6 +355,13 @@ describe(__filename, () => {
 
     it('returns `true` when user has ADDONS_REVIEW', () => {
       const permissions = [ADDONS_REVIEW];
+      const { state } = dispatchSignInActions({ userProps: { permissions } });
+
+      expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
+    });
+
+    it('returns `true` when user has STATIC_THEMES_REVIEW', () => {
+      const permissions = [STATS_VIEW, STATIC_THEMES_REVIEW];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -22,7 +22,7 @@ import reducer, {
 } from 'amo/reducers/users';
 import {
   ADDONS_CONTENTREVIEW,
-  ADDONS_POSTREVIEW,
+  ADDONS_POST_REVIEW,
   ADDONS_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
   REVIEWER_TOOLS_VIEW,
@@ -338,8 +338,8 @@ describe(__filename, () => {
   });
 
   describe('hasAnyReviewerRelatedPermission selector', () => {
-    it('returns `true` when user has ADDONS_POSTREVIEW', () => {
-      const permissions = [ADDONS_POSTREVIEW, STATS_VIEW];
+    it('returns `true` when user has ADDONS_POST_REVIEW', () => {
+      const permissions = [ADDONS_POST_REVIEW, STATS_VIEW];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -21,7 +21,7 @@ import reducer, {
   updateUserAccount,
 } from 'amo/reducers/users';
 import {
-  ADDONS_CONTENTREVIEW,
+  ADDONS_CONTENT_REVIEW,
   ADDONS_POST_REVIEW,
   ADDONS_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
@@ -345,8 +345,8 @@ describe(__filename, () => {
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
     });
 
-    it('returns `true` when user has ADDONS_CONTENTREVIEW', () => {
-      const permissions = [STATS_VIEW, ADDONS_CONTENTREVIEW];
+    it('returns `true` when user has ADDONS_CONTENT_REVIEW', () => {
+      const permissions = [STATS_VIEW, ADDONS_CONTENT_REVIEW];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);


### PR DESCRIPTION
Should fix https://github.com/mozilla/addons-frontend/issues/9217
Fixes https://github.com/mozilla/addons-frontend/issues/9219

---

I added two new permissions to make sure we display the reviewer name field for
users with these permissions. Our function to check reviewer permissions is
closer to the one used in addons-server (I believe `STATIC_THEMES_REVIEW` and
`THEMES_REVIEW` are equivalent).