### PR TITLE
Add `buildStaticAddonCard()` to `addons-frontend-blog-utils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ curl https://addons-dev.allizom.org/__version__
 
 This project also contains code to build a library named `addons-frontend-blog-utils` and offers the following commands:
 
-- `yarn build:blog-utils-dev`: build the library and start a watcher to rebuild the library on change
+- `yarn build:blog-utils-dev`: build the library, start a watcher to rebuild the library on change and serve a development page at http://127.0.0.1:11000
 - `yarn build:blog-utils-prod`: build the library in production mode
 
 This library is exclusively designed to work with [addons-blog][].

--- a/bin/serve-blog-utils
+++ b/bin/serve-blog-utils
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const path = require('path');
+
+const express = require('express');
+
+// config
+const port = 11000;
+const rootDir = path.join(__dirname, '..');
+
+const app = express();
+app.use(express.static(path.join(rootDir, 'dist')));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(rootDir, 'src', 'blog-utils', 'index.html'));
+});
+
+app.listen(port, (err) => {
+  if (err) {
+    console.error(err);
+  } else {
+    console.info(`blog-utils dev page is running at: http://127.0.0.1:${port}`);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "npm run clean && better-npm-run build",
     "build:blog-utils": "npm run clean && bin/create-package-json-for-blog-utils && better-npm-run build:blog-utils",
-    "build:blog-utils-dev": "NODE_ENV=development npm run build:blog-utils -- --watch",
+    "build:blog-utils-dev": "NODE_ENV=development concurrently 'npm run build:blog-utils -- --watch' 'bin/serve-blog-utils'",
     "build:blog-utils-prod": "NODE_ENV=production npm run build:blog-utils",
     "build-check": "bin/build-checks.js",
     "build-ci": "npm run build && npm run bundlesize",

--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -1,0 +1,53 @@
+/* @flow */
+import * as React from 'react';
+
+import { getAddonIconUrl } from 'amo/imageUtils';
+import { nl2br, sanitizeHTML } from 'amo/utils';
+import AddonBadges from 'amo/components/AddonBadges';
+import AddonTitle from 'amo/components/AddonTitle';
+import GetFirefoxButton, {
+  GET_FIREFOX_BUTTON_TYPE_ADDON,
+} from 'amo/components/GetFirefoxButton';
+import type { AddonType } from 'amo/types/addons';
+
+import './styles.scss';
+
+type Props = {|
+  addon: AddonType,
+|};
+
+const StaticAddonCard = ({ addon }: Props): React.Node => {
+  if (!addon) {
+    return null;
+  }
+
+  const summary = addon.summary ? addon.summary : addon.description;
+
+  return (
+    <div className="StaticAddonCard" data-addon-id={addon.id}>
+      <div className="AddonIcon">
+        <div className="AddonIconWrapper">
+          <img className="AddonIconImage" src={getAddonIconUrl(addon)} alt="" />
+        </div>
+      </div>
+
+      <AddonTitle addon={addon} />
+
+      <AddonBadges addon={addon} />
+
+      <p
+        className="AddonSummary"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={sanitizeHTML(nl2br(summary), ['a', 'br'])}
+      />
+
+      <GetFirefoxButton
+        addon={addon}
+        buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+        className="AddonFirefoxButton"
+      />
+    </div>
+  );
+};
+
+export default StaticAddonCard;

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -1,0 +1,91 @@
+@import '~amo/css/styles';
+
+$icon-size: 38px;
+
+.StaticAddonCard {
+  background-color: $white;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(58, 57, 68, 0.2);
+  display: grid;
+  grid-template-columns: ($icon-size + 8px) 2fr 1fr;
+  padding: 10px;
+
+  @include respond-to(medium) {
+    padding: 20px;
+  }
+}
+
+.AddonBadges {
+  grid-column: 4;
+  grid-row: 1;
+  margin-bottom: 14px;
+  width: auto;
+
+  @include respond-to(medium) {
+    grid-column: 4;
+    margin: 0 0 0 auto;
+  }
+}
+
+.AddonIcon {
+  grid-column: 1;
+  grid-row: 2;
+
+  .AddonIconWrapper {
+    height: $icon-size;
+    overflow: hidden;
+    width: $icon-size;
+  }
+
+  .AddonIconImage {
+    height: auto;
+    width: 100%;
+  }
+
+  @include respond-to(medium) {
+    grid-row: 1;
+  }
+}
+
+.AddonTitle {
+  grid-column: 2 / span 3;
+  grid-row: 2;
+  margin: 0;
+
+  &,
+  & .AddonTitle-author,
+  & .AddonTitle-author a,
+  & .AddonTitle-author a:link {
+    font-size: $font-size-m;
+    line-height: 1;
+  }
+
+  @include respond-to(medium) {
+    grid-column: 2 / span 2;
+    grid-row: 1;
+  }
+}
+
+.AddonSummary {
+  font-size: $font-size-s;
+  grid-column: 1 / span 4;
+  grid-row: 3;
+  line-height: 1.2;
+
+  @include respond-to(medium) {
+    grid-row: 2;
+  }
+}
+
+.GetFirefoxButton {
+  align-self: center;
+  grid-column: 1 / span 4;
+  grid-row: 4;
+  white-space: initial;
+  width: auto;
+
+  @include respond-to(medium) {
+    grid-column: 4;
+    grid-row: 3;
+  }
+}

