### PR TITLE
Update the URL for the promoted badges/shelf

### DIFF
--- a/src/amo/components/InstallWarning/index.js
+++ b/src/amo/components/InstallWarning/index.js
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import type { AppState } from 'amo/store';
-import { PROMOTED_ADDONS_SUMO_URL } from 'amo/constants';
+import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
   CLIENT_APP_FIREFOX,
@@ -43,7 +43,9 @@ type InternalProps = {|
 |};
 
 export const VARIANT_INCLUDE_WARNING_PROPOSED = 'includeWarning-proposed';
-const WARNING_LINK_DESTINATION = `${PROMOTED_ADDONS_SUMO_URL}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=install-warning`;
+const WARNING_LINK_DESTINATION = getPromotedBadgesLinkUrl({
+  utm_content: 'install-warning',
+});
 
 export class InstallWarningBase extends React.Component<InternalProps> {
   static defaultProps = {

--- a/src/amo/components/InstallWarning/index.js
+++ b/src/amo/components/InstallWarning/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 import makeClassName from 'classnames';
-import config from 'config';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import type { AppState } from 'amo/store';
+import { PROMOTED_ADDONS_SUMO_URL } from 'amo/constants';
 import {
   ADDON_TYPE_EXTENSION,
   CLIENT_APP_FIREFOX,
@@ -32,7 +32,6 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
-  _config: typeof config,
   _correctedLocationForPlatform: typeof correctedLocationForPlatform,
   _couldShowWarning?: () => boolean,
   _getPromotedCategory: typeof getPromotedCategory,
@@ -44,12 +43,10 @@ type InternalProps = {|
 |};
 
 export const VARIANT_INCLUDE_WARNING_PROPOSED = 'includeWarning-proposed';
-const WARNING_LINK_DESTINATION =
-  'https://support.mozilla.org/kb/recommended-extensions-program#w_what-are-the-risks-of-installing-non-recommended-extensions';
+const WARNING_LINK_DESTINATION = `${PROMOTED_ADDONS_SUMO_URL}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=install-warning`;
 
 export class InstallWarningBase extends React.Component<InternalProps> {
   static defaultProps = {
-    _config: config,
     _correctedLocationForPlatform: correctedLocationForPlatform,
     _getPromotedCategory: getPromotedCategory,
   };
@@ -88,7 +85,7 @@ export class InstallWarningBase extends React.Component<InternalProps> {
   };
 
   render() {
-    const { _config, className, i18n } = this.props;
+    const { className, i18n } = this.props;
 
     if (this.couldShowWarning()) {
       return (
@@ -99,11 +96,9 @@ export class InstallWarningBase extends React.Component<InternalProps> {
           className={makeClassName('InstallWarning', className)}
           type={genericWarningType}
         >
-          {_config.get('enableFeaturePromotedShelf')
-            ? i18n.gettext(
-                'This add-on is not actively monitored for security by Mozilla. Make sure you trust it before installing.',
-              )
-            : `This is not monitored for security through Mozilla's Recommended Extensions program. Make sure you trust it before installing.`}
+          {i18n.gettext(
+            'This add-on is not actively monitored for security by Mozilla. Make sure you trust it before installing.',
+          )}
         </Notice>
       );
     }

--- a/src/amo/components/PromotedAddonsCard/index.js
+++ b/src/amo/components/PromotedAddonsCard/index.js
@@ -4,7 +4,10 @@ import * as React from 'react';
 import { compose } from 'redux';
 
 import AddonsCard from 'amo/components/AddonsCard';
-import { LANDING_PAGE_PROMOTED_EXTENSION_COUNT } from 'amo/constants';
+import {
+  LANDING_PAGE_PROMOTED_EXTENSION_COUNT,
+  PROMOTED_ADDONS_SUMO_URL,
+} from 'amo/constants';
 import translate from 'core/i18n/translate';
 import tracking from 'core/tracking';
 import type { AddonType, CollectionAddonType } from 'core/types/addons';
@@ -77,7 +80,7 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
         </div>
         <a
           className="PromotedAddonsCard-headerLink"
-          href="https://support.mozilla.org/kb/recommended-extensions-program"
+          href={`${PROMOTED_ADDONS_SUMO_URL}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=promoted-addon-shelf#sponsored`}
           rel="noopener noreferrer"
           target="_blank"
           title={i18n.gettext(

--- a/src/amo/components/PromotedAddonsCard/index.js
+++ b/src/amo/components/PromotedAddonsCard/index.js
@@ -4,10 +4,8 @@ import * as React from 'react';
 import { compose } from 'redux';
 
 import AddonsCard from 'amo/components/AddonsCard';
-import {
-  LANDING_PAGE_PROMOTED_EXTENSION_COUNT,
-  PROMOTED_ADDONS_SUMO_URL,
-} from 'amo/constants';
+import { LANDING_PAGE_PROMOTED_EXTENSION_COUNT } from 'amo/constants';
+import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import translate from 'core/i18n/translate';
 import tracking from 'core/tracking';
 import type { AddonType, CollectionAddonType } from 'core/types/addons';
@@ -80,7 +78,9 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
         </div>
         <a
           className="PromotedAddonsCard-headerLink"
-          href={`${PROMOTED_ADDONS_SUMO_URL}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=promoted-addon-shelf#sponsored`}
+          href={`${getPromotedBadgesLinkUrl({
+            utm_content: 'promoted-addon-shelf',
+          })}#sponsored`}
           rel="noopener noreferrer"
           target="_blank"
           title={i18n.gettext(

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -21,3 +21,5 @@ export const LANDING_PAGE_THEME_COUNT = 3;
 export const LANDING_PAGE_PROMOTED_EXTENSION_COUNT = 6;
 
 export const DOWNLOAD_FIREFOX_BASE_URL = 'https://www.mozilla.org/firefox/new/';
+export const PROMOTED_ADDONS_SUMO_URL =
+  'https://support.mozilla.org/kb/add-on-badges';

--- a/src/amo/utils/index.js
+++ b/src/amo/utils/index.js
@@ -5,6 +5,7 @@ import url from 'url';
 import base62 from 'base62';
 import config from 'config';
 
+import { PROMOTED_ADDONS_SUMO_URL } from 'amo/constants';
 import { makeQueryString } from 'core/api';
 import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'core/constants';
 
@@ -35,7 +36,7 @@ export const makeQueryStringWithUTM = ({
 }: {|
   utm_source?: string,
   utm_medium?: string,
-  utm_campaign?: string,
+  utm_campaign?: string | null,
   utm_content: string,
 |}): string => {
   return makeQueryString({
@@ -84,4 +85,15 @@ export const checkInternalURL = ({
     isInternal,
     relativeURL,
   };
+};
+
+export const getPromotedBadgesLinkUrl = ({
+  utm_content,
+}: {|
+  utm_content: string,
+|}): string => {
+  return `${PROMOTED_ADDONS_SUMO_URL}${makeQueryStringWithUTM({
+    utm_campaign: null,
+    utm_content,
+  })}`;
 };

--- a/src/ui/components/PromotedBadge/index.js
+++ b/src/ui/components/PromotedBadge/index.js
@@ -3,7 +3,7 @@ import makeClassName from 'classnames';
 import * as React from 'react';
 import { compose } from 'redux';
 
-import { PROMOTED_ADDONS_SUMO_URL } from 'amo/constants';
+import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import translate from 'core/i18n/translate';
 import IconPromotedBadge from 'ui/components/IconPromotedBadge';
 import type {
@@ -33,7 +33,9 @@ export const PromotedBadgeBase = ({
 }: InternalProps) => {
   let label;
   let linkTitle;
-  const linkUrl = `${PROMOTED_ADDONS_SUMO_URL}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=promoted-addon-badge`;
+  const linkUrl = getPromotedBadgesLinkUrl({
+    utm_content: 'promoted-addon-badge',
+  });
   switch (category) {
     case 'line':
       label = i18n.gettext('By Firefox');

--- a/src/ui/components/PromotedBadge/index.js
+++ b/src/ui/components/PromotedBadge/index.js
@@ -3,6 +3,7 @@ import makeClassName from 'classnames';
 import * as React from 'react';
 import { compose } from 'redux';
 
+import { PROMOTED_ADDONS_SUMO_URL } from 'amo/constants';
 import translate from 'core/i18n/translate';
 import IconPromotedBadge from 'ui/components/IconPromotedBadge';
 import type {
@@ -32,15 +33,13 @@ export const PromotedBadgeBase = ({
 }: InternalProps) => {
   let label;
   let linkTitle;
-  let linkUrl;
+  const linkUrl = `${PROMOTED_ADDONS_SUMO_URL}?utm_source=addons.mozilla.org&utm_medium=referral&utm_content=promoted-addon-badge`;
   switch (category) {
     case 'line':
       label = i18n.gettext('By Firefox');
-      // TODO: Update URL when we know it.
       linkTitle = i18n.gettext(
         'This is an official add-on built by the creators of Mozilla Firefox.',
       );
-      linkUrl = 'https://support.mozilla.org/kb/recommended-extensions-program';
       break;
 
     case 'recommended':
@@ -48,17 +47,14 @@ export const PromotedBadgeBase = ({
       linkTitle = i18n.gettext(
         'Firefox only recommends add-ons that meet our standards for security and performance.',
       );
-      linkUrl = 'https://support.mozilla.org/kb/recommended-extensions-program';
       break;
 
     // This is the verified badge.
     default:
       label = i18n.gettext('Verified');
-      // TODO: Update URL when we know it.
       linkTitle = i18n.gettext(
         'This add-on has been reviewed to meet our standards for security and performance.',
       );
-      linkUrl = 'https://support.mozilla.org/kb/recommended-extensions-program';
       break;
   }
 

--- a/tests/unit/amo/components/TestInstallWarning.js
+++ b/tests/unit/amo/components/TestInstallWarning.js
@@ -4,6 +4,7 @@ import UAParser from 'ua-parser-js';
 import InstallWarning, {
   InstallWarningBase,
 } from 'amo/components/InstallWarning';
+import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
@@ -73,6 +74,17 @@ describe(__filename, () => {
     const root = render({ className });
 
     expect(root).toHaveClassName(className);
+  });
+
+  it('contains a correct link', () => {
+    const root = render();
+
+    expect(root.find(Notice)).toHaveProp(
+      'actionHref',
+      getPromotedBadgesLinkUrl({
+        utm_content: 'install-warning',
+      }),
+    );
   });
 
   describe('couldShowWarning', () => {

--- a/tests/unit/amo/components/TestInstallWarning.js
+++ b/tests/unit/amo/components/TestInstallWarning.js
@@ -19,7 +19,6 @@ import {
   dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
-  getFakeConfig,
   shallowUntilTarget,
   userAgentsByPlatform,
 } from 'tests/unit/helpers';
@@ -178,23 +177,4 @@ describe(__filename, () => {
     const root = render({ _couldShowWarning });
     expect(root.find(Notice)).toHaveLength(0);
   });
-
-  it.each([
-    [true, /security by Mozilla/],
-    [false, /Recommended Extensions program/],
-  ])(
-    'uses the expected test when enableFeaturePromotedShelf is %s',
-    (flagValue, expected) => {
-      const _couldShowWarning = sinon.stub().returns(true);
-
-      const root = render({
-        _config: getFakeConfig({
-          enableFeaturePromotedShelf: flagValue,
-        }),
-        _couldShowWarning,
-      });
-
-      expect(root.find(Notice).children().text()).toMatch(expected);
-    },
-  );
 });

--- a/tests/unit/amo/components/TestPromotedAddonsCard.js
+++ b/tests/unit/amo/components/TestPromotedAddonsCard.js
@@ -9,6 +9,7 @@ import PromotedAddonsCard, {
   PROMOTED_ADDON_IMPRESSION_ACTION,
   PromotedAddonsCardBase,
 } from 'amo/components/PromotedAddonsCard';
+import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
   createFakeTracking,
@@ -76,6 +77,12 @@ describe(__filename, () => {
     expect(header.find('.PromotedAddonsCard-headerLink')).toHaveProp(
       'rel',
       'noopener noreferrer',
+    );
+    expect(header.find('.PromotedAddonsCard-headerLink')).toHaveProp(
+      'href',
+      `${getPromotedBadgesLinkUrl({
+        utm_content: 'promoted-addon-shelf',
+      })}#sponsored`,
     );
   });
 

--- a/tests/unit/amo/utils/test_index.js
+++ b/tests/unit/amo/utils/test_index.js
@@ -1,6 +1,13 @@
 import url from 'url';
 
-import { getCanonicalURL, getAddonURL, checkInternalURL } from 'amo/utils';
+import { PROMOTED_ADDONS_SUMO_URL } from 'amo/constants';
+import {
+  checkInternalURL,
+  getAddonURL,
+  getCanonicalURL,
+  getPromotedBadgesLinkUrl,
+  makeQueryStringWithUTM,
+} from 'amo/utils';
 import { getFakeConfig } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -160,6 +167,19 @@ describe(__filename, () => {
           }).isInternal,
         ).toEqual(false);
       });
+    });
+  });
+
+  describe('getPromotedBadgesLinkUrl', () => {
+    it('returns a URL with utm_content specified', () => {
+      const utm_content = 'some-utm-content';
+
+      expect(getPromotedBadgesLinkUrl({ utm_content })).toEqual(
+        `${PROMOTED_ADDONS_SUMO_URL}${makeQueryStringWithUTM({
+          utm_campaign: null,
+          utm_content,
+        })}`,
+      );
     });
   });
 });

--- a/tests/unit/ui/components/TestPromotedBadge.js
+++ b/tests/unit/ui/components/TestPromotedBadge.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import {
   createFakeEvent,
   fakeI18n,
@@ -47,6 +48,12 @@ describe(__filename, () => {
       const root = render({ category });
 
       expect(root.find('.PromotedBadge-link')).toHaveProp('title', linkTitle);
+      expect(root.find('.PromotedBadge-link')).toHaveProp(
+        'href',
+        getPromotedBadgesLinkUrl({
+          utm_content: 'promoted-addon-badge',
+        }),
+      );
     },
   );
 

--- a/tests/unit/ui/components/TestPromotedBadge.js
+++ b/tests/unit/ui/components/TestPromotedBadge.js
@@ -32,25 +32,21 @@ describe(__filename, () => {
     [
       'line',
       'This is an official add-on built by the creators of Mozilla Firefox.',
-      'https://support.mozilla.org/kb/recommended-extensions-program',
     ],
     [
       'recommended',
       'Firefox only recommends add-ons that meet our standards for security and performance.',
-      'https://support.mozilla.org/kb/recommended-extensions-program',
     ],
     [
       'verified',
       'This add-on has been reviewed to meet our standards for security and performance.',
-      'https://support.mozilla.org/kb/recommended-extensions-program',
     ],
   ])(
     'passes the expected props to the link for category="%s"',
-    (category, linkTitle, linkUrl) => {
+    (category, linkTitle) => {
       const root = render({ category });
 
       expect(root.find('.PromotedBadge-link')).toHaveProp('title', linkTitle);
-      expect(root.find('.PromotedBadge-link')).toHaveProp('href', linkUrl);
     },
   );
 


### PR DESCRIPTION
Fixes #9622 

Also removes the gate for the installWarning new message.

This needs to be cherry-picked for this week's push.