### PR TITLE
Fix smoke tests

### DIFF
--- a/tests/smoke/docker-compose.functional-tests.yml
+++ b/tests/smoke/docker-compose.functional-tests.yml
@@ -1,0 +1,10 @@
+# This file is used to override the docker-compose file from addons-server.
+# It will build the current commit into a image and use that for creating
+# a AMO frontend for testing.
+version: "2.4"
+
+services:
+  addons-frontend:
+    image: addons-frontend
+    build: ../.
+    # This should build a local image if it isn't built already.

--- a/tests/smoke/setup_docker.sh
+++ b/tests/smoke/setup_docker.sh
@@ -2,14 +2,14 @@
 set -x
 git clone --depth 1 https://github.com/mozilla/addons-server.git
 docker build -f addons-server/Dockerfile --build-arg GROUP_ID=$(id -g) --build-arg USER_ID=$(id -u) -t addons/addons-server:latest addons-server/
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml up -d --build
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml ps
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml up -d --build
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml ps
 sudo chown -R  $USER:$USER .
 # Make sure dependencies get updated in worker and web container
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml exec worker make -f Makefile-docker update_deps update_assets
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml restart worker
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml exec web make -f Makefile-docker update_deps update_assets
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml restart web
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml exec web make setup-ui-tests
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml stop nginx
-docker-compose -f addons-server/docker-compose.yml -f tests/ui/docker-compose.functional-tests.yml up -d
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml exec worker make -f Makefile-docker update_deps update_assets
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml restart worker
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml exec web make -f Makefile-docker update_deps update_assets
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml restart web
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml exec web make setup-ui-tests
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml stop nginx
+docker-compose -f addons-server/docker-compose.yml -f docker-compose.functional-tests.yml up -d


### PR DESCRIPTION
Looks like a docker file in a different folder was used for the smoke tests. This only runs on circle-ci.