### PR TITLE
Read canUninstall when we can in global event listener

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -236,7 +236,9 @@ export const GLOBAL_EVENT_STATUS_MAP = {
   onDisabling: DISABLING,
 };
 // This mozAddonManager event has no one-to-one mapping.
+export const ON_INSTALLING_EVENT = 'onInstalling';
 export const ON_OPERATION_CANCELLED_EVENT = 'onOperationCancelled';
+export const ON_UNINSTALLED_EVENT = 'onUninstalled';
 
 // The events here are set directly on mozAddonManager
 // they will be fired by addons and themes.

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -470,7 +470,8 @@ describe(__filename, () => {
 
     it('calls the callback when onOperationCancelled is received', async () => {
       const _log = getFakeLogger();
-      const fakeAddon = fakeClientAddon();
+      const canUninstall = false;
+      const fakeAddon = fakeClientAddon({ canUninstall });
       fakeMozAddonManager.getAddonByID.resolves(fakeAddon);
 
       const handleChangeEvent = addonManager.addChangeListeners(
@@ -492,7 +493,7 @@ describe(__filename, () => {
         guid,
         needsRestart,
         status: addonManager.getAddonStatus({ addon: fakeAddon }),
-        canUninstall: true,
+        canUninstall,
       });
       sinon.assert.notCalled(_log.error);
     });

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -3,13 +3,15 @@ import {
   GLOBAL_EVENTS,
   GLOBAL_EVENT_STATUS_MAP,
   INSTALL_EVENT_LIST,
+  ON_INSTALLING_EVENT,
   ON_OPERATION_CANCELLED_EVENT,
+  ON_UNINSTALLED_EVENT,
   SET_ENABLE_NOT_AVAILABLE,
 } from 'core/constants';
 import { getFakeLogger, unexpectedSuccess } from 'tests/unit/helpers';
 
 const fakeClientAddon = (overrides = {}) => ({
-  canUninstall: false,
+  canUninstall: true,
   description: 'some desc',
   id: 'some@guid',
   isActive: true,
@@ -407,13 +409,28 @@ describe(__filename, () => {
     });
 
     describe('global events', () => {
-      const handleChangeEvent = addonManager.addChangeListeners(
-        fakeEventCallback,
-        fakeMozAddonManager,
-      );
+      let handleChangeEvent;
+      const fakeAddon = fakeClientAddon({ canUninstall: false });
+
+      beforeEach(() => {
+        fakeMozAddonManager.getAddonByID.resolves(fakeAddon);
+
+        handleChangeEvent = addonManager.addChangeListeners(
+          fakeEventCallback,
+          fakeMozAddonManager,
+        );
+      });
 
       GLOBAL_EVENTS.forEach((event) => {
         const status = GLOBAL_EVENT_STATUS_MAP[event];
+        // For these events, we cannot read the value of `canUninstall` because
+        // `getAddonByID()` cannot retrieve an add-on (this is expected).
+        const canUninstall = [
+          ON_INSTALLING_EVENT,
+          ON_UNINSTALLED_EVENT,
+        ].includes(event)
+          ? true
+          : fakeAddon.canUninstall;
 
         it(`calls callback with status ${status}`, async () => {
           const id = 'foo@whatever';
@@ -425,6 +442,7 @@ describe(__filename, () => {
             guid: id,
             needsRestart,
             status,
+            canUninstall,
           });
         });
       });
@@ -474,6 +492,7 @@ describe(__filename, () => {
         guid,
         needsRestart,
         status: addonManager.getAddonStatus({ addon: fakeAddon }),
+        canUninstall: true,
       });
       sinon.assert.notCalled(_log.error);
     });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9365

---

We listen to some global FF events to react accordingly when an add-on is installed, enabled, disabled, uninstalled, etc. This is handled in the `App` component [here](https://github.com/mozilla/addons-frontend/blob/f34b0d0efdbca225a07d5ff8e7abdb6cd2b3350e/src/amo/components/App/index.js#L95) and [here](https://github.com/mozilla/addons-frontend/blob/f34b0d0efdbca225a07d5ff8e7abdb6cd2b3350e/src/amo/components/App/index.js#L233-L235). The `_addChangeListeners` function is actually defined [here](https://github.com/mozilla/addons-frontend/blob/f34b0d0efdbca225a07d5ff8e7abdb6cd2b3350e/src/core/addonManager.js#L205).

In this patch, we read the `canUninstall` value of a Firefox add-on when possible so that the install button is updated when there are global changes as described in the issue linked above.

See this PR for some local setup instructions: https://github.com/mozilla/addons-frontend/pull/9359#issue-403717095