### PR TITLE
Call click/impression URLs from Promoted shelf on homepage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,7 +38,9 @@
     // This is used to upload files in the browser.
     "File": true,
     "FileReader": true,
-    "ProgressEvent": true
+    "ProgressEvent": true,
+    // Types that can be used with sendBeacon:
+    "BodyInit": true
   },
   "parser": "babel-eslint",
   "plugins": [

--- a/config/default.js
+++ b/config/default.js
@@ -130,6 +130,7 @@ module.exports = {
     'enableFeatureDiscoTaar',
     'enableFeatureExperienceSurvey',
     'enableFeaturePromotedShelf',
+    'enableFeatureUseAdzerk',
     'enableRequestID',
     'enableStrictMode',
     'experiments',
@@ -384,6 +385,7 @@ module.exports = {
   dismissedExperienceSurveyCookieName: 'dismissedExperienceSurvey',
 
   enableFeaturePromotedShelf: false,
+  enableFeatureUseAdzerk: false,
 
   extensionWorkshopUrl: 'https://extensionworkshop.com',
 

--- a/config/dev-amo.js
+++ b/config/dev-amo.js
@@ -33,4 +33,5 @@ module.exports = {
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
 
   enableFeaturePromotedShelf: true,
+  enableFeatureUseAdzerk: true,
 };

--- a/config/development-amo.js
+++ b/config/development-amo.js
@@ -33,4 +33,5 @@ module.exports = {
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
 
   enableFeaturePromotedShelf: true,
+  enableFeatureUseAdzerk: true,
 };

--- a/config/development.js
+++ b/config/development.js
@@ -32,6 +32,7 @@ module.exports = {
         "'self'",
         addonsServerDevCDN,
         analyticsHost,
+        apiDevHost,
         sentryHost,
         webpackHost,
         // This is needed for pino-devtools.

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -290,8 +290,8 @@ export class HomeBase extends React.Component {
             {_config.get('enableFeaturePromotedShelf') && isDesktopSite ? (
               <PromotedAddonsCard
                 addonInstallSource={INSTALL_SOURCE_PROMOTED_SHELF}
-                addons={promotedExtensions}
                 loading={loading}
+                shelfData={promotedShelf}
               />
             ) : null}
 

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -106,10 +106,23 @@ export type HeroShelvesType = {|
   secondary: SecondaryHeroShelfType,
 |};
 
+type ExternalPromotedAddonsShelfType = {|
+  addons: Array<PartialExternalAddonType>,
+  impressionData: string | null,
+  impressionURL: string | null,
+|};
+
+export type PromotedAddonsShelfType = {|
+  addons: Array<AddonType>,
+  impressionData: string | null,
+  impressionURL: string | null,
+|};
+
 export type HomeState = {
   collections: Array<Object | null>,
   heroShelves: HeroShelvesType | null,
   isLoading: boolean,
+  promotedAddonsShelf: PromotedAddonsShelfType | null,
   resetStateOnNextChange: boolean,
   resultsLoaded: boolean,
   shelves: { [shelfName: string]: Array<AddonType> | null },
@@ -119,6 +132,7 @@ export const initialState: HomeState = {
   collections: [],
   heroShelves: null,
   isLoading: false,
+  promotedAddonsShelf: null,
   resetStateOnNextChange: false,
   resultsLoaded: false,
   shelves: {},
@@ -170,6 +184,7 @@ type ApiAddonsResponse = {|
 type LoadHomeDataParams = {|
   collections: Array<Object | null>,
   heroShelves: ExternalHeroShelvesType,
+  promotedAddonsShelf: ExternalPromotedAddonsShelfType,
   shelves: { [shelfName: string]: ApiAddonsResponse },
 |};
 
@@ -181,6 +196,7 @@ type LoadHomeDataAction = {|
 export const loadHomeData = ({
   collections,
   heroShelves,
+  promotedAddonsShelf,
   shelves,
 }: LoadHomeDataParams): LoadHomeDataAction => {
   invariant(collections, 'collections is required');
@@ -191,6 +207,7 @@ export const loadHomeData = ({
     payload: {
       collections,
       heroShelves,
+      promotedAddonsShelf,
       shelves,
     },
   };
@@ -252,6 +269,22 @@ export const createInternalHeroShelves = (
   return shelves;
 };
 
+export const createInternalPromotedAddonsShelf = (
+  promotedAddonsShelf: ExternalPromotedAddonsShelfType,
+): PromotedAddonsShelfType | null => {
+  if (!promotedAddonsShelf) {
+    return null;
+  }
+
+  const { addons, impressionData, impressionURL } = promotedAddonsShelf;
+
+  return {
+    addons: addons.map((addon) => createInternalAddon(addon)),
+    impressionData,
+    impressionURL,
+  };
+};
+
 const reducer = (
   state: HomeState = initialState,
   action: Action,
@@ -275,7 +308,12 @@ const reducer = (
       };
 
     case LOAD_HOME_DATA: {
-      const { collections, heroShelves, shelves } = action.payload;
+      const {
+        collections,
+        heroShelves,
+        promotedAddonsShelf,
+        shelves,
+      } = action.payload;
 
       return {
         ...state,
@@ -293,6 +331,9 @@ const reducer = (
         }),
         heroShelves: createInternalHeroShelves(heroShelves),
         isLoading: false,
+        promotedAddonsShelf: createInternalPromotedAddonsShelf(
+          promotedAddonsShelf,
+        ),
         resultsLoaded: true,
         shelves: Object.keys(shelves).reduce((shelvesToLoad, shelfName) => {
           const response = shelves[shelfName];

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -154,10 +154,25 @@ export function* fetchHomeData({
       throw error;
     }
 
+    let promotedAddonsShelf = null;
+    try {
+      // TODO: Update this to use the correct API when available.
+      const promotedAddons = yield call(searchApi, promotedExtensionsParams);
+      promotedAddonsShelf = {
+        addons: promotedAddons.results,
+        impressionData: '',
+        impressionURL: '',
+      };
+    } catch (error) {
+      log.warn(`Promoted addons shelf failed to load: ${error}`);
+      throw error;
+    }
+
     yield put(
       loadHomeData({
         collections,
         heroShelves,
+        promotedAddonsShelf,
         shelves,
       }),
     );

--- a/src/amo/utils/index.js
+++ b/src/amo/utils/index.js
@@ -1,5 +1,5 @@
 /* @flow */
-/* eslint camelcase: 0 */
+/* global navigator */
 import url from 'url';
 
 import base62 from 'base62';
@@ -9,6 +9,7 @@ import { PROMOTED_ADDONS_SUMO_URL } from 'amo/constants';
 import { makeQueryString } from 'core/api';
 import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'core/constants';
 import { isValidLang } from 'core/i18n/utils';
+import log from 'core/logger';
 
 /*
  * Return a base62 object that encodes/decodes just like how Django does it
@@ -119,4 +120,23 @@ export const stripLangFromAmoUrl = ({
   }
 
   return urlString;
+};
+
+export const sendBeacon = ({
+  _log = log,
+  _navigator = typeof navigator !== 'undefined' ? navigator : null,
+  urlString,
+  data,
+}: {
+  _log?: typeof log,
+  _navigator?: typeof navigator | null,
+  urlString: string,
+  data?: BodyInit,
+}) => {
+  if (_navigator && _navigator.sendBeacon) {
+    _navigator.sendBeacon(urlString, data);
+    _log.debug(`Sending beacon to ${urlString}`);
+  } else {
+    _log.warn('navigator does not exist. Not sending a beacon.');
+  }
 };

--- a/stories/amo/PromotedAddonsCard.js
+++ b/stories/amo/PromotedAddonsCard.js
@@ -2,16 +2,21 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import { createInternalAddon } from 'core/reducers/addons';
+import { createInternalPromotedAddonsShelf } from 'amo/reducers/home';
 import { PromotedAddonsCardBase } from 'amo/components/PromotedAddonsCard';
-import { fakeAddon, fakeI18n } from 'tests/unit/helpers';
+import { createInternalAddon } from 'core/reducers/addons';
+import {
+  fakeAddon,
+  fakeI18n,
+  fakePromotedAddonsShelf,
+} from 'tests/unit/helpers';
 import type { InternalProps as PromotedAddonsCardProps } from 'amo/components/PromotedAddonsCard';
 
 import Provider from '../setup/Provider';
 
 const render = (moreProps: $Shape<PromotedAddonsCardProps> = {}) => {
   const props = {
-    addons: null,
+    shelfData: null,
     loading: false,
     ...moreProps,
   };
@@ -41,12 +46,22 @@ storiesOf('PromotedAddonsCard', module)
           {
             title: 'with 3 add-ons',
             sectionFn: () =>
-              render({ addons: Array(3).fill(createInternalAddon(fakeAddon)) }),
+              render({
+                shelfData: createInternalPromotedAddonsShelf({
+                  ...fakePromotedAddonsShelf,
+                  addons: Array(3).fill(createInternalAddon(fakeAddon)),
+                }),
+              }),
           },
           {
             title: 'with 6 add-ons',
             sectionFn: () =>
-              render({ addons: Array(6).fill(createInternalAddon(fakeAddon)) }),
+              render({
+                shelfData: createInternalPromotedAddonsShelf({
+                  ...fakePromotedAddonsShelf,
+                  addons: Array(6).fill(createInternalAddon(fakeAddon)),
+                }),
+              }),
           },
         ],
       },

--- a/tests/unit/amo/components/TestPromotedAddonsCard.js
+++ b/tests/unit/amo/components/TestPromotedAddonsCard.js
@@ -15,6 +15,7 @@ import {
   createFakeTracking,
   fakeAddon,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 
@@ -107,6 +108,31 @@ describe(__filename, () => {
     });
   });
 
+  it('configures AddonsCard to send a beacon when an add-on is clicked and feature is enabled', () => {
+    const _config = getFakeConfig({ enableFeatureUseAdzerk: true });
+    const _navigator = { sendBeacon: sinon.spy() };
+    const url = '/some/url';
+    const addon = createInternalAddon({ ...fakeAddon, url });
+
+    const root = render({ _config, _navigator, addons: [addon] });
+    const onAddonClick = root.find(AddonsCard).prop('onAddonClick');
+    onAddonClick(addon);
+
+    sinon.assert.calledWith(_navigator.sendBeacon, url);
+  });
+
+  it('does not configure AddonsCard to send a beacon when an add-on is clicked and feature is disabled', () => {
+    const _config = getFakeConfig({ enableFeatureUseAdzerk: false });
+    const _navigator = { sendBeacon: sinon.spy() };
+    const addon = createInternalAddon(fakeAddon);
+
+    const root = render({ _config, _navigator, addons: [addon] });
+    const onAddonClick = root.find(AddonsCard).prop('onAddonClick');
+    onAddonClick(addon);
+
+    sinon.assert.notCalled(_navigator.sendBeacon);
+  });
+
   it('configures AddonsCard to send a tracking event when an add-on is displayed', () => {
     const _tracking = createFakeTracking();
     const guid = 'some-guid';
@@ -121,5 +147,30 @@ describe(__filename, () => {
       category: PROMOTED_ADDON_HOMEPAGE_IMPRESSION_CATEGORY,
       label: guid,
     });
+  });
+
+  it('configures AddonsCard to send a beacon when an add-on is displayed and feature is enabled', () => {
+    const _config = getFakeConfig({ enableFeatureUseAdzerk: true });
+    const _navigator = { sendBeacon: sinon.spy() };
+    const url = '/some/url';
+    const addon = createInternalAddon({ ...fakeAddon, url });
+
+    const root = render({ _config, _navigator, addons: [addon] });
+    const onAddonImpression = root.find(AddonsCard).prop('onAddonImpression');
+    onAddonImpression(addon);
+
+    sinon.assert.calledWith(_navigator.sendBeacon, url);
+  });
+
+  it('does not configure AddonsCard to send a beacon when an add-on is displayed and feature is disabled', () => {
+    const _config = getFakeConfig({ enableFeatureUseAdzerk: false });
+    const _navigator = { sendBeacon: sinon.spy() };
+    const addon = createInternalAddon(fakeAddon);
+
+    const root = render({ _config, _navigator, addons: [addon] });
+    const onAddonImpression = root.find(AddonsCard).prop('onAddonImpression');
+    onAddonImpression(addon);
+
+    sinon.assert.notCalled(_navigator.sendBeacon);
   });
 });

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -7,6 +7,7 @@ import {
 import homeReducer, {
   abortFetchHomeData,
   createInternalHeroShelves,
+  createInternalPromotedAddonsShelf,
   fetchHomeData,
   initialState,
   loadHomeData,
@@ -23,6 +24,7 @@ import {
   dispatchClientMetadata,
   fakeAddon,
   fakePrimaryHeroShelfExternal,
+  fakePromotedAddonsShelf,
   getFakeConfig,
   createHeroShelves,
 } from 'tests/unit/helpers';
@@ -33,12 +35,14 @@ describe(__filename, () => {
       store,
       collections = [],
       heroShelves = createHeroShelves({ primaryProps: { addon: fakeAddon } }),
+      promotedAddonsShelf = null,
       shelves = {},
     }) => {
       store.dispatch(
         loadHomeData({
           collections,
           heroShelves,
+          promotedAddonsShelf,
           shelves,
         }),
       );
@@ -122,6 +126,22 @@ describe(__filename, () => {
 
       expect(homeState.heroShelves).toEqual(
         createInternalHeroShelves(heroShelves),
+      );
+    });
+
+    it('loads the promoted add-ons shelf', () => {
+      const { store } = dispatchClientMetadata();
+
+      const promotedAddonsShelf = fakePromotedAddonsShelf;
+      _loadHomeData({
+        store,
+        promotedAddonsShelf,
+      });
+
+      const homeState = store.getState().home;
+
+      expect(homeState.promotedAddonsShelf).toEqual(
+        createInternalPromotedAddonsShelf(promotedAddonsShelf),
       );
     });
 
@@ -441,12 +461,30 @@ describe(__filename, () => {
     });
 
     it('throws an exception if neither an addon nor an external entry is provided', () => {
-      const heroShelves = createHeroShelves({
-        primaryProps: { addon: undefined, external: undefined },
-      });
+      const heroShelves = createHeroShelves();
+      // We have to manually set these to undefined because createHeroShelves
+      // won't allow us to create an invalid shelf.
+      heroShelves.primary.addon = undefined;
+      heroShelves.primary.external = undefined;
       expect(() => createInternalHeroShelves(heroShelves)).toThrow(
         /Either primary.addon or primary.external is required/,
       );
+    });
+  });
+
+  describe('createInternalPromotedAddonsShelf', () => {
+    it('creates an internal representation of the promoted add-ons shelf', () => {
+      const addon = fakeAddon;
+      const promotedAddonsShelf = {
+        ...fakePromotedAddonsShelf,
+        addons: [addon],
+      };
+
+      expect(createInternalPromotedAddonsShelf(promotedAddonsShelf)).toEqual({
+        addons: [createInternalAddon(addon)],
+        impressionData: promotedAddonsShelf.impressionData,
+        impressionURL: promotedAddonsShelf.impressionData,
+      });
     });
   });
 });

--- a/tests/unit/amo/utils/test_index.js
+++ b/tests/unit/amo/utils/test_index.js
@@ -7,9 +7,10 @@ import {
   getCanonicalURL,
   getPromotedBadgesLinkUrl,
   makeQueryStringWithUTM,
+  sendBeacon,
   stripLangFromAmoUrl,
 } from 'amo/utils';
-import { getFakeConfig } from 'tests/unit/helpers';
+import { getFakeConfig, getFakeLogger } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('getCanonicalURL', () => {
@@ -256,6 +257,50 @@ describe(__filename, () => {
       const urlString = `https://somehost/${validLang}/${validLang}/somepath/`;
       expect(stripLangFromAmoUrl({ _checkInternalURL, urlString })).toEqual(
         `https://somehost/${validLang}/somepath/`,
+      );
+    });
+  });
+
+  describe('sendBeacon', () => {
+    it('should send a becaon if navigator.sendBeacon exists', () => {
+      const urlString = 'https://www.mozilla.org';
+      const _log = getFakeLogger();
+      const _navigator = { sendBeacon: sinon.spy() };
+
+      sendBeacon({ _log, _navigator, urlString });
+      sinon.assert.calledWith(_log.debug, `Sending beacon to ${urlString}`);
+      sinon.assert.calledWith(_navigator.sendBeacon, urlString);
+    });
+
+    it('can include data in a becaon', () => {
+      const urlString = 'https://www.mozilla.org';
+      const data = 'some-data';
+      const _log = getFakeLogger();
+      const _navigator = { sendBeacon: sinon.spy() };
+
+      sendBeacon({ _log, _navigator, urlString, data });
+      sinon.assert.calledWith(_navigator.sendBeacon, urlString, data);
+    });
+
+    it('should not send a becaon if navigator does not exist', () => {
+      const urlString = 'https://www.mozilla.org';
+      const _log = getFakeLogger();
+
+      sendBeacon({ _log, _navigator: null, urlString });
+      sinon.assert.calledWith(
+        _log.warn,
+        'navigator does not exist. Not sending a beacon.',
+      );
+    });
+
+    it('should not send a becaon if navigator.sendBeacon does not exist', () => {
+      const urlString = 'https://www.mozilla.org';
+      const _log = getFakeLogger();
+
+      sendBeacon({ _log, _navigator: { sendBeacon: null }, urlString });
+      sinon.assert.calledWith(
+        _log.warn,
+        'navigator does not exist. Not sending a beacon.',
       );
     });
   });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -274,7 +274,7 @@ export const createPrimaryHeroShelf = ({
   return {
     addon,
     description,
-    external,
+    external: external || fakePrimaryHeroShelfExternal,
     featured_image: featuredImage,
     gradient,
   };
@@ -1312,3 +1312,9 @@ export const createFakeBlockResult = ({
     ...others,
   };
 };
+
+export const fakePromotedAddonsShelf = Object.freeze({
+  addons: Array(6).fill(fakeAddon),
+  impressionData: '',
+  impressionURL: '',
+});


### PR DESCRIPTION
Fixes #9720 
Fixes #9721 

Because neither the Adzerk clickUrl nor the Adzerk impressionUrl are currently available in the API response, this patch simply uses `addon.url`. It therefore probably should land until those are available, but it can be reviewed and ready to land when those do become available.
