### PR TITLE
Show all domains in the permission list

### DIFF
--- a/src/amo/components/PermissionsCard/index.js
+++ b/src/amo/components/PermissionsCard/index.js
@@ -5,7 +5,7 @@ import { compose } from 'redux';
 
 import translate from 'core/i18n/translate';
 import Button from 'ui/components/Button';
-import Card from 'ui/components/Card';
+import ShowMoreCard from 'ui/components/ShowMoreCard';
 import type { AppState } from 'amo/store';
 import type { AddonVersionType } from 'core/reducers/versions';
 import type { UserAgentInfoType } from 'core/reducers/api';
@@ -45,7 +45,12 @@ export class PermissionsCardBase extends React.Component<Props> {
     }
 
     return (
-      <Card header={i18n.gettext('Permissions')} className="PermissionsCard">
+      <ShowMoreCard
+        header={i18n.gettext('Permissions')}
+        className="PermissionsCard"
+        id="AddonDescription-permissions-card"
+        maxHeight={300}
+      >
         <p className="PermissionsCard-subhead">
           {i18n.gettext('This add-on can:')}
         </p>
@@ -60,7 +65,7 @@ export class PermissionsCardBase extends React.Component<Props> {
         >
           {i18n.gettext('Learn more about permissions')}
         </Button>
-      </Card>
+      </ShowMoreCard>
     );
   }
 }

--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -114,13 +114,6 @@ export class PermissionUtils {
       permissions[type].push(value);
     }
 
-    // Add the host permissions.
-    if (permissions.hosts.length) {
-      permissionsToDisplay.push(
-        <HostPermissions permissions={permissions.hosts} />,
-      );
-    }
-
     // Next, show the native messaging permission if it is present.
     const nativeMessagingPermission = 'nativeMessaging';
     if (permissions.permissions.includes(nativeMessagingPermission)) {
@@ -133,7 +126,7 @@ export class PermissionUtils {
       );
     }
 
-    // Finally, show remaining permissions, sorted alphabetically by the
+    // Next, show remaining permissions, sorted alphabetically by the
     // permission string to match Firefox.
     const permissionsCopy = permissions.permissions.slice(0);
     for (const permission of permissionsCopy.sort()) {
@@ -153,6 +146,14 @@ export class PermissionUtils {
         );
       }
     }
+
+    // Finally, Add the host permissions.
+    if (permissions.hosts.length) {
+      permissionsToDisplay.push(
+        <HostPermissions permissions={permissions.hosts} />,
+      );
+    }
+
     return permissionsToDisplay;
   }
 }

