### PR TITLE
Prevent UserProfileEditPicture to be triggered when submitting the form with enter

### DIFF
--- a/src/amo/components/UserProfileEditPicture/index.js
+++ b/src/amo/components/UserProfileEditPicture/index.js
@@ -102,6 +102,7 @@ export class UserProfileEditPictureBase extends React.Component<InternalProps> {
           <ConfirmButton
             buttonType="cancel"
             className={confirmButtonClassName}
+            htmlType="button"
             id={confirmButtonClassName}
             message={i18n.gettext('Do you really want to delete this picture?')}
             onConfirm={onDelete}

--- a/src/ui/components/Button/index.js
+++ b/src/ui/components/Button/index.js
@@ -24,6 +24,7 @@ export type Props = {|
   disabled: boolean,
   externalDark?: boolean,
   href?: string,
+  htmlType?: string,
   micro: boolean,
   name?: number,
   noLink: boolean,
@@ -50,6 +51,7 @@ export default class Button extends React.Component<Props> {
   static defaultProps = {
     buttonType: 'none',
     disabled: false,
+    htmlType: 'submit',
     micro: false,
     noLink: false,
     puffy: false,
@@ -61,6 +63,7 @@ export default class Button extends React.Component<Props> {
       children,
       className,
       href,
+      htmlType,
       micro,
       puffy,
       noLink,
@@ -133,7 +136,8 @@ export default class Button extends React.Component<Props> {
     }
 
     return (
-      <button className={getClassName()} type="submit" {...props}>
+      // eslint-disable-next-line react/button-has-type
+      <button className={getClassName()} type={htmlType} {...props}>
         {children}
       </button>
     );

--- a/src/ui/components/ConfirmButton/index.js
+++ b/src/ui/components/ConfirmButton/index.js
@@ -12,6 +12,7 @@ import type { Props as ConfirmationDialogProps } from 'ui/components/Confirmatio
 
 type Props = {|
   buttonType?: ButtonType,
+  htmlType?: string,
   cancelButtonText?: $PropertyType<ConfirmationDialogProps, 'cancelButtonText'>,
   cancelButtonType?: $PropertyType<ConfirmationDialogProps, 'cancelButtonType'>,
   children: React.Element<any> | string,
@@ -69,6 +70,7 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
       className,
       confirmButtonText,
       confirmButtonType,
+      htmlType,
       id,
       message,
       onConfirm,
@@ -102,6 +104,7 @@ export class ConfirmButtonBase extends React.Component<InternalProps> {
         ) : (
           <Button
             buttonType={buttonType}
+            htmlType={htmlType}
             className="ConfirmButton-default-button"
             onClick={this.toggleConfirmation}
           >

--- a/tests/unit/amo/components/TestUserProfileEditPicture.js
+++ b/tests/unit/amo/components/TestUserProfileEditPicture.js
@@ -143,6 +143,15 @@ describe(__filename, () => {
     expect(root.find(ConfirmButton).children()).toHaveText(
       'Delete This Picture',
     );
+    // By default, a `ConfirmButton` (or even a `Button`) has type "submit" but
+    // we don't want that for this button as the `UserProfileEditPicture`
+    // component is meant to be rendered within the `UserProfileEdit` form.
+    // The first button with type "submit" in the form is triggered when we
+    // submit the form by pressing `enter`, and if this component had a button
+    // with type "submit", it would be the first one in the form, which is not
+    // what we want!
+    // See: https://github.com/mozilla/addons-frontend/issues/9493
+    expect(root.find(ConfirmButton)).toHaveProp('htmlType', 'button');
   });
 
   it('does not render a "delete" ConfirmButton when user has no picture URL', () => {

--- a/tests/unit/ui/components/TestButton.js
+++ b/tests/unit/ui/components/TestButton.js
@@ -147,5 +147,13 @@ describe(__filename, () => {
 
     expect(button.type()).toEqual('button');
     expect(button).toHaveProp('title', title);
+    expect(button).toHaveProp('type', 'submit');
+  });
+
+  it('renders a button with a different html type', () => {
+    const htmlType = 'button';
+    const button = render({ htmlType });
+
+    expect(button).toHaveProp('type', htmlType);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/9493