### PR TITLE
Show "all versions" when a block has min = 0 and max = *

### DIFF
--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -102,7 +102,7 @@ export class BlockBase extends React.Component<InternalProps> {
     return content;
   }
 
-  renderBlockData() {
+  renderVersions() {
     const { block, i18n } = this.props;
 
     if (!block) {
@@ -194,7 +194,7 @@ export class BlockBase extends React.Component<InternalProps> {
               )}
             />
             <p className="Block-metadata">
-              {this.renderBlockData()}
+              {this.renderVersions()}
               <br />
               {this.renderDateAndURL()}
             </p>

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -178,12 +178,16 @@ export class BlockBase extends React.Component<InternalProps> {
             />
             <p className="Block-metadata">
               {block ? (
-                i18n.sprintf(
-                  i18n.gettext('Versions blocked: %(min)s to %(max)s.'),
-                  {
-                    min: block.min_version,
-                    max: block.max_version,
-                  },
+                block.min_version === '0' && block.max_version === '*' ? (
+                  i18n.sprintf(
+                    i18n.gettext('Versions blocked: %(min)s to %(max)s.'),
+                    {
+                      min: block.min_version,
+                      max: block.max_version,
+                    },
+                  )
+                ) : (
+                  i18n.gettext('Versions blocked: all versions.')
                 )
               ) : (
                 <LoadingText />

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -102,6 +102,23 @@ export class BlockBase extends React.Component<InternalProps> {
     return content;
   }
 
+  renderBlockData() {
+    const { block, i18n } = this.props;
+
+    if (!block) {
+      return <LoadingText />;
+    }
+
+    if (block.min_version === '0' && block.max_version === '*') {
+      return i18n.gettext('Versions blocked: all versions.');
+    }
+
+    return i18n.sprintf(i18n.gettext('Versions blocked: %(min)s to %(max)s.'), {
+      min: block.min_version,
+      max: block.max_version,
+    });
+  }
+
   render() {
     const { block, errorHandler, i18n } = this.props;
 
@@ -177,21 +194,7 @@ export class BlockBase extends React.Component<InternalProps> {
               )}
             />
             <p className="Block-metadata">
-              {block ? (
-                block.min_version === '0' && block.max_version === '*' ? (
-                  i18n.sprintf(
-                    i18n.gettext('Versions blocked: %(min)s to %(max)s.'),
-                    {
-                      min: block.min_version,
-                      max: block.max_version,
-                    },
-                  )
-                ) : (
-                  i18n.gettext('Versions blocked: all versions.')
-                )
-              ) : (
-                <LoadingText />
-              )}
+              {this.renderBlockData()}
               <br />
               {this.renderDateAndURL()}
             </p>

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -213,7 +213,7 @@ describe(__filename, () => {
     expect(root.find('.Block-reason')).toHaveLength(0);
   });
 
-  it('renders the min/max versions if min is 0 and max is *', () => {
+  it('renders "all versions" when min is 0 and max is *', () => {
     const guid = 'some-guid';
     const min_version = '0';
     const max_version = '*';

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -213,7 +213,22 @@ describe(__filename, () => {
     expect(root.find('.Block-reason')).toHaveLength(0);
   });
 
-  it('renders the min/max versions', () => {
+  it('renders the min/max versions if min is 0 and max is *', () => {
+    const guid = 'some-guid';
+    const min_version = '0';
+    const max_version = '*';
+    const block = createFakeBlockResult({ guid, min_version, max_version });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-metadata')).toIncludeText(
+      `Versions blocked: all versions.`,
+    );
+  });
+
+  it('renders the min/max versions if min is not 0 and max is not *', () => {
     const guid = 'some-guid';
     const min_version = '12';
     const max_version = '34';


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #9250 

Changed the text of versions when `min_version` is `0` and `max_version` is `*`.

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->