### PR TITLE
Add script to do the l10n extraction

### DIFF
--- a/bin/run-l10n-extraction
+++ b/bin/run-l10n-extraction
@@ -9,6 +9,7 @@ set -u
 
 INITIAL_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 DIFF_WITH_ONE_LINE_CHANGE="1 file changed, 1 insertion(+), 1 deletion(-)"
+GIT_REMOTE="git@github.com:mozilla/addons-frontend.git"
 
 info() {
   local message="$1"
@@ -34,7 +35,7 @@ run_l10n_extraction() {
   fi
 
   # Make sure the 'master' branch is up-to-date.
-  git pull origin master
+  git pull "$GIT_REMOTE" master
 
   # Ensure the branch to extract the locales is clean.
   if [[ $(git branch --list "$branch") ]]; then
@@ -64,7 +65,8 @@ run_l10n_extraction() {
 
   git commit -a -m "Merge $app locales"
 
-  git push origin "$branch"
+  # We use force-push in case the branch already exists.
+  git push -f "$GIT_REMOTE" "$branch"
 
   git checkout "$INITIAL_GIT_BRANCH"
   git branch -D "$branch"

--- a/bin/run-l10n-extraction
+++ b/bin/run-l10n-extraction
@@ -8,6 +8,7 @@ set -o pipefail
 set -u
 
 INITIAL_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+GIT_CHANGES=$(git status --porcelain)
 DIFF_WITH_ONE_LINE_CHANGE="1 file changed, 1 insertion(+), 1 deletion(-)"
 GIT_REMOTE="git@github.com:mozilla/addons-frontend.git"
 
@@ -30,8 +31,14 @@ run_l10n_extraction() {
   local app="$1"
   local branch="$app-locales"
 
+  # Detect local (uncommitted) changes.
+  if [[ ! -z "$GIT_CHANGES" ]]; then
+    error "You have local changes, therefore this script cannot continue."
+  fi
+
+  # Switch to the `master` branch if we are not on it already.
   if [[ "$INITIAL_GIT_BRANCH" != "master" ]]; then
-    error "Please make sure you are on the 'master' branch."
+    git checkout master
   fi
 
   # Make sure the 'master' branch is up-to-date.

--- a/bin/run-l10n-extraction
+++ b/bin/run-l10n-extraction
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Exit immediately when a command fails.
+set -e
+# Make sure exit code are respected in a pipeline.
+set -o pipefail
+# Treat unset variables as an error an exit immediately.
+set -u
+
+INITIAL_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+DIFF_WITH_ONE_LINE_CHANGE="1 file changed, 1 insertion(+), 1 deletion(-)"
+
+info() {
+  local message="$1"
+
+  echo ""
+  echo "INFO: $message"
+  echo ""
+}
+
+error() {
+  local message="$1"
+
+  echo "ERROR: $message"
+  exit 1
+}
+
+run_l10n_extraction() {
+  local app="$1"
+  local branch="$app-locales"
+
+  if [[ "$INITIAL_GIT_BRANCH" != "master" ]]; then
+    error "Please make sure you are on the 'master' branch."
+  fi
+
+  # Make sure the 'master' branch is up-to-date.
+  git pull origin master
+
+  # Ensure the branch to extract the locales is clean.
+  if [[ $(git branch --list "$branch") ]]; then
+    info "Deleting branch '$branch' because it already exists"
+    git branch -D "$branch"
+  fi
+
+  info "Creating and switching to branch '$branch'"
+  git checkout -b "$branch"
+
+  NODE_APP_INSTANCE="$app" bin/extract-locales
+
+  local git_diff_stat
+  git_diff_stat=$(git diff --shortstat)
+
+  if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
+    info "No changes, aborting"
+    git checkout -- .
+    git checkout "$INITIAL_GIT_BRANCH"
+    git branch -d "$branch"
+    exit 0
+  fi
+
+  git commit -a -m "Extract $app locales"
+
+  NODE_APP_INSTANCE="$app" bin/merge-locales
+
+  git commit -a -m "Merge $app locales"
+
+  git push origin "$branch"
+
+  git checkout "$INITIAL_GIT_BRANCH"
+  git branch -D "$branch"
+
+  echo ""
+  echo "----------------------------------------------------------------------"
+  echo ""
+  echo "     You can now open the link below to submit your Pull Request:"
+  echo "     https://github.com/mozilla/addons-frontend/pull/new/$branch"
+  echo ""
+  echo "----------------------------------------------------------------------"
+}
+
+run_l10n_extraction "amo"
+run_l10n_extraction "disco"

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -22,6 +22,10 @@ NODE_APP_INSTANCE=[MY_APP] NODE_PATH='./:./src' bin/create-locales
 
 ## Updating locales
 
+TL;DR: run the following script from the `master` branch: `./bin/run-l10n-extraction`
+
+### The long story
+
 Once a week right after the forthcoming release [is tagged](http://addons.readthedocs.io/en/latest/server/push-duty.html), the locales for each app must be generated.
 
 This is a semi-automated process: a team member must create one pull request _per application_ with the following commits:
@@ -31,7 +35,7 @@ This is a semi-automated process: a team member must create one pull request _pe
 
 Each one of these steps are detailed in the sections below. Let's begin...
 
-### Extracting newly added strings
+#### Extracting newly added strings
 
 Start the process by creating a git branch and extracting the locales for a given app. This uses `amo` as an example app but you would need to repeat the process in a new branch for `disco` and any other activate application (example: `NODE_APP_INSTANCE=disco ...`).
 
@@ -70,7 +74,7 @@ When the application is under active development it's more likely that you will 
 git commit -a -m "Extract AMO locales"
 ```
 
-### Merging locale files
+#### Merging locale files
 
 After extracting new strings, you have to merge them into the existing locale files. Do this in your branch and commit:
 
@@ -88,7 +92,7 @@ Commit and continue to the next step:
 git commit -a -m "Merged AMO locales"
 ```
 
-### Finalizing the extract/merge process
+#### Finalizing the extract/merge process
 
 Now that you have extracted and merged locales for one application, it's time to create a pull request for your branch. For example:
 
@@ -98,7 +102,7 @@ git push origin amo-locales
 
 If the pull request passes all of our CI tests it is likely good to merge. You don't need to ask for a review unless you're unsure of something because often locale updates will be thousands of lines of minor diffs that can't be reasonably reviewed by a human. 🙂 If the pull request passes all of our CI tests it is likely good to merge. If necessary, repeat the process for the next application (eg. `amo`, `disco`, etc.).
 
-### Building the JS locale files
+#### Building the JS locale files
 
 This command creates the JSON files which are then built into JS bundles by webpack when the build step is run. This happens automatically as part of the deployment process.
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9373

---

The script handles both 'amo' and 'disco' apps. It takes care of ensuring the `master` branch is up-to-date before creating a specific branch for the extraction and it detects no changes. The push hero should only run the script once and it will create between 0 and 2 branches on GitHub. The script gives the links to these branches (if any) to open the pull requests.