### PR TITLE
Update/Fix the promoted badges

### DIFF
--- a/src/ui/components/PromotedBadge/styles.scss
+++ b/src/ui/components/PromotedBadge/styles.scss
@@ -113,7 +113,7 @@
     border-color: $green-80;
     color: $green-80;
 
-    .IconPromotedBadge-shellPath--line {
+    .IconPromotedBadge-shellPath--verified {
       fill: $green-80;
     }
   }
@@ -125,7 +125,7 @@
 }
 
 .PromotedBadge-label--line {
-  color: $black;
+  color: $grey-90;
 }
 
 .PromotedBadge-label--recommended {
@@ -133,11 +133,5 @@
 }
 
 .PromotedBadge-label--verified {
-  color: $green-70;
-
-  &:active,
-  &:focus,
-  &:hover {
-    color: $green-80;
-  }
+  color: $green-80;
 }


### PR DESCRIPTION
Fixes #9534 

Does the following:
- Makes the color of the label for the Verified label one shade darker.
- Changes the color of the label for the Line badge from black to grey-90.
- Fixes the bug that was causing the icon for the Verified badge to not change color on hover.

From Storybook:

<img width="782" alt="Screenshot 2020-07-21 15 01 58" src="https://user-images.githubusercontent.com/142755/88095442-24556b00-cb63-11ea-8d5f-75c2d39e17f3.png">
