### PR TITLE
Do not let saga throw

### DIFF
--- a/src/core/sagas/site.js
+++ b/src/core/sagas/site.js
@@ -4,20 +4,22 @@ import { call, put, select, takeLatest } from 'redux-saga/effects';
 import { getSiteStatus } from 'core/api/site';
 import { FETCH_SITE_STATUS, loadSiteStatus } from 'core/reducers/site';
 import { getState } from 'core/sagas/utils';
+import log from 'core/logger';
 import type { GetSiteStatusParams } from 'core/api/site';
 import type { Saga } from 'core/types/sagas';
 
-// This saga is not triggered by the UI but on the server side, hence do not
-// have a `errorHandler`. We do not want to miss any error so we let this saga
-// throw errors without catching them.
 export function* fetchSiteStatus(): Saga {
   const state = yield select(getState);
 
   const params: GetSiteStatusParams = { api: state.api };
 
-  const { read_only: readOnly, notice } = yield call(getSiteStatus, params);
+  try {
+    const { read_only: readOnly, notice } = yield call(getSiteStatus, params);
 
-  yield put(loadSiteStatus({ readOnly, notice }));
+    yield put(loadSiteStatus({ readOnly, notice }));
+  } catch (error) {
+    log.error(`Could not fetch site status: ${error}`);
+  }
 }
 
 export default function* siteSaga(): Saga {

--- a/tests/unit/core/sagas/test_site.js
+++ b/tests/unit/core/sagas/test_site.js
@@ -1,4 +1,5 @@
 import SagaTester from 'redux-saga-tester';
+import { END } from 'redux-saga';
 
 import * as api from 'core/api/site';
 import apiReducer from 'core/reducers/api';
@@ -47,20 +48,16 @@ describe(__filename, () => {
       mockApi.verify();
     });
 
-    it('allows exceptions to be thrown', () => {
-      const expectedError = new Error('this error should be thrown');
-      mockApi.expects('getSiteStatus').returns(Promise.reject(expectedError));
+    it('ignores exceptions', () => {
+      const apiError = new Error('this error should be ignored');
+      mockApi.expects('getSiteStatus').returns(Promise.reject(apiError));
 
       sagaTester.dispatch(fetchSiteStatus());
+      sagaTester.dispatch(END); // stop the saga.
 
-      return rootTask.done
-        .then(() => {
-          throw new Error('unexpected success');
-        })
-        .catch((error) => {
-          mockApi.verify();
-          expect(error).toBe(expectedError);
-        });
+      return rootTask.done.then(() => {
+        mockApi.verify();
+      });
     });
   });
 });

--- a/tests/unit/core/server/test_base.js
+++ b/tests/unit/core/server/test_base.js
@@ -339,6 +339,24 @@ describe(__filename, () => {
       mockUsersApi.verify();
     });
 
+    it('gracefully handles site status API errors', async () => {
+      mockSiteApi
+        .expects('getSiteStatus')
+        .once()
+        .rejects(new Error('Oh no, an API error'));
+
+      function* appSagas() {
+        yield all([fork(usersSaga), fork(siteSaga)]);
+      }
+
+      const response = await testClient({ appSagas })
+        .get('/en-US/firefox/')
+        .end();
+
+      expect(response.statusCode).toEqual(200);
+      mockSiteApi.verify();
+    });
+
     it('returns a 500 error page when retrieving the user profile fails', async () => {
       mockUsersApi
         .expects('currentUserAccount')


### PR DESCRIPTION
Refs https://github.com/mozilla/addons-frontend/issues/9419

---

This was not a good idea apparently, and https://redux-saga.js.org/docs/api/ describes why. Site status is useful but not critical I believe so we can simply ignore the error and log it.

There is also this action that has a similar behavior: https://github.com/mozilla/addons-frontend/blob/028800baa6801d39a0d43a7cd580aab0da116cbe/src/amo/sagas/users.js#L43-L59

It is less likely to cause an OOM because it requires authenticated calls. For this one, it is more important to fail for the reasons in the comment.