### PR TITLE
Display optional permissions

### DIFF
--- a/src/amo/components/PermissionsCard/index.js
+++ b/src/amo/components/PermissionsCard/index.js
@@ -35,12 +35,22 @@ export class PermissionsCardBase extends React.Component<Props> {
       platformFiles: version.platformFiles,
       userAgentInfo,
     });
-    if (!addonPermissions.length) {
+
+    if (
+      !addonPermissions.optional.length &&
+      !addonPermissions.required.length
+    ) {
       return null;
     }
 
-    const content = permissionUtils.formatPermissions(addonPermissions);
-    if (!content.length) {
+    const optionalContent = permissionUtils.formatPermissions(
+      addonPermissions.optional,
+    );
+    const requiredContent = permissionUtils.formatPermissions(
+      addonPermissions.required,
+    );
+
+    if (!optionalContent.length && !requiredContent.length) {
       return null;
     }
 
@@ -51,10 +61,26 @@ export class PermissionsCardBase extends React.Component<Props> {
         id="AddonDescription-permissions-card"
         maxHeight={300}
       >
-        <p className="PermissionsCard-subhead">
-          {i18n.gettext('This add-on can:')}
-        </p>
-        <ul className="PermissionsCard-list">{content}</ul>
+        {requiredContent.length ? (
+          <>
+            <p className="PermissionsCard-subhead--required">
+              {i18n.gettext('This add-on needs to:')}
+            </p>
+            <ul className="PermissionsCard-list--required">
+              {requiredContent}
+            </ul>
+          </>
+        ) : null}
+        {optionalContent.length ? (
+          <>
+            <p className="PermissionsCard-subhead--optional">
+              {i18n.gettext('This add-on may also ask to:')}
+            </p>
+            <ul className="PermissionsCard-list--optional">
+              {optionalContent}
+            </ul>
+          </>
+        ) : null}
         <Button
           buttonType="neutral"
           className="PermissionCard-learn-more"

--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -95,7 +95,7 @@ export class PermissionUtils {
     }
 
     permissions.optional = file.optional_permissions;
-    permissions.required = file.permissions || [];
+    permissions.required = file.permissions;
     return permissions;
   }
 

--- a/src/amo/components/PermissionsCard/permissions.js
+++ b/src/amo/components/PermissionsCard/permissions.js
@@ -66,16 +66,23 @@ export class PermissionUtils {
     };
   }
 
-  // Get a list of permissions from the correct platform file.
+  // Get lists of optional and required permissions from the correct platform file.
   getCurrentPermissions({
     platformFiles,
     userAgentInfo,
     _findFileForPlatform = findFileForPlatform,
-  }: GetCurrentPermissionsParams): Array<string> {
+  }: GetCurrentPermissionsParams): {
+    optional: Array<string>,
+    required: Array<string>,
+  } {
     const file = _findFileForPlatform({
       userAgentInfo,
       platformFiles,
     });
+    const permissions = {
+      optional: [],
+      required: [],
+    };
 
     if (!file) {
       log.debug(
@@ -84,9 +91,12 @@ export class PermissionUtils {
         platformFiles,
       );
 
-      return [];
+      return permissions;
     }
-    return file.permissions || [];
+
+    permissions.optional = file.optional_permissions;
+    permissions.required = file.permissions || [];
+    return permissions;
   }
 
   // Classify a permission as a host permission or a regular permission.

--- a/src/amo/components/PermissionsCard/styles.scss
+++ b/src/amo/components/PermissionsCard/styles.scss
@@ -9,12 +9,14 @@
   }
 }
 
