### PR TITLE
Use webpack's contenthash instead of chunkhash for better long-term caching

### DIFF
--- a/webpack.dev.config.babel.js
+++ b/webpack.dev.config.babel.js
@@ -50,8 +50,8 @@ export default {
   output: {
     ...webpackConfig.output,
     path: assetsPath,
-    filename: '[name]-[chunkhash].js',
-    chunkFilename: '[name]-[chunkhash].js',
+    filename: '[name]-[contenthash].js',
+    chunkFilename: '[name]-[contenthash].js',
     // We need to remove the protocol because of `yarn amo:dev-https`.
     publicPath: `//${webpackHost}:${webpackPort}/`,
   },

--- a/webpack.prod.config.babel.js
+++ b/webpack.prod.config.babel.js
@@ -24,8 +24,8 @@ export default {
   output: {
     crossOriginLoading: 'anonymous',
     path: path.join(__dirname, 'dist'),
-    filename: '[name]-[chunkhash].js',
-    chunkFilename: '[name]-[chunkhash].js',
+    filename: '[name]-[contenthash].js',
+    chunkFilename: '[name]-[contenthash].js',
     publicPath: config.has('staticHost') ? `${config.get('staticHost')}/` : '/',
   },
   module: {
@@ -64,8 +64,8 @@ export default {
   plugins: [
     ...getPlugins(),
     new MiniCssExtractPlugin({
-      filename: '[name]-[chunkhash].css',
-      chunkFilename: '[name]-[chunkhash].css',
+      filename: '[name]-[contenthash].css',
+      chunkFilename: '[name]-[contenthash].css',
     }),
     new WebpackIsomorphicToolsPlugin(webpackIsomorphicToolsConfig),
     new SubresourceIntegrityPlugin({ hashFuncNames: ['sha512'] }),


### PR DESCRIPTION
Fixes #10206