### PR TITLE
Set local ports to 700x because 400x is used for production

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,5 +12,6 @@
   "serverPort": "SERVER_PORT",
   "staticHost": "STATIC_HOST",
   "trackingEnabled": "TRACKING_ENABLED",
-  "webpackServerHost": "WEBPACK_SERVER_HOST"
+  "webpackServerHost": "WEBPACK_SERVER_HOST",
+  "webpackServerPort": "WEBPACK_SERVER_PORT"
 }

--- a/config/development-local.js
+++ b/config/development-local.js
@@ -1,13 +1,13 @@
 // This config should be used with a local addons-server setup.
 module.exports = {
   apiHost: 'http://olympia.test',
-  proxyPort: 6000,
+  proxyPort: 7000,
 
   serverHost: 'olympia.test',
 
   baseURL: 'http://olympia.test',
 
-  webpackServerPort: 6001,
+  webpackServerPort: 7001,
 
   mozillaUserId: 10968,
   CSP: false,

--- a/config/development-local.js
+++ b/config/development-local.js
@@ -1,13 +1,13 @@
 // This config should be used with a local addons-server setup.
 module.exports = {
   apiHost: 'http://olympia.test',
-  proxyPort: 4000,
+  proxyPort: 6000,
 
   serverHost: 'olympia.test',
 
   baseURL: 'http://olympia.test',
 
-  webpackServerPort: 4001,
+  webpackServerPort: 6001,
 
   mozillaUserId: 10968,
   CSP: false,


### PR DESCRIPTION
We're already using 6000 in code-manager, I guess for the same reasons? In short, `4000` is "reserved" for production and configured in our `Dockerfile`. It's annoying because it creates conflicts when we want to use Docker images.

5000 is used by code-manager.