### PR TITLE
use thumbnails for small theme previews

### DIFF
--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -29,6 +29,7 @@ type Props = {|
   // that will be rendered.
   placeholderCount: number,
   type?: 'horizontal' | 'vertical',
+  showFullSizePreview?: boolean,
   showMetadata?: boolean,
   showPromotedBadge?: boolean,
   showSummary?: boolean,
@@ -73,6 +74,7 @@ export default class AddonsCard extends React.Component<Props> {
       onAddonImpression,
       placeholderCount,
       useThemePlaceholder,
+      showFullSizePreview,
       showMetadata,
       showPromotedBadge,
       showSummary,
@@ -108,6 +110,7 @@ export default class AddonsCard extends React.Component<Props> {
               key={`${addon.slug}-${addon.type}`}
               onClick={onAddonClick}
               onImpression={onAddonImpression}
+              showFullSizePreview={showFullSizePreview}
               showMetadata={showMetadata}
               showPromotedBadge={showPromotedBadge}
               showSummary={

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -32,6 +32,7 @@ type Props = {|
   addonInstallSource?: string,
   onClick?: (addon: AddonType | CollectionAddonType) => void,
   onImpression?: (addon: AddonType | CollectionAddonType) => void,
+  showFullSizePreview?: boolean,
   showMetadata?: boolean,
   showPromotedBadge?: boolean,
   showSummary?: boolean,
@@ -50,6 +51,7 @@ type InternalProps = {|
 export class SearchResultBase extends React.Component<InternalProps> {
   static defaultProps = {
     _getPromotedCategory: getPromotedCategory,
+    showFullSizePreview: false,
     showMetadata: true,
     showPromotedBadge: true,
     showSummary: true,
@@ -90,6 +92,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
       clientApp,
       i18n,
       onImpression,
+      showFullSizePreview,
       showMetadata,
       showPromotedBadge,
       showSummary,
@@ -121,7 +124,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
     }
 
     if (addon && addon.type === ADDON_TYPE_STATIC_THEME) {
-      imageURL = getPreviewImage(addon);
+      imageURL = getPreviewImage(addon, { full: showFullSizePreview });
     }
 
     // Sets classes to handle fallback if theme preview is not available.

--- a/src/amo/components/SearchResults/index.js
+++ b/src/amo/components/SearchResults/index.js
@@ -67,6 +67,7 @@ export class SearchResultsBase extends React.Component<InternalProps> {
           footer={paginator}
           header={i18n.gettext('Search results')}
           loading={loading}
+          showFullSizePreview
         >
           {messageText ? (
             <p className="SearchResults-message">{messageText}</p>

--- a/src/amo/components/ThemeImage/index.js
+++ b/src/amo/components/ThemeImage/index.js
@@ -23,7 +23,7 @@ type InternalProps = {|
 export const ThemeImageBase = ({
   addon,
   i18n,
-  roundedCorners = false
+  roundedCorners = false,
 }: InternalProps) => {
   if (addon && ADDON_TYPE_STATIC_THEME === addon.type) {
     const label = i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
@@ -40,7 +40,7 @@ export const ThemeImageBase = ({
         <img
           alt={label}
           className="ThemeImage-image"
-          src={getPreviewImage(addon, { })}
+          src={getPreviewImage(addon, {})}
         />
       </div>
     );

--- a/src/amo/components/ThemeImage/index.js
+++ b/src/amo/components/ThemeImage/index.js
@@ -40,7 +40,7 @@ export const ThemeImageBase = ({
         <img
           alt={label}
           className="ThemeImage-image"
-          src={getPreviewImage(addon, {})}
+          src={getPreviewImage(addon)}
         />
       </div>
     );

--- a/src/amo/components/ThemeImage/index.js
+++ b/src/amo/components/ThemeImage/index.js
@@ -13,7 +13,6 @@ import './styles.scss';
 type Props = {|
   addon: AddonType | null,
   roundedCorners?: boolean,
-  useStandardSize?: boolean,
 |};
 
 type InternalProps = {|
@@ -24,8 +23,7 @@ type InternalProps = {|
 export const ThemeImageBase = ({
   addon,
   i18n,
-  roundedCorners = false,
-  useStandardSize = true,
+  roundedCorners = false
 }: InternalProps) => {
   if (addon && ADDON_TYPE_STATIC_THEME === addon.type) {
     const label = i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
@@ -42,7 +40,7 @@ export const ThemeImageBase = ({
         <img
           alt={label}
           className="ThemeImage-image"
-          src={getPreviewImage(addon, { useStandardSize })}
+          src={getPreviewImage(addon, { })}
         />
       </div>
     );

--- a/src/amo/imageUtils.js
+++ b/src/amo/imageUtils.js
@@ -7,27 +7,13 @@ export function getAddonIconUrl(addon) {
     : fallbackIcon;
 }
 
-export const getPreviewImage = (
-  addon,
-  { full = true, useStandardSize = true } = {},
-) => {
+export const getPreviewImage = (addon, { full = true } = {}) => {
   if (!addon.previews.length) {
     return null;
   }
 
-  let imageIndex = 0;
-
-  if (useStandardSize) {
-    if (!full) {
-      throw new Error("Currently there is no 'standard' thumbnail size");
-    }
-
-    // 720 is now the standard width for previews.
-    const width = 720;
-    imageIndex =
-      // The preview.w is the image width.
-      addon.previews.findIndex((preview) => preview.w === width);
-  }
+  // 720 is now the standard width for previews. The preview.w is the image width.
+  let imageIndex = addon.previews.findIndex((preview) => preview.w === 720);
 
   // This is a fallback for older themes that do not have this size generated.
   if (imageIndex < 0) {

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -211,4 +211,13 @@ describe(__filename, () => {
       onAddonImpression,
     );
   });
+
+  it('passes the showFullSizePreview prop through to SearchResult', () => {
+    const showFullSizePreview = true;
+    const root = render({ addons: [fakeAddon], showFullSizePreview });
+    expect(root.find(SearchResult)).toHaveProp(
+      'showFullSizePreview',
+      showFullSizePreview,
+    );
+  });
 });

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -368,8 +368,6 @@ describe(__filename, () => {
     expect(image.prop('src')).toEqual(headerImageFull);
   });
 
-  // TODO: This can be removed once migration happens.
-  // See: https://github.com/mozilla/addons-frontend/issues/5359
   it('displays a fallback image for themes that only have 1 preview option', () => {
     const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
 

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -328,6 +328,26 @@ describe(__filename, () => {
   });
 
   it('displays the thumbnail image as the default src for static theme', () => {
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
+
+    const root = render({
+      addon: createInternalAddonWithLang({
+        ...fakeAddon,
+        type: ADDON_TYPE_STATIC_THEME,
+        previews: [
+          {
+            ...fakePreview,
+            thumbnail_url: headerImageThumb,
+          },
+        ],
+      }),
+    });
+    const image = root.find('.SearchResult-icon');
+
+    expect(image.prop('src')).toEqual(headerImageThumb);
+  });
+
+  it('displays the full preview for static theme when showFullSizePreview: true', () => {
     const headerImageFull = 'https://addons.cdn.mozilla.net/full/12345.png';
 
     const root = render({
@@ -341,6 +361,7 @@ describe(__filename, () => {
           },
         ],
       }),
+      showFullSizePreview: true,
     });
     const image = root.find('.SearchResult-icon');
 
@@ -350,7 +371,7 @@ describe(__filename, () => {
   // TODO: This can be removed once migration happens.
   // See: https://github.com/mozilla/addons-frontend/issues/5359
   it('displays a fallback image for themes that only have 1 preview option', () => {
-    const headerImageFull = 'https://addons.cdn.mozilla.net/full/1.png';
+    const headerImageThumb = 'https://addons.cdn.mozilla.net/thumb/12345.png';
 
     const root = render({
       addon: createInternalAddonWithLang({
@@ -359,14 +380,14 @@ describe(__filename, () => {
         previews: [
           {
             ...fakePreview,
-            image_url: headerImageFull,
+            thumbnail_url: headerImageThumb,
           },
         ],
       }),
     });
     const image = root.find('.SearchResult-icon');
 
-    expect(image.prop('src')).toEqual(headerImageFull);
+    expect(image.prop('src')).toEqual(headerImageThumb);
   });
 
   it('displays a message if the static theme preview image is unavailable', () => {

--- a/tests/unit/amo/components/TestSearchResults.js
+++ b/tests/unit/amo/components/TestSearchResults.js
@@ -73,6 +73,7 @@ describe(__filename, () => {
     // Make sure it just renders AddonsCard in a loading state.
     expect(root.find(AddonsCard)).toHaveProp('addons', []);
     expect(root.find(AddonsCard)).toHaveProp('loading', true);
+    expect(root.find(AddonsCard)).toHaveProp('showFullSizePreview', true);
   });
 
   it('renders results', () => {
@@ -88,6 +89,7 @@ describe(__filename, () => {
 
     expect(root.find(AddonsCard)).toHaveProp('addons', results);
     expect(root.find(AddonsCard)).toHaveProp('loading', false);
+    expect(root.find(AddonsCard)).toHaveProp('showFullSizePreview', true);
   });
 
   it('sets add-on install source to search by default', () => {

--- a/tests/unit/amo/components/TestThemeImage.js
+++ b/tests/unit/amo/components/TestThemeImage.js
@@ -69,7 +69,7 @@ describe(__filename, () => {
     );
   });
 
-  it('passes useStandardSize to display a preview with 720 width', () => {
+  it('displays a preview with 720 width', () => {
     const fullImage720 = `${config.get('amoCDN')}/full/720.png`;
     const addon = createInternalAddonWithLang({
       ...fakeTheme,
@@ -86,30 +86,8 @@ describe(__filename, () => {
         },
       ],
     });
-    const root = render({ addon, useStandardSize: true });
+    const root = render({ addon });
 
     expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage720);
-  });
-
-  it('passes useStandardSize as false to display the first preview image', () => {
-    const fullImage600 = `${config.get('amoCDN')}/full/600.png`;
-    const addon = createInternalAddonWithLang({
-      ...fakeTheme,
-      type: ADDON_TYPE_STATIC_THEME,
-      previews: [
-        {
-          ...fakePreview,
-          image_size: [600, 500],
-          image_url: fullImage600,
-        },
-        {
-          ...fakePreview,
-          image_size: [720, 500],
-        },
-      ],
-    });
-    const root = render({ addon, useStandardSize: false });
-
-    expect(root.find('.ThemeImage-image')).toHaveProp('src', fullImage600);
   });
 });

--- a/tests/unit/amo/test_imageUtils.js
+++ b/tests/unit/amo/test_imageUtils.js
@@ -71,7 +71,7 @@ describe(__filename, () => {
       expect(image).toEqual(null);
     });
 
-    it('uses the standard preview size (720) when useStandardSize is true', () => {
+    it('uses the standard preview size (720)', () => {
       const image720 = `${config.get('amoCDN')}/full/12345.png`;
       const addon = createInternalAddonWithLang({
         previews: [
@@ -91,19 +91,14 @@ describe(__filename, () => {
         ],
       });
 
-      const image = getPreviewImage(addon, { useStandardSize: true });
+      const image = getPreviewImage(addon);
       expect(image).toEqual(image720);
     });
 
-    it('uses the first preview image when useStandardSize is false', () => {
-      const image300 = `${config.get('amoCDN')}/full/12345.png`;
+    it('returns the thumb image from the previews array when full is false', () => {
+      const thumbImage = `${config.get('amoCDN')}/thumb/12345.png`;
       const addon = createInternalAddonWithLang({
         previews: [
-          {
-            ...fakePreview,
-            image_size: [300, 200],
-            image_url: image300,
-          },
           {
             ...fakePreview,
             image_size: [500, 300],
@@ -111,33 +106,16 @@ describe(__filename, () => {
           {
             ...fakePreview,
             image_size: [720, 520],
-          },
-        ],
-      });
-
-      const image = getPreviewImage(addon, { useStandardSize: false });
-      expect(image).toEqual(image300);
-    });
-
-    it('returns the thumb image from the previews array when full and useStandardSize are false', () => {
-      const thumbImage = `${config.get('amoCDN')}/full/12345.png`;
-      const addon = createInternalAddonWithLang({
-        previews: [
-          {
-            ...fakePreview,
             thumbnail_url: thumbImage,
           },
         ],
       });
 
-      const image = getPreviewImage(addon, {
-        full: false,
-        useStandardSize: false,
-      });
+      const image = getPreviewImage(addon, { full: false });
       expect(image).toEqual(thumbImage);
     });
 
-    it('uses the first preview image when useStandardSize is true but the 720 size is not present', () => {
+    it('uses the first preview image when the 720 size is not present', () => {
       const image300 = `${config.get('amoCDN')}/full/12345.png`;
       const addon = createInternalAddonWithLang({
         previews: [
@@ -153,16 +131,8 @@ describe(__filename, () => {
         ],
       });
 
-      const image = getPreviewImage(addon, { useStandardSize: true });
+      const image = getPreviewImage(addon);
       expect(image).toEqual(image300);
-    });
-
-    it('throws an error if useStandardSize is true and full is false', () => {
-      const addon = createInternalAddonWithLang(fakeAddon);
-
-      expect(() => {
-        getPreviewImage(addon, { full: false, useStandardSize: true });
-      }).toThrowError(/Currently there is no 'standard' thumbnail size/);
     });
   });
 });


### PR DESCRIPTION
fixes #10095 - the saving isn't massive (this is the /themes/ page), but it's something for free.  If we reduce the thumbnail down to the size frontend actually displays we'll save a bit more (that'd be an addons-server change)
![Screenshot 2021-02-25 18 28 11](https://user-images.githubusercontent.com/768592/109287500-8b36b300-781b-11eb-86e0-cf4e9f6c6397.png)
![Screenshot 2021-02-25 18 28 07](https://user-images.githubusercontent.com/768592/109287502-8d990d00-781b-11eb-84be-4b5f04cc298b.png)