--- a/src/ui/components/HostPermissions/index.js
+++ b/src/ui/components/HostPermissions/index.js
@@ -27,7 +27,6 @@ type PermissionMessageType = HostPermissionMessageType | 'allUrlsMessageType';
 type GetPermissionStringParams = {|
   messageType: PermissionMessageType,
   param?: string | number,
-  multiple?: boolean,
 |};
 
 type GenerateHostPermissionsParams = {|
@@ -40,11 +39,8 @@ export class HostPermissionsBase extends React.Component<InternalProps> {
   getPermissionString({
     messageType,
     param,
-    multiple = false,
   }: GetPermissionStringParams): string {
     const { i18n } = this.props;
-
-    const paramNumber = parseInt(param, 10);
 
     // These should be kept in sync with Firefox's strings for webextension
     // host permissions which can be found in
@@ -53,31 +49,11 @@ export class HostPermissionsBase extends React.Component<InternalProps> {
       case allUrlsMessageType:
         return i18n.gettext('Access your data for all websites');
       case domainMessageType:
-        if (multiple) {
-          return i18n.sprintf(
-            i18n.ngettext(
-              'Access your data in %(param)s other domain',
-              'Access your data in %(param)s other domains',
-              paramNumber,
-            ),
-            { param: i18n.formatNumber(paramNumber) },
-          );
-        }
         return i18n.sprintf(
           i18n.gettext('Access your data for sites in the %(param)s domain'),
           { param },
         );
       case siteMessageType:
-        if (multiple) {
-          return i18n.sprintf(
-            i18n.ngettext(
-              'Access your data on %(param)s other site',
-              'Access your data on %(param)s other sites',
-              paramNumber,
-            ),
-            { param: i18n.formatNumber(paramNumber) },
-          );
-        }
         return i18n.sprintf(i18n.gettext('Access your data for %(param)s'), {
           param,
         });

--- a/src/ui/components/HostPermissions/index.js
+++ b/src/ui/components/HostPermissions/index.js
@@ -98,7 +98,7 @@ export class HostPermissionsBase extends React.Component<InternalProps> {
     messageType,
   }: GenerateHostPermissionsParams): Array<React.Element<typeof Permission>> {
     const hostPermissions = [];
-    for (const item of permissions.slice(0, 4)) {
+    for (const item of permissions) {
       // Add individual Permission components for the first 4 host permissions.
       hostPermissions.push(
         <Permission
@@ -106,20 +106,6 @@ export class HostPermissionsBase extends React.Component<InternalProps> {
           description={this.getPermissionString({ messageType, param: item })}
           key={item}
         />,
-      );
-    }
-    if (permissions.length > 4) {
-      // Replace the final individual permission with a "too many" permission.
-      hostPermissions[3] = (
-        <Permission
-          type="hostPermission"
-          description={this.getPermissionString({
-            messageType,
-            param: permissions.length - 3,
-            multiple: true,
-          })}
-          key={messageType}
-        />
       );
     }
     return hostPermissions;

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -27,7 +27,7 @@ type Props = {|
   className?: string,
   header?: React.Element<any> | string,
   id: string,
-  maxHeight?: number,
+  maxHeight: number,
 |};
 
 type InternalProps = {|
@@ -44,6 +44,10 @@ const initialUIState: UIStateType = {
 
 export class ShowMoreCardBase extends React.Component<InternalProps> {
   contents: HTMLElement | null;
+
+  static defaultProps = {
+    maxHeight: DEFAULT_MAX_HEIGHT,
+  };
 
   componentDidMount() {
     const { uiState } = this.props;
@@ -104,10 +108,7 @@ export class ShowMoreCardBase extends React.Component<InternalProps> {
     if (contents) {
       // If the contents are short enough they don't need a "show more" link; the
       // contents are expanded by default.
-      if (
-        uiState.showAllContent &&
-        contents.clientHeight >= (maxHeight || DEFAULT_MAX_HEIGHT)
-      ) {
+      if (uiState.showAllContent && contents.clientHeight >= maxHeight) {
         this.props.setUIState({
           ...uiState,
           showAllContent: false,

--- a/src/ui/components/ShowMoreCard/index.js
+++ b/src/ui/components/ShowMoreCard/index.js
@@ -15,7 +15,7 @@ import './styles.scss';
 
 // This refers to height of `Card-contents` CSS class,
 // beyond which it will add read more link.
-export const MAX_HEIGHT = 150;
+export const DEFAULT_MAX_HEIGHT = 150;
 
 type UIStateType = {|
   showAllContent: boolean,
@@ -27,6 +27,7 @@ type Props = {|
   className?: string,
   header?: React.Element<any> | string,
   id: string,
+  maxHeight?: number,
 |};
 
 type InternalProps = {|
@@ -99,11 +100,14 @@ export class ShowMoreCardBase extends React.Component<InternalProps> {
   }
 
   truncateToMaxHeight = (contents: HTMLElement | null) => {
-    const { uiState } = this.props;
+    const { maxHeight, uiState } = this.props;
     if (contents) {
       // If the contents are short enough they don't need a "show more" link; the
       // contents are expanded by default.
-      if (uiState.showAllContent && contents.clientHeight >= MAX_HEIGHT) {
+      if (
+        uiState.showAllContent &&
+        contents.clientHeight >= (maxHeight || DEFAULT_MAX_HEIGHT)
+      ) {
         this.props.setUIState({
           ...uiState,
           showAllContent: false,

--- a/src/ui/components/ShowMoreCard/styles.scss
+++ b/src/ui/components/ShowMoreCard/styles.scss
@@ -54,3 +54,17 @@
     }
   }
 }
+
+.PermissionsCard {
+  .Card-contents {
+    border-radius: 0;
+  }
+
+  .ShowMoreCard-contents {
+    max-height: 300px;
+  }
+
+  &.ShowMoreCard--expanded .ShowMoreCard-contents {
+    max-height: none;
+  }
+}

--- a/tests/unit/amo/components/TestPermissionUtils.js
+++ b/tests/unit/amo/components/TestPermissionUtils.js
@@ -115,7 +115,6 @@ describe(__filename, () => {
       expectPermission(result[1], 'bookmarks', 'Read and modify bookmarks');
       expectPermission(result[2], 'tabs', 'Access browser tabs');
       // HostPermissions component.
-      expect(result[3].props.permissions).toHaveLength(2);
       expect(result[3].props.permissions).toEqual([
         hostPermissionA,
         hostPermissionB,

--- a/tests/unit/amo/components/TestPermissionUtils.js
+++ b/tests/unit/amo/components/TestPermissionUtils.js
@@ -105,21 +105,21 @@ describe(__filename, () => {
       const result = permissionUtils.formatPermissions(testPermissions);
       expect(result).toHaveLength(4);
 
-      // HostPermissions component.
-      expect(result[0].props.permissions).toHaveLength(2);
-      expect(result[0].props.permissions).toEqual([
-        hostPermissionA,
-        hostPermissionB,
-      ]);
       // Native messaging next.
       expectPermission(
-        result[1],
+        result[0],
         'nativeMessaging',
         'Exchange messages with programs other than Firefox',
       );
       // Named permissions in alphabetical order.
-      expectPermission(result[2], 'bookmarks', 'Read and modify bookmarks');
-      expectPermission(result[3], 'tabs', 'Access browser tabs');
+      expectPermission(result[1], 'bookmarks', 'Read and modify bookmarks');
+      expectPermission(result[2], 'tabs', 'Access browser tabs');
+      // HostPermissions component.
+      expect(result[3].props.permissions).toHaveLength(2);
+      expect(result[3].props.permissions).toEqual([
+        hostPermissionA,
+        hostPermissionB,
+      ]);
     });
   });
 });

--- a/tests/unit/ui/components/TestHostPermissions.js
+++ b/tests/unit/ui/components/TestHostPermissions.js
@@ -34,7 +34,7 @@ describe(__filename, () => {
       '*://*.mozilla.co.uk/*',
     ];
     const root = render({ permissions });
-    expect(root.find(Permission)).toHaveLength(4);
+    expect(root.find(Permission)).toHaveLength(6);
     expectPermission(
       root.childAt(0),
       'Access your data for sites in the mozilla.org domain',
@@ -47,7 +47,18 @@ describe(__filename, () => {
       root.childAt(2),
       'Access your data for sites in the mozilla.ca domain',
     );
-    expectPermission(root.childAt(3), 'Access your data in 3 other domains');
+    expectPermission(
+      root.childAt(3),
+      'Access your data for sites in the mozilla.us domain',
+    );
+    expectPermission(
+      root.childAt(4),
+      'Access your data for sites in the mozilla.co.nz domain',
+    );
+    expectPermission(
+      root.childAt(5),
+      'Access your data for sites in the mozilla.co.uk domain',
+    );
   });
 
   it('formats site permissions', () => {
@@ -59,7 +70,7 @@ describe(__filename, () => {
       '*://awesome.mozilla.org/*',
     ];
     const root = render({ permissions });
-    expect(root.find(Permission)).toHaveLength(4);
+    expect(root.find(Permission)).toHaveLength(5);
     expectPermission(
       root.childAt(0),
       'Access your data for developer.mozilla.org',
@@ -69,7 +80,14 @@ describe(__filename, () => {
       'Access your data for addons.mozilla.org',
     );
     expectPermission(root.childAt(2), 'Access your data for www.mozilla.org');
-    expectPermission(root.childAt(3), 'Access your data on 2 other sites');
+    expectPermission(
+      root.childAt(3),
+      'Access your data for testing.mozilla.org',
+    );
+    expectPermission(
+      root.childAt(4),
+      'Access your data for awesome.mozilla.org',
+    );
   });
 
   it('returns a single host permission for all urls', () => {
@@ -111,7 +129,7 @@ describe(__filename, () => {
       '*://*.mozilla.co.uk/*',
     ];
     const root = render({ permissions });
-    expect(root.find(Permission)).toHaveLength(5);
+    expect(root.find(Permission)).toHaveLength(8);
     expectPermission(
       root.childAt(0),
       'Access your data for sites in the okta.com domain',
@@ -124,7 +142,22 @@ describe(__filename, () => {
       root.childAt(2),
       'Access your data for sites in the mozilla.com domain',
     );
-    expectPermission(root.childAt(3), 'Access your data in 4 other domains');
-    expectPermission(root.childAt(4), 'Access your data for trishulgoel.com');
+    expectPermission(
+      root.childAt(3),
+      'Access your data for sites in the mozilla.ca domain',
+    );
+    expectPermission(
+      root.childAt(4),
+      'Access your data for sites in the mozilla.us domain',
+    );
+    expectPermission(
+      root.childAt(5),
+      'Access your data for sites in the mozilla.co.nz domain',
+    );
+    expectPermission(
+      root.childAt(6),
+      'Access your data for sites in the mozilla.co.uk domain',
+    );
+    expectPermission(root.childAt(7), 'Access your data for trishulgoel.com');
   });
 });

--- a/tests/unit/ui/components/TestShowMoreCard.js
+++ b/tests/unit/ui/components/TestShowMoreCard.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import ShowMoreCard, {
   extractId,
   ShowMoreCardBase,
-  MAX_HEIGHT,
+  DEFAULT_MAX_HEIGHT,
 } from 'ui/components/ShowMoreCard';
 import {
   applyUIStateChanges,
@@ -42,7 +42,9 @@ describe(__filename, () => {
     const root = render({ store });
 
     // We are simulating the truncate method call.
-    root.instance().truncateToMaxHeight({ clientHeight: MAX_HEIGHT + 1 });
+    root
+      .instance()
+      .truncateToMaxHeight({ clientHeight: DEFAULT_MAX_HEIGHT + 1 });
 
     applyUIStateChanges({ root, store });
 
@@ -73,7 +75,7 @@ describe(__filename, () => {
       shallowOptions: { disableLifecycleMethods: true },
     });
 
-    root.instance().contents = { clientHeight: MAX_HEIGHT + 1 };
+    root.instance().contents = { clientHeight: DEFAULT_MAX_HEIGHT + 1 };
 
     root.instance().componentDidMount();
 
@@ -82,12 +84,32 @@ describe(__filename, () => {
     expect(root).not.toHaveClassName('ShowMoreCard--expanded');
   });
 
+  it('does not dispatch any setUIState if the content height is smaller than the maxHeight prop', () => {
+    const { store } = dispatchClientMetadata();
+
+    const root = render({
+      store,
+      shallowOptions: { disableLifecycleMethods: true },
+      maxHeight: DEFAULT_MAX_HEIGHT + 10,
+    });
+
+    root.instance().contents = { clientHeight: DEFAULT_MAX_HEIGHT + 1 };
+
+    root.instance().componentDidMount();
+
+    expect(() => applyUIStateChanges({ root, store })).toThrowError(
+      /not dispatched any setUIState/,
+    );
+  });
+
   it('truncates the contents if they are too long', () => {
     const { store } = dispatchClientMetadata();
     const root = render({ store });
 
     // We are simulating the truncate method call.
-    root.instance().truncateToMaxHeight({ clientHeight: MAX_HEIGHT + 1 });
+    root
+      .instance()
+      .truncateToMaxHeight({ clientHeight: DEFAULT_MAX_HEIGHT + 1 });
 
     applyUIStateChanges({ root, store });
 
@@ -200,7 +222,9 @@ describe(__filename, () => {
     const root = render({ store });
 
     // We are simulating the truncate method call.
-    root.instance().truncateToMaxHeight({ clientHeight: MAX_HEIGHT + 1 });
+    root
+      .instance()
+      .truncateToMaxHeight({ clientHeight: DEFAULT_MAX_HEIGHT + 1 });
 
     applyUIStateChanges({ root, store });
 


### PR DESCRIPTION
Fixes #7634
It looks like `ShowMoreCard` is good for this case. Thanks @willdurand for the suggestion.

In this patch, we
- Changed `Card` to `ShowMoreCard` in `PermssionsCard`, and listed all domains.
- moved all of "Access you data for *"(sites/domains) to the end of the list, so that we do not need to scroll down to see other permissions, especially when there are many sites/domains in this list.

New UI: http://localhost:3000/en-US/firefox/addon/all-of-the-permissionss/
![image](https://user-images.githubusercontent.com/4984681/78691820-4ed22f80-78b6-11ea-96da-2d343fe1b9a4.png)

