### PR TITLE
Fix space inconsistency of site notice in mobile view

### DIFF
--- a/src/amo/components/AppBanner/styles.scss
+++ b/src/amo/components/AppBanner/styles.scss
@@ -2,10 +2,11 @@
 
 .AppBanner {
   padding: $padding-page;
-  // Split the top padding in half so that we can put optional content
-  // in there when needed.
-  padding-bottom: $padding-page / 2;
-  padding-top: $padding-page / 2;
+  // When the div contains no child
+  &:empty {
+    padding: 0;
+    padding-bottom: $padding-page;
+  }
 
   & > *:not(:last-child) {
     margin-bottom: $padding-page / 2;


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #8827 

Fixed the inconsistency of spacing in the site notice in mobile view.

![Screenshot from 2020-03-20 03-36-47](https://user-images.githubusercontent.com/50856599/77119282-28aa3400-6a5c-11ea-95b8-cd4aa6c884ee.png)
 
<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
