### PR TITLE
Change mobile compatibility message for add-ons in Fenix collections

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -135,6 +135,7 @@ module.exports = {
     'enableStrictMode',
     'experiments',
     'extensionWorkshopUrl',
+    'fenixCompatibleGuids',
     'fxaConfig',
     'hrefLangsMap',
     'isDeployed',
@@ -394,4 +395,19 @@ module.exports = {
   // in default-amo and/or default-disco depending on the target app for the
   // experiment.
   experiments: {},
+
+  // The list of GUIDs for add-ons that are Fenix compatible. This is based on
+  // the contents of the collection at
+  // https://addons.mozilla.org/firefox/collections/4757633/3204bb44a6ef44d39ee34917f28055/
+  fenixCompatibleGuids: [
+    '{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}',
+    'jid1-BoFifL9Vbdl2zQ@jetpack',
+    'woop-NoopscooPsnSXQ@jetpack',
+    '{2e5ff8c8-32fe-46d0-9fc8-6b8986621f3c}',
+    'addon@darkreader.org',
+    '{73a6fe31-595d-460b-a920-fcc0f8843232}',
+    'jid1-MnnxcxisBPnSXQ@jetpack',
+    'https-everywhere@eff.org',
+    'uBlock0@raymondhill.net',
+  ],
 };

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -31,6 +31,7 @@ import WrongPlatformWarning from 'amo/components/WrongPlatformWarning';
 import { getAddonsForSlug } from 'amo/reducers/addonsByAuthors';
 import { reviewListURL } from 'amo/reducers/reviews';
 import { getAddonURL } from 'amo/utils';
+import { isFenixCompatible } from 'core/utils/compatibility';
 import { getVersionById } from 'core/reducers/versions';
 import {
   fetchAddon,
@@ -69,6 +70,7 @@ export const STATUS_PUBLIC = 'public';
 
 export class AddonBase extends React.Component {
   static propTypes = {
+    _isFenixCompatible: PropTypes.func,
     RatingManager: PropTypes.func,
     addon: PropTypes.object,
     addonIsLoading: PropTypes.bool,
@@ -90,6 +92,7 @@ export class AddonBase extends React.Component {
 
   static defaultProps = {
     config: defaultConfig,
+    _isFenixCompatible: isFenixCompatible,
     RatingManager: DefaultRatingManager,
   };
 
@@ -401,6 +404,7 @@ export class AddonBase extends React.Component {
 
   render() {
     const {
+      _isFenixCompatible,
       addon,
       addonsByAuthors,
       currentVersion,
@@ -507,23 +511,32 @@ export class AddonBase extends React.Component {
                   {i18n.gettext('Extension Metadata')}
                 </h2>
               </header>
-              <WrongPlatformWarning
-                addon={addon}
-                className="Addon-WrongPlatformWarning"
-                currentVersion={currentVersion}
-                fixAndroidLinkMessage={i18n.gettext(
-                  `This listing is not intended for this platform.
+              {addon ? (
+                <WrongPlatformWarning
+                  addon={addon}
+                  className="Addon-WrongPlatformWarning"
+                  currentVersion={currentVersion}
+                  fixAndroidLinkMessage={i18n.gettext(
+                    `This listing is not intended for this platform.
                     <a href="%(newLocation)s">Browse add-ons for Firefox on Android</a>.`,
-                )}
-                fixFirefoxLinkMessage={i18n.gettext(
-                  `This listing is not intended for this platform.
+                  )}
+                  fixFirefoxLinkMessage={i18n.gettext(
+                    `This listing is not intended for this platform.
                     <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
-                )}
-                fixFenixLinkMessage={i18n.gettext(
-                  `Not available on Firefox for Android. You can use this add-on with Firefox for Desktop.
+                  )}
+                  fixFenixLinkMessage={
+                    _isFenixCompatible({ addon })
+                      ? i18n.gettext(
+                          `You can install this add-on in the Add-ons Manager. 
+                        Learn more about <a href="%(newLocation)s">add-ons for Android</a>.`,
+                        )
+                      : i18n.gettext(
+                          `Not available on Firefox for Android. You can use this add-on with Firefox for Desktop.
                     Learn more about <a href="%(newLocation)s">add-ons for Android</a>.`,
-                )}
-              />
+                        )
+                  }
+                />
+              ) : null}
               {addon && <InstallWarning addon={addon} />}
             </Card>
 

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -113,10 +113,7 @@ export const isFenixCompatible = ({
 }): boolean => {
   // It is compatible if it is in the special collection, but rather than
   // query a collection, we store a list of add-on guids in a config key.
-  if (addon && _config.get('fenixCompatibleGuids').includes(addon.guid)) {
-    return true;
-  }
-  return false;
+  return Boolean(addon && _config.get('fenixCompatibleGuids').includes(addon.guid));
 };
 
 export type IsCompatibleWithUserAgentParams = {|

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -1,6 +1,7 @@
 /* @flow */
 /* global window */
 import { oneLine } from 'common-tags';
+import config from 'config';
 import invariant from 'invariant';
 import mozCompare from 'mozilla-version-comparator';
 
@@ -98,6 +99,21 @@ export const isFenix = (userAgentInfo: UserAgentInfoType): boolean => {
     os.name === USER_AGENT_OS_ANDROID &&
     mozCompare(browser.version, '69.0') >= 0
   ) {
+    return true;
+  }
+  return false;
+};
+
+export const isFenixCompatible = ({
+  _config = config,
+  addon,
+}: {
+  _config: typeof config,
+  addon: AddonType | null,
+}): boolean => {
+  // It is compatible if it is in the special collection, but rather than
+  // query a collection, we store a list of add-on guids in a config key.
+  if (addon && _config.get('fenixCompatibleGuids').includes(addon.guid)) {
     return true;
   }
   return false;

--- a/src/core/utils/compatibility.js
+++ b/src/core/utils/compatibility.js
@@ -113,7 +113,9 @@ export const isFenixCompatible = ({
 }): boolean => {
   // It is compatible if it is in the special collection, but rather than
   // query a collection, we store a list of add-on guids in a config key.
-  return Boolean(addon && _config.get('fenixCompatibleGuids').includes(addon.guid));
+  return Boolean(
+    addon && _config.get('fenixCompatibleGuids').includes(addon.guid),
+  );
 };
 
 export type IsCompatibleWithUserAgentParams = {|

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -267,6 +267,34 @@ describe(__filename, () => {
     );
   });
 
+  it('does not render a WrongPlatformWarning component without an addon', () => {
+    const root = shallowRender({
+      addon: null,
+    });
+
+    expect(root.find(WrongPlatformWarning)).toHaveLength(0);
+  });
+
+  it('passes the correct Fenix message to WrongPlatformWarning for a compatible add-on', () => {
+    const root = shallowRender({
+      _isFenixCompatible: sinon.stub().returns(true),
+    });
+
+    expect(root.find(WrongPlatformWarning).prop('fixFenixLinkMessage')).toMatch(
+      /You can install this add-on in the Add-ons Manager./,
+    );
+  });
+
+  it('passes the correct Fenix message to WrongPlatformWarning for an incompatible add-on', () => {
+    const root = shallowRender({
+      _isFenixCompatible: sinon.stub().returns(false),
+    });
+
+    expect(root.find(WrongPlatformWarning).prop('fixFenixLinkMessage')).toMatch(
+      /Not available on Firefox for Android./,
+    );
+  });
+
   it('renders without an add-on', () => {
     const errorHandler = createStubErrorHandler();
     const slugParam = 'some-addon'; // as passed through the URL.

--- a/tests/unit/core/utils/test_compatibility.js
+++ b/tests/unit/core/utils/test_compatibility.js
@@ -26,6 +26,7 @@ import {
   getClientCompatibility,
   isCompatibleWithUserAgent,
   isFenix,
+  isFenixCompatible,
   isFirefox,
   isQuantumCompatible,
   correctedLocationForPlatform,
@@ -35,6 +36,7 @@ import {
   createFakeLocation,
   fakeAddon,
   fakeVersion,
+  getFakeConfig,
   getFakeLogger,
   userAgents,
   userAgentsByPlatform,
@@ -1098,6 +1100,45 @@ describe(__filename, () => {
       userAgents.firefoxIOS.forEach((userAgent) => {
         expect(isFenix(UAParser(userAgent))).toEqual(false);
       });
+    });
+  });
+
+  describe('isFenixCompatible', () => {
+    it('returns true if the add-on is in the configured list', () => {
+      const guid = 'some-guid';
+      const addon = createInternalAddon({ ...fakeAddon, guid });
+      const _config = getFakeConfig({
+        fenixCompatibleGuids: [guid],
+      });
+
+      expect(isFenixCompatible({ _config, addon })).toEqual(true);
+    });
+
+    it('returns false if the add-on is not in the configured list', () => {
+      const guid = 'some-guid';
+      const addon = createInternalAddon({ ...fakeAddon, guid });
+      const _config = getFakeConfig({
+        fenixCompatibleGuids: [`${guid}-different`],
+      });
+
+      expect(isFenixCompatible({ _config, addon })).toEqual(false);
+    });
+
+    it('returns false if the configured list is empty', () => {
+      const addon = createInternalAddon({ ...fakeAddon, guid: 'some-guid' });
+      const _config = getFakeConfig({
+        fenixCompatibleGuids: [],
+      });
+
+      expect(isFenixCompatible({ _config, addon })).toEqual(false);
+    });
+
+    it('returns false if the addon is null', () => {
+      const _config = getFakeConfig({
+        fenixCompatibleGuids: ['some-guid'],
+      });
+
+      expect(isFenixCompatible({ _config, addon: null })).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
Fixes #9360 

With an incompatible add-on:

<img width="364" alt="Screen Shot 2020-09-14 at 2 32 28 PM" src="https://user-images.githubusercontent.com/142755/93124130-25a0a100-f697-11ea-9fde-e2bf85af59cb.png">

With a compatible add-on:

<img width="363" alt="Screen Shot 2020-09-14 at 2 31 39 PM" src="https://user-images.githubusercontent.com/142755/93124066-0f92e080-f697-11ea-86ec-e97da8737f0f.png">
