### PR TITLE
Fix for Issue #9411

### DIFF
--- a/src/ui/components/ShowMoreCard/styles.scss
+++ b/src/ui/components/ShowMoreCard/styles.scss
@@ -60,7 +60,8 @@
   }
 
   .ShowMoreCard-contents {
-    max-height: 300px;
+    // Chnaged this value for Issue #9411
+    max-height: 450px;
   }
 
   &.ShowMoreCard--expanded .ShowMoreCard-contents {


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #9411

The 'Learn more about" button is now visible without having to click on the 'Read More' first, as described in the issue.

After screenshot:

![87541121-65aace00-c6be-11ea-96d8-3c77a63a7236](https://user-images.githubusercontent.com/53997603/88844195-eeb61f00-d1ff-11ea-9299-fd8c423a41fd.png)


<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
 