### PR TITLE
Issue related to @mozilla/addons-frontend #9049. added margin 300px t…

### DIFF
--- a/src/ui/components/LoadingText/styles.scss
+++ b/src/ui/components/LoadingText/styles.scss
@@ -28,8 +28,9 @@
   display: inline-block;
   height: 1rem;
   line-height: 1;
-  margin: 0;
+  margin-left: 300px; // added new nisamova
   vertical-align: middle;
+  
 }
 
 @for $delay from 1 through 3 {


### PR DESCRIPTION
…o .LoadingText to move loading text to the right side of the Hero.



Fixes #9049 
This patch adds a margin-left that pushes loading text to the right side of the primary Hero.
