### PR TITLE
Add Silesian (szl) to supported languages

### DIFF
--- a/src/amo/languages.js
+++ b/src/amo/languages.js
@@ -545,6 +545,10 @@ export const unfilteredLanguages = {
     English: 'Swahili',
     native: 'Kiswahili',
   },
+  szl: {
+    English: 'Silesian',
+    native: '\u015al\u014dnski',
+  },
   ta: {
     English: 'Tamil',
     native: '\u0ba4\u0bae\u0bbf\u0bb4\u0bcd',


### PR DESCRIPTION
This locale (Silesian, native Ślōnski) is going to ride the trains with Firefox 87 to Beta, so we'll have a language pack for it.