### PR TITLE
Remove min-width in AddonSummaryCard

### DIFF
--- a/src/amo/components/AddonSummaryCard/styles.scss
+++ b/src/amo/components/AddonSummaryCard/styles.scss
@@ -13,7 +13,6 @@
 
 .AddonSummaryCard {
   @include respond-to(large) {
-    min-width: 300px;
     width: 35%;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9436

---

The `min-width` causes the flex layout to "push" the right panel to the right
because `330px` was more than `35%` and the right panel is configured to take
`65%` of the width. It looks good without `min-width` so I guess it's fine.