### PR TITLE
Deal with collections with null names

### DIFF
--- a/src/amo/components/CollectionDetails/index.js
+++ b/src/amo/components/CollectionDetails/index.js
@@ -61,7 +61,7 @@ export class CollectionDetailsBase extends React.Component<InternalProps> {
       <div className="CollectionDetails">
         <h1 className="CollectionDetails-title">
           {collection ? (
-            collection.name || i18n.gettext('Blank Name')
+            collection.name || i18n.gettext('(no name)')
           ) : (
             <LoadingText />
           )}

--- a/src/amo/components/CollectionDetails/index.js
+++ b/src/amo/components/CollectionDetails/index.js
@@ -60,7 +60,11 @@ export class CollectionDetailsBase extends React.Component<InternalProps> {
     return (
       <div className="CollectionDetails">
         <h1 className="CollectionDetails-title">
-          {collection ? collection.name : <LoadingText />}
+          {collection ? (
+            collection.name || i18n.gettext('Blank Name')
+          ) : (
+            <LoadingText />
+          )}
         </h1>
         <p className="CollectionDetails-description">
           {collection ? (

--- a/src/ui/components/UserCollection/index.js
+++ b/src/ui/components/UserCollection/index.js
@@ -51,7 +51,7 @@ export const UserCollectionBase = (props: InternalProps) => {
     <li className="UserCollection" key={id}>
       <Link className="UserCollection-link" {...linkProps}>
         <h2 className="UserCollection-name">
-          {loading ? <LoadingText /> : name || i18n.gettext('Blank Name')}
+          {loading ? <LoadingText /> : name || i18n.gettext('(no name)')}
         </h2>
         <p className="UserCollection-number">{numberText || <LoadingText />}</p>
       </Link>

--- a/src/ui/components/UserCollection/index.js
+++ b/src/ui/components/UserCollection/index.js
@@ -34,7 +34,6 @@ export const UserCollectionBase = (props: InternalProps) => {
     linkProps.href = '';
   } else {
     invariant(authorId, 'authorId is required');
-    invariant(name, 'name is required');
     invariant(slug, 'slug is required');
     invariant(
       numberOfAddons !== undefined && Number.isInteger(numberOfAddons),
@@ -51,7 +50,9 @@ export const UserCollectionBase = (props: InternalProps) => {
   return (
     <li className="UserCollection" key={id}>
       <Link className="UserCollection-link" {...linkProps}>
-        <h2 className="UserCollection-name">{name || <LoadingText />}</h2>
+        <h2 className="UserCollection-name">
+          {loading ? <LoadingText /> : name || i18n.gettext('Blank Name')}
+        </h2>
         <p className="UserCollection-number">{numberText || <LoadingText />}</p>
       </Link>
     </li>

--- a/tests/unit/amo/components/TestCollectionDetails.js
+++ b/tests/unit/amo/components/TestCollectionDetails.js
@@ -78,6 +78,20 @@ describe(__filename, () => {
     ]);
   });
 
+  it('can handle a blank name', () => {
+    const collection = createInternalCollectionWithLang({
+      detail: createFakeCollectionDetail({
+        name: null,
+      }),
+    });
+
+    const root = render({ collection });
+
+    expect(root.find('.CollectionDetails-title').children()).toHaveText(
+      'Blank Name',
+    );
+  });
+
   it('allows HTML entities in the Collection description', () => {
     const description = 'Apples &amp; carrots';
     const collection = createInternalCollectionWithLang({

--- a/tests/unit/amo/components/TestCollectionDetails.js
+++ b/tests/unit/amo/components/TestCollectionDetails.js
@@ -88,7 +88,7 @@ describe(__filename, () => {
     const root = render({ collection });
 
     expect(root.find('.CollectionDetails-title').children()).toHaveText(
-      'Blank Name',
+      '(no name)',
     );
   });
 

--- a/tests/unit/ui/components/TestUserCollection.js
+++ b/tests/unit/ui/components/TestUserCollection.js
@@ -40,6 +40,22 @@ describe(__filename, () => {
     );
   });
 
+  it('can render a collection with a null for a name', () => {
+    const props = {
+      authorId: 1234,
+      id: 1,
+      name: null,
+      numberOfAddons: 5,
+      slug: 'some-slug',
+    };
+
+    const root = render(props);
+
+    expect(root.find('.UserCollection-name').children()).toHaveText(
+      'Blank Name',
+    );
+  });
+
   it('renders singular text for a collection with 1 add-on', () => {
     const props = {
       authorId: 1234,

--- a/tests/unit/ui/components/TestUserCollection.js
+++ b/tests/unit/ui/components/TestUserCollection.js
@@ -52,7 +52,7 @@ describe(__filename, () => {
     const root = render(props);
 
     expect(root.find('.UserCollection-name').children()).toHaveText(
-      'Blank Name',
+      '(no name)',
     );
   });
 


### PR DESCRIPTION
Fixes #9977

Note that the repetition of the string (in this case "(no name)") in two templates is required to allow for l10n support.
