### PR TITLE
Detect Operating System in labels

### DIFF
--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -32,7 +32,7 @@ import Select from 'ui/components/Select';
 
 import './styles.scss';
 
-const NO_FILTER = '';
+const NO_FILTER = 'all';
 const sortSelectName = paramsToFilter.sort;
 
 export class SearchFiltersBase extends React.Component {
@@ -153,6 +153,25 @@ export class SearchFiltersBase extends React.Component {
     ];
   }
 
+  operatingSystemValue() {
+    const { filters, userAgentInfo } = this.props;
+    if (filters.operatingSystem === '') {
+      filters.operatingSystem = convertOSToFilterValue(userAgentInfo.os.name);
+    }
+    if (typeof filters.operatingSystem === 'undefined') {
+      return undefined;
+    }
+    return filters.operatingSystem;
+  }
+
+  operatingSystemDefaultValue() {
+    const { filters, userAgentInfo } = this.props;
+    if (typeof filters.operatingSystem === 'undefined') {
+      return convertOSToFilterValue(userAgentInfo.os.name);
+    }
+    return undefined;
+  }
+
   sortOptions() {
     const { i18n } = this.props;
 
@@ -169,7 +188,7 @@ export class SearchFiltersBase extends React.Component {
   }
 
   render() {
-    const { filters, i18n, userAgentInfo } = this.props;
+    const { filters, i18n } = this.props;
 
     const expandableCardName = 'SearchFilters';
     const selectedSortFields = filters.sort
@@ -233,11 +252,11 @@ export class SearchFiltersBase extends React.Component {
           </label>
           <Select
             className="SearchFilters-OperatingSystem SearchFilters-select"
-            defaultValue={convertOSToFilterValue(userAgentInfo.os.name)}
+            defaultValue={this.operatingSystemDefaultValue()}
             id="SearchFilters-OperatingSystem"
             name="operatingSystem"
             onChange={this.onSelectElementChange}
-            value={filters.operatingSystem || NO_FILTER}
+            value={this.operatingSystemValue()}
           >
             {this.operatingSystemOptions().map((option) => {
               return <option key={option.value} {...option} />;

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -233,10 +233,11 @@ export class SearchFiltersBase extends React.Component {
           </label>
           <Select
             className="SearchFilters-OperatingSystem SearchFilters-select"
+            defaultValue={convertOSToFilterValue(userAgentInfo.os.name)}
             id="SearchFilters-OperatingSystem"
             name="operatingSystem"
             onChange={this.onSelectElementChange}
-            value={convertOSToFilterValue(userAgentInfo.os.name)}
+            value={filters.operatingSystem || NO_FILTER}
           >
             {this.operatingSystemOptions().map((option) => {
               return <option key={option.value} {...option} />;

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
+import type { UserAgentInfoType } from 'core/reducers/api';
 
 import {
   ADDON_TYPE_EXTENSION,
@@ -22,7 +23,11 @@ import {
 import { withErrorHandler } from 'core/errorHandler';
 import log from 'core/logger';
 import translate from 'core/i18n/translate';
-import { convertFiltersToQueryParams, paramsToFilter } from 'core/searchUtils';
+import {
+  convertFiltersToQueryParams,
+  paramsToFilter,
+  convertOSToFilterValue,
+} from 'core/searchUtils';
 import ExpandableCard from 'ui/components/ExpandableCard';
 import Select from 'ui/components/Select';
 
@@ -164,7 +169,7 @@ export class SearchFiltersBase extends React.Component {
   }
 
   render() {
-    const { filters, i18n } = this.props;
+    const { filters, i18n, userAgentInfo } = this.props;
 
     const expandableCardName = 'SearchFilters';
     const selectedSortFields = filters.sort
@@ -231,7 +236,7 @@ export class SearchFiltersBase extends React.Component {
             id="SearchFilters-OperatingSystem"
             name="operatingSystem"
             onChange={this.onSelectElementChange}
-            value={filters.operatingSystem || NO_FILTER}
+            value={convertOSToFilterValue(userAgentInfo.os.name)}
           >
             {this.operatingSystemOptions().map((option) => {
               return <option key={option.value} {...option} />;
@@ -263,6 +268,7 @@ export function mapStateToProps(state) {
     clientApp: state.api.clientApp,
     filters: state.search.filters,
     lang: state.api.lang,
+    userAgentInfo: state.api.userAgentInfo,
   };
 }
 

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
-import type { UserAgentInfoType } from 'core/reducers/api';
 
 import {
   ADDON_TYPE_EXTENSION,
@@ -44,6 +43,7 @@ export class SearchFiltersBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     lang: PropTypes.string.isRequired,
     pathname: PropTypes.string.isRequired,
+    userAgentInfo: PropTypes.object.isRequired,
   };
 
   onSelectElementChange = (event) => {

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -4,6 +4,7 @@ import defaultConfig from 'config';
 import log from 'core/logger';
 
 export const operatingSystems = {
+  Ubuntu: 'linux',
   Linux: 'linux',
   'Mac OS': 'mac',
   Windows: 'windows',

--- a/tests/unit/amo/components/TestSearchFilters.js
+++ b/tests/unit/amo/components/TestSearchFilters.js
@@ -108,6 +108,18 @@ describe(__filename, () => {
     });
   });
 
+  it('checks value when there is no operatingSystem filter', () => {
+    const root = render();
+
+    expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp('value', '');
+  });
+
+  it('checks value when there is a operatingSystem filter', () => {
+    const root = render({ filters: { operatingSystem: 'windows' } });
+
+    expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp('value', 'windows');
+  });
+
   it('changes the URL when a new sort filter is selected', () => {
     const root = render({ filters: { query: 'Music player' } });
 

--- a/tests/unit/amo/components/TestSearchFilters.js
+++ b/tests/unit/amo/components/TestSearchFilters.js
@@ -113,7 +113,7 @@ describe(__filename, () => {
     });
   });
 
-  it('checks value when there is no operatingSystem filter and OS is Mac', () => {
+  it('checks defaultValue when there is no operatingSystem filter and OS is Mac', () => {
     const userAgent = userAgentsByPlatform.mac.firefox57;
     const parsedUserAgent = UAParser(userAgent);
     const osValue = convertOSToFilterValue(parsedUserAgent.os.name);
@@ -123,9 +123,14 @@ describe(__filename, () => {
       'defaultValue',
       osValue,
     );
+
+    expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp(
+      'value',
+      undefined,
+    );
   });
 
-  it('checks value when there is no operatingSystem filter and OS is Linux', () => {
+  it('checks defaultValue when there is no operatingSystem filter and OS is Linux', () => {
     const userAgent = userAgentsByPlatform.linux.firefox10;
     const parsedUserAgent = UAParser(userAgent);
     const osValue = convertOSToFilterValue(parsedUserAgent.os.name);
@@ -134,6 +139,11 @@ describe(__filename, () => {
     expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp(
       'defaultValue',
       osValue,
+    );
+
+    expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp(
+      'value',
+      undefined,
     );
   });
 
@@ -145,12 +155,13 @@ describe(__filename, () => {
     });
 
     expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp(
+      'defaultValue',
+      undefined,
+    );
+
+    expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp(
       'value',
       'windows',
-    );
-    expect(root.find('.SearchFilters-OperatingSystem')).toHaveProp(
-      'defaultValue',
-      'linux',
     );
   });
 


### PR DESCRIPTION
Fixes: https://github.com/mozilla/addons-frontend/issues/3169

Used: `convertOSToFilterValue(state.api.userAgentInfo.os.name)` to detect OS and it's corresponding filter value.

Before: 
![Screenshot from 2020-03-27 19-37-38](https://user-images.githubusercontent.com/58681517/77764664-066b7400-7063-11ea-8a1c-920241f95f37.png)

After:
![Screenshot from 2020-03-27 19-37-26](https://user-images.githubusercontent.com/58681517/77764674-0b302800-7063-11ea-9495-89a79271db60.png)
