### PR TITLE
Do not exit when there are no changes

### DIFF
--- a/bin/run-l10n-extraction
+++ b/bin/run-l10n-extraction
@@ -63,7 +63,7 @@ run_l10n_extraction() {
     git checkout -- .
     git checkout "$INITIAL_GIT_BRANCH"
     git branch -d "$branch"
-    exit 0
+    return
   fi
 
   git commit -a -m "Extract $app locales"


### PR DESCRIPTION
This is a small improvement to be able to run the extraction for both amo and disco, all the time. Previously, no changes for amo would stop the script and skip the extraction of the disco locales.