### PR TITLE
Fix OpenSearch title

### DIFF
--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -58,13 +58,13 @@ export class SearchFormBase extends React.Component<Props> {
     };
 
     let openSearchTitle = i18n.sprintf(
-      i18n.gettext('Firefox Add-ons (%(locale)s)'),
+      i18n.gettext('Firefox Add-ons'),
       i18nValues,
     );
 
     if (clientApp === CLIENT_APP_ANDROID) {
       openSearchTitle = i18n.sprintf(
-        i18n.gettext('Firefox Add-ons for Android (%(locale)s)'),
+        i18n.gettext('Firefox Add-ons for Android'),
         i18nValues,
       );
     }

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -52,23 +52,10 @@ export class SearchFormBase extends React.Component<Props> {
 
   render() {
     const { className, i18n, apiLang, clientApp } = this.props;
-
-    const i18nValues = {
-      locale: apiLang,
-    };
-
-    let openSearchTitle = i18n.sprintf(
-      i18n.gettext('Firefox Add-ons'),
-      i18nValues,
-    );
-
-    if (clientApp === CLIENT_APP_ANDROID) {
-      openSearchTitle = i18n.sprintf(
-        i18n.gettext('Firefox Add-ons for Android'),
-        i18nValues,
-      );
-    }
-
+    const openSearchTitle =
+      clientApp === CLIENT_APP_ANDROID
+        ? i18n.gettext('Firefox Add-ons for Android')
+        : i18n.gettext('Firefox Add-ons');
     return (
       <>
         <Helmet>

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -173,7 +173,7 @@ describe(__filename, () => {
 
     const link = root.find('link');
     expect(link).toHaveProp('href', `/${lang}/${clientApp}/opensearch.xml`);
-    expect(link).toHaveProp('title', `Firefox Add-ons for Android`);
+    expect(link).toHaveProp('title', 'Firefox Add-ons for Android');
   });
 
   it('renders an opensearch link for Firefox', () => {
@@ -186,6 +186,6 @@ describe(__filename, () => {
 
     const link = root.find('link');
     expect(link).toHaveProp('href', `/${lang}/${clientApp}/opensearch.xml`);
-    expect(link).toHaveProp('title', `Firefox Add-ons`);
+    expect(link).toHaveProp('title', 'Firefox Add-ons');
   });
 });

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -173,7 +173,6 @@ describe(__filename, () => {
 
     const link = root.find('link');
     expect(link).toHaveProp('href', `/${lang}/${clientApp}/opensearch.xml`);
-    expect(link).toHaveProp('title', `Firefox Add-ons for Android (${lang})`);
   });
 
   it('renders an opensearch link for Firefox', () => {
@@ -186,6 +185,5 @@ describe(__filename, () => {
 
     const link = root.find('link');
     expect(link).toHaveProp('href', `/${lang}/${clientApp}/opensearch.xml`);
-    expect(link).toHaveProp('title', `Firefox Add-ons (${lang})`);
   });
 });

--- a/tests/unit/amo/components/TestSearchForm.js
+++ b/tests/unit/amo/components/TestSearchForm.js
@@ -173,6 +173,7 @@ describe(__filename, () => {
 
     const link = root.find('link');
     expect(link).toHaveProp('href', `/${lang}/${clientApp}/opensearch.xml`);
+    expect(link).toHaveProp('title', `Firefox Add-ons for Android`);
   });
 
   it('renders an opensearch link for Firefox', () => {
@@ -185,5 +186,6 @@ describe(__filename, () => {
 
     const link = root.find('link');
     expect(link).toHaveProp('href', `/${lang}/${clientApp}/opensearch.xml`);
+    expect(link).toHaveProp('title', `Firefox Add-ons`);
   });
 });


### PR DESCRIPTION
Fixes #9284 

- Updated the SearchForm component by removing the locales in the openSearchTitle localization strings
- Revised test file by removing the expectations that the link titles include the locales

Before:
<img width="284" alt="Screen Shot 2020-03-25 at 10 23 18 AM" src="https://user-images.githubusercontent.com/28129806/77546771-bcc43300-6e82-11ea-9fb1-5e3fefc70eef.png">

After:
<img width="284" alt="Screen Shot 2020-03-25 at 10 22 20 AM" src="https://user-images.githubusercontent.com/28129806/77546789-c2217d80-6e82-11ea-9258-b2adabf042da.png">
