### PR TITLE
Add contextual link for a developer to manage their add-on

### DIFF
--- a/src/amo/components/AddonAuthorLinks/index.js
+++ b/src/amo/components/AddonAuthorLinks/index.js
@@ -17,20 +17,24 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
-  userId: number | null,
+  currentUserID: number | null,
 |};
 
 export class AddonAuthorLinksBase extends React.Component<InternalProps> {
   render() {
-    const { addon, i18n, userId } = this.props;
+    const { addon, i18n, currentUserID } = this.props;
 
     if (addon === null) {
       return null;
     }
 
-    const isAuthor = isAddonAuthor({ addon, userId });
+    const isAuthor = isAddonAuthor({ addon, userId: currentUserID });
 
-    const editLink = isAuthor ? (
+    if (!isAuthor) {
+      return null;
+    }
+
+    const editLink = (
       <li>
         <a
           className="AddonAuthorLinks-edit-link"
@@ -41,7 +45,7 @@ export class AddonAuthorLinksBase extends React.Component<InternalProps> {
           i18n.gettext('Edit add-on')}
         </a>
       </li>
-    ) : null;
+    );
 
     return (
       <DefinitionList className="AddonAuthorLinks">
@@ -60,7 +64,7 @@ export class AddonAuthorLinksBase extends React.Component<InternalProps> {
 
 export const mapStateToProps = (state: AppState) => {
   return {
-    userId: state.users.currentUserID,
+    currentUserID: state.users.currentUserID,
   };
 };
 

--- a/src/amo/components/AddonAuthorLinks/index.js
+++ b/src/amo/components/AddonAuthorLinks/index.js
@@ -1,0 +1,72 @@
+/* @flow */
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+
+import translate from 'core/i18n/translate';
+import type { AddonType } from 'core/types/addons';
+import DefinitionList, { Definition } from 'ui/components/DefinitionList';
+import type { I18nType } from 'core/types/i18n';
+import type { AppState } from 'amo/store';
+import { isAddonAuthor } from 'core/utils';
+
+type Props = {|
+  addon: AddonType | null,
+|};
+
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
+  userId: number | null,
+|};
+
+export class AddonAuthorLinksBase extends React.Component<InternalProps> {
+  render() {
+    const { addon, i18n, userId } = this.props;
+
+    if (addon === null) {
+      return null;
+    }
+
+    const isAuthor = isAddonAuthor({ addon, userId });
+
+    const editLink = isAuthor ? (
+      <li>
+        <a
+          className="AddonAuthorLinks-edit-link"
+          href={`/developers/addon/${addon.slug}/edit`}
+        >
+          {// eslint-disable-next-line max-len
+          // translators: This action allows the add-on developer to edit an add-on's properties.
+          i18n.gettext('Edit add-on')}
+        </a>
+      </li>
+    ) : null;
+
+    return (
+      <DefinitionList className="AddonAuthorLinks">
+        <Definition
+          term={
+            // translators: This is a list of links to Developer functions.
+            i18n.gettext('Author Links')
+          }
+        >
+          <ul className="AddonAuthorLinks-list">{editLink}</ul>
+        </Definition>
+      </DefinitionList>
+    );
+  }
+}
+
+export const mapStateToProps = (state: AppState) => {
+  return {
+    userId: state.users.currentUserID,
+  };
+};
+
+const AddonAuthorLinks: React.ComponentType<Props> = compose(
+  connect(mapStateToProps),
+  translate(),
+)(AddonAuthorLinksBase);
+
+export default AddonAuthorLinks;

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import AddonAdminLinks from 'amo/components/AddonAdminLinks';
+import AddonAuthorLinks from 'amo/components/AddonAuthorLinks';
 import Link from 'amo/components/Link';
 import { getVersionById, getVersionInfo } from 'core/reducers/versions';
 import { STATS_VIEW } from 'core/constants';
@@ -276,6 +277,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
           )}
         </DefinitionList>
         <AddonAdminLinks addon={addon} />
+        <AddonAuthorLinks addon={addon} />
       </>
     );
   }

