### PR TITLE
Add reducer and saga to fetch blocks

### DIFF
--- a/src/amo/reducers/blocks.js
+++ b/src/amo/reducers/blocks.js
@@ -1,4 +1,9 @@
 /* @flow */
+import invariant from 'invariant';
+
+export const FETCH_BLOCK: 'FETCH_BLOCK' = 'FETCH_BLOCK';
+export const ABORT_FETCH_BLOCK: 'ABORT_FETCH_BLOCK' = 'ABORT_FETCH_BLOCK';
+export const LOAD_BLOCK: 'LOAD_BLOCK' = 'LOAD_BLOCK';
 
 export type ExternalBlockType = {|
   id: number,
@@ -10,3 +15,108 @@ export type ExternalBlockType = {|
   reason: string | null,
   url: string | null,
 |};
+
+export type BlockType = {|
+  ...ExternalBlockType,
+|};
+
+export type BlocksState = {|
+  blocks: { [guid: string]: BlockType },
+|};
+
+export const initialState: BlocksState = {
+  blocks: {},
+};
+
+type FetchBlockParams = {|
+  errorHandlerId: string,
+  guid: string,
+|};
+
+export type FetchBlockAction = {|
+  type: typeof FETCH_BLOCK,
+  payload: FetchBlockParams,
+|};
+
+export const fetchBlock = ({
+  errorHandlerId,
+  guid,
+}: FetchBlockParams): FetchBlockAction => {
+  invariant(errorHandlerId, 'errorHandlerId is required');
+  invariant(guid, 'guid is required');
+
+  return {
+    type: FETCH_BLOCK,
+    payload: { errorHandlerId, guid },
+  };
+};
+
+type AbortFetchBlockParams = {|
+  guid: string,
+|};
+
+export type AbortFetchBlockAction = {|
+  type: typeof ABORT_FETCH_BLOCK,
+  payload: AbortFetchBlockParams,
+|};
+
+export const abortFetchBlock = ({
+  guid,
+}: AbortFetchBlockParams): AbortFetchBlockAction => {
+  return {
+    type: ABORT_FETCH_BLOCK,
+    payload: { guid },
+  };
+};
+
+type LoadBlockParams = {|
+  block: ExternalBlockType,
+|};
+
+export type LoadBlockAction = {|
+  type: typeof LOAD_BLOCK,
+  payload: LoadBlockParams,
+|};
+
+export const loadBlock = ({ block }: LoadBlockParams): LoadBlockAction => {
+  invariant(block, 'block is required');
+
+  return {
+    type: LOAD_BLOCK,
+    payload: { block },
+  };
+};
+
+type Action = FetchBlockAction | AbortFetchBlockAction | LoadBlockAction;
+
+const reducer = (
+  state: BlocksState = initialState,
+  action: Action,
+): BlocksState => {
+  switch (action.type) {
+    case ABORT_FETCH_BLOCK:
+      return {
+        ...state,
+        blocks: {
+          [action.payload.guid]: null,
+        },
+      };
+
+    case LOAD_BLOCK: {
+      const { block } = action.payload;
+
+      return {
+        ...state,
+        blocks: {
+          ...state.blocks,
+          [block.guid]: block,
+        },
+      };
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;

--- a/src/amo/sagas/blocks.js
+++ b/src/amo/sagas/blocks.js
@@ -1,0 +1,31 @@
+/* @flow */
+import { call, put, select, takeLatest } from 'redux-saga/effects';
+
+import { getBlock } from 'amo/api/blocks';
+import { FETCH_BLOCK, abortFetchBlock, loadBlock } from 'amo/reducers/blocks';
+import { createErrorHandler, getState } from 'core/sagas/utils';
+import type { FetchBlockAction } from 'amo/reducers/blocks';
+import type { Saga } from 'core/types/sagas';
+
+export function* fetchBlock({
+  payload: { errorHandlerId, guid },
+}: FetchBlockAction): Saga {
+  const errorHandler = createErrorHandler(errorHandlerId);
+
+  yield put(errorHandler.createClearingAction());
+
+  try {
+    const state = yield select(getState);
+
+    const block = yield call(getBlock, { apiState: state.api, guid });
+
+    yield put(loadBlock({ block }));
+  } catch (error) {
+    yield put(errorHandler.createErrorAction(error));
+    yield put(abortFetchBlock({ guid }));
+  }
+}
+
+export default function* blocksSaga(): Saga {
+  yield takeLatest(FETCH_BLOCK, fetchBlock);
+}

--- a/src/amo/sagas/index.js
+++ b/src/amo/sagas/index.js
@@ -2,6 +2,7 @@
 import { all, fork } from 'redux-saga/effects';
 
 import addonsByAuthors from 'amo/sagas/addonsByAuthors';
+import blocks from 'amo/sagas/blocks';
 import collections from 'amo/sagas/collections';
 import guides from 'amo/sagas/guides';
 import home from 'amo/sagas/home';
@@ -27,6 +28,7 @@ export default function* rootSaga(): Saga {
     fork(addons),
     fork(addonsByAuthors),
     fork(autocomplete),
+    fork(blocks),
     fork(categories),
     fork(collections),
     fork(guides),

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -6,6 +6,7 @@ import { connectRouter, routerMiddleware } from 'connected-react-router';
 
 import addonsByAuthors from 'amo/reducers/addonsByAuthors';
 import collections from 'amo/reducers/collections';
+import blocks from 'amo/reducers/blocks';
 import home from 'amo/reducers/home';
 import landing from 'amo/reducers/landing';
 import recommendations from 'amo/reducers/recommendations';
@@ -34,6 +35,7 @@ import uiState from 'core/reducers/uiState';
 import versions from 'core/reducers/versions';
 import { middleware } from 'core/store';
 import type { AddonsByAuthorsState } from 'amo/reducers/addonsByAuthors';
+import type { BlocksState } from 'amo/reducers/blocks';
 import type { CollectionsState } from 'amo/reducers/collections';
 import type { GuidesState } from 'amo/reducers/guides';
 import type { HomeState } from 'amo/reducers/home';
@@ -68,6 +70,7 @@ type InternalAppState = {|
   addonsByAuthors: AddonsByAuthorsState,
   api: ApiState,
   autocomplete: AutocompleteState,
+  blocks: BlocksState,
   categories: CategoriesState,
   collections: CollectionsState,
   errorPage: ErrorPageState,
@@ -126,6 +129,7 @@ export const reducers: AppReducersType = {
   addonsByAuthors,
   api,
   autocomplete,
+  blocks,
   categories,
   collections,
   errors,

--- a/tests/unit/amo/reducers/test_blocks.js
+++ b/tests/unit/amo/reducers/test_blocks.js
@@ -1,0 +1,50 @@
+import blocksReducer, {
+  abortFetchBlock,
+  initialState,
+  loadBlock,
+} from 'amo/reducers/blocks';
+import { createFakeBlockResult } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  describe('reducer', () => {
+    it('initializes properly', () => {
+      const state = blocksReducer(undefined, {});
+      expect(state).toEqual(initialState);
+    });
+
+    it('ignores unrelated actions', () => {
+      const state = blocksReducer(initialState, { type: 'UNRELATED_ACTION' });
+      expect(state).toEqual(initialState);
+    });
+
+    it('sets a block to null when fetchBlock is aborted', () => {
+      const guid = 'some-guid';
+      const state = blocksReducer(undefined, {});
+      expect(state.blocks).toEqual({});
+
+      const newState = blocksReducer(state, abortFetchBlock({ guid }));
+      expect(newState.blocks).toEqual({ [guid]: null });
+    });
+
+    it('stores a block in its state', () => {
+      const guid = 'some-guid';
+      const block = createFakeBlockResult({ guid });
+      const state = blocksReducer(undefined, {});
+
+      const newState = blocksReducer(state, loadBlock({ block }));
+      expect(newState.blocks[guid]).toEqual(block);
+    });
+
+    it('preserves existing blocks when loading new blocks', () => {
+      const guid1 = 'some-guid-1';
+      const guid2 = 'some-guid-2';
+      const block1 = createFakeBlockResult({ guid: guid1 });
+      const block2 = createFakeBlockResult({ guid: guid2 });
+      const state = blocksReducer(undefined, {});
+
+      let newState = blocksReducer(state, loadBlock({ block: block1 }));
+      newState = blocksReducer(newState, loadBlock({ block: block2 }));
+      expect(Object.keys(newState.blocks)).toEqual([guid1, guid2]);
+    });
+  });
+});

--- a/tests/unit/amo/sagas/test_blocks.js
+++ b/tests/unit/amo/sagas/test_blocks.js
@@ -1,0 +1,101 @@
+import SagaTester from 'redux-saga-tester';
+
+import * as blocksApi from 'amo/api/blocks';
+import blocksReducer, {
+  abortFetchBlock,
+  fetchBlock,
+  loadBlock,
+} from 'amo/reducers/blocks';
+import blocksSaga from 'amo/sagas/blocks';
+import { createApiError } from 'core/api';
+import apiReducer from 'core/reducers/api';
+import {
+  createFakeBlockResult,
+  createStubErrorHandler,
+  dispatchClientMetadata,
+} from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  let errorHandler;
+  let mockBlocksApi;
+  let sagaTester;
+
+  beforeEach(() => {
+    errorHandler = createStubErrorHandler();
+    mockBlocksApi = sinon.mock(blocksApi);
+    sagaTester = new SagaTester({
+      initialState: dispatchClientMetadata().state,
+      reducers: {
+        api: apiReducer,
+        blocks: blocksReducer,
+      },
+    });
+    sagaTester.start(blocksSaga);
+  });
+
+  describe('fetchBlock', () => {
+    function _fetchBlock(params) {
+      sagaTester.dispatch(
+        fetchBlock({
+          errorHandlerId: errorHandler.id,
+          guid: 'some-guid',
+          ...params,
+        }),
+      );
+    }
+
+    it('calls the API to fetch a block by GUID', async () => {
+      const state = sagaTester.getState();
+      const guid = 'some-guid';
+      const block = createFakeBlockResult({ guid });
+      mockBlocksApi
+        .expects('getBlock')
+        .withArgs({ apiState: state.api, guid })
+        .resolves(block);
+
+      _fetchBlock({ guid });
+
+      const loadAction = loadBlock({ block });
+
+      const receivedAction = await sagaTester.waitFor(loadAction.type);
+      mockBlocksApi.verify();
+
+      expect(receivedAction).toEqual(loadAction);
+    });
+
+    it('clears the error handler', async () => {
+      _fetchBlock();
+
+      const errorAction = errorHandler.createClearingAction();
+
+      const receivedAction = await sagaTester.waitFor(errorAction.type);
+      expect(receivedAction).toEqual(errorAction);
+    });
+
+    it('dispatches an error for a failed block fetch', async () => {
+      const guid = 'some-guid';
+      const error = createApiError({ response: { status: 500 } });
+      mockBlocksApi.expects('getBlock').rejects(error);
+
+      _fetchBlock({ guid });
+
+      const errorAction = errorHandler.createErrorAction(error);
+      const receivedAction = await sagaTester.waitFor(errorAction.type);
+
+      expect(receivedAction).toEqual(errorAction);
+    });
+
+    it('aborts fetching for a failed block fetch', async () => {
+      const guid = 'some-guid';
+      const error = createApiError({ response: { status: 500 } });
+      mockBlocksApi.expects('getBlock').rejects(error);
+
+      _fetchBlock({ guid });
+
+      const abortAction = abortFetchBlock({ guid });
+
+      const receivedAction = await sagaTester.waitFor(abortAction.type);
+      expect(receivedAction).toEqual(abortAction);
+    });
+  });
+});

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,5 +1,5 @@
 /* global Headers, Response */
-import url from 'url';
+import urllib from 'url';
 
 import { LOCATION_CHANGE } from 'connected-react-router';
 import PropTypes from 'prop-types';
@@ -984,7 +984,7 @@ export const getFakeConfig = (
  */
 export const urlWithTheseParams = (params) => {
   return sinon.match((urlString) => {
-    const { query } = url.parse(urlString, true);
+    const { query } = urllib.parse(urlString, true);
 
     for (const param in params) {
       if (
@@ -1297,3 +1297,20 @@ export function normalizeSpaces(text) {
   // https://www.fileformat.info/info/unicode/char/202f/index.htm
   return text ? text.replace(/\s/g, ' ') : text;
 }
+
+export const createFakeBlockResult = ({
+  guid = 'some-guid',
+  reason = 'some reason',
+  url = null,
+} = {}) => {
+  return {
+    id: 123,
+    created: '2020-01-22T10:09:01Z',
+    modified: '2020-01-22T10:09:01Z',
+    guid,
+    min_version: '0',
+    max_version: '*',
+    reason,
+    url,
+  };
+};


### PR DESCRIPTION
~~:warning: depends on https://github.com/mozilla/addons-frontend/pull/9232~~
Fixes https://github.com/mozilla/addons-frontend/issues/9233

---

Breaking down things in small pieces to ease the review process. The full branch is [here](https://github.com/mozilla/addons-frontend/tree/blocklist) (if needed). This does nothing unless we explicitely call the actions. The UI part (next patch) will rely on this patch.