### PR TITLE
Use the term Downloads instead of Users for dictionaries and langpacks

### DIFF
--- a/src/amo/components/AddonMeta/index.js
+++ b/src/amo/components/AddonMeta/index.js
@@ -10,6 +10,7 @@ import type { AddonType } from 'core/types/addons';
 import MetadataCard from 'ui/components/MetadataCard';
 import Rating from 'ui/components/Rating';
 import RatingsByStar from 'amo/components/RatingsByStar';
+import { ADDON_TYPE_DICT, ADDON_TYPE_LANG } from 'core/constants';
 import type { I18nType } from 'core/types/i18n';
 import type { ReactRouterLocationType } from 'core/types/router';
 
@@ -49,9 +50,16 @@ export class AddonMetaBase extends React.Component<InternalProps> {
       userTitle = i18n.gettext('Users');
     } else if (averageDailyUsers) {
       userCount = i18n.formatNumber(averageDailyUsers);
-      userTitle = i18n.ngettext('User', 'Users', averageDailyUsers);
+      userTitle =
+        // This is needed because of
+        // https://github.com/mozilla/addons-frontend/issues/9472
+        [ADDON_TYPE_DICT, ADDON_TYPE_LANG].includes(addon.type)
+          ? i18n.ngettext('Download', 'Downloads', averageDailyUsers)
+          : i18n.ngettext('User', 'Users', averageDailyUsers);
     } else {
-      userTitle = i18n.gettext('No Users');
+      userTitle = [ADDON_TYPE_DICT, ADDON_TYPE_LANG].includes(addon.type)
+        ? i18n.gettext('No Downloads')
+        : i18n.gettext('No Users');
     }
 
     let reviewCount = '';

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -8,7 +8,12 @@ import { compose } from 'redux';
 import Link from 'amo/components/Link';
 import { getAddonURL } from 'amo/utils';
 import translate from 'core/i18n/translate';
-import { CLIENT_APP_ANDROID, ADDON_TYPE_STATIC_THEME } from 'core/constants';
+import {
+  ADDON_TYPE_DICT,
+  ADDON_TYPE_LANG,
+  ADDON_TYPE_STATIC_THEME,
+  CLIENT_APP_ANDROID,
+} from 'core/constants';
 import { nl2br, sanitizeHTML } from 'core/utils';
 import { addQueryParams } from 'core/utils/url';
 import { getAddonIconUrl, getPreviewImage } from 'core/imageUtils';
@@ -128,6 +133,10 @@ export class SearchResultBase extends React.Component<InternalProps> {
       summary = <p className="SearchResult-summary" {...summaryProps} />;
     }
 
