### PR TITLE
Hide the promoted add-ons shelf if there are no add-ons

### DIFF
--- a/src/amo/components/PromotedAddonsCard/index.js
+++ b/src/amo/components/PromotedAddonsCard/index.js
@@ -71,6 +71,11 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
   render() {
     const { addonInstallSource, addons, className, i18n, loading } = this.props;
 
+    // Don't display anything if there are no add-ons.
+    if (Array.isArray(addons) && !addons.length) {
+      return null;
+    }
+
     const header = (
       <>
         <div className="PromotedAddonsCard-headerText">

--- a/tests/unit/amo/components/TestPromotedAddonsCard.js
+++ b/tests/unit/amo/components/TestPromotedAddonsCard.js
@@ -32,6 +32,11 @@ describe(__filename, () => {
     );
   };
 
+  it('displays nothing when addons is an empty array', () => {
+    const root = render({ addons: [] });
+    expect(root.find(AddonsCard)).toHaveLength(0);
+  });
+
   it('passes loading parameter to AddonsCard', () => {
     const root = render({ loading: true });
     expect(root.find(AddonsCard)).toHaveProp('loading', true);
@@ -69,7 +74,7 @@ describe(__filename, () => {
     );
   });
 
-  it('uses the proper `rel` property for the header link in AddonsCard', () => {
+  it('uses the expected properties for the header link in AddonsCard', () => {
     const root = render();
     const headerProp = root.find(AddonsCard).prop('header');
     const header = shallow(<div>{headerProp}</div>);


### PR DESCRIPTION
Fixes #9675 