### PR TITLE
Trim all params from the URL

### DIFF
--- a/src/core/middleware/trailingSlash.js
+++ b/src/core/middleware/trailingSlash.js
@@ -10,8 +10,17 @@ export function trailingSlashesMiddleware(
   next,
   { _config = config } = {},
 ) {
+  let redirect = false;
   const UrlParts = req.originalUrl.split('?');
   const UrlSlashSeparated = UrlParts[0].replace(/^\//, '').split('/');
+
+  // Trim all params on the URL.
+  UrlSlashSeparated.forEach((param, index) => {
+    UrlSlashSeparated[index] = decodeURIComponent(
+      UrlSlashSeparated[index],
+    ).trim();
+  });
+  const trimmedParts = `/${UrlSlashSeparated.join('/')}`;
 
   // If part of this URL should include a lang or clientApp, check for one
   // and make sure they're valid.
@@ -26,6 +35,11 @@ export function trailingSlashesMiddleware(
     UrlSlashSeparated[0] = '$clientApp';
   }
 
+  if (trimmedParts !== UrlParts[0]) {
+    UrlParts[0] = trimmedParts;
+    redirect = true;
+  }
+
   const urlToCheck = `/${UrlSlashSeparated.join('/')}`;
 
   // If the URL doesn't end with a trailing slash, and it isn't an exception,
@@ -35,6 +49,10 @@ export function trailingSlashesMiddleware(
     UrlParts[0].substr(-1) !== '/'
   ) {
     UrlParts[0] = `${UrlParts[0]}/`;
+    redirect = true;
+  }
+
+  if (redirect) {
     return res.redirect(301, UrlParts.join('?'));
   }
 

--- a/tests/unit/core/middleware/test_trailingSlashMiddleware.js
+++ b/tests/unit/core/middleware/test_trailingSlashMiddleware.js
@@ -182,6 +182,59 @@ describe(__filename, () => {
     sinon.assert.notCalled(fakeNext);
   });
 
+  it('should trim params', () => {
+    const fakeReq = {
+      originalUrl: '/foo / search?q=foo&category=bar',
+      headers: {},
+    };
+    trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
+      _config: fakeConfig,
+    });
+    sinon.assert.calledWith(
+      fakeRes.redirect,
+      301,
+      '/foo/search/?q=foo&category=bar',
+    );
+    sinon.assert.notCalled(fakeNext);
+  });
+
+  it('trims encoded params', () => {
+    const url = '/foo / search?q=foo&category=bar';
+    const originalUrl = encodeURI(url);
+    const fakeReq = {
+      originalUrl,
+      headers: {},
+    };
+
+    expect(url !== originalUrl).toEqual(true);
+
+    trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
+      _config: fakeConfig,
+    });
+    sinon.assert.calledWith(
+      fakeRes.redirect,
+      301,
+      '/foo/search/?q=foo&category=bar',
+    );
+    sinon.assert.notCalled(fakeNext);
+  });
+
+  it('trims params even when a trailing slash exists', () => {
+    const fakeReq = {
+      originalUrl: '/foo / search/?q=foo&category=bar',
+      headers: {},
+    };
+    trailingSlashesMiddleware(fakeReq, fakeRes, fakeNext, {
+      _config: fakeConfig,
+    });
+    sinon.assert.calledWith(
+      fakeRes.redirect,
+      301,
+      '/foo/search/?q=foo&category=bar',
+    );
+    sinon.assert.notCalled(fakeNext);
+  });
+
   it('should handle several ? in URL (though that should never happen)', () => {
     const fakeReq = {
       originalUrl: '/foo/search?q=foo&category=bar?test=bad',


### PR DESCRIPTION
Fixes #9667 

I like @willdurand's idea of dealing with this once and for all with middleware. I ended up adding a bit of code to our `trailingSlash` middleware. This might not be ideal, as now this middleware does two things, instead of just one, but I didn't really want to add another piece of middleware that could potentially do yet another redirect. Perhaps we just need to rename this middleware now?
 