### PR TITLE
Add docs about Fenix custom builds

### DIFF
--- a/docs/fenix.md
+++ b/docs/fenix.md
@@ -1,6 +1,6 @@
 # Fenix
 
-It is sometimes useful to test AMO with a Fenix build pointing to -dev or -stage given the tight integration between these two components. In the sequel of this page, we describe how to construct a custom Fenix build.
+It is sometimes useful to test AMO with a Fenix build pointing to -dev or -stage given the tight integration between these two components. We describe how to construct a custom Fenix build below.
 
 The first step is to get a working Android development environment. The easiest way is to install [Android Studio](https://developer.android.com/studio). Follow the [Fenix build instructions](https://github.com/mozilla-mobile/fenix#build-instructions) to get the Fenix code and construct a debug build (which will download the dependencies and compile the code).
 

--- a/docs/fenix.md
+++ b/docs/fenix.md
@@ -1,0 +1,56 @@
+# Fenix
+
+It is sometimes useful to test AMO with a Fenix build pointing to -dev or -stage given the tight integration between these two components. In the sequel, we describe how to construct a custom Fenix build.
+
+The first step is to get a working Android development environment. The easiest way is to install [Android Studio](https://developer.android.com/studio). Follow the [Fenix build instructions](https://github.com/mozilla-mobile/fenix#build-instructions) to get the Fenix code and construct a debug build (which will download the dependencies and compile the code).
+
+Android Studio provides virtual devices _via_ the [AVD Manager](https://developer.android.com/studio/run/managing-avds) in case you do not have a real Android-compatible device. In order to run the Fenix debug build created before, either configure a new virtual device or use your own device, then run the following command in the Fenix root directory:
+
+```
+$ ./gradlew installDebug
+```
+
+For more information, you can find more information on this page: https://developer.android.com/studio/build/building-cmdline#RunningOnDevice
+
+## Custom build for AMO
+
+Once you ensured that you can compile, install and run a debug Fenix build, let's update the build configuration for AMO -stage. Only a few values have to be changed in the `app/build.gradle` file as shown below:
+
+```diff
+
+diff --git a/app/build.gradle b/app/build.gradle
+index cd7c44f2d..78e0ffd2e 100644
+--- a/app/build.gradle
++++ b/app/build.gradle
+@@ -38,11 +38,11 @@ android {
+         resValue "bool", "IS_DEBUG", "false"
+         buildConfigField "boolean", "USE_RELEASE_VERSIONING", "false"
+         // This should be the "public" base URL of AMO.
+-        buildConfigField "String", "AMO_BASE_URL", "\"https://addons.mozilla.org\""
+-        buildConfigField "String", "AMO_COLLECTION_NAME", "\"7dfae8669acc4312a65e8ba5553036\""
+-        buildConfigField "String", "AMO_COLLECTION_USER", "\"mozilla\""
++        buildConfigField "String", "AMO_BASE_URL", "\"https://addons.allizom.org\""
++        buildConfigField "String", "AMO_COLLECTION_NAME", "\"fenix\""
++        buildConfigField "String", "AMO_COLLECTION_USER", "\"11686491\""
+         // This should be the base URL used to call the AMO API.
+-        buildConfigField "String", "AMO_SERVER_URL", "\"https://services.addons.mozilla.org\""
++        buildConfigField "String", "AMO_SERVER_URL", "\"https://addons.allizom.org\""
+         def deepLinkSchemeValue = "fenix-dev"
+         buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
+         manifestPlaceholders = [
+```
+
+You may want to use your own values for `AMO_COLLECTION_USER` and `AMO_COLLECTION_NAME`. These values are used to determine which add-ons can be installed in Fenix based on an AMO collection. In this diff above, the ["fenix" collection](https://addons.allizom.org/en-US/firefox/collections/11686491/fenix/) is owned by [willdurand](https://github.com/willdurand).
+
+Recompile and install the custom build with the following command:
+
+```
+$ ./gradlew installDebug
+```
+
+The last step is to configure some prefs to be able to install -dev/-stage add-ons. Open `about:config` in your Fenix custom build and create/update the following prefs:
+
+- `extensions.webapi.testing` set to `true`
+- `xpinstall.signatures.dev-root` set to `true`
+
+You should now be able to install add-ons from https://addons.allizom.org/ based on the list specified above.

--- a/docs/fenix.md
+++ b/docs/fenix.md
@@ -1,6 +1,6 @@
 # Fenix
 
-It is sometimes useful to test AMO with a Fenix build pointing to -dev or -stage given the tight integration between these two components. In the sequel, we describe how to construct a custom Fenix build.
+It is sometimes useful to test AMO with a Fenix build pointing to -dev or -stage given the tight integration between these two components. In the sequel of this page, we describe how to construct a custom Fenix build.
 
 The first step is to get a working Android development environment. The easiest way is to install [Android Studio](https://developer.android.com/studio). Follow the [Fenix build instructions](https://github.com/mozilla-mobile/fenix#build-instructions) to get the Fenix code and construct a debug build (which will download the dependencies and compile the code).
 

--- a/docs/fenix.md
+++ b/docs/fenix.md
@@ -54,3 +54,5 @@ The last step is to configure some prefs to be able to install -dev/-stage add-o
 - `xpinstall.signatures.dev-root` set to `true`
 
 You should now be able to install add-ons from https://addons.allizom.org/ based on the list specified above.
+
+Note: the commands above usually output different APKs for different architectures. All generated APKs can be found in `app/build/outputs/apk/debug` in case you need to share them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,3 +6,5 @@
 - [Internationalization (i18n)](./i18n.md)
 - [Our Approach to Writing CSS](./css.md)
 - [Testing](./testing.md)
+- [Fenix](./fenix.md)
+- [Windows](./windows.md)


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10022

---

I added a new section in our docs to explain how to build a Fenix custom build targetting a specific AMO env.