### PR TITLE
Use overflow-wrap: anywhere, everywhere

### DIFF
--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -31,7 +31,9 @@ textarea {
 *::before,
 *::after {
   box-sizing: inherit;
-  overflow-wrap: break-word;
+  // We use `anywhere` instead of `break-word` so that it works even when the
+  // container does not have a well-defined width.
+  overflow-wrap: anywhere;
 }
 
 body {

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -107,9 +107,6 @@
   font-size: $font-size-l;
   line-height: 1.188;
   margin: 14px 0 0 0;
-  // TODO: maybe remove the rule below, see:
-  // https://github.com/mozilla/addons-frontend/issues/9423
-  overflow-wrap: anywhere;
 
   @include respond-to(extraExtraLarge) {
     font-size: $font-size-hero-heading;

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -21,7 +21,6 @@ $icon-default-size: 32px;
   // This margin gives the recommended badge some space.
   @include margin-end(8px);
 
-  overflow-wrap: anywhere;
   text-decoration: none;
 
   &,

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -43,9 +43,6 @@
   font-size: $font-size-hero-message-headline;
   line-height: 1.333;
   margin: 0;
-  // TODO: maybe remove the rule below, see:
-  // https://github.com/mozilla/addons-frontend/issues/9423
-  overflow-wrap: anywhere;
 
   .LoadingText {
     height: 1em;
@@ -53,9 +50,6 @@
 }
 
 .SecondaryHero-message-description {
-  // TODO: maybe remove the rule below, see:
-  // https://github.com/mozilla/addons-frontend/issues/9423
-  overflow-wrap: anywhere;
   padding: $padding-page 0;
 
   @include respond-to(large) {
@@ -113,9 +107,6 @@
 .SecondaryHero-message-link,
 .SecondaryHero-module-description,
 .SecondaryHero-module-link {
-  // TODO: maybe remove the rule below, see:
-  // https://github.com/mozilla/addons-frontend/issues/9423
-  overflow-wrap: anywhere;
   width: 100%;
 
   .LoadingText {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9433

Fixes https://github.com/mozilla/addons-frontend/issues/9432

Fixes https://github.com/mozilla/addons-frontend/issues/9436

---

Given the regressions mentioned in the issues above, I think we should use
`anywhere` all the time because `break-word` seems to only work when the
container has a well-defined width while `anywhere` will work in all cases.