### PR TITLE
Get rid of the `NODE_APP_INSTANCE` env var requirement, and some code that is needed for multiple apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       env: COMMAND=build-ci
     - stage:
       <<: *node-next
-      env: COMMAND=build-all
+      env: COMMAND=build
     # Run the unit/integration tests.
     - stage:
       <<: *node-prod

--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ The following are scripts that are used in deployment - you generally won't need
 
 The env vars are:
 
-- `NODE_APP_INSTANCE`: the name of the app, e.g., `amo`
 - `NODE_ENV`: the node environment, e.g. `production` or `development`
 - `NODE_CONFIG_ENV`: the name of the configuration to load, e.g., `dev`, `stage`, `prod`
 
@@ -296,11 +295,11 @@ The env vars are:
 | yarn start | Starts the express server (requires env vars)  |
 | yarn build | Builds the libs (all apps) (requires env vars) |
 
-**Example:** Building and running a production instance of the AMO app:
+**Example:** Building and running a production instance of the app:
 
 ```
-NODE_APP_INSTANCE=amo NODE_ENV=production NODE_CONFIG_ENV=prod yarn build
-NODE_APP_INSTANCE=amo NODE_ENV=production NODE_CONFIG_ENV=prod yarn start
+NODE_ENV=production NODE_CONFIG_ENV=prod yarn build
+NODE_ENV=production NODE_CONFIG_ENV=prod yarn start
 ```
 
 **Note: To run the app locally in production mode you'll need to create a config file for local production builds.** It must be saved as `config/local-prod-amo.js` and should look like:

