### PR TITLE
Add new Block page

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -116,6 +116,7 @@ module.exports = {
     'cookieSecure',
     'defaultLang',
     'dismissedExperienceSurveyCookieName',
+    'enableBlockPage',
     'enableDevTools',
     'enableFeatureDiscoTaar',
     'enableFeatureExperienceSurvey',
@@ -365,6 +366,8 @@ module.exports = {
   //
 
   enableFeatureDiscoTaar: false,
+
+  enableBlockPage: false,
 
   // Please use the `enableFeature` prefix, see:
   // https://github.com/mozilla/addons-frontend/issues/6362.

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -31,4 +31,6 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  enableBlockPage: true,
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -31,4 +31,6 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  enableBlockPage: true,
 };

--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -79,7 +79,13 @@ const Routes = ({ _config = config }: Props = {}) => (
 
     <Route exact path="/:lang/:application/guides/:slug/" component={Guides} />
 
-    <Route exact path="/:lang/:application/blocked/:guid/" component={Block} />
+    {_config.get('enableBlockPage') && (
+      <Route
+        exact
+        path="/:lang/:application/blocked/:guid/"
+        component={Block}
+      />
+    )}
 
     <Route
       exact

--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -20,6 +20,7 @@ import NotAuthorizedPage from 'amo/pages/ErrorPages/NotAuthorizedPage';
 import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import ServerErrorPage from 'amo/pages/ErrorPages/ServerErrorPage';
 import Guides from 'amo/pages/Guides';
+import Block from 'amo/pages/Block';
 import Home from 'amo/pages/Home';
 import LandingPage from 'amo/pages/LandingPage';
 import LanguageTools from 'amo/pages/LanguageTools';
@@ -77,6 +78,8 @@ const Routes = ({ _config = config }: Props = {}) => (
     <Route exact path="/:lang/:application/addon/:slug/" component={Addon} />
 
     <Route exact path="/:lang/:application/guides/:slug/" component={Guides} />
+
+    <Route exact path="/:lang/:application/blocked/:guid/" component={Block} />
 
     <Route
       exact

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -1,0 +1,207 @@
+/* @flow */
+import Helmet from 'react-helmet';
+import * as React from 'react';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+
+import Card from 'ui/components/Card';
+import LoadingText from 'ui/components/LoadingText';
+import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
+import Page from 'amo/components/Page';
+import { withFixedErrorHandler } from 'core/errorHandler';
+import translate from 'core/i18n/translate';
+import { sanitizeHTML } from 'core/utils';
+import { fetchBlock } from 'amo/reducers/blocks';
+import type { AppState } from 'amo/store';
+import type { ErrorHandlerType } from 'core/errorHandler';
+import type { I18nType } from 'core/types/i18n';
+import type { DispatchFunc } from 'core/types/redux';
+import type { ReactRouterMatchType } from 'core/types/router';
+import type { BlockType } from 'amo/reducers/blocks';
+
+import './styles.scss';
+
+type Props = {|
+  match: {
+    ...ReactRouterMatchType,
+    params: {| guid: string |},
+  },
+|};
+
+type InternalProps = {|
+  ...Props,
+  block: BlockType | void | null,
+  dispatch: DispatchFunc,
+  errorHandler: ErrorHandlerType,
+  i18n: I18nType,
+|};
+
+const CRITERIA_URL =
+  'https://extensionworkshop.com/documentation/publish/add-ons-blocking-process/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=blocked-addon';
+const POLICIES_URL =
+  'https://extensionworkshop.com/documentation/publish/add-on-policies/?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=blocked-addon';
+const SUPPORT_URL =
+  'https://support.mozilla.org/kb/add-ons-cause-issues-are-on-blocklist';
+
+export class BlockBase extends React.Component<InternalProps> {
+  constructor(props: InternalProps) {
+    super(props);
+
+    const {
+      block,
+      dispatch,
+      errorHandler,
+      match: {
+        params: { guid },
+      },
+    } = this.props;
+
+    if (block === undefined) {
+      dispatch(fetchBlock({ errorHandlerId: errorHandler.id, guid }));
+    }
+  }
+
+  renderReason() {
+    const { block } = this.props;
+
+    if (block && block.reason === null) {
+      // Do not render a paragraph when it is not needed.
+      return null;
+    }
+
+    return (
+      <p className="Block-reason">{block ? block.reason : <LoadingText />}</p>
+    );
+  }
+
+  renderDateAndURL() {
+    const { block, i18n } = this.props;
+
+    if (!block) {
+      return <LoadingText />;
+    }
+
+    const content = [
+      i18n.sprintf(i18n.gettext('Blocked on %(date)s.'), {
+        date: i18n.moment(block.created).format('ll'),
+      }),
+    ];
+
+    if (block.url) {
+      content.push(
+        ' ',
+        <a key={block.url} href={block.url}>
+          {i18n.gettext('View block request')}
+        </a>,
+        '.',
+      );
+    }
+
+    return content;
+  }
+
+  render() {
+    const { block, i18n } = this.props;
+
+    if (block === null) {
+      return <NotFoundPage />;
+    }
+
+    const title = i18n.gettext(`This add-on has been blocked for your
+      protection.`);
+
+    return (
+      <Page>
+        <div className="Block-page">
+          <Helmet>
+            <title>{title}</title>
+          </Helmet>
+
+          <Card className="Block-content" header={title}>
+            <h2>{i18n.gettext('Why was it blocked?')}</h2>
+            <p
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={sanitizeHTML(
+                i18n.sprintf(
+                  i18n.gettext(`This add-on violates %(startLink)sMozilla's
+                    Add-on Policies%(endLink)s.`),
+                  {
+                    startLink: `<a href="${POLICIES_URL}">`,
+                    endLink: '</a>',
+                  },
+                ),
+                ['a'],
+              )}
+            />
+            {this.renderReason()}
+
+            <h2>{i18n.gettext('What does this mean?')}</h2>
+            <p>
+              {i18n.gettext(`The problematic add-on or plugin will be
+                automatically disabled and no longer usable.`)}
+            </p>
+            <p
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={sanitizeHTML(
+                i18n.sprintf(
+                  i18n.gettext(`When Mozilla becomes aware of add-ons, plugins,
+                    or other third-party software that seriously compromises
+                    Firefox security, stability, or performance and meets
+                    %(criteriaStartLink)scertain criteria%(criteriaEndLink)s,
+                    the software may be blocked from general use. For more
+                    information, please read %(supportStartLink)sthis support
+                    article%(supportEndLink)s.`),
+                  {
+                    criteriaStartLink: `<a href="${CRITERIA_URL}">`,
+                    criteriaEndLink: '</a>',
+                    supportStartLink: `<a href="${SUPPORT_URL}">`,
+                    supportEndLink: '</a>',
+                  },
+                ),
+                ['a'],
+              )}
+            />
+            <p className="Block-metadata">
+              {block ? (
+                i18n.sprintf(
+                  i18n.gettext('Versions blocked: %(min)s to %(max)s.'),
+                  {
+                    min: block.min_version,
+                    max: block.max_version,
+                  },
+                )
+              ) : (
+                <LoadingText />
+              )}
+              <br />
+              {this.renderDateAndURL()}
+            </p>
+          </Card>
+        </div>
+      </Page>
+    );
+  }
+}
+
+const mapStateToProps = (
+  state: AppState,
+  ownProps: InternalProps,
+): $Shape<InternalProps> => {
+  const { blocks } = state;
+
+  return {
+    block: blocks.blocks[ownProps.match.params.guid],
+  };
+};
+
+export const extractId = (ownProps: InternalProps) => {
+  return ownProps.match.params.guid;
+};
+
+const Block: React.ComponentType<Props> = compose(
+  translate(),
+  connect(mapStateToProps),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
+)(BlockBase);
+
+export default Block;

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -7,11 +7,13 @@ import { connect } from 'react-redux';
 import Card from 'ui/components/Card';
 import LoadingText from 'ui/components/LoadingText';
 import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
+import ServerErrorPage from 'amo/pages/ErrorPages/ServerErrorPage';
 import Page from 'amo/components/Page';
 import { withFixedErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import { sanitizeHTML } from 'core/utils';
 import { fetchBlock } from 'amo/reducers/blocks';
+import log from 'core/logger';
 import type { AppState } from 'amo/store';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type { I18nType } from 'core/types/i18n';
@@ -101,10 +103,16 @@ export class BlockBase extends React.Component<InternalProps> {
   }
 
   render() {
-    const { block, i18n } = this.props;
+    const { block, errorHandler, i18n } = this.props;
 
-    if (block === null) {
-      return <NotFoundPage />;
+    if (errorHandler.hasError()) {
+      log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
+
+      if (errorHandler.capturedError.responseStatusCode === 404) {
+        return <NotFoundPage />;
+      }
+
+      return <ServerErrorPage />;
     }
 
     const title = i18n.gettext(`This add-on has been blocked for your

--- a/src/amo/pages/Block/styles.scss
+++ b/src/amo/pages/Block/styles.scss
@@ -1,0 +1,5 @@
+@import '~amo/css/styles';
+
+.Block-page {
+  @include page-padding();
+}

--- a/tests/unit/amo/components/TestRoutes.js
+++ b/tests/unit/amo/components/TestRoutes.js
@@ -58,4 +58,22 @@ describe(__filename, () => {
       expect(root.find({ path })).toHaveProp('component', NotFoundPage);
     });
   });
+
+  describe('Block page', () => {
+    const path = '/:lang/:application/blocked/:guid/';
+
+    it('declares a route for the new Block page if feature is enabled', () => {
+      const _config = getFakeConfig({ enableBlockPage: true });
+      const root = render({ _config });
+
+      expect(root.find({ path })).toHaveLength(1);
+    });
+
+    it('does not declare a route for the new Block page if feature is disabled', () => {
+      const _config = getFakeConfig({ enableBlockPage: false });
+      const root = render({ _config });
+
+      expect(root.find({ path })).toHaveLength(0);
+    });
+  });
 });

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -1,0 +1,218 @@
+/* eslint camelcase: 0 */
+import * as React from 'react';
+
+import Block, { extractId, BlockBase } from 'amo/pages/Block';
+import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
+import Page from 'amo/components/Page';
+import Card from 'ui/components/Card';
+import LoadingText from 'ui/components/LoadingText';
+import { abortFetchBlock, fetchBlock, loadBlock } from 'amo/reducers/blocks';
+import {
+  createFakeBlockResult,
+  createStubErrorHandler,
+  dispatchClientMetadata,
+  fakeI18n,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  const render = ({ guid = 'some-guid', ...props } = {}) => {
+    const allProps = {
+      store: dispatchClientMetadata().store,
+      i18n: fakeI18n(),
+      match: {
+        params: {
+          guid,
+        },
+      },
+      ...props,
+    };
+
+    return shallowUntilTarget(<Block {...allProps} />, BlockBase);
+  };
+
+  it('dispatches fetchBlock when block is undefined', () => {
+    const { store } = dispatchClientMetadata();
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+    const errorHandler = createStubErrorHandler();
+    const guid = 'some-guid';
+
+    render({ errorHandler, store, guid });
+
+    sinon.assert.calledWith(
+      dispatchSpy,
+      fetchBlock({ guid, errorHandlerId: errorHandler.id }),
+    );
+
+    sinon.assert.calledOnce(dispatchSpy);
+  });
+
+  it('does not fetch a block if it has already been loaded', () => {
+    const guid = 'some-guid';
+    const block = createFakeBlockResult({ guid });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    render({ store, guid });
+
+    sinon.assert.notCalled(dispatchSpy);
+  });
+
+  it('does not fetch a block if fetch was aborted', () => {
+    const guid = 'some-guid';
+    const { store } = dispatchClientMetadata();
+    store.dispatch(abortFetchBlock({ guid }));
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    render({ store, guid });
+
+    sinon.assert.notCalled(dispatchSpy);
+  });
+
+  it('fetches a block if it has not already been loaded', () => {
+    const guid1 = 'some-guid-already-loaded';
+    const guid2 = 'some-guid-not-loaded-yet';
+    const block1 = createFakeBlockResult({ guid: guid1 });
+    const errorHandler = createStubErrorHandler();
+    const { store } = dispatchClientMetadata();
+    // We load the block with `guid-1`.
+    store.dispatch(loadBlock({ block: block1 }));
+    const dispatchSpy = sinon.spy(store, 'dispatch');
+
+    // We want to render the page with `guid-2`.
+    render({ errorHandler, store, guid: guid2 });
+
+    sinon.assert.calledWith(
+      dispatchSpy,
+      fetchBlock({ guid: guid2, errorHandlerId: errorHandler.id }),
+    );
+
+    sinon.assert.calledOnce(dispatchSpy);
+  });
+
+  it('renders a NotFoundPage when the block was not found', () => {
+    const guid = 'some-guid';
+    const { store } = dispatchClientMetadata();
+    store.dispatch(abortFetchBlock({ guid }));
+
+    const root = render({ store, guid });
+
+    expect(root.find(NotFoundPage)).toHaveLength(1);
+  });
+
+  it('renders a page with loading indicators when a block has not been loaded yet', () => {
+    const partialTitle = 'This add-on has been';
+
+    const root = render();
+
+    expect(root.find(Page)).toHaveLength(1);
+    expect(root.find('title')).toIncludeText(partialTitle);
+    expect(root.find(Card)).toHaveLength(1);
+    expect(root.find(Card)).toHaveProp(
+      'header',
+      expect.stringMatching(partialTitle),
+    );
+    expect(root.find(LoadingText)).toHaveLength(3);
+    expect(root.find('.Block-reason').find(LoadingText)).toHaveLength(1);
+    // 1. versions blocked
+    // 2. date and URL
+    expect(root.find('.Block-metadata').find(LoadingText)).toHaveLength(2);
+  });
+
+  it('renders a paragraph with the reason when the block has one', () => {
+    const guid = 'some-guid';
+    const reason = 'this is a reason for a block';
+    const block = createFakeBlockResult({ guid, reason });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-reason')).toHaveLength(1);
+    expect(root.find('.Block-reason')).toHaveText(reason);
+  });
+
+  it('does not render a reason if the block does not have one', () => {
+    const guid = 'some-guid';
+    const reason = null;
+    const block = createFakeBlockResult({ guid, reason });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-reason')).toHaveLength(0);
+  });
+
+  it('renders the min/max versions', () => {
+    const guid = 'some-guid';
+    const min_version = '12';
+    const max_version = '34';
+    const block = createFakeBlockResult({ guid, min_version, max_version });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-metadata')).toIncludeText(
+      `Versions blocked: ${min_version} to ${max_version}`,
+    );
+  });
+
+  it('renders the block date', () => {
+    const guid = 'some-guid';
+    const created = '2020-01-29T11:10:02Z';
+    const block = createFakeBlockResult({ guid, created });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+    const i18n = fakeI18n();
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-metadata')).toIncludeText(
+      `Blocked on ${i18n.moment(created).format('ll')}`,
+    );
+  });
+
+  it('renders the block URL if there is one', () => {
+    const guid = 'some-guid';
+    const url = 'http://example.org/block/reason/maybe';
+    const block = createFakeBlockResult({ guid, url });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-metadata').html()).toContain(
+      `<a href="${url}">View block request</a>.`,
+    );
+  });
+
+  it('does not render any link when there is no block URL', () => {
+    const guid = 'some-guid';
+    const url = null;
+    const block = createFakeBlockResult({ guid, url });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-metadata')).not.toIncludeText(
+      'View block request',
+    );
+  });
+
+  describe('extractId', () => {
+    it('returns a unique ID based on the GUID', () => {
+      const guid = 'this-is-not-a-guid';
+      const ownProps = {
+        match: {
+          params: { guid },
+        },
+      };
+
+      expect(extractId(ownProps)).toEqual(guid);
+    });
+  });
+});

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1296,6 +1296,7 @@ export const createFakeBlockResult = ({
   guid = 'some-guid',
   reason = 'some reason',
   url = null,
+  ...others
 } = {}) => {
   return {
     id: 123,
@@ -1306,5 +1307,6 @@ export const createFakeBlockResult = ({
     max_version: '*',
     reason,
     url,
+    ...others,
   };
 };


### PR DESCRIPTION
~~:warning: depends on https://github.com/mozilla/addons-frontend/pull/9235~~
Fixes https://github.com/mozilla/addons-frontend/issues/9216

---

This patch introduces a new patch to show blocked add-ons (blocks). It is behind a feature flag, only enabled in -dev/local dev.

Screenshots:

![Screen Shot 2020-03-18 at 10 15 45](https://user-images.githubusercontent.com/217628/76953167-8df00f00-690e-11ea-968b-b86d4637ae9e.png)

![Screen Shot 2020-03-18 at 10 17 49](https://user-images.githubusercontent.com/217628/76953171-8f213c00-690e-11ea-9d3d-f1dafe004cd6.png)
