### PR TITLE
Add the Promoted add-ons shelf to the home page

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -129,6 +129,7 @@ module.exports = {
     'enableFeatureBlockPage',
     'enableFeatureDiscoTaar',
     'enableFeatureExperienceSurvey',
+    'enableFeaturePromotedShelf',
     'enableFeatureUseUtmParams',
     'enableRequestID',
     'enableStrictMode',
@@ -383,6 +384,8 @@ module.exports = {
   dismissedExperienceSurveyCookieName: 'dismissedExperienceSurvey',
 
   enableFeatureUseUtmParams: true,
+
+  enableFeaturePromotedShelf: false,
 
   extensionWorkshopUrl: 'https://extensionworkshop.com',
 

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -31,4 +31,6 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  enableFeaturePromotedShelf: true,
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -31,4 +31,6 @@ module.exports = {
   },
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  enableFeaturePromotedShelf: true,
 };

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -14,6 +14,7 @@ import HeroRecommendation from 'amo/components/HeroRecommendation';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import Page from 'amo/components/Page';
+import PromotedAddonsCard from 'amo/components/PromotedAddonsCard';
 import SecondaryHero from 'amo/components/SecondaryHero';
 import { fetchHomeData } from 'amo/reducers/home';
 import {
@@ -21,6 +22,7 @@ import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   INSTALL_SOURCE_FEATURED,
+  INSTALL_SOURCE_PROMOTED_SHELF,
   SEARCH_SORT_POPULAR,
   SEARCH_SORT_RANDOM,
   SEARCH_SORT_TRENDING,
@@ -70,6 +72,7 @@ export const getFeaturedCollectionsMetadata = (i18n) => {
 
 export class HomeBase extends React.Component {
   static propTypes = {
+    _config: PropTypes.object,
     _getFeaturedCollectionsMetadata: PropTypes.func,
     clientApp: PropTypes.string.isRequired,
     collections: PropTypes.array.isRequired,
@@ -85,6 +88,7 @@ export class HomeBase extends React.Component {
   };
 
   static defaultProps = {
+    _config: config,
     _getFeaturedCollectionsMetadata: getFeaturedCollectionsMetadata,
     includeRecommendedThemes: true,
     includeTrendingExtensions: false,
@@ -194,6 +198,7 @@ export class HomeBase extends React.Component {
 
   render() {
     const {
+      _config,
       _getFeaturedCollectionsMetadata,
       clientApp,
       collections,
@@ -235,6 +240,14 @@ export class HomeBase extends React.Component {
 
     const showHeroPromo = clientApp !== CLIENT_APP_ANDROID;
 
+    const { promotedExtensions } = shelves;
+    if (Array.isArray(promotedExtensions)) {
+      // If there are fewer than 6 promoted extensions, just use the first 3.
+      if (promotedExtensions.length < 6) {
+        promotedExtensions.splice(3);
+      }
+    }
+
     return (
       <Page isHomePage showWrongPlatformWarning={!showHeroPromo}>
         <div className="Home">
@@ -267,6 +280,14 @@ export class HomeBase extends React.Component {
           ) : null}
 
           <div className="Home-content">
+            {_config.get('enableFeaturePromotedShelf') && showHeroPromo ? (
+              <PromotedAddonsCard
+                addonInstallSource={INSTALL_SOURCE_PROMOTED_SHELF}
+                addons={promotedExtensions}
+                loading={loading}
+              />
+            ) : null}
+
             {showHeroPromo ? (
               <SecondaryHero shelfData={heroShelves && heroShelves.secondary} />
             ) : null}

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -6,6 +6,7 @@ import { getCollectionAddons } from 'amo/api/collections';
 import { getHeroShelves } from 'amo/api/hero';
 import {
   LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_PROMOTED_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
 import {
@@ -19,6 +20,7 @@ import {
   SEARCH_SORT_POPULAR,
   SEARCH_SORT_RANDOM,
   SEARCH_SORT_TRENDING,
+  SPONSORED,
 } from 'core/constants';
 import { search as searchApi } from 'core/api/search';
 import log from 'core/logger';
@@ -122,6 +124,16 @@ export function* fetchHomeData({
       },
     };
 
+    const promotedExtensionsParams: SearchParams = {
+      api: state.api,
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        page_size: String(LANDING_PAGE_PROMOTED_EXTENSION_COUNT),
+        promoted: SPONSORED,
+        sort: SEARCH_SORT_RANDOM,
+      },
+    };
+
     let shelves = {};
     try {
       shelves = yield all({
@@ -134,6 +146,7 @@ export function* fetchHomeData({
         trendingExtensions: includeTrendingExtensions
           ? call(searchApi, trendingExtensionsParams)
           : null,
+        promotedExtensions: call(searchApi, promotedExtensionsParams),
       });
     } catch (error) {
       log.warn(`Home add-ons failed to load: ${error}`);

--- a/src/core/api/search.js
+++ b/src/core/api/search.js
@@ -23,6 +23,7 @@ export type SearchFilters = {|
   operatingSystem?: string,
   page?: string,
   page_size?: string,
+  promoted?: string,
   query?: string,
   recommended?: boolean,
   sort?: string,

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -109,6 +109,7 @@ export const INSTALL_SOURCE_DISCOVERY = 'discovery-promo';
 export const INSTALL_SOURCE_FEATURED = 'featured';
 export const INSTALL_SOURCE_HERO_PROMO = 'hp-dl-promo';
 export const INSTALL_SOURCE_MOST_POPULAR = 'mostpopular';
+export const INSTALL_SOURCE_PROMOTED_SHELF = 'homepage-sponsored-shelf';
 export const INSTALL_SOURCE_SEARCH = 'search';
 export const INSTALL_SOURCE_TOP_RATED = 'rating';
 export const INSTALL_SOURCE_TRENDING = 'hotness';

--- a/src/core/searchUtils.js
+++ b/src/core/searchUtils.js
@@ -20,6 +20,7 @@ export const paramsToFilter = {
   // TODO: Change our filter to `pageSize`, for consistency.
   page_size: 'page_size',
   platform: 'operatingSystem',
+  promoted: 'promoted',
   q: 'query',
   recommended: 'recommended',
   sort: 'sort',

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -15,6 +15,7 @@ import HeadMetaTags from 'amo/components/HeadMetaTags';
 import HeroRecommendation from 'amo/components/HeroRecommendation';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Page from 'amo/components/Page';
+import PromotedAddonsCard from 'amo/components/PromotedAddonsCard';
 import SecondaryHero from 'amo/components/SecondaryHero';
 import {
   FETCH_HOME_DATA,
@@ -43,6 +44,7 @@ import {
   dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 
@@ -105,6 +107,101 @@ describe(__filename, () => {
       expect(shelf).toHaveProp('loading', true);
     },
   );
+
+  it('renders a promoted extensions shelf if turned on', () => {
+    const { store } = dispatchClientMetadata({
+      clientApp: CLIENT_APP_FIREFOX,
+    });
+
+    const addon = fakeAddon;
+    const promotedExtensions = createAddonsApiResult([addon]);
+
+    _loadHomeData({
+      store,
+      shelves: { promotedExtensions },
+    });
+
+    const root = render({
+      _config: getFakeConfig({
+        enableFeaturePromotedShelf: true,
+      }),
+      store,
+    });
+
+    expect(root.find(PromotedAddonsCard)).toHaveProp('addons', [
+      createInternalAddon(addon),
+    ]);
+  });
+
+  it('does not render a promoted extensions shelf if turned off', () => {
+    const { store } = dispatchClientMetadata({
+      clientApp: CLIENT_APP_FIREFOX,
+    });
+
+    const addon = fakeAddon;
+    const promotedExtensions = createAddonsApiResult([addon]);
+
+    _loadHomeData({
+      store,
+      shelves: { promotedExtensions },
+    });
+
+    const root = render({
+      _config: getFakeConfig({
+        enableFeaturePromotedShelf: false,
+      }),
+      store,
+    });
+
+    expect(root.find(PromotedAddonsCard)).toHaveLength(0);
+  });
+
+  it('does not render a promoted extensions shelf on android', () => {
+    const { store } = dispatchClientMetadata({
+      clientApp: CLIENT_APP_ANDROID,
+    });
+
+    const addon = fakeAddon;
+    const promotedExtensions = createAddonsApiResult([addon]);
+
+    _loadHomeData({
+      store,
+      shelves: { promotedExtensions },
+    });
+
+    const root = render({
+      _config: getFakeConfig({
+        enableFeaturePromotedShelf: true,
+      }),
+      store,
+    });
+
+    expect(root.find(PromotedAddonsCard)).toHaveLength(0);
+  });
+
+  it('only includes 3 promoted extensions if fewer than 6 are returned', () => {
+    const { store } = dispatchClientMetadata({
+      clientApp: CLIENT_APP_FIREFOX,
+    });
+
+    const addon = fakeAddon;
+    const promotedExtensions = createAddonsApiResult(Array(5).fill(addon));
+
+    _loadHomeData({
+      store,
+      shelves: { promotedExtensions },
+    });
+
+    const root = render({
+      _config: getFakeConfig({
+        enableFeaturePromotedShelf: true,
+      }),
+      store,
+    });
+
+    const addons = root.find(PromotedAddonsCard).prop('addons');
+    expect(addons.length).toEqual(3);
+  });
 
   it('renders a recommended extensions shelf', () => {
     const root = render();

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -174,8 +174,8 @@ describe(__filename, () => {
         .withArgs({
           ...baseArgs,
           filters: {
-            page_size: String(LANDING_PAGE_PROMOTED_EXTENSION_COUNT),
             addonType: ADDON_TYPE_EXTENSION,
+            page_size: String(LANDING_PAGE_PROMOTED_EXTENSION_COUNT),
             promoted: SPONSORED,
             sort: SEARCH_SORT_RANDOM,
           },

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -4,6 +4,7 @@ import * as collectionsApi from 'amo/api/collections';
 import * as heroApi from 'amo/api/hero';
 import {
   LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_PROMOTED_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
 import homeReducer, {
@@ -20,6 +21,7 @@ import {
   SEARCH_SORT_POPULAR,
   SEARCH_SORT_RANDOM,
   SEARCH_SORT_TRENDING,
+  SPONSORED,
 } from 'core/constants';
 import apiReducer from 'core/reducers/api';
 import {
@@ -137,7 +139,7 @@ describe(__filename, () => {
             sort: SEARCH_SORT_POPULAR,
           },
         })
-        .resolves(recommendedExtensions);
+        .resolves(popularExtensions);
 
       const popularThemes = createAddonsApiResult([fakeAddon]);
       mockSearchApi
@@ -150,7 +152,7 @@ describe(__filename, () => {
             sort: SEARCH_SORT_POPULAR,
           },
         })
-        .resolves(recommendedExtensions);
+        .resolves(popularThemes);
 
       const trendingExtensions = createAddonsApiResult([fakeAddon]);
       mockSearchApi
@@ -164,7 +166,21 @@ describe(__filename, () => {
             sort: SEARCH_SORT_TRENDING,
           },
         })
-        .resolves(recommendedExtensions);
+        .resolves(trendingExtensions);
+
+      const promotedExtensions = createAddonsApiResult([fakeAddon]);
+      mockSearchApi
+        .expects('search')
+        .withArgs({
+          ...baseArgs,
+          filters: {
+            page_size: String(LANDING_PAGE_PROMOTED_EXTENSION_COUNT),
+            addonType: ADDON_TYPE_EXTENSION,
+            promoted: SPONSORED,
+            sort: SEARCH_SORT_RANDOM,
+          },
+        })
+        .resolves(promotedExtensions);
 
       const heroShelves = createHeroShelves();
       mockHeroApi
@@ -188,6 +204,7 @@ describe(__filename, () => {
           recommendedThemes,
           popularExtensions,
           popularThemes,
+          promotedExtensions,
           trendingExtensions,
         },
       });
@@ -214,6 +231,9 @@ describe(__filename, () => {
       const popularThemes = createAddonsApiResult([fakeAddon]);
       mockSearchApi.expects('search').resolves(popularThemes);
 
+      const promotedExtensions = createAddonsApiResult([fakeAddon]);
+      mockSearchApi.expects('search').resolves(promotedExtensions);
+
       const heroShelves = createHeroShelves();
       mockHeroApi.expects('getHeroShelves').resolves(heroShelves);
 
@@ -230,6 +250,7 @@ describe(__filename, () => {
           recommendedThemes,
           popularExtensions,
           popularThemes,
+          promotedExtensions,
           trendingExtensions: null,
         },
       });
@@ -254,6 +275,9 @@ describe(__filename, () => {
       const trendingExtensions = createAddonsApiResult([fakeAddon]);
       mockSearchApi.expects('search').resolves(trendingExtensions);
 
+      const promotedExtensions = createAddonsApiResult([fakeAddon]);
+      mockSearchApi.expects('search').resolves(promotedExtensions);
+
       const heroShelves = createHeroShelves();
       mockHeroApi.expects('getHeroShelves').resolves(heroShelves);
 
@@ -270,6 +294,7 @@ describe(__filename, () => {
           recommendedThemes: null,
           popularExtensions,
           popularThemes,
+          promotedExtensions,
           trendingExtensions,
         },
       });
@@ -303,6 +328,9 @@ describe(__filename, () => {
         const trendingExtensions = createAddonsApiResult([fakeAddon]);
         mockSearchApi.expects('search').resolves(trendingExtensions);
 
+        const promotedExtensions = createAddonsApiResult([fakeAddon]);
+        mockSearchApi.expects('search').resolves(promotedExtensions);
+
         const heroShelves = createHeroShelves();
         mockHeroApi.expects('getHeroShelves').resolves(heroShelves);
 
@@ -321,6 +349,7 @@ describe(__filename, () => {
             recommendedThemes: null,
             popularExtensions,
             popularThemes,
+            promotedExtensions,
             trendingExtensions,
           },
         });
@@ -381,7 +410,7 @@ describe(__filename, () => {
 
       const error = new Error('some API error maybe');
 
-      mockSearchApi.expects('search').exactly(5).rejects(error);
+      mockSearchApi.expects('search').exactly(6).rejects(error);
 
       _fetchHomeData({ collectionsToFetch: [{ slug, userId }] });
 


### PR DESCRIPTION
Fixes #9518 

<img width="1389" alt="Screen Shot 2020-09-11 at 10 14 06 AM" src="https://user-images.githubusercontent.com/142755/92936215-d39e1800-f417-11ea-9261-f341171a82dc.png">
