### PR TITLE
Rename loadAddonResults to loadAddon

### DIFF
--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -23,7 +23,7 @@ export const FETCH_ADDON_INFO: 'FETCH_ADDON_INFO' = 'FETCH_ADDON_INFO';
 export const LOAD_ADDON_INFO: 'LOAD_ADDON_INFO' = 'LOAD_ADDON_INFO';
 
 export const FETCH_ADDON: 'FETCH_ADDON' = 'FETCH_ADDON';
-export const LOAD_ADDON_RESULTS: 'LOAD_ADDON_RESULTS' = 'LOAD_ADDON_RESULTS';
+export const LOAD_ADDON: 'LOAD_ADDON' = 'LOAD_ADDON';
 
 type AddonID = number;
 
@@ -81,25 +81,21 @@ export function fetchAddon({
   };
 }
 
-type LoadAddonResultsParams = {|
-  addons: Array<ExternalAddonType>,
+type LoadAddonParams = {|
+  addon: ExternalAddonType,
 |};
 
-export type LoadAddonResultsAction = {|
-  payload: LoadAddonResultsParams,
-  type: typeof LOAD_ADDON_RESULTS,
+export type LoadAddonAction = {|
+  payload: LoadAddonParams,
+  type: typeof LOAD_ADDON,
 |};
 
-export function loadAddonResults({
-  addons,
-}: LoadAddonResultsParams = {}): LoadAddonResultsAction {
-  if (!addons) {
-    throw new Error('addons are required');
-  }
+export function loadAddon({ addon }: LoadAddonParams = {}): LoadAddonAction {
+  invariant(addon, 'addon is required');
 
   return {
-    type: LOAD_ADDON_RESULTS,
-    payload: { addons },
+    type: LOAD_ADDON,
+    payload: { addon },
   };
 }
 
@@ -315,7 +311,7 @@ type Action =
   | FetchAddonAction
   | FetchAddonInfoAction
   | LoadAddonInfoAction
-  | LoadAddonResultsAction
+  | LoadAddonAction
   | UnloadAddonReviewsAction
   | UpdateRatingCountsAction;
 
@@ -335,29 +331,27 @@ export default function addonsReducer(
       };
     }
 
-    case LOAD_ADDON_RESULTS: {
-      const { addons: loadedAddons } = action.payload;
+    case LOAD_ADDON: {
+      const { addon: loadedAddon } = action.payload;
 
       const byID = { ...state.byID };
       const byGUID = { ...state.byGUID };
       const bySlug = { ...state.bySlug };
       const loadingBySlug = { ...state.loadingBySlug };
 
-      loadedAddons.forEach((loadedAddon) => {
-        const addon = createInternalAddon(loadedAddon);
-        // Flow wants hash maps with string keys.
-        // See: https://zhenyong.github.io/flowtype/docs/objects.html#objects-as-maps
-        byID[`${addon.id}`] = addon;
+      const addon = createInternalAddon(loadedAddon);
+      // Flow wants hash maps with string keys.
+      // See: https://zhenyong.github.io/flowtype/docs/objects.html#objects-as-maps
+      byID[`${addon.id}`] = addon;
 
-        if (addon.slug) {
-          bySlug[addon.slug.toLowerCase()] = addon.id;
-          loadingBySlug[addon.slug.toLowerCase()] = false;
-        }
+      if (addon.slug) {
+        bySlug[addon.slug.toLowerCase()] = addon.id;
+        loadingBySlug[addon.slug.toLowerCase()] = false;
+      }
 
-        if (addon.guid) {
-          byGUID[addon.guid] = addon.id;
-        }
-      });
+      if (addon.guid) {
+        byGUID[addon.guid] = addon.id;
+      }
 
       return {
         ...state,

--- a/src/core/reducers/versions.js
+++ b/src/core/reducers/versions.js
@@ -418,11 +418,12 @@ const reducer = (
 
     case LOAD_ADDON:
       // This is needed to use a common logic to store add-ons.
-      // Also, we don't use `break` in this case block on purpose.
       //
-      // eslint-disable-next-line no-param-reassign, no-fallthrough
+      // eslint-disable-next-line no-param-reassign
       action.payload.addons = [action.payload.addon];
-
+    // Also, we don't use `break` in this case block on purpose.
+    //
+    // eslint-disable-next-line no-fallthrough
     case LOAD_ADDONS_BY_AUTHORS:
     case LOAD_COLLECTION_ADDONS:
     case LOAD_CURRENT_COLLECTION:

--- a/src/core/reducers/versions.js
+++ b/src/core/reducers/versions.js
@@ -19,7 +19,7 @@ import {
   OS_WINDOWS,
 } from 'core/constants';
 import log from 'core/logger';
-import { LOAD_ADDON_RESULTS } from 'core/reducers/addons';
+import { LOAD_ADDON } from 'core/reducers/addons';
 import { SEARCH_LOADED } from 'core/reducers/search';
 import { findFileForPlatform } from 'core/utils';
 import { formatFilesize } from 'core/i18n/utils';
@@ -416,8 +416,14 @@ const reducer = (
       };
     }
 
+    case LOAD_ADDON:
+      // This is needed to use a common logic to store add-ons.
+      // Also, we don't use `break` in this case block on purpose.
+      //
+      // eslint-disable-next-line no-param-reassign, no-fallthrough
+      action.payload.addons = [action.payload.addon];
+
     case LOAD_ADDONS_BY_AUTHORS:
-    case LOAD_ADDON_RESULTS:
     case LOAD_COLLECTION_ADDONS:
     case LOAD_CURRENT_COLLECTION:
     case LOAD_CURRENT_COLLECTION_PAGE:

--- a/src/core/sagas/addons.js
+++ b/src/core/sagas/addons.js
@@ -7,7 +7,7 @@ import {
   FETCH_ADDON,
   FETCH_ADDON_INFO,
   loadAddonInfo,
-  loadAddonResults,
+  loadAddon,
 } from 'core/reducers/addons';
 import log from 'core/logger';
 import { createErrorHandler, getState } from 'core/sagas/utils';
@@ -28,13 +28,14 @@ export function* fetchAddon({
 }: FetchAddonAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
+
   try {
     const state = yield select(getState);
 
     const params: FetchAddonParams = { api: state.api, slug };
     const addon = yield call(fetchAddonFromApi, params);
 
-    yield put(loadAddonResults({ addons: [addon] }));
+    yield put(loadAddon({ addon }));
   } catch (error) {
     log.warn(`Failed to load add-on with slug ${slug}: ${error}`);
     yield put(errorHandler.createErrorAction(error));

--- a/src/disco/sagas/disco.js
+++ b/src/disco/sagas/disco.js
@@ -2,7 +2,7 @@
 import { call, put, select, takeLatest } from 'redux-saga/effects';
 
 import log from 'core/logger';
-import { loadAddonResults } from 'core/reducers/addons';
+import { loadAddon } from 'core/reducers/addons';
 import { createErrorHandler, getState } from 'core/sagas/utils';
 import {
   GET_DISCO_RESULTS,
@@ -34,7 +34,10 @@ export function* fetchDiscoveryAddons({
 
     const addons = createExternalAddonMap({ results });
 
-    yield put(loadAddonResults({ addons }));
+    for (const addon of addons) {
+      yield put(loadAddon({ addon }));
+    }
+
     yield put(loadDiscoResults({ results }));
   } catch (error) {
     log.warn(`Failed to fetch discovery add-ons: ${error}`);

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -30,7 +30,7 @@ import createStore from 'amo/store';
 import {
   createInternalAddon,
   fetchAddon as fetchAddonAction,
-  loadAddonResults,
+  loadAddon,
 } from 'core/reducers/addons';
 import {
   EXTENSIONS_BY_AUTHORS_PAGE_SIZE,
@@ -143,11 +143,11 @@ function shallowRender(...args) {
 }
 
 describe(__filename, () => {
-  const _loadAddonResults = ({ addon = fakeAddon }) => {
-    return loadAddonResults({ addons: [addon] });
+  const _loadAddon = ({ addon = fakeAddon }) => {
+    return loadAddon({ addon });
   };
 
-  const _loadAddonResultsByAuthors = ({ addon, addonsByAuthors }) => {
+  const _loadAddonByAuthors = ({ addon, addonsByAuthors }) => {
     return loadAddonsByAuthors({
       addons: addonsByAuthors,
       authorIds: [123],
@@ -362,7 +362,7 @@ describe(__filename, () => {
     const { store } = dispatchSignInActions();
     const addon = { ...fakeAddon, current_version: null };
 
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
 
     const root = renderComponent({ store });
 
@@ -561,7 +561,7 @@ describe(__filename, () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
     const addon = fakeAddon;
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
     renderComponent({
@@ -586,7 +586,7 @@ describe(__filename, () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
     const addon = { ...fakeAddon, slug };
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
     renderComponent({
@@ -609,7 +609,7 @@ describe(__filename, () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
     const addon = fakeAddon;
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
     renderComponent({
@@ -637,7 +637,7 @@ describe(__filename, () => {
       slug: '-1234',
     };
 
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
     renderComponent({
@@ -656,7 +656,7 @@ describe(__filename, () => {
     const clientApp = CLIENT_APP_FIREFOX;
     const { store } = dispatchClientMetadata({ clientApp });
     const addon = { ...fakeAddon, slug };
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
 
     const fakeDispatch = sinon.spy(store, 'dispatch');
     renderComponent({
@@ -709,7 +709,7 @@ describe(__filename, () => {
     };
 
     const { store } = dispatchClientMetadata();
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
 
     const root = renderComponent({ params: { slug: addon.slug }, store });
 
@@ -1135,7 +1135,7 @@ describe(__filename, () => {
         },
       };
 
-      store.dispatch(_loadAddonResults({ addon }));
+      store.dispatch(_loadAddon({ addon }));
 
       const root = renderComponent({
         addon: createInternalAddon(addon),
@@ -1278,10 +1278,10 @@ describe(__filename, () => {
     const dispatchAddonData = ({ addon, addonsByAuthors }) => {
       const { store } = dispatchClientMetadata();
 
-      store.dispatch(_loadAddonResults({ addon }));
+      store.dispatch(_loadAddon({ addon }));
 
       if (addonsByAuthors) {
-        store.dispatch(_loadAddonResultsByAuthors({ addon, addonsByAuthors }));
+        store.dispatch(_loadAddonByAuthors({ addon, addonsByAuthors }));
       }
 
       return { store };
@@ -1460,7 +1460,7 @@ describe(__filename, () => {
     }
 
     function fetchAddon({ addon = fakeAddon } = {}) {
-      store.dispatch(_loadAddonResults({ addon }));
+      store.dispatch(_loadAddon({ addon }));
     }
 
     function _mapStateToProps(
@@ -1514,7 +1514,7 @@ describe(__filename, () => {
     beforeEach(() => {
       addon = fakeAddon;
       store = dispatchClientMetadata().store;
-      store.dispatch(_loadAddonResults({ addon }));
+      store.dispatch(_loadAddon({ addon }));
     });
 
     it('renders the InstallButtonWrapper', () => {
@@ -1590,7 +1590,7 @@ describe(__filename, () => {
   it('passes an error to the AddonInstallError component', () => {
     const addon = fakeAddon;
     const { store } = dispatchClientMetadata();
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
     // User clicks the install button.
     store.dispatch(
       setInstallState({
@@ -1612,7 +1612,7 @@ describe(__filename, () => {
     const { store } = dispatchClientMetadata({ clientApp });
     const guid = 'this_is@a.guid';
     const addon = { ...fakeAddon, guid };
-    store.dispatch(_loadAddonResults({ addon }));
+    store.dispatch(_loadAddon({ addon }));
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
     renderComponent({ params: { slug: guid }, store });
@@ -1637,7 +1637,7 @@ describe(__filename, () => {
     });
 
     it('renders the InstallWarning if an add-on exists', () => {
-      store.dispatch(_loadAddonResults({ addon }));
+      store.dispatch(_loadAddon({ addon }));
       const root = renderComponent({ store });
 
       expect(root.find(InstallWarning)).toHaveLength(1);
@@ -1651,7 +1651,7 @@ describe(__filename, () => {
 
     it('passes the addon to the InstallWarning', () => {
       const internalAddon = createInternalAddon(addon);
-      store.dispatch(_loadAddonResults({ addon }));
+      store.dispatch(_loadAddon({ addon }));
 
       const root = renderComponent({ addon: internalAddon, store });
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -147,7 +147,7 @@ describe(__filename, () => {
     return loadAddon({ addon });
   };
 
-  const _loadAddonByAuthors = ({ addon, addonsByAuthors }) => {
+  const _loadAddonsByAuthors = ({ addon, addonsByAuthors }) => {
     return loadAddonsByAuthors({
       addons: addonsByAuthors,
       authorIds: [123],
@@ -1281,7 +1281,7 @@ describe(__filename, () => {
       store.dispatch(_loadAddon({ addon }));
 
       if (addonsByAuthors) {
-        store.dispatch(_loadAddonByAuthors({ addon, addonsByAuthors }));
+        store.dispatch(_loadAddonsByAuthors({ addon, addonsByAuthors }));
       }
 
       return { store };

--- a/tests/unit/amo/pages/TestAddonInfo.js
+++ b/tests/unit/amo/pages/TestAddonInfo.js
@@ -13,7 +13,7 @@ import {
   fetchAddon,
   fetchAddonInfo,
   loadAddonInfo,
-  loadAddonResults,
+  loadAddon,
 } from 'core/reducers/addons';
 import {
   FETCH_VERSION,
@@ -66,8 +66,8 @@ describe(__filename, () => {
     return shallowUntilTarget(<AddonInfo {...props} />, AddonInfoBase);
   };
 
-  const _loadAddonResults = (addons = [fakeAddon]) => {
-    store.dispatch(loadAddonResults({ addons }));
+  const _loadAddon = (addon = fakeAddon) => {
+    store.dispatch(loadAddon({ addon }));
   };
 
   const _loadAddonInfo = ({
@@ -121,7 +121,7 @@ describe(__filename, () => {
       const slug = 'some-slug';
       const newSlug = 'some-other-slug';
       const addon = { ...fakeAddon, slug };
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');
       const errorHandler = createStubErrorHandler();
       render({
@@ -236,7 +236,7 @@ describe(__filename, () => {
     it('fetches an addonVersion when no version is loaded', () => {
       const slug = 'some-addon-slug';
       const addon = { ...fakeAddon, slug };
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       const errorHandler = createStubErrorHandler();
 
       const dispatch = sinon.stub(store, 'dispatch');
@@ -267,7 +267,7 @@ describe(__filename, () => {
     it('does not fetch an addonVersion when the addon has no current version', () => {
       const slug = 'some-addon-slug';
       const addon = { ...fakeAddon, slug, current_version: null };
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
 
       const dispatch = sinon.stub(store, 'dispatch');
 
@@ -282,7 +282,7 @@ describe(__filename, () => {
     it('fetches an addonVersion when the loaded version has no license text', () => {
       const slug = 'some-addon-slug';
       const addon = { ...fakeAddon, slug };
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       _loadVersions({
         slug,
         versions: [
@@ -311,7 +311,7 @@ describe(__filename, () => {
     it('does not fetch an addonVersion when the loaded version has license text', () => {
       const slug = 'some-addon-slug';
       const addon = { ...fakeAddon, slug };
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       _loadVersions({
         slug,
         versions: [
@@ -340,7 +340,7 @@ describe(__filename, () => {
     it('does not fetch an addonVersion if one is already loading', () => {
       const slug = 'some-addon-slug';
       const addon = { ...fakeAddon, slug };
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       const errorHandler = createStubErrorHandler();
 
       store.dispatch(
@@ -370,7 +370,8 @@ describe(__filename, () => {
       const newSlug = 'some-other-slug';
       const addon = { ...fakeAddon, slug };
       const newAddon = { ...fakeAddon, slug: newSlug };
-      _loadAddonResults([addon, newAddon]);
+      _loadAddon(addon);
+      _loadAddon(newAddon);
       const dispatch = sinon.stub(store, 'dispatch');
       const errorHandler = createStubErrorHandler();
 
@@ -393,7 +394,7 @@ describe(__filename, () => {
   it('does not fetch an addon if one is already loaded', () => {
     const slug = 'some-addon-slug';
     const addon = { ...fakeAddon, slug };
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     const errorHandler = createStubErrorHandler();
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
@@ -455,7 +456,7 @@ describe(__filename, () => {
 
   it('renders an AddonSummaryCard with an addon', () => {
     const addon = fakeAddon;
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     const root = render({ infoType: ADDON_INFO_TYPE_PRIVACY_POLICY });
 
     const summary = root.find(AddonSummaryCard);
@@ -478,7 +479,7 @@ describe(__filename, () => {
     const slug = 'some-slug';
     const addon = { ...fakeAddon, slug };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
 
     const root = render({
       infoType: ADDON_INFO_TYPE_PRIVACY_POLICY,
@@ -494,7 +495,7 @@ describe(__filename, () => {
   });
 
   it('renders a robots meta tag', () => {
-    _loadAddonResults();
+    _loadAddon();
     const root = render();
 
     expect(root.find('meta[name="robots"]')).toHaveLength(1);
@@ -517,7 +518,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const addonInfo = { ...fakeAddonInfo, privacy_policy: privacyPolicy };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadAddonInfo({ addonInfo, slug });
 
     const root = render({
@@ -538,7 +539,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const addonInfo = { ...fakeAddonInfo, eula };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadAddonInfo({ addonInfo, slug });
 
     const root = render({
@@ -562,7 +563,7 @@ describe(__filename, () => {
       license: { ...fakeVersion.license, text: licenseText },
     };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadVersions({ slug, versions: [addonVersion] });
 
     const root = render({
@@ -583,7 +584,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const addonInfo = { ...fakeAddonInfo, privacy_policy: privacyPolicy };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadAddonInfo({ addonInfo, slug });
 
     const root = render({
@@ -600,7 +601,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const addonInfo = { ...fakeAddonInfo, privacy_policy: privacyPolicy };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadAddonInfo({ addonInfo, slug });
 
     const root = render({
@@ -619,7 +620,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const addonInfo = { ...fakeAddonInfo, privacy_policy: privacyPolicy };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadAddonInfo({ addonInfo, slug });
 
     const root = render({

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -32,7 +32,7 @@ import {
 import {
   fetchAddon,
   createInternalAddon,
-  loadAddonResults,
+  loadAddon,
 } from 'core/reducers/addons';
 import Card from 'ui/components/Card';
 import ErrorList from 'ui/components/ErrorList';
@@ -87,8 +87,8 @@ describe(__filename, () => {
     );
   };
 
-  const loadAddon = (addon = fakeAddon) => {
-    store.dispatch(loadAddonResults({ addons: [addon] }));
+  const _loadAddon = (addon = fakeAddon) => {
+    store.dispatch(loadAddon({ addon }));
   };
 
   const _fetchReviews = (params = {}) => {
@@ -126,7 +126,7 @@ describe(__filename, () => {
   } = {}) => {
     const addonSlug = 'example-slug';
     const addon = { ...fakeAddon, slug: addonSlug };
-    loadAddon(addon);
+    _loadAddon(addon);
 
     _setAddonReviews({ reviews });
 
@@ -169,7 +169,7 @@ describe(__filename, () => {
       };
       const addon = createInternalAddon(externalAddon);
 
-      loadAddon(externalAddon);
+      _loadAddon(externalAddon);
 
       const root = render();
 
@@ -191,7 +191,7 @@ describe(__filename, () => {
       };
       const addon = createInternalAddon(externalAddon);
 
-      loadAddon(externalAddon);
+      _loadAddon(externalAddon);
 
       const root = render();
 
@@ -211,7 +211,7 @@ describe(__filename, () => {
         },
       };
 
-      loadAddon(externalAddon);
+      _loadAddon(externalAddon);
 
       const root = render();
 
@@ -220,7 +220,7 @@ describe(__filename, () => {
 
     it('renders an AddonSummaryCard with an addon', () => {
       const addon = fakeAddon;
-      loadAddon(addon);
+      _loadAddon(addon);
       const root = render();
 
       const summary = root.find(AddonSummaryCard);
@@ -237,7 +237,7 @@ describe(__filename, () => {
     });
 
     it('does not paginate before reviews have loaded', () => {
-      loadAddon(fakeAddon);
+      _loadAddon(fakeAddon);
       const root = render({ reviews: null });
 
       expect(root.find(Paginate)).toHaveLength(0);
@@ -287,7 +287,7 @@ describe(__filename, () => {
     });
 
     it('ignores other add-ons', () => {
-      loadAddon();
+      _loadAddon();
       const root = render({
         params: { addonSlug: 'other-slug' },
       });
@@ -296,7 +296,7 @@ describe(__filename, () => {
 
     it('fetches reviews if needed', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
-      loadAddon(addon);
+      _loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');
       const errorHandler = createStubErrorHandler();
 
@@ -318,7 +318,7 @@ describe(__filename, () => {
     it('does not fetch reviews if they are already loading', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
       const errorHandler = createStubErrorHandler();
-      loadAddon(addon);
+      _loadAddon(addon);
       store.dispatch(
         _fetchReviews({
           addonSlug: addon.slug,
@@ -394,7 +394,7 @@ describe(__filename, () => {
 
     it('fetches reviews when the page changes', () => {
       const addonSlug = fakeAddon.slug;
-      loadAddon(fakeAddon);
+      _loadAddon(fakeAddon);
       // Set up loaded data for a different page.
       _setAddonReviews({
         addonSlug,
@@ -421,7 +421,7 @@ describe(__filename, () => {
 
     it('fetches reviews by score', () => {
       const addon = { ...fakeAddon, slug: 'some-other-slug' };
-      loadAddon(addon);
+      _loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');
       const errorHandler = createStubErrorHandler();
 
@@ -444,7 +444,7 @@ describe(__filename, () => {
 
     it('fetches with a null score when score is not in URL', () => {
       const addon = { ...fakeAddon };
-      loadAddon(addon);
+      _loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');
 
       const root = render({
@@ -488,7 +488,7 @@ describe(__filename, () => {
 
     it('fetches reviews when the score changes', () => {
       const addonSlug = fakeAddon.slug;
-      loadAddon(fakeAddon);
+      _loadAddon(fakeAddon);
       _setAddonReviews({
         addonSlug,
         reviews: [fakeReview],
@@ -539,7 +539,7 @@ describe(__filename, () => {
 
     it('dispatches a view context for the add-on', () => {
       const addon = fakeAddon;
-      loadAddon(addon);
+      _loadAddon(addon);
       const dispatch = sinon.stub(store, 'dispatch');
       render();
 
@@ -559,7 +559,7 @@ describe(__filename, () => {
 
     it('does not dispatch a view context for similar add-ons', () => {
       const addon1 = fakeAddon;
-      loadAddon(addon1);
+      _loadAddon(addon1);
       _setAddonReviews();
       const dispatch = sinon.stub(store, 'dispatch');
       const root = render();
@@ -577,7 +577,7 @@ describe(__filename, () => {
       const addon1 = { ...fakeAddon, type: ADDON_TYPE_EXTENSION };
       const addon2 = { ...addon1, type: ADDON_TYPE_STATIC_THEME };
 
-      loadAddon(addon1);
+      _loadAddon(addon1);
       const dispatch = sinon.stub(store, 'dispatch');
       const root = render();
 
@@ -652,7 +652,7 @@ describe(__filename, () => {
         { ...fakeReview, id: 1, score: 1 },
         { ...fakeReview, id: 2, score: 2 },
       ];
-      loadAddon(addon);
+      _loadAddon(addon);
       _setAddonReviews({ addon, reviews });
 
       const tree = render();
@@ -681,7 +681,7 @@ describe(__filename, () => {
 
     it('renders content when no reviews exist', () => {
       const addon = { ...fakeAddon };
-      loadAddon(addon);
+      _loadAddon(addon);
       _setAddonReviews({ addon, reviews: [] });
 
       const root = render();
@@ -732,7 +732,7 @@ describe(__filename, () => {
     });
 
     it('renders a class name with its type', () => {
-      loadAddon({
+      _loadAddon({
         ...fakeAddon,
         type: ADDON_TYPE_STATIC_THEME,
       });
@@ -745,7 +745,7 @@ describe(__filename, () => {
 
     it('produces an addon URL', () => {
       const addon = fakeAddon;
-      loadAddon(addon);
+      _loadAddon(addon);
       expect(render().instance().addonURL()).toEqual(getAddonURL(addon.slug));
     });
 
@@ -764,7 +764,7 @@ describe(__filename, () => {
           count: 200,
         },
       };
-      loadAddon(addon);
+      _loadAddon(addon);
       // These are the actual review results returned by the API.
       const reviewCount = 5;
       _setAddonReviews({ addon, reviews: Array(reviewCount).fill(fakeReview) });
@@ -784,7 +784,7 @@ describe(__filename, () => {
     it('configures CardList header with LoadingText', () => {
       const addonSlug = 'example-slug';
       const addon = { ...fakeAddon, slug: addonSlug };
-      loadAddon(addon);
+      _loadAddon(addon);
       // Set up a state where reviews have not yet been loaded.
       const root = render({ params: { addonSlug } });
 
@@ -803,7 +803,7 @@ describe(__filename, () => {
         reviews = Array(DEFAULT_API_PAGE_SIZE + 2).fill(fakeReview),
         ...otherProps
       } = {}) => {
-        loadAddon(addon);
+        _loadAddon(addon);
         _setAddonReviews({ addon, page, reviews });
 
         return render({
@@ -821,7 +821,7 @@ describe(__filename, () => {
       it('configures a paginator with the right URL', () => {
         const addonSlug = 'adblock-plus';
         const addon = { ...fakeAddon, id: 8765, slug: addonSlug };
-        loadAddon(addon);
+        _loadAddon(addon);
         const root = renderWithPagination({ addon, params: { addonSlug } });
 
         const paginator = renderFooter(root);
@@ -835,7 +835,7 @@ describe(__filename, () => {
         const location = createFakeLocation({ query: { utm_campaign } });
         const addonSlug = 'adblock-plus';
         const addon = { ...fakeAddon, id: 8765, slug: addonSlug };
-        loadAddon(addon);
+        _loadAddon(addon);
 
         const root = renderWithPagination({
           addon,
@@ -881,7 +881,7 @@ describe(__filename, () => {
 
     it('renders an HTML title', () => {
       const addon = fakeAddon;
-      loadAddon(addon);
+      _loadAddon(addon);
       const root = render();
       expect(root.find('title')).toHaveText(`Reviews for ${addon.name}`);
     });
@@ -918,7 +918,7 @@ describe(__filename, () => {
     it('renders FeaturedAddonReview', () => {
       const reviewId = 8765;
       const addon = { ...fakeAddon };
-      loadAddon(addon);
+      _loadAddon(addon);
       _setAddonReviews({ reviews: [{ ...fakeReview }] });
 
       const root = render({ params: { reviewId } });
@@ -932,7 +932,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      loadAddon(addon);
+      _loadAddon(addon);
       dispatchSignInActions({ store, userId });
       const dispatchSpy = sinon.spy(store, 'dispatch');
 
@@ -952,7 +952,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      loadAddon(addon);
+      _loadAddon(addon);
       dispatchSignInActions({ store, userId });
       const dispatchSpy = sinon.spy(store, 'dispatch');
 
@@ -975,7 +975,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      loadAddon(addon);
+      _loadAddon(addon);
       dispatchSignInActions({ store, userId });
 
       const error = createApiError({
@@ -1001,7 +1001,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      loadAddon(addon);
+      _loadAddon(addon);
       dispatchSignInActions({ store, userId });
 
       const fetchAction = fetchReviewPermissions({
@@ -1024,7 +1024,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon };
       const userId = 66432;
 
-      loadAddon(addon);
+      _loadAddon(addon);
       signInAndSetReviewPermissions({
         addonId: addon.id,
         userId,
@@ -1053,7 +1053,7 @@ describe(__filename, () => {
       ];
       const userId = 99654;
 
-      loadAddon(addon);
+      _loadAddon(addon);
       _setAddonReviews({ reviews });
       signInAndSetReviewPermissions({
         addonId: addon.id,
@@ -1073,7 +1073,7 @@ describe(__filename, () => {
     it('passes siteUserCanReply to FeaturedAddonReview', () => {
       const reviewId = 8765;
       const addon = { ...fakeAddon };
-      loadAddon(addon);
+      _loadAddon(addon);
       _setAddonReviews({ addon, reviews: [{ ...fakeReview }] });
       signInAndSetReviewPermissions({
         addonId: addon.id,
@@ -1091,7 +1091,7 @@ describe(__filename, () => {
   it('renders a "description" meta tag', () => {
     const addonSlug = 'example-slug';
     const addon = { ...fakeAddon, slug: addonSlug };
-    loadAddon(addon);
+    _loadAddon(addon);
 
     const root = render({ params: { addonSlug } });
 
@@ -1109,7 +1109,7 @@ describe(__filename, () => {
       const addonSlug = 'example-slug';
       if (preloadAddon) {
         addon = { ...fakeAddon, slug: addonSlug };
-        loadAddon(addon);
+        _loadAddon(addon);
       }
 
       const root = render({ params: { addonSlug }, ...props });

--- a/tests/unit/amo/pages/TestAddonVersions.js
+++ b/tests/unit/amo/pages/TestAddonVersions.js
@@ -12,7 +12,7 @@ import { ErrorHandler } from 'core/errorHandler';
 import {
   createInternalAddon,
   fetchAddon,
-  loadAddonResults,
+  loadAddon,
 } from 'core/reducers/addons';
 import {
   createInternalVersion,
@@ -66,8 +66,8 @@ describe(__filename, () => {
     return shallowUntilTarget(<AddonVersions {...props} />, AddonVersionsBase);
   };
 
-  const _loadAddonResults = (addons = [fakeAddon]) => {
-    store.dispatch(loadAddonResults({ addons }));
+  const _loadAddon = (addon = fakeAddon) => {
+    store.dispatch(loadAddon({ addon }));
   };
 
   const _loadVersions = ({
@@ -111,7 +111,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const errorHandler = createStubErrorHandler();
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
 
@@ -157,7 +157,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const errorHandler = createStubErrorHandler();
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
 
     const dispatch = sinon.stub(store, 'dispatch');
 
@@ -204,7 +204,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const errorHandler = createStubErrorHandler();
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     store.dispatch(fetchVersions({ errorHandlerId: errorHandler.id, slug }));
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
@@ -228,7 +228,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const errorHandler = createStubErrorHandler();
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadVersions({ slug });
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
@@ -253,7 +253,7 @@ describe(__filename, () => {
     const addon = { ...fakeAddon, slug };
     const errorHandler = createStubErrorHandler();
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
 
     const dispatch = sinon.stub(store, 'dispatch');
 
@@ -285,7 +285,7 @@ describe(__filename, () => {
     const slug = 'some-slug';
     const addon = { ...fakeAddon, slug };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
 
     const root = render({
       params: { slug },
@@ -301,7 +301,7 @@ describe(__filename, () => {
     const versions = [fakeVersion];
     const expectedHeader = `${addon.name} version history - ${versions.length} version`;
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadVersions({ slug, versions });
 
     const root = render({
@@ -321,7 +321,7 @@ describe(__filename, () => {
     const versions = [fakeVersion, fakeVersion];
     const expectedHeader = `${addon.name} version history - ${versions.length} versions`;
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
     _loadVersions({ slug, versions });
 
     const root = render({
@@ -335,7 +335,7 @@ describe(__filename, () => {
     const slug = 'some-addon-slug';
     const addon = { ...fakeAddon, slug };
 
-    _loadAddonResults([addon]);
+    _loadAddon(addon);
 
     const root = render({
       params: { slug },
@@ -381,7 +381,7 @@ describe(__filename, () => {
       const addon = { ...fakeAddon, slug, current_version: version1 };
       const version2 = { ...fakeVersion, id: 2 };
 
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       _loadVersions({ slug, versions: [version1, version2] });
 
       const root = render({
@@ -408,7 +408,7 @@ describe(__filename, () => {
       const slug = 'some-addon-slug';
       const addon = { ...fakeAddon, slug };
 
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       _loadVersions({ slug, versions: [] });
 
       const root = render({
@@ -427,7 +427,7 @@ describe(__filename, () => {
       const version2 = { ...fakeVersion, id: 2 };
       const version3 = { ...fakeVersion, id: 3 };
 
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       _loadVersions({ slug, versions: [version1, version2, version3] });
 
       const root = render({
@@ -447,7 +447,7 @@ describe(__filename, () => {
       const version2 = { ...fakeVersion, id: 2 };
       const version3 = { ...fakeVersion, id: 3 };
 
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       _loadVersions({ slug, versions: [version1, version2, version3] });
 
       const root = render({
@@ -476,7 +476,7 @@ describe(__filename, () => {
       const version2 = { ...fakeVersion, id: 2 };
       const version3 = { ...fakeVersion, id: 3 };
 
-      _loadAddonResults([addon]);
+      _loadAddon(addon);
       _loadVersions({ slug, versions: [version1, version2, version3] });
 
       const root = render({

--- a/tests/unit/core/reducers/test_versions.js
+++ b/tests/unit/core/reducers/test_versions.js
@@ -15,7 +15,7 @@ import {
 import { formatFilesize } from 'core/i18n/utils';
 import { DEFAULT_API_PAGE_SIZE } from 'core/api';
 import { ADDON_TYPE_EXTENSION, OS_MAC, OS_WINDOWS } from 'core/constants';
-import { loadAddonResults } from 'core/reducers/addons';
+import { loadAddon } from 'core/reducers/addons';
 import { searchLoad } from 'core/reducers/search';
 import versionsReducer, {
   createInternalVersion,
@@ -763,17 +763,15 @@ describe(__filename, () => {
       });
     });
 
-    describe('LOAD_ADDON_RESULTS', () => {
+    describe('LOAD_ADDON', () => {
       it('loads versions', () => {
         const state = versionsReducer(
           undefined,
-          loadAddonResults({
-            addons: [
-              {
-                ...fakeAddon,
-                current_version: version,
-              },
-            ],
+          loadAddon({
+            addon: {
+              ...fakeAddon,
+              current_version: version,
+            },
           }),
         );
 

--- a/tests/unit/core/sagas/test_addons.js
+++ b/tests/unit/core/sagas/test_addons.js
@@ -6,7 +6,7 @@ import addonsReducer, {
   fetchAddon,
   fetchAddonInfo,
   loadAddonInfo,
-  loadAddonResults,
+  loadAddon,
 } from 'core/reducers/addons';
 import apiReducer from 'core/reducers/api';
 import addonsSaga from 'core/sagas/addons';
@@ -58,7 +58,7 @@ describe(__filename, () => {
 
       _fetchAddon({ slug: fakeAddon.slug });
 
-      const expectedAction = loadAddonResults({ addons: [fakeAddon] });
+      const expectedAction = loadAddon({ addon: fakeAddon });
       await sagaTester.waitFor(expectedAction.type);
 
       mockApi.verify();
@@ -69,7 +69,7 @@ describe(__filename, () => {
 
       _fetchAddon();
 
-      const expectedAction = loadAddonResults({ addons: [fakeAddon] });
+      const expectedAction = loadAddon({ addon: fakeAddon });
       await sagaTester.waitFor(expectedAction.type);
 
       expect(sagaTester.getCalledActions()[1]).toEqual(

--- a/tests/unit/disco/helpers.js
+++ b/tests/unit/disco/helpers.js
@@ -1,4 +1,4 @@
-import { loadAddonResults } from 'core/reducers/addons';
+import { loadAddon } from 'core/reducers/addons';
 import { ADDON_TYPE_EXTENSION } from 'core/constants';
 import {
   createExternalAddonMap,
@@ -25,7 +25,10 @@ export function loadDiscoResultsIntoState(
   const { results } = createFetchDiscoveryResult(addonResults);
   const addons = createExternalAddonMap({ results });
 
-  store.dispatch(loadAddonResults({ addons }));
+  for (const addon of addons) {
+    store.dispatch(loadAddon({ addon }));
+  }
+
   store.dispatch(loadDiscoResults({ results }));
 
   return store.getState();

--- a/tests/unit/disco/sagas/test_disco.js
+++ b/tests/unit/disco/sagas/test_disco.js
@@ -1,6 +1,6 @@
 import SagaTester from 'redux-saga-tester';
 
-import addonsReducer, { loadAddonResults } from 'core/reducers/addons';
+import addonsReducer, { loadAddon } from 'core/reducers/addons';
 import apiReducer from 'core/reducers/api';
 import * as api from 'disco/api';
 import discoResultsReducer, {
@@ -97,7 +97,10 @@ describe(__filename, () => {
       const calledActions = sagaTester.getCalledActions();
 
       const addons = createExternalAddonMap({ results });
-      expect(calledActions[1]).toEqual(loadAddonResults({ addons }));
+
+      expect(addons.length).toEqual(2);
+      expect(calledActions[1]).toEqual(loadAddon({ addon: addons[0] }));
+      expect(calledActions[2]).toEqual(loadAddon({ addon: addons[1] }));
     });
 
     it('includes a telemetry client ID in the API request', async () => {


### PR DESCRIPTION
This is needed to implement a fix for https://github.com/mozilla/addons-frontend/issues/9692