### PR TITLE
Honor `canUninstall` prop

### DIFF
--- a/src/amo/components/InstallButtonWrapper/index.js
+++ b/src/amo/components/InstallButtonWrapper/index.js
@@ -38,6 +38,7 @@ export type Props = {|
 type InternalProps = {|
   ...Props,
   ...WithInstallHelpersInjectedProps,
+  canUninstall: $PropertyType<InstalledAddon, 'canUninstall'>,
   clientApp: string,
   currentVersion: AddonVersionType | null,
   installStatus: $PropertyType<InstalledAddon, 'status'>,
@@ -48,6 +49,7 @@ export const InstallButtonWrapperBase = (props: InternalProps) => {
   const {
     _getClientCompatibility = getClientCompatibility,
     addon,
+    canUninstall,
     className,
     clientApp,
     currentVersion,
@@ -56,11 +58,11 @@ export const InstallButtonWrapperBase = (props: InternalProps) => {
     enable,
     getFirefoxButtonType,
     hasAddonManager,
-    isAddonEnabled,
     install,
     installStatus,
-    setCurrentStatus,
+    isAddonEnabled,
     puffy,
+    setCurrentStatus,
     uninstall,
     userAgentInfo,
   } = props;
@@ -86,6 +88,7 @@ export const InstallButtonWrapperBase = (props: InternalProps) => {
       >
         <AMInstallButton
           addon={addon}
+          canUninstall={canUninstall}
           className={className ? `AMInstallButton--${className}` : ''}
           currentVersion={currentVersion}
           defaultButtonText={defaultButtonText}
@@ -124,6 +127,7 @@ export function mapStateToProps(state: AppState, ownProps: InternalProps) {
   }
 
   return {
+    canUninstall: installedAddon.canUninstall,
     clientApp: state.api.clientApp,
     currentVersion,
     installStatus: installedAddon.status || UNKNOWN,

--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -48,6 +48,7 @@ import './styles.scss';
 type Props = {|
   ...WithInstallHelpersInjectedProps,
   addon: AddonType,
+  canUninstall: boolean | void,
   className?: string,
   currentVersion: AddonVersionType | null,
   defaultButtonText?: string,
@@ -240,6 +241,7 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
 
   render() {
     const {
+      canUninstall,
       className,
       currentVersion,
       defaultInstallSource,
@@ -288,11 +290,16 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
     if (!buttonIsDisabled) {
       if ([ENABLED, INSTALLED].includes(status)) {
         buttonProps.buttonType = 'neutral';
-        buttonProps.onClick = this.uninstallAddon;
         buttonProps.className = makeClassName(
           buttonProps.className,
           'AMInstallButton-button--uninstall',
         );
+
+        if (canUninstall === false) {
+          buttonProps.disabled = true;
+        } else {
+          buttonProps.onClick = this.uninstallAddon;
+        }
       } else if (status === DISABLED) {
         buttonProps.buttonType = 'neutral';
         buttonProps.onClick = this.enableAddon;

--- a/src/core/installAddon.js
+++ b/src/core/installAddon.js
@@ -312,7 +312,13 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
             type,
           });
 
-          dispatch(setInstallState({ ...payload, status }));
+          dispatch(
+            setInstallState({
+              ...payload,
+              status,
+              canUninstall: clientAddon.canUninstall,
+            }),
+          );
         },
         (error) => {
           _log.info(oneLine`Add-on "${guid}" not found so setting status to

--- a/src/core/reducers/installations.js
+++ b/src/core/reducers/installations.js
@@ -17,6 +17,7 @@ import {
 import type { AddonType } from 'core/types/addons';
 
 export type InstalledAddon = {
+  canUninstall?: boolean,
   downloadProgress?: number,
   error?: string,
   guid: $PropertyType<AddonType, 'guid'>,
@@ -104,6 +105,11 @@ export default function installations(
       return {
         ...state,
         [payload.guid]: {
+          // By default, we should be able to uninstall an add-on.
+          canUninstall:
+            typeof payload.canUninstall !== 'undefined'
+              ? payload.canUninstall
+              : true,
           downloadProgress: 0,
           error: payload.error,
           guid: payload.guid,

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -54,6 +54,7 @@ type InternalProps = {|
   _getClientCompatibility: typeof getClientCompatibility,
   _tracking: typeof tracking,
   addon: AddonType,
+  canUninstall: $PropertyType<InstalledAddon, 'canUninstall'>,
   clientApp: string,
   currentVersion: AddonVersionType,
   error: string | void,
@@ -191,6 +192,7 @@ export class AddonBase extends React.Component<InternalProps> {
     const {
       _getClientCompatibility,
       addon,
+      canUninstall,
       clientApp,
       currentVersion,
       defaultInstallSource,
@@ -265,6 +267,7 @@ export class AddonBase extends React.Component<InternalProps> {
 
           <AMInstallButton
             addon={addon}
+            canUninstall={canUninstall}
             className="Addon-install-button"
             currentVersion={currentVersion}
             defaultInstallSource={defaultInstallSource}
@@ -302,6 +305,7 @@ function mapStateToProps(state: AppState, ownProps: Props) {
   }
 
   return {
+    canUninstall: installation.canUninstall,
     clientApp: state.api.clientApp,
     currentVersion,
     error: installation.error,

--- a/stories/core/AMInstallButton.js
+++ b/stories/core/AMInstallButton.js
@@ -13,6 +13,7 @@ import Provider from '../setup/Provider';
 const render = (otherProps) => {
   const props = {
     addon: createInternalAddon(fakeAddon),
+    canUninstall: true,
     currentVersion: createInternalVersion(fakeVersion),
     defaultInstallSource: 'storybook',
     disabled: false,
@@ -41,6 +42,12 @@ const createChapters = ({ puffy }) => [
     sections: validInstallStates.map((status) => ({
       title: `disabled state with installation status = ${status}`,
       sectionFn: () => render({ puffy, status, disabled: true }),
+    })),
+  },
+  {
+    sections: validInstallStates.map((status) => ({
+      title: `canUninstall = false and installation status = ${status}`,
+      sectionFn: () => render({ puffy, status, canUninstall: false }),
     })),
   },
 ];

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -251,6 +251,25 @@ describe(__filename, () => {
     expect(root.find(AMInstallButton)).toHaveProp('status', INSTALLED);
   });
 
+  it('passes the canUninstall prop from the installation state to AMInstallButton', () => {
+    const addon = fakeAddon;
+    const canUninstall = true;
+
+    store.dispatch(
+      setInstallState({
+        ...fakeInstalledAddon,
+        guid: addon.guid,
+        canUninstall,
+      }),
+    );
+
+    const root = render({
+      addon: createInternalAddon(addon),
+    });
+
+    expect(root.find(AMInstallButton)).toHaveProp('canUninstall', canUninstall);
+  });
+
   it('passes the expected status to AMInstallButton when the add-on is not installed', () => {
     const root = render();
 

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -298,6 +298,7 @@ describe(__filename, () => {
       expect(button).toHaveLength(1);
       expect(button).toHaveProp('buttonType', 'neutral');
       expect(button).toHaveProp('onClick', root.instance().uninstallAddon);
+      expect(button).toHaveProp('disabled', false);
       expect(button).toHaveClassName('AMInstallButton-button');
       expect(button).toHaveClassName('AMInstallButton-button--uninstall');
 
@@ -306,6 +307,42 @@ describe(__filename, () => {
       expect(icon).toHaveProp('name', 'delete');
 
       expect(root.find('.AMInstallButton-loading-button')).toHaveLength(0);
+    },
+  );
+
+  it.each([ENABLED, INSTALLED])(
+    'allows to uninstall an add-on when canUninstall is undefined and add-on is %s',
+    (status) => {
+      const root = render({ status, canUninstall: undefined });
+
+      const button = root.find(Button);
+      expect(button).toHaveLength(1);
+      expect(button).toHaveProp('onClick', root.instance().uninstallAddon);
+      expect(button).toHaveProp('disabled', false);
+    },
+  );
+
+  it.each([ENABLED, INSTALLED])(
+    'allows to uninstall an add-on when canUninstall is true and add-on is %s',
+    (status) => {
+      const root = render({ status, canUninstall: true });
+
+      const button = root.find(Button);
+      expect(button).toHaveLength(1);
+      expect(button).toHaveProp('onClick', root.instance().uninstallAddon);
+      expect(button).toHaveProp('disabled', false);
+    },
+  );
+
+  it.each([ENABLED, INSTALLED])(
+    'does not allow to uninstall an add-on when canUninstall is false and add-on is %s',
+    (status) => {
+      const root = render({ status, canUninstall: false });
+
+      const button = root.find(Button);
+      expect(button).toHaveLength(1);
+      expect(button).not.toHaveProp('onClick', root.instance().uninstallAddon);
+      expect(button).toHaveProp('disabled', true);
     },
   );
 

--- a/tests/unit/core/reducers/test_installations.js
+++ b/tests/unit/core/reducers/test_installations.js
@@ -41,6 +41,7 @@ describe(__filename, () => {
       ),
     ).toEqual({
       [guid]: {
+        canUninstall: true, // The default value should be `true`.
         downloadProgress: 0,
         error: undefined,
         guid,
@@ -49,6 +50,34 @@ describe(__filename, () => {
         url: 'https://cdn.amo/download/my-addon.xpi',
       },
     });
+  });
+
+  it('passes down canUninstall when defined', () => {
+    const guid = 'my-addon@me.com';
+    let canUninstall = true;
+
+    expect(
+      installations(
+        undefined,
+        setInstallState({
+          ...fakeInstalledAddon,
+          guid,
+          canUninstall,
+        }),
+      ),
+    ).toMatchObject({ [guid]: { canUninstall } });
+
+    canUninstall = false;
+    expect(
+      installations(
+        undefined,
+        setInstallState({
+          ...fakeInstalledAddon,
+          guid,
+          canUninstall,
+        }),
+      ),
+    ).toMatchObject({ [guid]: { canUninstall } });
   });
 
   it('passes down needsRestart=true', () => {

--- a/tests/unit/core/test_installAddon.js
+++ b/tests/unit/core/test_installAddon.js
@@ -442,6 +442,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: ENABLED,
               url: installURL,
@@ -468,6 +469,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: ENABLED,
               url: installURL,
@@ -498,6 +500,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: DISABLED,
               url: installURL,
@@ -528,6 +531,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: DISABLED,
               url: installURL,
@@ -558,6 +562,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: INACTIVE,
               url: installURL,
@@ -589,6 +594,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: ENABLED,
               url: installURL,
@@ -620,6 +626,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: DISABLED,
               url: installURL,
@@ -651,6 +658,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: DISABLED,
               url: installURL,
@@ -730,6 +738,7 @@ describe(__filename, () => {
           sinon.assert.calledWith(
             dispatch,
             setInstallState({
+              canUninstall: undefined,
               guid: addon.guid,
               status: ENABLED,
               url: `${installURL}?src=${defaultInstallSource}`,
@@ -760,6 +769,39 @@ describe(__filename, () => {
           _log.debug,
           'no currentVersion, aborting setCurrentStatus()',
         );
+      });
+
+      it('sets the canUninstall prop', () => {
+        const installURL = 'http://the.url/';
+        const addon = getAddon();
+        loadVersionWithInstallUrl(installURL);
+
+        const canUninstall = false;
+        const { root, dispatch } = renderWithInstallHelpers({
+          _addonManager: getFakeAddonManagerWrapper({
+            getAddon: Promise.resolve({
+              canUninstall,
+              isActive: true,
+              isEnabled: true,
+            }),
+          }),
+          addon,
+          defaultInstallSource: null,
+          store,
+        });
+        const { setCurrentStatus } = root.instance().props;
+
+        return setCurrentStatus().then(() => {
+          sinon.assert.calledWith(
+            dispatch,
+            setInstallState({
+              canUninstall,
+              guid: addon.guid,
+              status: ENABLED,
+              url: installURL,
+            }),
+          );
+        });
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/8418
~~⚠️ depends on #9356 so only the third commit is relevant~~

---

In order to test this patch locally, follow these steps (not the usual setup because `mozAddonManager` is required): https://github.com/mozilla/addons-frontend/blob/master/docs/moz-addon-manager.md#developing-with-a-local-https-server-recommended, and then follow these other steps to create a `policies.json` file: https://github.com/mozilla/addons-frontend/issues/8418#issuecomment-603903349

It's a bit annoying but you have to restart FF after you created the `policies.json` file... The nice thing is that browsing `about:policies` will tell you if everything works as intended or not.

### Storybook screenshots:

<img width="415" alt="Screen Shot 2020-04-15 at 14 49 09" src="https://user-images.githubusercontent.com/217628/79338962-6c437100-7f28-11ea-8a4b-38a67e52df48.png">
<img width="414" alt="Screen Shot 2020-04-15 at 14 49 02" src="https://user-images.githubusercontent.com/217628/79338963-6cdc0780-7f28-11ea-8bdd-71a919ed5823.png">