-.PermissionsCard-subhead {
+.PermissionsCard-subhead--optional,
+.PermissionsCard-subhead--required {
   color: $grey-50;
   margin: 0;
 }
 
-.PermissionsCard-list {
+.PermissionsCard-list--optional,
+.PermissionsCard-list--required {
   list-style: none;
   padding: 0;
 

--- a/src/core/reducers/versions.js
+++ b/src/core/reducers/versions.js
@@ -40,6 +40,7 @@ export type AddonFileType = {|
   is_mozilla_signed_extension: boolean,
   is_restart_required: boolean,
   is_webextension: boolean,
+  optional_permissions: Array<string>,
   permissions?: Array<string>,
   platform: 'all' | 'android' | 'mac' | 'linux' | 'windows',
   size: number,

--- a/src/core/reducers/versions.js
+++ b/src/core/reducers/versions.js
@@ -41,7 +41,7 @@ export type AddonFileType = {|
   is_restart_required: boolean,
   is_webextension: boolean,
   optional_permissions: Array<string>,
-  permissions?: Array<string>,
+  permissions: Array<string>,
   platform: 'all' | 'android' | 'mac' | 'linux' | 'windows',
   size: number,
   status: AddonStatusType,

--- a/tests/unit/amo/components/TestPermissionUtils.js
+++ b/tests/unit/amo/components/TestPermissionUtils.js
@@ -56,19 +56,6 @@ describe(__filename, () => {
         required: [],
       });
     });
-
-    it('returns an empty array of required permissions if none exist', () => {
-      const optionalPermissions = ['webRequest'];
-      findFileForPlatformStub.returns({
-        optional_permissions: optionalPermissions,
-        permissions: undefined,
-      });
-
-      expect(_getCurrentPermissions()).toEqual({
-        optional: optionalPermissions,
-        required: [],
-      });
-    });
   });
 
   describe('classifyPermission', () => {

--- a/tests/unit/amo/components/TestPermissionUtils.js
+++ b/tests/unit/amo/components/TestPermissionUtils.js
@@ -35,22 +35,39 @@ describe(__filename, () => {
     };
 
     it('returns permissions from a found file', () => {
+      const optionalPermissions = ['webRequest'];
       const permissions = ['bookmarks'];
-      findFileForPlatformStub.returns({ permissions });
+      findFileForPlatformStub.returns({
+        optional_permissions: optionalPermissions,
+        permissions,
+      });
 
-      expect(_getCurrentPermissions()).toEqual(permissions);
+      expect(_getCurrentPermissions()).toEqual({
+        optional: optionalPermissions,
+        required: permissions,
+      });
     });
 
-    it('returns an empty array if no file was found', () => {
+    it('returns empty arrays if no file was found', () => {
       findFileForPlatformStub.returns(undefined);
 
-      expect(_getCurrentPermissions()).toEqual([]);
+      expect(_getCurrentPermissions()).toEqual({
+        optional: [],
+        required: [],
+      });
     });
 
-    it('returns an empty array if no permissions were found', () => {
-      findFileForPlatformStub.returns({ permissions: undefined });
+    it('returns an empty array of required permissions if none exist', () => {
+      const optionalPermissions = ['webRequest'];
+      findFileForPlatformStub.returns({
+        optional_permissions: optionalPermissions,
+        permissions: undefined,
+      });
 
-      expect(_getCurrentPermissions()).toEqual([]);
+      expect(_getCurrentPermissions()).toEqual({
+        optional: optionalPermissions,
+        required: [],
+      });
     });
   });
 

--- a/tests/unit/amo/components/TestPermissionsCard.js
+++ b/tests/unit/amo/components/TestPermissionsCard.js
@@ -21,13 +21,14 @@ describe(__filename, () => {
     store = dispatchClientMetadata().store;
   });
 
-  const createVersionWithPermissions = (permissions) => {
+  const createVersionWithPermissions = (optional, required) => {
     return createInternalVersion({
       ...fakeVersion,
       files: [
         {
           ...fakePlatformFile,
-          permissions,
+          optional_permissions: optional,
+          permissions: required,
         },
       ],
     });
@@ -52,30 +53,81 @@ describe(__filename, () => {
     });
 
     it('renders nothing for a version with no permissions', () => {
-      const root = render({ version: createVersionWithPermissions([]) });
+      const root = render({ version: createVersionWithPermissions([], []) });
       expect(root).not.toHaveClassName('PermissionsCard');
     });
 
     it('renders nothing for a version with no displayable permissions', () => {
       const root = render({
-        version: createVersionWithPermissions(['activeTab']),
+        version: createVersionWithPermissions(['activeTab'], ['activeTab']),
       });
       expect(root).not.toHaveClassName('PermissionsCard');
     });
   });
 
   describe('with permissions', () => {
-    it('renders itself', () => {
+    it('renders learn more button', () => {
       const permission = 'bookmarks';
       const root = render({
-        version: createVersionWithPermissions([permission]),
+        version: createVersionWithPermissions([], [permission]),
       });
       expect(root).toHaveClassName('PermissionsCard');
-      expect(root.find('p')).toHaveClassName('PermissionsCard-subhead');
-      expect(root.find('ul')).toHaveClassName('PermissionsCard-list');
       expect(root.find(Button)).toHaveClassName('PermissionCard-learn-more');
       expect(root.find(Button)).toHaveProp('externalDark', true);
+    });
+
+    it('renders required permissions only', () => {
+      const permission = 'bookmarks';
+      const root = render({
+        version: createVersionWithPermissions([], [permission]),
+      });
+      expect(root).toHaveClassName('PermissionsCard');
+      expect(root.find('p')).toHaveClassName(
+        'PermissionsCard-subhead--required',
+      );
+      expect(root.find('ul')).toHaveClassName('PermissionsCard-list--required');
       expect(root.find(Permission)).toHaveProp('type', permission);
+      expect(root.find('.PermissionsCard-subhead--optional')).toHaveLength(0);
+      expect(root.find('.PermissionsCard-list--optional')).toHaveLength(0);
+    });
+
+    it('renders optional permissions only', () => {
+      const permission = 'bookmarks';
+      const root = render({
+        version: createVersionWithPermissions([permission], []),
+      });
+      expect(root).toHaveClassName('PermissionsCard');
+      expect(root.find('p')).toHaveClassName(
+        'PermissionsCard-subhead--optional',
+      );
+      expect(root.find('ul')).toHaveClassName('PermissionsCard-list--optional');
+      expect(root.find(Permission)).toHaveProp('type', permission);
+      expect(root.find('.PermissionsCard-subhead--required')).toHaveLength(0);
+      expect(root.find('.PermissionsCard-list--required')).toHaveLength(0);
+    });
+
+    it('renders both optional and required permissions', () => {
+      const optionalPermission = 'bookmarks';
+      const requiredPermission = 'history';
+      const root = render({
+        version: createVersionWithPermissions(
+          [optionalPermission],
+          [requiredPermission],
+        ),
+      });
+      expect(root).toHaveClassName('PermissionsCard');
+      expect(root.find('p').at(0)).toHaveClassName(
+        'PermissionsCard-subhead--required',
+      );
+      expect(
+        root.find('.PermissionsCard-list--required').find(Permission),
+      ).toHaveProp('type', requiredPermission);
+      expect(root.find('p').at(1)).toHaveClassName(
+        'PermissionsCard-subhead--optional',
+      );
+      expect(
+        root.find('.PermissionsCard-list--optional').find(Permission),
+      ).toHaveProp('type', optionalPermission);
     });
   });
 });

--- a/tests/unit/amo/components/TestPermissionsCard.js
+++ b/tests/unit/amo/components/TestPermissionsCard.js
@@ -21,7 +21,10 @@ describe(__filename, () => {
     store = dispatchClientMetadata().store;
   });
 
-  const createVersionWithPermissions = (optional, required) => {
+  const createVersionWithPermissions = ({
+    optional = [],
+    required = [],
+  } = {}) => {
     return createInternalVersion({
       ...fakeVersion,
       files: [
@@ -53,13 +56,16 @@ describe(__filename, () => {
     });
 
     it('renders nothing for a version with no permissions', () => {
-      const root = render({ version: createVersionWithPermissions([], []) });
+      const root = render({ version: createVersionWithPermissions() });
       expect(root).not.toHaveClassName('PermissionsCard');
     });
 
     it('renders nothing for a version with no displayable permissions', () => {
       const root = render({
-        version: createVersionWithPermissions(['activeTab'], ['activeTab']),
+        version: createVersionWithPermissions({
+          optional: ['activeTab'],
+          required: ['activeTab'],
+        }),
       });
       expect(root).not.toHaveClassName('PermissionsCard');
     });
@@ -69,7 +75,7 @@ describe(__filename, () => {
     it('renders learn more button', () => {
       const permission = 'bookmarks';
       const root = render({
-        version: createVersionWithPermissions([], [permission]),
+        version: createVersionWithPermissions({ required: [permission] }),
       });
       expect(root).toHaveClassName('PermissionsCard');
       expect(root.find(Button)).toHaveClassName('PermissionCard-learn-more');
@@ -79,7 +85,7 @@ describe(__filename, () => {
     it('renders required permissions only', () => {
       const permission = 'bookmarks';
       const root = render({
-        version: createVersionWithPermissions([], [permission]),
+        version: createVersionWithPermissions({ required: [permission] }),
       });
       expect(root).toHaveClassName('PermissionsCard');
       expect(root.find('p')).toHaveClassName(
@@ -94,7 +100,7 @@ describe(__filename, () => {
     it('renders optional permissions only', () => {
       const permission = 'bookmarks';
       const root = render({
-        version: createVersionWithPermissions([permission], []),
+        version: createVersionWithPermissions({ optional: [permission] }),
       });
       expect(root).toHaveClassName('PermissionsCard');
       expect(root.find('p')).toHaveClassName(
@@ -110,10 +116,10 @@ describe(__filename, () => {
       const optionalPermission = 'bookmarks';
       const requiredPermission = 'history';
       const root = render({
-        version: createVersionWithPermissions(
-          [optionalPermission],
-          [requiredPermission],
-        ),
+        version: createVersionWithPermissions({
+          optional: [optionalPermission],
+          required: [requiredPermission],
+        }),
       });
       expect(root).toHaveClassName('PermissionsCard');
       expect(root.find('p').at(0)).toHaveClassName(

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -64,6 +64,7 @@ export const fakePlatformFile = Object.freeze({
   is_mozilla_signed_extension: false,
   is_restart_required: false,
   is_webextension: true,
+  optional_permissions: ['*://developer.mozilla.org/*', 'bookmarks'],
   permissions: ['activeTab', 'webRequest'],
   platform: OS_ALL,
   size: 123,


### PR DESCRIPTION
Fixes #9542 

Here's what it looks like:

<img width="488" alt="Screenshot 2020-07-29 13 58 01" src="https://user-images.githubusercontent.com/142755/88835748-b7b22000-d1a3-11ea-9104-3c89699d4981.png">

I noticed a visual bug here, but it's not a regression. It seems to exist on prod as well. The bottom of the permissions box doesn't have rounded corners. I'll file a separate issue for that.
