### PR TITLE
Remove HTML tags in the reason of a block

### DIFF
--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -72,7 +72,9 @@ export class BlockBase extends React.Component<InternalProps> {
     }
 
     return (
-      <p className="Block-reason">{block ? sanitizeHTML(block.reason).__html : <LoadingText />}</p>
+      <p className="Block-reason">
+        {block ? sanitizeHTML(block.reason).__html : <LoadingText />}
+      </p>
     );
   }
 

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -71,10 +71,8 @@ export class BlockBase extends React.Component<InternalProps> {
       return null;
     }
 
-    const { __html = '' } = sanitizeHTML(block.reason);
-
     return (
-      <p className="Block-reason">{block ? __html : <LoadingText />}</p>
+      <p className="Block-reason">{block ? sanitizeHTML(block.reason).__html : <LoadingText />}</p>
     );
   }
 

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -71,8 +71,10 @@ export class BlockBase extends React.Component<InternalProps> {
       return null;
     }
 
+    const { __html = '' } = sanitizeHTML(block.reason);
+
     return (
-      <p className="Block-reason">{block ? block.reason : <LoadingText />}</p>
+      <p className="Block-reason">{block ? __html : <LoadingText />}</p>
     );
   }
 

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -243,6 +243,21 @@ describe(__filename, () => {
     );
   });
 
+  it('renders the reason with HTML tags removed', () => {
+    const guid = 'some-guid';
+    const reason = '<a>this is a reason for a block</a>';
+    const block = createFakeBlockResult({ guid, reason });
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadBlock({ block }));
+
+    const root = render({ store, guid });
+
+    expect(root.find('.Block-reason')).toHaveLength(1);
+    expect(root.find('.Block-reason')).toHaveText(
+      'this is a reason for a block',
+    );
+  });
+
   it('renders the block date', () => {
     const guid = 'some-guid';
     const created = '2020-01-29T11:10:02Z';

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -252,7 +252,6 @@ describe(__filename, () => {
 
     const root = render({ store, guid });
 
-    expect(root.find('.Block-reason')).toHaveLength(1);
     expect(root.find('.Block-reason')).toHaveText(
       'this is a reason for a block',
     );


### PR DESCRIPTION
Fixes #9271

This patch removes HTML tags in _reason_.