--- a/src/blog-utils/index.html
+++ b/src/blog-utils/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+	<!--
+		THIS PAGE IS FOR DEVELOPMENT PURPOSES ONLY
+	-->
+	<head>
+		<meta charset="utf-8">
+		<title>blog-utils</title>
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha512-NhSC1YmyruXifcj/KFRWoC561YpHpc5Jtzgvbuzx5VozKpWvQ+4nXhPdFgmx8xqexRcpAglTj9sIBWINXa8x5w==" crossorigin="anonymous" />
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/inter-ui/3.15.1/inter.min.css" integrity="sha512-LmuBiKMv0sdyc1LQk0LPrsjj3KSoVgVpAXUoFGY8Ye5Zi1mff0it3I42dkh3/NGQgtkqiHcdWOcHGUmOzYLETQ==" crossorigin="anonymous" />
+		<link href="/style.css" rel="stylesheet" type="text/css">
+		<style>
+			body {
+				font-family: Inter;
+			}
+
+			header {
+				margin-bottom: 3em;
+				text-align: center;
+			}
+
+			.content {
+				margin: 1em auto;
+				max-width: 900px;
+				padding: 1em;
+			}
+		</style>
+	</head>
+	<body>
+		<header>
+			<h1>addons-frontend-blog-utils</h1>
+		</header>
+
+		<div class="content">
+			<p>User-Agent switcher:</p>
+			<div class="addon-card" data-addon-id="853731"></div>
+
+			<p>uBlock Origin:</p>
+			<div class="addon-card" data-addon-id="607454"></div>
+
+			<p>AMO info (not a recommended extension)</p>
+			<div class="addon-card" data-addon-id="1000795"></div>
+		</div>
+
+		<footer id="footer"></footer>
+	</body>
+	<script src="/web.js"></script>
+	<script>
+		document.querySelectorAll('.addon-card').forEach(async (card) => {
+			try {
+				card.outerHTML = await AddonsFrontendBlogUtils.buildStaticAddonCard({ addonId: card.dataset.addonId });
+			} catch (e) {
+				console.error(`unable to build static card: ${e}`);
+			}
+		});
+
+		document.querySelector('#footer').outerHTML = AddonsFrontendBlogUtils.buildFooter();
+	</script>
+</html>

