### PR TITLE
Remove obsolete permissions

### DIFF
--- a/src/amo/components/AddonAdminLinks/index.js
+++ b/src/amo/components/AddonAdminLinks/index.js
@@ -6,10 +6,9 @@ import { compose } from 'redux';
 import {
   ADDONS_CONTENT_REVIEW,
   ADDONS_EDIT,
-  ADDONS_POST_REVIEW,
-  ADMIN_TOOLS_VIEW,
-  THEMES_REVIEW,
+  ADDONS_REVIEW,
   ADDON_TYPE_STATIC_THEME,
+  STATIC_THEMES_REVIEW,
 } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { hasPermission } from 'amo/reducers/users';
@@ -25,22 +24,20 @@ type Props = {|
 type InternalProps = {|
   ...Props,
   i18n: I18nType,
-  hasAdminPermission: boolean,
   hasCodeReviewPermission: boolean,
   hasContentReviewPermission: boolean,
   hasEditPermission: boolean,
-  hasThemeReviewPermission: boolean,
+  hasStaticThemeReviewPermission: boolean,
 |};
 
 export class AddonAdminLinksBase extends React.Component<InternalProps> {
   render() {
     const {
       addon,
-      hasAdminPermission,
       hasCodeReviewPermission,
       hasContentReviewPermission,
       hasEditPermission,
-      hasThemeReviewPermission,
+      hasStaticThemeReviewPermission,
       i18n,
     } = this.props;
 
@@ -51,14 +48,13 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
     const isTheme = addon.type === ADDON_TYPE_STATIC_THEME;
 
     const showCodeReviewLink = hasCodeReviewPermission && !isTheme;
-    const showThemeReviewLink = hasThemeReviewPermission && isTheme;
+    const showStaticThemeReviewLink = hasStaticThemeReviewPermission && isTheme;
     const showContentReviewLink = hasContentReviewPermission && !isTheme;
     const hasALink =
       hasEditPermission ||
-      hasAdminPermission ||
       showContentReviewLink ||
       showCodeReviewLink ||
-      showThemeReviewLink;
+      showStaticThemeReviewLink;
 
     if (!hasALink) {
       return null;
@@ -79,20 +75,19 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
       </li>
     ) : null;
 
-    const adminLink =
-      hasAdminPermission && hasEditPermission ? (
-        <li>
-          <a
-            className="AddonAdminLinks-admin-link"
-            href={`/admin/models/addons/addon/${addon.id}`}
-          >
-            {
-              // translators: This action allows an admin to maintain an add-on.
-              i18n.gettext('Admin add-on')
-            }
-          </a>
-        </li>
-      ) : null;
+    const adminLink = hasEditPermission ? (
+      <li>
+        <a
+          className="AddonAdminLinks-admin-link"
+          href={`/admin/models/addons/addon/${addon.id}`}
+        >
+          {
+            // translators: This action allows an admin to maintain an add-on.
+            i18n.gettext('Admin add-on')
+          }
+        </a>
+      </li>
+    ) : null;
 
     const contentReviewLink = showContentReviewLink ? (
       <li>
@@ -114,7 +109,7 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
       : // translators: This action allows a reviewer to perform a review of an add-on's code.
         i18n.gettext('Review add-on code');
     const codeReviewLink =
-      showCodeReviewLink || showThemeReviewLink ? (
+      showCodeReviewLink || showStaticThemeReviewLink ? (
         <li>
           <a
             className={`AddonAdminLinks-${
@@ -149,11 +144,10 @@ export class AddonAdminLinksBase extends React.Component<InternalProps> {
 
 export const mapStateToProps = (state: AppState) => {
   return {
-    hasAdminPermission: hasPermission(state, ADMIN_TOOLS_VIEW),
-    hasCodeReviewPermission: hasPermission(state, ADDONS_POST_REVIEW),
+    hasCodeReviewPermission: hasPermission(state, ADDONS_REVIEW),
     hasContentReviewPermission: hasPermission(state, ADDONS_CONTENT_REVIEW),
     hasEditPermission: hasPermission(state, ADDONS_EDIT),
-    hasThemeReviewPermission: hasPermission(state, THEMES_REVIEW),
+    hasStaticThemeReviewPermission: hasPermission(state, STATIC_THEMES_REVIEW),
   };
 };
 

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -10,7 +10,7 @@ import Link from 'amo/components/Link';
 import AddonReviewManager from 'amo/components/AddonReviewManager';
 import FlagReviewMenu from 'amo/components/FlagReviewMenu';
 import { reviewListURL } from 'amo/reducers/reviews';
-import { ADDONS_EDIT, ADMIN_TOOLS_VIEW } from 'core/constants';
+import { ADDONS_EDIT, USERS_EDIT } from 'core/constants';
 import { withErrorHandler } from 'core/errorHandler';
 import translate from 'core/i18n/translate';
 import log from 'core/logger';
@@ -71,7 +71,7 @@ type InternalProps = {|
   dispatch: DispatchFunc,
   editingReview: boolean,
   errorHandler: ErrorHandlerType,
-  hasAdminPermission: boolean,
+  hasUsersEditPermission: boolean,
   i18n: I18nType,
   replyingToReview: boolean,
   siteUser: UserType | null,
@@ -333,7 +333,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       editingReview,
       errorHandler,
       flaggable,
-      hasAdminPermission,
+      hasUsersEditPermission,
       i18n,
       location,
       replyingToReview,
@@ -348,7 +348,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
     let byLine;
     const noAuthor = shortByLine || this.isReply();
-    const showUserProfileLink = !noAuthor && hasAdminPermission;
+    const showUserProfileLink = !noAuthor && hasUsersEditPermission;
 
     if (review) {
       // eslint-disable-next-line no-nested-ternary
@@ -613,7 +613,7 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
     beginningToDeleteReview,
     deletingReview,
     editingReview,
-    hasAdminPermission: hasPermission(state, ADMIN_TOOLS_VIEW),
+    hasUsersEditPermission: hasPermission(state, USERS_EDIT),
     replyingToReview,
     siteUser: getCurrentUser(state.users),
     siteUserCanManageReplies: ownProps.siteUserCanReply || siteUserHasReplyPerm,

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -29,7 +29,6 @@ import Paginate from 'core/components/Paginate';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
-  ADMIN_TOOLS,
   USERS_EDIT,
 } from 'core/constants';
 import { withFixedErrorHandler } from 'core/errorHandler';
@@ -512,11 +511,7 @@ export function mapStateToProps(state: AppState, ownProps: Props) {
       currentUser &&
       (currentUser.id === userId || hasPermission(state, USERS_EDIT));
 
-    canAdminUser =
-      currentUser &&
-      user &&
-      hasPermission(state, ADMIN_TOOLS) &&
-      hasPermission(state, USERS_EDIT);
+    canAdminUser = currentUser && user && hasPermission(state, USERS_EDIT);
 
     reviews = getReviewsByUserId(state.reviews, userId);
   } else {

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -6,7 +6,6 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 import {
   ADDONS_CONTENT_REVIEW,
   ADDONS_EDIT,
-  ADDONS_POST_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
   ADDONS_REVIEW,
   ADDONS_REVIEW_UNLISTED,
@@ -14,7 +13,6 @@ import {
   RATINGS_MODERATE,
   REVIEWER_TOOLS_VIEW,
   STATIC_THEMES_REVIEW,
-  THEMES_REVIEW,
 } from 'core/constants';
 import type { AppState } from 'amo/store';
 import type { ExternalSiteStatus } from 'core/reducers/site';
@@ -515,14 +513,12 @@ export const hasAnyReviewerRelatedPermission = (state: AppState): boolean => {
   return (
     permissions.includes(ADDONS_CONTENT_REVIEW) ||
     permissions.includes(ADDONS_EDIT) ||
-    permissions.includes(ADDONS_POST_REVIEW) ||
     permissions.includes(ADDONS_RECOMMENDED_REVIEW) ||
     permissions.includes(ADDONS_REVIEW) ||
     permissions.includes(ADDONS_REVIEW_UNLISTED) ||
     permissions.includes(RATINGS_MODERATE) ||
     permissions.includes(REVIEWER_TOOLS_VIEW) ||
-    permissions.includes(STATIC_THEMES_REVIEW) ||
-    permissions.includes(THEMES_REVIEW)
+    permissions.includes(STATIC_THEMES_REVIEW)
   );
 };
 

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -263,15 +263,10 @@ export const ERROR_ADDON_DISABLED_BY_ADMIN = 'ERROR_ADDON_DISABLED_BY_ADMIN';
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Maximum_delay_value
 export const maximumSetTimeoutDelay = 2147483647;
 
-// Can access the website admin interface index page. Inner pages may require
-// other/additional permissions.
-export const ADMIN_TOOLS_VIEW = 'AdminTools:View';
 // Allows viewing and editing of any add-ons details in developer tools.
 export const ADDONS_EDIT = 'Addons:Edit';
 // Can access the add-on reviewer tools to approve/reject add-on submissions.
 export const ADDONS_REVIEW = 'Addons:Review';
-// Can access the theme reviewer tools to approve/reject theme submissions.
-export const THEMES_REVIEW = 'Personas:Review';
 // Can view statistics for all addons, regardless of privacy settings.
 export const STATS_VIEW = 'Stats:View';
 // Can edit all Mozilla-owned collections.
@@ -280,8 +275,6 @@ export const MOZILLA_COLLECTIONS_EDIT = 'Admin:Curation';
 export const FEATURED_THEMES_COLLECTION_EDIT = 'Collections:Contribute';
 // The slug for the special Featured Themes collection.
 export const FEATURED_THEMES_COLLECTION_SLUG = 'featured-personas';
-// Can confirm approval of automatically approved add-ons.
-export const ADDONS_POST_REVIEW = 'Addons:PostReview';
 // Can approve add-ons content.
 export const ADDONS_CONTENT_REVIEW = 'Addons:ContentReview';
 // Can review unlisted add-ons.
@@ -290,8 +283,6 @@ export const ADDONS_REVIEW_UNLISTED = 'Addons:ReviewUnlisted';
 export const RATINGS_MODERATE = 'Ratings:Moderate';
 // Can edit user accounts.
 export const USERS_EDIT = 'Users:Edit';
-// Can access admin functions.
-export const ADMIN_TOOLS = 'Admin:Tools';
 // Super powers. It means absolutely all permissions.
 export const ALL_SUPER_POWERS = '*:*';
 // Can view only the reviewer tools.

--- a/tests/unit/amo/components/TestAddonAdminLinks.js
+++ b/tests/unit/amo/components/TestAddonAdminLinks.js
@@ -6,10 +6,9 @@ import AddonAdminLinks, {
 import {
   ADDONS_CONTENT_REVIEW,
   ADDONS_EDIT,
-  ADDONS_POST_REVIEW,
+  ADDONS_REVIEW,
   ADDON_TYPE_STATIC_THEME,
-  ADMIN_TOOLS_VIEW,
-  THEMES_REVIEW,
+  STATIC_THEMES_REVIEW,
 } from 'core/constants';
 import { createInternalAddon } from 'core/reducers/addons';
 import {
@@ -84,7 +83,7 @@ describe(__filename, () => {
   });
 
   it('does not show an edit add-on link if the user does not have permission', () => {
-    const root = renderWithPermissions({ permissions: ADMIN_TOOLS_VIEW });
+    const root = renderWithPermissions({ permissions: ADDONS_REVIEW });
 
     expect(root.find('.AddonAdminLinks')).toHaveLength(1);
     expect(root.find('.AddonAdminLinks-edit-link')).toHaveLength(0);
@@ -106,7 +105,7 @@ describe(__filename, () => {
 
     const root = renderWithPermissions({
       addon,
-      permissions: [ADMIN_TOOLS_VIEW, ADDONS_EDIT],
+      permissions: [ADDONS_EDIT],
     });
 
     expect(root.find('.AddonAdminLinks-admin-link')).toHaveProp(
@@ -114,18 +113,6 @@ describe(__filename, () => {
       `/admin/models/addons/addon/${id}`,
     );
   });
-
-  it.each([ADMIN_TOOLS_VIEW, ADDONS_EDIT])(
-    'does not show an admin add-on link if the user only has the %s permission',
-    (permission) => {
-      const root = renderWithPermissions({
-        permissions: permission,
-      });
-
-      expect(root.find('.AddonAdminLinks')).toHaveLength(1);
-      expect(root.find('.AddonAdminLinks-admin-link')).toHaveLength(0);
-    },
-  );
 
   it('shows a content review link if the user has permission', () => {
     const root = renderWithPermissions({ permissions: ADDONS_CONTENT_REVIEW });
@@ -156,7 +143,7 @@ describe(__filename, () => {
   });
 
   it('shows a code review link for an extension if the user has permission', () => {
-    const root = renderWithPermissions({ permissions: ADDONS_POST_REVIEW });
+    const root = renderWithPermissions({ permissions: ADDONS_REVIEW });
 
     expect(root.find('.AddonAdminLinks-codeReview-link')).toHaveProp(
       'href',
@@ -181,7 +168,7 @@ describe(__filename, () => {
         slug,
         type: ADDON_TYPE_STATIC_THEME,
       }),
-      permissions: THEMES_REVIEW,
+      permissions: STATIC_THEMES_REVIEW,
     });
 
     expect(root.find('.AddonAdminLinks-themeReview-link')).toHaveProp(
@@ -212,7 +199,7 @@ describe(__filename, () => {
         ...fakeAddon,
         slug,
       }),
-      permissions: [ADDONS_EDIT, THEMES_REVIEW],
+      permissions: [ADDONS_EDIT, STATIC_THEMES_REVIEW],
     });
 
     expect(root.find('.AddonAdminLinks')).toHaveLength(1);

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -5,7 +5,11 @@ import Link from 'amo/components/Link';
 import SectionLinks from 'amo/components/SectionLinks';
 import { makeQueryStringWithUTM } from 'amo/utils';
 import AuthenticateButton from 'core/components/AuthenticateButton';
-import { CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX } from 'core/constants';
+import {
+  ADDONS_REVIEW,
+  CLIENT_APP_ANDROID,
+  CLIENT_APP_FIREFOX,
+} from 'core/constants';
 import DropdownMenu from 'ui/components/DropdownMenu';
 import { loadSiteStatus, loadedPageIsAnonymous } from 'core/reducers/site';
 import {
@@ -138,7 +142,7 @@ describe(__filename, () => {
   it('displays the reviewer tools link when user has a reviewer permission', () => {
     const { store } = dispatchSignInActions({
       userProps: {
-        permissions: ['Addons:PostReview'],
+        permissions: [ADDONS_REVIEW],
       },
     });
     const wrapper = renderHeader({ store });

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -22,7 +22,6 @@ import Paginate from 'core/components/Paginate';
 import {
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
-  ADMIN_TOOLS,
   CLIENT_APP_FIREFOX,
   USERS_EDIT,
 } from 'core/constants';
@@ -622,7 +621,7 @@ describe(__filename, () => {
   it('does not render an admin link if no user is found', () => {
     const { store } = signInUserWithProps({
       userId: 1,
-      permissions: [USERS_EDIT, ADMIN_TOOLS],
+      permissions: [USERS_EDIT],
     });
 
     const root = renderUserProfile({
@@ -637,7 +636,7 @@ describe(__filename, () => {
     const userId = 1;
     const { store } = signInUserWithProps({
       userId,
-      permissions: [USERS_EDIT, ADMIN_TOOLS],
+      permissions: [USERS_EDIT],
     });
 
     const user = createUserAccountResponse({ userId });

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -24,11 +24,7 @@ import {
   logOutUser,
 } from 'amo/reducers/users';
 import { createApiError } from 'core/api';
-import {
-  ADDONS_POST_REVIEW,
-  CLIENT_APP_FIREFOX,
-  USERS_EDIT,
-} from 'core/constants';
+import { ADDONS_REVIEW, CLIENT_APP_FIREFOX, USERS_EDIT } from 'core/constants';
 import AuthenticateButton from 'core/components/AuthenticateButton';
 import { ErrorHandler } from 'core/errorHandler';
 import ErrorList from 'ui/components/ErrorList';
@@ -440,7 +436,7 @@ describe(__filename, () => {
     const root = renderUserProfileEdit({
       userProps: defaultUserProps({
         reviewer_name: reviewerName,
-        permissions: [ADDONS_POST_REVIEW],
+        permissions: [ADDONS_REVIEW],
       }),
     });
 
@@ -573,7 +569,7 @@ describe(__filename, () => {
 
     const root = renderUserProfileEdit({
       userProps: defaultUserProps({
-        permissions: [ADDONS_POST_REVIEW],
+        permissions: [ADDONS_REVIEW],
         reviewer_name: '', // The API would return a value !== undefined for a reviewer.
       }),
     });
@@ -628,7 +624,7 @@ describe(__filename, () => {
 
   it('dispatches updateUserAccount action with all fields on submit for reviewers', () => {
     const { params, store } = signInUserWithProps({
-      permissions: [ADDONS_POST_REVIEW],
+      permissions: [ADDONS_REVIEW],
       reviewer_name: 'My Reviewer Name',
     });
     const dispatchSpy = sinon.spy(store, 'dispatch');

--- a/tests/unit/amo/reducers/test_users.js
+++ b/tests/unit/amo/reducers/test_users.js
@@ -24,15 +24,12 @@ import reducer, {
 } from 'amo/reducers/users';
 import {
   ADDONS_CONTENT_REVIEW,
-  ADDONS_POST_REVIEW,
   ADDONS_RECOMMENDED_REVIEW,
   ADDONS_REVIEW,
-  ADMIN_TOOLS_VIEW,
   ALL_SUPER_POWERS,
   REVIEWER_TOOLS_VIEW,
   STATIC_THEMES_REVIEW,
   STATS_VIEW,
-  THEMES_REVIEW,
 } from 'core/constants';
 import {
   createUserAccountResponse,
@@ -334,17 +331,17 @@ describe(__filename, () => {
 
   describe('hasPermission selector', () => {
     it('returns `true` when user has the given permission', () => {
-      const permissions = [ADMIN_TOOLS_VIEW, STATS_VIEW];
+      const permissions = [STATS_VIEW];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
       expect(hasPermission(state, STATS_VIEW)).toEqual(true);
     });
 
     it('returns `false` when user does not have the given permission', () => {
-      const permissions = [ADMIN_TOOLS_VIEW, STATS_VIEW];
+      const permissions = [STATS_VIEW];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
-      expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
+      expect(hasPermission(state, STATIC_THEMES_REVIEW)).toEqual(false);
     });
 
     it('returns `false` when user state has no permissions', () => {
@@ -352,20 +349,20 @@ describe(__filename, () => {
         userProps: { permissions: null },
       });
 
-      expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
+      expect(hasPermission(state, STATIC_THEMES_REVIEW)).toEqual(false);
     });
 
     it('returns `false` when user is not logged in', () => {
       const { state } = dispatchClientMetadata();
 
-      expect(hasPermission(state, THEMES_REVIEW)).toEqual(false);
+      expect(hasPermission(state, STATIC_THEMES_REVIEW)).toEqual(false);
     });
 
     it('returns `true` when user is admin', () => {
       const permissions = [ALL_SUPER_POWERS];
       const { state } = dispatchSignInActions({ userProps: { permissions } });
 
-      expect(hasPermission(state, THEMES_REVIEW)).toEqual(true);
+      expect(hasPermission(state, STATIC_THEMES_REVIEW)).toEqual(true);
     });
 
     it('returns `true` when user has a broad permission', () => {
@@ -391,13 +388,6 @@ describe(__filename, () => {
   });
 
   describe('hasAnyReviewerRelatedPermission selector', () => {
-    it('returns `true` when user has ADDONS_POST_REVIEW', () => {
-      const permissions = [ADDONS_POST_REVIEW, STATS_VIEW];
-      const { state } = dispatchSignInActions({ userProps: { permissions } });
-
-      expect(hasAnyReviewerRelatedPermission(state)).toEqual(true);
-    });
-
     it('returns `true` when user has ADDONS_CONTENT_REVIEW', () => {
       const permissions = [STATS_VIEW, ADDONS_CONTENT_REVIEW];
       const { state } = dispatchSignInActions({ userProps: { permissions } });


### PR DESCRIPTION
Fixes #9788.

This patch removes obsolete permissions and adapts related permission checks.