### PR TITLE
Allow target locales with 3 parts

### DIFF
--- a/src/amo/pages/LanguageTools/index.js
+++ b/src/amo/pages/LanguageTools/index.js
@@ -203,7 +203,7 @@ export class LanguageToolsBase extends React.Component<Props> {
                         return addon.target_locale === language.locale;
                       }
 
-                      const re = new RegExp(`^${language.locale}(-\\w+)?$`);
+                      const re = new RegExp(`^${language.locale}(-\\w+){0,2}$`);
 
                       return (
                         addon.target_locale && re.test(addon.target_locale)

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -260,6 +260,13 @@ describe(__filename, () => {
         target_locale: 'az-IR',
         type: ADDON_TYPE_DICT,
       }),
+      createFakeLanguageTool({
+        id: 3,
+        lang,
+        name: 'Azerbaijani Foo',
+        target_locale: 'az-IR-foo',
+        type: ADDON_TYPE_DICT,
+      }),
     ];
 
     const { store } = dispatchClientMetadata({ lang });
@@ -276,6 +283,7 @@ describe(__filename, () => {
     ]);
     expect(root.find(LanguageToolList).at(1)).toHaveProp('languageTools', [
       createInternalLanguageTool(addons[1], lang),
+      createInternalLanguageTool(addons[2], lang),
     ]);
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10071

---

I am not sure we can have locales with more than 3 parts so I kept things quite restricted for now.