### PR TITLE
Update browserslist config to exclude IE <= 11

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,4 @@
-last 2 versions
+# defaults
+> 0.5%, last 2 versions, Firefox ESR, not dead
+# we don't want to support IE anymore
+not ie <= 11

--- a/tests/unit/amo/components/Errors/TestNotAuthorized.js
+++ b/tests/unit/amo/components/Errors/TestNotAuthorized.js
@@ -13,7 +13,7 @@ import {
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  const render = ({ ...props }) => {
+  const render = ({ ...props } = {}) => {
     const { store } = dispatchSignInActions();
 
     const error = createApiError({

--- a/tests/unit/amo/components/Errors/TestServerError.js
+++ b/tests/unit/amo/components/Errors/TestServerError.js
@@ -13,7 +13,7 @@ import {
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  const render = ({ ...props }) => {
+  const render = ({ ...props } = {}) => {
     const { store } = dispatchSignInActions();
 
     const error = createApiError({

--- a/tests/unit/amo/components/TestCategories.js
+++ b/tests/unit/amo/components/TestCategories.js
@@ -31,7 +31,7 @@ describe(__filename, () => {
     store = dispatchClientMetadata().store;
   });
 
-  function render({ ...props }) {
+  function render({ ...props } = {}) {
     const errorHandler = createStubErrorHandler();
 
     return shallow(

--- a/tests/unit/amo/components/TestSuggestedPages.js
+++ b/tests/unit/amo/components/TestSuggestedPages.js
@@ -7,7 +7,7 @@ import SuggestedPages, {
 import { fakeI18n, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  const render = ({ ...props }) => {
+  const render = ({ ...props } = {}) => {
     const allProps = { ...props, i18n: fakeI18n() };
 
     return shallowUntilTarget(


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10171

---

According to bundlesize, js bundle size goes from `435.43KB` to `384.98KB`. IE isn't very used these days (according to various marketshare websites). It's the 18th browser on GA production over the last 12 months (13K users, SeaMonkey had 33K fwiw)