### PR TITLE
Handle 401s on the server and show a message when user is logged out

### DIFF
--- a/src/core/components/SiteNotices/index.js
+++ b/src/core/components/SiteNotices/index.js
@@ -16,6 +16,7 @@ type Props = {||};
 type MappedProps = {|
   siteIsReadOnly: boolean,
   siteNotice: string | null,
+  currentUserWasLoggedOut: boolean,
 |};
 
 type InternalProps = {|
@@ -35,7 +36,12 @@ const sanitizeNoticeHTML = (text: string): string => {
 
 export class SiteNoticesBase extends React.Component<InternalProps> {
   render() {
-    const { i18n, siteIsReadOnly, siteNotice } = this.props;
+    const {
+      i18n,
+      siteIsReadOnly,
+      siteNotice,
+      currentUserWasLoggedOut,
+    } = this.props;
 
     const notices = [];
 
@@ -70,6 +76,19 @@ export class SiteNoticesBase extends React.Component<InternalProps> {
       );
     }
 
+    if (currentUserWasLoggedOut) {
+      notices.push(
+        <Notice
+          className="SiteNotices"
+          id="user-was-logged-out"
+          type="warning"
+          key="user-was-logged-out"
+        >
+          {i18n.gettext('You have been logged out.')}
+        </Notice>,
+      );
+    }
+
     return notices;
   }
 }
@@ -78,6 +97,7 @@ const mapStateToProps = (state: AppState): MappedProps => {
   return {
     siteIsReadOnly: state.site.readOnly,
     siteNotice: state.site.notice,
+    currentUserWasLoggedOut: state.users.currentUserWasLoggedOut,
   };
 };
 

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -447,12 +447,19 @@ function baseServer(
 
         const finalHTML = renderHTML({ props, pageProps, store });
 
+        const { redirectTo, users } = store.getState();
+
         // A redirection has been requested, let's do it.
-        const { redirectTo } = store.getState();
         if (redirectTo && redirectTo.url) {
           _log.debug(oneLine`Redirection requested:
             url=${redirectTo.url} status=${redirectTo.status}`);
           return res.redirect(redirectTo.status, redirectTo.url);
+        }
+
+        // See: https://github.com/mozilla/addons-frontend/issues/9482
+        if (users && users.currentUserWasLoggedOut === true) {
+          req.universalCookies.remove(config.get('cookieName'));
+          _log.debug('Cleared auth cookie');
         }
 
         return sendHTML({ res, html: finalHTML });

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -122,18 +122,16 @@ describe(__filename, () => {
 
       let state = store.getState().users;
       expect(state.currentUserWasLoggedOut).toEqual(true);
-      expect(state.resetStateOnNextChange).toEqual(false);
 
       // Perform two client-side location changes.
       state = reducer(state, { type: LOCATION_CHANGE }, _config);
-      expect(state.resetStateOnNextChange).toEqual(true);
+      expect(state.currentUserWasLoggedOut).toEqual(true);
 
       state = reducer(state, { type: LOCATION_CHANGE }, _config);
       expect(state.currentUserWasLoggedOut).toEqual(false);
-      expect(state.resetStateOnNextChange).toEqual(false);
     });
 
-    it('does not reset `currentUserWasLoggedOut` after only one location changes on the client', () => {
+    it('does not reset `currentUserWasLoggedOut` after only one location change on the client', () => {
       const _config = getFakeConfig({ server: false });
       const { store } = dispatchSignInActions();
       store.dispatch(logOutUser());
@@ -141,12 +139,9 @@ describe(__filename, () => {
       const state = store.getState().users;
       expect(state.currentUserWasLoggedOut).toEqual(true);
 
-      const newState = reducer(state, { type: LOCATION_CHANGE }, _config);
+      reducer(state, { type: LOCATION_CHANGE }, _config);
 
-      expect(newState).toEqual({
-        ...state,
-        resetStateOnNextChange: true,
-      });
+      expect(state.currentUserWasLoggedOut).toEqual(true);
     });
   });
 

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -12,11 +12,13 @@ import usersReducer, {
   loadCurrentUserAccount,
   loadUserAccount,
   loadUserNotifications,
+  logOutUser,
   unloadUserAccount,
   unsubscribeNotification,
   updateUserAccount,
 } from 'amo/reducers/users';
 import * as api from 'amo/api/users';
+import { createApiError } from 'core/api';
 import { setAuthToken } from 'core/actions';
 import apiReducer from 'core/reducers/api';
 import { loadSiteStatus } from 'core/reducers/site';
@@ -95,6 +97,21 @@ describe(__filename, () => {
           mockApi.verify();
           expect(error).toBe(expectedError);
         });
+    });
+
+    it('handles 401 responses', async () => {
+      const expectedError = createApiError({ response: { status: 401 } });
+      mockApi
+        .expects('currentUserAccount')
+        .returns(Promise.reject(expectedError));
+
+      sagaTester.dispatch(setAuthToken(userAuthToken()));
+
+      const expectedAction = logOutUser();
+      const calledAction = await sagaTester.waitFor(expectedAction.type);
+      expect(calledAction).toEqual(expectedAction);
+
+      mockApi.verify();
     });
   });
 

