### PR TITLE
Do away with appName

### DIFF
--- a/bin/build-checks.js
+++ b/bin/build-checks.js
@@ -3,14 +3,5 @@
 
 const chalk = require('chalk');
 require('@babel/register');
-const config = require('config');
 
-const appName = config.get('appName');
-
-// Bail if appName isn't set.
-if (!appName) {
-  console.log(chalk.red('appName not set in config'));
-  process.exit(1);
-}
-
-console.log(chalk.green(`\n--->  BUILDING: ${appName}\n`));
+console.log(chalk.green(`\n--->  BUILDING app\n`));

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -12,19 +12,13 @@ const config = require('config');
 const po2json = require('po2json');
 const glob = require('glob');
 const shelljs = require('shelljs');
-const chalk = require('chalk');
 const toSource = require('tosource');
 const { oneLine } = require('common-tags');
 
-const appName = config.get('appName');
-
-if (!appName) {
-  console.log(chalk.red('appName not set in config'));
-  process.exit(1);
-}
+const { APP_NAME } = require('../src/core/constants');
 
 const localeDir = path.join(__dirname, '../locale');
-const poFiles = glob.sync(`${localeDir}/**/${appName}.po`);
+const poFiles = glob.sync(`${localeDir}/**/${APP_NAME}.po`);
 const dest = path.join(__dirname, '../src/locale/');
 
 const getLocaleModulePath = (locale, { _config = config } = {}) => {

--- a/bin/build-locales
+++ b/bin/build-locales
@@ -15,10 +15,8 @@ const shelljs = require('shelljs');
 const toSource = require('tosource');
 const { oneLine } = require('common-tags');
 
-const { APP_NAME } = require('../src/core/constants');
-
 const localeDir = path.join(__dirname, '../locale');
-const poFiles = glob.sync(`${localeDir}/**/${APP_NAME}.po`);
+const poFiles = glob.sync(`${localeDir}/**/amo.po`);
 const dest = path.join(__dirname, '../src/locale/');
 
 const getLocaleModulePath = (locale, { _config = config } = {}) => {

--- a/bin/create-locales
+++ b/bin/create-locales
@@ -9,7 +9,6 @@
 require('@babel/register');
 
 
-const chalk = require('chalk');
 const config = require('config');
 const fs = require('fs');
 const path = require('path');
@@ -18,15 +17,8 @@ const shell = require('shelljs');
 const supportedLangs = config.get('langs');
 const localeDir = path.join(__dirname, '../locale');
 const templateDir = path.join(localeDir, 'templates/LC_MESSAGES');
-const langToLocale = require('../src/core/i18n/utils').langToLocale;
-
-const appName = config.get('appName');
-
-if (!appName) {
-  console.log(
-    chalk.red('appName not set in config'));
-  process.exit(1);
-}
+const { langToLocale } = require('../src/core/i18n/utils');
+const { APP_NAME } = require('../src/core/constants');
 
 
 let lang;
@@ -36,14 +28,14 @@ let outputFile;
 for (lang of supportedLangs) {
   locale = langToLocale(lang);
   shell.exec(`mkdir -p ${localeDir}/${locale}/LC_MESSAGES/`);
-  outputFile = path.join(localeDir, locale, 'LC_MESSAGES', `${appName}.po`);
+  outputFile = path.join(localeDir, locale, 'LC_MESSAGES', `${APP_NAME}.po`);
   try {
     fs.statSync(outputFile);
     // eslint-disable-next-line no-console
     console.log(`${outputFile} already exists skipping`);
   } catch (e) {
     if (e.code === 'ENOENT') {
-      shell.exec(`msginit --no-translator --input=${templateDir}/${appName}.pot
+      shell.exec(`msginit --no-translator --input=${templateDir}/${APP_NAME}.pot
                   --output-file=${outputFile} -l ${locale}`.replace('\n', ' '));
     } else {
       throw e;

--- a/bin/create-locales
+++ b/bin/create-locales
@@ -18,7 +18,6 @@ const supportedLangs = config.get('langs');
 const localeDir = path.join(__dirname, '../locale');
 const templateDir = path.join(localeDir, 'templates/LC_MESSAGES');
 const { langToLocale } = require('../src/core/i18n/utils');
-const { APP_NAME } = require('../src/core/constants');
 
 
 let lang;
@@ -28,14 +27,14 @@ let outputFile;
 for (lang of supportedLangs) {
   locale = langToLocale(lang);
   shell.exec(`mkdir -p ${localeDir}/${locale}/LC_MESSAGES/`);
-  outputFile = path.join(localeDir, locale, 'LC_MESSAGES', `${APP_NAME}.po`);
+  outputFile = path.join(localeDir, locale, 'LC_MESSAGES', 'amo.po');
   try {
     fs.statSync(outputFile);
     // eslint-disable-next-line no-console
     console.log(`${outputFile} already exists skipping`);
   } catch (e) {
     if (e.code === 'ENOENT') {
-      shell.exec(`msginit --no-translator --input=${templateDir}/${APP_NAME}.pot
+      shell.exec(`msginit --no-translator --input=${templateDir}/amo.pot
                   --output-file=${outputFile} -l ${locale}`.replace('\n', ' '));
     } else {
       throw e;

--- a/bin/merge-locales
+++ b/bin/merge-locales
@@ -2,25 +2,18 @@
 
 /* eslint-disable no-console */
 require('@babel/register');
-const config = require('config');
+
 const glob = require('glob');
 const path = require('path');
 const shell = require('shelljs');
-const chalk = require('chalk');
 
 const localeDir = path.join(__dirname, '../locale');
 
-const appName = config.get('appName');
+const { APP_NAME } = require('../src/core/constants');
 
-if (!appName) {
-  console.log(
-    chalk.red('appName not set in config'));
-  process.exit(1);
-}
-
-const poFiles = glob.sync(`${localeDir}/**/${appName}.po`);
+const poFiles = glob.sync(`${localeDir}/**/${APP_NAME}.po`);
 const template =
-  path.join(localeDir, `templates/LC_MESSAGES/${appName}.pot`);
+  path.join(localeDir, `templates/LC_MESSAGES/${APP_NAME}.pot`);
 
 poFiles.forEach((poFile) => {
   const dir = path.dirname(poFile);

--- a/bin/merge-locales
+++ b/bin/merge-locales
@@ -9,11 +9,9 @@ const shell = require('shelljs');
 
 const localeDir = path.join(__dirname, '../locale');
 
-const { APP_NAME } = require('../src/core/constants');
-
-const poFiles = glob.sync(`${localeDir}/**/${APP_NAME}.po`);
+const poFiles = glob.sync(`${localeDir}/**/amo.po`);
 const template =
-  path.join(localeDir, `templates/LC_MESSAGES/${APP_NAME}.pot`);
+  path.join(localeDir, `templates/LC_MESSAGES/amo.pot`);
 
 poFiles.forEach((poFile) => {
   const dir = path.dirname(poFile);

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -10,9 +10,11 @@ const cookie = require('cookie');
 const httpProxy = require('http-proxy');
 const pino = require('pino');
 
+const { APP_NAME } = require('../src/core/constants');
+
 const log = pino({
   level: config.get('loggingLevel'),
-  name: `${config.get('appName')}.proxy`,
+  name: `${APP_NAME}.proxy`,
 });
 
 const useHttpsForDev = process.env.USE_HTTPS_FOR_DEV;

--- a/bin/proxy.js
+++ b/bin/proxy.js
@@ -10,11 +10,9 @@ const cookie = require('cookie');
 const httpProxy = require('http-proxy');
 const pino = require('pino');
 
-const { APP_NAME } = require('../src/core/constants');
-
 const log = pino({
   level: config.get('loggingLevel'),
-  name: `${APP_NAME}.proxy`,
+  name: 'proxy',
 });
 
 const useHttpsForDev = process.env.USE_HTTPS_FOR_DEV;

--- a/bin/server.js
+++ b/bin/server.js
@@ -2,21 +2,12 @@
 /* eslint-disable global-require, no-console */
 const path = require('path');
 
-const chalk = require('chalk');
 const chokidar = require('chokidar');
 require('@babel/register')({
   plugins: ['dynamic-import-node'],
 });
 const config = require('config');
 const touch = require('touch');
-
-const appName = config.get('appName');
-
-if (!appName) {
-  console.log(
-    chalk.red('appName not set in config'));
-  process.exit(1);
-}
 
 if (process.env.NODE_ENV === 'development') {
   if (!require('piping')({

--- a/config/default.js
+++ b/config/default.js
@@ -6,18 +6,12 @@ import path from 'path';
 
 import { addonsServerProdCDN, analyticsHost, prodDomain, apiProdHost, baseUrlProd, sentryHost } from './lib/shared';
 
-const appName = 'amo';
-if (!appName) {
-  throw new Error('An appName is required.');
-}
-
 const addonsFrontendCDN = 'https://addons-amo.cdn.mozilla.net';
 const basePath = path.resolve(__dirname, '../');
 const distPath = path.join(basePath, 'dist');
 const loadableStatsFilename = 'loadable-stats.json';
 
 module.exports = {
-  appName,
   basePath,
 
   // This is needed for code-splitting.
@@ -104,7 +98,6 @@ module.exports = {
     'apiHost',
     'apiPath',
     'apiVersion',
-    'appName',
     'authTokenValidFor',
     'baseURL',
     'cookieMaxAge',

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -10,6 +10,7 @@ import { render } from 'react-dom';
 import { loadableReady } from '@loadable/component';
 
 import Root from 'core/components/Root';
+import { APP_NAME } from 'core/constants';
 import { langToLocale, makeI18n, sanitizeLanguage } from 'core/i18n/utils';
 import log from 'core/logger';
 import { addQueryParamsToHistory } from 'core/utils';
@@ -33,8 +34,6 @@ export default async function createClient(
     await fetchBufferedLogs();
   }
 
-  const appName = _config.get('appName');
-
   // This code needs to come before anything else so we get logs/errors if
   // anything else in this function goes wrong.
   const publicSentryDsn = _config.get('publicSentryDsn');
@@ -47,7 +46,7 @@ export default async function createClient(
         // `DEPLOYMENT_VERSION` is injected by webpack at build time (thanks to
         // the `DefinePlugin`).
         // See: https://github.com/mozilla/addons-frontend/issues/8270
-        release: getSentryRelease({ appName, version: DEPLOYMENT_VERSION }),
+        release: getSentryRelease({ version: DEPLOYMENT_VERSION }),
       })
       .install();
   } else {
@@ -105,7 +104,7 @@ export default async function createClient(
   if (sagas && sagaMiddleware) {
     sagaMiddleware.run(sagas);
   } else {
-    log.warn(`sagas not found for this app (src/${appName}/sagas)`);
+    log.warn(`sagas not found`);
   }
 
   let i18nData = {};
@@ -113,7 +112,7 @@ export default async function createClient(
     if (locale !== langToLocale(_config.get('defaultLang'))) {
       i18nData = await new Promise((resolve) => {
         // eslint-disable-next-line max-len, global-require, import/no-dynamic-require
-        require(`bundle-loader?name=[name]-i18n-[folder]!../../locale/${locale}/${appName}.js`)(
+        require(`bundle-loader?name=[name]-i18n-[folder]!../../locale/${locale}/${APP_NAME}.js`)(
           resolve,
         );
       });

--- a/src/core/client/base.js
+++ b/src/core/client/base.js
@@ -10,7 +10,6 @@ import { render } from 'react-dom';
 import { loadableReady } from '@loadable/component';
 
 import Root from 'core/components/Root';
-import { APP_NAME } from 'core/constants';
 import { langToLocale, makeI18n, sanitizeLanguage } from 'core/i18n/utils';
 import log from 'core/logger';
 import { addQueryParamsToHistory } from 'core/utils';
@@ -112,7 +111,7 @@ export default async function createClient(
     if (locale !== langToLocale(_config.get('defaultLang'))) {
       i18nData = await new Promise((resolve) => {
         // eslint-disable-next-line max-len, global-require, import/no-dynamic-require
-        require(`bundle-loader?name=[name]-i18n-[folder]!../../locale/${locale}/${APP_NAME}.js`)(
+        require(`bundle-loader?name=[name]-i18n-[folder]!../../locale/${locale}/amo.js`)(
           resolve,
         );
       });

--- a/src/core/components/ServerHtml/index.js
+++ b/src/core/components/ServerHtml/index.js
@@ -6,7 +6,7 @@ import serialize from 'serialize-javascript';
 import { Helmet } from 'react-helmet';
 import config from 'config';
 
-import { LTR } from 'core/constants';
+import { APP_NAME, LTR } from 'core/constants';
 
 const JS_CHUNK_EXCLUDES = new RegExp(
   `(?:${config.get('jsChunkExclusions').join('|')})`,
@@ -14,7 +14,6 @@ const JS_CHUNK_EXCLUDES = new RegExp(
 
 export default class ServerHtml extends Component {
   static propTypes = {
-    appName: PropTypes.string.isRequired,
     appState: PropTypes.object.isRequired,
     assets: PropTypes.object.isRequired,
     chunkExtractor: PropTypes.object.isRequired,
@@ -55,11 +54,10 @@ export default class ServerHtml extends Component {
   }
 
   getStatic({ filePath, type, index }) {
-    const { appName } = this.props;
     const leafName = filePath.split('/').pop();
 
     // Only output files for the current app.
-    if (leafName.startsWith(appName) && !JS_CHUNK_EXCLUDES.test(leafName)) {
+    if (leafName.startsWith(APP_NAME) && !JS_CHUNK_EXCLUDES.test(leafName)) {
       const sriProps = this.getSriProps(leafName);
 
       switch (type) {
@@ -114,13 +112,13 @@ export default class ServerHtml extends Component {
   }
 
   renderStyles() {
-    const { _config, chunkExtractor } = this.props;
+    const { chunkExtractor } = this.props;
 
     return chunkExtractor
       .getMainAssets('style')
       .filter(
         // We render the main bundle with `getScript()`, so we skip it here.
-        (asset) => asset.chunk !== _config.get('appName'),
+        (asset) => asset.chunk !== APP_NAME,
       )
       .map((asset) => {
         const sriProps = this.getSriProps(asset.filename);
@@ -169,13 +167,13 @@ export default class ServerHtml extends Component {
   }
 
   renderAsyncScripts() {
-    const { _config, chunkExtractor } = this.props;
+    const { chunkExtractor } = this.props;
 
     return chunkExtractor
       .getMainAssets('script')
       .filter(
         // We render the main bundle with `getScript()`, so we skip it here.
-        (asset) => asset.chunk !== _config.get('appName'),
+        (asset) => asset.chunk !== APP_NAME,
       )
       .map((asset) => {
         const sriProps = this.getSriProps(asset.filename);

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -324,3 +324,5 @@ export type PromotedCategoryType =
   | typeof SPOTLIGHT
   | typeof STRATEGIC
   | typeof VERIFIED;
+
+export const APP_NAME = 'amo';

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -326,3 +326,4 @@ export type PromotedCategoryType =
   | typeof VERIFIED;
 
 export const APP_NAME = 'amo';
+export const WEBPACK_ENTRYPOINT = APP_NAME;

--- a/src/core/logger.js
+++ b/src/core/logger.js
@@ -1,6 +1,6 @@
 import config from 'config';
 
-import { AMO_REQUEST_ID_HEADER } from 'core/constants';
+import { AMO_REQUEST_ID_HEADER, APP_NAME } from 'core/constants';
 
 let pino = null;
 let httpContext = null;
@@ -32,7 +32,7 @@ if (config.get('server')) {
 
 const pinoLogger = pino({
   level: config.get('loggingLevel'),
-  name: config.get('appName'),
+  name: APP_NAME,
   // That is how the upstream library implements this... See:
   // https://github.com/pinojs/pino/blob/220e3d019fe22167a59cfe26260f6c2b4d0ea22b/lib/time.js#L5
   // Note: `true` is the default value for this parameter.

--- a/src/core/server/base.js
+++ b/src/core/server/base.js
@@ -21,7 +21,7 @@ import { ChunkExtractor, ChunkExtractorManager } from '@loadable/server';
 import log from 'core/logger';
 import { REGION_CODE_HEADER, createApiError } from 'core/api';
 import Root from 'core/components/Root';
-import { AMO_REQUEST_ID_HEADER, APP_NAME } from 'core/constants';
+import { AMO_REQUEST_ID_HEADER, WEBPACK_ENTRYPOINT } from 'core/constants';
 import ServerHtml from 'core/components/ServerHtml';
 import * as middleware from 'core/middleware';
 import requestId from 'core/middleware/requestId';
@@ -68,7 +68,7 @@ export function getPageProps({ store, req, res, config }) {
   // Code-splitting.
   const chunkExtractor = new ChunkExtractor({
     stats: JSON.parse(fs.readFileSync(config.get('loadableStatsFile'))),
-    entrypoints: [APP_NAME],
+    entrypoints: [WEBPACK_ENTRYPOINT],
   });
 
   // Check the lang supplied by res.locals.lang for validity
@@ -297,7 +297,7 @@ function baseServer(
         let sagas = appSagas;
         if (!sagas) {
           // eslint-disable-next-line global-require, import/no-dynamic-require
-          sagas = require(`${APP_NAME}/sagas`).default;
+          sagas = require('amo/sagas').default;
         }
         runningSagas = sagaMiddleware.run(sagas);
 
@@ -348,7 +348,7 @@ function baseServer(
       try {
         if (locale !== langToLocale(config.get('defaultLang'))) {
           // eslint-disable-next-line global-require, import/no-dynamic-require
-          i18nData = require(`../../locale/${locale}/${APP_NAME}.js`);
+          i18nData = require(`../../locale/${locale}/amo.js`);
         }
       } catch (e) {
         _log.info(`Locale JSON not found or required for locale: "${locale}"`);
@@ -498,8 +498,8 @@ export function runServer({
       // now fire up the actual server.
       return new Promise((resolve, reject) => {
         /* eslint-disable global-require, import/no-dynamic-require */
-        const App = require(`${APP_NAME}/components/App`).default;
-        const createStore = require(`${APP_NAME}/store`).default;
+        const App = require('amo/components/App').default;
+        const createStore = require('amo/store').default;
         /* eslint-enable global-require, import/no-dynamic-require */
         let server = baseServer(App, createStore);
         if (listen === true) {

--- a/src/core/utils/sentry.js
+++ b/src/core/utils/sentry.js
@@ -1,13 +1,9 @@
 /* @flow */
 
 type GetSentryReleaseParams = {|
-  appName: string,
   version: string,
 |};
 
-export const getSentryRelease = ({
-  appName,
-  version,
-}: GetSentryReleaseParams) => {
-  return `addons-frontend-${appName}@${version}`;
+export const getSentryRelease = ({ version }: GetSentryReleaseParams) => {
+  return `addons-frontend@${version}`;
 };

--- a/tests/unit/core/client/test_base.js
+++ b/tests/unit/core/client/test_base.js
@@ -74,7 +74,6 @@ describe(__filename, () => {
       sinon.assert.calledWith(_RavenJs.config, publicSentryDsn, {
         logger: 'client-js',
         release: getSentryRelease({
-          appName: _config.get('appName'),
           version: deploymentVersion,
         }),
       });

--- a/tests/unit/core/components/TestServerHtml.js
+++ b/tests/unit/core/components/TestServerHtml.js
@@ -33,7 +33,6 @@ describe(__filename, () => {
 
   function render(opts = {}) {
     const pageProps = {
-      appName: 'amo',
       appState: { appStateExample: { things: 'lots-of-things' } },
       assets: fakeAssets,
       chunkExtractor: createFakeChunkExtractor(),

--- a/tests/unit/core/utils/test_sentry.js
+++ b/tests/unit/core/utils/test_sentry.js
@@ -3,11 +3,10 @@ import { getSentryRelease } from 'core/utils/sentry';
 describe(__filename, () => {
   describe('getSentryRelease', () => {
     it('creates a release ID', () => {
-      const appName = 'app';
       const version = '1.2.3';
 
-      expect(getSentryRelease({ appName, version })).toEqual(
-        `addons-frontend-${appName}@${version}`,
+      expect(getSentryRelease({ version })).toEqual(
+        `addons-frontend@${version}`,
       );
     });
   });

--- a/webpack-common.js
+++ b/webpack-common.js
@@ -7,6 +7,7 @@ import webpack from 'webpack';
 import LoadablePlugin from '@loadable/webpack-plugin';
 
 import 'core/polyfill';
+import { APP_NAME } from 'core/constants';
 import { getClientConfig } from 'core/utils';
 import { getDeploymentVersion } from 'core/utils/build';
 
@@ -133,7 +134,6 @@ export function getPlugins({
   excludeOtherAppLocales = true,
   includeLoadablePlugin = true,
 } = {}) {
-  const appName = config.get('appName');
   const clientConfig = getClientConfig(config);
 
   const plugins = [
@@ -174,7 +174,7 @@ export function getPlugins({
       // This allow us to exclude locales for other apps being built.
       new webpack.ContextReplacementPlugin(
         /locale$/,
-        new RegExp(`^\\.\\/.*?\\/${appName}\\.js$`),
+        new RegExp(`^\\.\\/.*?\\/${APP_NAME}\\.js$`),
       ),
     );
   }

--- a/webpack-common.js
+++ b/webpack-common.js
@@ -7,7 +7,6 @@ import webpack from 'webpack';
 import LoadablePlugin from '@loadable/webpack-plugin';
 
 import 'core/polyfill';
-import { APP_NAME } from 'core/constants';
 import { getClientConfig } from 'core/utils';
 import { getDeploymentVersion } from 'core/utils/build';
 
@@ -174,7 +173,7 @@ export function getPlugins({
       // This allow us to exclude locales for other apps being built.
       new webpack.ContextReplacementPlugin(
         /locale$/,
-        new RegExp(`^\\.\\/.*?\\/${APP_NAME}\\.js$`),
+        new RegExp(`^\\.\\/.*?\\/amo\\.js$`),
       ),
     );
   }

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -9,6 +9,7 @@ import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 import { getPlugins, getRules } from './webpack-common';
 import webpackConfig from './webpack.prod.config.babel';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
+import { APP_NAME } from './src/core/constants';
 
 const localDevelopment = config.util.getEnv('NODE_ENV') === 'development';
 
@@ -35,9 +36,7 @@ const assetsPath = path.resolve(__dirname, 'dist');
 
 const hmr = `webpack-hot-middleware/client?path=//${webpackHost}:${webpackPort}/__webpack_hmr`;
 
-const appName = config.get('appName');
-
-const entryPoints = { [appName]: [hmr, `${appName}/client`] };
+const entryPoints = { [APP_NAME]: [hmr, `${APP_NAME}/client`] };
 
 // We do not want the production optimization settings in development.
 delete webpackConfig.optimization;

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -9,7 +9,7 @@ import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 import { getPlugins, getRules } from './webpack-common';
 import webpackConfig from './webpack.prod.config.babel';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
-import { APP_NAME, WEBPACK_ENTRYPOINT } from './src/core/constants';
+import { WEBPACK_ENTRYPOINT } from './src/core/constants';
 
 const localDevelopment = config.util.getEnv('NODE_ENV') === 'development';
 
@@ -36,7 +36,7 @@ const assetsPath = path.resolve(__dirname, 'dist');
 
 const hmr = `webpack-hot-middleware/client?path=//${webpackHost}:${webpackPort}/__webpack_hmr`;
 
-const entryPoints = { [WEBPACK_ENTRYPOINT]: [hmr, `${APP_NAME}/client`] };
+const entryPoints = { [WEBPACK_ENTRYPOINT]: [hmr, 'amo/client'] };
 
 // We do not want the production optimization settings in development.
 delete webpackConfig.optimization;

--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -9,7 +9,7 @@ import WebpackIsomorphicToolsPlugin from 'webpack-isomorphic-tools/plugin';
 import { getPlugins, getRules } from './webpack-common';
 import webpackConfig from './webpack.prod.config.babel';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
-import { APP_NAME } from './src/core/constants';
+import { APP_NAME, WEBPACK_ENTRYPOINT } from './src/core/constants';
 
 const localDevelopment = config.util.getEnv('NODE_ENV') === 'development';
 
@@ -36,7 +36,7 @@ const assetsPath = path.resolve(__dirname, 'dist');
 
 const hmr = `webpack-hot-middleware/client?path=//${webpackHost}:${webpackPort}/__webpack_hmr`;
 
-const entryPoints = { [APP_NAME]: [hmr, `${APP_NAME}/client`] };
+const entryPoints = { [WEBPACK_ENTRYPOINT]: [hmr, `${APP_NAME}/client`] };
 
 // We do not want the production optimization settings in development.
 delete webpackConfig.optimization;

--- a/webpack.l10n.config.babel.js
+++ b/webpack.l10n.config.babel.js
@@ -2,18 +2,11 @@
 import fs from 'fs';
 
 import chalk from 'chalk';
-import config from 'config';
 import webpack from 'webpack';
 
 import { getRules } from './webpack-common';
 import webpackConfig from './webpack.prod.config.babel';
-
-const appName = config.get('appName');
-
-if (!appName) {
-  console.log(chalk.red('appName not set in config'));
-  process.exit(1);
-}
+import { APP_NAME } from './src/core/constants';
 
 if (process.env.NODE_ENV !== 'production') {
   console.log(chalk.red('This should be run with NODE_ENV="production"'));
@@ -35,7 +28,7 @@ const babelL10nPlugins = [
     'module:babel-gettext-extractor',
     {
       headers: {
-        'Project-Id-Version': appName,
+        'Project-Id-Version': APP_NAME,
         'Report-Msgid-Bugs-To': 'EMAIL@ADDRESS',
         'POT-Creation-Date': potCreationDate,
         'PO-Revision-Date': 'YEAR-MO-DA HO:MI+ZONE',
@@ -56,7 +49,7 @@ const babelL10nPlugins = [
         npgettext: ['msgctxt', 'msgid', 'msgid_plural', 'count'],
         dnpgettext: ['domain', 'msgctxt', 'msgid', 'msgid_plural', 'count'],
       },
-      fileName: `locale/templates/LC_MESSAGES/${appName}.pot`,
+      fileName: `locale/templates/LC_MESSAGES/${APP_NAME}.pot`,
       baseDirectory: process.cwd(),
       stripTemplateLiteralIndent: true,
     },
@@ -70,13 +63,13 @@ const babelOptions = {
 
 export default {
   ...webpackConfig,
-  entry: { [appName]: `${appName}/client` },
+  entry: { [APP_NAME]: `${APP_NAME}/client` },
   module: {
     rules: getRules({ babelOptions }),
   },
   plugins: [
     // Don't generate modules for locale files.
-    new webpack.IgnorePlugin(new RegExp(`locale\\/.*\\/${appName}\\.js$`)),
+    new webpack.IgnorePlugin(new RegExp(`locale\\/.*\\/${APP_NAME}\\.js$`)),
     ...webpackConfig.plugins,
   ],
 };

--- a/webpack.l10n.config.babel.js
+++ b/webpack.l10n.config.babel.js
@@ -6,7 +6,7 @@ import webpack from 'webpack';
 
 import { getRules } from './webpack-common';
 import webpackConfig from './webpack.prod.config.babel';
-import { APP_NAME, WEBPACK_ENTRYPOINT } from './src/core/constants';
+import { WEBPACK_ENTRYPOINT } from './src/core/constants';
 
 if (process.env.NODE_ENV !== 'production') {
   console.log(chalk.red('This should be run with NODE_ENV="production"'));
@@ -63,7 +63,7 @@ const babelOptions = {
 
 export default {
   ...webpackConfig,
-  entry: { [WEBPACK_ENTRYPOINT]: `${APP_NAME}/client` },
+  entry: { [WEBPACK_ENTRYPOINT]: 'amo/client' },
   module: {
     rules: getRules({ babelOptions }),
   },

--- a/webpack.l10n.config.babel.js
+++ b/webpack.l10n.config.babel.js
@@ -6,7 +6,7 @@ import webpack from 'webpack';
 
 import { getRules } from './webpack-common';
 import webpackConfig from './webpack.prod.config.babel';
-import { APP_NAME } from './src/core/constants';
+import { APP_NAME, WEBPACK_ENTRYPOINT } from './src/core/constants';
 
 if (process.env.NODE_ENV !== 'production') {
   console.log(chalk.red('This should be run with NODE_ENV="production"'));
@@ -28,7 +28,7 @@ const babelL10nPlugins = [
     'module:babel-gettext-extractor',
     {
       headers: {
-        'Project-Id-Version': APP_NAME,
+        'Project-Id-Version': 'amo',
         'Report-Msgid-Bugs-To': 'EMAIL@ADDRESS',
         'POT-Creation-Date': potCreationDate,
         'PO-Revision-Date': 'YEAR-MO-DA HO:MI+ZONE',
@@ -49,7 +49,7 @@ const babelL10nPlugins = [
         npgettext: ['msgctxt', 'msgid', 'msgid_plural', 'count'],
         dnpgettext: ['domain', 'msgctxt', 'msgid', 'msgid_plural', 'count'],
       },
-      fileName: `locale/templates/LC_MESSAGES/${APP_NAME}.pot`,
+      fileName: `locale/templates/LC_MESSAGES/amo.pot`,
       baseDirectory: process.cwd(),
       stripTemplateLiteralIndent: true,
     },
@@ -63,13 +63,13 @@ const babelOptions = {
 
 export default {
   ...webpackConfig,
-  entry: { [APP_NAME]: `${APP_NAME}/client` },
+  entry: { [WEBPACK_ENTRYPOINT]: `${APP_NAME}/client` },
   module: {
     rules: getRules({ babelOptions }),
   },
   plugins: [
     // Don't generate modules for locale files.
-    new webpack.IgnorePlugin(new RegExp(`locale\\/.*\\/${APP_NAME}\\.js$`)),
+    new webpack.IgnorePlugin(new RegExp(`locale\\/.*\\/amo\\.js$`)),
     ...webpackConfig.plugins,
   ],
 };

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -11,9 +11,9 @@ import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
 import SriDataPlugin from './src/core/server/sriDataPlugin';
 import { getPlugins, getRules } from './webpack-common';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
-import { APP_NAME, WEBPACK_ENTRYPOINT } from './src/core/constants';
+import { WEBPACK_ENTRYPOINT } from './src/core/constants';
 
-const entryPoints = { [WEBPACK_ENTRYPOINT]: `${APP_NAME}/client` };
+const entryPoints = { [WEBPACK_ENTRYPOINT]: 'amo/client' };
 
 export default {
   bail: true,

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -11,10 +11,9 @@ import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
 import SriDataPlugin from './src/core/server/sriDataPlugin';
 import { getPlugins, getRules } from './webpack-common';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
+import { APP_NAME } from './src/core/constants';
 
-const appName = config.get('appName');
-
-const entryPoints = { [appName]: `${appName}/client` };
+const entryPoints = { [APP_NAME]: `${APP_NAME}/client` };
 
 export default {
   bail: true,

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -11,9 +11,9 @@ import OptimizeCssAssetsPlugin from 'optimize-css-assets-webpack-plugin';
 import SriDataPlugin from './src/core/server/sriDataPlugin';
 import { getPlugins, getRules } from './webpack-common';
 import webpackIsomorphicToolsConfig from './src/core/server/webpack-isomorphic-tools-config';
-import { APP_NAME } from './src/core/constants';
+import { APP_NAME, WEBPACK_ENTRYPOINT } from './src/core/constants';
 
-const entryPoints = { [APP_NAME]: `${APP_NAME}/client` };
+const entryPoints = { [WEBPACK_ENTRYPOINT]: `${APP_NAME}/client` };
 
 export default {
   bail: true,


### PR DESCRIPTION
Fixes #9840 

This is the next step towards eliminating the multiple-app logic for AMO and eventually combining `amo` and `core`. It does away with the `appName` config variable, and replaces it with a constant for now. Eventually we can probably get rid of much of the code that now uses `APP_NAME`, but I wanted to take this in small steps. I've tested locally and everything seem to work.
