### PR TITLE
Add story for AMInstallButton

### DIFF
--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -12,6 +12,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import {
   ADDON_TYPE_STATIC_THEME,
   DISABLED,
+  DISABLING,
   DOWNLOADING,
   ENABLED,
   ENABLING,
@@ -183,7 +184,13 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
       return true;
     }
 
-    return [DOWNLOADING, ENABLING, INSTALLING, UNINSTALLING].includes(status);
+    return [
+      DISABLING,
+      DOWNLOADING,
+      ENABLING,
+      INSTALLING,
+      UNINSTALLING,
+    ].includes(status);
   }
 
   getButtonText() {
@@ -197,6 +204,8 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
         return i18n.gettext('Remove');
       case ENABLING:
         return i18n.gettext('Enabling');
+      case DISABLING:
+        return i18n.gettext('Disabling');
       case DOWNLOADING:
         return i18n.gettext('Downloading');
       case INSTALLING:

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -18,7 +18,6 @@ export const validInstallStates = [
   DISABLING,
   DOWNLOADING,
   ENABLED,
-  ENABLED,
   ENABLING,
   ERROR,
   INACTIVE,

--- a/stories/core/AMInstallButton.js
+++ b/stories/core/AMInstallButton.js
@@ -6,12 +6,7 @@ import AMInstallButton from 'core/components/AMInstallButton';
 import { createInternalAddon } from 'core/reducers/addons';
 import { createInternalVersion } from 'core/reducers/versions';
 import { validInstallStates } from 'core/constants';
-import {
-  dispatchClientMetadata,
-  fakeAddon,
-  fakeVersion,
-  fakeI18n,
-} from 'tests/unit/helpers';
+import { fakeAddon, fakeVersion } from 'tests/unit/helpers';
 
 import Provider from '../setup/Provider';
 

--- a/stories/core/AMInstallButton.js
+++ b/stories/core/AMInstallButton.js
@@ -1,0 +1,64 @@
+/* @flow */
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import AMInstallButton from 'core/components/AMInstallButton';
+import { createInternalAddon } from 'core/reducers/addons';
+import { createInternalVersion } from 'core/reducers/versions';
+import { validInstallStates } from 'core/constants';
+import {
+  dispatchClientMetadata,
+  fakeAddon,
+  fakeVersion,
+  fakeI18n,
+} from 'tests/unit/helpers';
+
+import Provider from '../setup/Provider';
+
+const render = (otherProps) => {
+  const props = {
+    addon: createInternalAddon(fakeAddon),
+    currentVersion: createInternalVersion(fakeVersion),
+    defaultInstallSource: 'storybook',
+    disabled: false,
+    enable: () => Promise.resolve(true),
+    hasAddonManager: true,
+    install: () => Promise.resolve(true),
+    isAddonEnabled: () => Promise.resolve(true),
+    puffy: true,
+    setCurrentStatus: () => Promise.resolve(true),
+    status: 'UNKNOWN',
+    uninstall: () => Promise.resolve(true),
+    ...otherProps,
+  };
+
+  return <AMInstallButton {...props} />;
+};
+
+const createChapters = ({ puffy }) => [
+  {
+    sections: validInstallStates.map((status) => ({
+      title: `installation status = ${status}`,
+      sectionFn: () => render({ puffy, status }),
+    })),
+  },
+  {
+    sections: validInstallStates.map((status) => ({
+      title: `disabled state with installation status = ${status}`,
+      sectionFn: () => render({ puffy, status, disabled: true }),
+    })),
+  },
+];
+
+storiesOf('AMInstallButton', module)
+  .addDecorator((story) => (
+    <div className="AMInstallButton--storybook">
+      <Provider story={story()} />
+    </div>
+  ))
+  .addWithChapters('all puffy variants', {
+    chapters: createChapters({ puffy: true }),
+  })
+  .addWithChapters('all non-puffy variants', {
+    chapters: createChapters({ puffy: false }),
+  });

--- a/stories/index.js
+++ b/stories/index.js
@@ -6,6 +6,7 @@ import './setup/styles.scss';
 
 // Components
 import './amo/HeroRecommendation';
+import './core/AMInstallButton';
 import './ui/Badge';
 import './ui/Button';
 import './ui/IconRecommendedBadge';

--- a/stories/setup/styles.scss
+++ b/stories/setup/styles.scss
@@ -36,3 +36,8 @@ body {
 .chapter-h3 {
   margin-top: 48px;
 }
+
+// This is needed to mimic the style in `src/amo/pages/Addon/styles.scss`.
+.AMInstallButton--storybook .AMInstallButton-loading-button {
+  width: 48px;
+}

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -8,6 +8,7 @@ import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_FIREFOX,
   DISABLED,
+  DISABLING,
   DOWNLOADING,
   ENABLED,
   ENABLING,
@@ -343,7 +344,7 @@ describe(__filename, () => {
     expect(button.childAt(1)).toHaveText(defaultButtonText);
   });
 
-  it.each([DOWNLOADING, ENABLING, INSTALLING, UNINSTALLING])(
+  it.each([DOWNLOADING, DISABLING, ENABLING, INSTALLING, UNINSTALLING])(
     'renders a loading Icon when add-on is %s',
     (status) => {
       const root = render({ status });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9355

---

This patch adds a new story in our storybook and...

- fixes a duplicate constant entry
- adds support for the `DISABLING` state

You can try this patch by fetching the branch and running `yarn && yarn storybook` locally.