--- a/tests/unit/amo/sagas/test_users.js
+++ b/tests/unit/amo/sagas/test_users.js
@@ -99,6 +99,24 @@ describe(__filename, () => {
         });
     });
 
+    it('throws api errors when status is not 401', async () => {
+      const expectedError = createApiError({ response: { status: 400 } });
+      mockApi
+        .expects('currentUserAccount')
+        .returns(Promise.reject(expectedError));
+
+      sagaTester.dispatch(setAuthToken(userAuthToken()));
+
+      return rootTask.done
+        .then(() => {
+          throw new Error('unexpected success');
+        })
+        .catch((error) => {
+          mockApi.verify();
+          expect(error).toBe(expectedError);
+        });
+    });
+
     it('handles 401 responses', async () => {
       const expectedError = createApiError({ response: { status: 401 } });
       mockApi

--- a/tests/unit/core/components/TestSiteNotices.js
+++ b/tests/unit/core/components/TestSiteNotices.js
@@ -85,6 +85,14 @@ describe(__filename, () => {
     expect(root.find(Notice)).toHaveLength(2);
   });
 
+  it('does not render the "logged out" notice when user is logged in', () => {
+    const { store } = dispatchSignInActions();
+
+    const root = render({ store });
+
+    expect(root.find(Notice)).toHaveLength(0);
+  });
+
   it('renders a notice when user has been logged out', () => {
     const { store } = dispatchSignInActions();
     store.dispatch(logOutUser());

--- a/tests/unit/core/components/TestSiteNotices.js
+++ b/tests/unit/core/components/TestSiteNotices.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 
 import SiteNotices, { SiteNoticesBase } from 'core/components/SiteNotices';
+import { logOutUser } from 'amo/reducers/users';
 import { loadSiteStatus } from 'core/reducers/site';
 import Notice from 'ui/components/Notice';
 import {
   dispatchClientMetadata,
+  dispatchSignInActions,
   fakeI18n,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
@@ -81,5 +83,15 @@ describe(__filename, () => {
     const root = render({ store });
 
     expect(root.find(Notice)).toHaveLength(2);
+  });
+
+  it('renders a notice when user has been logged out', () => {
+    const { store } = dispatchSignInActions();
+    store.dispatch(logOutUser());
+
+    const root = render({ store });
+
+    expect(root.find(Notice)).toHaveLength(1);
+    expect(root.find(Notice)).toHaveProp('id', 'user-was-logged-out');
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9482

---

This patch should fix the issue above. In addition, we also show the notice when a user logs out manually. I find this behavior more consistent. It will require two location changes to make the message disappear in this specific case but I think that's fine.

I tried this patch by editing my auth cookie value (putting random chars to make it invalid).