### PR TITLE
Remove contrib:welcome stalebot exclusion

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,7 +14,6 @@ onlyLabels: []
 exemptLabels:
   - "contrib: maybe good first bug"
   - "contrib: good first bug"
-  - "contrib: welcome"
   - "component: security"
   - "state: blocked"
   - "state: blocked by upstream"


### PR DESCRIPTION
Removes the `contrib:welcome` label from stalebot exclusions.