### PR TITLE
RE: Update - Consolidate API requests for the home page shelves

### DIFF
--- a/src/amo/api/homeShelves.js
+++ b/src/amo/api/homeShelves.js
@@ -1,0 +1,15 @@
+/* @flow */
+import { callApi } from 'amo/api';
+import type { ApiState } from 'amo/reducers/api';
+import type { HomeShelvesType } from 'amo/reducers/home';
+
+export type GetHomeShelvesParams = {| api: ApiState |};
+
+export const getHomeShelves = ({
+  api,
+}: GetHomeShelvesParams): Promise<HomeShelvesType> => {
+  return callApi({
+    apiState: api,
+    endpoint: 'shelves',
+  });
+};

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -1,0 +1,119 @@
+/* @flow */
+import * as React from 'react';
+import config from 'config';
+
+import LandingAddonsCard from 'amo/components/LandingAddonsCard';
+import LoadingText from 'amo/components/LoadingText';
+import {
+  INSTALL_SOURCE_FEATURED,
+  INSTALL_SOURCE_FEATURED_COLLECTION,
+  LANDING_PAGE_EXTENSION_COUNT,
+  LANDING_PAGE_THEME_COUNT,
+} from 'amo/constants';
+import translate from 'amo/i18n/translate';
+import { checkInternalURL } from 'amo/utils';
+import type { ResultShelfType } from 'amo/reducers/home';
+import type { I18nType } from 'amo/types/i18n';
+
+type Props = {|
+  loading: boolean,
+  shelves: Array<ResultShelfType>,
+|};
+
+type InternalProps = {|
+  _checkInternalURL: typeof checkInternalURL,
+  i18n: I18nType,
+  ...Props,
+|};
+
+export const HOMESHELVES_ENDPOINT_COLLECTIONS = 'collections';
+export const HOMESHELVES_ENDPOINT_SEARCH = 'search';
+export const HOMESHELVES_ENDPOINT_SEARCH_THEMES = 'search-themes';
+
+export const HomepageShelvesBase = (props: InternalProps): React.Node => {
+  const {
+    _checkInternalURL = checkInternalURL,
+    i18n,
+    loading,
+    shelves,
+  } = props;
+
+  let shelvesContent;
+
+  if (loading) {
+    shelvesContent = (
+      <div className="HomepageShelves-loading">
+        {[1, 2, 3].map((key) => {
+          return (
+            <LandingAddonsCard
+              className="HomepageShelves-loading-card"
+              key={`HomepageShelves-loading-${key}`}
+              header={<LoadingText width={100} />}
+              loading
+            />
+          );
+        })}
+      </div>
+    );
+  } else {
+    shelvesContent = shelves.map((shelf) => {
+      const { addons, criteria, endpoint, footer, title } = shelf;
+      const MOZILLA_USER_ID = config.get('mozillaUserId');
+      const shelfKey = title.replace(/\s/g, '-');
+
+      const footerText =
+        footer && footer.text
+          ? footer.text
+          : i18n.sprintf(i18n.gettext('See more %(categoryName)s'), {
+              categoryName: title.toLowerCase(),
+            });
+
+      const addonInstallSource =
+        endpoint === HOMESHELVES_ENDPOINT_COLLECTIONS
+          ? INSTALL_SOURCE_FEATURED_COLLECTION
+          : INSTALL_SOURCE_FEATURED;
+
+      const count =
+        endpoint === HOMESHELVES_ENDPOINT_SEARCH_THEMES
+          ? LANDING_PAGE_THEME_COUNT
+          : LANDING_PAGE_EXTENSION_COUNT;
+
+      let footerLink;
+      if (footer && footer.url) {
+        const internalUrlCheck = _checkInternalURL({ urlString: footer.url });
+        if (internalUrlCheck.isInternal) {
+          footerLink = internalUrlCheck.relativeURL;
+        } else {
+          footerLink = { href: footer.url };
+        }
+      } else {
+        footerLink =
+          endpoint === HOMESHELVES_ENDPOINT_COLLECTIONS
+            ? `/collections/${MOZILLA_USER_ID}/${criteria}/`
+            : `/search/${criteria}`;
+      }
+
+      return (
+        <LandingAddonsCard
+          addonInstallSource={addonInstallSource}
+          addons={addons}
+          className={`Home-${shelfKey}`}
+          footerText={footerText}
+          footerLink={footerLink}
+          header={title}
+          isTheme={endpoint === HOMESHELVES_ENDPOINT_SEARCH_THEMES}
+          key={shelfKey}
+          placeholderCount={count}
+        />
+      );
+    });
+  }
+
+  return <div className="Home-HomepageShelves">{shelvesContent}</div>;
+};
+
+const HomepageShelves: React.ComponentType<Props> = translate()(
+  HomepageShelvesBase,
+);
+
+export default HomepageShelves;

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -42,6 +42,8 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
 
   if (loading) {
     shelvesContent = (
+      // Display loading shelves to keep components that fall below the fold from
+      // shifting after homepage shelves are loaded from the API
       <div className="HomepageShelves-loading">
         {[1, 2, 3].map((key) => {
           return (
@@ -109,7 +111,7 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
     });
   }
 
-  return <div className="Home-HomepageShelves">{shelvesContent}</div>;
+  return <div className="HomepageShelves">{shelvesContent}</div>;
 };
 
 const HomepageShelves: React.ComponentType<Props> = translate()(

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -26,7 +26,7 @@ type Props = {|
   footerText?: string,
   header?: React.Node,
   isTheme?: boolean,
-  loading: boolean,
+  loading?: boolean,
 |};
 
 export default class LandingAddonsCard extends React.Component<Props> {
@@ -48,17 +48,29 @@ export default class LandingAddonsCard extends React.Component<Props> {
     } = this.props;
 
     let footerLinkHtml = null;
+    const footerLinkProps = {};
     const count = isTheme ? LANDING_PAGE_THEME_COUNT : placeholderCount;
+
     if (addons && addons.length >= count) {
-      let linkTo = footerLink;
-      if (linkTo && typeof linkTo === 'object') {
-        // As a convenience, fix the query parameter.
-        linkTo = {
-          ...linkTo,
-          query: convertFiltersToQueryParams(linkTo.query),
-        };
+      if (footerLink && typeof footerLink === 'object') {
+        // If an href has been passed, use that for the Link.
+        if (footerLink.href) {
+          footerLinkProps.href = footerLink.href;
+          footerLinkProps.prependClientApp = false;
+          footerLinkProps.prependLang = false;
+        } else {
+          // As a convenience, fix the query parameter.
+          footerLinkProps.to = {
+            ...footerLink,
+            query: convertFiltersToQueryParams(footerLink.query),
+          };
+        }
+      } else {
+        // It's just a string, so pass it into the `to` prop.
+        footerLinkProps.to = footerLink;
       }
-      footerLinkHtml = <Link to={linkTo}>{footerText}</Link>;
+
+      footerLinkHtml = <Link {...footerLinkProps}>{footerText}</Link>;
     }
 
     return (

--- a/src/amo/components/SecondaryHero/index.js
+++ b/src/amo/components/SecondaryHero/index.js
@@ -8,7 +8,7 @@ import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'amo/constants';
 import { addQueryParams } from 'amo/utils/url';
 import LoadingText from 'amo/components/LoadingText';
 import type {
-  HeroCallToActionType,
+  CallToActionType,
   SecondaryHeroShelfType,
 } from 'amo/reducers/home';
 import type { AnchorEvent } from 'amo/types/dom';
@@ -58,7 +58,7 @@ export const SecondaryHeroBase = ({
     });
   };
 
-  const getLinkProps = (link: HeroCallToActionType | null) => {
+  const getLinkProps = (link: CallToActionType | null) => {
     const props = { onClick: onHeroClick };
     if (link) {
       const urlInfo = _checkInternalURL({ urlString: link.url });

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -13,7 +13,6 @@ import CollectionDetailsCard from 'amo/components/CollectionDetailsCard';
 import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import Link from 'amo/components/Link';
 import Page from 'amo/components/Page';
-import { isFeaturedCollection } from 'amo/pages/Home';
 import {
   collectionEditUrl,
   collectionName,
@@ -33,7 +32,6 @@ import Paginate from 'amo/components/Paginate';
 import {
   COLLECTION_SORT_DATE_ADDED_DESCENDING,
   INSTALL_SOURCE_COLLECTION,
-  INSTALL_SOURCE_FEATURED_COLLECTION,
 } from 'amo/constants';
 import { withFixedErrorHandler } from 'amo/errorHandler';
 import translate from 'amo/i18n/translate';
@@ -82,7 +80,6 @@ type InternalProps = {|
   ...Props,
   ...PropsFromState,
   ...DefaultProps,
-  _isFeaturedCollection: typeof isFeaturedCollection,
   dispatch: DispatchFunc,
   errorHandler: ErrorHandlerType,
   history: ReactRouterHistoryType,
@@ -139,9 +136,7 @@ export class CollectionBase extends React.Component<InternalProps> {
 
   static defaultProps: {|
     ...DefaultProps,
-    _isFeaturedCollection: typeof isFeaturedCollection,
   |} = {
-    _isFeaturedCollection: isFeaturedCollection,
     creating: false,
     editing: false,
   };
@@ -412,7 +407,6 @@ export class CollectionBase extends React.Component<InternalProps> {
 
   renderCollection(): React.Node {
     const {
-      _isFeaturedCollection,
       collection,
       creating,
       editing,
@@ -466,11 +460,6 @@ export class CollectionBase extends React.Component<InternalProps> {
           );
     }
 
-    const addonInstallSource =
-      collection && _isFeaturedCollection(collection)
-        ? INSTALL_SOURCE_FEATURED_COLLECTION
-        : INSTALL_SOURCE_COLLECTION;
-
     return (
       <div className="Collection-wrapper">
         <div className="Collection-detail-wrapper">
@@ -497,7 +486,7 @@ export class CollectionBase extends React.Component<InternalProps> {
           )}
           {!creating && (
             <AddonsCard
-              addonInstallSource={addonInstallSource}
+              addonInstallSource={INSTALL_SOURCE_COLLECTION}
               addons={addons}
               deleteNote={this.deleteNote}
               editing={editing}

--- a/src/amo/pages/Home/index.js
+++ b/src/amo/pages/Home/index.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import config from 'config';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
@@ -7,26 +6,23 @@ import { compose } from 'redux';
 import { setViewContext } from 'amo/actions/viewContext';
 import Card from 'amo/components/Card';
 import CategoryIcon from 'amo/components/CategoryIcon';
-import FeaturedCollectionCard from 'amo/components/FeaturedCollectionCard';
 import HeadLinks from 'amo/components/HeadLinks';
 import HeadMetaTags from 'amo/components/HeadMetaTags';
 import HeroRecommendation from 'amo/components/HeroRecommendation';
+import HomepageShelves from 'amo/components/HomepageShelves';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import LoadingText from 'amo/components/LoadingText';
 import Page from 'amo/components/Page';
 import SecondaryHero from 'amo/components/SecondaryHero';
 import {
-  LANDING_PAGE_EXTENSION_COUNT,
   MOBILE_HOME_PAGE_EXTENSION_COUNT,
   ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_FIREFOX,
   INSTALL_SOURCE_FEATURED,
   RECOMMENDED,
-  SEARCH_SORT_POPULAR,
   SEARCH_SORT_RANDOM,
-  SEARCH_SORT_TRENDING,
   VIEW_CONTEXT_HOME,
 } from 'amo/constants';
 import { withErrorHandler } from 'amo/errorHandler';
@@ -36,64 +32,16 @@ import { getCategoryResultsPathname } from 'amo/utils/categories';
 
 import './styles.scss';
 
-export const MOZILLA_USER_ID = config.get('mozillaUserId');
-
-export const FEATURED_COLLECTIONS = [
-  { slug: 'privacy-matters', userId: MOZILLA_USER_ID },
-  { slug: 'password-managers', userId: MOZILLA_USER_ID },
-];
-
-export const isFeaturedCollection = (
-  collection,
-  { featuredCollections = FEATURED_COLLECTIONS } = {},
-) => {
-  return featuredCollections.some((featured) => {
-    return (
-      featured.slug === collection.slug &&
-      featured.userId === collection.authorId
-    );
-  });
-};
-
-export const getFeaturedCollectionsMetadata = (i18n) => {
-  return [
-    {
-      footerText: i18n.gettext('See more enhanced privacy extensions'),
-      header: i18n.gettext('Enhanced privacy extensions'),
-      isTheme: false,
-      ...FEATURED_COLLECTIONS[0],
-    },
-    {
-      footerText: i18n.gettext('See more recommended password managers'),
-      header: i18n.gettext('Recommended password managers'),
-      isTheme: false,
-      ...FEATURED_COLLECTIONS[1],
-    },
-  ];
-};
-
 export class HomeBase extends React.Component {
   static propTypes = {
-    _config: PropTypes.object,
-    _getFeaturedCollectionsMetadata: PropTypes.func,
-    collections: PropTypes.array.isRequired,
     dispatch: PropTypes.func.isRequired,
     errorHandler: PropTypes.object.isRequired,
-    heroShelves: PropTypes.object,
+    homeShelves: PropTypes.object,
     i18n: PropTypes.object.isRequired,
-    includeRecommendedThemes: PropTypes.bool,
-    includeTrendingExtensions: PropTypes.bool,
     isDesktopSite: PropTypes.bool,
     isLoading: PropTypes.bool,
     resultsLoaded: PropTypes.bool.isRequired,
-    shelves: PropTypes.object.isRequired,
-  };
-
-  static defaultProps = {
-    _config: config,
-    _getFeaturedCollectionsMetadata: getFeaturedCollectionsMetadata,
-    includeRecommendedThemes: true,
-    includeTrendingExtensions: false,
+    shelves: PropTypes.object,
   };
 
   constructor(props) {
@@ -110,8 +58,6 @@ export class HomeBase extends React.Component {
     const {
       dispatch,
       errorHandler,
-      includeRecommendedThemes,
-      includeTrendingExtensions,
       isDesktopSite,
       isLoading,
       resultsLoaded,
@@ -126,10 +72,7 @@ export class HomeBase extends React.Component {
     if (!resultsLoaded && !isLoading) {
       dispatch(
         fetchHomeData({
-          collectionsToFetch: FEATURED_COLLECTIONS,
           errorHandlerId: errorHandler.id,
-          includeRecommendedThemes,
-          includeTrendingExtensions,
           isDesktopSite,
         }),
       );
@@ -194,14 +137,14 @@ export class HomeBase extends React.Component {
   }
 
   renderHeroHeader() {
-    const { heroShelves } = this.props;
+    const { homeShelves } = this.props;
     return (
       <div className="Home-heroHeader">
         <h2 className="Home-heroHeader-title">
-          {heroShelves ? heroShelves.secondary.headline : <LoadingText />}
+          {homeShelves ? homeShelves.secondary.headline : <LoadingText />}
         </h2>
         <h3 className="Home-heroHeader-subtitle">
-          {heroShelves ? heroShelves.secondary.description : <LoadingText />}
+          {homeShelves ? homeShelves.secondary.description : <LoadingText />}
         </h3>
       </div>
     );
@@ -209,13 +152,9 @@ export class HomeBase extends React.Component {
 
   render() {
     const {
-      _getFeaturedCollectionsMetadata,
-      collections,
       errorHandler,
-      heroShelves,
+      homeShelves,
       i18n,
-      includeRecommendedThemes,
-      includeTrendingExtensions,
       isDesktopSite,
       resultsLoaded,
       shelves,
@@ -224,29 +163,7 @@ export class HomeBase extends React.Component {
     const themesHeader = i18n.gettext(`Change the way Firefox looks with
       themes.`);
 
-    const featuredCollectionsMetadata = _getFeaturedCollectionsMetadata(i18n);
-
     const loading = resultsLoaded === false;
-
-    // This is a helper function (closure) configured to render a featured
-    // collection by index.
-    const renderFeaturedCollection = (index) => {
-      const metadata = featuredCollectionsMetadata[index];
-
-      const collection = collections[index];
-      if (loading || collection) {
-        return (
-          <FeaturedCollectionCard
-            addons={collection}
-            className="Home-FeaturedCollection"
-            loading={loading}
-            {...metadata}
-          />
-        );
-      }
-
-      return null;
-    };
 
     return (
       <Page isHomePage showWrongPlatformWarning={!isDesktopSite}>
@@ -275,120 +192,46 @@ export class HomeBase extends React.Component {
           {isDesktopSite ? (
             <HeroRecommendation
               errorHandler={errorHandler}
-              shelfData={heroShelves ? heroShelves.primary : undefined}
+              shelfData={homeShelves ? homeShelves.primary : undefined}
             />
           ) : null}
 
           <div className="Home-content">
             {isDesktopSite ? (
               <SecondaryHero
-                shelfData={heroShelves ? heroShelves.secondary : undefined}
+                shelfData={homeShelves ? homeShelves.secondary : undefined}
               />
             ) : null}
 
             {!isDesktopSite ? this.renderHeroHeader() : null}
 
-            <LandingAddonsCard
-              addonInstallSource={INSTALL_SOURCE_FEATURED}
-              addons={shelves.recommendedExtensions}
-              className="Home-RecommendedExtensions"
-              header={i18n.gettext('Recommended extensions')}
-              footerText={i18n.gettext('See more recommended extensions')}
-              footerLink={{
-                pathname: '/search/',
-                query: {
-                  addonType: ADDON_TYPE_EXTENSION,
-                  promoted: RECOMMENDED,
-                  sort: SEARCH_SORT_RANDOM,
-                },
-              }}
-              loading={loading}
-              placeholderCount={
-                isDesktopSite
-                  ? LANDING_PAGE_EXTENSION_COUNT
-                  : MOBILE_HOME_PAGE_EXTENSION_COUNT
-              }
-            />
+            {isDesktopSite ? (
+              <HomepageShelves
+                loading={loading}
+                shelves={homeShelves ? homeShelves.results : []}
+              />
+            ) : (
+              <LandingAddonsCard
+                addonInstallSource={INSTALL_SOURCE_FEATURED}
+                addons={shelves.recommendedExtensions}
+                className="Home-RecommendedExtensions"
+                header={i18n.gettext('Recommended extensions')}
+                footerText={i18n.gettext('See more recommended extensions')}
+                footerLink={{
+                  pathname: '/search/',
+                  query: {
+                    addonType: ADDON_TYPE_EXTENSION,
+                    promoted: RECOMMENDED,
+                    sort: SEARCH_SORT_RANDOM,
+                  },
+                }}
+                loading={loading}
+                placeholderCount={MOBILE_HOME_PAGE_EXTENSION_COUNT}
+              />
+            )}
 
             {isDesktopSite ? (
               <>
-                <LandingAddonsCard
-                  addonInstallSource={INSTALL_SOURCE_FEATURED}
-                  addons={shelves.popularThemes}
-                  className="Home-PopularThemes"
-                  header={i18n.gettext('Popular themes')}
-                  footerText={i18n.gettext('See more popular themes')}
-                  footerLink={{
-                    pathname: '/search/',
-                    query: {
-                      addonType: ADDON_TYPE_STATIC_THEME,
-                      sort: SEARCH_SORT_POPULAR,
-                    },
-                  }}
-                  isTheme
-                  loading={loading}
-                />
-
-                {renderFeaturedCollection(0)}
-
-                <LandingAddonsCard
-                  addonInstallSource={INSTALL_SOURCE_FEATURED}
-                  addons={shelves.popularExtensions}
-                  className="Home-PopularExtensions"
-                  header={i18n.gettext('Popular extensions')}
-                  footerText={i18n.gettext('See more popular extensions')}
-                  footerLink={{
-                    pathname: '/search/',
-                    query: {
-                      addonType: ADDON_TYPE_EXTENSION,
-                      promoted: RECOMMENDED,
-                      sort: SEARCH_SORT_POPULAR,
-                    },
-                  }}
-                  loading={loading}
-                />
-
-                {includeRecommendedThemes && (
-                  <LandingAddonsCard
-                    addonInstallSource={INSTALL_SOURCE_FEATURED}
-                    addons={shelves.recommendedThemes}
-                    className="Home-RecommendedThemes"
-                    footerText={i18n.gettext('See more recommended themes')}
-                    footerLink={{
-                      pathname: '/search/',
-                      query: {
-                        addonType: ADDON_TYPE_STATIC_THEME,
-                        promoted: RECOMMENDED,
-                        sort: SEARCH_SORT_RANDOM,
-                      },
-                    }}
-                    header={i18n.gettext('Recommended themes')}
-                    isTheme
-                    loading={loading}
-                  />
-                )}
-
-                {renderFeaturedCollection(1)}
-
-                {includeTrendingExtensions && (
-                  <LandingAddonsCard
-                    addonInstallSource={INSTALL_SOURCE_FEATURED}
-                    addons={shelves.trendingExtensions}
-                    className="Home-TrendingExtensions"
-                    header={i18n.gettext('Trending extensions')}
-                    footerText={i18n.gettext('See more trending extensions')}
-                    footerLink={{
-                      pathname: '/search/',
-                      query: {
-                        addonType: ADDON_TYPE_EXTENSION,
-                        promoted: RECOMMENDED,
-                        sort: SEARCH_SORT_TRENDING,
-                      },
-                    }}
-                    loading={loading}
-                  />
-                )}
-
                 <Card
                   className="Home-SubjectShelf Home-CuratedThemes"
                   header={themesHeader}
@@ -412,8 +255,7 @@ export class HomeBase extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    collections: state.home.collections,
-    heroShelves: state.home.heroShelves,
+    homeShelves: state.home.homeShelves,
     isDesktopSite: state.api.clientApp === CLIENT_APP_FIREFOX,
     isLoading: state.home.isLoading,
     resultsLoaded: state.home.resultsLoaded,

--- a/src/amo/reducers/versions.js
+++ b/src/amo/reducers/versions.js
@@ -446,40 +446,41 @@ const reducer = (
     }
 
     case LOAD_HOME_DATA: {
-      const { collections, shelves } = action.payload;
+      const { homeShelves, shelves } = action.payload;
 
       const newVersions = {};
-      for (const shelf of Object.keys(shelves)) {
-        if (shelves[shelf]) {
-          for (const addon of shelves[shelf].results) {
-            if (addon.current_version) {
-              const currentVersion = addon.current_version;
-              let version = createInternalVersion(currentVersion, state.lang);
-              // license and release_notes are omitted from the search endpoint results,
-              // use them from an existing version if available.
-              const { id } = currentVersion;
-              const existingVersion = getVersionById({ id, state });
-              if (existingVersion) {
-                version = {
-                  ...version,
-                  license: existingVersion.license,
-                  releaseNotes: existingVersion.releaseNotes,
-                };
-              }
-              newVersions[id] = version;
-            }
+
+      const addNewVersions = (addon) => {
+        if (addon.current_version) {
+          const currentVersion = addon.current_version;
+          let version = createInternalVersion(currentVersion, state.lang);
+          // license and release_notes are omitted from the search endpoint results,
+          // use them from an existing version if available.
+          const { id } = currentVersion;
+          const existingVersion = getVersionById({ id, state });
+          if (existingVersion) {
+            version = {
+              ...version,
+              license: existingVersion.license,
+              releaseNotes: existingVersion.releaseNotes,
+            };
+          }
+          newVersions[id] = version;
+        }
+      };
+
+      if (homeShelves && homeShelves.results) {
+        for (const shelf of homeShelves.results) {
+          for (const addon of shelf.addons) {
+            addNewVersions(addon);
           }
         }
       }
 
-      for (const collection of collections) {
-        if (collection && collection.results) {
-          for (const addon of collection.results) {
-            const version = createInternalVersion(
-              addon.addon.current_version,
-              state.lang,
-            );
-            newVersions[version.id] = version;
+      for (const shelf of Object.keys(shelves)) {
+        if (shelves[shelf]) {
+          for (const addon of shelves[shelf].results) {
+            addNewVersions(addon);
           }
         }
       }

--- a/src/amo/sagas/home.js
+++ b/src/amo/sagas/home.js
@@ -1,41 +1,27 @@
 /* @flow */
-import { oneLine } from 'common-tags';
-import { all, call, put, select, takeLatest } from 'redux-saga/effects';
+import { call, put, select, takeLatest } from 'redux-saga/effects';
 
-import { getCollectionAddons } from 'amo/api/collections';
-import { getHeroShelves } from 'amo/api/hero';
+import { getHomeShelves } from 'amo/api/homeShelves';
+import { search as searchApi } from 'amo/api/search';
 import {
-  LANDING_PAGE_EXTENSION_COUNT,
-  LANDING_PAGE_THEME_COUNT,
-  MOBILE_HOME_PAGE_EXTENSION_COUNT,
   ADDON_TYPE_EXTENSION,
-  ADDON_TYPE_STATIC_THEME,
+  MOBILE_HOME_PAGE_EXTENSION_COUNT,
   RECOMMENDED,
-  SEARCH_SORT_POPULAR,
   SEARCH_SORT_RANDOM,
-  SEARCH_SORT_TRENDING,
 } from 'amo/constants';
+import log from 'amo/logger';
 import {
   FETCH_HOME_DATA,
   abortFetchHomeData,
   loadHomeData,
 } from 'amo/reducers/home';
-import { search as searchApi } from 'amo/api/search';
-import log from 'amo/logger';
 import { createErrorHandler, getState } from 'amo/sagas/utils';
-import type { GetCollectionAddonsParams } from 'amo/api/collections';
-import type { FetchHomeDataAction } from 'amo/reducers/home';
 import type { SearchParams } from 'amo/api/search';
+import type { FetchHomeDataAction } from 'amo/reducers/home';
 import type { Saga } from 'amo/types/sagas';
 
 export function* fetchHomeData({
-  payload: {
-    collectionsToFetch,
-    errorHandlerId,
-    includeRecommendedThemes,
-    includeTrendingExtensions,
-    isDesktopSite,
-  },
+  payload: { errorHandlerId, isDesktopSite },
 }: FetchHomeDataAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
 
@@ -43,122 +29,34 @@ export function* fetchHomeData({
 
   const state = yield select(getState);
 
-  const recommendedSearchFilters = {
-    page_size: String(
-      isDesktopSite
-        ? LANDING_PAGE_EXTENSION_COUNT
-        : MOBILE_HOME_PAGE_EXTENSION_COUNT,
-    ),
-    promoted: RECOMMENDED,
-    sort: SEARCH_SORT_RANDOM,
-  };
   const recommendedExtensionsParams: SearchParams = {
     api: state.api,
     filters: {
       addonType: ADDON_TYPE_EXTENSION,
-      ...recommendedSearchFilters,
+      page_size: String(MOBILE_HOME_PAGE_EXTENSION_COUNT),
+      promoted: RECOMMENDED,
+      sort: SEARCH_SORT_RANDOM,
     },
   };
 
   try {
-    let heroShelves = null;
+    let homeShelves = null;
     try {
-      heroShelves = yield call(getHeroShelves, { api: state.api });
+      homeShelves = yield call(getHomeShelves, { api: state.api });
     } catch (error) {
-      log.warn(`Home hero shelves failed to load: ${error}`);
+      log.warn(`Home shelves failed to load: ${error}`);
       throw error;
     }
 
     if (isDesktopSite) {
-      const collections = [];
-      for (const collection of collectionsToFetch) {
-        try {
-          const params: GetCollectionAddonsParams = {
-            api: state.api,
-            slug: collection.slug,
-            userId: collection.userId,
-          };
-          const result = yield call(getCollectionAddons, params);
-          collections.push(result);
-        } catch (error) {
-          log.warn(
-            oneLine`Home collection: ${collection.userId}/${collection.slug}
-          failed to load: ${error}`,
-          );
-          if (
-            error.response &&
-            [401, 403, 404].includes(error.response.status)
-          ) {
-            // The collection was not found or is marked private.
-            collections.push(null);
-          } else {
-            throw error;
-          }
-        }
-      }
-
-      const recommendedThemesParams: SearchParams = {
-        api: state.api,
-        filters: {
-          addonType: ADDON_TYPE_STATIC_THEME,
-          ...recommendedSearchFilters,
-          page_size: String(LANDING_PAGE_THEME_COUNT),
-        },
-      };
-      const popularExtensionsParams: SearchParams = {
-        api: state.api,
-        filters: {
-          addonType: ADDON_TYPE_EXTENSION,
-          page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-          promoted: RECOMMENDED,
-          sort: SEARCH_SORT_POPULAR,
-        },
-      };
-      const popularThemesParams: SearchParams = {
-        api: state.api,
-        filters: {
-          addonType: ADDON_TYPE_STATIC_THEME,
-          page_size: String(LANDING_PAGE_THEME_COUNT),
-          sort: SEARCH_SORT_POPULAR,
-        },
-      };
-      const trendingExtensionsParams: SearchParams = {
-        api: state.api,
-        filters: {
-          addonType: ADDON_TYPE_EXTENSION,
-          page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-          promoted: RECOMMENDED,
-          sort: SEARCH_SORT_TRENDING,
-        },
-      };
-
-      let shelves = {};
-      try {
-        shelves = yield all({
-          recommendedExtensions: call(searchApi, recommendedExtensionsParams),
-          recommendedThemes: includeRecommendedThemes
-            ? call(searchApi, recommendedThemesParams)
-            : null,
-          popularExtensions: call(searchApi, popularExtensionsParams),
-          popularThemes: call(searchApi, popularThemesParams),
-          trendingExtensions: includeTrendingExtensions
-            ? call(searchApi, trendingExtensionsParams)
-            : null,
-        });
-      } catch (error) {
-        log.warn(`Home add-ons failed to load: ${error}`);
-        throw error;
-      }
-
       yield put(
         loadHomeData({
-          collections,
-          heroShelves,
-          shelves,
+          homeShelves,
+          shelves: {},
         }),
       );
     } else {
-      // Mobile homepage logic.
+      // Mobile homepage logic
       let recommendedExtensions;
       try {
         recommendedExtensions = yield call(
@@ -166,14 +64,13 @@ export function* fetchHomeData({
           recommendedExtensionsParams,
         );
       } catch (error) {
-        log.warn(`Home add-ons failed to load: ${error}`);
+        log.warn(`Mobile homepage add-ons failed to load: ${error}`);
         throw error;
       }
 
       yield put(
         loadHomeData({
-          collections: [],
-          heroShelves,
+          homeShelves,
           shelves: { recommendedExtensions },
         }),
       );

--- a/tests/unit/amo/api/test_homeShelves.js
+++ b/tests/unit/amo/api/test_homeShelves.js
@@ -1,0 +1,22 @@
+import * as api from 'amo/api';
+import { getHomeShelves } from 'amo/api/homeShelves';
+import { createApiResponse, dispatchClientMetadata } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  it('calls the homepage shelves API', async () => {
+    const mockApi = sinon.mock(api);
+    const apiState = dispatchClientMetadata().store.getState().api;
+
+    mockApi
+      .expects('callApi')
+      .withArgs({
+        endpoint: 'shelves',
+        apiState,
+      })
+      .once()
+      .returns(createApiResponse());
+
+    await getHomeShelves({ api: apiState });
+    mockApi.verify();
+  });
+});

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -26,8 +26,8 @@ import LoadingText from 'amo/components/LoadingText';
 import {
   createFakeEvent,
   createFakeTracking,
-  createHeroShelves,
-  createInternalHeroShelvesWithLang,
+  createHomeShelves,
+  createInternalHomeShelvesWithLang,
   createLocalizedString,
   createStubErrorHandler,
   dispatchClientMetadata,
@@ -39,8 +39,8 @@ import {
 
 describe(__filename, () => {
   const createShelfData = (primaryProps = {}) => {
-    return createInternalHeroShelvesWithLang(
-      createHeroShelves({ primaryProps }),
+    return createInternalHomeShelvesWithLang(
+      createHomeShelves({ primaryProps }),
     ).primary;
   };
 

--- a/tests/unit/amo/components/TestHomepageShelves.js
+++ b/tests/unit/amo/components/TestHomepageShelves.js
@@ -1,0 +1,244 @@
+import config from 'config';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import {
+  HOMESHELVES_ENDPOINT_COLLECTIONS,
+  HOMESHELVES_ENDPOINT_SEARCH,
+  HOMESHELVES_ENDPOINT_SEARCH_THEMES,
+  HomepageShelvesBase,
+} from 'amo/components/HomepageShelves';
+import LandingAddonsCard from 'amo/components/LandingAddonsCard';
+import {
+  INSTALL_SOURCE_FEATURED_COLLECTION,
+  INSTALL_SOURCE_FEATURED,
+} from 'amo/constants';
+import { createInternalShelf } from 'amo/reducers/home';
+import {
+  DEFAULT_LANG_IN_TESTS,
+  createLocalizedString,
+  fakeI18n,
+  fakeShelf,
+  fakeAddon,
+} from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  const render = (props = {}) => {
+    return shallow(
+      <HomepageShelvesBase i18n={fakeI18n()} shelves={[]} {...props} />,
+    );
+  };
+
+  const _createShelf = (overrides = {}) =>
+    createInternalShelf(
+      {
+        ...fakeShelf,
+        ...overrides,
+      },
+      DEFAULT_LANG_IN_TESTS,
+    );
+
+  it('renders shelves in a loading state', () => {
+    const root = render({ loading: true });
+
+    const loadingCards = root.find('.HomepageShelves-loading-card');
+    expect(loadingCards).toHaveLength(3);
+    loadingCards.forEach((card) => {
+      expect(card).toHaveProp('loading', true);
+    });
+  });
+
+  it('renders shelves in a loaded state', () => {
+    const shelf1FooterText = 'Footer Text 1';
+    const shelf2FooterText = 'Footer Text 2';
+    const shelf1Title = 'First Shelf';
+    const shelf2Title = 'Second Shelf';
+    const shelf1 = _createShelf({
+      addons: [{ ...fakeAddon, slug: 'slug1' }],
+      criteria: '?sort=rating',
+      endpoint: HOMESHELVES_ENDPOINT_SEARCH,
+      footer: {
+        url: '/1',
+        outgoing: '/1',
+        text: createLocalizedString(shelf1FooterText),
+      },
+      title: createLocalizedString(shelf1Title),
+      url: 'https://addons.mozilla.org/1',
+    });
+
+    const shelf2 = _createShelf({
+      addons: [{ ...fakeAddon, slug: 'slug2' }],
+      criteria: '?sort=users',
+      endpoint: HOMESHELVES_ENDPOINT_SEARCH_THEMES,
+      footer: {
+        url: '/2',
+        outgoing: '/2',
+        text: createLocalizedString(shelf2FooterText),
+      },
+      title: createLocalizedString(shelf2Title),
+      url: 'https://addons.mozilla.org/2',
+    });
+
+    const root = render({ shelves: [shelf1, shelf2] });
+
+    const landingCards = root.find(LandingAddonsCard);
+    expect(landingCards).toHaveLength(2);
+
+    const card1 = landingCards.at(0);
+    expect(card1).toHaveProp('addons', shelf1.addons);
+    expect(card1).toHaveProp('footerText', shelf1FooterText);
+    expect(card1).toHaveProp('footerLink', shelf1.footer.url);
+    expect(card1).toHaveProp('header', shelf1Title);
+    expect(card1).not.toHaveProp('loading');
+    expect(card1).toHaveClassName('Home-First-Shelf');
+
+    const card2 = landingCards.at(1);
+    expect(card2).toHaveProp('addons', shelf2.addons);
+    expect(card2).toHaveProp('footerText', shelf2FooterText);
+    expect(card2).toHaveProp('footerLink', shelf2.footer.url);
+    expect(card2).toHaveProp('header', shelf2Title);
+    expect(card2).not.toHaveProp('loading');
+    expect(card2).toHaveClassName('Home-Second-Shelf');
+  });
+
+  it.each([
+    [false, HOMESHELVES_ENDPOINT_COLLECTIONS],
+    [false, HOMESHELVES_ENDPOINT_SEARCH],
+    [true, HOMESHELVES_ENDPOINT_SEARCH_THEMES],
+  ])('passes isTheme as %s when endpoint is %s', (isTheme, endpoint) => {
+    const root = render({
+      shelves: [_createShelf({ endpoint })],
+    });
+
+    expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', isTheme);
+  });
+
+  it.each([
+    [4, HOMESHELVES_ENDPOINT_COLLECTIONS],
+    [4, HOMESHELVES_ENDPOINT_SEARCH],
+    [3, HOMESHELVES_ENDPOINT_SEARCH_THEMES],
+  ])(
+    'passes placeholderCount as %s when endpoint is %s',
+    (placeholderCount, endpoint) => {
+      const root = render({
+        shelves: [_createShelf({ endpoint })],
+      });
+
+      expect(root.find(LandingAddonsCard)).toHaveProp(
+        'placeholderCount',
+        placeholderCount,
+      );
+    },
+  );
+
+  it.each([
+    [INSTALL_SOURCE_FEATURED_COLLECTION, HOMESHELVES_ENDPOINT_COLLECTIONS],
+    [INSTALL_SOURCE_FEATURED, HOMESHELVES_ENDPOINT_SEARCH],
+    [INSTALL_SOURCE_FEATURED, HOMESHELVES_ENDPOINT_SEARCH_THEMES],
+  ])(
+    'passes addonInstallSource as %s when endpoint is %s',
+    (addonInstallSource, endpoint) => {
+      const root = render({
+        shelves: [_createShelf({ endpoint })],
+      });
+
+      expect(root.find(LandingAddonsCard)).toHaveProp(
+        'addonInstallSource',
+        addonInstallSource,
+      );
+    },
+  );
+
+  it('generates a default footerText', () => {
+    const title = 'Shelf Title';
+    const root = render({
+      shelves: [
+        _createShelf({
+          footer: { ...fakeShelf.footer, text: '' },
+          title: createLocalizedString(title),
+        }),
+      ],
+    });
+
+    expect(root.find(LandingAddonsCard)).toHaveProp(
+      'footerText',
+      `See more ${title.toLowerCase()}`,
+    );
+  });
+
+  it('passes an object with an href for an external link', () => {
+    const _checkInternalURL = sinon.stub().returns({ isInternal: false });
+    const url = 'link';
+    const root = render({
+      _checkInternalURL,
+      shelves: [
+        _createShelf({
+          footer: { ...fakeShelf.footer, url },
+        }),
+      ],
+    });
+
+    expect(root.find(LandingAddonsCard)).toHaveProp('footerLink', {
+      href: url,
+    });
+    sinon.assert.calledWith(_checkInternalURL, { urlString: url });
+  });
+
+  it('passes a relative URL for an internal link', () => {
+    const url = 'https://some.internal/url';
+    const fixedURL = '/url';
+    const _checkInternalURL = sinon
+      .stub()
+      .returns({ isInternal: true, relativeURL: fixedURL });
+    const root = render({
+      _checkInternalURL,
+      shelves: [
+        _createShelf({
+          footer: { ...fakeShelf.footer, url },
+        }),
+      ],
+    });
+
+    expect(root.find(LandingAddonsCard)).toHaveProp('footerLink', fixedURL);
+    sinon.assert.calledWith(_checkInternalURL, { urlString: url });
+  });
+
+  it('generates a default footerLink for a collection', () => {
+    const slug = 'some-collection-slug';
+    const root = render({
+      shelves: [
+        _createShelf({
+          criteria: slug,
+          endpoint: HOMESHELVES_ENDPOINT_COLLECTIONS,
+          footer: { ...fakeShelf.footer, url: '' },
+        }),
+      ],
+    });
+
+    expect(root.find(LandingAddonsCard)).toHaveProp(
+      'footerLink',
+      `/collections/${config.get('mozillaUserId')}/${slug}/`,
+    );
+  });
+
+  it.each([HOMESHELVES_ENDPOINT_SEARCH, HOMESHELVES_ENDPOINT_SEARCH_THEMES])(
+    'generates a default footerLink for %s',
+    (endpoint) => {
+      const criteria = '?sort=users';
+      const root = render({
+        shelves: [
+          _createShelf({
+            criteria,
+            endpoint,
+            footer: { ...fakeShelf.footer, url: '' },
+          }),
+        ],
+      });
+
+      expect(root.find(LandingAddonsCard)).toHaveProp(
+        'footerLink',
+        `/search/${criteria}`,
+      );
+    },
+  );
+});

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -171,6 +171,16 @@ describe(__filename, () => {
     );
   });
 
+  it('accepts an object with an href for the footer link', () => {
+    const url = '/some/link/';
+    const footerLink = { href: url };
+    const root = render({ footerLink });
+    expect(root.find(AddonsCard).prop('footerLink').props.href).toEqual(url);
+    expect(root.find(AddonsCard).prop('footerLink').props.to).toEqual(
+      undefined,
+    );
+  });
+
   it.each([true, false])(
     'sets useThemePlaceholder to the value of isTheme on the AddonsCard',
     (isTheme) => {

--- a/tests/unit/amo/components/TestSecondaryHero.js
+++ b/tests/unit/amo/components/TestSecondaryHero.js
@@ -12,15 +12,15 @@ import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'amo/constants';
 import {
   createFakeEvent,
   createFakeTracking,
-  createHeroShelves,
-  createInternalHeroShelvesWithLang,
+  createHomeShelves,
+  createInternalHomeShelvesWithLang,
   fakeAddon,
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   const createShelfData = (secondaryProps = {}) => {
-    return createInternalHeroShelvesWithLang(
-      createHeroShelves({ primaryProps: { addon: fakeAddon }, secondaryProps }),
+    return createInternalHomeShelvesWithLang(
+      createHomeShelves({ primaryProps: { addon: fakeAddon }, secondaryProps }),
     ).secondary;
   };
 

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -33,8 +33,6 @@ import {
   CLIENT_APP_FIREFOX,
   COLLECTION_SORT_DATE_ADDED_DESCENDING,
   COLLECTION_SORT_NAME,
-  INSTALL_SOURCE_COLLECTION,
-  INSTALL_SOURCE_FEATURED_COLLECTION,
 } from 'amo/constants';
 import { ErrorHandler } from 'amo/errorHandler';
 import { sendServerRedirect } from 'amo/reducers/redirectTo';
@@ -728,42 +726,6 @@ describe(__filename, () => {
     expect(paginator).toHaveProp('pathname', `/collections/${userId}/${slug}/`);
     expect(paginator).toHaveProp('queryParams', filters);
     expect(wrapper.find('.Collection-edit-link')).toHaveLength(0);
-  });
-
-  it('declares an install source for non-featured collections', () => {
-    const { store } = dispatchClientMetadata();
-
-    _loadCurrentCollection({ store });
-
-    const _isFeaturedCollection = sinon.spy(() => false);
-    const wrapper = renderComponent({
-      store,
-      _isFeaturedCollection,
-    });
-
-    expect(wrapper.find(AddonsCard)).toHaveProp(
-      'addonInstallSource',
-      INSTALL_SOURCE_COLLECTION,
-    );
-    sinon.assert.called(_isFeaturedCollection);
-  });
-
-  it('declares an install source for featured collections', () => {
-    const { store } = dispatchClientMetadata();
-
-    _loadCurrentCollection({ store });
-
-    const _isFeaturedCollection = sinon.spy(() => true);
-    const wrapper = renderComponent({
-      store,
-      _isFeaturedCollection,
-    });
-
-    expect(wrapper.find(AddonsCard)).toHaveProp(
-      'addonInstallSource',
-      INSTALL_SOURCE_FEATURED_COLLECTION,
-    );
-    sinon.assert.called(_isFeaturedCollection);
   });
 
   it('renders a CollectionControls component', () => {

--- a/tests/unit/amo/reducers/test_versions.js
+++ b/tests/unit/amo/reducers/test_versions.js
@@ -35,6 +35,7 @@ import {
   createFakeCollectionDetail,
   createInternalVersionWithLang,
   createLocalizedString,
+  fakeShelf,
   fakeAddon,
   fakeI18n,
   fakeFile,
@@ -499,28 +500,7 @@ describe(__filename, () => {
     });
 
     describe('LOAD_HOME_DATA', () => {
-      it('loads versions from shelves', () => {
-        const state = versionsReducer(
-          stateWithLang,
-          loadHomeData({
-            collections: [],
-            shelves: {
-              recommendedExtensions: createAddonsApiResult([
-                { ...fakeAddon, current_version: version },
-              ]),
-            },
-          }),
-        );
-
-        expect(
-          getVersionById({
-            state,
-            id: versionId,
-          }),
-        ).toEqual(createInternalVersionWithLang(version));
-      });
-
-      it('maintains license and release notes from pre-existing versions', () => {
+      it('maintains license and release notes from pre-existing versions when loading homeShelves', () => {
         let state = versionsReducer(
           stateWithLang,
           loadVersions({ slug: fakeAddon.slug, versions: [version] }),
@@ -541,52 +521,9 @@ describe(__filename, () => {
         state = versionsReducer(
           state,
           loadHomeData({
-            collections: [],
-            shelves: {
-              recommendedExtensions: searchResult,
+            homeShelves: {
+              results: [{ ...fakeShelf, addons: [searchResult] }],
             },
-          }),
-        );
-
-        expect(
-          getVersionById({
-            state,
-            id: versionId,
-          }),
-        ).toEqual(createInternalVersionWithLang(version));
-      });
-
-      it('handles invalid shelves', () => {
-        const state = versionsReducer(
-          stateWithLang,
-          loadHomeData({
-            collections: [],
-            shelves: {
-              recommendedExtensions: null,
-            },
-          }),
-        );
-
-        expect(state).toEqual(stateWithLang);
-      });
-
-      it('loads versions for collections', () => {
-        const versionId2 = 111;
-        const version2 = { ...fakeVersion, id: versionId2 };
-        const fakeCollectionAddon1 = createFakeCollectionAddon({
-          addon: { ...fakeAddon, current_version: version },
-        });
-        const fakeCollectionAddon2 = createFakeCollectionAddon({
-          addon: { ...fakeAddon, current_version: version2 },
-        });
-
-        const state = versionsReducer(
-          stateWithLang,
-          loadHomeData({
-            collections: [
-              { results: [fakeCollectionAddon1] },
-              { results: [fakeCollectionAddon2] },
-            ],
             shelves: {},
           }),
         );
@@ -597,12 +534,54 @@ describe(__filename, () => {
             id: versionId,
           }),
         ).toEqual(createInternalVersionWithLang(version));
+      });
+
+      it('maintains license and release notes from pre-existing versions when loading shelves', () => {
+        let state = versionsReducer(
+          stateWithLang,
+          loadVersions({ slug: fakeAddon.slug, versions: [version] }),
+        );
+
+        // Create a search result with missing license and release_notes.
+        const result = createAddonsApiResult([
+          {
+            ...fakeAddon,
+            current_version: {
+              ...version,
+              license: undefined,
+              release_notes: undefined,
+            },
+          },
+        ]);
+
+        state = versionsReducer(
+          state,
+          loadHomeData({
+            homeShelves: null,
+            shelves: {
+              someShelf: result,
+            },
+          }),
+        );
+
         expect(
           getVersionById({
             state,
-            id: versionId2,
+            id: versionId,
           }),
-        ).toEqual(createInternalVersionWithLang(version2));
+        ).toEqual(createInternalVersionWithLang(version));
+      });
+
+      it('handles invalid homeShelves', () => {
+        const state = versionsReducer(
+          stateWithLang,
+          loadHomeData({
+            homeShelves: null,
+            shelves: {},
+          }),
+        );
+
+        expect(state).toEqual(stateWithLang);
       });
     });
 

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -1,17 +1,10 @@
 import SagaTester from 'redux-saga-tester';
 
-import * as collectionsApi from 'amo/api/collections';
-import * as heroApi from 'amo/api/hero';
 import {
-  LANDING_PAGE_EXTENSION_COUNT,
-  LANDING_PAGE_THEME_COUNT,
   MOBILE_HOME_PAGE_EXTENSION_COUNT,
   ADDON_TYPE_EXTENSION,
-  ADDON_TYPE_STATIC_THEME,
   RECOMMENDED,
-  SEARCH_SORT_POPULAR,
   SEARCH_SORT_RANDOM,
-  SEARCH_SORT_TRENDING,
 } from 'amo/constants';
 import homeReducer, {
   abortFetchHomeData,
@@ -21,29 +14,27 @@ import homeReducer, {
 import homeSaga from 'amo/sagas/home';
 import { createApiError } from 'amo/api';
 import * as searchApi from 'amo/api/search';
+import * as shelvesApi from 'amo/api/homeShelves';
 import apiReducer from 'amo/reducers/api';
 import {
   createAddonsApiResult,
-  createFakeCollectionAddonsListResponse,
-  createHeroShelves,
+  createHomeShelves,
   createStubErrorHandler,
   dispatchClientMetadata,
   fakeAddon,
-  fakeTheme,
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
+  let baseArgs;
   let errorHandler;
-  let mockCollectionsApi;
-  let mockHeroApi;
   let mockSearchApi;
+  let mockShelvesApi;
   let sagaTester;
 
   beforeEach(() => {
     errorHandler = createStubErrorHandler();
-    mockCollectionsApi = sinon.mock(collectionsApi);
-    mockHeroApi = sinon.mock(heroApi);
     mockSearchApi = sinon.mock(searchApi);
+    mockShelvesApi = sinon.mock(shelvesApi);
     sagaTester = new SagaTester({
       initialState: dispatchClientMetadata().state,
       reducers: {
@@ -52,159 +43,55 @@ describe(__filename, () => {
       },
     });
     sagaTester.start(homeSaga);
+
+    const state = sagaTester.getState();
+    baseArgs = { api: state.api };
   });
 
   describe('fetchHomeData', () => {
     function _fetchHomeData(params) {
       sagaTester.dispatch(
         fetchHomeData({
-          collectionsToFetch: [{ slug: 'some-slug', user: 'some-user' }],
           errorHandlerId: errorHandler.id,
-          includeRecommendedThemes: true,
-          includeTrendingExtensions: true,
           isDesktopSite: true,
           ...params,
         }),
       );
     }
 
-    it('calls the APIs to fetch the data to display on home for the desktop site', async () => {
-      const state = sagaTester.getState();
+    it('clears the error handler', async () => {
+      _fetchHomeData();
 
-      const firstCollectionSlug = 'collection-slug';
-      const firstCollectionUserId = 123;
-      const secondCollectionSlug = 'collection-slug-2';
-      const secondCollectionUserId = 456;
+      const errorAction = errorHandler.createClearingAction();
 
-      const baseArgs = { api: state.api };
+      const expectedAction = await sagaTester.waitFor(errorAction.type);
+      expect(expectedAction).toEqual(errorAction);
+    });
 
-      const firstCollection = createFakeCollectionAddonsListResponse();
-      const secondCollection = createFakeCollectionAddonsListResponse();
-      mockCollectionsApi
-        .expects('getCollectionAddons')
-        .withArgs({
-          ...baseArgs,
-          slug: firstCollectionSlug,
-          userId: firstCollectionUserId,
-        })
-        .resolves(firstCollection);
-      mockCollectionsApi
-        .expects('getCollectionAddons')
-        .withArgs({
-          ...baseArgs,
-          slug: secondCollectionSlug,
-          userId: secondCollectionUserId,
-        })
-        .resolves(secondCollection);
-      const collections = [firstCollection, secondCollection];
+    it('calls the API to fetch the data to display on home for the desktop site', async () => {
+      mockSearchApi.expects('search').exactly(0);
 
-      const recommendedExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-            addonType: ADDON_TYPE_EXTENSION,
-            promoted: RECOMMENDED,
-            sort: SEARCH_SORT_RANDOM,
-          },
-        })
-        .resolves(recommendedExtensions);
-
-      const recommendedThemes = createAddonsApiResult([fakeTheme]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            page_size: String(LANDING_PAGE_THEME_COUNT),
-            addonType: ADDON_TYPE_STATIC_THEME,
-            promoted: RECOMMENDED,
-            sort: SEARCH_SORT_RANDOM,
-          },
-        })
-        .resolves(recommendedThemes);
-
-      const popularExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-            addonType: ADDON_TYPE_EXTENSION,
-            promoted: RECOMMENDED,
-            sort: SEARCH_SORT_POPULAR,
-          },
-        })
-        .resolves(popularExtensions);
-
-      const popularThemes = createAddonsApiResult([fakeAddon]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            page_size: String(LANDING_PAGE_THEME_COUNT),
-            addonType: ADDON_TYPE_STATIC_THEME,
-            sort: SEARCH_SORT_POPULAR,
-          },
-        })
-        .resolves(popularThemes);
-
-      const trendingExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi
-        .expects('search')
-        .withArgs({
-          ...baseArgs,
-          filters: {
-            page_size: String(LANDING_PAGE_EXTENSION_COUNT),
-            addonType: ADDON_TYPE_EXTENSION,
-            promoted: RECOMMENDED,
-            sort: SEARCH_SORT_TRENDING,
-          },
-        })
-        .resolves(trendingExtensions);
-
-      const heroShelves = createHeroShelves();
-      mockHeroApi
-        .expects('getHeroShelves')
+      const homeShelves = createHomeShelves();
+      mockShelvesApi
+        .expects('getHomeShelves')
         .withArgs(baseArgs)
-        .resolves(heroShelves);
+        .resolves(homeShelves);
 
-      _fetchHomeData({
-        collectionsToFetch: [
-          { slug: firstCollectionSlug, userId: firstCollectionUserId },
-          { slug: secondCollectionSlug, userId: secondCollectionUserId },
-        ],
-        includeRecommendedThemes: true,
-      });
+      _fetchHomeData({ isDesktopSite: true });
 
       const loadAction = loadHomeData({
-        collections,
-        heroShelves,
-        shelves: {
-          recommendedExtensions,
-          recommendedThemes,
-          popularExtensions,
-          popularThemes,
-          trendingExtensions,
-        },
+        homeShelves,
+        shelves: {},
       });
 
       const expectedAction = await sagaTester.waitFor(loadAction.type);
-      mockCollectionsApi.verify();
       mockSearchApi.verify();
+      mockShelvesApi.verify();
 
       expect(expectedAction).toEqual(loadAction);
     });
 
     it('calls the APIs to fetch the data to display on home for the mobile site', async () => {
-      const state = sagaTester.getState();
-
-      const baseArgs = { api: state.api };
-
       const recommendedExtensions = createAddonsApiResult([fakeAddon]);
       mockSearchApi
         .expects('search')
@@ -219,214 +106,33 @@ describe(__filename, () => {
         })
         .resolves(recommendedExtensions);
 
-      const heroShelves = createHeroShelves();
-      mockHeroApi
-        .expects('getHeroShelves')
+      const homeShelves = createHomeShelves();
+      mockShelvesApi
+        .expects('getHomeShelves')
         .withArgs(baseArgs)
-        .resolves(heroShelves);
+        .resolves(homeShelves);
 
       _fetchHomeData({ isDesktopSite: false });
 
       const loadAction = loadHomeData({
-        collections: [],
-        heroShelves,
+        homeShelves,
         shelves: {
           recommendedExtensions,
         },
       });
 
       const expectedAction = await sagaTester.waitFor(loadAction.type);
-      mockCollectionsApi.verify();
+      mockShelvesApi.verify();
       mockSearchApi.verify();
 
       expect(expectedAction).toEqual(loadAction);
     });
 
-    it('does not fetch trending extensions if includeTrendingExtensions is false', async () => {
-      const collections = [];
-
-      const recommendedExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi.expects('search').resolves(recommendedExtensions);
-
-      const recommendedThemes = createAddonsApiResult([fakeTheme]);
-      mockSearchApi.expects('search').resolves(recommendedThemes);
-
-      const popularExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi.expects('search').resolves(popularExtensions);
-
-      const popularThemes = createAddonsApiResult([fakeAddon]);
-      mockSearchApi.expects('search').resolves(popularThemes);
-
-      const heroShelves = createHeroShelves();
-      mockHeroApi.expects('getHeroShelves').resolves(heroShelves);
-
-      _fetchHomeData({
-        collectionsToFetch: [],
-        includeTrendingExtensions: false,
-      });
-
-      const loadAction = loadHomeData({
-        collections,
-        heroShelves,
-        shelves: {
-          recommendedExtensions,
-          recommendedThemes,
-          popularExtensions,
-          popularThemes,
-          trendingExtensions: null,
-        },
-      });
-
-      const expectedAction = await sagaTester.waitFor(loadAction.type);
-      mockSearchApi.verify();
-      expect(expectedAction).toEqual(loadAction);
-    });
-
-    it('does not fetch recommended themes if includeRecommendedThemes is false', async () => {
-      const collections = [];
-
-      const recommendedExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi.expects('search').resolves(recommendedExtensions);
-
-      const popularExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi.expects('search').resolves(popularExtensions);
-
-      const popularThemes = createAddonsApiResult([fakeAddon]);
-      mockSearchApi.expects('search').resolves(popularThemes);
-
-      const trendingExtensions = createAddonsApiResult([fakeAddon]);
-      mockSearchApi.expects('search').resolves(trendingExtensions);
-
-      const heroShelves = createHeroShelves();
-      mockHeroApi.expects('getHeroShelves').resolves(heroShelves);
-
-      _fetchHomeData({
-        collectionsToFetch: [],
-        includeRecommendedThemes: false,
-      });
-
-      const loadAction = loadHomeData({
-        collections,
-        heroShelves,
-        shelves: {
-          recommendedExtensions,
-          recommendedThemes: null,
-          popularExtensions,
-          popularThemes,
-          trendingExtensions,
-        },
-      });
-
-      const expectedAction = await sagaTester.waitFor(loadAction.type);
-      mockSearchApi.verify();
-      expect(expectedAction).toEqual(loadAction);
-    });
-
-    it.each([401, 403, 404])(
-      'loads a null for a collection that returns a %i',
-      async (status) => {
-        const error = createApiError({ response: { status } });
-
-        const firstCollectionSlug = 'collection-slug';
-        const firstCollectionUserId = 'user-id-or-name';
-
-        mockCollectionsApi.expects('getCollectionAddons').rejects(error);
-
-        const collections = [null];
-
-        const recommendedExtensions = createAddonsApiResult([fakeAddon]);
-        mockSearchApi.expects('search').resolves(recommendedExtensions);
-
-        const popularExtensions = createAddonsApiResult([fakeAddon]);
-        mockSearchApi.expects('search').resolves(popularExtensions);
-
-        const popularThemes = createAddonsApiResult([fakeAddon]);
-        mockSearchApi.expects('search').resolves(popularThemes);
-
-        const trendingExtensions = createAddonsApiResult([fakeAddon]);
-        mockSearchApi.expects('search').resolves(trendingExtensions);
-
-        const heroShelves = createHeroShelves();
-        mockHeroApi.expects('getHeroShelves').resolves(heroShelves);
-
-        _fetchHomeData({
-          collectionsToFetch: [
-            { slug: firstCollectionSlug, userId: firstCollectionUserId },
-          ],
-          includeRecommendedThemes: false,
-        });
-
-        const loadAction = loadHomeData({
-          collections,
-          heroShelves,
-          shelves: {
-            recommendedExtensions,
-            recommendedThemes: null,
-            popularExtensions,
-            popularThemes,
-            trendingExtensions,
-          },
-        });
-
-        const expectedAction = await sagaTester.waitFor(loadAction.type);
-        expect(expectedAction).toEqual(loadAction);
-      },
-    );
-
-    it('clears the error handler', async () => {
-      _fetchHomeData();
-
-      const errorAction = errorHandler.createClearingAction();
-
-      const expectedAction = await sagaTester.waitFor(errorAction.type);
-      expect(expectedAction).toEqual(errorAction);
-    });
-
-    it('dispatches an error for a failed collection fetch', async () => {
+    it('dispatches an error for a failed homeShelves fetch', async () => {
       const error = createApiError({ response: { status: 500 } });
-
-      mockHeroApi.expects('getHeroShelves').resolves(createHeroShelves());
-
-      mockCollectionsApi.expects('getCollectionAddons').rejects(error);
+      mockShelvesApi.expects('getHomeShelves').rejects(error);
 
       _fetchHomeData();
-
-      const errorAction = errorHandler.createErrorAction(error);
-      const expectedAction = await sagaTester.waitFor(errorAction.type);
-      expect(expectedAction).toEqual(errorAction);
-    });
-
-    it('aborts fetching for a failed collection fetch', async () => {
-      const error = createApiError({ response: { status: 500 } });
-
-      mockHeroApi.expects('getHeroShelves').resolves(createHeroShelves());
-
-      mockCollectionsApi.expects('getCollectionAddons').rejects(error);
-
-      _fetchHomeData();
-
-      const abortAction = abortFetchHomeData();
-
-      const expectedAction = await sagaTester.waitFor(abortAction.type);
-      expect(expectedAction).toEqual(abortAction);
-    });
-
-    it('dispatches an error for a failed search fetch for the desktop site', async () => {
-      const slug = 'collection-slug';
-      const userId = 123;
-
-      mockHeroApi.expects('getHeroShelves').resolves(createHeroShelves());
-
-      const firstCollection = createFakeCollectionAddonsListResponse();
-      mockCollectionsApi
-        .expects('getCollectionAddons')
-        .resolves(firstCollection);
-
-      const error = new Error('some API error maybe');
-
-      mockSearchApi.expects('search').exactly(6).rejects(error);
-
-      _fetchHomeData({ collectionsToFetch: [{ slug, userId }] });
 
       const errorAction = errorHandler.createErrorAction(error);
       const expectedAction = await sagaTester.waitFor(errorAction.type);
@@ -434,11 +140,10 @@ describe(__filename, () => {
     });
 
     it('dispatches an error for a failed search fetch for the mobile site', async () => {
-      mockHeroApi.expects('getHeroShelves').resolves(createHeroShelves());
+      mockShelvesApi.expects('getHomeShelves').resolves(createHomeShelves());
 
-      const error = new Error('some API error maybe');
-
-      mockSearchApi.expects('search').exactly(1).rejects(error);
+      const error = createApiError({ response: { status: 500 } });
+      mockSearchApi.expects('search').rejects(error);
 
       _fetchHomeData({ isDesktopSite: false });
 
@@ -447,21 +152,25 @@ describe(__filename, () => {
       expect(expectedAction).toEqual(errorAction);
     });
 
+    it('aborts fetching for a failed homeShelves fetch', async () => {
+      const error = createApiError({ response: { status: 500 } });
+      mockShelvesApi.expects('getHomeShelves').rejects(error);
+
+      _fetchHomeData();
+
+      const abortAction = abortFetchHomeData();
+
+      const expectedAction = await sagaTester.waitFor(abortAction.type);
+      expect(expectedAction).toEqual(abortAction);
+    });
+
     it('aborts fetching for a failed search fetch', async () => {
-      mockHeroApi.expects('getHeroShelves').resolves(createHeroShelves());
+      mockShelvesApi.expects('getHomeShelves').resolves(createHomeShelves());
 
-      const firstCollection = createFakeCollectionAddonsListResponse();
-      mockCollectionsApi
-        .expects('getCollectionAddons')
-        .resolves(firstCollection);
-
-      const error = new Error('some API error maybe');
-
+      const error = createApiError({ response: { status: 500 } });
       mockSearchApi.expects('search').rejects(error);
 
-      _fetchHomeData({
-        collectionsToFetch: [{ slug: 'collection-slug', userId: 123 }],
-      });
+      _fetchHomeData({ isDesktopSite: false });
 
       const abortAction = abortFetchHomeData();
 
@@ -469,29 +178,19 @@ describe(__filename, () => {
       expect(expectedAction).toEqual(abortAction);
     });
 
-    it('dispatches an error for a failed hero fetch', async () => {
+    it('does not attempt a search fetch after a failed homeShelves fetch', async () => {
+      mockSearchApi.expects('search').exactly(0);
+
       const error = createApiError({ response: { status: 500 } });
+      mockShelvesApi.expects('getHomeShelves').rejects(error);
 
-      mockHeroApi.expects('getHeroShelves').rejects(error);
-
-      _fetchHomeData();
+      _fetchHomeData({ isDesktopSite: false });
 
       const errorAction = errorHandler.createErrorAction(error);
-      const expectedAction = await sagaTester.waitFor(errorAction.type);
-      expect(expectedAction).toEqual(errorAction);
-    });
+      await sagaTester.waitFor(errorAction.type);
 
-    it('aborts fetching for a failed hero fetch', async () => {
-      const error = createApiError({ response: { status: 500 } });
-
-      mockHeroApi.expects('getHeroShelves').rejects(error);
-
-      _fetchHomeData();
-
-      const abortAction = abortFetchHomeData();
-
-      const expectedAction = await sagaTester.waitFor(abortAction.type);
-      expect(expectedAction).toEqual(abortAction);
+      mockShelvesApi.verify();
+      mockSearchApi.verify();
     });
   });
 });

--- a/tests/unit/amo/sagas/test_home.js
+++ b/tests/unit/amo/sagas/test_home.js
@@ -25,7 +25,7 @@ import {
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
-  let baseArgs;
+  let baseApiArgs;
   let errorHandler;
   let mockSearchApi;
   let mockShelvesApi;
@@ -45,7 +45,7 @@ describe(__filename, () => {
     sagaTester.start(homeSaga);
 
     const state = sagaTester.getState();
-    baseArgs = { api: state.api };
+    baseApiArgs = { api: state.api };
   });
 
   describe('fetchHomeData', () => {
@@ -74,7 +74,7 @@ describe(__filename, () => {
       const homeShelves = createHomeShelves();
       mockShelvesApi
         .expects('getHomeShelves')
-        .withArgs(baseArgs)
+        .withArgs(baseApiArgs)
         .resolves(homeShelves);
 
       _fetchHomeData({ isDesktopSite: true });
@@ -96,7 +96,7 @@ describe(__filename, () => {
       mockSearchApi
         .expects('search')
         .withArgs({
-          ...baseArgs,
+          ...baseApiArgs,
           filters: {
             page_size: String(MOBILE_HOME_PAGE_EXTENSION_COUNT),
             addonType: ADDON_TYPE_EXTENSION,
@@ -109,7 +109,7 @@ describe(__filename, () => {
       const homeShelves = createHomeShelves();
       mockShelvesApi
         .expects('getHomeShelves')
-        .withArgs(baseArgs)
+        .withArgs(baseApiArgs)
         .resolves(homeShelves);
 
       _fetchHomeData({ isDesktopSite: false });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -393,7 +393,7 @@ export const createSecondaryHeroShelf = ({
 };
 
 export const createHomeShelves = ({
-  resultsProps,
+  resultsProps = [fakeShelf],
   primaryProps = {},
   secondaryProps = {},
 } = {}) => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -23,7 +23,7 @@ import {
   OS_ALL,
 } from 'amo/constants';
 import { createInternalCollection } from 'amo/reducers/collections';
-import { createInternalHeroShelves } from 'amo/reducers/home';
+import { createInternalHomeShelves } from 'amo/reducers/home';
 import createStore from 'amo/store';
 import { getDjangoBase62, addQueryParamsToHistory } from 'amo/utils';
 import { setError } from 'amo/actions/errors';
@@ -224,6 +224,20 @@ export const fakeReview = Object.freeze({
   body: 'It is Okay',
 });
 
+export const fakeShelf = Object.freeze({
+  title: createLocalizedString('Top Rated Themes'),
+  url:
+    'https://addons-dev.allizom.org/api/v5/addons/search/?sort=rating&type=statictheme',
+  endpoint: 'search-themes',
+  criteria: '?sort=rating&type=statictheme',
+  footer: {
+    url: 'http://testserver/extensions/',
+    text: createLocalizedString('See more top rated themes'),
+    outgoing: '',
+  },
+  addons: [fakeAddon],
+});
+
 export function createExternalReview({
   addonId = fakeReview.addon.id,
   addonSlug = fakeReview.addon.slug,
@@ -378,11 +392,13 @@ export const createSecondaryHeroShelf = ({
   };
 };
 
-export const createHeroShelves = ({
+export const createHomeShelves = ({
+  resultsProps,
   primaryProps = {},
   secondaryProps = {},
 } = {}) => {
   return {
+    results: resultsProps || [fakeShelf],
     primary: createPrimaryHeroShelf(primaryProps),
     secondary: createSecondaryHeroShelf(secondaryProps),
   };
@@ -1428,11 +1444,11 @@ export const createInternalVersionWithLang = (
   return createInternalVersion(version, lang);
 };
 
-export const createInternalHeroShelvesWithLang = (
-  heroShelves,
+export const createInternalHomeShelvesWithLang = (
+  homeShelves,
   lang = DEFAULT_LANG_IN_TESTS,
 ) => {
-  return createInternalHeroShelves(heroShelves, lang);
+  return createInternalHomeShelves(homeShelves, lang);
 };
 
 export const createInternalCollectionWithLang = ({


### PR DESCRIPTION
Fixes #9996 

Per #10065, this pull request was rebased on top of the current master and has the same commits to see what codecov generates.

In addition, this pull request includes the following updates:
- `tests/unit/helpers.js` - adds default value of `[fakeShelf]` to param `resultsProps`
- `tests/unit/amo/sagas/test_home.js` - updates `baseArgs` to `baseApiArgs`
- `components/HomepageShelves/index.js` - updates className from `Home-HomepageShelves` to just `HomepageShelves`, and adds a comment to explain displaying 3 loading shelves

@willdurand, @bobsilverberg - Please review when you have a moment. Thank you!