### PR TITLE
handle urls is an object with url & outgoing; drop wrap_outgoing

### DIFF
--- a/src/amo/api/hero.js
+++ b/src/amo/api/hero.js
@@ -12,6 +12,5 @@ export const getHeroShelves = ({
     apiState: api,
     auth: true,
     endpoint: 'hero',
-    wrapOutgoingLinks: false,
   });
 };

--- a/src/amo/api/shelves.js
+++ b/src/amo/api/shelves.js
@@ -11,6 +11,5 @@ export const getSponsoredShelf = ({
   return callApi({
     apiState: api,
     endpoint: 'shelves/sponsored/',
-    wrapOutgoingLinks: false,
   });
 };

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -12,7 +12,7 @@ import { STATS_VIEW } from 'core/constants';
 import translate from 'core/i18n/translate';
 import { hasPermission } from 'amo/reducers/users';
 import type { AddonType } from 'core/types/addons';
-import { isAddonAuthor, trimAndAddProtocolToUrl } from 'core/utils';
+import { isAddonAuthor } from 'core/utils';
 import Card from 'ui/components/Card';
 import DefinitionList, { Definition } from 'ui/components/DefinitionList';
 import LoadingText from 'ui/components/LoadingText';
@@ -58,8 +58,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       });
     }
 
-    let homepage =
-      addon.homepage && trimAndAddProtocolToUrl(addon.homepage.outgoing);
+    let homepage = addon.homepage.outgoing
     if (homepage) {
       homepage = (
         <li>
@@ -70,8 +69,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       );
     }
 
-    let supportUrl =
-      addon.support_url && trimAndAddProtocolToUrl(addon.support_url.outgoing);
+    let supportUrl = addon.support_url.outgoing
     if (supportUrl) {
       supportUrl = (
         <li>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -58,7 +58,8 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       });
     }
 
-    let homepage = trimAndAddProtocolToUrl(addon.homepage);
+    let homepage =
+      addon.homepage && trimAndAddProtocolToUrl(addon.homepage.outgoing);
     if (homepage) {
       homepage = (
         <li>
@@ -69,7 +70,8 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       );
     }
 
-    let supportUrl = trimAndAddProtocolToUrl(addon.support_url);
+    let supportUrl =
+      addon.support_url && trimAndAddProtocolToUrl(addon.support_url.outgoing);
     if (supportUrl) {
       supportUrl = (
         <li>

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -58,7 +58,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       });
     }
 
-    let homepage = addon.homepage.outgoing
+    let homepage = addon.homepage && addon.homepage.outgoing;
     if (homepage) {
       homepage = (
         <li>
@@ -69,7 +69,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       );
     }
 
