### PR TITLE
Add the post-write hook to run linters

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,6 @@
 {
     "hooks": {
-        "pre-commit": "flow && lint-staged"
-    } 
+        "pre-commit": "flow && lint-staged",
+        "post-rewrite": "flow && lint-staged"
+    }
 }


### PR DESCRIPTION
Fixes #10232

@bobsilverberg, can you please verify its helping you to run on `cherry-pick --continue`, thanks