--- a/src/blog-utils/styles.scss
+++ b/src/blog-utils/styles.scss
@@ -1,1 +1,0 @@
-@import '~amo/css/styles';

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import AddonTitle from 'amo/components/AddonTitle';
+import AddonBadges from 'amo/components/AddonBadges';
+import StaticAddonCard from 'blog-utils/StaticAddonCard';
+import GetFirefoxButton, {
+  GET_FIREFOX_BUTTON_TYPE_ADDON,
+} from 'amo/components/GetFirefoxButton';
+import {
+  fakeAddon,
+  createLocalizedString,
+  createInternalAddonWithLang,
+} from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  const render = ({ addon }) => {
+    return shallow(<StaticAddonCard addon={addon} />);
+  };
+
+  it('renders nothing when add-on is falsey', () => {
+    const root = render({ addon: null });
+
+    expect(root.find('.StaticAddonCard')).toHaveLength(0);
+  });
+
+  it('renders a static add-on card', () => {
+    const addon = createInternalAddonWithLang(fakeAddon);
+
+    const root = render({ addon });
+
+    expect(root.find('.StaticAddonCard')).toHaveLength(1);
+    expect(root).toHaveProp('data-addon-id', addon.id);
+
+    expect(root.find(AddonTitle)).toHaveLength(1);
+    expect(root.find(AddonTitle)).toHaveProp('addon', addon);
+
+    expect(root.find(AddonBadges)).toHaveLength(1);
+    expect(root.find(AddonBadges)).toHaveProp('addon', addon);
+
+    expect(root.find('.AddonSummary').html()).toContain(addon.summary);
+
+    expect(root.find(GetFirefoxButton)).toHaveLength(1);
+    expect(root.find(GetFirefoxButton)).toHaveProp('addon', addon);
+    expect(root.find(GetFirefoxButton)).toHaveProp(
+      'buttonType',
+      GET_FIREFOX_BUTTON_TYPE_ADDON,
+    );
+  });
+
+  it('displays the description if there is no summary', () => {
+    const addon = createInternalAddonWithLang({ ...fakeAddon, summary: null });
+
+    const root = render({ addon });
+
+    expect(root.find('.AddonSummary').html()).not.toContain(addon.summary);
+    expect(root.find('.AddonSummary').html()).toContain(addon.description);
+  });
+
+  it('sanitizes the summary', () => {
+    const scriptHTML = createLocalizedString(
+      '<script>alert(document.cookie);</script>',
+    );
+
+    const root = render({
+      addon: createInternalAddonWithLang({
+        ...fakeAddon,
+        summary: scriptHTML,
+      }),
+    });
+
+    // Make sure an actual script tag was not created.
+    expect(root.find('.AddonSummary script')).toHaveLength(0);
+    // Make sure the script has been removed.
+    expect(root.find('.AddonSummary').html()).not.toContain('<script>');
+  });
+});

--- a/tests/unit/blog-utils/test_index.js
+++ b/tests/unit/blog-utils/test_index.js
@@ -1,6 +1,7 @@
 import cheerio from 'cheerio';
 
-import { buildFooter } from 'blog-utils';
+import { buildFooter, buildStaticAddonCard } from 'blog-utils';
+import { fakeAddon } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('buildFooter', () => {
@@ -9,6 +10,50 @@ describe(__filename, () => {
 
       expect(html('.Footer')).toHaveLength(1);
       expect(html('.Footer-language-picker')).toHaveLength(0);
+    });
+  });
+
+  describe('buildStaticAddonCard', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const mockFetch = (jsonData = {}) => {
+      return jest.spyOn(global, 'fetch').mockResolvedValue({
+        json: jest.fn().mockResolvedValue(jsonData),
+      });
+    };
+
+    it('calls the API to fetch an add-on', async () => {
+      const addonId = 123;
+      const fetch = mockFetch({ ...fakeAddon, id: addonId });
+
+      await buildStaticAddonCard({ addonId });
+
+      expect(fetch).toHaveBeenCalledWith(
+        `https://addons.mozilla.org/api/v5/addons/addon/${addonId}/?lang=en-US&app=firefox`,
+      );
+    });
+
+    it('renders a StaticAddonCard', async () => {
+      const addonId = 123;
+      mockFetch({ ...fakeAddon, id: addonId });
+
+      const html = cheerio.load(await buildStaticAddonCard({ addonId }));
+
+      expect(html('.StaticAddonCard')).toHaveLength(1);
+    });
+
+    it('lets the caller catch and handle errors', async () => {
+      const addonId = 123;
+      const anError = new Error('error in json()');
+      jest.spyOn(global, 'fetch').mockResolvedValue({
+        json: () => {
+          throw anError;
+        },
+      });
+
+      await expect(buildStaticAddonCard({ addonId })).rejects.toEqual(anError);
     });
   });
 });


### PR DESCRIPTION
Fixes #10297 

---

This patch adds a new function to the `blog-utils` library, which allows to build static add-on cards (for the blog). The `dev` command for this library will start a small server to serve an HTML page for development purposes.

I'll add the rest of the UI (ratings, number of users) in a different patch. Same for the cosmetic changes to have the same look&feel as in the mocks (which weren't finalized at the time of writing).

## Screenshots

Note: buttons are blue now

![Screen Shot 2021-03-32 at 11 22 14](https://user-images.githubusercontent.com/217628/113122112-995d6200-9213-11eb-957d-8a824b6adb71.png)

![Screen Shot 2021-03-32 at 11 22 53](https://user-images.githubusercontent.com/217628/113122101-97939e80-9213-11eb-8a24-dfa98ec5f824.png)

![Screen Shot 2021-03-32 at 11 22 44](https://user-images.githubusercontent.com/217628/113122109-98c4cb80-9213-11eb-80f8-7454d24ddc8b.png)
