### PR TITLE
Prevent re-render of PromotedAddonsCard

### DIFF
--- a/src/amo/components/PromotedAddonsCard/index.js
+++ b/src/amo/components/PromotedAddonsCard/index.js
@@ -25,13 +25,13 @@ export const PROMOTED_ADDON_IMPRESSION_ACTION = 'sponsored-impression';
 type Props = {|
   addonInstallSource?: string,
   className?: string,
-  loading: boolean,
 |};
 
 export type InternalProps = {|
   ...Props,
   _tracking: typeof tracking,
   i18n: I18nType,
+  resultsLoaded: boolean,
   shelves: { [shelfName: string]: Array<AddonType> | null },
 |};
 
@@ -75,7 +75,7 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
       addonInstallSource,
       className,
       i18n,
-      loading,
+      resultsLoaded,
       shelves,
     } = this.props;
 
@@ -123,7 +123,7 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
         onAddonImpression={this.onAddonImpression}
         showPromotedBadge={false}
         type="horizontal"
-        loading={loading}
+        loading={resultsLoaded === false}
         placeholderCount={LANDING_PAGE_PROMOTED_EXTENSION_COUNT}
       />
     );
@@ -131,7 +131,10 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
 }
 
 export function mapStateToProps(state: AppState) {
-  return { shelves: state.home.shelves };
+  return {
+    resultsLoaded: state.home.resultsLoaded,
+    shelves: state.home.shelves,
+  };
 }
 
 const PromotedAddonsCard: React.ComponentType<Props> = compose(

--- a/src/amo/components/PromotedAddonsCard/index.js
+++ b/src/amo/components/PromotedAddonsCard/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 import makeClassName from 'classnames';
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import AddonsCard from 'amo/components/AddonsCard';
@@ -8,6 +9,7 @@ import { LANDING_PAGE_PROMOTED_EXTENSION_COUNT } from 'amo/constants';
 import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import translate from 'core/i18n/translate';
 import tracking from 'core/tracking';
+import type { AppState } from 'amo/store';
 import type { AddonType, CollectionAddonType } from 'core/types/addons';
 import type { I18nType } from 'core/types/i18n';
 
@@ -22,15 +24,15 @@ export const PROMOTED_ADDON_IMPRESSION_ACTION = 'sponsored-impression';
 
 type Props = {|
   addonInstallSource?: string,
-  addons?: Array<AddonType> | null,
   className?: string,
   loading: boolean,
 |};
 
 export type InternalProps = {|
   ...Props,
-  i18n: I18nType,
   _tracking: typeof tracking,
+  i18n: I18nType,
+  shelves: { [shelfName: string]: Array<AddonType> | null },
 |};
 
 export class PromotedAddonsCardBase extends React.Component<InternalProps> {
@@ -69,11 +71,25 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
   };
 
   render() {
-    const { addonInstallSource, addons, className, i18n, loading } = this.props;
+    const {
+      addonInstallSource,
+      className,
+      i18n,
+      loading,
+      shelves,
+    } = this.props;
 
-    // Don't display anything if there are no add-ons.
-    if (Array.isArray(addons) && !addons.length) {
+    const { promotedExtensions } = shelves;
+    if (Array.isArray(promotedExtensions) && !promotedExtensions.length) {
+      // Don't display anything if there are no add-ons.
       return null;
+    }
+
+    if (Array.isArray(promotedExtensions)) {
+      // If there are fewer than 6 promoted extensions, just use the first 3.
+      if (promotedExtensions.length < 6) {
+        promotedExtensions.splice(3);
+      }
     }
 
     const header = (
@@ -100,7 +116,7 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
     return (
       <AddonsCard
         addonInstallSource={addonInstallSource}
-        addons={addons}
+        addons={promotedExtensions}
         className={makeClassName('PromotedAddonsCard', className)}
         header={header}
         onAddonClick={this.onAddonClick}
@@ -114,8 +130,13 @@ export class PromotedAddonsCardBase extends React.Component<InternalProps> {
   }
 }
 
-const PromotedAddonsCard: React.ComponentType<Props> = compose(translate())(
-  PromotedAddonsCardBase,
-);
+export function mapStateToProps(state: AppState) {
+  return { shelves: state.home.shelves };
+}
+
+const PromotedAddonsCard: React.ComponentType<Props> = compose(
+  connect(mapStateToProps),
+  translate(),
+)(PromotedAddonsCardBase);
 
 export default PromotedAddonsCard;

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -247,14 +247,6 @@ export class HomeBase extends React.Component {
       return null;
     };
 
-    const { promotedExtensions } = shelves;
-    if (Array.isArray(promotedExtensions)) {
-      // If there are fewer than 6 promoted extensions, just use the first 3.
-      if (promotedExtensions.length < 6) {
-        promotedExtensions.splice(3);
-      }
-    }
-
     return (
       <Page isHomePage showWrongPlatformWarning={!isDesktopSite}>
         <div className="Home">
@@ -290,7 +282,6 @@ export class HomeBase extends React.Component {
             {_config.get('enableFeatureSponsoredShelf') && isDesktopSite ? (
               <PromotedAddonsCard
                 addonInstallSource={INSTALL_SOURCE_PROMOTED_SHELF}
-                addons={promotedExtensions}
                 loading={loading}
               />
             ) : null}

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -282,7 +282,6 @@ export class HomeBase extends React.Component {
             {_config.get('enableFeatureSponsoredShelf') && isDesktopSite ? (
               <PromotedAddonsCard
                 addonInstallSource={INSTALL_SOURCE_PROMOTED_SHELF}
-                loading={loading}
               />
             ) : null}
 

--- a/stories/amo/PromotedAddonsCard.js
+++ b/stories/amo/PromotedAddonsCard.js
@@ -11,7 +11,7 @@ import Provider from '../setup/Provider';
 
 const render = (moreProps: $Shape<PromotedAddonsCardProps> = {}) => {
   const props = {
-    addons: null,
+    shelves: {},
     loading: false,
     ...moreProps,
   };
@@ -41,12 +41,24 @@ storiesOf('PromotedAddonsCard', module)
           {
             title: 'with 3 add-ons',
             sectionFn: () =>
-              render({ addons: Array(3).fill(createInternalAddon(fakeAddon)) }),
+              render({
+                shelves: {
+                  promotedExtensions: Array(3).fill(
+                    createInternalAddon(fakeAddon),
+                  ),
+                },
+              }),
           },
           {
             title: 'with 6 add-ons',
             sectionFn: () =>
-              render({ addons: Array(6).fill(createInternalAddon(fakeAddon)) }),
+              render({
+                shelves: {
+                  promotedExtensions: Array(6).fill(
+                    createInternalAddon(fakeAddon),
+                  ),
+                },
+              }),
           },
         ],
       },

--- a/stories/amo/PromotedAddonsCard.js
+++ b/stories/amo/PromotedAddonsCard.js
@@ -11,8 +11,8 @@ import Provider from '../setup/Provider';
 
 const render = (moreProps: $Shape<PromotedAddonsCardProps> = {}) => {
   const props = {
+    resultsLoaded: true,
     shelves: {},
-    loading: false,
     ...moreProps,
   };
   return (
@@ -36,7 +36,7 @@ storiesOf('PromotedAddonsCard', module)
         sections: [
           {
             title: 'loading',
-            sectionFn: () => render({ loading: true }),
+            sectionFn: () => render({ resultsLoaded: false }),
           },
           {
             title: 'with 3 add-ons',

--- a/tests/unit/amo/components/TestPromotedAddonsCard.js
+++ b/tests/unit/amo/components/TestPromotedAddonsCard.js
@@ -9,7 +9,7 @@ import PromotedAddonsCard, {
   PROMOTED_ADDON_IMPRESSION_ACTION,
   PromotedAddonsCardBase,
 } from 'amo/components/PromotedAddonsCard';
-import { loadHomeData } from 'amo/reducers/home';
+import { fetchHomeData, loadHomeData } from 'amo/reducers/home';
 import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -63,10 +63,15 @@ describe(__filename, () => {
   });
 
   it('passes loading parameter to AddonsCard', () => {
-    const root = render({ loading: true });
+    store.dispatch(
+      fetchHomeData({ collectionsToFetch: [], errorHandlerId: 'some-id' }),
+    );
+
+    let root = render();
     expect(root.find(AddonsCard)).toHaveProp('loading', true);
 
-    root.setProps({ loading: false });
+    _loadPromotedExtensions({ addons: [fakeAddon] });
+    root = render();
     expect(root.find(AddonsCard)).toHaveProp('loading', false);
   });
 

--- a/tests/unit/amo/components/TestPromotedAddonsCard.js
+++ b/tests/unit/amo/components/TestPromotedAddonsCard.js
@@ -9,20 +9,34 @@ import PromotedAddonsCard, {
   PROMOTED_ADDON_IMPRESSION_ACTION,
   PromotedAddonsCardBase,
 } from 'amo/components/PromotedAddonsCard';
+import { loadHomeData } from 'amo/reducers/home';
 import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
+  createAddonsApiResult,
   createFakeTracking,
+  createHeroShelves,
+  dispatchClientMetadata,
   fakeAddon,
   fakeI18n,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
+  let _tracking;
+  let store;
+
+  beforeEach(() => {
+    _tracking = createFakeTracking();
+    store = dispatchClientMetadata().store;
+  });
+
   const render = (customProps = {}) => {
     const props = {
+      _tracking,
       i18n: fakeI18n(),
       loading: false,
+      store,
       ...customProps,
     };
 
@@ -32,8 +46,19 @@ describe(__filename, () => {
     );
   };
 
-  it('displays nothing when addons is an empty array', () => {
-    const root = render({ addons: [] });
+  const _loadPromotedExtensions = ({ addons = [] }) => {
+    store.dispatch(
+      loadHomeData({
+        collections: [],
+        heroShelves: createHeroShelves(),
+        shelves: { promotedExtensions: createAddonsApiResult(addons) },
+      }),
+    );
+  };
+
+  it('displays nothing when promotedExtensions is an empty array', () => {
+    _loadPromotedExtensions({ addons: [] });
+    const root = render();
     expect(root.find(AddonsCard)).toHaveLength(0);
   });
 
@@ -45,15 +70,14 @@ describe(__filename, () => {
     expect(root.find(AddonsCard)).toHaveProp('loading', false);
   });
 
-  it('passes addons to AddonsCard', () => {
-    const addons = [
-      createInternalAddon({
-        ...fakeAddon,
-        slug: 'custom-addon',
-      }),
-    ];
-    const root = render({ addons });
-    expect(root.find(AddonsCard)).toHaveProp('addons', addons);
+  it('passes promotedExtensions to AddonsCard', () => {
+    const addon = fakeAddon;
+    _loadPromotedExtensions({ addons: [addon] });
+    const root = render();
+
+    expect(root.find(AddonsCard)).toHaveProp('addons', [
+      createInternalAddon(addon),
+    ]);
   });
 
   it('can pass a custom classname to AddonsCard', () => {
@@ -92,13 +116,13 @@ describe(__filename, () => {
   });
 
   it('configures AddonsCard to send a tracking event when an add-on is clicked', () => {
-    const _tracking = createFakeTracking();
     const guid = 'some-guid';
-    const addon = createInternalAddon({ ...fakeAddon, guid });
+    const addon = { ...fakeAddon, guid };
+    _loadPromotedExtensions({ addons: [addon] });
 
-    const root = render({ _tracking, addons: [addon] });
+    const root = render();
     const onAddonClick = root.find(AddonsCard).prop('onAddonClick');
-    onAddonClick(addon);
+    onAddonClick(createInternalAddon(addon));
 
     sinon.assert.calledWith(_tracking.sendEvent, {
       action: PROMOTED_ADDON_CLICK_ACTION,
@@ -108,18 +132,27 @@ describe(__filename, () => {
   });
 
   it('configures AddonsCard to send a tracking event when an add-on is displayed', () => {
-    const _tracking = createFakeTracking();
     const guid = 'some-guid';
-    const addon = createInternalAddon({ ...fakeAddon, guid });
+    const addon = { ...fakeAddon, guid };
+    _loadPromotedExtensions({ addons: [addon] });
 
-    const root = render({ _tracking, addons: [addon] });
+    const root = render();
     const onAddonImpression = root.find(AddonsCard).prop('onAddonImpression');
-    onAddonImpression(addon);
+    onAddonImpression(createInternalAddon(addon));
 
     sinon.assert.calledWith(_tracking.sendEvent, {
       action: PROMOTED_ADDON_IMPRESSION_ACTION,
       category: PROMOTED_ADDON_HOMEPAGE_IMPRESSION_CATEGORY,
       label: guid,
     });
+  });
+
+  it('only includes 3 promoted extensions if fewer than 6 are returned', () => {
+    _loadPromotedExtensions({ addons: Array(5).fill(fakeAddon) });
+
+    const root = render();
+
+    const addons = root.find(AddonsCard).prop('addons');
+    expect(addons.length).toEqual(3);
   });
 });

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -115,14 +115,6 @@ describe(__filename, () => {
       clientApp: CLIENT_APP_FIREFOX,
     });
 
-    const addon = fakeAddon;
-    const promotedExtensions = createAddonsApiResult([addon]);
-
-    _loadHomeData({
-      store,
-      shelves: { promotedExtensions },
-    });
-
     const root = render({
       _config: getFakeConfig({
         enableFeatureSponsoredShelf: true,
@@ -130,9 +122,7 @@ describe(__filename, () => {
       store,
     });
 
-    expect(root.find(PromotedAddonsCard)).toHaveProp('addons', [
-      createInternalAddon(addon),
-    ]);
+    expect(root.find(PromotedAddonsCard)).toHaveLength(1);
   });
 
   it('does not render a promoted extensions shelf if turned off', () => {
@@ -156,30 +146,6 @@ describe(__filename, () => {
     });
 
     expect(root.find(PromotedAddonsCard)).toHaveLength(0);
-  });
-
-  it('only includes 3 promoted extensions if fewer than 6 are returned', () => {
-    const { store } = dispatchClientMetadata({
-      clientApp: CLIENT_APP_FIREFOX,
-    });
-
-    const addon = fakeAddon;
-    const promotedExtensions = createAddonsApiResult(Array(5).fill(addon));
-
-    _loadHomeData({
-      store,
-      shelves: { promotedExtensions },
-    });
-
-    const root = render({
-      _config: getFakeConfig({
-        enableFeatureSponsoredShelf: true,
-      }),
-      store,
-    });
-
-    const addons = root.find(PromotedAddonsCard).prop('addons');
-    expect(addons.length).toEqual(3);
   });
 
   it.each([CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX])(

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -441,9 +441,12 @@ describe(__filename, () => {
     });
 
     it('throws an exception if neither an addon nor an external entry is provided', () => {
-      const heroShelves = createHeroShelves({
-        primaryProps: { addon: undefined, external: undefined },
-      });
+      const heroShelves = createHeroShelves();
+      // createHeroShelves won't allow an invalid shelf to be created, so we
+      // must do this.
+      heroShelves.primary.addon = undefined;
+      heroShelves.primary.external = undefined;
+
       expect(() => createInternalHeroShelves(heroShelves)).toThrow(
         /Either primary.addon or primary.external is required/,
       );

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -274,7 +274,10 @@ export const createPrimaryHeroShelf = ({
   return {
     addon,
     description,
-    external,
+    external:
+      addon === undefined && external === undefined
+        ? 'external-link'
+        : external,
     featured_image: featuredImage,
     gradient,
   };


### PR DESCRIPTION
Fixes #9737 

This prevents the double-render of the `PromotedAddonsCard`, which was causing two sets of events to be dispatched. We're still not sure why this issue only appears with SSR, but this is an acceptable fix for the problem.

I am going to expand on this to move the logic to fetch the `addons` into the `PromotedAddonsCard` as well, but that can be done in a follow-up.