### PR TITLE
[fix]: Added tabIndex property for skipping tab accessibility

### DIFF
--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -91,14 +91,21 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
     const { addon, errorHandler, i18n, groupedRatings, location } = this.props;
     const loading = (!addon || !groupedRatings) && !errorHandler.hasError();
 
-    const linkTitles = {
-      /* eslint-disable quote-props */
-      '5': i18n.gettext('Read all five-star reviews'),
-      '4': i18n.gettext('Read all four-star reviews'),
-      '3': i18n.gettext('Read all three-star reviews'),
-      '2': i18n.gettext('Read all two-star reviews'),
-      '1': i18n.gettext('Read all one-star reviews'),
-      /* eslint-enable quote-props */
+    const getLinkTitle = (star, count = '') => {
+      switch (star) {
+        case '5':
+          return i18n.gettext(`Read all ${count} five-star reviews`);
+        case '4':
+          return i18n.gettext(`Read all ${count} four-star reviews`);
+        case '3':
+          return i18n.gettext(`Read all ${count} three-star reviews`);
+        case '2':
+          return i18n.gettext(`Read all ${count} two-star reviews`);
+        case '1':
+          return i18n.gettext(`Read all ${count} one-star reviews`);
+        default:
+          return '';
+      }
     };
 
     return (
@@ -109,17 +116,18 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
             let starCount;
             let starCountNode;
 
-            function createLink(text, tab = true) {
+            function createLink(text, count, tab = true) {
               invariant(addon, 'addon was unexpectedly empty');
 
               return (
                 <Link
-                  title={linkTitles[star] || ''}
+                  title={getLinkTitle(star, count) || ''}
                   to={reviewListURL({
                     addonSlug: addon.slug,
                     score: star,
                     src: location.query.src,
                   })}
+                  aria-hidden={!tab}
                   tabIndex={tab ? null : '-1'}
                 >
                   {text}
@@ -135,7 +143,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
               starCountNode = loading ? (
                 <LoadingText minWidth={95} />
               ) : (
-                createLink(i18n.formatNumber(starCount || 0))
+                createLink(i18n.formatNumber(starCount || 0), starCount)
               );
             }
 
@@ -145,7 +153,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
                   {loading ? (
                     <LoadingText minWidth={95} />
                   ) : (
-                    createLink(i18n.formatNumber(star), false)
+                    createLink(i18n.formatNumber(star), starCount, false)
                   )}
                   <IconStar selected />
                 </div>
@@ -159,6 +167,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
                           ? this.renderBarValue(starCount)
                           : null}
                       </div>,
+                      starCount,
                       false,
                     )
                   )}

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -81,6 +81,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
             'RatingsByStar-partialBar': width < 100,
           },
         )}
+        tabIndex="-1"
         style={{ width: `${width}%` }}
       />
     );
@@ -108,7 +109,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
             let starCount;
             let starCountNode;
 
-            function createLink(text) {
+            function createLink(text, tab = true) {
               invariant(addon, 'addon was unexpectedly empty');
 
               return (
@@ -119,6 +120,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
                     score: star,
                     src: location.query.src,
                   })}
+                  tabIndex={tab ? null : '-1'}
                 >
                   {text}
                 </Link>
@@ -143,7 +145,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
                   {loading ? (
                     <LoadingText minWidth={95} />
                   ) : (
-                    createLink(i18n.formatNumber(star))
+                    createLink(i18n.formatNumber(star), false)
                   )}
                   <IconStar selected />
                 </div>
@@ -157,6 +159,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
                           ? this.renderBarValue(starCount)
                           : null}
                       </div>,
+                      false,
                     )
                   )}
                 </div>

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -119,6 +119,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
             function createLink(text, count, tab = true) {
               invariant(addon, 'addon was unexpectedly empty');
 
+              const attributes = tab ? {} : { 'aria-hidden': true };
               return (
                 <Link
                   title={getLinkTitle(star, count) || ''}
@@ -127,7 +128,7 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
                     score: star,
                     src: location.query.src,
                   })}
-                  aria-hidden={!tab}
+                  {...attributes}
                   tabIndex={tab ? null : '-1'}
                 >
                   {text}

--- a/tests/unit/amo/components/TestRatingsByStar.js
+++ b/tests/unit/amo/components/TestRatingsByStar.js
@@ -160,11 +160,31 @@ describe(__filename, () => {
     }
 
     it.each([[counts], [bars]], (links) => {
-      validateLink(links.at(0), '5', 'Read all five-star reviews');
-      validateLink(links.at(1), '4', 'Read all four-star reviews');
-      validateLink(links.at(2), '3', 'Read all three-star reviews');
-      validateLink(links.at(3), '2', 'Read all two-star reviews');
-      validateLink(links.at(4), '1', 'Read all one-star reviews');
+      validateLink(
+        links.at(0),
+        '5',
+        `Read all ${grouping['5']} five-star reviews`,
+      );
+      validateLink(
+        links.at(1),
+        '4',
+        `Read all ${grouping['4']} four-star reviews`,
+      );
+      validateLink(
+        links.at(2),
+        '3',
+        `Read all ${grouping['3']} three-star reviews`,
+      );
+      validateLink(
+        links.at(3),
+        '2',
+        `Read all ${grouping['2']} two-star reviews`,
+      );
+      validateLink(
+        links.at(4),
+        '1',
+        `Read all ${grouping['1']} one-star reviews`,
+      );
     });
 
     expect(counts.at(0).children()).toHaveText('5');
@@ -196,11 +216,31 @@ describe(__filename, () => {
       expect(link).toHaveProp('title', expectedTitle);
     }
 
-    validateLink(counts.at(0), '5', 'Read all five-star reviews');
-    validateLink(counts.at(1), '4', 'Read all four-star reviews');
-    validateLink(counts.at(2), '3', 'Read all three-star reviews');
-    validateLink(counts.at(3), '2', 'Read all two-star reviews');
-    validateLink(counts.at(4), '1', 'Read all one-star reviews');
+    validateLink(
+      counts.at(0),
+      '5',
+      `Read all ${grouping['5']} five-star reviews`,
+    );
+    validateLink(
+      counts.at(1),
+      '4',
+      `Read all ${grouping['4']} four-star reviews`,
+    );
+    validateLink(
+      counts.at(2),
+      '3',
+      `Read all ${grouping['3']} three-star reviews`,
+    );
+    validateLink(
+      counts.at(3),
+      '2',
+      `Read all ${grouping['2']} two-star reviews`,
+    );
+    validateLink(
+      counts.at(4),
+      '1',
+      `Read all ${grouping['1']} one-star reviews`,
+    );
   });
 
   it('adds a `src` query parameter to the review links when available in the location', () => {
@@ -324,11 +364,7 @@ describe(__filename, () => {
     const root = render({ addon, i18n: fakeI18n({ lang: 'de' }) });
 
     expect(
-      root
-        .find('.RatingsByStar-count')
-        .at(0)
-        .find(Link)
-        .children(),
+      root.find('.RatingsByStar-count').at(0).find(Link).children(),
     ).toHaveText('1.000');
   });
 


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #8860 

Added `tabIndex` property for skipping tab accessibility from star and bar links as mentioned in the issue. 

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