--- a/tests/unit/amo/components/TestAddonAuthorLinks.js
+++ b/tests/unit/amo/components/TestAddonAuthorLinks.js
@@ -32,7 +32,7 @@ describe(__filename, () => {
     );
   }
 
-  const renderWithPermissions = ({
+  const renderWithSignedUser = ({
     addon = createInternalAddon({
       ...fakeAddon,
       slug,
@@ -52,30 +52,24 @@ describe(__filename, () => {
     return render({ addon });
   };
 
-  it('returns nothing if the userId is null / not logged in', () => {
-    const root = renderWithPermissions({});
+  it('returns nothing if the user is not logged in', () => {
+    const root = renderWithSignedUser({});
 
     expect(root.find('.AddonAuthorLinks')).toHaveLength(0);
     expect(root.find('.AddonAuthorLinks-edit-link')).toHaveLength(0);
   });
 
-  it('returns edit link if the author of the add-on in logged in', () => {
-    const root = renderWithPermissions({ userId: 10642015 });
-
-    expect(root.find('.AddonAuthorLinks')).toHaveLength(1);
-    expect(root.find('.AddonAuthorLinks-edit-link')).toHaveLength(1);
-  });
-
-  it('returns nothing if the non-author of the add-on in logged in', () => {
-    const root = renderWithPermissions({ userId: 10642014 });
+  it('returns nothing if a signed-in user is not the author of the add-on', () => {
+    const root = renderWithSignedUser({ userId: 10642014 });
 
     expect(root.find('.AddonAuthorLinks')).toHaveLength(0);
     expect(root.find('.AddonAuthorLinks-edit-link')).toHaveLength(0);
   });
 
   it('shows an edit add-on link if the user is author', () => {
-    const root = renderWithPermissions({ userId: 10642015 });
+    const root = renderWithSignedUser({ userId: 10642015 });
 
+    expect(root.find('.AddonAuthorLinks')).toHaveLength(1);
     expect(root.find('.AddonAuthorLinks-edit-link')).toHaveProp(
       'href',
       `/developers/addon/${slug}/edit`,
@@ -83,5 +77,11 @@ describe(__filename, () => {
     expect(root.find('.AddonAuthorLinks-edit-link').children()).toHaveText(
       'Edit add-on',
     );
+  });
+
+  it('returns nothing if the add-on is null', () => {
+    const root = renderWithSignedUser({ addon: null });
+
+    expect(root.find('.AddonAuthorLinks')).toHaveLength(0);
   });
 });

--- a/tests/unit/amo/components/TestAddonAuthorLinks.js
+++ b/tests/unit/amo/components/TestAddonAuthorLinks.js
@@ -1,0 +1,86 @@
+import * as React from 'react';
+
+import AddonAuthorLinks, {
+  AddonAuthorLinksBase,
+} from 'amo/components/AddonAuthorLinks';
+import { createInternalAddon } from 'core/reducers/addons';
+import {
+  dispatchClientMetadata,
+  dispatchSignInActions,
+  fakeAddon,
+} from 'tests/unit/helpers';
+import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  let store;
+  const slug = 'some-slug';
+
+  beforeEach(() => {
+    store = dispatchClientMetadata().store;
+  });
+
+  function render(props = {}) {
+    return shallowUntilTarget(
+      <AddonAuthorLinks
+        addon={props.addon || createInternalAddon(fakeAddon)}
+        i18n={fakeI18n()}
+        store={store}
+        {...props}
+      />,
+      AddonAuthorLinksBase,
+    );
+  }
+
+  const renderWithPermissions = ({
+    addon = createInternalAddon({
+      ...fakeAddon,
+      slug,
+      authors: [
+        {
+          id: 10642015,
+          name: 'avgupt',
+          picture_url: 'http://cdn.a.m.o/myphoto.jpg',
+          url: 'http://a.m.o/en-GB/firefox/user/avgupt/',
+          username: 'avgupt',
+        },
+      ],
+    }),
+    userId,
+  }) => {
+    dispatchSignInActions({ store, userId });
+    return render({ addon });
+  };
+
+  it('returns nothing if the userId is null / not logged in', () => {
+    const root = renderWithPermissions({});
+
+    expect(root.find('.AddonAuthorLinks')).toHaveLength(0);
+    expect(root.find('.AddonAuthorLinks-edit-link')).toHaveLength(0);
+  });
+
+  it('returns edit link if the author of the add-on in logged in', () => {
+    const root = renderWithPermissions({ userId: 10642015 });
+
+    expect(root.find('.AddonAuthorLinks')).toHaveLength(1);
+    expect(root.find('.AddonAuthorLinks-edit-link')).toHaveLength(1);
+  });
+
+  it('returns nothing if the non-author of the add-on in logged in', () => {
+    const root = renderWithPermissions({ userId: 10642014 });
+
+    expect(root.find('.AddonAuthorLinks')).toHaveLength(0);
+    expect(root.find('.AddonAuthorLinks-edit-link')).toHaveLength(0);
+  });
+
+  it('shows an edit add-on link if the user is author', () => {
+    const root = renderWithPermissions({ userId: 10642015 });
+
+    expect(root.find('.AddonAuthorLinks-edit-link')).toHaveProp(
+      'href',
+      `/developers/addon/${slug}/edit`,
+    );
+    expect(root.find('.AddonAuthorLinks-edit-link').children()).toHaveText(
+      'Edit add-on',
+    );
+  });
+});

--- a/tests/unit/amo/components/TestAddonAuthorLinks.js
+++ b/tests/unit/amo/components/TestAddonAuthorLinks.js
@@ -53,7 +53,7 @@ describe(__filename, () => {
   };
 
   it('returns nothing if the user is not logged in', () => {
-    const root = renderWithSignedUser({});
+    const root = render();
 
     expect(root.find('.AddonAuthorLinks')).toHaveLength(0);
     expect(root.find('.AddonAuthorLinks-edit-link')).toHaveLength(0);

--- a/tests/unit/amo/components/TestAddonAuthorLinks.js
+++ b/tests/unit/amo/components/TestAddonAuthorLinks.js
@@ -8,8 +8,9 @@ import {
   dispatchClientMetadata,
   dispatchSignInActions,
   fakeAddon,
+  fakeI18n,
+  shallowUntilTarget,
 } from 'tests/unit/helpers';
-import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   let store;

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import AddonAdminLinks from 'amo/components/AddonAdminLinks';
+import AddonAuthorLinks from 'amo/components/AddonAuthorLinks';
 import AddonMoreInfo, { AddonMoreInfoBase } from 'amo/components/AddonMoreInfo';
 import Link from 'amo/components/Link';
 import { loadVersions } from 'core/reducers/versions';
@@ -539,5 +540,12 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find(AddonAdminLinks)).toHaveProp('addon', addon);
+  });
+
+  it('renders author links', () => {
+    const addon = createInternalAddon(fakeAddon);
+    const root = render({ addon });
+
+    expect(root.find(AddonAuthorLinks)).toHaveProp('addon', addon);
   });
 });


### PR DESCRIPTION
Fixes:https://github.com/mozilla/addons-frontend/issues/2756

Add contextual link for a developer to manage their add-on

Before:
![Screenshot from 2020-03-23 21-40-51](https://user-images.githubusercontent.com/58681517/77337611-204d4400-6d4f-11ea-9418-d62609954d2f.png)


After:
![Screenshot from 2020-03-23 21-40-21](https://user-images.githubusercontent.com/58681517/77337626-24796180-6d4f-11ea-8d43-9285dd31b9d3.png)
