### PR TITLE
Fix wrapping of Flagged notice

### DIFF
--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -100,6 +100,12 @@
   &:first-child:nth-last-child(2),
   &:first-child:nth-last-child(2) ~ & {
     max-width: 50%;
+
+    // The above rule doesn't work when a review has been flagged, as there is a
+    // hidden sibling, so we need to override it.
+    &.AddonReviewCard-control--flagged {
+      max-width: 100%;
+    }
   }
 
   @include respond-to(medium) {

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -114,6 +114,7 @@ export class FlagReviewMenuBase extends React.Component<InternalProps> {
 
     return (
       <TooltipMenu
+        className={wasFlagged ? `${String(openerClass)}--flagged` : undefined}
         idPrefix="flag-review-"
         items={items}
         openerClass={openerClass}

--- a/src/amo/components/TooltipMenu/index.js
+++ b/src/amo/components/TooltipMenu/index.js
@@ -8,6 +8,7 @@ import ListItem from 'amo/components/ListItem';
 import './styles.scss';
 
 type Props = {|
+  className?: string,
   idPrefix?: string,
   items: Array<null | React.Element<typeof ListItem>>,
   openerClass?: string,
@@ -20,6 +21,7 @@ export default class TooltipMenu extends React.Component<Props> {
 
   render() {
     const {
+      className,
       idPrefix,
       items,
       openerClass,
@@ -49,7 +51,11 @@ export default class TooltipMenu extends React.Component<Props> {
         >
           <button
             aria-describedby={describedBy}
-            className={makeClassName('TooltipMenu-opener', openerClass)}
+            className={makeClassName(
+              'TooltipMenu-opener',
+              openerClass,
+              className,
+            )}
             title={openerTitle}
             type="button"
           >

--- a/tests/unit/amo/components/TestFlagReviewMenu.js
+++ b/tests/unit/amo/components/TestFlagReviewMenu.js
@@ -65,6 +65,30 @@ describe(__filename, () => {
     expect(root.find(TooltipMenu)).toHaveProp('openerClass', openerClass);
   });
 
+  it('passes a custom className when flagged', () => {
+    const openerClass = 'SomeClass';
+    const review = createInternalReview(fakeReview);
+    store.dispatch(
+      setReviewWasFlagged({
+        reason: REVIEW_FLAG_REASON_SPAM,
+        reviewId: review.id,
+      }),
+    );
+
+    const root = render({ openerClass, review });
+
+    expect(root.find(TooltipMenu)).toHaveProp(
+      'className',
+      `${openerClass}--flagged`,
+    );
+  });
+
+  it('does not pass a custom className when not flagged', () => {
+    const root = render();
+
+    expect(root.find(TooltipMenu)).toHaveProp('className', undefined);
+  });
+
   describe('interacting with different users', () => {
     it('requires you to be signed in', () => {
       store.dispatch(logOutUser());

--- a/tests/unit/amo/components/TestTooltipMenu.js
+++ b/tests/unit/amo/components/TestTooltipMenu.js
@@ -29,6 +29,21 @@ describe(__filename, () => {
     expect(opener).toHaveClassName('MyClass');
   });
 
+  it('accepts a custom className', () => {
+    const root = render({ className: 'CustomClass' });
+
+    const opener = root.find('.TooltipMenu-opener');
+    expect(opener).toHaveClassName('CustomClass');
+  });
+
+  it('works with both a custom className and an openerClass', () => {
+    const root = render({ className: 'CustomClass', openerClass: 'MyClass' });
+
+    const opener = root.find('.TooltipMenu-opener');
+    expect(opener).toHaveClassName('MyClass');
+    expect(opener).toHaveClassName('CustomClass');
+  });
+
   it('renders an opener with text', () => {
     const openerText = 'Open the thing';
     const root = render({ openerText });


### PR DESCRIPTION
Fixes #10138 

Before:

<img width="863" alt="Screen Shot 2021-03-01 at 8 58 41 AM" src="https://user-images.githubusercontent.com/142755/109522886-c08e0b80-7a7c-11eb-8b20-48f5455f5dd0.png">

After:

<img width="868" alt="Screen Shot 2021-03-01 at 10 55 52 AM" src="https://user-images.githubusercontent.com/142755/109522916-c97edd00-7a7c-11eb-80c7-e057ca3bf55a.png">
