### PR TITLE
Add add-on name to the `Block` page

### DIFF
--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -115,8 +115,15 @@ export class BlockBase extends React.Component<InternalProps> {
       return <ServerErrorPage />;
     }
 
-    const title = i18n.gettext(`This add-on has been blocked for your
-      protection.`);
+    const title =
+      block && block.addon_name
+        ? i18n.sprintf(
+            i18n.gettext(`%(addonName)s has been blocked for your protection.`),
+            {
+              addonName: block.addon_name,
+            },
+          )
+        : i18n.gettext(`This add-on has been blocked for your protection.`);
 
     return (
       <Page>

--- a/src/amo/reducers/blocks.js
+++ b/src/amo/reducers/blocks.js
@@ -6,12 +6,13 @@ export const ABORT_FETCH_BLOCK: 'ABORT_FETCH_BLOCK' = 'ABORT_FETCH_BLOCK';
 export const LOAD_BLOCK: 'LOAD_BLOCK' = 'LOAD_BLOCK';
 
 export type ExternalBlockType = {|
-  id: number,
+  addon_name: string | null,
   created: string,
-  modified: string,
   guid: string,
-  min_version: string,
+  id: number,
   max_version: string,
+  min_version: string,
+  modified: string,
   reason: string | null,
   url: string | null,
 |};

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -155,6 +155,39 @@ describe(__filename, () => {
     expect(root.find('.Block-metadata').find(LoadingText)).toHaveLength(2);
   });
 
+  it('renders a generic header/title when the block has no add-on name', () => {
+    const guid = 'some-guid';
+    const addonName = null;
+    const block = createFakeBlockResult({ guid, addonName });
+    const partialTitle = `This add-on has been`;
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('title')).toIncludeText(partialTitle);
+    expect(root.find(Card)).toHaveProp(
+      'header',
+      expect.stringMatching(partialTitle),
+    );
+  });
+
+  it('renders the name of the add-on in the title/header when the block has one', () => {
+    const guid = 'some-guid';
+    const addonName = 'some-addon-name';
+    const block = createFakeBlockResult({ guid, addonName });
+
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find(Card)).toHaveProp(
+      'header',
+      expect.stringMatching(`${addonName} has been`),
+    );
+  });
+
   it('renders a paragraph with the reason when the block has one', () => {
     const guid = 'some-guid';
     const reason = 'this is a reason for a block';

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1293,6 +1293,7 @@ export function normalizeSpaces(text) {
 }
 
 export const createFakeBlockResult = ({
+  addonName = 'some-addon-name',
   guid = 'some-guid',
   reason = 'some reason',
   url = null,
@@ -1305,6 +1306,7 @@ export const createFakeBlockResult = ({
     guid,
     min_version: '0',
     max_version: '*',
+    addon_name: addonName,
     reason,
     url,
     ...others,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9249

---

Screenshot:

![Screen Shot 2020-03-20 at 18 17 13](https://user-images.githubusercontent.com/217628/77189637-2c7b9c00-6ad8-11ea-8eba-c42fc9430ad9.png)
