### PR TITLE
Add a new group for history deps in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,5 +36,6 @@
         "qhistory"
       ],
       "groupName": "history"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,12 @@
     {
       "packagePatterns": ["@loadable/*"],
       "groupName": "loadable components"
-    }
+    },
+    {
+      "packagePatterns": [
+        "history",
+        "qhistory"
+      ],
+      "groupName": "history"
   ]
 }


### PR DESCRIPTION
I think this would avoid further breakage given that both should be kept in sync (based on the two recent PRs we have).