### PR TITLE
Respect prefers-reduced-motion: reduce

### DIFF
--- a/src/core/components/AMInstallButton/styles.scss
+++ b/src/core/components/AMInstallButton/styles.scss
@@ -104,6 +104,13 @@
       [dir='rtl'] & {
         animation-name: move-rtl;
       }
+
+      // Center the blue ball when we disable animations.
+      @media (prefers-reduced-motion: reduce) {
+        @include margin-start(14px);
+
+        animation: none;
+      }
     }
 
     .AMInstallButton-loader-ball {
@@ -112,6 +119,10 @@
       border-radius: 50%;
       height: $height;
       width: $width;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
     }
   }
 
@@ -124,6 +135,11 @@
 
     .AMInstallButton-loader-container {
       @include margin-start(16px);
+
+      // Center the blue ball when we disable animations.
+      @media (prefers-reduced-motion: reduce) {
+        @include margin-start(22px);
+      }
     }
   }
 }

--- a/src/ui/components/LoadingText/styles.scss
+++ b/src/ui/components/LoadingText/styles.scss
@@ -39,5 +39,9 @@
       1.5}s
       infinite
       cubic-bezier(0.65, 0.05, 0.36, 1);
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9351

---

This patch adds some `prefers-reduced-motion` media queries to disable animations for the following components:

- `AMInstallButton`: see #9351
- `LoadingText`: I am not sure we have an issue for that yet but I think if #9351 is a problem then the animation for this component is also a problem


### Screenshots/Gifs

#### Before

regular install button:

![2020-04-13 16 11 22](https://user-images.githubusercontent.com/217628/79128080-35901e00-7da3-11ea-9e67-e208310617bd.gif)

"puffy" install button:

![2020-04-13 16 11 05](https://user-images.githubusercontent.com/217628/79128088-36c14b00-7da3-11ea-9f48-c373010d227f.gif)

Loading indicator:

![2020-04-13 16 11 52](https://user-images.githubusercontent.com/217628/79128074-33c65a80-7da3-11ea-831c-7595f3953c48.gif)

#### After

regular install button:

<img width="432" alt="Screen Shot 2020-04-13 at 16 10 28" src="https://user-images.githubusercontent.com/217628/79127460-3bd1ca80-7da2-11ea-88e6-fdbd463a15cf.png">

"puffy" install button:

<img width="697" alt="Screen Shot 2020-04-13 at 16 10 49" src="https://user-images.githubusercontent.com/217628/79127464-3d9b8e00-7da2-11ea-986f-7ff385543587.png">

Loading indicator:

<img width="710" alt="Screen Shot 2020-04-13 at 16 12 02" src="https://user-images.githubusercontent.com/217628/79127465-3e342480-7da2-11ea-825e-25e0f6248c4d.png">
