### PR TITLE
Fetch grouped ratings along with add-on detail

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -5,7 +5,6 @@ import type { FlagReviewReasonType } from 'amo/constants';
 import type {
   ExternalReviewReplyType,
   ExternalReviewType,
-  GroupedRatingsType,
 } from 'amo/api/reviews';
 import type { UserId } from 'amo/reducers/users';
 
@@ -14,8 +13,6 @@ export const SHOW_EDIT_REVIEW_FORM: 'SHOW_EDIT_REVIEW_FORM' =
   'SHOW_EDIT_REVIEW_FORM';
 export const SHOW_REPLY_TO_REVIEW_FORM: 'SHOW_REPLY_TO_REVIEW_FORM' =
   'SHOW_REPLY_TO_REVIEW_FORM';
-export const FETCH_GROUPED_RATINGS: 'FETCH_GROUPED_RATINGS' =
-  'FETCH_GROUPED_RATINGS';
 export const FETCH_REVIEW: 'FETCH_REVIEW' = 'FETCH_REVIEW';
 export const FETCH_REVIEW_PERMISSIONS: 'FETCH_REVIEW_PERMISSIONS' =
   'FETCH_REVIEW_PERMISSIONS';
@@ -32,7 +29,6 @@ export const HIDE_EDIT_REVIEW_FORM: 'HIDE_EDIT_REVIEW_FORM' =
 export const HIDE_REPLY_TO_REVIEW_FORM: 'HIDE_REPLY_TO_REVIEW_FORM' =
   'HIDE_REPLY_TO_REVIEW_FORM';
 export const SET_ADDON_REVIEWS: 'SET_ADDON_REVIEWS' = 'SET_ADDON_REVIEWS';
-export const SET_GROUPED_RATINGS: 'SET_GROUPED_RATINGS' = 'SET_GROUPED_RATINGS';
 export const SET_INTERNAL_REVIEW: 'SET_INTERNAL_REVIEW' = 'SET_INTERNAL_REVIEW';
 export const SET_USER_REVIEWS: 'SET_USER_REVIEWS' = 'SET_USER_REVIEWS';
 export const SET_REVIEW: 'SET_REVIEW' = 'SET_REVIEW';
