### PR TITLE
Introducing the `addons-frontend-card` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,15 @@ curl https://addons-dev.allizom.org/__version__
 
 :bulb: You can install the [amo-info extension](https://addons.mozilla.org/en-US/firefox/addon/amo-info/) to easily view this information.
 
+## Addons Frontend Card
+
+This project also contains code to build a library named `addons-frontend-card` and offers the following commands:
+
+- `yarn build:card-dev`: build the library and start a watcher to rebuild the library on change
+- `yarn build:card-prod`: build the library in production mode
+
+This library is exclusively designed to work with [addons-blog][].
+
 ## Core technologies
 
 - Based on Redux + React
@@ -351,3 +360,4 @@ curl https://addons-dev.allizom.org/__version__
 [bundlesize]: https://github.com/siddharthkp/bundlesize
 [jest]: https://jestjs.io/docs/en/getting-started.html
 [prettier]: https://prettier.io/
+[addons-blog]: https://github.com/mozilla/addons-blog

--- a/bin/create-package-json-for-card
+++ b/bin/create-package-json-for-card
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const packageJson = require('../package.json');
+
+const distDir = path.join(__dirname, '..', 'dist');
+const content = `{
+  "name": "addons-frontend-card",
+  "version": "${packageJson.version}",
+  "main": "node.js",
+  "browser": "web.js",
+  "style": "style.css",
+  "dependencies": {
+    "jsdom": "${packageJson.dependencies.jsdom}",
+    "node-fetch": "2.6.1"
+  }
+}
+`;
+
+fs.writeFile(path.join(distDir, 'package.json'), content, 'utf-8', (err) => {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  console.log('done');
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "scripts": {
     "build": "npm run clean && better-npm-run build",
+    "build:card": "npm run clean && bin/create-package-json-for-card && better-npm-run build:card",
+    "build:card-dev": "NODE_ENV=development npm run build:card -- --watch",
+    "build:card-prod": "NODE_ENV=production npm run build:card",
     "build-check": "bin/build-checks.js",
     "build-ci": "npm run build && npm run bundlesize",
     "build-locales": "bin/build-locales",
@@ -45,6 +48,14 @@
       "env": {
         "NODE_ICU_DATA": "./node_modules/full-icu",
         "NODE_PATH": "./:./src"
+      }
+    },
+    "build:card": {
+      "command": "webpack --config webpack.card.config.babel.js",
+      "env": {
+        "NODE_ICU_DATA": "./node_modules/full-icu",
+        "NODE_PATH": "./:./src",
+        "NODE_CONFIG_ENV": "prod"
       }
     },
     "amo:olympia": {

--- a/src/card/index.js
+++ b/src/card/index.js
@@ -1,0 +1,111 @@
+/* global fetch */
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'connected-react-router';
+import { createMemoryHistory } from 'history';
+import 'isomorphic-fetch';
+
+import { getAddonIconUrl } from 'amo/imageUtils';
+import I18nProvider from 'amo/i18n/Provider';
+import { makeI18n } from 'amo/i18n/utils';
+import { createInternalAddon } from 'amo/reducers/addons';
+import { setClientApp, setLang } from 'amo/reducers/api';
+import createStore from 'amo/store';
+import { nl2br, sanitizeHTML } from 'amo/utils';
+import AddonBadges from 'amo/components/AddonBadges';
+import AddonTitle from 'amo/components/AddonTitle';
+import Footer from 'amo/components/Footer';
+import GetFirefoxButton, {
+  GET_FIREFOX_BUTTON_TYPE_ADDON,
+} from 'amo/components/GetFirefoxButton';
+import type { AddonType } from 'amo/types/addons';
+
+import './styles.scss';
+
+const AMO_BASE_URL = 'https://addons.mozilla.org';
+
+type StaticAddonCardProps = {|
+  addon: AddonType,
+|};
+
+const StaticAddonCard = ({ addon }: StaticAddonCardProps) => {
+  if (!addon) {
+    return null;
+  }
+
+  const summary = addon.summary ? addon.summary : addon.description;
+
+  return (
+    <div className="StaticAddonCard" data-addon-id={addon.id}>
+      <div className="AddonIcon">
+        <div className="AddonIconWrapper">
+          <img className="AddonIconImage" src={getAddonIconUrl(addon)} alt="" />
+        </div>
+      </div>
+
+      <AddonTitle addon={addon} />
+
+      <AddonBadges addon={addon} />
+
+      <p
+        className="AddonSummary"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={sanitizeHTML(nl2br(summary), ['a', 'br'])}
+      />
+
+      <GetFirefoxButton
+        addon={addon}
+        buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+        className="AddonFirefoxButton"
+      />
+    </div>
+  );
+};
+
+const render = ({ app, lang, component }) => {
+  const i18n = makeI18n({}, lang);
+  const { store } = createStore();
+
+  store.dispatch(setClientApp(app));
+  store.dispatch(setLang(lang));
+
+  return renderToStaticMarkup(
+    <I18nProvider i18n={i18n}>
+      <Provider store={store}>
+        <ConnectedRouter history={createMemoryHistory()}>
+          {component}
+        </ConnectedRouter>
+      </Provider>
+    </I18nProvider>,
+  );
+};
+
+export const buildStaticAddonCard = async (props: {| addonId: number |}) => {
+  const { addonId } = props;
+
+  const app = 'firefox';
+  const lang = 'en-US';
+
+  try {
+    const response = await fetch(
+      `${AMO_BASE_URL}/api/v5/addons/addon/${addonId}/?lang=${lang}&app=${app}`,
+    );
+    const apiAddon = await response.json();
+    const addon = createInternalAddon(apiAddon, lang);
+
+    return render({ app, lang, component: <StaticAddonCard addon={addon} /> });
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(`Error: ${e}`);
+  }
+
+  return null;
+};
+
+export const buildFooter = () => {
+  const app = 'firefox';
+  const lang = 'en-US';
+
+  return render({ app, lang, component: <Footer noLangPicker /> });
+};

--- a/src/card/styles.scss
+++ b/src/card/styles.scss
@@ -1,0 +1,76 @@
+@import '~amo/css/styles';
+
+.StaticAddonCard {
+  border-radius: 10px;
+  box-shadow: 0 0 4px transparentize($black, 0.5);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding: 1em;
+
+  @include respond-to(medium) {
+    grid-template-columns: fr 1fr 1fr;
+  }
+}
+
+.AddonBadges {
+  grid-column: 2;
+  grid-row: 1;
+  margin: 0 0 0 auto;
+  width: auto;
+
+  @include respond-to(medium) {
+    grid-column: 3;
+  }
+}
+
+.AddonIcon {
+  grid-column: 1;
+  grid-row: 1;
+
+  @include respond-to(medium) {
+    grid-column: 1 / span 2;
+    min-height: 96px;
+  }
+}
+
+.AddonIconWrapper {
+  height: 48px;
+  overflow: hidden;
+  width: 48px;
+
+  @include respond-to(medium) {
+    height: 64px;
+    overflow: hidden;
+    width: 64px;
+  }
+}
+
+.AddonIconImage {
+  height: auto;
+  width: 100%;
+}
+
+.AddonTitle {
+  grid-column: 1 / span 3;
+  grid-row: 2;
+}
+
+.AddonSummary {
+  font-size: $font-size-m;
+  grid-column: 1 / span 2;
+  grid-row: 3;
+  overflow-x: auto;
+}
+
+.GetFirefoxButton {
+  align-self: center;
+  grid-column: 1 / span 2;
+  grid-row: 4;
+  white-space: initial;
+  width: auto;
+
+  @include respond-to(medium) {
+    grid-column: 3;
+    grid-row: 3;
+  }
+}

--- a/src/card/tracking.js
+++ b/src/card/tracking.js
@@ -1,0 +1,8 @@
+// This is a no-op tracking implementation.
+export default {
+  sendEvent() {},
+  pageView() {},
+  settPage() {},
+  setDimension() {},
+  sendWebVitalStats() {},
+};

--- a/tests/unit/card/test_index.js
+++ b/tests/unit/card/test_index.js
@@ -1,0 +1,14 @@
+import cheerio from 'cheerio';
+
+import { buildFooter } from 'card';
+
+describe(__filename, () => {
+  describe('buildFooter', () => {
+    it('returns the footer HTML', () => {
+      const html = cheerio.load(buildFooter());
+
+      expect(html('.Footer')).toHaveLength(1);
+      expect(html('.Footer-language-picker')).toHaveLength(0);
+    });
+  });
+});

--- a/webpack.card.config.babel.js
+++ b/webpack.card.config.babel.js
@@ -1,0 +1,82 @@
+/* eslint-disable max-len, import/no-extraneous-dependencies */
+import path from 'path';
+
+import webpack from 'webpack';
+import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import TerserPlugin from 'terser-webpack-plugin';
+
+import { getPlugins, getRules } from './webpack-common';
+
+const makeConfig = ({ target, externals = {} }) => ({
+  mode: process.env.NODE_ENV,
+  devtool: false,
+  entry: {
+    'index': 'card',
+  },
+  output: {
+    filename: `${target}.js`,
+    library: {
+      name: 'AddonsFrontendCard',
+      type: 'umd',
+    },
+    globalObject: 'this',
+  },
+  target,
+  externals,
+  module: {
+    rules: getRules({ fileLimit: 20000 }),
+  },
+  plugins: [
+    ...getPlugins({ withBrowserWindow: target === 'web' }),
+    new webpack.NormalModuleReplacementPlugin(
+      /amo\/tracking/,
+      'card/tracking.js',
+    ),
+    new MiniCssExtractPlugin({ filename: 'style.css' }),
+  ],
+  resolve: {
+    modules: [path.resolve(__dirname, 'src'), 'node_modules'],
+  },
+  optimization: {
+    minimizer: [
+      // We do not use UglifyJsPlugin because it does not work as intended with
+      // our config, but TerserPlugin is very similar.
+      new TerserPlugin({
+        // This has been enabled by default in terser-webpack-plugin 2.0.0 but
+        // we were not using it before.
+        extractComments: false,
+        // Even though devtool is set to source-map, this must be true to
+        // output source maps:
+        sourceMap: false,
+        // Do not change these options without busting the cache.
+        // See: https://github.com/mozilla/addons-frontend/issues/5796
+        terserOptions: {
+          output: {
+            comments: false,
+          },
+          compress: {
+            drop_console: true,
+          },
+        },
+      }),
+      new CssMinimizerPlugin(),
+    ],
+  },
+});
+
+export default [
+  makeConfig({
+    target: 'web',
+    externals: {
+      'amo/window': 'window',
+    },
+  }),
+  makeConfig({
+    target: 'node',
+    externals: {
+      jsdom: 'jsdom',
+      'node-fetch': 'commonjs2 node-fetch',
+    },
+  }),
+];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2912,6 +2912,15 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz#b848ebc0ab230cf313d194a4775a30155d50ae40"
   integrity sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==
 
+canvas@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.7.0.tgz#3ce3fe30c69595ccd2bd1232967e681c026be61e"
+  integrity sha512-pzCxtkHb+5su5MQjTtepMDlIOtaXo277x0C0u3nMOxtkhTyQ+h2yNKhlROAaDllWgRyePAUitC08sXw26Eb6aw==
+  dependencies:
+    nan "^2.14.0"
+    node-pre-gyp "^0.15.0"
+    simple-get "^3.0.3"
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -3845,6 +3854,13 @@ debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, d
   dependencies:
     ms "2.1.2"
 
+debug@^3.2.6:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize-keys@^1.0.0, decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -3970,7 +3986,7 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-detect-libc@^1.0.3:
+detect-libc@^1.0.2, detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -5315,6 +5331,13 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-minipass@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+  dependencies:
+    minipass "^2.6.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -6018,7 +6041,7 @@ husky@^4.3.6:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-iconv-lite@0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6042,7 +6065,7 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore-walk@3.0.3:
+ignore-walk@3.0.3, ignore-walk@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
   integrity sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
@@ -8268,12 +8291,27 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
   integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
   dependencies:
     yallist "^4.0.0"
+
+minizlib@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
 
 minizlib@^2.1.1:
   version "2.1.2"
@@ -8296,7 +8334,7 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -8399,6 +8437,11 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 multimatch@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
@@ -8468,6 +8511,15 @@ nearley@^2.7.10:
     moo "^0.5.0"
     railroad-diagrams "^1.0.0"
     randexp "0.4.6"
+
+needle@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.6.0.tgz#24dbb55f2509e2324b4a99d61f413982013ccdbe"
+  integrity sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -8552,6 +8604,22 @@ node-notifier@^8.0.0:
     shellwords "^0.1.1"
     uuid "^8.3.0"
     which "^2.0.2"
+
+node-pre-gyp@^0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz#c2fc383276b74c7ffa842925241553e8b40f1087"
+  integrity sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.3"
+    needle "^2.5.0"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
 
 node-releases@^1.1.70:
   version "1.1.71"
@@ -8667,6 +8735,27 @@ normalize.css@8.0.1:
   resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
   integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
 
+npm-bundled@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
+  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+
+npm-packlist@^1.1.6:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
+  integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
+  dependencies:
+    ignore-walk "^3.0.1"
+    npm-bundled "^1.0.1"
+    npm-normalize-package-bin "^1.0.1"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -8681,7 +8770,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.0, npmlog@^4.0.1, npmlog@^4.1.2:
+npmlog@^4.0.0, npmlog@^4.0.1, npmlog@^4.0.2, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -10925,7 +11014,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.2.8:
+rimraf@^2.2.8, rimraf@^2.6.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -12151,6 +12240,19 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+tar@^4.4.2:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
 tar@^6.0.2:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
@@ -13375,6 +13477,11 @@ y18n@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
   integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
+yallist@^3.0.0, yallist@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This is the code required to build a new npm library based on addons-frontend. The name of this library is `addons-frontend-card` and it is currently published under a different name (see: https://github.com/willdurand/addons-frontend-card and https://www.npmjs.com/package/@willdurand/addons-frontend-card). This library is designed to be consumed by https://github.com/mozilla/addons-blog. It provides the following features:

1. expose the HTML of the AMO footer to avoid recreating it from scratch for the blog
2. provide a function to render a "static add-on card" given an add-on ID
3. CSS

The code is "isomorphic", i.e. it works on the server (node) as well as in the browser, which is a requirement for the WordPress theme. There are some screenshots here: https://github.com/mozilla/addons-blog/pull/39

I believe we bundle a bit too much code because we have to set up most of the addons-frontend stack to render components _but_ this package is not intended for "production" runtime. It'll be used by the build process in addons-blog and on our "private" WP instance for previews. That being said, I stripped a bunch of code already.

The `bin` script builds a `package.json` file for the library and tries to use the same constraints for the dependencies (for `node-fetch`, it's not possible but we might be able to infer its version by running `yarn ls`
or something like this).

We currently don't have an easy way to work on the static card. It's the first time I miss Storybook, heh. My current workflow is to run `yarn build:card-dev` and serve the following HTML:

<details>

```html
<html>
	<head>
		<link href="./dist/style.css" rel="stylesheet" type="text/css">
	</head>
	<body>
		<div class="addon-card" data-addon-id="853731"></div>
		<footer id="footer"></footer>
	</body>
	<script src="./dist/web.js"></script>
	<script>
		document.querySelectorAll('.addon-card').forEach(async (card) => {
			try {
				card.outerHTML = await AddonsFrontendCard.buildStaticAddonCard({ addonId: card.dataset.addonId });
			} catch (e) {
				console.error(`unable to build static card: ${e}`);
			}
		});
		document.querySelector('#footer').outerHTML = AddonsFrontendCard.buildFooter();
	</script>
</html>
```

</details>

---

Ideally, we'd be able to release this package automatically _via_ Circle CI. I think we could use a special tag pattern to run the build&release process without triggering a deployment. We could also release the lib for all commits on the main branch (using the special `@next` npm version?) but I am not sure this is really needed.