### PR TITLE
Show more Recommended add-ons in the Android homepage

### DIFF
--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -19,6 +19,7 @@ export type FlagReviewReasonType =
 export const LANDING_PAGE_EXTENSION_COUNT = 4;
 export const LANDING_PAGE_THEME_COUNT = 3;
 export const LANDING_PAGE_PROMOTED_EXTENSION_COUNT = 6;
+export const MOBILE_HOME_PAGE_EXTENSION_COUNT = 10;
 
 export const DOWNLOAD_FIREFOX_BASE_URL = 'https://www.mozilla.org/firefox/new/';
 export const PROMOTED_ADDONS_SUMO_URL =

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -16,6 +16,10 @@ import Link from 'amo/components/Link';
 import Page from 'amo/components/Page';
 import SponsoredAddonsShelf from 'amo/components/SponsoredAddonsShelf';
 import SecondaryHero from 'amo/components/SecondaryHero';
+import {
+  LANDING_PAGE_EXTENSION_COUNT,
+  MOBILE_HOME_PAGE_EXTENSION_COUNT,
+} from 'amo/constants';
 import { fetchHomeData } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
@@ -76,7 +80,6 @@ export class HomeBase extends React.Component {
   static propTypes = {
     _config: PropTypes.object,
     _getFeaturedCollectionsMetadata: PropTypes.func,
-    clientApp: PropTypes.string.isRequired,
     collections: PropTypes.array.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
@@ -84,6 +87,7 @@ export class HomeBase extends React.Component {
     i18n: PropTypes.object.isRequired,
     includeRecommendedThemes: PropTypes.bool,
     includeTrendingExtensions: PropTypes.bool,
+    isDesktopSite: PropTypes.bool,
     isLoading: PropTypes.bool,
     resultsLoaded: PropTypes.bool.isRequired,
     shelves: PropTypes.object.isRequired,
@@ -112,6 +116,7 @@ export class HomeBase extends React.Component {
       errorHandler,
       includeRecommendedThemes,
       includeTrendingExtensions,
+      isDesktopSite,
       isLoading,
       resultsLoaded,
     } = this.props;
@@ -129,6 +134,7 @@ export class HomeBase extends React.Component {
           errorHandlerId: errorHandler.id,
           includeRecommendedThemes,
           includeTrendingExtensions,
+          isDesktopSite,
         }),
       );
     }
@@ -207,18 +213,16 @@ export class HomeBase extends React.Component {
     const {
       _config,
       _getFeaturedCollectionsMetadata,
-      clientApp,
       collections,
       errorHandler,
       heroShelves,
       i18n,
       includeRecommendedThemes,
       includeTrendingExtensions,
+      isDesktopSite,
       resultsLoaded,
       shelves,
     } = this.props;
-
-    const isDesktopSite = clientApp === CLIENT_APP_FIREFOX;
 
     const themesHeader = i18n.gettext(`Change the way Firefox looks with
       themes.`);
@@ -308,6 +312,11 @@ export class HomeBase extends React.Component {
                 },
               }}
               loading={loading}
