### PR TITLE
Stop passing an install source/`src` param to Addon Manager

### DIFF
--- a/src/amo/components/AddonVersionCard/index.js
+++ b/src/amo/components/AddonVersionCard/index.js
@@ -9,7 +9,6 @@ import { GET_FIREFOX_BUTTON_TYPE_ADDON } from 'amo/components/GetFirefoxButton';
 import InstallButtonWrapper from 'amo/components/InstallButtonWrapper';
 import InstallWarning from 'amo/components/InstallWarning';
 import Link from 'amo/components/Link';
-import { INSTALL_SOURCE_DETAIL_PAGE } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { getVersionInfo } from 'core/reducers/versions';
 import { sanitizeUserHTML } from 'core/utils';
@@ -186,7 +185,6 @@ export const AddonVersionCardBase = (props: InternalProps) => {
         {addon && version && (
           <InstallButtonWrapper
             addon={addon}
-            defaultInstallSource={INSTALL_SOURCE_DETAIL_PAGE}
             getFirefoxButtonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
             version={version}
           />

--- a/src/amo/components/InstallButtonWrapper/index.js
+++ b/src/amo/components/InstallButtonWrapper/index.js
@@ -26,7 +26,6 @@ export type Props = {|
   addon: AddonType,
   className?: string,
   defaultButtonText?: string,
-  defaultInstallSource: string,
   getFirefoxButtonType: GetFirefoxButtonTypeType,
   puffy?: boolean,
   // TODO: this is a false positive since eslint-react-plugin >= 7.18.0 (it was
@@ -54,7 +53,6 @@ export const InstallButtonWrapperBase = (props: InternalProps) => {
     clientApp,
     currentVersion,
     defaultButtonText,
-    defaultInstallSource,
     enable,
     getFirefoxButtonType,
     hasAddonManager,
@@ -92,7 +90,6 @@ export const InstallButtonWrapperBase = (props: InternalProps) => {
           className={className ? `AMInstallButton--${className}` : ''}
           currentVersion={currentVersion}
           defaultButtonText={defaultButtonText}
-          defaultInstallSource={defaultInstallSource}
           disabled={!isCompatible}
           enable={enable}
           hasAddonManager={hasAddonManager}

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -46,7 +46,6 @@ import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_LANG,
   ADDON_TYPE_STATIC_THEME,
-  INSTALL_SOURCE_DETAIL_PAGE,
 } from 'core/constants';
 import { nl2br, sanitizeHTML, sanitizeUserHTML } from 'core/utils';
 import { getAddonIconUrl } from 'core/imageUtils';
@@ -499,7 +498,6 @@ export class AddonBase extends React.Component {
                   {addon && (
                     <InstallButtonWrapper
                       addon={addon}
-                      defaultInstallSource={INSTALL_SOURCE_DETAIL_PAGE}
                       getFirefoxButtonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
                     />
                   )}

--- a/src/core/components/AMInstallButton/index.js
+++ b/src/core/components/AMInstallButton/index.js
@@ -6,7 +6,6 @@ import invariant from 'invariant';
 import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import {
@@ -40,7 +39,6 @@ import type { WithInstallHelpersInjectedProps } from 'core/installAddon';
 import type { UserAgentInfoType } from 'core/reducers/api';
 import type { AddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
-import type { ReactRouterLocationType } from 'core/types/router';
 import type { ButtonType } from 'ui/components/Button';
 
 import './styles.scss';
@@ -52,7 +50,6 @@ type Props = {|
   className?: string,
   currentVersion: AddonVersionType | null,
   defaultButtonText?: string,
-  defaultInstallSource: string,
   disabled: boolean,
   puffy?: boolean,
   status: string,
@@ -65,7 +62,6 @@ type InternalProps = {|
   _tracking: typeof tracking,
   _window: typeof window,
   i18n: I18nType,
-  location: ReactRouterLocationType,
   userAgentInfo: UserAgentInfoType,
 |};
 
@@ -244,10 +240,8 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
       canUninstall,
       className,
       currentVersion,
-      defaultInstallSource,
       disabled,
       hasAddonManager,
-      location,
       status,
       userAgentInfo,
     } = this.props;
@@ -258,8 +252,6 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
 
     const installURL = currentVersion
       ? findInstallURL({
-          defaultInstallSource,
-          location,
           platformFiles: currentVersion.platformFiles,
           userAgentInfo,
         })
@@ -357,7 +349,6 @@ export function mapStateToProps(state: AppState) {
 }
 
 const AMInstallButton: React.ComponentType<Props> = compose(
-  withRouter,
   connect(mapStateToProps),
   translate(),
 )(AMInstallButtonBase);

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -213,11 +213,7 @@ export function isCompatibleWithUserAgent({
   const { platformFiles } = currentVersion;
   if (
     addon.type === ADDON_TYPE_EXTENSION &&
-    !_findInstallURL({
-      appendSource: false,
-      platformFiles,
-      userAgentInfo,
-    })
+    !_findInstallURL({ platformFiles, userAgentInfo })
   ) {
     return {
       compatible: false,

--- a/src/disco/components/Addon/index.js
+++ b/src/disco/components/Addon/index.js
@@ -43,7 +43,6 @@ const CSS_TRANSITION_TIMEOUT = { enter: 700, exit: 300 };
 
 type Props = {|
   addonId: $PropertyType<DiscoResultType, 'addonId'>,
-  defaultInstallSource: string,
   description: $PropertyType<DiscoResultType, 'description'>,
   heading: $PropertyType<DiscoResultType, 'heading'>,
 |};
@@ -196,7 +195,6 @@ export class AddonBase extends React.Component<InternalProps> {
       canUninstall,
       clientApp,
       currentVersion,
-      defaultInstallSource,
       enable,
       hasAddonManager,
       heading,
@@ -271,7 +269,6 @@ export class AddonBase extends React.Component<InternalProps> {
             canUninstall={canUninstall}
             className="Addon-install-button"
             currentVersion={currentVersion}
-            defaultInstallSource={defaultInstallSource}
             disabled={!compatible}
             enable={enable}
             hasAddonManager={hasAddonManager}

--- a/src/disco/pages/DiscoPane/index.js
+++ b/src/disco/pages/DiscoPane/index.js
@@ -11,11 +11,7 @@ import { oneLine } from 'common-tags';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import tracking from 'core/tracking';
-import {
-  DISCO_NAVIGATION_CATEGORY,
-  INSTALL_SOURCE_DISCOVERY,
-  INSTALL_STATE,
-} from 'core/constants';
+import { DISCO_NAVIGATION_CATEGORY, INSTALL_STATE } from 'core/constants';
 import InfoDialog from 'core/components/InfoDialog';
 import { addChangeListeners } from 'core/addonManager';
 import log from 'core/logger';
@@ -217,7 +213,6 @@ export class DiscoPaneBase extends React.Component<InternalProps> {
         {results.map((item) => (
           <Addon
             addonId={item.addonId}
-            defaultInstallSource={INSTALL_SOURCE_DISCOVERY}
             description={item.description}
             heading={item.heading}
             key={item.addonId}

--- a/stories/core/AMInstallButton.js
+++ b/stories/core/AMInstallButton.js
@@ -15,7 +15,6 @@ const render = (otherProps) => {
     addon: createInternalAddon(fakeAddon),
     canUninstall: true,
     currentVersion: createInternalVersion(fakeVersion),
-    defaultInstallSource: 'storybook',
     disabled: false,
     enable: () => Promise.resolve(true),
     hasAddonManager: true,

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -33,7 +33,6 @@ describe(__filename, () => {
     return shallowUntilTarget(
       <InstallButtonWrapper
         addon={createInternalAddon(fakeAddon)}
-        defaultInstallSource="some-install-source"
         location={createFakeLocation()}
         store={store}
         {...props}

--- a/tests/unit/core/components/TestAMInstallButton.js
+++ b/tests/unit/core/components/TestAMInstallButton.js
@@ -72,7 +72,6 @@ describe(__filename, () => {
     addon: createInternalAddon(fakeAddon),
     cookies: fakeCookies(),
     currentVersion: createInternalVersion(fakeVersion),
-    defaultInstallSource: '',
     disabled: false,
     enable: sinon.stub(),
     hasAddonManager: true,
@@ -147,19 +146,6 @@ describe(__filename, () => {
     expect(root.find(Button).childAt(1)).toHaveText('Install Theme');
   });
 
-  it('uses router location to create install URLs', () => {
-    const externalSource = 'my-blog';
-    const installURL = 'https://addons.mozilla.org/download';
-    const root = render({
-      currentVersion: createInternalVersionWithInstallURL({ installURL }),
-      defaultInstallSource: 'this-should-be-overidden',
-      location: createFakeLocation({ query: { src: externalSource } }),
-    });
-
-    const button = root.find(Button);
-    expect(button).toHaveProp('href', `${installURL}?src=${externalSource}`);
-  });
-
   it('disables the button when disabled prop is true', () => {
     const installURL = 'https://addons.mozilla.org/download';
     const root = render({
@@ -197,20 +183,6 @@ describe(__filename, () => {
 
     expect(root.find(Button)).toHaveProp('disabled', true);
     expect(root.find(Button)).toHaveProp('href', undefined);
-  });
-
-  it('adds defaultInstallSource to extension buttons', () => {
-    const installURL = 'https://addons.mozilla.org/download';
-    const defaultInstallSource = 'homepage';
-    const root = render({
-      currentVersion: createInternalVersionWithInstallURL({ installURL }),
-      defaultInstallSource,
-    });
-
-    expect(root.find(Button)).toHaveProp(
-      'href',
-      `${installURL}?src=${defaultInstallSource}`,
-    );
   });
 
   it('calls the `install` helper to install an extension', async () => {

--- a/tests/unit/core/test_addonManager.js
+++ b/tests/unit/core/test_addonManager.js
@@ -211,45 +211,13 @@ describe(__filename, () => {
   });
 
   describe('install()', () => {
-    // See: https://github.com/mozilla/addons-frontend/issues/9202
-    it('uses the `src` query parameter in the URL when provided', async () => {
-      const url = 'http://example.com/path/to/file.xpi?src=src-in-install-url';
-
-      await addonManager.install(url, fakeCallback, {
-        _mozAddonManager: fakeMozAddonManager,
-        defaultInstallSource: 'default-src',
-      });
-
-      sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
-        url:
-          'http://example.com/path/to/file.xpi?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=src-in-install-url',
-        hash: undefined,
-      });
-    });
-
-    it('uses the default install source when the URL does not have a `src` query parameter', async () => {
-      const url = 'http://example.com/path/to/file.xpi';
-      const defaultInstallSource = 'default-src';
-
-      await addonManager.install(url, fakeCallback, {
-        _mozAddonManager: fakeMozAddonManager,
-        defaultInstallSource,
-      });
-
-      sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
-        url: `${url}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=${defaultInstallSource}`,
-        hash: undefined,
-      });
-    });
-
     it('should call mozAddonManager.createInstall() with url', async () => {
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        defaultInstallSource: 'home',
       });
 
       sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
-        url: `${fakeInstallUrl}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=home`,
+        url: fakeInstallUrl,
         hash: undefined,
       });
     });
@@ -259,12 +227,11 @@ describe(__filename, () => {
 
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        defaultInstallSource: 'home',
         hash,
       });
 
       sinon.assert.calledWith(fakeMozAddonManager.createInstall, {
-        url: `${fakeInstallUrl}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=home`,
+        url: fakeInstallUrl,
         hash,
       });
     });
@@ -272,7 +239,6 @@ describe(__filename, () => {
     it('should call installObj.addEventListener to setup events', async () => {
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        defaultInstallSource: 'home',
       });
 
       // It registers an extra onInstallFailed and onInstallEnded listener.
@@ -285,7 +251,6 @@ describe(__filename, () => {
     it('should call installObj.install()', async () => {
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        defaultInstallSource: 'home',
       });
 
       sinon.assert.called(fakeInstallObj.install);
@@ -300,7 +265,6 @@ describe(__filename, () => {
         addonManager
           .install(fakeInstallUrl, fakeCallback, {
             _mozAddonManager: fakeMozAddonManager,
-            defaultInstallSource: 'home',
           })
           // The second argument is the reject function.
           .then(unexpectedSuccess, () => {
@@ -325,7 +289,6 @@ describe(__filename, () => {
         _log,
         _mozAddonManager: fakeMozAddonManager,
         onIgnoredRejection: () => finishInstall(),
-        defaultInstallSource: 'home',
       });
 
       await installToFinish;
@@ -337,22 +300,11 @@ describe(__filename, () => {
 
       await addonManager.install(fakeInstallUrl, fakeCallback, {
         _mozAddonManager: fakeMozAddonManager,
-        defaultInstallSource: 'home',
       });
 
       fakeInstallObj.onDownloadProgressListener(fakeEvent);
 
       sinon.assert.calledWith(fakeCallback, fakeInstallObj, fakeEvent);
-    });
-
-    it('requires a src', () => {
-      return addonManager
-        .install(fakeInstallUrl, fakeCallback, {
-          _mozAddonManager: fakeMozAddonManager,
-        })
-        .then(unexpectedSuccess, (e) => {
-          expect(e.message).toEqual('No src for add-on install');
-        });
     });
   });
 

--- a/tests/unit/disco/components/TestAddon.js
+++ b/tests/unit/disco/components/TestAddon.js
@@ -48,7 +48,6 @@ describe(__filename, () => {
   function getProps({
     addon,
     addonProps,
-    defaultInstallSource = 'some-install-source',
     description = 'test-editorial-description',
     heading = 'test-heading',
     ...customProps
@@ -69,7 +68,6 @@ describe(__filename, () => {
     const props = {
       _getClientCompatibility: () => ({ compatible: true, reason: null }),
       addonId: addonToLoad.id,
-      defaultInstallSource,
       description,
       heading,
       i18n: fakeI18n(),


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9556

---

We don't want to use `?src=` anymore and FF tracks attribution using UTM params in the url of the page itself nowadays.