### PR TITLE
Make more space for the navigation links at smaller screen resolutions

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -229,7 +229,12 @@ export class HeaderBase extends React.Component {
             {this.renderMenuOrAuthButton()}
           </div>
 
-          <SearchForm className="Header-search-form" pathname="/search/" />
+          <SearchForm
+            className={makeClassName('Header-search-form', {
+              'Header-search-form--desktop': clientApp === CLIENT_APP_FIREFOX,
+            })}
+            pathname="/search/"
+          />
         </div>
       </header>
     );

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -214,10 +214,6 @@
     grid-column: 3 / 3;
     grid-row: 2 / 2;
     margin-top: 6px;
-    max-width: 160px;
-  }
-
-  @include respond-to(large) {
     max-width: 250px;
   }
 
@@ -226,5 +222,11 @@
     margin: 0;
     max-width: 284px;
     width: 100%;
+  }
+}
+
+.Header-search-form--desktop {
+  @include respond-to(medium) {
+    max-width: 160px;
   }
 }

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -223,10 +223,18 @@
     max-width: 284px;
     width: 100%;
   }
-}
 
-.Header-search-form--desktop {
-  @include respond-to(medium) {
-    max-width: 160px;
+  &.Header-search-form--desktop {
+    @include respond-to(medium) {
+      max-width: 160px;
+    }
+
+    @include respond-to(large) {
+      max-width: 250px;
+    }
+
+    @include respond-to(extraLarge) {
+      max-width: 284px;
+    }
   }
 }

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -214,6 +214,10 @@
     grid-column: 3 / 3;
     grid-row: 2 / 2;
     margin-top: 6px;
+    max-width: 160px;
+  }
+
+  @include respond-to(large) {
     max-width: 250px;
   }
 

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -16,10 +16,15 @@
   color: $grey-40;
   display: inline-block;
   font-weight: 400;
-  margin: 0 12px;
+  margin: 0 8px;
   outline: none;
+  overflow-wrap: break-word;
   padding: 0 0 2px;
   text-decoration: none;
+
+  @include respond-to(large) {
+    margin: 0 12px;
+  }
 
   &::after {
     background: transparent;

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -18,6 +18,8 @@
   font-weight: 400;
   margin: 0 8px;
   outline: none;
+  // This is required to deal with the section links wrapping at a smaller
+  // screen resolution.
   overflow-wrap: break-word;
   padding: 0 0 2px;
   text-decoration: none;

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import Header, { HeaderBase } from 'amo/components/Header';
 import Link from 'amo/components/Link';
+import SearchForm from 'amo/components/SearchForm';
 import SectionLinks from 'amo/components/SectionLinks';
 import { makeQueryStringWithUTM } from 'amo/utils';
 import AuthenticateButton from 'amo/components/AuthenticateButton';
@@ -246,5 +247,25 @@ describe(__filename, () => {
     const root = renderHeader({ store });
 
     expect(root.find(SectionLinks)).toHaveLength(0);
+  });
+
+  it('adds a className to the search form for the desktop site', () => {
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
+
+    const root = renderHeader({ store });
+
+    expect(root.find(SearchForm)).toHaveClassName(
+      'Header-search-form--desktop',
+    );
+  });
+
+  it('does not add a className to the search form for the mobile site', () => {
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID });
+
+    const root = renderHeader({ store });
+
+    expect(root.find(SearchForm)).not.toHaveClassName(
+      'Header-search-form--desktop',
+    );
   });
 });


### PR DESCRIPTION
Fixes #10254 

This fixes the wrapping of the navigation links at `500px` and `900px`, as well as an issue with the "More..." menu.

<details>
<summary>At `500px`</summary>

Before:
![Screen Shot 2021-03-23 at 9 57 47 AM](https://user-images.githubusercontent.com/142755/112163382-5a039580-8bc3-11eb-9e37-520dd5178fe7.png)

After:
![Screen Shot 2021-03-23 at 9 57 09 AM](https://user-images.githubusercontent.com/142755/112163415-625bd080-8bc3-11eb-94e6-cfc24c885919.png)
</details>

<details>
<summary>At `900px`</summary>

Before:
![Screen Shot 2021-03-23 at 9 58 25 AM](https://user-images.githubusercontent.com/142755/112163492-769fcd80-8bc3-11eb-99e0-c71536a36ff2.png)

After:
![Screen Shot 2021-03-23 at 9 58 50 AM](https://user-images.githubusercontent.com/142755/112163530-7f909f00-8bc3-11eb-975a-5127060b968a.png)
</details>