@@ -254,50 +250,6 @@ export function setReviewPermissions({
   return {
     type: SET_REVIEW_PERMISSIONS,
     payload: { addonId, userId, canReplyToReviews },
-  };
-}
-
-type FetchGroupedRatingsParams = {|
-  addonId: number,
-  errorHandlerId: string,
-|};
-
-export type FetchGroupedRatingsAction = {|
-  type: typeof FETCH_GROUPED_RATINGS,
-  payload: FetchGroupedRatingsParams,
-|};
-
-export function fetchGroupedRatings({
-  addonId,
-  errorHandlerId,
-}: FetchGroupedRatingsParams): FetchGroupedRatingsAction {
-  invariant(addonId, 'addonId is required');
-  invariant(errorHandlerId, 'errorHandlerId is required');
-  return {
-    type: FETCH_GROUPED_RATINGS,
-    payload: { addonId, errorHandlerId },
-  };
-}
-
-type SetGroupedRatingsParams = {|
-  addonId: number,
-  grouping: GroupedRatingsType,
-|};
-
-export type SetGroupedRatingsAction = {|
-  type: typeof SET_GROUPED_RATINGS,
-  payload: SetGroupedRatingsParams,
-|};
-
-export function setGroupedRatings({
-  addonId,
-  grouping,
-}: SetGroupedRatingsParams): SetGroupedRatingsAction {
-  invariant(addonId, 'addonId is required');
-  invariant(grouping, 'grouping is required');
-  return {
-    type: SET_GROUPED_RATINGS,
-    payload: { addonId, grouping },
   };
 }
 

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -233,10 +233,15 @@ export function callApi({
 
 export type FetchAddonParams = {|
   api: ApiState,
+  showGroupedRatings?: boolean,
   slug: string,
 |};
 
-export function fetchAddon({ api, slug }: FetchAddonParams) {
+export function fetchAddon({
+  api,
+  showGroupedRatings = false,
+  slug,
+}: FetchAddonParams) {
   const { clientApp, userAgentInfo } = api;
   const appVersion = userAgentInfo.browser.version;
   if (!appVersion) {
@@ -249,6 +254,7 @@ export function fetchAddon({ api, slug }: FetchAddonParams) {
     endpoint: addQueryParams(`addons/addon/${slug}`, {
       app: clientApp || '',
       appversion: appVersion || '',
+      show_grouped_ratings: String(showGroupedRatings),
     }),
     auth: true,
     apiState: api,

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -143,28 +143,15 @@ export type GetReviewsParams = {|
   page?: string,
   page_size?: string,
   score?: string,
-  show_grouped_ratings?: boolean,
   show_permissions_for?: number,
   user?: number,
   version?: number,
-|};
-
-// A count of add-on ratings per star. These will all be 0 for add-ons
-// that have not yet been rated.
-export type GroupedRatingsType = {|
-  '1': number,
-  '2': number,
-  '3': number,
-  '4': number,
-  '5': number,
 |};
 
 export type GetReviewsApiResponse = {|
   ...PaginatedApiResponse<ExternalReviewType>,
   // This is undefined unless the request contained addon and show_permissions_for.
   can_reply?: boolean,
-  // This is undefined unless the request contained ?show_grouped_ratings=true.
-  grouped_ratings?: GroupedRatingsType,
 |};
 
 export function getReviews({

--- a/src/amo/components/RatingsByStar/index.js
+++ b/src/amo/components/RatingsByStar/index.js
@@ -2,26 +2,16 @@
 import makeClassName from 'classnames';
 import invariant from 'invariant';
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withRouter } from 'react-router-dom';
 
 import Link from 'amo/components/Link';
-import { fetchGroupedRatings } from 'amo/actions/reviews';
-import {
-  groupedRatingsAreLoading as getGroupedRatingsAreLoading,
-  reviewListURL,
-} from 'amo/reducers/reviews';
-import { withFixedErrorHandler } from 'amo/errorHandler';
+import { reviewListURL } from 'amo/reducers/reviews';
 import translate from 'amo/i18n/translate';
 import LoadingText from 'amo/components/LoadingText';
 import IconStar from 'amo/components/IconStar';
-import type { GroupedRatingsType } from 'amo/api/reviews';
-import type { AppState } from 'amo/store';
 import type { AddonType } from 'amo/types/addons';
-import type { ErrorHandlerType } from 'amo/types/errorHandler';
 import type { I18nType } from 'amo/types/i18n';
-import type { DispatchFunc } from 'amo/types/redux';
 import type { ReactRouterLocationType } from 'amo/types/router';
 
 import './styles.scss';
@@ -32,52 +22,11 @@ type Props = {|
 
 type InternalProps = {|
   ...Props,
-  dispatch: DispatchFunc,
-  errorHandler: ErrorHandlerType,
-  groupedRatings?: GroupedRatingsType,
-  groupedRatingsAreLoading: boolean,
   i18n: I18nType,
   location: ReactRouterLocationType,
 |};
 
 export class RatingsByStarBase extends React.Component<InternalProps> {
-  constructor(props: InternalProps) {
-    super(props);
-
-    // TODO: this is intended to load on the server (before mount) but it
-    // does not.
-    // See: https://github.com/mozilla/addons-frontend/issues/5854
-    this.loadDataIfNeeded();
-  }
-
-  componentDidUpdate() {
-    this.loadDataIfNeeded();
-  }
-
-  loadDataIfNeeded() {
-    const {
-      addon,
-      dispatch,
-      errorHandler,
-      groupedRatings,
-      groupedRatingsAreLoading,
-    } = this.props;
-
-    if (
-      !errorHandler.hasError() &&
-      addon &&
-      !groupedRatings &&
-      !groupedRatingsAreLoading
-    ) {
-      dispatch(
-        fetchGroupedRatings({
-          addonId: addon.id,
-          errorHandlerId: errorHandler.id,
-        }),
-      );
-    }
-  }
-
   renderBarValue(starCount: number) {
     const { addon } = this.props;
     invariant(addon, 'addon is required');
@@ -102,8 +51,8 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
   }
 
   render() {
-    const { addon, errorHandler, i18n, groupedRatings, location } = this.props;
-    const loading = (!addon || !groupedRatings) && !errorHandler.hasError();
+    const { addon, i18n, location } = this.props;
+    const loading = !addon;
 
     const linkTitles = {
       /* eslint-disable quote-props */
@@ -117,11 +66,9 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
 
     return (
       <div className="RatingsByStar">
-        {errorHandler.renderErrorIfPresent()}
         <div className="RatingsByStar-graph">
           {['5', '4', '3', '2', '1'].map((star) => {
             let starCount;
-            let starCountNode;
 
             function createLink(text) {
               invariant(addon, 'addon was unexpectedly empty');
@@ -140,17 +87,15 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
               );
             }
 
-            if (!errorHandler.hasError()) {
-              if (groupedRatings) {
-                starCount = groupedRatings[star];
-              }
-
-              starCountNode = loading ? (
-                <LoadingText width={100} />
-              ) : (
-                createLink(i18n.formatNumber(starCount || 0))
-              );
+            if (addon && addon.ratings) {
+              starCount = addon.ratings.grouped_counts[star];
             }
+
+            const starCountNode = loading ? (
+              <LoadingText width={100} />
+            ) : (
+              createLink(i18n.formatNumber(starCount || 0))
+            );
 
             return (
               <React.Fragment key={star}>
@@ -185,24 +130,9 @@ export class RatingsByStarBase extends React.Component<InternalProps> {
   }
 }
 
-const mapStateToProps = (state: AppState, ownProps: Props) => {
-  const addonId = ownProps.addon ? ownProps.addon.id : null;
-  return {
-    groupedRatings: addonId ? state.reviews.groupedRatings[addonId] : undefined,
-    groupedRatingsAreLoading: getGroupedRatingsAreLoading(state, addonId),
-  };
-};
-
-export const extractId = (props: Props) => {
-  const { addon } = props;
-  return addon ? `addon-${addon.id.toString()}` : '';
-};
-
 const RatingsByStar: React.ComponentType<Props> = compose(
   withRouter,
   translate(),
-  connect(mapStateToProps),
-  withFixedErrorHandler({ fileName: __filename, extractId }),
 )(RatingsByStarBase);
 
 export default RatingsByStar;

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -117,7 +117,13 @@ export class AddonBase extends React.Component {
 
         dispatch(setViewContext(addon.type));
       } else if (!addonIsLoading) {
-        dispatch(fetchAddon({ slug: params.slug, errorHandler }));
+        dispatch(
+          fetchAddon({
+            showGroupedRatings: true,
+            slug: params.slug,
+            errorHandler,
+          }),
+        );
       }
     }
   }
@@ -145,7 +151,13 @@ export class AddonBase extends React.Component {
     }
 
     if (!addonIsLoading && (!newAddon || oldParams.slug !== params.slug)) {
-      dispatch(fetchAddon({ slug: params.slug, errorHandler }));
+      dispatch(
+        fetchAddon({
+          showGroupedRatings: true,
+          slug: params.slug,
+          errorHandler,
+        }),
+      );
     }
   }
 

--- a/src/amo/pages/AddonInfo/index.js
+++ b/src/amo/pages/AddonInfo/index.js
@@ -107,7 +107,7 @@ export class AddonInfoBase extends React.Component<InternalProps> {
     const addonHasChanged = oldAddon && oldAddon.slug !== slug;
 
     if ((!addon || addonHasChanged) && !addonIsLoading) {
-      dispatch(fetchAddon({ slug, errorHandler }));
+      dispatch(fetchAddon({ showGroupedRatings: true, slug, errorHandler }));
     }
 
     if (infoType === ADDON_INFO_TYPE_CUSTOM_LICENSE) {

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -123,7 +123,13 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
 
     if (!addon) {
       if (!addonIsLoading) {
-        dispatch(fetchAddon({ slug: addonSlug, errorHandler }));
+        dispatch(
+          fetchAddon({
+            showGroupedRatings: true,
+            slug: addonSlug,
+            errorHandler,
+          }),
+        );
       }
     } else if (
       // This is the first time rendering the component.

--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -94,7 +94,7 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
     const addonHasChanged = oldAddon && oldAddon.slug !== slug;
 
     if ((!addon || addonHasChanged) && !addonIsLoading) {
-      dispatch(fetchAddon({ slug, errorHandler }));
+      dispatch(fetchAddon({ showGroupedRatings: true, slug, errorHandler }));
     }
 
     if (!areVersionsLoading && (!versions || addonHasChanged)) {

--- a/src/amo/sagas/addons.js
+++ b/src/amo/sagas/addons.js
@@ -24,7 +24,7 @@ import type {
 import type { Saga } from 'amo/types/sagas';
 
 export function* fetchAddon({
-  payload: { errorHandlerId, slug },
+  payload: { errorHandlerId, showGroupedRatings, slug },
 }: FetchAddonAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
   yield put(errorHandler.createClearingAction());
@@ -32,7 +32,11 @@ export function* fetchAddon({
   try {
     const state = yield select(getState);
 
-    const params: FetchAddonParams = { api: state.api, slug };
+    const params: FetchAddonParams = {
+      api: state.api,
+      showGroupedRatings,
+      slug,
+    };
     const addon = yield call(fetchAddonFromApi, params);
 
     yield put(loadAddon({ addon, slug }));

--- a/src/amo/types/addons.js
+++ b/src/amo/types/addons.js
@@ -79,6 +79,16 @@ export type PreviewType = {|
   w: number,
 |};
 
+// A count of add-on ratings per star. These will all be 0 for add-ons
+// that have not yet been rated.
+export type GroupedRatingsType = {|
+  '1': number,
+  '2': number,
+  '3': number,
+  '4': number,
+  '5': number,
+|};
+
 /*
  * This is the external API representation of an add-on.
  *
@@ -119,6 +129,7 @@ export type ExternalAddonType = {|
     average: number,
     bayesian_average: number,
     count: number,
+    grouped_counts: GroupedRatingsType,
     text_count: number,
   |},
   requires_payment?: boolean,

--- a/tests/unit/amo/api/test_index.js
+++ b/tests/unit/amo/api/test_index.js
@@ -553,6 +553,34 @@ describe(__filename, () => {
       mockWindow.verify();
     });
 
+    it('can accept and pass showGroupedRatings', async () => {
+      mockWindow
+        .expects('fetch')
+        .withArgs(
+          urlWithTheseParams({
+            show_grouped_ratings: 'true',
+          }),
+        )
+        .returns(mockResponse());
+
+      await _fetchAddon({ showGroupedRatings: true });
+      mockWindow.verify();
+    });
+
+    it('defaults showGroupedRatings to false', async () => {
+      mockWindow
+        .expects('fetch')
+        .withArgs(
+          urlWithTheseParams({
+            show_grouped_ratings: 'false',
+          }),
+        )
+        .returns(mockResponse());
+
+      await _fetchAddon();
+      mockWindow.verify();
+    });
+
     it('passes app and appversion', async () => {
       const userAgent =
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:61.0) Gecko/20100101 Firefox/61.0';

--- a/tests/unit/amo/api/test_reviews.js
+++ b/tests/unit/amo/api/test_reviews.js
@@ -155,7 +155,6 @@ describe(__filename, () => {
       const params = {
         user: 123,
         addon: 321,
-        show_grouped_ratings: 1,
         score: 5,
       };
       const fakeResponse = getReviewsResponse({ reviews: [fakeReview] });

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -328,6 +328,7 @@ describe(__filename, () => {
       dispatchSpy,
       fetchAddonAction({
         errorHandler: root.instance().props.errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );
@@ -342,6 +343,7 @@ describe(__filename, () => {
     store.dispatch(
       fetchAddonAction({
         errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );
@@ -384,6 +386,7 @@ describe(__filename, () => {
       dispatchSpy,
       fetchAddonAction({
         errorHandler: root.instance().props.errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );
@@ -403,6 +406,7 @@ describe(__filename, () => {
       dispatchSpy,
       fetchAddonAction({
         errorHandler: root.instance().props.errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );

--- a/tests/unit/amo/pages/TestAddonInfo.js
+++ b/tests/unit/amo/pages/TestAddonInfo.js
@@ -104,6 +104,7 @@ describe(__filename, () => {
         dispatch,
         fetchAddon({
           errorHandler,
+          showGroupedRatings: true,
           slug,
         }),
       );
@@ -143,6 +144,7 @@ describe(__filename, () => {
         dispatch,
         fetchAddon({
           errorHandler,
+          showGroupedRatings: true,
           slug: newSlug,
         }),
       );
@@ -238,6 +240,7 @@ describe(__filename, () => {
         dispatch,
         fetchAddon({
           errorHandler,
+          showGroupedRatings: true,
           slug,
         }),
       );
@@ -401,6 +404,7 @@ describe(__filename, () => {
       fakeDispatch,
       fetchAddon({
         errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );
@@ -423,6 +427,7 @@ describe(__filename, () => {
       fakeDispatch,
       fetchAddon({
         errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -258,6 +258,7 @@ describe(__filename, () => {
         dispatch,
         fetchAddon({
           slug: addonSlug,
+          showGroupedRatings: true,
           errorHandler,
         }),
       );
@@ -281,6 +282,7 @@ describe(__filename, () => {
         fakeDispatch,
         fetchAddon({
           slug: addonSlug,
+          showGroupedRatings: true,
           errorHandler,
         }),
       );

--- a/tests/unit/amo/pages/TestAddonVersions.js
+++ b/tests/unit/amo/pages/TestAddonVersions.js
@@ -95,6 +95,7 @@ describe(__filename, () => {
       dispatch,
       fetchAddon({
         errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );
@@ -118,6 +119,7 @@ describe(__filename, () => {
       fakeDispatch,
       fetchAddon({
         errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );
@@ -140,6 +142,7 @@ describe(__filename, () => {
       fakeDispatch,
       fetchAddon({
         errorHandler,
+        showGroupedRatings: true,
         slug,
       }),
     );
@@ -168,6 +171,7 @@ describe(__filename, () => {
       dispatch,
       fetchAddon({
         errorHandler,
+        showGroupedRatings: true,
         slug: newSlug,
       }),
     );

--- a/tests/unit/amo/sagas/test_addons.js
+++ b/tests/unit/amo/sagas/test_addons.js
@@ -53,10 +53,14 @@ describe(__filename, () => {
       mockApi
         .expects('fetchAddon')
         .once()
-        .withArgs({ slug: fakeAddon.slug, api: { ...apiState } })
+        .withArgs({
+          showGroupedRatings: true,
+          slug: fakeAddon.slug,
+          api: { ...apiState },
+        })
         .returns(Promise.resolve(fakeAddon));
 
-      _fetchAddon({ slug: fakeAddon.slug });
+      _fetchAddon({ showGroupedRatings: true, slug: fakeAddon.slug });
 
       const expectedAction = loadAddon({
         addon: fakeAddon,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -39,7 +39,7 @@ import * as coreApi from 'amo/api';
 import { getAddonStatus } from 'amo/addonManager';
 import { ErrorHandler } from 'amo/errorHandler';
 import { makeI18n } from 'amo/i18n/utils';
-import { createInternalAddon } from 'amo/reducers/addons';
+import { createGroupedRatings, createInternalAddon } from 'amo/reducers/addons';
 import {
   autocompleteLoad,
   autocompleteStart,
@@ -149,6 +149,7 @@ export const fakeAddon = Object.freeze({
   ratings: {
     average: 3.5,
     count: 10,
+    grouped_counts: createGroupedRatings(),
     text_count: 5,
   },
   requires_payment: false,


### PR DESCRIPTION
Fixes #10074 

This is a bit more involved because we are changing the way we store grouped ratings. Previous to this patch, because we were retrieving them separately from add-on details, we stored the grouped ratings separately, in the `reviews` state. This patch removes all of the code that supported fetching them separately and storing them in the `reviews` state and instead will always retrieve them with the add-on details and store them in the `addons` state with the add-on itself.