### PR TITLE
Add support for versionId in blocked page path

### DIFF
--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -82,7 +82,7 @@ const Routes = ({ _config = config }: Props = {}) => (
     {_config.get('enableBlockPage') && (
       <Route
         exact
-        path="/:lang/:application/blocked-addon/:guid/"
+        path="/:lang/:application/blocked-addon/:guid/:versionId?/"
         component={Block}
       />
     )}

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -26,7 +26,7 @@ import './styles.scss';
 type Props = {|
   match: {
     ...ReactRouterMatchType,
-    params: {| guid: string |},
+    params: {| guid: string, versionId?: string |},
   },
 |};
 

--- a/tests/unit/amo/components/TestRoutes.js
+++ b/tests/unit/amo/components/TestRoutes.js
@@ -60,7 +60,7 @@ describe(__filename, () => {
   });
 
   describe('Block page', () => {
-    const path = '/:lang/:application/blocked-addon/:guid/';
+    const path = '/:lang/:application/blocked-addon/:guid/:versionId?/';
 
     it('declares a route for the new Block page if feature is enabled', () => {
       const _config = getFakeConfig({ enableBlockPage: true });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9324

---

Test URL: http://localhost:3000/en-US/firefox/blocked-addon/%7B46551EC9-40F0-4e47-8E18-8E5CF550CFB8%7D/