### PR TITLE
Fix max content width for the new dev comments card

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -316,7 +316,10 @@ export class AddonBase extends React.Component {
         header={i18n.gettext('Developer comments')}
         id={showMoreCardName}
       >
-        <div dangerouslySetInnerHTML={devComments} />
+        <div
+          className="Addon-developer-comments-contents"
+          dangerouslySetInnerHTML={devComments}
+        />
       </ShowMoreCard>
     );
     /* eslint-enable react/no-danger */

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -158,7 +158,8 @@
       }
     }
 
-    .AddonDescription-contents {
+    .AddonDescription-contents,
+    .Addon-developer-comments-contents {
       max-width: 550px;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9273

---

Before:

<img width="811" alt="Screen Shot 2020-03-24 at 16 54 19" src="https://user-images.githubusercontent.com/217628/77447656-33fcb700-6df0-11ea-8c45-6684733b4e06.png">

After:

<img width="815" alt="Screen Shot 2020-03-24 at 16 54 12" src="https://user-images.githubusercontent.com/217628/77447646-319a5d00-6df0-11ea-925a-beaf40b61dd0.png">