### PR TITLE
Support non-Recommended extensions in the Primary Hero area

### DIFF
--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -221,7 +221,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           <div className="HeroRecommendation-title-text">
             {loading ? <LoadingText width={20} /> : titleText}
           </div>
-          {![LINE, RECOMMENDED].includes(promotedCategory) ? (
+          {![LINE, RECOMMENDED].includes(promotedCategory) && !loading ? (
             <a
               className="HeroRecommendation-title-link"
               href={`${getPromotedBadgesLinkUrl({

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -72,9 +72,10 @@
   }
 }
 
-.HeroRecommendation-recommended {
+.HeroRecommendation-title-text {
   @include font-medium();
 
+  display: inline;
   font-size: $font-size-s;
   letter-spacing: 0.1em;
   line-height: 1.143;
@@ -90,9 +91,25 @@
   }
 }
 
+.HeroRecommendation-title-link {
+  font-size: $font-size-micro;
+  @include margin-start(12px);
+
+  &,
+  &:active,
+  &:hover,
+  &:link,
+  &:visited {
+    color: $white;
+    font-weight: normal;
+    opacity: 0.5;
+    text-decoration: none;
+  }
+}
+
 .HeroRecommendation-body,
 .HeroRecommendation-heading,
-.HeroRecommendation-recommended {
+.HeroRecommendation-title {
   width: 100%;
 
   .LoadingText {
@@ -145,7 +162,7 @@
     }
   }
 
-  .HeroRecommendation-recommended,
+  .HeroRecommendation-title,
   .HeroRecommendation-heading,
   .HeroRecommendation-body,
   .HeroRecommendation-link {

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -102,6 +102,13 @@ describe(__filename, () => {
       },
     );
 
+    it('does not display an additional link when loading', () => {
+      const _getPromotedCategory = sinon.stub().returns(SPONSORED);
+
+      const root = render({ _getPromotedCategory, shelfData: null });
+      expect(root.find('.HeroRecommendation-title-link')).toHaveLength(0);
+    });
+
     it.each([LINE, RECOMMENDED])(
       'does not display an additional link for %s add-ons',
       (category) => {

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -12,11 +12,18 @@ import HeroRecommendation, {
 } from 'amo/components/HeroRecommendation';
 import { createInternalHeroShelves } from 'amo/reducers/home';
 import { getAddonURL } from 'amo/utils';
-import { addQueryParams } from 'core/utils/url';
+import {
+  DEFAULT_UTM_SOURCE,
+  DEFAULT_UTM_MEDIUM,
+  LINE,
+  RECOMMENDED,
+  SPONSORED,
+  VERIFIED,
+} from 'core/constants';
 import { loadSiteStatus } from 'core/reducers/site';
+import { addQueryParams } from 'core/utils/url';
 import ErrorList from 'ui/components/ErrorList';
 import LoadingText from 'ui/components/LoadingText';
-import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'core/constants';
 import {
   createFakeEvent,
   createFakeTracking,
@@ -69,6 +76,42 @@ describe(__filename, () => {
         root.instance().makeCallToActionURL(),
       );
     });
+
+    it.each([
+      [LINE, 'BY FIREFOX'],
+      [RECOMMENDED, 'RECOMMENDED'],
+      [SPONSORED, 'SPONSORED'],
+      [VERIFIED, 'SPONSORED'],
+      ['unknown category', 'SPONSORED'],
+    ])('displays the expected title for %s add-ons', (category, title) => {
+      const _getPromotedCategory = sinon.stub().returns(category);
+      const shelfData = createShelfData({ addon: fakeAddon });
+
+      const root = render({ _getPromotedCategory, shelfData });
+      expect(root.find('.HeroRecommendation-title-text')).toHaveText(title);
+    });
+
+    it.each([SPONSORED, VERIFIED, 'unknown category'])(
+      'displays an additional link for %s add-ons',
+      (category) => {
+        const _getPromotedCategory = sinon.stub().returns(category);
+        const shelfData = createShelfData({ addon: fakeAddon });
+
+        const root = render({ _getPromotedCategory, shelfData });
+        expect(root.find('.HeroRecommendation-title-link')).toHaveLength(1);
+      },
+    );
+
+    it.each([LINE, RECOMMENDED])(
+      'does not display an additional link for %s add-ons',
+      (category) => {
+        const _getPromotedCategory = sinon.stub().returns(category);
+        const shelfData = createShelfData({ addon: fakeAddon });
+
+        const root = render({ _getPromotedCategory, shelfData });
+        expect(root.find('.HeroRecommendation-title-link')).toHaveLength(0);
+      },
+    );
   });
 
   describe('for an external item', () => {


### PR DESCRIPTION
Depends on https://github.com/mozilla/addons-server/issues/15741
Fixes #9764 

Note that this mustn't land before https://github.com/mozilla/addons-server/issues/15741 is fixed. I'll mark it as "do not merge".