### PR TITLE
Collect web-vitals whenever possible

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -127,6 +127,7 @@ module.exports = {
     'trackingEnabled',
     'trackingId',
     'trackingSendInitPageView',
+    'trackingSendWebVitals',
     'unsupportedHrefLangs',
     'validClientAppUrlExceptions',
     'validClientApplications',
@@ -294,6 +295,8 @@ module.exports = {
   trackingId: 'UA-36116321-7',
   // send a page view on initialization.
   trackingSendInitPageView: true,
+  // send web vitals stats to GA
+  trackingSendWebVitals: false,
 
   enablePostCssLoader: true,
 

--- a/config/dev.js
+++ b/config/dev.js
@@ -13,6 +13,8 @@ module.exports = {
 
   enableDevTools: true,
 
+  trackingSendWebVitals: true,
+
   // Content security policy.
   CSP: {
     directives: {

--- a/package.json
+++ b/package.json
@@ -252,6 +252,7 @@
     "url-loader": "4.1.1",
     "utf8": "3.0.0",
     "uuid": "8.3.2",
+    "web-vitals": "1.1.0",
     "webpack-isomorphic-tools": "3.0.6"
   },
   "devDependencies": {

--- a/tests/unit/amo/test_tracking.js
+++ b/tests/unit/amo/test_tracking.js
@@ -200,6 +200,66 @@ describe(__filename, () => {
       tracking.setDimension({ dimension, value });
       sinon.assert.calledWith(window.ga, 'set', dimension, value);
     });
+
+    it('should not send the web vitals when trackingSendWebVitals is false', () => {
+      const _getCLS = sinon.stub();
+      const _getFID = sinon.stub();
+      const _getLCP = sinon.stub();
+
+      createTracking({
+        configOverrides: { trackingSendWebVitals: false },
+        paramOverrides: {
+          _getCLS,
+          _getFID,
+          _getLCP,
+        },
+      });
+
+      sinon.assert.notCalled(_getCLS);
+      sinon.assert.notCalled(_getFID);
+      sinon.assert.notCalled(_getLCP);
+    });
+
+    it('should send the web vitals when trackingSendWebVitals is true', () => {
+      const _getCLS = sinon.stub();
+      const _getFID = sinon.stub();
+      const _getLCP = sinon.stub();
+
+      createTracking({
+        configOverrides: { trackingSendWebVitals: true },
+        paramOverrides: {
+          _getCLS,
+          _getFID,
+          _getLCP,
+        },
+      });
+
+      sinon.assert.calledOnce(_getCLS);
+      sinon.assert.calledOnce(_getFID);
+      sinon.assert.calledOnce(_getLCP);
+    });
+  });
+
+  describe('sendWebVitalStats', () => {
+    it('sends web vitals data to GA', () => {
+      const tracking = createTracking();
+      const fakeCLS = {
+        name: 'CLS',
+        id: 'some-id',
+        delta: 123,
+      };
+
+      tracking.sendWebVitalStats(fakeCLS);
+
+      sinon.assert.calledWith(window.ga, 'send', 'event', {
+        eventCategory: 'Web Vitals',
+        eventAction: fakeCLS.name,
+        eventLabel: fakeCLS.id,
+        eventValue: Math.round(fakeCLS.delta * 1000),
+        nonInteraction: true,
+        transport: 'beacon',
+      });
+    });
   });
 
   describe('getAddonTypeForTracking', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17739,6 +17739,11 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
+web-vitals@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-1.1.0.tgz#7f410d9a1f7a1cd5d952806b45776204b47dc274"
+  integrity sha512-1cx54eRxY/+M0KNKdNpNnuXAXG+vJEvwScV4DiV9rOYDguHoeDIzm09ghBohOPtkqPO5OtPC14FWkNva3SDisg==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"


### PR DESCRIPTION
fixes #10041

---

This patch uses the web-vitals js lib to record the 3 most useful web vitals metrics and push the data to GA.

I used this patch to try it locally (with Chrome):


```diff
diff --git a/config/development.js b/config/development.js
index 2e2b0ea40..9e371b30b 100644
--- a/config/development.js
+++ b/config/development.js
@@ -21,7 +21,8 @@ module.exports = {
   restrictSearchResultsToAppVersion: false,

   fxaConfig: 'local',
-  trackingEnabled: false,
+  trackingEnabled: true,
+  trackingSendWebVitals: true,
   loggingLevel: 'debug',

   amoCDN: addonsServerDevCDN,
```

The patch enables this feature for -dev only right now. Once I have some stats collected on -dev (mainly by myself). I'll double check GA, the Web Vitals dashboard and, if everything looks good, I'll update the config to enable the feature in all envs.