-    let supportUrl = addon.support_url.outgoing
+    let supportUrl = addon.support_url && addon.support_url.outgoing;
     if (supportUrl) {
       supportUrl = (
         <li>

--- a/src/amo/components/ContributeCard/index.js
+++ b/src/amo/components/ContributeCard/index.js
@@ -100,7 +100,9 @@ export const ContributeCardBase = ({
         <Button
           buttonType="action"
           className="ContributeCard-button"
-          href={addon.contributions_url}
+          href={
+            (addon.contributions_url && addon.contributions_url.outgoing) || ''
+          }
           onClick={onButtonClick}
           target="_blank"
           puffy

--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -94,7 +94,7 @@ export class BlockBase extends React.Component<InternalProps> {
     if (block.url) {
       content.push(
         ' ',
-        <a key={block.url} href={block.url}>
+        <a key={block.url.url} href={block.url.outgoing}>
           {i18n.gettext('View block request')}
         </a>,
         '.',

--- a/src/amo/reducers/blocks.js
+++ b/src/amo/reducers/blocks.js
@@ -1,6 +1,8 @@
 /* @flow */
 import invariant from 'invariant';
 
+import type { OutgoingUrl } from 'core/types/api';
+
 export const FETCH_BLOCK: 'FETCH_BLOCK' = 'FETCH_BLOCK';
 export const ABORT_FETCH_BLOCK: 'ABORT_FETCH_BLOCK' = 'ABORT_FETCH_BLOCK';
 export const LOAD_BLOCK: 'LOAD_BLOCK' = 'LOAD_BLOCK';
@@ -14,7 +16,7 @@ export type ExternalBlockType = {|
   min_version: string,
   modified: string,
   reason: string | null,
-  url: string | null,
+  url: OutgoingUrl | null,
 |};
 
 export type BlockType = {|

--- a/src/amo/reducers/blocks.js
+++ b/src/amo/reducers/blocks.js
@@ -1,7 +1,7 @@
 /* @flow */
 import invariant from 'invariant';
 
-import type { OutgoingUrl } from 'core/types/api';
+import type { UrlWithOutgoing } from 'core/types/api';
 
 export const FETCH_BLOCK: 'FETCH_BLOCK' = 'FETCH_BLOCK';
 export const ABORT_FETCH_BLOCK: 'ABORT_FETCH_BLOCK' = 'ABORT_FETCH_BLOCK';
@@ -16,7 +16,7 @@ export type ExternalBlockType = {|
   min_version: string,
   modified: string,
   reason: string | null,
-  url: OutgoingUrl | null,
+  url: UrlWithOutgoing | null,
 |};
 
 export type BlockType = {|

--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -83,6 +83,7 @@ export type PrimaryHeroShelfType =
 
 export type HeroCallToActionType = {|
   url: string,
+  outgoing: string,
   text: string,
 |};
 

--- a/src/core/api/index.js
+++ b/src/core/api/index.js
@@ -81,7 +81,6 @@ type CallApiParams = {|
   _config?: typeof config,
   version?: string,
   _log?: typeof log,
-  wrapOutgoingLinks?: boolean,
 |};
 
 export function callApi({
@@ -96,7 +95,6 @@ export function callApi({
   _config = config,
   version = _config.get('apiVersion'),
   _log = log,
-  wrapOutgoingLinks = true,
 }: CallApiParams): Promise<any> {
   if (!endpoint) {
     return Promise.reject(
@@ -128,7 +126,6 @@ export function callApi({
     ...parsedUrl.query,
     ...params,
     lang: apiState.lang,
-    wrap_outgoing_links: wrapOutgoingLinks || null,
   });
 
   const options = {

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -178,6 +178,14 @@ export function createInternalAddon(
   apiAddon: ExternalAddonType | PartialExternalAddonType,
   lang: string,
 ): AddonType {
+  const homepage_url = apiAddon.homepage ? apiAddon.homepage.url : null;
+  const homepage_outgoing = apiAddon.homepage
+    ? apiAddon.homepage.outgoing
+    : null;
+  const support_url = apiAddon.support_url ? apiAddon.support_url.url : null;
+  const support_outgoing = apiAddon.support_url
+    ? apiAddon.support_url.outgoing
+    : null;
   const addon: AddonType = {
     authors: apiAddon.authors,
     average_daily_users: apiAddon.average_daily_users,
@@ -195,7 +203,13 @@ export function createInternalAddon(
     guid: apiAddon.guid,
     has_eula: apiAddon.has_eula,
     has_privacy_policy: apiAddon.has_privacy_policy,
-    homepage: selectLocalizedContent(apiAddon.homepage, lang),
+    homepage:
+      homepage_url && homepage_outgoing
+        ? {
+            url: selectLocalizedContent(homepage_url, lang),
+            outgoing: selectLocalizedContent(homepage_outgoing, lang),
+          }
+        : null,
     icon_url: apiAddon.icon_url,
     id: apiAddon.id,
     is_disabled: apiAddon.is_disabled,
@@ -216,7 +230,13 @@ export function createInternalAddon(
     status: apiAddon.status,
     summary: selectLocalizedContent(apiAddon.summary, lang),
     support_email: selectLocalizedContent(apiAddon.support_email, lang),
-    support_url: selectLocalizedContent(apiAddon.support_url, lang),
+    support_url:
+      support_url && support_outgoing
+        ? {
+            url: selectLocalizedContent(support_url, lang),
+            outgoing: selectLocalizedContent(support_outgoing, lang),
+          }
+        : null,
     tags: apiAddon.tags,
     target_locale: apiAddon.target_locale,
     type: apiAddon.type,

--- a/src/core/reducers/addons.js
+++ b/src/core/reducers/addons.js
@@ -174,18 +174,21 @@ export const createInternalPreviews = (
   }));
 };
 
+const selectLocalizedUrlWithOutgoing = (url, lang) => {
+  if (url && url.url && url.outgoing) {
+    return {
+      url: selectLocalizedContent(url.url, lang),
+      outgoing: selectLocalizedContent(url.outgoing, lang),
+    };
+  }
+
+  return null;
+};
+
 export function createInternalAddon(
   apiAddon: ExternalAddonType | PartialExternalAddonType,
   lang: string,
 ): AddonType {
-  const homepage_url = apiAddon.homepage ? apiAddon.homepage.url : null;
-  const homepage_outgoing = apiAddon.homepage
-    ? apiAddon.homepage.outgoing
-    : null;
-  const support_url = apiAddon.support_url ? apiAddon.support_url.url : null;
-  const support_outgoing = apiAddon.support_url
-    ? apiAddon.support_url.outgoing
-    : null;
   const addon: AddonType = {
     authors: apiAddon.authors,
     average_daily_users: apiAddon.average_daily_users,
@@ -203,13 +206,7 @@ export function createInternalAddon(
     guid: apiAddon.guid,
     has_eula: apiAddon.has_eula,
     has_privacy_policy: apiAddon.has_privacy_policy,
-    homepage:
-      homepage_url && homepage_outgoing
-        ? {
-            url: selectLocalizedContent(homepage_url, lang),
-            outgoing: selectLocalizedContent(homepage_outgoing, lang),
-          }
-        : null,
+    homepage: selectLocalizedUrlWithOutgoing(apiAddon.homepage, lang),
     icon_url: apiAddon.icon_url,
     id: apiAddon.id,
     is_disabled: apiAddon.is_disabled,
@@ -230,13 +227,7 @@ export function createInternalAddon(
     status: apiAddon.status,
     summary: selectLocalizedContent(apiAddon.summary, lang),
     support_email: selectLocalizedContent(apiAddon.support_email, lang),
-    support_url:
-      support_url && support_outgoing
-        ? {
-            url: selectLocalizedContent(support_url, lang),
-            outgoing: selectLocalizedContent(support_outgoing, lang),
-          }
-        : null,
+    support_url: selectLocalizedUrlWithOutgoing(apiAddon.support_url, lang),
     tags: apiAddon.tags,
     target_locale: apiAddon.target_locale,
     type: apiAddon.type,

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -6,9 +6,9 @@ import type {
 } from 'core/reducers/versions';
 import type { AddonTypeType, PromotedCategoryType } from 'core/constants';
 import type {
-  LocalizedOutgoingUrl,
+  LocalizedUrlWithOutgoing,
   LocalizedString,
-  OutgoingUrl,
+  UrlWithOutgoing,
 } from 'core/types/api';
 
 export type AddonStatusType =
@@ -96,7 +96,7 @@ export type ExternalAddonType = {|
   authors?: Array<AddonAuthorType>,
   average_daily_users?: number,
   categories?: Object,
-  contributions_url?: OutgoingUrl,
+  contributions_url: UrlWithOutgoing | null,
   created: Date,
   // If you make an API request as an admin for an incomplete
   // add-on (status=0) then the current_version could be null.
@@ -108,7 +108,7 @@ export type ExternalAddonType = {|
   guid: string,
   has_eula?: boolean,
   has_privacy_policy?: boolean,
-  homepage?: LocalizedOutgoingUrl,
+  homepage: LocalizedUrlWithOutgoing | null,
   icon_url?: string,
   id: number,
   is_disabled?: boolean,
@@ -132,7 +132,7 @@ export type ExternalAddonType = {|
   status?: AddonStatusType,
   summary?: LocalizedString,
   support_email?: LocalizedString,
-  support_url?: LocalizedOutgoingUrl,
+  support_url: LocalizedUrlWithOutgoing | null,
   tags?: Array<string>,
   target_locale?: string,
   type: AddonTypeType,
@@ -155,12 +155,12 @@ export type AddonType = {|
   // normalized l10n fields
   description: string | null,
   developer_comments: string | null,
-  homepage: OutgoingUrl | null,
+  homepage: UrlWithOutgoing | null,
   name: string,
   previews?: Array<PreviewType>,
   summary: string | null,
   support_email: string | null,
-  support_url: OutgoingUrl | null,
+  support_url: UrlWithOutgoing | null,
   // Here are some custom properties for our internal representation.
   currentVersionId: VersionIdType | null,
   isMozillaSignedExtension: boolean,

--- a/src/core/types/addons.js
+++ b/src/core/types/addons.js
@@ -5,7 +5,11 @@ import type {
   PartialExternalAddonVersionType,
 } from 'core/reducers/versions';
 import type { AddonTypeType, PromotedCategoryType } from 'core/constants';
-import type { LocalizedString } from 'core/types/api';
+import type {
+  LocalizedOutgoingUrl,
+  LocalizedString,
+  OutgoingUrl,
+} from 'core/types/api';
 
 export type AddonStatusType =
   | 'lite'
@@ -92,7 +96,7 @@ export type ExternalAddonType = {|
   authors?: Array<AddonAuthorType>,
   average_daily_users?: number,
   categories?: Object,
-  contributions_url: string,
+  contributions_url?: OutgoingUrl,
   created: Date,
   // If you make an API request as an admin for an incomplete
   // add-on (status=0) then the current_version could be null.
@@ -104,7 +108,7 @@ export type ExternalAddonType = {|
   guid: string,
   has_eula?: boolean,
   has_privacy_policy?: boolean,
-  homepage?: LocalizedString,
+  homepage?: LocalizedOutgoingUrl,
   icon_url?: string,
   id: number,
   is_disabled?: boolean,
@@ -128,7 +132,7 @@ export type ExternalAddonType = {|
   status?: AddonStatusType,
   summary?: LocalizedString,
   support_email?: LocalizedString,
-  support_url?: LocalizedString,
+  support_url?: LocalizedOutgoingUrl,
   tags?: Array<string>,
   target_locale?: string,
   type: AddonTypeType,
@@ -151,12 +155,12 @@ export type AddonType = {|
   // normalized l10n fields
   description: string | null,
   developer_comments: string | null,
-  homepage: string | null,
+  homepage: OutgoingUrl | null,
   name: string,
   previews?: Array<PreviewType>,
   summary: string | null,
   support_email: string | null,
-  support_url: string | null,
+  support_url: OutgoingUrl | null,
   // Here are some custom properties for our internal representation.
   currentVersionId: VersionIdType | null,
   isMozillaSignedExtension: boolean,

--- a/src/core/types/api.js
+++ b/src/core/types/api.js
@@ -22,12 +22,12 @@ export type LocalizedString = {
   [locale: string]: string,
 };
 
-export type OutgoingUrl = {|
+export type UrlWithOutgoing = {|
   outgoing: string,
   url: string,
 |};
 
-export type LocalizedOutgoingUrl = {
+export type LocalizedUrlWithOutgoing = {|
   outgoing: LocalizedString,
   url: LocalizedString,
-};
+|};

--- a/src/core/types/api.js
+++ b/src/core/types/api.js
@@ -21,3 +21,13 @@ export type PaginatedApiResponse<ResultType> = {|
 export type LocalizedString = {
   [locale: string]: string,
 };
+
+export type OutgoingUrl = {|
+  outgoing: string,
+  url: string,
+|};
+
+export type LocalizedOutgoingUrl = {
+  outgoing: LocalizedString,
+  url: LocalizedString,
+};

--- a/src/core/utils/index.js
+++ b/src/core/utils/index.js
@@ -216,14 +216,6 @@ export const safePromise = (callback) => (...args) => {
   }
 };
 
-export function trimAndAddProtocolToUrl(urlToCheck) {
-  let urlToReturn = urlToCheck ? urlToCheck.trim() : null;
-  if (urlToReturn && !urlToReturn.match(/^https?:\/\//)) {
-    urlToReturn = `http://${urlToReturn}`;
-  }
-  return urlToReturn;
-}
-
 /*
  * Decodes HTML entities into their respective symbols.
  */

--- a/tests/unit/amo/api/test_hero.js
+++ b/tests/unit/amo/api/test_hero.js
@@ -14,7 +14,6 @@ describe(__filename, () => {
         endpoint: 'hero',
         apiState,
         // See https://github.com/mozilla/addons-frontend/issues/8826.
-        wrapOutgoingLinks: false,
       })
       .once()
       .returns(createApiResponse());

--- a/tests/unit/amo/api/test_shelves.js
+++ b/tests/unit/amo/api/test_shelves.js
@@ -12,7 +12,6 @@ describe(__filename, () => {
       .withArgs({
         endpoint: 'shelves/sponsored/',
         apiState,
-        wrapOutgoingLinks: false,
       })
       .once()
       .returns(createApiResponse());

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -72,7 +72,10 @@ describe(__filename, () => {
     const addon = createInternalAddonWithLang({
       ...fakeAddon,
       homepage: null,
-      support_url: createLocalizedString('foo.com'),
+      support_url: {
+        url: createLocalizedString('foo.com'),
+        outgoing: createLocalizedString('baa.com'),
+      },
     });
     const root = render({ addon });
 
@@ -130,13 +133,16 @@ describe(__filename, () => {
   it('renders the homepage of an add-on', () => {
     const addon = createInternalAddonWithLang({
       ...fakeAddon,
-      homepage: createLocalizedString('http://hamsterdance.com/'),
+      homepage: {
+        url: createLocalizedString('http://hamsterdance.com/'),
+        outgoing: createLocalizedString('https://outgoing.mozilla.org/hamster'),
+      },
     });
     const root = render({ addon });
     const link = root.find('.AddonMoreInfo-homepage-link');
 
     expect(link).toIncludeText('Homepage');
-    expect(link).toHaveProp('href', 'http://hamsterdance.com/');
+    expect(link).toHaveProp('href', 'https://outgoing.mozilla.org/hamster');
   });
 
   it('does not render a support link if none exists', () => {
@@ -150,13 +156,16 @@ describe(__filename, () => {
   it('renders the support link of an add-on', () => {
     const addon = createInternalAddonWithLang({
       ...fakeAddon,
-      support_url: createLocalizedString('http://support.hampsterdance.com/'),
+      support_url: {
+        url: createLocalizedString('http://support.hampsterdance.com/'),
+        outgoing: createLocalizedString('https://outgoing.mozilla.org/hamster'),
+      },
     });
     const root = render({ addon });
     const link = root.find('.AddonMoreInfo-support-link');
 
     expect(link).toIncludeText('Support site');
-    expect(link).toHaveProp('href', 'http://support.hampsterdance.com/');
+    expect(link).toHaveProp('href', 'https://outgoing.mozilla.org/hamster');
   });
 
   it('renders the email link of an add-on', () => {

--- a/tests/unit/amo/components/TestContributeCard.js
+++ b/tests/unit/amo/components/TestContributeCard.js
@@ -26,7 +26,10 @@ describe(__filename, () => {
   const createAddon = (params) => {
     return createInternalAddonWithLang({
       ...fakeAddon,
-      contributions_url: 'https://paypal.me/babar',
+      contributions_url: {
+        url: 'https://paypal.me/babar',
+        outgoing: 'https://outgoing.mozilla.org/qqq',
+      },
       type: ADDON_TYPE_EXTENSION,
       ...params,
     });
@@ -56,14 +59,17 @@ describe(__filename, () => {
   });
 
   it('does not render anything if add-on has no contributions URL', () => {
-    const root = render({ addon: createAddon({ contributions_url: '' }) });
+    const root = render({ addon: createAddon({ contributions_url: null }) });
     expect(root.find(Card)).toHaveLength(0);
   });
 
   it('renders a Button with a contributions URL', () => {
     const root = render();
     expect(root.find(Button)).toHaveLength(1);
-    expect(root.find(Button)).toHaveProp('href', 'https://paypal.me/babar');
+    expect(root.find(Button)).toHaveProp(
+      'href',
+      'https://outgoing.mozilla.org/qqq',
+    );
     expect(root.find(Button).children().at(1)).toHaveText('Contribute now');
     expect(root.find(Button)).toHaveProp('target', '_blank');
   });
@@ -134,7 +140,7 @@ describe(__filename, () => {
 
   it('sends a tracking event when the button is clicked', () => {
     const _tracking = createFakeTracking();
-    const contributionsUrl = 'some/url';
+    const contributionsUrl = { url: 'some/url', outgoing: 'some/other/url' };
     const guid = 'some-guid';
     const addon = createInternalAddonWithLang({
       ...fakeAddon,

--- a/tests/unit/amo/components/TestContributeCard.js
+++ b/tests/unit/amo/components/TestContributeCard.js
@@ -150,9 +150,7 @@ describe(__filename, () => {
 
     const root = render({ _tracking, addon });
 
-    const event = createFakeEvent({
-      currentTarget: { href: contributionsUrl },
-    });
+    const event = createFakeEvent();
 
     root.find('.ContributeCard-button').simulate('click', event);
 

--- a/tests/unit/amo/components/TestSecondaryHero.js
+++ b/tests/unit/amo/components/TestSecondaryHero.js
@@ -29,7 +29,7 @@ describe(__filename, () => {
   };
 
   it('renders a message with an internal link', () => {
-    const cta = { text: 'cta text', url: 'some/url' };
+    const cta = { text: 'cta text', url: 'some/url', outgoing: 'out/url' };
     const _checkInternalURL = sinon
       .stub()
       .returns({ isInternal: true, relativeURL: cta.url });
@@ -62,7 +62,7 @@ describe(__filename, () => {
 
   it('renders a message with an external link', () => {
     const _checkInternalURL = sinon.stub().returns({ isInternal: false });
-    const cta = { text: 'cta text', url: 'some/url' };
+    const cta = { text: 'cta text', url: 'some/url', outgoing: 'out/url' };
     const shelfData = createShelfData({ cta });
 
     const root = render({ _checkInternalURL, shelfData });
@@ -96,7 +96,7 @@ describe(__filename, () => {
 
   it('sends a tracking event when the cta is clicked', () => {
     const _tracking = createFakeTracking();
-    const cta = { text: 'cta text', url: 'some/url' };
+    const cta = { text: 'cta text', url: 'some/url', outgoing: 'out/url' };
     const shelfData = createShelfData({ cta });
 
     const root = render({ _tracking, shelfData });
@@ -128,7 +128,7 @@ describe(__filename, () => {
     const module1 = {
       icon: 'icon1',
       description: 'module1 description',
-      cta: { text: 'cta1 text', url: 'cta/url1' },
+      cta: { text: 'cta1 text', url: 'cta/url1', outgoing: 'out/url1' },
     };
     const module2 = {
       icon: 'icon2',
@@ -138,7 +138,7 @@ describe(__filename, () => {
     const module3 = {
       icon: 'icon3',
       description: 'module3 description',
-      cta: { text: 'cta3 text', url: 'cta/url3' },
+      cta: { text: 'cta3 text', url: 'cta/url3', outgoing: 'out/url3' },
     };
 
     const shelfData = createShelfData({

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -274,7 +274,10 @@ describe(__filename, () => {
 
   it('renders the block URL if there is one', () => {
     const guid = 'some-guid';
-    const url = 'http://example.org/block/reason/maybe';
+    const url = {
+      url: 'http://example.org/block/reason/maybe',
+      outgoing: 'https://outgoing.mozilla.org/bbb',
+    };
     const block = createFakeBlockResult({ guid, url });
     const { store } = dispatchClientMetadata();
     store.dispatch(loadBlock({ block }));
@@ -282,7 +285,7 @@ describe(__filename, () => {
     const root = render({ store, guid });
 
     expect(root.find('.Block-metadata').html()).toContain(
-      `<a href="${url}">View block request</a>.`,
+      `<a href="${url.outgoing}">View block request</a>.`,
     );
   });
 

--- a/tests/unit/core/api/test_index.js
+++ b/tests/unit/core/api/test_index.js
@@ -56,7 +56,7 @@ describe(__filename, () => {
 
       mockWindow
         .expects('fetch')
-        .withArgs(urlWithTheseParams({ lang, wrap_outgoing_links: true }))
+        .withArgs(urlWithTheseParams({ lang }))
         .returns(createApiResponse());
 
       await api.callApi({ endpoint: 'resource', apiState: state.api });
@@ -88,26 +88,6 @@ describe(__filename, () => {
       });
 
       await api.callApi({ endpoint: 'resource', apiState: state.api });
-      mockWindow.verify();
-    });
-
-    it('can exclude wrap_outgoing_links param', async () => {
-      const { state } = dispatchClientMetadata();
-
-      mockWindow
-        .expects('fetch')
-        .withArgs(
-          sinon.match(
-            (urlString) => !urlString.includes('wrap_outgoing_links'),
-          ),
-        )
-        .returns(createApiResponse());
-
-      await api.callApi({
-        endpoint: 'resource',
-        apiState: state.api,
-        wrapOutgoingLinks: false,
-      });
       mockWindow.verify();
     });
 
@@ -264,7 +244,7 @@ describe(__filename, () => {
       const endpoint = 'some-endpoint/';
       mockWindow
         .expects('fetch')
-        .withArgs(sinon.match(`/api/${apiVersion}/${endpoint}?`))
+        .withArgs(sinon.match(`/api/${apiVersion}/${endpoint}`))
         .returns(createApiResponse());
 
       await api.callApi({ endpoint });
@@ -275,7 +255,7 @@ describe(__filename, () => {
       const endpoint = '/some-endpoint/';
       mockWindow
         .expects('fetch')
-        .withArgs(sinon.match(`/api/${apiVersion}/some-endpoint/?`))
+        .withArgs(sinon.match(`/api/${apiVersion}/some-endpoint/`))
         .returns(createApiResponse());
 
       await api.callApi({ endpoint });

--- a/tests/unit/core/reducers/test_addons.js
+++ b/tests/unit/core/reducers/test_addons.js
@@ -824,24 +824,36 @@ describe(__filename, () => {
     it('coverts localized strings into simple strings', () => {
       const description = 'Some description';
       const developer_comments = 'developer comments';
-      const homepage = 'https://myhomepage.com';
+      const homepage = {
+        url: 'https://myhomepage.com',
+        outgoing: 'https://outgoing.mozilla.org/myh',
+      };
       const name = 'My addon';
       const previews = [fakePreview];
       const summary = 'A summary';
       const support_email = 'someemail@mozilla.com';
-      const support_url = 'https://support.com';
+      const support_url = {
+        url: 'https://support.com',
+        outgoing: 'https://outgoing.mozilla.org/sup',
+      };
 
       const addon = createInternalAddon(
         {
           ...fakeAddon,
           description: createLocalizedString(description, lang),
           developer_comments: createLocalizedString(developer_comments, lang),
-          homepage: createLocalizedString(homepage, lang),
+          homepage: {
+            url: createLocalizedString(homepage.url, lang),
+            outgoing: createLocalizedString(homepage.outgoing, lang),
+          },
           name: createLocalizedString(name, lang),
           previews,
           summary: createLocalizedString(summary, lang),
           support_email: createLocalizedString(support_email, lang),
-          support_url: createLocalizedString(support_url, lang),
+          support_url: {
+            url: createLocalizedString(support_url.url, lang),
+            outgoing: createLocalizedString(support_url.outgoing, lang),
+          },
         },
         lang,
       );

--- a/tests/unit/core/utils/test_index.js
+++ b/tests/unit/core/utils/test_index.js
@@ -30,7 +30,6 @@ import {
   safePromise,
   sanitizeHTML,
   sanitizeUserHTML,
-  trimAndAddProtocolToUrl,
   visibleAddonType,
 } from 'core/utils';
 import { createPlatformFiles } from 'core/reducers/versions';
@@ -408,22 +407,6 @@ describe(__filename, () => {
       return asPromised().then(unexpectedSuccess, (error) => {
         expect(error.message).toEqual(message);
       });
-    });
-  });
-
-  describe('trimAndAddProtocolToUrl', () => {
-    it('adds a protocol to a URL if missing', () => {
-      expect(trimAndAddProtocolToUrl('test.com')).toEqual('http://test.com');
-    });
-
-    it('trims whitespace on a URL', () => {
-      expect(trimAndAddProtocolToUrl(' test.com ')).toEqual('http://test.com');
-    });
-
-    it('works with HTTPS URLs', () => {
-      expect(trimAndAddProtocolToUrl('https://test.com')).toEqual(
-        'https://test.com',
-      );
     });
   });
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -123,7 +123,7 @@ export const fakeAddon = Object.freeze({
   authors: [fakeAuthor],
   average_daily_users: 100,
   categories: { firefox: ['other'] },
-  contributions_url: '',
+  contributions_url: null,
   created: '2014-11-22T10:09:01Z',
   current_version: fakeVersion,
   description: createLocalizedString(
@@ -134,7 +134,10 @@ export const fakeAddon = Object.freeze({
   guid: '1234@my-addons.firefox',
   has_eula: true,
   has_privacy_policy: true,
-  homepage: createLocalizedString('http://hamsterdance.com/'),
+  homepage: {
+    'url': createLocalizedString('http://hamsterdance.com/'),
+    'outgoing': createLocalizedString('https://outgoing.mozilla.org/hamster'),
+  },
   id: 1234,
   icon_url: 'https://addons.cdn.mozilla.net/webdev-64.png',
   is_disabled: false,
@@ -155,7 +158,12 @@ export const fakeAddon = Object.freeze({
   status: 'public',
   summary: createLocalizedString('This is a summary of the chill out add-on'),
   support_email: null,
-  support_url: createLocalizedString('http://support.hampsterdance.com/'),
+  support_url: {
+    url: createLocalizedString('http://support.hampsterdance.com/'),
+    outgoing: createLocalizedString(
+      'https://outgoing.mozilla.org/supporthamster',
+    ),
+  },
   tags: ['chilling'],
   type: ADDON_TYPE_EXTENSION,
   url: 'https://addons.m.o/addon/chill-out/',
@@ -304,24 +312,40 @@ export const createPrimaryHeroShelf = ({
 };
 
 export const createSecondaryHeroShelf = ({
-  cta = { url: 'https://mozilla.org', text: 'Some cta text' },
+  cta = {
+    url: 'https://mozilla.org',
+    outgoing: 'https://outgoing/',
+    text: 'Some cta text',
+  },
   description = 'Secondary shelf description',
   headline = 'Secondary shelf headline',
   modules = [
     {
       icon: 'icon1',
       description: 'module 1 description',
-      cta: { url: 'https://mozilla.org/1', text: 'module 1 cta text' },
+      cta: {
+        url: 'https://mozilla.org/1',
+        outgoing: 'https://outgoing/1',
+        text: 'module 1 cta text',
+      },
     },
     {
       icon: 'icon2',
       description: 'module 2 description',
-      cta: { url: 'https://mozilla.org/2', text: 'module 2 cta text' },
+      cta: {
+        url: 'https://mozilla.org/2',
+        outgoing: 'https://outgoing/2',
+        text: 'module 2 cta text',
+      },
     },
     {
       icon: 'icon3',
       description: 'module 3 description',
-      cta: { url: 'https://mozilla.org/3', text: 'module 3 cta text' },
+      cta: {
+        url: 'https://mozilla.org/3',
+        outgoing: 'https://outgoing/3',
+        text: 'module 3 cta text',
+      },
     },
   ],
 } = {}) => {


### PR DESCRIPTION
fixes #9911 - I hope!

Currently we're only using either url _or_ outgoing so I didn't think I needed to add any new tests, but to be able to implement https://github.com/mozilla/addons-frontend/issues/3580 I thought it easiest store both in the internal models now (rather than throw one away in the reducers).