### PR TITLE
Revert "Update dependency @loadable/server to v5.14.2 (#10035)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   "homepage": "https://github.com/mozilla/addons-frontend#readme",
   "dependencies": {
     "@loadable/component": "5.14.1",
-    "@loadable/server": "5.14.2",
+    "@loadable/server": "5.14.0",
     "@mozilla-protocol/tokens": "5.0.5",
     "@willdurand/isomorphic-formdata": "1.2.0",
     "base62": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     hoist-non-react-statics "^3.3.1"
     react-is "^16.12.0"
 
-"@loadable/server@5.14.2":
-  version "5.14.2"
-  resolved "https://registry.yarnpkg.com/@loadable/server/-/server-5.14.2.tgz#8e1467655633184cc7f9418b76741f48d24c4d29"
-  integrity sha512-2CkcmHx5PUEBn8evIvHPyOncMtWMNTu68ON1rnyAJnd+2MCq+eWMPKIR8DAdJYf56iVArBOBI0nyo3N+6laCPw==
+"@loadable/server@5.14.0":
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/@loadable/server/-/server-5.14.0.tgz#8aa83166aaad7401a14d8a1b04a7e1cc169ca6c4"
+  integrity sha512-oiZiHzUdkOsDzZNXU6fsZ7U0W3+nWZRljVCFCeR8CZSXEKUfXAllUf8tx5G385q7vapAQpXM7U8EzgDns3Q4vQ==
   dependencies:
     lodash "^4.17.15"
 


### PR DESCRIPTION
This reverts commit 169816984c729392fb0ca30026128d8a7aba842a.

Fixes https://github.com/mozilla/addons-frontend/issues/10059