### PR TITLE
Add style for fixing site notice text overflow

### DIFF
--- a/src/ui/components/Notice/styles.scss
+++ b/src/ui/components/Notice/styles.scss
@@ -63,6 +63,7 @@
   display: inline-block;
   margin: 0;
   padding: 4px 0;
+  word-break: break-word;
 
   .Notice-light & {
     padding: 0;


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #9281
Fixed the overflow of the text by adding `word-break: break-word` as suggested in the issue.

#### Screenshot:
![Screenshot from 2020-03-25 02-06-08](https://user-images.githubusercontent.com/50856599/77474519-46e9a880-6e3d-11ea-890a-dddb6b3081c0.png)

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
