### PR TITLE
Introduce anonymous pages

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -95,6 +95,13 @@ module.exports = {
   // client caching.
   faviconVersion: 2,
 
+  // URL patterns of anonymous/stateless pages. These pages won't authenticate
+  // the logged in user (if any) and should not contain any non-public data (so
+  // that we can cache them).
+  anonymousPagePatterns: [
+    '/blocked-addon/',
+  ],
+
   // The keys listed here will be exposed on the client.
   // Since by definition client-side code is public these config keys
   // must not contain sensitive data.

--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -32,6 +32,7 @@ export class HeaderBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     isHomePage: PropTypes.bool.isRequired,
     isReviewer: PropTypes.bool.isRequired,
+    loadedPageIsAnonymous: PropTypes.bool.isRequired,
     location: PropTypes.object.isRequired,
     siteIsReadOnly: PropTypes.bool.isRequired,
     siteUser: PropTypes.object,
@@ -45,16 +46,113 @@ export class HeaderBase extends React.Component {
     this.props.handleLogOut({ api: this.props.api });
   };
 
-  render() {
+  renderMenuOrAuthButton() {
     const {
-      _config,
       i18n,
-      isHomePage,
       isReviewer,
-      location,
+      loadedPageIsAnonymous,
       siteIsReadOnly,
       siteUser,
     } = this.props;
+
+    if (loadedPageIsAnonymous) {
+      // The server has loaded a page that is marked as anonymous so we do not
+      // want to render any menu or authentication button here so that
+      // logged-in users are not confused.
+      return null;
+    }
+
+    return siteUser ? (
+      <DropdownMenu
+        text={siteUser.name}
+        className="Header-authenticate-button Header-button"
+      >
+        <DropdownMenuItem>{i18n.gettext('My Account')}</DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link
+            className="Header-user-menu-collections-link"
+            to="/collections/"
+          >
+            {i18n.gettext('View My Collections')}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link
+            className="Header-user-menu-view-profile-link"
+            to={siteUser ? `/user/${siteUser.id}/` : null}
+          >
+            {i18n.gettext('View My Profile')}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link
+            className="Header-user-menu-edit-profile-link"
+            to={siteUser ? '/users/edit' : null}
+          >
+            {i18n.gettext('Edit My Profile')}
+          </Link>
+        </DropdownMenuItem>
+
+        <DropdownMenuItem>{i18n.gettext('Tools')}</DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link
+            href="/developers/addon/submit/distribution"
+            prependClientApp={false}
+          >
+            {i18n.gettext('Submit a New Add-on')}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link href="/developers/theme/submit" prependClientApp={false}>
+            {i18n.gettext('Submit a New Theme')}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link
+            className="Header-user-menu-developers-submissions-link"
+            href="/developers/addons/"
+            prependClientApp={false}
+          >
+            {i18n.gettext('Manage My Submissions')}
+          </Link>
+        </DropdownMenuItem>
+        {isReviewer && (
+          <DropdownMenuItem>
+            <Link
+              className="Header-user-menu-reviewer-tools-link"
+              href="/reviewers/"
+              prependClientApp={false}
+            >
+              {i18n.gettext('Reviewer Tools')}
+            </Link>
+          </DropdownMenuItem>
+        )}
+
+        <DropdownMenuItem
+          className="Header-logout-button"
+          detached
+          disabled={siteIsReadOnly}
+          onClick={this.handleLogOut}
+          title={
+            siteIsReadOnly
+              ? i18n.gettext(`This action is currently unavailable.
+                          Please reload the page in a moment.`)
+              : null
+          }
+        >
+          {i18n.gettext('Log out')}
+        </DropdownMenuItem>
+      </DropdownMenu>
+    ) : (
+      <AuthenticateButton
+        className="Header-authenticate-button Header-button"
+        noIcon
+      />
+    );
+  }
+
+  render() {
+    const { _config, i18n, isHomePage, location } = this.props;
 
     const headerLink = (
       <Link className="Header-title" to="/">
@@ -110,98 +208,7 @@ export class HeaderBase extends React.Component {
               className="Header-download-button Header-button"
             />
 
-            {siteUser ? (
-              <DropdownMenu
-                text={siteUser.name}
-                className="Header-authenticate-button Header-button"
-              >
-                <DropdownMenuItem>
-                  {i18n.gettext('My Account')}
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Link
-                    className="Header-user-menu-collections-link"
-                    to="/collections/"
-                  >
-                    {i18n.gettext('View My Collections')}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Link
-                    className="Header-user-menu-view-profile-link"
-                    to={siteUser ? `/user/${siteUser.id}/` : null}
-                  >
-                    {i18n.gettext('View My Profile')}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Link
-                    className="Header-user-menu-edit-profile-link"
-                    to={siteUser ? '/users/edit' : null}
-                  >
-                    {i18n.gettext('Edit My Profile')}
-                  </Link>
-                </DropdownMenuItem>
-
-                <DropdownMenuItem>{i18n.gettext('Tools')}</DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Link
-                    href="/developers/addon/submit/distribution"
-                    prependClientApp={false}
-                  >
-                    {i18n.gettext('Submit a New Add-on')}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Link
-                    href="/developers/theme/submit"
-                    prependClientApp={false}
-                  >
-                    {i18n.gettext('Submit a New Theme')}
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <Link
-                    className="Header-user-menu-developers-submissions-link"
-                    href="/developers/addons/"
-                    prependClientApp={false}
-                  >
-                    {i18n.gettext('Manage My Submissions')}
-                  </Link>
-                </DropdownMenuItem>
-                {isReviewer && (
-                  <DropdownMenuItem>
-                    <Link
-                      className="Header-user-menu-reviewer-tools-link"
-                      href="/reviewers/"
-                      prependClientApp={false}
-                    >
-                      {i18n.gettext('Reviewer Tools')}
-                    </Link>
-                  </DropdownMenuItem>
-                )}
-
-                <DropdownMenuItem
-                  className="Header-logout-button"
-                  detached
-                  disabled={siteIsReadOnly}
-                  onClick={this.handleLogOut}
-                  title={
-                    siteIsReadOnly
-                      ? i18n.gettext(`This action is currently unavailable.
-                          Please reload the page in a moment.`)
-                      : null
-                  }
-                >
-                  {i18n.gettext('Log out')}
-                </DropdownMenuItem>
-              </DropdownMenu>
-            ) : (
-              <AuthenticateButton
-                className="Header-authenticate-button Header-button"
-                noIcon
-              />
-            )}
+            {this.renderMenuOrAuthButton()}
           </div>
 
           <SearchForm className="Header-search-form" pathname="/search/" />
@@ -215,6 +222,7 @@ export const mapStateToProps = (state) => {
   return {
     api: state.api,
     isReviewer: hasAnyReviewerRelatedPermission(state),
+    loadedPageIsAnonymous: state.site.loadedPageIsAnonymous,
     siteIsReadOnly: state.site.readOnly,
     siteUser: getCurrentUser(state.users),
   };

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -81,9 +81,13 @@ export default async function createClient(
       // When `forceRefresh` is `true`, client side navigation is disabled and
       // all links will trigger a full page reload. This is what we want when
       // the server has loaded an anoynmous page.
-      forceRefresh: initialState
-        ? initialState.site.loadedPageIsAnonymous
-        : false,
+      //
+      // Note: we check the presence of the `site` state because the `disco`
+      // app uses the same code but does not use this state.
+      forceRefresh:
+        initialState && initialState.site
+          ? initialState.site.loadedPageIsAnonymous
+          : false,
     }),
   });
 

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -22,6 +22,7 @@ export default async function createClient(
     _FastClick = FastClick,
     _RavenJs = RavenJs,
     _config = config,
+    _createBrowserHistory = createBrowserHistory,
     _tracking = tracking,
     sagas = null,
   } = {},
@@ -76,7 +77,14 @@ export default async function createClient(
   }
 
   const history = addQueryParamsToHistory({
-    history: createBrowserHistory(),
+    history: _createBrowserHistory({
+      // When `forceRefresh` is `true`, client side navigation is disabled and
+      // all links will trigger a full page reload. This is what we want when
+      // the server has loaded an anoynmous page.
+      forceRefresh: initialState
+        ? initialState.site.loadedPageIsAnonymous
+        : false,
+    }),
   });
 
   // See: https://github.com/mozilla/addons-frontend/issues/8647

--- a/src/core/reducers/site.js
+++ b/src/core/reducers/site.js
@@ -1,7 +1,8 @@
 /* @flow */
-
 export const FETCH_SITE_STATUS: 'FETCH_SITE_STATUS' = 'FETCH_SITE_STATUS';
 export const LOAD_SITE_STATUS: 'LOAD_SITE_STATUS' = 'LOAD_SITE_STATUS';
+export const LOADED_PAGE_IS_ANONYMOUS: 'LOADED_PAGE_IS_ANONYMOUS' =
+  'LOADED_PAGE_IS_ANONYMOUS';
 
 export type ExternalSiteStatus = {
   read_only: boolean,
@@ -11,11 +12,13 @@ export type ExternalSiteStatus = {
 export type SiteState = {
   readOnly: boolean,
   notice: string | null,
+  loadedPageIsAnonymous: boolean,
 };
 
 export const initialState: SiteState = {
   readOnly: false,
   notice: null,
+  loadedPageIsAnonymous: false,
 };
 
 export type FetchSiteStatusAction = {|
@@ -50,7 +53,22 @@ export const loadSiteStatus = ({
   };
 };
 
-type Action = FetchSiteStatusAction | LoadSiteStatusAction;
+export type LoadedPageIsAnonymousAction = {|
+  type: typeof LOADED_PAGE_IS_ANONYMOUS,
+  payload: {},
+|};
+
+export const loadedPageIsAnonymous = (): LoadedPageIsAnonymousAction => {
+  return {
+    type: LOADED_PAGE_IS_ANONYMOUS,
+    payload: {},
+  };
+};
+
+type Action =
+  | FetchSiteStatusAction
+  | LoadSiteStatusAction
+  | LoadedPageIsAnonymousAction;
 
 export default function siteReducer(
   state: SiteState = initialState,
@@ -62,6 +80,11 @@ export default function siteReducer(
         ...state,
         readOnly: action.payload.readOnly,
         notice: action.payload.notice,
+      };
+    case LOADED_PAGE_IS_ANONYMOUS:
+      return {
+        ...state,
+        loadedPageIsAnonymous: true,
       };
     default:
       return state;

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -5,7 +5,7 @@ import Link from 'amo/components/Link';
 import { makeQueryStringWithUTM } from 'amo/utils';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import DropdownMenu from 'ui/components/DropdownMenu';
-import { loadSiteStatus } from 'core/reducers/site';
+import { loadSiteStatus, loadedPageIsAnonymous } from 'core/reducers/site';
 import {
   createFakeEvent,
   createFakeLocation,
@@ -203,5 +203,23 @@ describe(__filename, () => {
 
     expect(root.find('.Header-logout-button')).toHaveProp('disabled', false);
     expect(root.find('.Header-logout-button')).toHaveProp('title', null);
+  });
+
+  it('does not render a menu when the loaded page is anonymous and user is logged in', () => {
+    const { store } = dispatchSignInActions();
+    store.dispatch(loadedPageIsAnonymous());
+
+    const root = renderHeader({ store });
+
+    expect(root.find(DropdownMenu)).toHaveLength(0);
+  });
+
+  it('does not render a menu when the loaded page is anonymous and user is logged out', () => {
+    const { store } = dispatchClientMetadata();
+    store.dispatch(loadedPageIsAnonymous());
+
+    const root = renderHeader({ store });
+
+    expect(root.find(AuthenticateButton)).toHaveLength(0);
   });
 });

--- a/tests/unit/core/client/test_base.js
+++ b/tests/unit/core/client/test_base.js
@@ -142,7 +142,7 @@ describe(__filename, () => {
       sinon.assert.calledWith(_createBrowserHistory, { forceRefresh: false });
     });
 
-    it('reads the initial state when creating a browser history', async () => {
+    it('reads the initial state when creating a browser history and sets `forceRefresh` to the value of the loadedPageIsAnonymous prop', async () => {
       const _createBrowserHistory = sinon.spy(createBrowserHistory);
       const { store } = createAmoStore();
       store.dispatch(loadedPageIsAnonymous());

--- a/tests/unit/core/reducers/test_site.js
+++ b/tests/unit/core/reducers/test_site.js
@@ -1,4 +1,8 @@
-import reducer, { initialState, loadSiteStatus } from 'core/reducers/site';
+import reducer, {
+  initialState,
+  loadSiteStatus,
+  loadedPageIsAnonymous,
+} from 'core/reducers/site';
 
 describe(__filename, () => {
   describe('reducer', () => {
@@ -14,7 +18,15 @@ describe(__filename, () => {
 
       const state = reducer(undefined, loadSiteStatus({ readOnly, notice }));
 
-      expect(state).toMatchObject({ readOnly, notice });
+      expect(state).toEqual(expect.objectContaining({ readOnly, notice }));
+    });
+
+    it('marks the loaded page as anonymous', () => {
+      const state = reducer(undefined, loadedPageIsAnonymous());
+
+      expect(state).toEqual(
+        expect.objectContaining({ loadedPageIsAnonymous: true }),
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9283

---

This patch introduces a new configuration parameter: `anoynmousPagePatterns`.
It should contain a list of URL patterns that the server side will check before
a lot of code is executed.

On the server, when an URL matches (in the context of the `amo` app), we will
not load the current user. Instead, we will mark the loaded page as "anonymous".

After that, the client loads and looks at the value of a `site` state prop
in the initial state. This can only be set by the server side. This check
allows us to configure the client side navigation (history/router) so that any
link will force a page reload. This is because for other pages we want to load
the current logged-in user (if any).

### Screencast

![2020-03-30 15 44 15](https://user-images.githubusercontent.com/217628/77919504-8e3cc280-729d-11ea-93c3-c581084d11b0.gif)
