### PR TITLE
Use `promoted` from the API response in place of `is_recommended`

### DIFF
--- a/src/amo/components/AddonBadges/index.js
+++ b/src/amo/components/AddonBadges/index.js
@@ -38,7 +38,7 @@ export class AddonBadgesBase extends React.Component<InternalProps> {
 
     return (
       <div className="AddonBadges">
-        {addon.is_recommended && clientApp !== CLIENT_APP_ANDROID ? (
+        {addon.isRecommended && clientApp !== CLIENT_APP_ANDROID ? (
           <PromotedBadge category="recommended" size="large" />
         ) : null}
         {addon.isRestartRequired ? (

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -26,6 +26,7 @@ import {
 import Icon from 'ui/components/Icon';
 import type { AppState } from 'amo/store';
 import type { UserAgentInfoType } from 'core/reducers/api';
+import type { SuggestionType } from 'core/reducers/autocomplete';
 import type { I18nType } from 'core/types/i18n';
 import type { DispatchFunc } from 'core/types/redux';
 import type { ReactRouterLocationType } from 'core/types/router';
@@ -35,16 +36,6 @@ import './styles.scss';
 
 export const SEARCH_TERM_MIN_LENGTH = 2;
 export const SEARCH_TERM_MAX_LENGTH = 100;
-
-// TODO: port reducers/autocomplete.js to Flow and move this there.
-export type SuggestionType = {|
-  addonId: number,
-  iconUrl: string,
-  isRecommended: boolean,
-  name: string,
-  type: string,
-  url: string,
-|};
 
 // TODO: create a type for the inverse of paramsToFilter in
 // core/searchUtils and move this there.

--- a/src/amo/components/CollectionAddAddon/index.js
+++ b/src/amo/components/CollectionAddAddon/index.js
@@ -13,7 +13,7 @@ import translate from 'core/i18n/translate';
 import withUIState from 'core/withUIState';
 import Card from 'ui/components/Card';
 import Notice from 'ui/components/Notice';
-import type { SuggestionType } from 'amo/components/AutoSearchInput';
+import type { SuggestionType } from 'core/reducers/autocomplete';
 import type {
   CollectionFilters,
   CollectionType,

--- a/src/amo/components/GuidesAddonCard/index.js
+++ b/src/amo/components/GuidesAddonCard/index.js
@@ -64,7 +64,7 @@ export class GuidesAddonCardBase extends React.Component<InternalProps> {
                       linkToAddon
                     />
                   </span>
-                  {addon && addon.is_recommended && (
+                  {addon && addon.isRecommended && (
                     <PromotedBadge category="recommended" size="small" />
                   )}
                 </div>

--- a/src/amo/components/InstallWarning/index.js
+++ b/src/amo/components/InstallWarning/index.js
@@ -67,7 +67,7 @@ export class InstallWarningBase extends React.Component<InternalProps> {
           isFirefox({ userAgentInfo }) &&
           clientApp === CLIENT_APP_FIREFOX &&
           addon.type === ADDON_TYPE_EXTENSION &&
-          !addon.is_recommended;
+          !addon.isRecommended;
   };
 
   render() {

--- a/src/amo/components/SearchForm/index.js
+++ b/src/amo/components/SearchForm/index.js
@@ -12,11 +12,9 @@ import AutoSearchInput from 'amo/components/AutoSearchInput';
 import { CLIENT_APP_ANDROID } from 'core/constants';
 import { convertFiltersToQueryParams } from 'core/searchUtils';
 import translate from 'core/i18n/translate';
-import type {
-  SearchFilters,
-  SuggestionType,
-} from 'amo/components/AutoSearchInput';
+import type { SearchFilters } from 'amo/components/AutoSearchInput';
 import type { AppState } from 'amo/store';
+import type { SuggestionType } from 'core/reducers/autocomplete';
 import type { I18nType } from 'core/types/i18n';
 import type { ReactRouterHistoryType } from 'core/types/router';
 

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -177,7 +177,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
               {addonTitle}
               {showRecommendedBadge &&
               addon &&
-              addon.is_recommended &&
+              addon.isRecommended &&
               clientApp !== CLIENT_APP_ANDROID ? (
                 <PromotedBadge
                   category="recommended"

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -309,3 +309,19 @@ export const DISCO_TAAR_CLIENT_ID_HEADER = 'moz-client-id';
 
 export const DEFAULT_UTM_SOURCE = 'addons.mozilla.org';
 export const DEFAULT_UTM_MEDIUM = 'referral';
+
+// Promoted categories
+export const LINE = 'line';
+export const RECOMMENDED = 'recommended';
+export const SPONSORED = 'sponsored';
+export const SPOTLIGHT = 'spotlight';
+export const STRATEGIC = 'strategic';
+export const VERIFIED = 'verified';
+
+export type PromotedCategoryType =
+  | typeof LINE
+  | typeof RECOMMENDED
+  | typeof SPONSORED
+  | typeof SPOTLIGHT
+  | typeof STRATEGIC
+  | typeof VERIFIED;

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -12,6 +12,7 @@ import type {
 } from 'amo/actions/reviews';
 import type { ExternalAddonInfoType } from 'amo/api/addonInfo';
 import type { AppState } from 'amo/store';
+import { RECOMMENDED } from 'core/constants';
 import type { ErrorHandlerType } from 'core/errorHandler';
 import type {
   AddonType,
@@ -170,13 +171,16 @@ export function createInternalAddon(
     id: apiAddon.id,
     is_disabled: apiAddon.is_disabled,
     is_experimental: apiAddon.is_experimental,
-    is_recommended: apiAddon.is_recommended,
+    isRecommended: Boolean(
+      apiAddon.promoted && apiAddon.promoted.category === RECOMMENDED,
+    ),
     is_source_public: apiAddon.is_source_public,
     last_updated: apiAddon.last_updated,
     latest_unlisted_version: apiAddon.latest_unlisted_version,
     locale_disambiguation: apiAddon.locale_disambiguation,
     name: apiAddon.name,
     previews: apiAddon.previews,
+    promoted: apiAddon.promoted,
     ratings: apiAddon.ratings,
     requires_payment: apiAddon.requires_payment,
     review_url: apiAddon.review_url,

--- a/src/core/reducers/autocomplete.js
+++ b/src/core/reducers/autocomplete.js
@@ -1,7 +1,9 @@
 /* @flow */
 import invariant from 'invariant';
 
+import { RECOMMENDED } from 'core/constants';
 import { getAddonIconUrl } from 'core/imageUtils';
+import type { PromotedType } from 'core/types/addons';
 
 export const AUTOCOMPLETE_LOADED: 'AUTOCOMPLETE_LOADED' = 'AUTOCOMPLETE_LOADED';
 export const AUTOCOMPLETE_STARTED: 'AUTOCOMPLETE_STARTED' =
@@ -13,24 +15,25 @@ export const AUTOCOMPLETE_CANCELLED: 'AUTOCOMPLETE_CANCELLED' =
 type ExternalSuggestion = {|
   icon_url: string,
   id: number,
-  is_recommended: boolean,
   name: string,
+  promoted: PromotedType | null,
   type: string,
   url: string,
 |};
 
-type Suggestion = {|
+export type SuggestionType = {|
   addonId: number,
   iconUrl: string,
   isRecommended: boolean,
   name: string,
+  promoted: PromotedType | null,
   type: string,
   url: string,
 |};
 
 export type AutocompleteState = {|
   loading: boolean,
-  suggestions: Array<Suggestion>,
+  suggestions: Array<SuggestionType>,
 |};
 
 const initialState: AutocompleteState = {
@@ -94,12 +97,16 @@ export function autocompleteLoad({
 
 export const createInternalSuggestion = (
   externalSuggestion: ExternalSuggestion,
-): Suggestion => {
+): SuggestionType => {
   return {
     addonId: externalSuggestion.id,
     iconUrl: getAddonIconUrl(externalSuggestion),
-    isRecommended: externalSuggestion.is_recommended,
+    isRecommended: Boolean(
+      externalSuggestion.promoted &&
+        externalSuggestion.promoted.category === RECOMMENDED,
+    ),
     name: externalSuggestion.name,
+    promoted: externalSuggestion.promoted,
     type: externalSuggestion.type,
     url: externalSuggestion.url,
   };

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -4,7 +4,7 @@ import type {
   ExternalAddonVersionType,
   PartialExternalAddonVersionType,
 } from 'core/reducers/versions';
-import type { AddonTypeType } from 'core/constants';
+import type { AddonTypeType, PromotedCategoryType } from 'core/constants';
 
 export type AddonStatusType =
   | 'lite'
@@ -44,6 +44,11 @@ export type LanguageToolType = {|
   url: string,
 |};
 
+export type PromotedType = {|
+  category: PromotedCategoryType,
+  apps: Array<string>,
+|};
+
 /*
  * This is the external API representation of an add-on.
  *
@@ -73,13 +78,13 @@ export type ExternalAddonType = {|
   id: number,
   is_disabled?: boolean,
   is_experimental?: boolean,
-  is_recommended?: boolean,
   is_source_public?: boolean,
   last_updated: Date | null,
   latest_unlisted_version?: ?ExternalAddonVersionType,
   locale_disambiguation?: string,
   name: string,
   previews?: Array<Object>,
+  promoted: PromotedType | null,
   ratings?: {|
     average: number,
     bayesian_average: number,
@@ -113,6 +118,7 @@ export type AddonType = {|
   // Here are some custom properties for our internal representation.
   currentVersionId: VersionIdType | null,
   isMozillaSignedExtension: boolean,
+  isRecommended: boolean,
   isRestartRequired: boolean,
   isWebExtension: boolean,
 |};

--- a/tests/unit/amo/components/TestAddonBadges.js
+++ b/tests/unit/amo/components/TestAddonBadges.js
@@ -6,6 +6,7 @@ import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
+  RECOMMENDED,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -47,7 +48,7 @@ describe(__filename, () => {
   it('displays a recommended badge for a recommended add-on', () => {
     const addon = createInternalAddon({
       ...fakeAddon,
-      is_recommended: true,
+      promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
     });
     const root = shallowRender({ addon });
 
@@ -61,7 +62,7 @@ describe(__filename, () => {
 
     const addon = createInternalAddon({
       ...fakeAddon,
-      is_recommended: true,
+      promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
       type: ADDON_TYPE_EXTENSION,
     });
     const root = shallowRender({ addon, store });

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -11,8 +11,10 @@ import AutoSearchInput, {
 import SearchSuggestion from 'amo/components/SearchSuggestion';
 import {
   ADDON_TYPE_EXTENSION,
+  CLIENT_APP_FIREFOX,
   OS_LINUX,
   OS_WINDOWS,
+  RECOMMENDED,
   SEARCH_SORT_POPULAR,
   SEARCH_SORT_RANDOM,
 } from 'core/constants';
@@ -608,7 +610,10 @@ describe(__filename, () => {
       const isRecommended = true;
       const name = 'uBlock Origin';
       const suggestionData = createInternalSuggestion(
-        createFakeAutocompleteResult({ name, is_recommended: isRecommended }),
+        createFakeAutocompleteResult({
+          name,
+          promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
+        }),
       );
       const suggestion = renderSuggestion({ suggestionData });
 

--- a/tests/unit/amo/components/TestGuidesAddonCard.js
+++ b/tests/unit/amo/components/TestGuidesAddonCard.js
@@ -9,7 +9,14 @@ import GuidesAddonCard, {
 import InstallButtonWrapper from 'amo/components/InstallButtonWrapper';
 import InstallWarning from 'amo/components/InstallWarning';
 import { setInstallError, setInstallState } from 'core/reducers/installations';
-import { FATAL_ERROR, INSTALLING, UNKNOWN } from 'core/constants';
+import {
+  CLIENT_APP_FIREFOX,
+  FATAL_ERROR,
+  INSTALLING,
+  RECOMMENDED,
+  UNKNOWN,
+  VERIFIED,
+} from 'core/constants';
 import { createInternalAddon, loadAddonResults } from 'core/reducers/addons';
 import {
   dispatchClientMetadata,
@@ -106,14 +113,27 @@ describe(__filename, () => {
 
   it('renders a PromotedBadge when the add-on is recommended', () => {
     const root = render({
-      addon: createInternalAddon({ ...fakeAddon, is_recommended: true }),
+      addon: createInternalAddon({
+        ...fakeAddon,
+        promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
+      }),
     });
     expect(root.find(PromotedBadge)).toHaveLength(1);
   });
 
   it('does not render a PromotedBadge when the add-on is not recommended', () => {
     const root = render({
-      addon: createInternalAddon({ ...fakeAddon, is_recommended: false }),
+      addon: createInternalAddon({
+        ...fakeAddon,
+        promoted: { category: VERIFIED, apps: [CLIENT_APP_FIREFOX] },
+      }),
+    });
+    expect(root.find(PromotedBadge)).toHaveLength(0);
+  });
+
+  it('does not render a PromotedBadge when the add-on is not promoted', () => {
+    const root = render({
+      addon: createInternalAddon({ ...fakeAddon, promoted: null }),
     });
     expect(root.find(PromotedBadge)).toHaveLength(0);
   });

--- a/tests/unit/amo/components/TestInstallWarning.js
+++ b/tests/unit/amo/components/TestInstallWarning.js
@@ -9,6 +9,8 @@ import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
+  RECOMMENDED,
+  VERIFIED,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -53,7 +55,7 @@ describe(__filename, () => {
   // This is an add-on that would cause a warning to be displayed.
   const addonThatWouldShowWarning = {
     ...fakeAddon,
-    is_recommended: false,
+    promoted: { category: VERIFIED, apps: [CLIENT_APP_FIREFOX] },
     type: ADDON_TYPE_EXTENSION,
   };
 
@@ -97,7 +99,7 @@ describe(__filename, () => {
       const component = renderWithWarning({
         addon: createInternalAddon({
           ...addonThatWouldShowWarning,
-          is_recommended: true,
+          promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
         }),
       });
 

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -9,6 +9,8 @@ import {
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
   DEFAULT_UTM_SOURCE,
+  RECOMMENDED,
+  VERIFIED,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -34,7 +36,7 @@ describe(__filename, () => {
     ...fakeAddon,
     authors: [{ name: 'A funky déveloper' }, { name: 'A groovy developer' }],
     average_daily_users: 5253,
-    is_recommended: false,
+    promoted: null,
     name: 'A search result',
     slug: 'a-search-result',
   });
@@ -477,7 +479,7 @@ describe(__filename, () => {
     const root = render({
       addon: createInternalAddon({
         ...fakeAddon,
-        is_recommended: true,
+        promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
       }),
     });
 
@@ -488,7 +490,7 @@ describe(__filename, () => {
     const root = render({
       addon: createInternalAddon({
         ...fakeAddon,
-        is_recommended: true,
+        promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
       }),
     });
 
@@ -502,7 +504,7 @@ describe(__filename, () => {
     const root = render({
       addon: createInternalAddon({
         ...fakeAddon,
-        is_recommended: true,
+        promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
       }),
       showRecommendedBadge: false,
     });
@@ -518,7 +520,7 @@ describe(__filename, () => {
     const root = render({
       addon: createInternalAddon({
         ...fakeAddon,
-        is_recommended: true,
+        promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
       }),
       store,
     });
@@ -530,7 +532,18 @@ describe(__filename, () => {
     const root = render({
       addon: createInternalAddon({
         ...fakeAddon,
-        is_recommended: false,
+        promoted: { category: VERIFIED, apps: [CLIENT_APP_FIREFOX] },
+      }),
+    });
+
+    expect(root.find(PromotedBadge)).toHaveLength(0);
+  });
+
+  it('does not display a recommended badge when the addon is not promoted', () => {
+    const root = render({
+      addon: createInternalAddon({
+        ...fakeAddon,
+        promoted: null,
       }),
     });
 

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -3,7 +3,12 @@ import {
   unloadAddonReviews,
   updateRatingCounts,
 } from 'amo/actions/reviews';
-import { ADDON_TYPE_EXTENSION } from 'core/constants';
+import {
+  ADDON_TYPE_EXTENSION,
+  CLIENT_APP_FIREFOX,
+  RECOMMENDED,
+  VERIFIED,
+} from 'core/constants';
 import addons, {
   createInternalAddon,
   createInternalAddonInfo,
@@ -887,6 +892,35 @@ describe(__filename, () => {
         });
         expect(getAddonInfoBySlug({ slug: 'some-slug', state })).toEqual(null);
       });
+    });
+  });
+
+  describe('createInternalAddon', () => {
+    it('sets isRecommended to true for a recommended add-on', () => {
+      expect(
+        createInternalAddon({
+          ...fakeAddon,
+          promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
+        }).isRecommended,
+      ).toEqual(true);
+    });
+
+    it('sets isRecommended to false for a non-recommended add-on', () => {
+      expect(
+        createInternalAddon({
+          ...fakeAddon,
+          promoted: { category: VERIFIED, apps: [CLIENT_APP_FIREFOX] },
+        }).isRecommended,
+      ).toEqual(false);
+    });
+
+    it('sets isRecommended to false for a non-promoted add-on', () => {
+      expect(
+        createInternalAddon({
+          ...fakeAddon,
+          promoted: null,
+        }).isRecommended,
+      ).toEqual(false);
     });
   });
 });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -5,6 +5,7 @@ import {
 } from 'amo/actions/reviews';
 import {
   ADDON_TYPE_EXTENSION,
+  CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
   RECOMMENDED,
   VERIFIED,
@@ -896,14 +897,22 @@ describe(__filename, () => {
   });
 
   describe('createInternalAddon', () => {
-    it('sets isRecommended to true for a recommended add-on', () => {
-      expect(
-        createInternalAddon({
-          ...fakeAddon,
-          promoted: { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] },
-        }).isRecommended,
-      ).toEqual(true);
-    });
+    it.each(
+      [CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX],
+      [CLIENT_APP_FIREFOX],
+      [CLIENT_APP_ANDROID],
+      [],
+    )(
+      'sets isRecommended to true for a recommended add-on, apps: %s',
+      (apps) => {
+        expect(
+          createInternalAddon({
+            ...fakeAddon,
+            promoted: { category: RECOMMENDED, apps },
+          }).isRecommended,
+        ).toEqual(true);
+      },
+    );
 
     it('sets isRecommended to false for a non-recommended add-on', () => {
       expect(

--- a/tests/unit/core/reducers/test_autocomplete.js
+++ b/tests/unit/core/reducers/test_autocomplete.js
@@ -1,3 +1,4 @@
+import { CLIENT_APP_FIREFOX, RECOMMENDED, VERIFIED } from 'core/constants';
 import reducer, {
   autocompleteCancel,
   autocompleteLoad,
@@ -63,8 +64,9 @@ describe(__filename, () => {
     });
 
     it('sets the suggestion properties', () => {
+      const promoted = { category: RECOMMENDED, apps: [CLIENT_APP_FIREFOX] };
       const result = createFakeAutocompleteResult({
-        is_recommended: true,
+        promoted,
         name: 'baz',
       });
       const results = [result];
@@ -78,11 +80,38 @@ describe(__filename, () => {
         {
           addonId: result.id,
           iconUrl: result.icon_url,
-          isRecommended: result.is_recommended,
+          isRecommended: true,
           name: result.name,
+          promoted,
           url: result.url,
         },
       ]);
+    });
+
+    it('sets the isRecommended to false when the add-on is not recommended', () => {
+      const result = createFakeAutocompleteResult({
+        promoted: { category: VERIFIED, apps: [CLIENT_APP_FIREFOX] },
+        name: 'baz',
+      });
+
+      const { suggestions } = reducer(
+        undefined,
+        autocompleteLoad({ results: [result] }),
+      );
+      expect(suggestions[0].isRecommended).toEqual(false);
+    });
+
+    it('sets the isRecommended to false when the add-on is not promoted', () => {
+      const result = createFakeAutocompleteResult({
+        promoted: null,
+        name: 'baz',
+      });
+
+      const { suggestions } = reducer(
+        undefined,
+        autocompleteLoad({ results: [result] }),
+      );
+      expect(suggestions[0].isRecommended).toEqual(false);
     });
 
     it('excludes AUTOCOMPLETE_LOADED results with null names', () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -129,6 +129,7 @@ export const fakeAddon = Object.freeze({
   last_updated: '2018-11-22T10:09:01Z',
   name: 'Chill Out',
   previews: [fakePreview],
+  promoted: null,
   ratings: {
     average: 3.5,
     count: 10,
@@ -511,6 +512,7 @@ export function createFakeAutocompleteResult({
     icon_url: `${config.get('amoCDN')}/${name}.png`,
     is_recommended: false,
     name,
+    promoted: null,
     url: `https://example.org/en-US/firefox/addons/${name}/`,
     ...props,
   };


### PR DESCRIPTION
Fixes #9579 

This removes the use of `is_recommended` from the API response, and uses `promoted` instead. To keep this patch simple, I've kept an internal `isRecommended` property for the `Addon` type, which is now based on the contents of `promoted`. This also makes `promoted` available in the `Addon` object so it can be used in the future when we start to support other categories.