--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ Here are some commands you can run:
 | yarn amo:dev-https | Same as `amo:dev` but with HTTPS, available at: https://example.com:3000/. [Read about setting up this environment](docs/moz-addon-manager.md#developing-with-a-local-https-server-recommended) |
 | yarn amo:no-proxy | Start the dev server without a proxy (for amo) using data from Docker |
 | yarn amo:stage | Start the dev server/proxy (for amo) using data from the staging server (https://addons.allizom.org/) |
-| yarn build | Build an app specified with the `NODE_APP_INSTANCE` environment variable. |
-| yarn build-all | Build all the applications. |
-| yarn build-ci | Run the `build-all` and `bundlesize` npm scripts. |
+| yarn build | Build the app. |
+| yarn build-ci | Run the `build` and `bundlesize` npm scripts. |
 | yarn bundlesize | Run [bundlesize][] to check the generated AMO bundle sizes. [Building AMO is required first](#building-and-running-services). |
 | yarn flow | Run Flow. By default this checks for errors and exits |
 | yarn flow:check | Explicitly check for Flow errors and exit |

--- a/bin/build-checks.js
+++ b/bin/build-checks.js
@@ -9,7 +9,7 @@ const appName = config.get('appName');
 
 // Bail if appName isn't set.
 if (!appName) {
-  console.log(chalk.red('Please specify the appName with NODE_APP_INSTANCE'));
+  console.log(chalk.red('appName not set in config'));
   process.exit(1);
 }
 

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -19,7 +19,7 @@ const { oneLine } = require('common-tags');
 const appName = config.get('appName');
 
 if (!appName) {
-  console.log(chalk.red('Please specify the appName with NODE_APP_INSTANCE'));
+  console.log(chalk.red('appName not set in config'));
   process.exit(1);
 }
 
@@ -61,36 +61,32 @@ poFiles.forEach((pofile) => {
   });
   const localeObject = JSON.parse(json);
 
-  // Add the moment locale JS into our locale file, if one is available and
-  // we're building for AMO (which is the only app that uses moment right
-  // now).
-  if (appName === 'amo') {
-    var defineLocale = null;
-    try {
-      const localeModulePath = getLocaleModulePath(locale);
+  // Add the moment locale JS into our locale file, if one is available.
+  var defineLocale = null;
+  try {
+    const localeModulePath = getLocaleModulePath(locale);
 
-      // Check for the locale first; if it doesn't exist we don't have
-      // a moment locale that matches.
-      fs.accessSync(`./node_modules/${localeModulePath}.js`);
+    // Check for the locale first; if it doesn't exist we don't have
+    // a moment locale that matches.
+    fs.accessSync(`./node_modules/${localeModulePath}.js`);
 
-      // We're using `new Function()` here to create a function out of the
-      // raw code; this function won't be executed but will be written out by
-      // `toSource()` so that it can be used later (at runtime, by moment).
-      defineLocale = new Function(`
-        // By requiring this module, the new locale is defined and
-        // registered internally for moment.js
-        require('${localeModulePath}');`);
-    } catch (e) {
-      // We ignore missing locale errors for en_US as its moment's default
-      // locale so we don't need to provide a translation.
-      if (locale !== 'en_US') {
-        console.info(oneLine`No moment i18n available for ${locale};
-          consider adding one or creating a mapping.`);
-      }
+    // We're using `new Function()` here to create a function out of the
+    // raw code; this function won't be executed but will be written out by
+    // `toSource()` so that it can be used later (at runtime, by moment).
+    defineLocale = new Function(`
+      // By requiring this module, the new locale is defined and
+      // registered internally for moment.js
+      require('${localeModulePath}');`);
+  } catch (e) {
+    // We ignore missing locale errors for en_US as its moment's default
+    // locale so we don't need to provide a translation.
+    if (locale !== 'en_US') {
+      console.info(oneLine`No moment i18n available for ${locale};
+        consider adding one or creating a mapping.`);
     }
-
-    localeObject._momentDefineLocale = defineLocale;
   }
+
+  localeObject._momentDefineLocale = defineLocale;
 
   // This is used to force cache-busting of the JS via changing all locale JS.
   // DO NOT REMOVE! See https://github.com/mozilla/addons-frontend/issues/4927

--- a/bin/create-locales
+++ b/bin/create-locales
@@ -24,7 +24,7 @@ const appName = config.get('appName');
 
 if (!appName) {
   console.log(
-    chalk.red('Please specify the appName with NODE_APP_INSTANCE'));
+    chalk.red('appName not set in config'));
   process.exit(1);
 }
 

--- a/bin/merge-locales
+++ b/bin/merge-locales
@@ -14,7 +14,7 @@ const appName = config.get('appName');
 
 if (!appName) {
   console.log(
-    chalk.red('Please specify the appName with NODE_APP_INSTANCE'));
+    chalk.red('appName not set in config'));
   process.exit(1);
 }
 

--- a/bin/run-l10n-extraction
+++ b/bin/run-l10n-extraction
@@ -28,68 +28,73 @@ error() {
   exit 1
 }
 
+run_l10n_extraction() {
+  local branch="amo-locales"
+
+  info "Starting l10n extraction"
+
+  # Detect local (uncommitted) changes.
+  if [[ ! -z "$GIT_CHANGES" ]]; then
+    error "You have local changes, therefore this script cannot continue."
+  fi
+
+  # Switch to the `master` branch if we are not on it already.
+  if [[ "$INITIAL_GIT_BRANCH" != "master" ]]; then
+    git checkout master
+  fi
+
+  # Make sure the 'master' branch is up-to-date.
+  git pull "$GIT_REMOTE" master
+
+  # Update dependencies
+  yarn >> "$LOG_FILE" 2>&1
+
+  # Ensure the branch to extract the locales is clean.
+  if [[ $(git branch --list "$branch") ]]; then
+    info "Deleting branch '$branch' because it already exists"
+    git branch -D "$branch"
+  fi
+
+  info "Creating and switching to branch '$branch'"
+  git checkout -b "$branch"
+
+  info "Extracting locales (this can take several minutes)"
+  bin/extract-locales >> "$LOG_FILE" 2>&1
+
+  local git_diff_stat
+  git_diff_stat=$(git diff --shortstat)
+
+  if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
+    info "No locale changes, nothing to update, ending process"
+    git checkout -- .
+    git checkout "$INITIAL_GIT_BRANCH"
+    git branch -d "$branch"
+    return
+  fi
+
+  git commit -a -m "Extract locales"
+
+  info "Merging locales"
+  bin/merge-locales >> "$LOG_FILE" 2>&1
+
+  git commit -a -m "Merge locales"
+
+  # We use force-push in case the branch already exists.
+  git push -f "$GIT_REMOTE" "$branch"
+
+  git checkout "$INITIAL_GIT_BRANCH"
+  git branch -D "$branch"
+
+  echo ""
+  echo "----------------------------------------------------------------------"
+  echo ""
+  echo "     You can now open the link below to submit your Pull Request:"
+  echo "     https://github.com/mozilla/addons-frontend/pull/new/$branch"
+  echo ""
+  echo "----------------------------------------------------------------------"
+}
+
 # Clear log file
 echo "" > "$LOG_FILE"
 
-branch="amo-locales"
-
-info "Starting l10n extraction"
-
-# Detect local (uncommitted) changes.
-if [[ ! -z "$GIT_CHANGES" ]]; then
-  error "You have local changes, therefore this script cannot continue."
-fi
-
-# Switch to the `master` branch if we are not on it already.
-if [[ "$INITIAL_GIT_BRANCH" != "master" ]]; then
-  git checkout master
-fi
-
-# Make sure the 'master' branch is up-to-date.
-git pull "$GIT_REMOTE" master
-
-# Update dependencies
-yarn >> "$LOG_FILE" 2>&1
-
-# Ensure the branch to extract the locales is clean.
-if [[ $(git branch --list "$branch") ]]; then
-  info "Deleting branch '$branch' because it already exists"
-  git branch -D "$branch"
-fi
-
-info "Creating and switching to branch '$branch'"
-git checkout -b "$branch"
-
-info "Extracting locales (this can take several minutes)"
-bin/extract-locales >> "$LOG_FILE" 2>&1
-
-git_diff_stat=$(git diff --shortstat)
-
-if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
-  info "No locale changes, nothing to update, ending process"
-  git checkout -- .
-  git checkout "$INITIAL_GIT_BRANCH"
-  git branch -d "$branch"
-  return
-fi
-
-git commit -a -m "Extract locales"
-
-info "Merging locales"
-bin/merge-locales >> "$LOG_FILE" 2>&1
-
-git commit -a -m "Merge locales"
-
-# We use force-push in case the branch already exists.
-git push -f "$GIT_REMOTE" "$branch"
-
-git checkout "$INITIAL_GIT_BRANCH"
-git branch -D "$branch"
-
-echo ""
-echo "----------------------------------------------------------------------"
-echo ""
-echo "     You can now open the link below to submit your Pull Request:"
-echo "     https://github.com/mozilla/addons-frontend/pull/new/$branch"
-echo ""
-echo "----------------------------------------------------------------------"
+run_l10n_extraction

--- a/bin/run-l10n-extraction
+++ b/bin/run-l10n-extraction
@@ -28,74 +28,68 @@ error() {
   exit 1
 }
 
-run_l10n_extraction() {
-  local app="$1"
-  local branch="$app-locales"
-
-  info "Starting l10n extraction for $app"
-
-  # Detect local (uncommitted) changes.
-  if [[ ! -z "$GIT_CHANGES" ]]; then
-    error "You have local changes, therefore this script cannot continue."
-  fi
-
-  # Switch to the `master` branch if we are not on it already.
-  if [[ "$INITIAL_GIT_BRANCH" != "master" ]]; then
-    git checkout master
-  fi
-
-  # Make sure the 'master' branch is up-to-date.
-  git pull "$GIT_REMOTE" master
-
-  # Update dependencies
-  yarn >> "$LOG_FILE" 2>&1
-
-  # Ensure the branch to extract the locales is clean.
-  if [[ $(git branch --list "$branch") ]]; then
-    info "Deleting branch '$branch' because it already exists"
-    git branch -D "$branch"
-  fi
-
-  info "Creating and switching to branch '$branch'"
-  git checkout -b "$branch"
-
-  info "Extracting locales (this can take several minutes)"
-  NODE_APP_INSTANCE="$app" bin/extract-locales >> "$LOG_FILE" 2>&1
-
-  local git_diff_stat
-  git_diff_stat=$(git diff --shortstat)
-
-  if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
-    info "No locale changes for $app, nothing to update, ending process for $app"
-    git checkout -- .
-    git checkout "$INITIAL_GIT_BRANCH"
-    git branch -d "$branch"
-    return
-  fi
-
-  git commit -a -m "Extract $app locales"
-
-  info "Merging locales"
-  NODE_APP_INSTANCE="$app" bin/merge-locales >> "$LOG_FILE" 2>&1
-
-  git commit -a -m "Merge $app locales"
-
-  # We use force-push in case the branch already exists.
-  git push -f "$GIT_REMOTE" "$branch"
-
-  git checkout "$INITIAL_GIT_BRANCH"
-  git branch -D "$branch"
-
-  echo ""
-  echo "----------------------------------------------------------------------"
-  echo ""
-  echo "     You can now open the link below to submit your Pull Request:"
-  echo "     https://github.com/mozilla/addons-frontend/pull/new/$branch"
-  echo ""
-  echo "----------------------------------------------------------------------"
-}
-
 # Clear log file
 echo "" > "$LOG_FILE"
 
-run_l10n_extraction "amo"
+branch="amo-locales"
+
+info "Starting l10n extraction"
+
+# Detect local (uncommitted) changes.
+if [[ ! -z "$GIT_CHANGES" ]]; then
+  error "You have local changes, therefore this script cannot continue."
+fi
+
+# Switch to the `master` branch if we are not on it already.
+if [[ "$INITIAL_GIT_BRANCH" != "master" ]]; then
+  git checkout master
+fi
+
+# Make sure the 'master' branch is up-to-date.
+git pull "$GIT_REMOTE" master
+
+# Update dependencies
+yarn >> "$LOG_FILE" 2>&1
+
+# Ensure the branch to extract the locales is clean.
+if [[ $(git branch --list "$branch") ]]; then
+  info "Deleting branch '$branch' because it already exists"
+  git branch -D "$branch"
+fi
+
+info "Creating and switching to branch '$branch'"
+git checkout -b "$branch"
+
+info "Extracting locales (this can take several minutes)"
+bin/extract-locales >> "$LOG_FILE" 2>&1
+
+git_diff_stat=$(git diff --shortstat)
+
+if [[ -z "$git_diff_stat" ]] || [[ "$git_diff_stat" == *"$DIFF_WITH_ONE_LINE_CHANGE"* ]]; then
+  info "No locale changes, nothing to update, ending process"
+  git checkout -- .
+  git checkout "$INITIAL_GIT_BRANCH"
+  git branch -d "$branch"
+  return
+fi
+
+git commit -a -m "Extract locales"
+
+info "Merging locales"
+bin/merge-locales >> "$LOG_FILE" 2>&1
+
+git commit -a -m "Merge locales"
+
+# We use force-push in case the branch already exists.
+git push -f "$GIT_REMOTE" "$branch"
+
+git checkout "$INITIAL_GIT_BRANCH"
+git branch -D "$branch"
+
+echo ""
+echo "----------------------------------------------------------------------"
+echo ""
+echo "     You can now open the link below to submit your Pull Request:"
+echo "     https://github.com/mozilla/addons-frontend/pull/new/$branch"
+echo ""
+echo "----------------------------------------------------------------------"

--- a/bin/server.js
+++ b/bin/server.js
@@ -14,7 +14,7 @@ const appName = config.get('appName');
 
 if (!appName) {
   console.log(
-    chalk.red('Please specify the appName with NODE_APP_INSTANCE'));
+    chalk.red('appName not set in config'));
   process.exit(1);
 }
 

--- a/config/default.js
+++ b/config/default.js
@@ -6,15 +6,9 @@ import path from 'path';
 
 import { addonsServerProdCDN, analyticsHost, prodDomain, apiProdHost, baseUrlProd, sentryHost } from './lib/shared';
 
-const appName = process.env.NODE_APP_INSTANCE || null;
-const validAppNames = [
-  'amo',
-];
-
-// Throw if the appName supplied is not valid.
-if (appName && !validAppNames.includes(appName)) {
-  throw new Error(
-    `App "${appName}" is not enabled; valid app names: ${validAppNames}`);
+const appName = 'amo';
+if (!appName) {
+  throw new Error('An appName is required.');
 }
 
 const addonsFrontendCDN = 'https://addons-amo.cdn.mozilla.net';
@@ -70,9 +64,6 @@ module.exports = {
   // Disable this in development when working with stage data, which is
   // very out-of-date and mostly not 57+ compatible.
   restrictSearchResultsToAppVersion: true,
-
-  // The canonical list of enabled apps.
-  validAppNames,
 
   // The node server host and port.
   serverHost: '127.0.0.1',

--- a/config/development.js
+++ b/config/development.js
@@ -38,8 +38,6 @@ module.exports = {
 
   enableStrictMode: true,
 
-  // I had to add this to get it to work, but I think there's a better way.
-  proxyPort: 3000,
   serverPort: 3000,
   webpackServerHost,
   webpackServerPort,

--- a/config/development.js
+++ b/config/development.js
@@ -38,6 +38,8 @@ module.exports = {
 
   enableStrictMode: true,
 
+  // I had to add this to get it to work, but I think there's a better way.
+  proxyPort: 3000,
   serverPort: 3000,
   webpackServerHost,
   webpackServerPort,

--- a/config/test.js
+++ b/config/test.js
@@ -4,7 +4,6 @@ const fixturesPath = path.join(__dirname, '..', 'tests', '__fixtures__');
 
 // Put any test configuration overrides here.
 module.exports = {
-  appName: 'test-app-set-from-config',
   // No test should touch the API so seeing this would indicate a bug.
   apiHost: 'http://if-you-see-this-host-file-a-bug',
   allowErrorSimulation: true,

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -7,8 +7,6 @@ Some commands wrap standard gettext tools. To run these commands you'll need to 
 - Run `yarn` to install all the project dependencies.
 - Install the [gettext](https://www.gnu.org/software/gettext/) tools for your platform and make sure they're on your `$PATH` by checking the output of `which gettext`.
 
-_NOTE: All the instructions below show `[MY_APP]`; replace that with the name of the app you are updating, e.g. `NODE_APP_INSTANCE=disco bin/create-locales`_
-
 ## Adding a new language/locale
 
 The supported languages are defined in the configuration. See [`config/default.js`](https://bit.ly/1XScjwq) and look for the `langs` list.
@@ -17,7 +15,7 @@ Add the new language to the list and then run:
 
 ```
 # create the locale for a newly added language.
-NODE_APP_INSTANCE=[MY_APP] NODE_PATH='./:./src' bin/create-locales
+NODE_PATH='./:./src' bin/create-locales
 ```
 
 ## Updating locales
@@ -28,7 +26,7 @@ TL;DR: run the following script from the `master` branch: `./bin/run-l10n-extrac
 
 Once a week right after the forthcoming release [is tagged](http://addons.readthedocs.io/en/latest/server/push-duty.html), the locales for each app must be generated.
 
-This is a semi-automated process: a team member must create one pull request _per application_ with the following commits:
+This is a semi-automated process: a team member must create a pull request with the following commits:
 
 1.  A commit containing the extraction of newly added strings
 2.  A commit containing a merge of localizations
@@ -37,13 +35,13 @@ Each one of these steps are detailed in the sections below. Let's begin...
 
 #### Extracting newly added strings
 
-Start the process by creating a git branch and extracting the locales for a given app. This uses `amo` as an example app but you would need to repeat the process in a new branch for `disco` and any other activate application (example: `NODE_APP_INSTANCE=disco ...`).
+Start the process by creating a git branch and extracting the locales.
 
 ```
 git checkout master
 git pull
 git checkout -b amo-locales
-NODE_APP_INSTANCE=amo bin/extract-locales
+bin/extract-locales
 ```
 
 This extracts all strings wrapped with `i18n.gettext()` or any other function supported by [Jed][jed] (the library we use in JavaScript to carry out replacements for the string keys in the current locale).
@@ -79,7 +77,7 @@ git commit -a -m "Extract AMO locales"
 After extracting new strings, you have to merge them into the existing locale files. Do this in your branch and commit:
 
 ```
-NODE_APP_INSTANCE=amo bin/merge-locales
+bin/merge-locales
 ```
 
 Keep an eye out for [fuzzy strings](https://www.gnu.org/software/gettext/manual/html_node/Fuzzy-Entries.html) by running `git diff` and searching for a comment that looks like `# fuzzy`. This comment means the localization may not exactly match the source text; a localizer needs to review it. As per our configuration, the application will not display fuzzy translations. These strings will fall back to English.
@@ -100,7 +98,7 @@ Now that you have extracted and merged locales for one application, it's time to
 git push origin amo-locales
 ```
 
-If the pull request passes all of our CI tests it is likely good to merge. You don't need to ask for a review unless you're unsure of something because often locale updates will be thousands of lines of minor diffs that can't be reasonably reviewed by a human. 🙂 If the pull request passes all of our CI tests it is likely good to merge. If necessary, repeat the process for the next application (eg. `amo`, `disco`, etc.).
+If the pull request passes all of our CI tests it is likely good to merge. You don't need to ask for a review unless you're unsure of something because often locale updates will be thousands of lines of minor diffs that can't be reasonably reviewed by a human. 🙂 If the pull request passes all of our CI tests it is likely good to merge.
 
 #### Building the JS locale files
 
@@ -110,7 +108,7 @@ Since dist files are created when needed you only need to build and commit the J
 
 ```
 # build the JSON.
-NODE_APP_INSTANCE=[MY_APP] bin/build-locales
+bin/build-locales
 ```
 
 ## Setting up translations

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,3 @@
 - [Internationalization (i18n)](./i18n.md)
 - [Our Approach to Writing CSS](./css.md)
 - [Testing](./testing.md)
-- [Hybrid Content Telemetry (disco pane)](./telemetry.md)

--- a/docs/moz-addon-manager.md
+++ b/docs/moz-addon-manager.md
@@ -1,6 +1,6 @@
 # Develop features for mozAddonManager
 
-The AMO and Discovery Pane apps use the [`mozAddonManager`](https://bugzilla.mozilla.org/show_bug.cgi?id=1310752) web API to achieve a more seamless add-on installation user experience. However, this API is only available to a limited list of domains. If you go to https://addons.mozilla.org (production) in Firefox then `mozAddonManager` is available on the page. If you go to a non-production site (local, development or staging) then it's not by default.
+The AMO app uses the [`mozAddonManager`](https://bugzilla.mozilla.org/show_bug.cgi?id=1310752) web API to achieve a more seamless add-on installation user experience. However, this API is only available to a limited list of domains. If you go to https://addons.mozilla.org (production) in Firefox then `mozAddonManager` is available on the page. If you go to a non-production site (local, development or staging) then it's not by default.
 
 ## Turning on mozAddonManager in -dev and -stage environments
 
@@ -64,7 +64,7 @@ It is possible to serve the local development version of this project with HTTPS
 5. Start `addons-frontend` with the command below:
 
    ```
-   yarn amo:dev-https  # or yarn disco:https for Disco Pane
+   yarn amo:dev-https
    ```
 
 This allows you to browse the project at https://example.com:3000/ (and not `localhost`).

--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
   },
   "scripts": {
     "build": "npm run clean && better-npm-run build",
-    "build-all": "npm run clean && NODE_APP_INSTANCE=amo better-npm-run build",
     "build-check": "bin/build-checks.js",
-    "build-ci": "npm run build-all && npm run bundlesize",
+    "build-ci": "npm run build && npm run bundlesize",
     "build-locales": "bin/build-locales",
     "bundlesize": "bundlesize",
     "extract-locales": "better-npm-run extract-locales",
@@ -37,7 +36,7 @@
     "storybook-build": "better-npm-run storybook-build",
     "storybook-deploy": "storybook-to-ghpages --script storybook-build",
     "storybook-smoke-test": "better-npm-run storybook-smoke-test",
-    "test-ci": "bin/config-check.js && NODE_APP_INSTANCE=amo npm run build-locales && better-npm-run test-ci && codecov",
+    "test-ci": "bin/config-check.js && npm run build-locales && better-npm-run test-ci && codecov",
     "test": "bin/config-check.js && better-npm-run jest --watch",
     "test-coverage": "bin/config-check.js && better-npm-run jest --coverage --watch",
     "test-coverage-once": "bin/config-check.js && better-npm-run jest --coverage",
@@ -54,17 +53,13 @@
       }
     },
     "amo": {
-      "command": "better-npm-run start-dev-proxy",
-      "env": {
-        "NODE_APP_INSTANCE": "amo"
-      }
+      "command": "better-npm-run start-dev-proxy"
     },
     "amo:dev": {
       "command": "better-npm-run start-dev-proxy",
       "env": {
         "AMO_CDN": "https://addons-dev-cdn.allizom.org",
-        "PROXY_API_HOST": "https://addons-dev.allizom.org",
-        "NODE_APP_INSTANCE": "amo"
+        "PROXY_API_HOST": "https://addons-dev.allizom.org"
       }
     },
     "amo:dev-https": {
@@ -79,14 +74,12 @@
     "amo:ui-tests": {
       "command": "better-npm-run start-dev-proxy",
       "env": {
-        "NODE_APP_INSTANCE": "amo",
         "NODE_ENV": "production"
       }
     },
     "amo:no-proxy": {
       "command": "better-npm-run start-dev",
       "env": {
-        "NODE_APP_INSTANCE": "amo",
         "PROXY_ENABLED": "false"
       }
     },
@@ -96,8 +89,7 @@
         "AMO_CDN": "https://addons-stage-cdn.allizom.org",
         "PROXY_API_HOST": "https://addons.allizom.org",
         "FXA_CONFIG": "local",
-        "CSP": false,
-        "NODE_APP_INSTANCE": "amo"
+        "CSP": false
       }
     },
     "extract-locales": {

--- a/src/core/components/ServerHtml/index.js
+++ b/src/core/components/ServerHtml/index.js
@@ -114,13 +114,13 @@ export default class ServerHtml extends Component {
   }
 
   renderStyles() {
-    const { chunkExtractor } = this.props;
+    const { _config, chunkExtractor } = this.props;
 
     return chunkExtractor
       .getMainAssets('style')
       .filter(
         // We render the main bundle with `getScript()`, so we skip it here.
-        (asset) => asset.chunk !== 'amo',
+        (asset) => asset.chunk !== _config.get('appName'),
       )
       .map((asset) => {
         const sriProps = this.getSriProps(asset.filename);
@@ -169,13 +169,13 @@ export default class ServerHtml extends Component {
   }
 
   renderAsyncScripts() {
-    const { chunkExtractor } = this.props;
+    const { _config, chunkExtractor } = this.props;
 
     return chunkExtractor
       .getMainAssets('script')
       .filter(
         // We render the main bundle with `getScript()`, so we skip it here.
-        (asset) => asset.chunk !== 'amo',
+        (asset) => asset.chunk !== _config.get('appName'),
       )
       .map((asset) => {
         const sriProps = this.getSriProps(asset.filename);

--- a/src/core/components/ServerHtml/index.js
+++ b/src/core/components/ServerHtml/index.js
@@ -114,13 +114,13 @@ export default class ServerHtml extends Component {
   }
 
   renderStyles() {
-    const { _config, chunkExtractor } = this.props;
+    const { chunkExtractor } = this.props;
 
     return chunkExtractor
       .getMainAssets('style')
       .filter(
         // We render the main bundle with `getScript()`, so we skip it here.
-        (asset) => !_config.get('validAppNames').includes(asset.chunk),
+        (asset) => asset.chunk !== 'amo',
       )
       .map((asset) => {
         const sriProps = this.getSriProps(asset.filename);
@@ -169,13 +169,13 @@ export default class ServerHtml extends Component {
   }
 
   renderAsyncScripts() {
-    const { _config, chunkExtractor } = this.props;
+    const { chunkExtractor } = this.props;
 
     return chunkExtractor
       .getMainAssets('script')
       .filter(
         // We render the main bundle with `getScript()`, so we skip it here.
-        (asset) => !_config.get('validAppNames').includes(asset.chunk),
+        (asset) => asset.chunk !== 'amo',
       )
       .map((asset) => {
         const sriProps = this.getSriProps(asset.filename);

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -263,7 +263,6 @@ function baseServer(
       }
 
       const isAnonymousPage =
-        appName === 'amo' &&
         config
           .get('anonymousPagePatterns')
           .filter((pattern) => new RegExp(pattern).test(req.originalUrl))
@@ -493,9 +492,7 @@ export function runServer({
 
   return new Promise((resolve) => {
     if (!appName) {
-      throw new Error(
-        `Please specify a valid appName from ${config.get('validAppNames')}`,
-      );
+      throw new Error(`Please specify an appName in config`);
     }
     resolve();
   })

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -164,13 +164,11 @@ function baseServer(
     _HotShots,
     _createHistory = createHistory,
     _log = log,
-    appInstanceName = null,
     appSagas,
     config = defaultConfig,
   } = {},
 ) {
-  const appName =
-    appInstanceName !== null ? appInstanceName : config.get('appName');
+  const appName = config.get('appName');
 
   const app = new Express();
   app.disable('x-powered-by');
@@ -506,9 +504,7 @@ export function runServer({
         const App = require(`${appName}/components/App`).default;
         const createStore = require(`${appName}/store`).default;
         /* eslint-enable global-require, import/no-dynamic-require */
-        let server = baseServer(App, createStore, {
-          appInstanceName: appName,
-        });
+        let server = baseServer(App, createStore);
         if (listen === true) {
           if (useHttpsForDev) {
             if (host === 'example.com') {

--- a/tests/__fixtures__/loadable-stats.json
+++ b/tests/__fixtures__/loadable-stats.json
@@ -1,6 +1,6 @@
 {
   "namedChunkGroups": {
-    "test-app-set-from-config": {
+    "amo": {
       "assets": [],
       "childAssets": {
         "preload": []

--- a/tests/unit/core/components/TestServerHtml.js
+++ b/tests/unit/core/components/TestServerHtml.js
@@ -204,16 +204,14 @@ describe(__filename, () => {
       expect(link).toHaveProp('rel', 'stylesheet');
     });
 
-    it('excludes the main bundle', () => {
-      const _config = getFakeConfig({ validAppNames: ['main'] });
-
+    it('excludes the amo bundle', () => {
       const fooAsset = { chunk: 'foo', url: '/foo.css' };
-      const mainAsset = { chunk: 'main', url: '/main.css' };
+      const mainAsset = { chunk: 'amo', url: '/main.css' };
       const chunkExtractor = createFakeChunkExtractor({
         getMainAssets: () => [fooAsset, mainAsset],
       });
 
-      const root = render({ _config, chunkExtractor, includeSri: false });
+      const root = render({ chunkExtractor, includeSri: false });
 
       expect(root.find('link[data-chunk]')).toHaveLength(1);
       expect(root.find(`link[data-chunk="${mainAsset.chunk}"]`)).toHaveLength(
@@ -300,16 +298,14 @@ describe(__filename, () => {
       expect(link).toHaveProp('src', asset.url);
     });
 
-    it('excludes the main bundle', () => {
-      const _config = getFakeConfig({ validAppNames: ['main'] });
-
+    it('excludes the amo bundle', () => {
       const fooAsset = { chunk: 'foo', url: '/foo.js' };
-      const mainAsset = { chunk: 'main', url: '/main.js' };
+      const mainAsset = { chunk: 'amo', url: '/main.js' };
       const chunkExtractor = createFakeChunkExtractor({
         getMainAssets: () => [fooAsset, mainAsset],
       });
 
-      const root = render({ _config, chunkExtractor, includeSri: false });
+      const root = render({ chunkExtractor, includeSri: false });
 
       expect(root.find('script[data-chunk]')).toHaveLength(1);
       expect(root.find(`script[data-chunk="${mainAsset.chunk}"]`)).toHaveLength(

--- a/tests/unit/core/middleware/test_cspMiddleware.js
+++ b/tests/unit/core/middleware/test_cspMiddleware.js
@@ -122,7 +122,7 @@ describe(__filename, () => {
       middleware(req, res, nextSpy);
       const cspHeader = res.get('content-security-policy');
       const policy = parse(cspHeader);
-      const cdnHost = 'https://addons.cdn.mozilla.net';
+      const cdnHost = 'https://addons-amo.cdn.mozilla.net';
       expect(policy['style-src']).toEqual([cdnHost]);
       sinon.assert.calledOnce(nextSpy);
     });

--- a/tests/unit/core/middleware/test_cspMiddleware.js
+++ b/tests/unit/core/middleware/test_cspMiddleware.js
@@ -21,14 +21,9 @@ const apiHosts = {
 
 describe(__filename, () => {
   const existingNodeEnv = process.env.NODE_ENV;
-  const existingNodeAppInstance = process.env.NODE_APP_INSTANCE;
 
   afterEach(() => {
     process.env.NODE_ENV = existingNodeEnv;
-    delete process.env.NODE_APP_INSTANCE;
-    if (existingNodeAppInstance) {
-      process.env.NODE_APP_INSTANCE = existingNodeAppInstance;
-    }
   });
 
   describe('CSP Config', () => {
@@ -117,7 +112,6 @@ describe(__filename, () => {
   describe('CSP Middleware', () => {
     it('provides the expected style-src directive', () => {
       process.env.NODE_ENV = 'prod';
-      process.env.NODE_APP_INSTANCE = 'amo';
       jest.resetModules();
       // eslint-disable-next-line global-require
       const config = require('config');
@@ -128,7 +122,7 @@ describe(__filename, () => {
       middleware(req, res, nextSpy);
       const cspHeader = res.get('content-security-policy');
       const policy = parse(cspHeader);
-      const cdnHost = 'https://addons-amo.cdn.mozilla.net';
+      const cdnHost = 'https://addons.cdn.mozilla.net';
       expect(policy['style-src']).toEqual([cdnHost]);
       sinon.assert.calledOnce(nextSpy);
     });

--- a/tests/unit/core/middleware/test_frameguardMiddleware.js
+++ b/tests/unit/core/middleware/test_frameguardMiddleware.js
@@ -10,7 +10,7 @@ describe(__filename, () => {
     process.env.NODE_ENV = existingNodeEnv;
   });
 
-  it(`provides the expected x-frame-options headers`, () => {
+  it('provides the expected x-frame-options headers', () => {
     process.env.NODE_ENV = 'production';
     jest.resetModules();
     // eslint-disable-next-line global-require

--- a/tests/unit/core/middleware/test_frameguardMiddleware.js
+++ b/tests/unit/core/middleware/test_frameguardMiddleware.js
@@ -1,36 +1,28 @@
-import config from 'config';
 import MockExpressRequest from 'mock-express-request';
 import MockExpressResponse from 'mock-express-response';
 
 import { frameguard } from 'core/middleware';
-
-const appsList = config.get('validAppNames');
 
 describe(__filename, () => {
   const existingNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {
     process.env.NODE_ENV = existingNodeEnv;
-    delete process.env.NODE_APP_INSTANCE;
   });
 
-  for (const appName of appsList) {
-    // eslint-disable-next-line no-loop-func
-    it(`provides the expected x-frame-options headers for ${appName}`, () => {
-      process.env.NODE_ENV = 'production';
-      process.env.NODE_APP_INSTANCE = appName;
-      jest.resetModules();
-      // eslint-disable-next-line global-require
-      const conf = require('config');
-      const middleware = frameguard({ _config: conf });
-      const nextSpy = sinon.stub();
-      const req = new MockExpressRequest();
-      const res = new MockExpressResponse();
-      middleware(req, res, nextSpy);
-      expect(res.get('x-frame-options')).toEqual('DENY');
-      sinon.assert.calledOnce(nextSpy);
-    });
-  }
+  it(`provides the expected x-frame-options headers`, () => {
+    process.env.NODE_ENV = 'production';
+    jest.resetModules();
+    // eslint-disable-next-line global-require
+    const conf = require('config');
+    const middleware = frameguard({ _config: conf });
+    const nextSpy = sinon.stub();
+    const req = new MockExpressRequest();
+    const res = new MockExpressResponse();
+    middleware(req, res, nextSpy);
+    expect(res.get('x-frame-options')).toEqual('DENY');
+    sinon.assert.calledOnce(nextSpy);
+  });
 
   it('does not blow up if optional args not defined', () => {
     frameguard();

--- a/tests/unit/core/server/test_base.js
+++ b/tests/unit/core/server/test_base.js
@@ -94,7 +94,6 @@ export class ServerTestHelper {
 
   testClient({
     App = StubApp,
-    appInstanceName = 'testapp',
     store = null,
     sagaMiddleware = null,
     appSagas = null,
@@ -114,7 +113,6 @@ export class ServerTestHelper {
 
     const app = baseServer(App, _createStoreAndSagas, {
       appSagas: appSagas || fakeSaga,
-      appInstanceName,
       config,
       ...baseServerParams,
     });
@@ -523,14 +521,13 @@ describe(__filename, () => {
       );
     });
 
-    it('handles requests slightly differently when app is amo and loaded page is anonymous', async () => {
+    it('handles requests slightly differently when loaded page is anonymous', async () => {
       const url = '/en-US/firefox/';
       const config = getFakeConfig({ anonymousPagePatterns: [url] });
       const token = userAuthToken();
       const { store, sagaMiddleware } = createStoreAndSagas();
 
       const response = await testClient({
-        appInstanceName: 'amo',
         config,
         store,
         sagaMiddleware,
@@ -553,7 +550,6 @@ describe(__filename, () => {
       const { store, sagaMiddleware } = createStoreAndSagas();
 
       await testClient({
-        appInstanceName: 'amo',
         config,
         store,
         sagaMiddleware,

--- a/tests/unit/test_frameGuardConfig.js
+++ b/tests/unit/test_frameGuardConfig.js
@@ -1,27 +1,11 @@
-/* eslint-disable global-require */
-import config from 'config';
-
-const appsList = config.get('validAppNames');
-
 describe(__filename, () => {
-  const existingNodeEnv = process.env.NODE_ENV;
-
-  afterEach(() => {
-    process.env.NODE_ENV = existingNodeEnv;
-    delete process.env.NODE_APP_INSTANCE;
+  it(`should default frameGuard to "deny" in production`, () => {
+    process.env.NODE_ENV = 'production';
+    jest.resetModules();
+    // eslint-disable-next-line global-require
+    const conf = require('config');
+    const frameGuardConfig = conf.get('frameGuard');
+    expect(frameGuardConfig.action).toEqual('deny');
+    expect(frameGuardConfig.domain).toEqual(undefined);
   });
-
-  for (const appName of appsList) {
-    // eslint-disable-next-line no-loop-func
-    it(`should default frameGuard to "deny" for ${appName} in production`, () => {
-      process.env.NODE_ENV = 'production';
-      process.env.NODE_APP_INSTANCE = appName;
-      jest.resetModules();
-      // eslint-disable-next-line global-require
-      const conf = require('config');
-      const frameGuardConfig = conf.get('frameGuard');
-      expect(frameGuardConfig.action).toEqual('deny');
-      expect(frameGuardConfig.domain).toEqual(undefined);
-    });
-  }
 });

--- a/tests/unit/test_frameGuardConfig.js
+++ b/tests/unit/test_frameGuardConfig.js
@@ -1,5 +1,5 @@
 describe(__filename, () => {
-  it(`should default frameGuard to "deny" in production`, () => {
+  it('should default frameGuard to "deny" in production', () => {
     process.env.NODE_ENV = 'production';
     jest.resetModules();
     // eslint-disable-next-line global-require

--- a/tests/unit/test_prefixConfig.js
+++ b/tests/unit/test_prefixConfig.js
@@ -1,11 +1,4 @@
 describe(__filename, () => {
-  const existingNodeEnv = process.env.NODE_ENV;
-
-  afterEach(() => {
-    process.env.NODE_ENV = existingNodeEnv;
-    delete process.env.NODE_APP_INSTANCE;
-  });
-
   it(`checks clientAppRoutes items are present in validClientAppUrlExceptions`, () => {
     /*
      * Without this the clientAppRoutes will not work as expected. If you want
@@ -13,7 +6,6 @@ describe(__filename, () => {
      * and validClientAppUrlExceptions in the app config.
      */
     process.env.NODE_ENV = 'production';
-    process.env.NODE_APP_INSTANCE = 'amo';
     jest.resetModules();
     // eslint-disable-next-line global-require
     const conf = require('config');

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -36,12 +36,8 @@ const assetsPath = path.resolve(__dirname, 'dist');
 const hmr = `webpack-hot-middleware/client?path=//${webpackHost}:${webpackPort}/__webpack_hmr`;
 
 const appName = config.get('appName');
-const appsBuildList = appName ? [appName] : config.get('validAppNames');
 
-const entryPoints = {};
-for (const app of appsBuildList) {
-  entryPoints[app] = [hmr, `${app}/client`];
-}
+const entryPoints = { [appName]: [hmr, `${appName}/client`] };
 
 // We do not want the production optimization settings in development.
 delete webpackConfig.optimization;

--- a/webpack.l10n.config.babel.js
+++ b/webpack.l10n.config.babel.js
@@ -11,7 +11,7 @@ import webpackConfig from './webpack.prod.config.babel';
 const appName = config.get('appName');
 
 if (!appName) {
-  console.log(chalk.red('Please specify the appName with NODE_APP_INSTANCE'));
+  console.log(chalk.red('appName not set in config'));
   process.exit(1);
 }
 

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -13,12 +13,8 @@ import { getPlugins, getRules } from './webpack-common';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
 
 const appName = config.get('appName');
-const appsBuildList = appName ? [appName] : config.get('validAppNames');
 
-const entryPoints = {};
-for (const app of appsBuildList) {
-  entryPoints[app] = `${app}/client`;
-}
+const entryPoints = { [appName]: `${appName}/client` };
 
 export default {
   mode: 'production',


### PR DESCRIPTION
Fixes #9807 
Depends on ~~https://github.com/mozilla/addons-frontend/issues/9832~~

Something is not quite right with the way the `config` is being built. It looks like, when `amo:dev` is run, it's picking up `development.js` instead of `development-amo.js`, but I can't seem to locate the code that is controlling that.

Other than that I think these changes are working. Note that it's not possible to test `run-l10n-extraction` without first hacking it to prevent it from switching to `master`, because after it switches to master, it runs the wrong versions of the script.

I think more testing is needed, but first I need to figure out how to fix the `config` issue discussed above.