+    // This is needed for https://github.com/mozilla/addons-frontend/issues/9472
+    const useDownloadsInsteadOfUsers =
+      addon && [ADDON_TYPE_LANG, ADDON_TYPE_DICT].includes(addon.type);
+
     return (
       <div className="SearchResult-wrapper">
         <div className="SearchResult-result">
@@ -197,11 +206,17 @@ export class SearchResultBase extends React.Component<InternalProps> {
             <span className="SearchResult-users-text">
               {averageDailyUsers !== null && averageDailyUsers !== undefined ? (
                 i18n.sprintf(
-                  i18n.ngettext(
-                    '%(total)s user',
-                    '%(total)s users',
-                    averageDailyUsers,
-                  ),
+                  useDownloadsInsteadOfUsers
+                    ? i18n.ngettext(
+                        '%(total)s download',
+                        '%(total)s downloads',
+                        averageDailyUsers,
+                      )
+                    : i18n.ngettext(
+                        '%(total)s user',
+                        '%(total)s users',
+                        averageDailyUsers,
+                      ),
                   { total: i18n.formatNumber(averageDailyUsers) },
                 )
               ) : (

--- a/tests/unit/amo/components/TestAddonMeta.js
+++ b/tests/unit/amo/components/TestAddonMeta.js
@@ -9,6 +9,7 @@ import Link from 'amo/components/Link';
 import RatingsByStar from 'amo/components/RatingsByStar';
 import { reviewListURL } from 'amo/reducers/reviews';
 import { createInternalAddon } from 'core/reducers/addons';
+import { ADDON_TYPE_DICT, ADDON_TYPE_LANG } from 'core/constants';
 import {
   createContextWithFakeRouter,
   createFakeLocation,
@@ -85,6 +86,54 @@ describe(__filename, () => {
       });
       expect(getUserCount(root).content).toMatch(/^1\.000/);
     });
+
+    it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG])(
+      'renders the download count for %s',
+      (addonType) => {
+        const root = render({
+          addon: createInternalAddon({
+            ...fakeAddon,
+            type: addonType,
+            average_daily_users: 2,
+          }),
+        });
+
+        expect(getUserCount(root).content).toEqual('2');
+        expect(getUserCount(root).title).toEqual('Downloads');
+      },
+    );
+
+    it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG])(
+      'renders one download for %s',
+      (addonType) => {
+        const root = render({
+          addon: createInternalAddon({
+            ...fakeAddon,
+            type: addonType,
+            average_daily_users: 1,
+          }),
+        });
+
+        expect(getUserCount(root).content).toEqual('1');
+        expect(getUserCount(root).title).toEqual('Download');
+      },
+    );
+
+    it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG])(
+      'renders no downloads for %s',
+      (addonType) => {
+        const root = render({
+          addon: createInternalAddon({
+            ...fakeAddon,
+            type: addonType,
+            average_daily_users: 0,
+          }),
+        });
+
+        expect(getUserCount(root).content).toEqual('');
+        expect(getUserCount(root).title).toEqual('No Downloads');
+      },
+    );
   });
 
   describe('ratings', () => {

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -5,6 +5,8 @@ import * as React from 'react';
 import SearchResult, { SearchResultBase } from 'amo/components/SearchResult';
 import { getAddonURL } from 'amo/utils';
 import {
+  ADDON_TYPE_DICT,
+  ADDON_TYPE_LANG,
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
@@ -141,6 +143,17 @@ describe(__filename, () => {
     ).toContain('6 233');
   });
 
+  it('renders 0 users', () => {
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        average_daily_users: 0,
+      }),
+    });
+
+    expect(root.find('.SearchResult-users')).toIncludeText('0 users');
+  });
+
   it('renders the user count as singular', () => {
     const root = render({
       addon: createInternalAddon({
@@ -151,6 +164,51 @@ describe(__filename, () => {
 
     expect(root.find('.SearchResult-users')).toIncludeText('1 user');
   });
+
+  it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG])(
+    'renders 0 downloads for %s',
+    (addonType) => {
+      const root = render({
+        addon: createInternalAddon({
+          ...fakeAddon,
+          type: addonType,
+          average_daily_users: 0,
+        }),
+      });
+
+      expect(root.find('.SearchResult-users')).toIncludeText('0 downloads');
+    },
+  );
+
+  it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG])(
+    'renders 1 download for %s',
+    (addonType) => {
+      const root = render({
+        addon: createInternalAddon({
+          ...fakeAddon,
+          type: addonType,
+          average_daily_users: 1,
+        }),
+      });
+
+      expect(root.find('.SearchResult-users')).toIncludeText('1 download');
+    },
+  );
+
+  it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG])(
+    'renders the number of downloads for %s',
+    (addonType) => {
+      const root = render({
+        addon: createInternalAddon({
+          ...fakeAddon,
+          type: addonType,
+          average_daily_users: 3,
+        }),
+      });
+
+      expect(root.find('.SearchResult-users')).toIncludeText('3 downloads');
+    },
+  );
 
   it('links the li element to the detail page', () => {
     const slug = 'some-addon-slug';


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9472

---

I did not use a feature flag because I think we'll make the addons-server changes in the same tag: the only problem if this does not happen is that we'll see "Downloads" for a number of users instead of a number of actual downloads (the addons-server changes being about updating `average_daily_users` with download data instead of usage data)