### PR TITLE
Revert lazy loading of images on extension detail page and theme search results

### DIFF
--- a/src/amo/components/ScreenShots/index.js
+++ b/src/amo/components/ScreenShots/index.js
@@ -79,7 +79,6 @@ export default class ScreenShots extends React.Component<Props> {
                       src={preview.thumbnail_src}
                       width={preview.thumbnail_w}
                       height={preview.thumbnail_h}
-                      loading="lazy"
                     />
                   )}
                 </Item>

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -189,7 +189,6 @@ export class SearchResultBase extends React.Component<InternalProps> {
                 })}
                 src={imageURL}
                 alt={addon ? `${addon.name}` : ''}
-                loading="lazy"
               />
             ) : (
               <p className="SearchResult-notheme">

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -50,7 +50,6 @@ describe(__filename, () => {
       expect(image).toHaveProp('width', preview.thumbnail_w);
       expect(image).toHaveProp('height', preview.thumbnail_h);
       expect(image).toHaveProp('alt', preview.title);
-      expect(image).toHaveProp('loading', 'lazy');
     });
   });
 

--- a/tests/unit/amo/components/TestSearchResult.js
+++ b/tests/unit/amo/components/TestSearchResult.js
@@ -366,7 +366,6 @@ describe(__filename, () => {
     const image = root.find('.SearchResult-icon');
 
     expect(image.prop('src')).toEqual(headerImageFull);
-    expect(image.prop('loading')).toEqual('lazy');
   });
 
   it('displays a fallback image for themes that only have 1 preview option', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10266

We will investigate a more subtle approach but for now it's not clear it improves things since it delays the initial loading of images that are in the viewport as well.