### PR TITLE
Update timing middleware to output time in logs

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -57,10 +57,8 @@ module.exports = {
   serverHost: '127.0.0.1',
   serverPort: 4000,
 
-  // By default, sending stats to DataDog is enabled but the host setting
-  // must also be non-empty.
-  useDatadog: true,
-  // These are set with environment variables.
+  // These are set with environment variables. We do not use datadog anymore
+  // but statsd/influxdb/grafana.
   datadogHost: null,
   datadogPort: null,
 

--- a/src/amo/middleware/datadogTiming.js
+++ b/src/amo/middleware/datadogTiming.js
@@ -9,28 +9,34 @@ export const datadogTiming = ({
   _log = log,
   _HotShots = HotShots,
 } = {}) => {
-  // We aren't adding any global DataDog tags here because we already
-  // get a few automatically. They are configured at the EC2 instance
-  // level. For example: env:dev, env:stage, or env:production
-  const client = new _HotShots({
-    host: _config.get('datadogHost'),
-    port: _config.get('datadogPort'),
-    prefix: 'addons_frontend.server.',
-  });
+  if (_config.get('datadogHost')) {
+    const client = new _HotShots({
+      host: _config.get('datadogHost'),
+      port: _config.get('datadogPort'),
+      prefix: 'addons_frontend.server.',
+    });
 
-  client.socket.on('error', (error) => {
-    _log.error(`DataDog client socket error: ${error}`);
-  });
+    client.socket.on('error', (error) => {
+      _log.error(`statsd client socket error: ${error}`);
+    });
 
+    return responseTime((req, res, time) => {
+      // TODO: generate a key based on the rendered component, which I think is
+      // in server/base.js -> match() -> renderProps.components
+
+      client.increment(`response_code.${res.statusCode}.count`);
+
+      const responseTypeKey = `response.${req.method}`;
+      client.increment(`${responseTypeKey}.count`);
+      // The time variable is response time in milleseconds.
+      client.timing(`${responseTypeKey}.time`, time);
+
+      _log.info(`response time: key=${responseTypeKey}.time value=${time}ms`);
+    });
+  }
+
+  // When there is no host configured, we only log the time.
   return responseTime((req, res, time) => {
-    // TODO: generate a key based on the rendered component, which
-    // I think is in server/base.js -> match() -> renderProps.components
-
-    client.increment(`response_code.${res.statusCode}.count`);
-
-    const responseTypeKey = `response.${req.method}`;
-    client.increment(`${responseTypeKey}.count`);
-    // The time variable is response time in milleseconds.
-    client.timing(`${responseTypeKey}.time`, time);
+    _log.info(`response time: ${time}ms`);
   });
 };

--- a/src/amo/middleware/index.js
+++ b/src/amo/middleware/index.js
@@ -2,4 +2,4 @@ export { prefixMiddleware } from './prefixMiddleware';
 export { trailingSlashesMiddleware } from './trailingSlash';
 export { csp, frameguard, hsts } from './security';
 export { serveAssetsLocally } from './staticAssets';
-export { datadogTiming } from './datadogTiming';
+export { responseTime } from './responseTime';

--- a/src/amo/middleware/responseTime.js
+++ b/src/amo/middleware/responseTime.js
@@ -1,10 +1,10 @@
 import config from 'config';
 import HotShots from 'hot-shots';
-import responseTime from 'response-time';
+import expressResponseTime from 'response-time';
 
 import log from 'amo/logger';
 
-export const datadogTiming = ({
+export const responseTime = ({
   _config = config,
   _log = log,
   _HotShots = HotShots,
@@ -20,7 +20,7 @@ export const datadogTiming = ({
       _log.error(`statsd client socket error: ${error}`);
     });
 
-    return responseTime((req, res, time) => {
+    return expressResponseTime((req, res, time) => {
       // TODO: generate a key based on the rendered component, which I think is
       // in server/base.js -> match() -> renderProps.components
 
@@ -36,7 +36,7 @@ export const datadogTiming = ({
   }
 
   // When there is no host configured, we only log the time.
-  return responseTime((req, res, time) => {
+  return expressResponseTime((req, res, time) => {
     _log.info(`response time: ${time}ms`);
   });
 };

--- a/src/amo/server/base.js
+++ b/src/amo/server/base.js
@@ -171,10 +171,8 @@ function baseServer(
     app.use(requestId);
   }
 
-  if (config.get('useDatadog') && config.get('datadogHost')) {
-    _log.info('Recording DataDog timing stats for all responses');
-    app.use(middleware.datadogTiming({ _HotShots }));
-  }
+  _log.info('Recording timing stats for all responses');
+  app.use(middleware.datadogTiming({ _config: config, _HotShots }));
 
   // Set HTTP Strict Transport Security headers
   app.use(middleware.hsts());

--- a/src/amo/server/base.js
+++ b/src/amo/server/base.js
@@ -171,8 +171,7 @@ function baseServer(
     app.use(requestId);
   }
 
-  _log.info('Recording timing stats for all responses');
-  app.use(middleware.datadogTiming({ _config: config, _HotShots }));
+  app.use(middleware.responseTime({ _config: config, _HotShots }));
 
   // Set HTTP Strict Transport Security headers
   app.use(middleware.hsts());

--- a/tests/unit/amo/middleware/test_datadogTiming.js
+++ b/tests/unit/amo/middleware/test_datadogTiming.js
@@ -28,10 +28,10 @@ describe(__filename, () => {
 
     const testClient = (params = {}) => {
       const config = getFakeConfig({
-        useDatadog: true,
         datadogHost: 'localhost',
         datadogPort: 1111,
       });
+
       return serverTestHelper.testClient({
         config,
         _HotShots: StubHotShots,
@@ -47,20 +47,8 @@ describe(__filename, () => {
       serverTestHelper.afterEach();
     });
 
-    it('can be disabled explicitly', async () => {
+    it('requires a host to send data', async () => {
       const config = getFakeConfig({
-        useDatadog: false,
-        datadogHost: 'localhost',
-        datadogPort: 1111,
-      });
-      await testClient({ config }).get('/');
-
-      sinon.assert.notCalled(hotShotsClient.timing);
-    });
-
-    it('requires a host even when enabled', async () => {
-      const config = getFakeConfig({
-        useDatadog: true,
         datadogHost: null,
         datadogPort: null,
       });
@@ -112,15 +100,15 @@ describe(__filename, () => {
   });
 
   describe('configuration', () => {
-    it('configures the client', () => {
-      const datadogHost = 'some-datadog-host';
-      const datadogPort = 3333;
+    const datadogHost = 'some-datadog-host';
+    const datadogPort = 3333;
 
-      const _config = getFakeConfig({
-        useDatadog: true,
-        datadogHost,
-        datadogPort,
-      });
+    const _config = getFakeConfig({
+      datadogHost,
+      datadogPort,
+    });
+
+    it('configures the client', () => {
       datadogTiming({ _config, _HotShots: StubHotShots });
 
       sinon.assert.calledWithMatch(StubHotShots, {
@@ -130,7 +118,7 @@ describe(__filename, () => {
     });
 
     it('sets up a prefix', () => {
-      datadogTiming({ _HotShots: StubHotShots });
+      datadogTiming({ _config, _HotShots: StubHotShots });
 
       sinon.assert.calledWithMatch(StubHotShots, {
         prefix: 'addons_frontend.server.',
@@ -139,7 +127,7 @@ describe(__filename, () => {
 
     it('sets up error handling', () => {
       const _log = getFakeLogger();
-      datadogTiming({ _log, _HotShots: StubHotShots });
+      datadogTiming({ _config, _HotShots: StubHotShots, _log });
 
       const error = new Error('some socket error');
       hotShotsClient.socket.emit('error', error);

--- a/tests/unit/amo/middleware/test_responseTime.js
+++ b/tests/unit/amo/middleware/test_responseTime.js
@@ -114,13 +114,6 @@ describe(__filename, () => {
       sinon.assert.calledWithMatch(StubHotShots, {
         host: datadogHost,
         port: datadogPort,
-      });
-    });
-
-    it('sets up a prefix', () => {
-      responseTime({ _config, _HotShots: StubHotShots });
-
-      sinon.assert.calledWithMatch(StubHotShots, {
         prefix: 'addons_frontend.server.',
       });
     });

--- a/tests/unit/amo/middleware/test_responseTime.js
+++ b/tests/unit/amo/middleware/test_responseTime.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 
-import { datadogTiming } from 'amo/middleware/datadogTiming';
+import { responseTime } from 'amo/middleware/responseTime';
 import { getFakeConfig, getFakeLogger } from 'tests/unit/helpers';
 import { ServerTestHelper } from 'tests/unit/amo/server/test_base';
 
@@ -109,7 +109,7 @@ describe(__filename, () => {
     });
 
     it('configures the client', () => {
-      datadogTiming({ _config, _HotShots: StubHotShots });
+      responseTime({ _config, _HotShots: StubHotShots });
 
       sinon.assert.calledWithMatch(StubHotShots, {
         host: datadogHost,
@@ -118,7 +118,7 @@ describe(__filename, () => {
     });
 
     it('sets up a prefix', () => {
-      datadogTiming({ _config, _HotShots: StubHotShots });
+      responseTime({ _config, _HotShots: StubHotShots });
 
       sinon.assert.calledWithMatch(StubHotShots, {
         prefix: 'addons_frontend.server.',
@@ -127,7 +127,7 @@ describe(__filename, () => {
 
     it('sets up error handling', () => {
       const _log = getFakeLogger();
-      datadogTiming({ _config, _HotShots: StubHotShots, _log });
+      responseTime({ _config, _HotShots: StubHotShots, _log });
 
       const error = new Error('some socket error');
       hotShotsClient.socket.emit('error', error);


### PR DESCRIPTION
Fixes #10202

---

I also renamed the middleware because we aren't using datadog anymore. Config remains the same because it's configured elsewhere.