+              placeholderCount={
+                isDesktopSite
+                  ? LANDING_PAGE_EXTENSION_COUNT
+                  : MOBILE_HOME_PAGE_EXTENSION_COUNT
+              }
             />
 
             {isDesktopSite ? (
@@ -412,9 +421,9 @@ export class HomeBase extends React.Component {
 
 export function mapStateToProps(state) {
   return {
-    clientApp: state.api.clientApp,
     collections: state.home.collections,
     heroShelves: state.home.heroShelves,
+    isDesktopSite: state.api.clientApp === CLIENT_APP_FIREFOX,
     isLoading: state.home.isLoading,
     resultsLoaded: state.home.resultsLoaded,
     shelves: state.home.shelves,

--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -184,3 +184,7 @@
     line-height: 1;
   }
 }
+
+.Home-content .Card-contents .AddonsCard-list {
+  grid-auto-flow: row dense;
+}

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -21,8 +21,6 @@ export const ABORT_FETCH_HOME_DATA: 'ABORT_FETCH_HOME_DATA' =
   'ABORT_FETCH_HOME_DATA';
 export const FETCH_HOME_DATA: 'FETCH_HOME_DATA' = 'FETCH_HOME_DATA';
 export const LOAD_HOME_DATA: 'LOAD_HOME_DATA' = 'LOAD_HOME_DATA';
-export const LOAD_MOBILE_HOME_DATA: 'LOAD_MOBILE_HOME_DATA' =
-  'LOAD_MOBILE_HOME_DATA';
 
 export type PrimaryHeroShelfExternalType = {|
   id: string,
@@ -204,33 +202,10 @@ export const loadHomeData = ({
   };
 };
 
-type LoadMobileHomeDataParams = {|
-  heroShelves: ExternalHeroShelvesType,
-  shelves: { [shelfName: string]: ApiAddonsResponse },
-|};
-
-type LoadMobileHomeDataAction = {|
-  type: typeof LOAD_MOBILE_HOME_DATA,
-  payload: LoadMobileHomeDataParams,
-|};
-
-export const loadMobileHomeData = ({
-  heroShelves,
-  shelves,
-}: LoadMobileHomeDataParams): LoadMobileHomeDataAction => {
-  invariant(shelves, 'shelves is required');
-
-  return {
-    type: LOAD_MOBILE_HOME_DATA,
-    payload: { heroShelves, shelves },
-  };
-};
-
 type Action =
   | AbortFetchHomeDataAction
   | FetchHomeDataAction
   | LoadHomeDataAction
-  | LoadMobileHomeDataAction
   | SetClientAppAction;
 
 const createInternalAddons = (
@@ -315,26 +290,6 @@ const reducer = (
           }
           return null;
         }),
-        heroShelves: createInternalHeroShelves(heroShelves),
-        isLoading: false,
-        resultsLoaded: true,
-        shelves: Object.keys(shelves).reduce((shelvesToLoad, shelfName) => {
-          const response = shelves[shelfName];
-
-          return {
-            ...shelvesToLoad,
-            [shelfName]: response ? createInternalAddons(response) : null,
-          };
-        }, {}),
-      };
-    }
-
-    case LOAD_MOBILE_HOME_DATA: {
-      const { heroShelves, shelves } = action.payload;
-
-      return {
-        ...state,
-        collections: [],
         heroShelves: createInternalHeroShelves(heroShelves),
         isLoading: false,
         resultsLoaded: true,

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -21,6 +21,8 @@ export const ABORT_FETCH_HOME_DATA: 'ABORT_FETCH_HOME_DATA' =
   'ABORT_FETCH_HOME_DATA';
 export const FETCH_HOME_DATA: 'FETCH_HOME_DATA' = 'FETCH_HOME_DATA';
 export const LOAD_HOME_DATA: 'LOAD_HOME_DATA' = 'LOAD_HOME_DATA';
+export const LOAD_MOBILE_HOME_DATA: 'LOAD_MOBILE_HOME_DATA' =
+  'LOAD_MOBILE_HOME_DATA';
 
 export type PrimaryHeroShelfExternalType = {|
   id: string,
@@ -138,6 +140,7 @@ type FetchHomeDataParams = {|
   errorHandlerId: string,
   includeRecommendedThemes: boolean,
   includeTrendingExtensions: boolean,
+  isDesktopSite: boolean,
 |};
 
 export type FetchHomeDataAction = {|
@@ -150,6 +153,7 @@ export const fetchHomeData = ({
   errorHandlerId,
   includeRecommendedThemes,
   includeTrendingExtensions,
+  isDesktopSite,
 }: FetchHomeDataParams): FetchHomeDataAction => {
   invariant(errorHandlerId, 'errorHandlerId is required');
   invariant(collectionsToFetch, 'collectionsToFetch is required');
@@ -161,6 +165,7 @@ export const fetchHomeData = ({
       errorHandlerId,
       includeRecommendedThemes,
       includeTrendingExtensions,
+      isDesktopSite,
     },
   };
 };
@@ -199,10 +204,33 @@ export const loadHomeData = ({
   };
 };
 
+type LoadMobileHomeDataParams = {|
+  heroShelves: ExternalHeroShelvesType,
+  shelves: { [shelfName: string]: ApiAddonsResponse },
+|};
+
+type LoadMobileHomeDataAction = {|
+  type: typeof LOAD_MOBILE_HOME_DATA,
+  payload: LoadMobileHomeDataParams,
+|};
+
+export const loadMobileHomeData = ({
+  heroShelves,
+  shelves,
+}: LoadMobileHomeDataParams): LoadMobileHomeDataAction => {
+  invariant(shelves, 'shelves is required');
+
+  return {
+    type: LOAD_MOBILE_HOME_DATA,
+    payload: { heroShelves, shelves },
+  };
+};
+
 type Action =
   | AbortFetchHomeDataAction
   | FetchHomeDataAction
   | LoadHomeDataAction
+  | LoadMobileHomeDataAction
   | SetClientAppAction;
 
 const createInternalAddons = (
@@ -287,6 +315,26 @@ const reducer = (
           }
           return null;
         }),
+        heroShelves: createInternalHeroShelves(heroShelves),
+        isLoading: false,
+        resultsLoaded: true,
+        shelves: Object.keys(shelves).reduce((shelvesToLoad, shelfName) => {
+          const response = shelves[shelfName];
+
+          return {
+            ...shelvesToLoad,
+            [shelfName]: response ? createInternalAddons(response) : null,
+          };
+        }, {}),
+      };
+    }
+
+    case LOAD_MOBILE_HOME_DATA: {
+      const { heroShelves, shelves } = action.payload;
+
+      return {
+        ...state,
+        collections: [],
         heroShelves: createInternalHeroShelves(heroShelves),
         isLoading: false,
         resultsLoaded: true,

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -14,7 +14,6 @@ import {
   FETCH_HOME_DATA,
   abortFetchHomeData,
   loadHomeData,
-  loadMobileHomeData,
 } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
@@ -187,7 +186,8 @@ export function* fetchHomeData({
       }
 
       yield put(
-        loadMobileHomeData({
+        loadHomeData({
+          collections: [],
           heroShelves,
           shelves: { recommendedExtensions },
         }),

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -8,11 +8,13 @@ import {
   LANDING_PAGE_EXTENSION_COUNT,
   LANDING_PAGE_PROMOTED_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
+  MOBILE_HOME_PAGE_EXTENSION_COUNT,
 } from 'amo/constants';
 import {
   FETCH_HOME_DATA,
   abortFetchHomeData,
   loadHomeData,
+  loadMobileHomeData,
 } from 'amo/reducers/home';
 import {
   ADDON_TYPE_EXTENSION,
@@ -37,15 +39,33 @@ export function* fetchHomeData({
     errorHandlerId,
     includeRecommendedThemes,
     includeTrendingExtensions,
+    isDesktopSite,
   },
 }: FetchHomeDataAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
   yield put(errorHandler.createClearingAction());
 
-  try {
-    const state = yield select(getState);
+  const state = yield select(getState);
 
+  const recommendedSearchFilters = {
+    page_size: String(
+      isDesktopSite
+        ? LANDING_PAGE_EXTENSION_COUNT
+        : MOBILE_HOME_PAGE_EXTENSION_COUNT,
+    ),
+    promoted: RECOMMENDED,
+    sort: SEARCH_SORT_RANDOM,
+  };
+  const recommendedExtensionsParams: SearchParams = {
+    api: state.api,
+    filters: {
+      addonType: ADDON_TYPE_EXTENSION,
+      ...recommendedSearchFilters,
+    },
+  };
+
+  try {
     let heroShelves = null;
     try {
       heroShelves = yield call(getHeroShelves, { api: state.api });
@@ -54,113 +74,125 @@ export function* fetchHomeData({
       throw error;
     }
 
-    const collections = [];
-    for (const collection of collectionsToFetch) {
-      try {
-        const params: GetCollectionAddonsParams = {
-          api: state.api,
-          slug: collection.slug,
-          userId: collection.userId,
-        };
-        const result = yield call(getCollectionAddons, params);
-        collections.push(result);
-      } catch (error) {
-        log.warn(
-          oneLine`Home collection: ${collection.userId}/${collection.slug}
+    if (isDesktopSite) {
+      const collections = [];
+      for (const collection of collectionsToFetch) {
+        try {
+          const params: GetCollectionAddonsParams = {
+            api: state.api,
+            slug: collection.slug,
+            userId: collection.userId,
+          };
+          const result = yield call(getCollectionAddons, params);
+          collections.push(result);
+        } catch (error) {
+          log.warn(
+            oneLine`Home collection: ${collection.userId}/${collection.slug}
           failed to load: ${error}`,
-        );
-        if (error.response && [401, 403, 404].includes(error.response.status)) {
-          // The collection was not found or is marked private.
-          collections.push(null);
-        } else {
-          throw error;
+          );
+          if (
+            error.response &&
+            [401, 403, 404].includes(error.response.status)
+          ) {
+            // The collection was not found or is marked private.
+            collections.push(null);
+          } else {
+            throw error;
+          }
         }
       }
+
+      const recommendedThemesParams: SearchParams = {
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_STATIC_THEME,
+          ...recommendedSearchFilters,
+          page_size: String(LANDING_PAGE_THEME_COUNT),
+        },
+      };
+      const popularExtensionsParams: SearchParams = {
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_EXTENSION,
+          page_size: String(LANDING_PAGE_EXTENSION_COUNT),
+          promoted: RECOMMENDED,
+          sort: SEARCH_SORT_POPULAR,
+        },
+      };
+      const popularThemesParams: SearchParams = {
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_STATIC_THEME,
+          page_size: String(LANDING_PAGE_THEME_COUNT),
+          sort: SEARCH_SORT_POPULAR,
+        },
+      };
+      const trendingExtensionsParams: SearchParams = {
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_EXTENSION,
+          page_size: String(LANDING_PAGE_EXTENSION_COUNT),
+          promoted: RECOMMENDED,
+          sort: SEARCH_SORT_TRENDING,
+        },
+      };
+
+      const promotedExtensionsParams: SearchParams = {
+        api: state.api,
+        filters: {
+          addonType: ADDON_TYPE_EXTENSION,
+          page_size: String(LANDING_PAGE_PROMOTED_EXTENSION_COUNT),
+          promoted: SPONSORED,
+          sort: SEARCH_SORT_RANDOM,
+        },
+      };
+
+      let shelves = {};
+      try {
+        shelves = yield all({
+          recommendedExtensions: call(searchApi, recommendedExtensionsParams),
+          recommendedThemes: includeRecommendedThemes
+            ? call(searchApi, recommendedThemesParams)
+            : null,
+          popularExtensions: call(searchApi, popularExtensionsParams),
+          popularThemes: call(searchApi, popularThemesParams),
+          trendingExtensions: includeTrendingExtensions
+            ? call(searchApi, trendingExtensionsParams)
+            : null,
+          promotedExtensions: call(searchApi, promotedExtensionsParams),
+        });
+      } catch (error) {
+        log.warn(`Home add-ons failed to load: ${error}`);
+        throw error;
+      }
+
+      yield put(
+        loadHomeData({
+          collections,
+          heroShelves,
+          shelves,
+        }),
+      );
+    } else {
+      // Mobile homepage logic.
+      let recommendedExtensions;
+      try {
+        recommendedExtensions = yield call(
+          searchApi,
+          recommendedExtensionsParams,
+        );
+      } catch (error) {
+        log.warn(`Home add-ons failed to load: ${error}`);
+        throw error;
+      }
+
+      yield put(
+        loadMobileHomeData({
+          heroShelves,
+          shelves: { recommendedExtensions },
+        }),
+      );
     }
-
-    const recommendedSearchFilters = {
-      page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-      promoted: RECOMMENDED,
-      sort: SEARCH_SORT_RANDOM,
-    };
-    const recommendedExtensionsParams: SearchParams = {
-      api: state.api,
-      filters: {
-        addonType: ADDON_TYPE_EXTENSION,
-        ...recommendedSearchFilters,
-      },
-    };
-    const recommendedThemesParams: SearchParams = {
-      api: state.api,
-      filters: {
-        addonType: ADDON_TYPE_STATIC_THEME,
-        ...recommendedSearchFilters,
-        page_size: String(LANDING_PAGE_THEME_COUNT),
-      },
-    };
-    const popularExtensionsParams: SearchParams = {
-      api: state.api,
-      filters: {
-        addonType: ADDON_TYPE_EXTENSION,
-        page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-        promoted: RECOMMENDED,
-        sort: SEARCH_SORT_POPULAR,
-      },
-    };
-    const popularThemesParams: SearchParams = {
-      api: state.api,
-      filters: {
-        addonType: ADDON_TYPE_STATIC_THEME,
-        page_size: String(LANDING_PAGE_THEME_COUNT),
-        sort: SEARCH_SORT_POPULAR,
-      },
-    };
-    const trendingExtensionsParams: SearchParams = {
-      api: state.api,
-      filters: {
-        addonType: ADDON_TYPE_EXTENSION,
-        page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-        promoted: RECOMMENDED,
-        sort: SEARCH_SORT_TRENDING,
-      },
-    };
-
-    const promotedExtensionsParams: SearchParams = {
-      api: state.api,
-      filters: {
-        addonType: ADDON_TYPE_EXTENSION,
-        page_size: String(LANDING_PAGE_PROMOTED_EXTENSION_COUNT),
-        promoted: SPONSORED,
-        sort: SEARCH_SORT_RANDOM,
-      },
-    };
-
-    let shelves = {};
-    try {
-      shelves = yield all({
-        recommendedExtensions: call(searchApi, recommendedExtensionsParams),
-        recommendedThemes: includeRecommendedThemes
-          ? call(searchApi, recommendedThemesParams)
-          : null,
-        popularExtensions: call(searchApi, popularExtensionsParams),
-        popularThemes: call(searchApi, popularThemesParams),
-        trendingExtensions: includeTrendingExtensions
-          ? call(searchApi, trendingExtensionsParams)
-          : null,
-        promotedExtensions: call(searchApi, promotedExtensionsParams),
-      });
-    } catch (error) {
-      log.warn(`Home add-ons failed to load: ${error}`);
-      throw error;
-    }
-
-    yield put(
-      loadHomeData({
-        collections,
-        heroShelves,
-        shelves,
-      }),
-    );
   } catch (error) {
     yield put(errorHandler.createErrorAction(error));
     yield put(abortFetchHomeData());

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -18,6 +18,10 @@ import Page from 'amo/components/Page';
 import SponsoredAddonsShelf from 'amo/components/SponsoredAddonsShelf';
 import SecondaryHero from 'amo/components/SecondaryHero';
 import {
+  LANDING_PAGE_EXTENSION_COUNT,
+  MOBILE_HOME_PAGE_EXTENSION_COUNT,
+} from 'amo/constants';
+import {
   FETCH_HOME_DATA,
   createInternalHeroShelves,
   fetchHomeData,
@@ -167,6 +171,12 @@ describe(__filename, () => {
         },
       });
       expect(shelf).toHaveProp('loading', true);
+      expect(shelf).toHaveProp(
+        'placeholderCount',
+        clientApp === CLIENT_APP_ANDROID
+          ? MOBILE_HOME_PAGE_EXTENSION_COUNT
+          : LANDING_PAGE_EXTENSION_COUNT,
+      );
     },
   );
 
@@ -282,7 +292,7 @@ describe(__filename, () => {
     const includeRecommendedThemes = false;
     const includeTrendingExtensions = false;
     const errorHandler = createStubErrorHandler();
-    const { store } = dispatchClientMetadata();
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
 
@@ -302,6 +312,34 @@ describe(__filename, () => {
         collectionsToFetch: FEATURED_COLLECTIONS,
         includeRecommendedThemes,
         includeTrendingExtensions,
+        isDesktopSite: true,
+      }),
+    );
+  });
+
+  it('passes isDesktopSite: false to fetchHomeData on Android', () => {
+    const includeRecommendedThemes = false;
+    const includeTrendingExtensions = false;
+    const errorHandler = createStubErrorHandler();
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID });
+
+    const fakeDispatch = sinon.stub(store, 'dispatch');
+
+    render({
+      errorHandler,
+      includeRecommendedThemes,
+      includeTrendingExtensions,
+      store,
+    });
+
+    sinon.assert.calledWith(
+      fakeDispatch,
+      fetchHomeData({
+        errorHandlerId: errorHandler.id,
+        collectionsToFetch: FEATURED_COLLECTIONS,
+        includeRecommendedThemes,
+        includeTrendingExtensions,
+        isDesktopSite: false,
       }),
     );
   });
@@ -319,7 +357,7 @@ describe(__filename, () => {
   // This test case should be updated when we change the `defaultProps`.
   it('fetches add-ons with some defaults', () => {
     const errorHandler = createStubErrorHandler();
-    const { store } = dispatchClientMetadata();
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
     render({ errorHandler, store });
@@ -333,6 +371,7 @@ describe(__filename, () => {
         collectionsToFetch: FEATURED_COLLECTIONS,
         includeRecommendedThemes: true,
         includeTrendingExtensions: false,
+        isDesktopSite: true,
       }),
     );
   });
@@ -396,7 +435,7 @@ describe(__filename, () => {
   it('dispatches an action to fetch the add-ons to display on update', () => {
     const includeRecommendedThemes = false;
     const includeTrendingExtensions = false;
-    const { store } = dispatchClientMetadata();
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
 
     const fakeDispatch = sinon.stub(store, 'dispatch');
 
@@ -419,6 +458,7 @@ describe(__filename, () => {
         collectionsToFetch: FEATURED_COLLECTIONS,
         includeRecommendedThemes,
         includeTrendingExtensions,
+        isDesktopSite: true,
       }),
     );
   });

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -10,7 +10,6 @@ import homeReducer, {
   fetchHomeData,
   initialState,
   loadHomeData,
-  loadMobileHomeData,
 } from 'amo/reducers/home';
 import { createInternalAddon } from 'core/reducers/addons';
 import { ADDON_TYPE_STATIC_THEME, CLIENT_APP_FIREFOX } from 'core/constants';
@@ -59,267 +58,141 @@ describe(__filename, () => {
       expect(state).toEqual(initialState);
     });
 
-    describe('loadHomeData', () => {
-      it('loads collections', () => {
-        const { store } = dispatchClientMetadata();
+    it('loads collections', () => {
+      const { store } = dispatchClientMetadata();
 
-        _loadHomeData({
-          store,
-          collections: [
-            createFakeCollectionAddonsListResponse({
-              addons: Array(10).fill(createFakeCollectionAddon()),
-            }),
-          ],
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.resultsLoaded).toEqual(true);
-        expect(homeState.collections).toHaveLength(1);
-        expect(homeState.collections[0]).toHaveLength(
-          LANDING_PAGE_EXTENSION_COUNT,
-        );
-        expect(homeState.collections[0]).toEqual(
-          Array(LANDING_PAGE_EXTENSION_COUNT).fill(
-            createInternalAddon(fakeAddon),
-          ),
-        );
-      });
-
-      it('loads shelves', () => {
-        const { store } = dispatchClientMetadata();
-        const shelfName1 = 'someShelfName1';
-        const shelfName2 = 'someShelfName2';
-        const addon1 = { ...fakeAddon, slug: 'addon1' };
-        const addon2 = { ...fakeAddon, slug: 'addon2' };
-
-        _loadHomeData({
-          store,
-          shelves: {
-            [shelfName1]: createAddonsApiResult([addon1]),
-            [shelfName2]: createAddonsApiResult([addon2]),
-          },
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.shelves[shelfName1]).toEqual([
-          createInternalAddon(addon1),
-        ]);
-        expect(homeState.shelves[shelfName2]).toEqual([
-          createInternalAddon(addon2),
-        ]);
-      });
-
-      it('loads hero shelves', () => {
-        const { store } = dispatchClientMetadata();
-
-        const heroShelves = _createHeroShelves();
-        _loadHomeData({
-          store,
-          heroShelves,
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.heroShelves).toEqual(
-          createInternalHeroShelves(heroShelves),
-        );
-      });
-
-      it('sets null when a shelf has no response', () => {
-        const { store } = dispatchClientMetadata();
-        const shelfName1 = 'someShelfName1';
-        const shelfName2 = 'someShelfName2';
-        const addon1 = { ...fakeAddon, slug: 'addon1' };
-
-        _loadHomeData({
-          store,
-          shelves: {
-            [shelfName1]: createAddonsApiResult([addon1]),
-            [shelfName2]: null,
-          },
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.shelves[shelfName1]).toEqual([
-          createInternalAddon(addon1),
-        ]);
-        expect(homeState.shelves[shelfName2]).toEqual(null);
-      });
-
-      it('loads the the correct amount of theme add-ons in a collection to display on homepage', () => {
-        const { store } = dispatchClientMetadata();
-
-        _loadHomeData({
-          store,
-          collections: [
-            createFakeCollectionAddonsListResponse({
-              addons: Array(10).fill({
-                ...createFakeCollectionAddon({
-                  addon: {
-                    ...fakeAddon,
-                    type: ADDON_TYPE_STATIC_THEME,
-                  },
-                }),
-              }),
-            }),
-          ],
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.resultsLoaded).toEqual(true);
-        expect(homeState.collections).toHaveLength(1);
-
-        expect(homeState.collections[0]).toEqual(
-          Array(LANDING_PAGE_THEME_COUNT).fill(
-            createInternalAddon({
-              ...fakeAddon,
-              type: ADDON_TYPE_STATIC_THEME,
-            }),
-          ),
-        );
-      });
-
-      it('loads a null for a missing collection', () => {
-        const { store } = dispatchClientMetadata();
-
-        _loadHomeData({
-          store,
-          collections: [null],
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.collections).toHaveLength(1);
-        expect(homeState.collections[0]).toEqual(null);
-      });
-
-      it('sets `isLoading` to `false` and `resultsLoaded` to `true` after loading data', () => {
-        const { store } = dispatchClientMetadata();
-
-        store.dispatch(
-          fetchHomeData({
-            collectionsToFetch: [],
-            errorHandlerId: 'some-error-handler-id',
+      _loadHomeData({
+        store,
+        collections: [
+          createFakeCollectionAddonsListResponse({
+            addons: Array(10).fill(createFakeCollectionAddon()),
           }),
-        );
-
-        _loadHomeData({ store });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.isLoading).toEqual(false);
-        expect(homeState.resultsLoaded).toEqual(true);
+        ],
       });
+
+      const homeState = store.getState().home;
+
+      expect(homeState.resultsLoaded).toEqual(true);
+      expect(homeState.collections).toHaveLength(1);
+      expect(homeState.collections[0]).toHaveLength(
+        LANDING_PAGE_EXTENSION_COUNT,
+      );
+      expect(homeState.collections[0]).toEqual(
+        Array(LANDING_PAGE_EXTENSION_COUNT).fill(
+          createInternalAddon(fakeAddon),
+        ),
+      );
     });
 
-    describe('loadMobileHomeData', () => {
-      const _loadMobileHomeData = ({
+    it('loads shelves', () => {
+      const { store } = dispatchClientMetadata();
+      const shelfName1 = 'someShelfName1';
+      const shelfName2 = 'someShelfName2';
+      const addon1 = { ...fakeAddon, slug: 'addon1' };
+      const addon2 = { ...fakeAddon, slug: 'addon2' };
+
+      _loadHomeData({
         store,
-        heroShelves = createHeroShelves({ primaryProps: { addon: fakeAddon } }),
-        shelves = {},
-      }) => {
-        store.dispatch(
-          loadMobileHomeData({
-            heroShelves,
-            shelves,
+        shelves: {
+          [shelfName1]: createAddonsApiResult([addon1]),
+          [shelfName2]: createAddonsApiResult([addon2]),
+        },
+      });
+
+      const homeState = store.getState().home;
+
+      expect(homeState.shelves[shelfName1]).toEqual([
+        createInternalAddon(addon1),
+      ]);
+      expect(homeState.shelves[shelfName2]).toEqual([
+        createInternalAddon(addon2),
+      ]);
+    });
+
+    it('loads hero shelves', () => {
+      const { store } = dispatchClientMetadata();
+
+      const heroShelves = _createHeroShelves();
+      _loadHomeData({
+        store,
+        heroShelves,
+      });
+
+      const homeState = store.getState().home;
+
+      expect(homeState.heroShelves).toEqual(
+        createInternalHeroShelves(heroShelves),
+      );
+    });
+
+    it('sets null when a shelf has no response', () => {
+      const { store } = dispatchClientMetadata();
+      const shelfName1 = 'someShelfName1';
+      const shelfName2 = 'someShelfName2';
+      const addon1 = { ...fakeAddon, slug: 'addon1' };
+
+      _loadHomeData({
+        store,
+        shelves: {
+          [shelfName1]: createAddonsApiResult([addon1]),
+          [shelfName2]: null,
+        },
+      });
+
+      const homeState = store.getState().home;
+
+      expect(homeState.shelves[shelfName1]).toEqual([
+        createInternalAddon(addon1),
+      ]);
+      expect(homeState.shelves[shelfName2]).toEqual(null);
+    });
+
+    it('loads the the correct amount of theme add-ons in a collection to display on homepage', () => {
+      const { store } = dispatchClientMetadata();
+
+      _loadHomeData({
+        store,
+        collections: [
+          createFakeCollectionAddonsListResponse({
+            addons: Array(10).fill({
+              ...createFakeCollectionAddon({
+                addon: {
+                  ...fakeAddon,
+                  type: ADDON_TYPE_STATIC_THEME,
+                },
+              }),
+            }),
           }),
-        );
-      };
-
-      it('loads shelves', () => {
-        const { store } = dispatchClientMetadata();
-        const shelfName1 = 'someShelfName1';
-        const shelfName2 = 'someShelfName2';
-        const addon1 = { ...fakeAddon, slug: 'addon1' };
-        const addon2 = { ...fakeAddon, slug: 'addon2' };
-
-        _loadMobileHomeData({
-          store,
-          shelves: {
-            [shelfName1]: createAddonsApiResult([addon1]),
-            [shelfName2]: createAddonsApiResult([addon2]),
-          },
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.shelves[shelfName1]).toEqual([
-          createInternalAddon(addon1),
-        ]);
-        expect(homeState.shelves[shelfName2]).toEqual([
-          createInternalAddon(addon2),
-        ]);
+        ],
       });
 
-      it('loads hero shelves', () => {
-        const { store } = dispatchClientMetadata();
+      const homeState = store.getState().home;
 
-        const heroShelves = _createHeroShelves();
-        _loadMobileHomeData({
-          store,
-          heroShelves,
-        });
+      expect(homeState.resultsLoaded).toEqual(true);
+      expect(homeState.collections).toHaveLength(1);
 
-        const homeState = store.getState().home;
-
-        expect(homeState.heroShelves).toEqual(
-          createInternalHeroShelves(heroShelves),
-        );
-      });
-
-      it('sets null when a shelf has no response', () => {
-        const { store } = dispatchClientMetadata();
-        const shelfName1 = 'someShelfName1';
-        const shelfName2 = 'someShelfName2';
-        const addon1 = { ...fakeAddon, slug: 'addon1' };
-
-        _loadMobileHomeData({
-          store,
-          shelves: {
-            [shelfName1]: createAddonsApiResult([addon1]),
-            [shelfName2]: null,
-          },
-        });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.shelves[shelfName1]).toEqual([
-          createInternalAddon(addon1),
-        ]);
-        expect(homeState.shelves[shelfName2]).toEqual(null);
-      });
-
-      it('sets `collections` to an empty array', () => {
-        const { store } = dispatchClientMetadata();
-
-        _loadMobileHomeData({ store });
-
-        const homeState = store.getState().home;
-
-        expect(homeState.collections).toEqual([]);
-      });
-
-      it('sets `isLoading` to `false` and `resultsLoaded` to `true` after loading data', () => {
-        const { store } = dispatchClientMetadata();
-
-        store.dispatch(
-          fetchHomeData({
-            collectionsToFetch: [],
-            errorHandlerId: 'some-error-handler-id',
+      expect(homeState.collections[0]).toEqual(
+        Array(LANDING_PAGE_THEME_COUNT).fill(
+          createInternalAddon({
+            ...fakeAddon,
+            type: ADDON_TYPE_STATIC_THEME,
           }),
-        );
+        ),
+      );
+    });
 
-        _loadMobileHomeData({ store });
+    it('loads a null for a missing collection', () => {
+      const { store } = dispatchClientMetadata();
 
-        const homeState = store.getState().home;
-
-        expect(homeState.isLoading).toEqual(false);
-        expect(homeState.resultsLoaded).toEqual(true);
+      _loadHomeData({
+        store,
+        collections: [null],
       });
+
+      const homeState = store.getState().home;
+
+      expect(homeState.collections).toHaveLength(1);
+      expect(homeState.collections[0]).toEqual(null);
     });
 
     it('returns null for an empty collection', () => {
@@ -351,6 +224,23 @@ describe(__filename, () => {
 
       expect(state.resultsLoaded).toEqual(false);
       expect(state.isLoading).toEqual(true);
+    });
+
+    it('sets `isLoading` to `false` after loading data', () => {
+      const { store } = dispatchClientMetadata();
+
+      store.dispatch(
+        fetchHomeData({
+          collectionsToFetch: [],
+          errorHandlerId: 'some-error-handler-id',
+        }),
+      );
+
+      _loadHomeData({ store });
+
+      const homeState = store.getState().home;
+
+      expect(homeState.isLoading).toEqual(false);
     });
 
     it('aborts fetching of data', () => {

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -10,6 +10,7 @@ import homeReducer, {
   fetchHomeData,
   initialState,
   loadHomeData,
+  loadMobileHomeData,
 } from 'amo/reducers/home';
 import { createInternalAddon } from 'core/reducers/addons';
 import { ADDON_TYPE_STATIC_THEME, CLIENT_APP_FIREFOX } from 'core/constants';
@@ -58,141 +59,267 @@ describe(__filename, () => {
       expect(state).toEqual(initialState);
     });
 
-    it('loads collections', () => {
-      const { store } = dispatchClientMetadata();
+    describe('loadHomeData', () => {
+      it('loads collections', () => {
+        const { store } = dispatchClientMetadata();
 
-      _loadHomeData({
-        store,
-        collections: [
-          createFakeCollectionAddonsListResponse({
-            addons: Array(10).fill(createFakeCollectionAddon()),
-          }),
-        ],
+        _loadHomeData({
+          store,
+          collections: [
+            createFakeCollectionAddonsListResponse({
+              addons: Array(10).fill(createFakeCollectionAddon()),
+            }),
+          ],
+        });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.resultsLoaded).toEqual(true);
+        expect(homeState.collections).toHaveLength(1);
+        expect(homeState.collections[0]).toHaveLength(
+          LANDING_PAGE_EXTENSION_COUNT,
+        );
+        expect(homeState.collections[0]).toEqual(
+          Array(LANDING_PAGE_EXTENSION_COUNT).fill(
+            createInternalAddon(fakeAddon),
+          ),
+        );
       });
 
-      const homeState = store.getState().home;
+      it('loads shelves', () => {
+        const { store } = dispatchClientMetadata();
+        const shelfName1 = 'someShelfName1';
+        const shelfName2 = 'someShelfName2';
+        const addon1 = { ...fakeAddon, slug: 'addon1' };
+        const addon2 = { ...fakeAddon, slug: 'addon2' };
 
-      expect(homeState.resultsLoaded).toEqual(true);
-      expect(homeState.collections).toHaveLength(1);
-      expect(homeState.collections[0]).toHaveLength(
-        LANDING_PAGE_EXTENSION_COUNT,
-      );
-      expect(homeState.collections[0]).toEqual(
-        Array(LANDING_PAGE_EXTENSION_COUNT).fill(
-          createInternalAddon(fakeAddon),
-        ),
-      );
-    });
+        _loadHomeData({
+          store,
+          shelves: {
+            [shelfName1]: createAddonsApiResult([addon1]),
+            [shelfName2]: createAddonsApiResult([addon2]),
+          },
+        });
 
-    it('loads shelves', () => {
-      const { store } = dispatchClientMetadata();
-      const shelfName1 = 'someShelfName1';
-      const shelfName2 = 'someShelfName2';
-      const addon1 = { ...fakeAddon, slug: 'addon1' };
-      const addon2 = { ...fakeAddon, slug: 'addon2' };
+        const homeState = store.getState().home;
 
-      _loadHomeData({
-        store,
-        shelves: {
-          [shelfName1]: createAddonsApiResult([addon1]),
-          [shelfName2]: createAddonsApiResult([addon2]),
-        },
+        expect(homeState.shelves[shelfName1]).toEqual([
+          createInternalAddon(addon1),
+        ]);
+        expect(homeState.shelves[shelfName2]).toEqual([
+          createInternalAddon(addon2),
+        ]);
       });
 
-      const homeState = store.getState().home;
+      it('loads hero shelves', () => {
+        const { store } = dispatchClientMetadata();
 
-      expect(homeState.shelves[shelfName1]).toEqual([
-        createInternalAddon(addon1),
-      ]);
-      expect(homeState.shelves[shelfName2]).toEqual([
-        createInternalAddon(addon2),
-      ]);
-    });
+        const heroShelves = _createHeroShelves();
+        _loadHomeData({
+          store,
+          heroShelves,
+        });
 
-    it('loads hero shelves', () => {
-      const { store } = dispatchClientMetadata();
+        const homeState = store.getState().home;
 
-      const heroShelves = _createHeroShelves();
-      _loadHomeData({
-        store,
-        heroShelves,
+        expect(homeState.heroShelves).toEqual(
+          createInternalHeroShelves(heroShelves),
+        );
       });
 
-      const homeState = store.getState().home;
+      it('sets null when a shelf has no response', () => {
+        const { store } = dispatchClientMetadata();
+        const shelfName1 = 'someShelfName1';
+        const shelfName2 = 'someShelfName2';
+        const addon1 = { ...fakeAddon, slug: 'addon1' };
 
-      expect(homeState.heroShelves).toEqual(
-        createInternalHeroShelves(heroShelves),
-      );
-    });
+        _loadHomeData({
+          store,
+          shelves: {
+            [shelfName1]: createAddonsApiResult([addon1]),
+            [shelfName2]: null,
+          },
+        });
 
-    it('sets null when a shelf has no response', () => {
-      const { store } = dispatchClientMetadata();
-      const shelfName1 = 'someShelfName1';
-      const shelfName2 = 'someShelfName2';
-      const addon1 = { ...fakeAddon, slug: 'addon1' };
+        const homeState = store.getState().home;
 
-      _loadHomeData({
-        store,
-        shelves: {
-          [shelfName1]: createAddonsApiResult([addon1]),
-          [shelfName2]: null,
-        },
+        expect(homeState.shelves[shelfName1]).toEqual([
+          createInternalAddon(addon1),
+        ]);
+        expect(homeState.shelves[shelfName2]).toEqual(null);
       });
 
-      const homeState = store.getState().home;
+      it('loads the the correct amount of theme add-ons in a collection to display on homepage', () => {
+        const { store } = dispatchClientMetadata();
 
-      expect(homeState.shelves[shelfName1]).toEqual([
-        createInternalAddon(addon1),
-      ]);
-      expect(homeState.shelves[shelfName2]).toEqual(null);
-    });
-
-    it('loads the the correct amount of theme add-ons in a collection to display on homepage', () => {
-      const { store } = dispatchClientMetadata();
-
-      _loadHomeData({
-        store,
-        collections: [
-          createFakeCollectionAddonsListResponse({
-            addons: Array(10).fill({
-              ...createFakeCollectionAddon({
-                addon: {
-                  ...fakeAddon,
-                  type: ADDON_TYPE_STATIC_THEME,
-                },
+        _loadHomeData({
+          store,
+          collections: [
+            createFakeCollectionAddonsListResponse({
+              addons: Array(10).fill({
+                ...createFakeCollectionAddon({
+                  addon: {
+                    ...fakeAddon,
+                    type: ADDON_TYPE_STATIC_THEME,
+                  },
+                }),
               }),
             }),
-          }),
-        ],
+          ],
+        });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.resultsLoaded).toEqual(true);
+        expect(homeState.collections).toHaveLength(1);
+
+        expect(homeState.collections[0]).toEqual(
+          Array(LANDING_PAGE_THEME_COUNT).fill(
+            createInternalAddon({
+              ...fakeAddon,
+              type: ADDON_TYPE_STATIC_THEME,
+            }),
+          ),
+        );
       });
 
-      const homeState = store.getState().home;
+      it('loads a null for a missing collection', () => {
+        const { store } = dispatchClientMetadata();
 
-      expect(homeState.resultsLoaded).toEqual(true);
-      expect(homeState.collections).toHaveLength(1);
+        _loadHomeData({
+          store,
+          collections: [null],
+        });
 
-      expect(homeState.collections[0]).toEqual(
-        Array(LANDING_PAGE_THEME_COUNT).fill(
-          createInternalAddon({
-            ...fakeAddon,
-            type: ADDON_TYPE_STATIC_THEME,
+        const homeState = store.getState().home;
+
+        expect(homeState.collections).toHaveLength(1);
+        expect(homeState.collections[0]).toEqual(null);
+      });
+
+      it('sets `isLoading` to `false` and `resultsLoaded` to `true` after loading data', () => {
+        const { store } = dispatchClientMetadata();
+
+        store.dispatch(
+          fetchHomeData({
+            collectionsToFetch: [],
+            errorHandlerId: 'some-error-handler-id',
           }),
-        ),
-      );
+        );
+
+        _loadHomeData({ store });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.isLoading).toEqual(false);
+        expect(homeState.resultsLoaded).toEqual(true);
+      });
     });
 
-    it('loads a null for a missing collection', () => {
-      const { store } = dispatchClientMetadata();
-
-      _loadHomeData({
+    describe('loadMobileHomeData', () => {
+      const _loadMobileHomeData = ({
         store,
-        collections: [null],
+        heroShelves = createHeroShelves({ primaryProps: { addon: fakeAddon } }),
+        shelves = {},
+      }) => {
+        store.dispatch(
+          loadMobileHomeData({
+            heroShelves,
+            shelves,
+          }),
+        );
+      };
+
+      it('loads shelves', () => {
+        const { store } = dispatchClientMetadata();
+        const shelfName1 = 'someShelfName1';
+        const shelfName2 = 'someShelfName2';
+        const addon1 = { ...fakeAddon, slug: 'addon1' };
+        const addon2 = { ...fakeAddon, slug: 'addon2' };
+
+        _loadMobileHomeData({
+          store,
+          shelves: {
+            [shelfName1]: createAddonsApiResult([addon1]),
+            [shelfName2]: createAddonsApiResult([addon2]),
+          },
+        });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.shelves[shelfName1]).toEqual([
+          createInternalAddon(addon1),
+        ]);
+        expect(homeState.shelves[shelfName2]).toEqual([
+          createInternalAddon(addon2),
+        ]);
       });
 
-      const homeState = store.getState().home;
+      it('loads hero shelves', () => {
+        const { store } = dispatchClientMetadata();
 
-      expect(homeState.collections).toHaveLength(1);
-      expect(homeState.collections[0]).toEqual(null);
+        const heroShelves = _createHeroShelves();
+        _loadMobileHomeData({
+          store,
+          heroShelves,
+        });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.heroShelves).toEqual(
+          createInternalHeroShelves(heroShelves),
+        );
+      });
+
+      it('sets null when a shelf has no response', () => {
+        const { store } = dispatchClientMetadata();
+        const shelfName1 = 'someShelfName1';
+        const shelfName2 = 'someShelfName2';
+        const addon1 = { ...fakeAddon, slug: 'addon1' };
+
+        _loadMobileHomeData({
+          store,
+          shelves: {
+            [shelfName1]: createAddonsApiResult([addon1]),
+            [shelfName2]: null,
+          },
+        });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.shelves[shelfName1]).toEqual([
+          createInternalAddon(addon1),
+        ]);
+        expect(homeState.shelves[shelfName2]).toEqual(null);
+      });
+
+      it('sets `collections` to an empty array', () => {
+        const { store } = dispatchClientMetadata();
+
+        _loadMobileHomeData({ store });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.collections).toEqual([]);
+      });
+
+      it('sets `isLoading` to `false` and `resultsLoaded` to `true` after loading data', () => {
+        const { store } = dispatchClientMetadata();
+
+        store.dispatch(
+          fetchHomeData({
+            collectionsToFetch: [],
+            errorHandlerId: 'some-error-handler-id',
+          }),
+        );
+
+        _loadMobileHomeData({ store });
+
+        const homeState = store.getState().home;
+
+        expect(homeState.isLoading).toEqual(false);
+        expect(homeState.resultsLoaded).toEqual(true);
+      });
     });
 
     it('returns null for an empty collection', () => {
@@ -224,23 +351,6 @@ describe(__filename, () => {
 
       expect(state.resultsLoaded).toEqual(false);
       expect(state.isLoading).toEqual(true);
-    });
-
-    it('sets `isLoading` to `false` after loading data', () => {
-      const { store } = dispatchClientMetadata();
-
-      store.dispatch(
-        fetchHomeData({
-          collectionsToFetch: [],
-          errorHandlerId: 'some-error-handler-id',
-        }),
-      );
-
-      _loadHomeData({ store });
-
-      const homeState = store.getState().home;
-
-      expect(homeState.isLoading).toEqual(false);
     });
 
     it('aborts fetching of data', () => {

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -12,7 +12,6 @@ import homeReducer, {
   abortFetchHomeData,
   fetchHomeData,
   loadHomeData,
-  loadMobileHomeData,
 } from 'amo/reducers/home';
 import homeSaga from 'amo/sagas/home';
 import { createApiError } from 'core/api';
@@ -247,7 +246,8 @@ describe(__filename, () => {
 
       _fetchHomeData({ isDesktopSite: false });
 
-      const loadAction = loadMobileHomeData({
+      const loadAction = loadHomeData({
+        collections: [],
         heroShelves,
         shelves: {
           recommendedExtensions,


### PR DESCRIPTION
Fixes #9863 

This change creates separate logic for retrieving and loading data for the home page for the desktop site vs. the mobile site. This is something we've been thinking about doing, and this was an ideal opportunity to do it. This means that, when visiting the mobile home page, the browser will only make 2 API requests, which is all the data it needs, whereas for the desktop home page it makes several API requests.

This involved adding a new function into the reducer, to load data for the mobile home page, as well as to add a param to indicate if we're fetching data for the desktop or mobile site. I also required changes to the saga to call different APIs for each case. 

