### PR TITLE
Pass options when removing auth cookie

### DIFF
--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -460,6 +460,7 @@ function baseServer(
         if (users && users.currentUserWasLoggedOut === true) {
           req.universalCookies.remove(config.get('cookieName'), {
             httpOnly: true,
+            sameSite: 'lax',
             secure: true,
           });
           _log.debug('Cleared auth cookie');

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -458,7 +458,10 @@ function baseServer(
 
         // See: https://github.com/mozilla/addons-frontend/issues/9482
         if (users && users.currentUserWasLoggedOut === true) {
-          req.universalCookies.remove(config.get('cookieName'));
+          req.universalCookies.remove(config.get('cookieName'), {
+            httpOnly: true,
+            secure: true,
+          });
           _log.debug('Cleared auth cookie');
         }
 

--- a/tests/unit/core/server/test_base.js
+++ b/tests/unit/core/server/test_base.js
@@ -588,10 +588,13 @@ describe(__filename, () => {
       const { api, users } = store.getState();
 
       expect(response.statusCode).toEqual(200);
-      expect(response.headers['set-cookie'][0]).toContain(
+      const auth_cookie = response.headers['set-cookie'][0];
+      expect(auth_cookie).toContain(
         `${defaultConfig.get('cookieName')}=; Max-Age=0;`,
       );
-      expect(response.headers['set-cookie'][0]).toContain('HttpOnly');
+      expect(auth_cookie).toContain('HttpOnly');
+      expect(auth_cookie).toContain('Secure');
+      expect(auth_cookie).toContain('Lax');
       expect(api.token).toEqual(null);
       expect(users.currentUserWasLoggedOut).toEqual(true);
       mockUsersApi.verify();

--- a/tests/unit/core/server/test_base.js
+++ b/tests/unit/core/server/test_base.js
@@ -591,6 +591,7 @@ describe(__filename, () => {
       expect(response.headers['set-cookie'][0]).toContain(
         `${defaultConfig.get('cookieName')}=; Max-Age=0;`,
       );
+      expect(response.headers['set-cookie'][0]).toContain('HttpOnly');
       expect(api.token).toEqual(null);
       expect(users.currentUserWasLoggedOut).toEqual(true);
       mockUsersApi.verify();


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9490

Fixes https://github.com/mozilla/addons-frontend/issues/9491

---

This should make sure the cookie is deleted in the browser.

It won't fix the 404 I think because in some cases, we send API requests in parallel.