### PR TITLE
Enable web vitals collection in all envs

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -296,7 +296,7 @@ module.exports = {
   // send a page view on initialization.
   trackingSendInitPageView: true,
   // send web vitals stats to GA
-  trackingSendWebVitals: false,
+  trackingSendWebVitals: true,
 
   enablePostCssLoader: true,
 

--- a/config/dev.js
+++ b/config/dev.js
@@ -13,8 +13,6 @@ module.exports = {
 
   enableDevTools: true,
 
-  trackingSendWebVitals: true,
-
   // Content security policy.
   CSP: {
     directives: {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10070

---

We did collect some data on -dev but it's a bit tricky to make good use of it
because we don't have enough data. Let's enable this feature in all envs and
see what we get on -prod in a week.