### PR TITLE
Enforce naming convention for experiment ids

### DIFF
--- a/src/amo/withExperiment.js
+++ b/src/amo/withExperiment.js
@@ -52,6 +52,7 @@ export const EXPERIMENT_ENROLLMENT_CATEGORY = 'AMO Experiment Enrollment -';
 // This is a special variant value that indicates the the user is not enrolled
 // in the experiment.
 export const NOT_IN_EXPERIMENT = 'notInExperiment';
+export const EXPERIMENT_ID_REGEXP: RegExp = /\d{8}_.+/;
 
 export type WithExperimentInjectedProps = {|
   isExperimentEnabled: boolean,
@@ -133,6 +134,10 @@ export const withExperiment = ({
   WrappedComponent: React.ComponentType<any>,
 ) => {
   invariant(defaultId, 'id is required');
+  invariant(
+    EXPERIMENT_ID_REGEXP.test(defaultId),
+    'id must match the pattern YYYYMMDD_experiment_id',
+  );
   invariant(defaultVariants, 'variants is required');
 
   class WithExperiment extends React.Component<withExperimentInternalProps> {

--- a/tests/unit/amo/test_withExperiment.js
+++ b/tests/unit/amo/test_withExperiment.js
@@ -316,6 +316,8 @@ describe(__filename, () => {
   });
 
   it('does not have any invalid experiment ids defined in the config', () => {
+    // If this test fails it is because an experimentId does not match the
+    // expected format of YYYYMMDD_ExperimentName.
     for (const experimentId of Object.keys(config.get('experiments'))) {
       expect(EXPERIMENT_ID_REGEXP.test(experimentId)).toEqual(true);
     }

--- a/tests/unit/amo/test_withExperiment.js
+++ b/tests/unit/amo/test_withExperiment.js
@@ -21,13 +21,16 @@ describe(__filename, () => {
     }
   }
 
+  const makeId = (id) => `20210219_${id}`;
+
   const renderWithExperiment = ({
     props,
     experimentProps,
     context = fakeCookies(),
   } = {}) => {
+    const id = makeId('some-id');
     const allExperimentProps = {
-      id: 'some-id',
+      id,
       ...experimentProps,
     };
 
@@ -44,7 +47,7 @@ describe(__filename, () => {
     };
 
     const SomeComponent = withExperiment({
-      id: 'some-id',
+      id,
       variants: [
         { id: 'some-variant-a', percentage: 0.5 },
         { id: 'some-variant-b', percentage: 0.5 },
@@ -92,7 +95,7 @@ describe(__filename, () => {
   });
 
   it('creates a cookie upon construction if none has been loaded', () => {
-    const id = 'hero';
+    const id = makeId('hero');
     const cookies = fakeCookies({
       get: sinon.stub().returns(undefined),
     });
@@ -109,7 +112,7 @@ describe(__filename, () => {
   });
 
   it('calls getVariant to set a value for a cookie upon construction if none has been loaded', () => {
-    const id = 'hero';
+    const id = makeId('hero');
     const cookies = fakeCookies({
       get: sinon.stub().returns(undefined),
     });
@@ -137,7 +140,7 @@ describe(__filename, () => {
   });
 
   it('sends an enrollment event upon construction if no cookie has been loaded', () => {
-    const id = 'hero';
+    const id = makeId('hero');
     const cookies = fakeCookies({
       get: sinon.stub().returns(undefined),
     });
@@ -172,7 +175,7 @@ describe(__filename, () => {
   });
 
   it('does not create a cookie upon construction if one has been loaded', () => {
-    const id = 'hero';
+    const id = makeId('hero');
     const cookies = fakeCookies({
       get: sinon.stub().returns(`${id}Experiment`),
     });
@@ -184,7 +187,7 @@ describe(__filename, () => {
   });
 
   it('does not send an enrollment event upon construction if a cookie has been loaded', () => {
-    const id = 'hero';
+    const id = makeId('hero');
     const cookies = fakeCookies({
       get: sinon.stub().returns(`${id}Experiment`),
     });
@@ -200,7 +203,7 @@ describe(__filename, () => {
   });
 
   it('does not send an enrollment event upon construction if the experiment is disabled', () => {
-    const id = 'hero';
+    const id = makeId('hero');
     const cookies = fakeCookies({
       get: sinon.stub().returns(undefined),
     });
@@ -222,7 +225,7 @@ describe(__filename, () => {
   });
 
   it('allows a custom cookie configuration', () => {
-    const id = 'custom_cookie_config';
+    const id = makeId('custom_cookie_config');
     const cookies = fakeCookies();
     const cookieConfig = { path: '/test' };
 
@@ -247,7 +250,7 @@ describe(__filename, () => {
   });
 
   it('can be disabled by configuration', () => {
-    const id = 'disabled_experiment';
+    const id = makeId('disabled_experiment');
     const cookies = fakeCookies();
     const _config = getFakeConfig({
       experiments: {
@@ -262,7 +265,7 @@ describe(__filename, () => {
   });
 
   it('sets isExperimentEnabled prop to false when experiment is disabled by config', () => {
-    const id = 'disabled_experiment';
+    const id = makeId('disabled_experiment');
     const _config = getFakeConfig({
       experiments: {
         [id]: false,
@@ -283,7 +286,7 @@ describe(__filename, () => {
   });
 
   it('sets isUserInExperiment prop to false when the experiment is disabled', () => {
-    const id = 'disabled_experiment';
+    const id = makeId('disabled_experiment');
     const _config = getFakeConfig({
       experiments: {
         [id]: false,
@@ -302,6 +305,12 @@ describe(__filename, () => {
 
     const root = render({ props: { _config } });
     expect(root).toHaveProp('isExperimentEnabled', false);
+  });
+
+  it('throws an exception for a badly formatted experimentId', () => {
+    expect(() => {
+      render({ experimentProps: { id: 'bad-id' } });
+    }).toThrow(/id must match the pattern YYYYMMDD_experiment_id/);
   });
 
   describe('getVariant', () => {

--- a/tests/unit/amo/test_withExperiment.js
+++ b/tests/unit/amo/test_withExperiment.js
@@ -1,8 +1,10 @@
+import config from 'config';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import {
   EXPERIMENT_ENROLLMENT_CATEGORY,
+  EXPERIMENT_ID_REGEXP,
   NOT_IN_EXPERIMENT,
   defaultCookieConfig,
   getVariant,
@@ -311,6 +313,12 @@ describe(__filename, () => {
     expect(() => {
       render({ experimentProps: { id: 'bad-id' } });
     }).toThrow(/id must match the pattern YYYYMMDD_experiment_id/);
+  });
+
+  it('does not have any invalid experiment ids defined in the config', () => {
+    for (const experimentId of Object.keys(config.get('experiments'))) {
+      expect(EXPERIMENT_ID_REGEXP.test(experimentId)).toEqual(true);
+    }
   });
 
   describe('getVariant', () => {


### PR DESCRIPTION
Fixes #9137 

This fixes #9137 in the most basic way, ensuring that a runtime exception will be thrown if an invalidly formatted `experimentId` is encountered, which is likely good enough, but it won't catch this when the tests are run in development. It also won't catch a case where more than one experiment is defined with the same `experimentId`.

If we want to test for both of those, we could put all `experimentId`s into a single config key, and then we can write a test which checks the config both for formatting and for uniqueness.

@willdurand What do you think of that approach? It could be done as a separate follow-up patch to this.
