### PR TITLE
Add api logic to call the blocklist endpoint

### DIFF
--- a/src/amo/api/blocks.js
+++ b/src/amo/api/blocks.js
@@ -1,0 +1,16 @@
+/* @flow */
+import { callApi } from 'core/api';
+import type { ApiState } from 'core/reducers/api';
+import type { ExternalBlockType } from 'amo/reducers/blocks';
+
+export type GetBlockParams = {| apiState: ApiState, guid: string |};
+
+export const getBlock = ({
+  apiState,
+  guid,
+}: GetBlockParams): Promise<ExternalBlockType> => {
+  return callApi({
+    apiState,
+    endpoint: `blocklist/block/${guid}/`,
+  });
+};

--- a/src/amo/reducers/blocks.js
+++ b/src/amo/reducers/blocks.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+export type ExternalBlockType = {|
+  id: number,
+  created: string,
+  modified: string,
+  guid: string,
+  min_version: string,
+  max_version: string,
+  reason: string | null,
+  url: string | null,
+|};

--- a/tests/unit/amo/api/test_blocks.js
+++ b/tests/unit/amo/api/test_blocks.js
@@ -1,0 +1,23 @@
+import * as api from 'core/api';
+import { getBlock } from 'amo/api/blocks';
+import { createApiResponse, dispatchClientMetadata } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  it('calls the API to retrieve a block', async () => {
+    const mockApi = sinon.mock(api);
+    const apiState = dispatchClientMetadata().store.getState().api;
+    const guid = 'some-guid';
+
+    mockApi
+      .expects('callApi')
+      .withArgs({
+        endpoint: `blocklist/block/${guid}/`,
+        apiState,
+      })
+      .once()
+      .returns(createApiResponse());
+
+    await getBlock({ apiState, guid });
+    mockApi.verify();
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9231

---

Breaking down things in small pieces to ease the review process. The full branch is [here](https://github.com/mozilla/addons-frontend/tree/blocklist) (if needed). This does not do much yet but it will be used in the next patch.