### PR TITLE
Display "(no name)" for collections with missing names in AddAddonToCollection

### DIFF
--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -9,6 +9,7 @@ import {
   addAddonToCollection,
   expandCollections,
   fetchUserCollections,
+  collectionName,
 } from 'amo/reducers/collections';
 import { getCurrentUser } from 'amo/reducers/users';
 import { withFixedErrorHandler } from 'amo/errorHandler';
@@ -156,10 +157,6 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
     );
   }
 
-  getBlankName(): string {
-    return this.props.i18n.gettext('(no name)');
-  }
-
   getSelectData(): SelectData {
     const {
       addon,
@@ -222,7 +219,7 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
           // belongs to, they will see an error.
           collectionOptions.push(
             this.createOption({
-              text: collection.name || this.getBlankName(),
+              text: collectionName({ name: collection.name, i18n }),
               key: `collection-${collection.id}`,
               onSelect: () => {
                 this.addToCollection(collection);
@@ -244,7 +241,7 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
       addedNotices = addonInCollections.map((collection) => {
         const notice = i18n.sprintf(
           i18n.gettext('Added to %(collectionName)s'),
-          { collectionName: collection.name || this.getBlankName() },
+          { collectionName: collectionName({ name: collection.name, i18n }) },
         );
         return (
           <Notice

--- a/src/amo/components/AddAddonToCollection/index.js
+++ b/src/amo/components/AddAddonToCollection/index.js
@@ -156,6 +156,10 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
     );
   }
 
+  getBlankName(): string {
+    return this.props.i18n.gettext('(no name)');
+  }
+
   getSelectData(): SelectData {
     const {
       addon,
@@ -218,7 +222,7 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
           // belongs to, they will see an error.
           collectionOptions.push(
             this.createOption({
-              text: collection.name,
+              text: collection.name || this.getBlankName(),
               key: `collection-${collection.id}`,
               onSelect: () => {
                 this.addToCollection(collection);
@@ -240,7 +244,7 @@ export class AddAddonToCollectionBase extends React.Component<InternalProps> {
       addedNotices = addonInCollections.map((collection) => {
         const notice = i18n.sprintf(
           i18n.gettext('Added to %(collectionName)s'),
-          { collectionName: collection.name },
+          { collectionName: collection.name || this.getBlankName() },
         );
         return (
           <Notice

--- a/src/amo/components/CollectionDetails/index.js
+++ b/src/amo/components/CollectionDetails/index.js
@@ -6,6 +6,7 @@ import { compose } from 'redux';
 import {
   beginEditingCollectionDetails,
   collectionEditUrl,
+  collectionName,
   collectionUrl,
   convertFiltersToQueryParams,
 } from 'amo/reducers/collections';
@@ -61,7 +62,7 @@ export class CollectionDetailsBase extends React.Component<InternalProps> {
       <div className="CollectionDetails">
         <h1 className="CollectionDetails-title">
           {collection ? (
-            collection.name || i18n.gettext('(no name)')
+            collectionName({ name: collection.name, i18n })
           ) : (
             <LoadingText />
           )}

--- a/src/amo/components/UserCollection/index.js
+++ b/src/amo/components/UserCollection/index.js
@@ -6,6 +6,7 @@ import { compose } from 'redux';
 import translate from 'amo/i18n/translate';
 import Link from 'amo/components/Link';
 import LoadingText from 'amo/components/LoadingText';
+import { collectionName } from 'amo/reducers/collections';
 import type { I18nType } from 'amo/types/i18n';
 
 import './styles.scss';
@@ -51,7 +52,7 @@ export const UserCollectionBase = (props: InternalProps) => {
     <li className="UserCollection" key={id}>
       <Link className="UserCollection-link" {...linkProps}>
         <h2 className="UserCollection-name">
-          {loading ? <LoadingText /> : name || i18n.gettext('(no name)')}
+          {loading ? <LoadingText /> : collectionName({ name, i18n })}
         </h2>
         <p className="UserCollection-number">{numberText || <LoadingText />}</p>
       </Link>

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -16,6 +16,7 @@ import Page from 'amo/components/Page';
 import { isFeaturedCollection } from 'amo/pages/Home';
 import {
   collectionEditUrl,
+  collectionName,
   collectionUrl,
   convertFiltersToQueryParams,
   deleteCollectionAddonNotes,
@@ -517,14 +518,14 @@ export class CollectionBase extends React.Component<InternalProps> {
         : i18n.gettext(`Download and create Firefox collections to keep track
           of favorite extensions and themes. Explore the %(collectionName)s.`),
       {
-        collectionName: collection.name,
+        collectionName: collectionName({ name: collection.name, i18n }),
         collectionDescription: collection.description,
       },
     );
   }
 
   render() {
-    const { collection, errorHandler } = this.props;
+    const { collection, errorHandler, i18n } = this.props;
 
     if (errorHandler.hasError()) {
       log.warn(`Captured API Error: ${errorHandler.capturedError.messages}`);
@@ -539,7 +540,7 @@ export class CollectionBase extends React.Component<InternalProps> {
         <div className="Collection">
           {collection && (
             <Helmet>
-              <title>{collection.name}</title>
+              <title>{collectionName({ name: collection.name, i18n })}</title>
               <meta name="description" content={this.getPageDescription()} />
             </Helmet>
           )}

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -8,6 +8,7 @@ import { createInternalAddon } from 'amo/reducers/addons';
 import { selectLocalizedContent } from 'amo/reducers/utils';
 import type { CollectionAddonType, ExternalAddonType } from 'amo/types/addons';
 import type { LocalizedString } from 'amo/types/api';
+import type { I18nType } from 'amo/types/i18n';
 
 export const ADD_ADDON_TO_COLLECTION: 'ADD_ADDON_TO_COLLECTION' =
   'ADD_ADDON_TO_COLLECTION';
@@ -1003,6 +1004,14 @@ export const collectionEditUrl = ({
     collectionSlug,
   })}edit/`;
 };
+
+export const collectionName = ({
+  i18n,
+  name,
+}: {|
+  i18n: I18nType,
+  name?: string,
+|}): string => name || i18n.gettext('(no name)');
 
 type Action =
   | AbortFetchCurrentCollection

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -8,6 +8,7 @@ import AddAddonToCollection, {
 import {
   addAddonToCollection,
   addonAddedToCollection,
+  collectionName,
   fetchUserCollections,
   loadUserCollections,
 } from 'amo/reducers/collections';
@@ -296,7 +297,7 @@ describe(__filename, () => {
       expect(option).toHaveText(firstName);
     });
 
-    it('displays "(no name)" for collections without names', () => {
+    it('displays expected name for collections without names', () => {
       const addon = createInternalAddonWithLang({ ...fakeAddon, id: 234 });
       const userId = 10;
 
@@ -313,7 +314,9 @@ describe(__filename, () => {
       const root = render({ addon });
       const option = root.find('optgroup .AddAddonToCollection-option').at(0);
 
-      expect(option).toHaveText(root.instance().getBlankName());
+      expect(option).toHaveText(
+        collectionName({ name: null, i18n: fakeI18n() }),
+      );
     });
 
     it('shows a notice that you added to a collection', () => {
@@ -386,7 +389,7 @@ describe(__filename, () => {
       expect(text(1)).toContain(`Added to ${secondName}`);
     });
 
-    it('uses "(no name)" in the notice when the collection name is missing', () => {
+    it('uses expected name in the notice when the collection name is missing', () => {
       const addon = createInternalAddonWithLang(fakeAddon);
       const userId = 10;
 
@@ -412,7 +415,7 @@ describe(__filename, () => {
       const notice = root.find(Notice);
       expect(notice.prop('type')).toEqual('success');
       expect(notice.childAt(0).text()).toContain(
-        `Added to ${root.instance().getBlankName()}`,
+        `Added to ${collectionName({ name: null, i18n: fakeI18n() })}`,
       );
     });
 

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import AddAddonToCollection, {
-  extractId,
   AddAddonToCollectionBase,
+  extractId,
   mapStateToProps,
 } from 'amo/components/AddAddonToCollection';
 import {
@@ -296,6 +296,26 @@ describe(__filename, () => {
       expect(option).toHaveText(firstName);
     });
 
+    it('displays "(no name)" for collections without names', () => {
+      const addon = createInternalAddonWithLang({ ...fakeAddon, id: 234 });
+      const userId = 10;
+
+      const { firstCollection, secondCollection } = createSomeCollections({
+        firstName: null,
+        userId,
+      });
+
+      signInAndDispatchCollections({
+        userId,
+        collections: [firstCollection, secondCollection],
+      });
+
+      const root = render({ addon });
+      const option = root.find('optgroup .AddAddonToCollection-option').at(0);
+
+      expect(option).toHaveText(root.instance().getBlankName());
+    });
+
     it('shows a notice that you added to a collection', () => {
       const addon = createInternalAddonWithLang(fakeAddon);
       const firstName = 'a collection';
@@ -364,6 +384,36 @@ describe(__filename, () => {
       };
       expect(text(0)).toContain(`Added to ${firstName}`);
       expect(text(1)).toContain(`Added to ${secondName}`);
+    });
+
+    it('uses "(no name)" in the notice when the collection name is missing', () => {
+      const addon = createInternalAddonWithLang(fakeAddon);
+      const userId = 10;
+
+      const { firstCollection } = createSomeCollections({
+        firstName: null,
+        userId,
+      });
+
+      signInAndDispatchCollections({
+        userId,
+        collections: [firstCollection],
+      });
+      store.dispatch(
+        addonAddedToCollection({
+          addonId: addon.id,
+          userId,
+          collectionId: firstCollection.id,
+        }),
+      );
+
+      const root = render({ addon });
+
+      const notice = root.find(Notice);
+      expect(notice.prop('type')).toEqual('success');
+      expect(notice.childAt(0).text()).toContain(
+        `Added to ${root.instance().getBlankName()}`,
+      );
     });
 
     it('does nothing when you select the prompt', () => {

--- a/tests/unit/amo/components/TestCollectionDetails.js
+++ b/tests/unit/amo/components/TestCollectionDetails.js
@@ -8,6 +8,7 @@ import MetadataCard from 'amo/components/MetadataCard';
 import {
   beginEditingCollectionDetails,
   collectionEditUrl,
+  collectionName,
   collectionUrl,
   convertFiltersToQueryParams,
 } from 'amo/reducers/collections';
@@ -88,7 +89,7 @@ describe(__filename, () => {
     const root = render({ collection });
 
     expect(root.find('.CollectionDetails-title').children()).toHaveText(
-      '(no name)',
+      collectionName({ name: null, i18n: fakeI18n() }),
     );
   });
 

--- a/tests/unit/amo/components/TestUserCollection.js
+++ b/tests/unit/amo/components/TestUserCollection.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { collectionName } from 'amo/reducers/collections';
 import UserCollection, {
   UserCollectionBase,
 } from 'amo/components/UserCollection';
@@ -52,7 +53,7 @@ describe(__filename, () => {
     const root = render(props);
 
     expect(root.find('.UserCollection-name').children()).toHaveText(
-      '(no name)',
+      collectionName({ name: null, i18n: fakeI18n() }),
     );
   });
 

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -18,6 +18,7 @@ import ConfirmButton from 'amo/components/ConfirmButton';
 import ErrorList from 'amo/components/ErrorList';
 import LoadingText from 'amo/components/LoadingText';
 import {
+  collectionName,
   deleteCollection,
   deleteCollectionAddonNotes,
   fetchCurrentCollection,
@@ -975,6 +976,22 @@ describe(__filename, () => {
     expect(wrapper.find('title')).toHaveText(defaultCollectionName);
   });
 
+  it('renders an HTML title for a collection with a missing name', () => {
+    const { store } = dispatchClientMetadata();
+
+    _loadCurrentCollection({
+      detail: createFakeCollectionDetail({
+        name: null,
+      }),
+      store,
+    });
+
+    const wrapper = renderComponent({ store });
+    expect(wrapper.find('title')).toHaveText(
+      collectionName({ name: null, i18n: fakeI18n() }),
+    );
+  });
+
   it('does not render an HTML title when there is no collection loaded', () => {
     const wrapper = renderComponent();
     expect(wrapper.find('title')).toHaveLength(0);
@@ -1497,6 +1514,27 @@ describe(__filename, () => {
     expect(root.find('meta[name="description"]')).toHaveLength(1);
     expect(root.find('meta[name="description"]').prop('content')).toMatch(
       new RegExp(`Explore the ${name}.`),
+    );
+  });
+
+  it('renders a "description" meta tag for a collection with a missing name', () => {
+    const name = null;
+    const description = '';
+
+    const { store } = dispatchClientMetadata();
+    const detail = createFakeCollectionDetail({ description, name });
+    _loadCurrentCollection({ detail, store });
+
+    const root = renderComponent({ store });
+
+    expect(root.find('meta[name="description"]')).toHaveLength(1);
+    expect(root.find('meta[name="description"]').prop('content')).toMatch(
+      new RegExp(
+        collectionName({
+          name,
+          i18n: fakeI18n(),
+        }),
+      ),
     );
   });
 

--- a/tests/unit/amo/reducers/test_collections.js
+++ b/tests/unit/amo/reducers/test_collections.js
@@ -8,6 +8,7 @@ import reducer, {
   beginCollectionModification,
   beginEditingCollectionDetails,
   collectionEditUrl,
+  collectionName,
   collectionUrl,
   convertFiltersToQueryParams,
   createCollection,
@@ -42,6 +43,7 @@ import {
   createInternalCollectionWithLang,
   createStubErrorHandler,
   fakeAddon,
+  fakeI18n,
   onLocationChanged,
 } from 'tests/unit/helpers';
 
@@ -1116,6 +1118,19 @@ describe(__filename, () => {
         '/base/url/edit/',
       );
       sinon.assert.calledWith(_collectionUrl, { ...params });
+    });
+  });
+
+  describe('collectionName', () => {
+    it('returns the collection name if it exists', () => {
+      const name = 'some name';
+      expect(collectionName({ name, i18n: fakeI18n() })).toEqual(name);
+    });
+
+    it('returns the expected string if name is missing', () => {
+      expect(collectionName({ name: null, i18n: fakeI18n() })).toEqual(
+        '(no name)',
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #9994 
