### PR TITLE
Update `SearchTools` page component

### DIFF
--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import { ADDON_TYPE_EXTENSION } from 'amo/constants';
 import translate from 'amo/i18n/translate';
+import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import { sendServerRedirect } from 'amo/reducers/redirectTo';
 import { getCategoryResultsPathname } from 'amo/utils/categories';
 import type { AppState } from 'amo/store';

--- a/src/amo/pages/SearchTools/index.js
+++ b/src/amo/pages/SearchTools/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
+import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import { ADDON_TYPE_EXTENSION } from 'amo/constants';
 import translate from 'amo/i18n/translate';
 import { sendServerRedirect } from 'amo/reducers/redirectTo';
@@ -42,10 +43,10 @@ export class SearchToolsBase extends React.Component<InternalProps> {
     );
   }
 
-  // This will never be called, as we always do a server redirect in the
-  // constructor.
-  render(): null {
-    return null;
+  // This should never be called, as we always do a server redirect in the
+  // constructor. We show a 404 page anyway in case we cannot perform a redirect.
+  render(): React.Node {
+    return <NotFoundPage />;
   }
 }
 

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -3,11 +3,7 @@ import * as React from 'react';
 import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import SearchTools, { SearchToolsBase } from 'amo/pages/SearchTools';
 import { sendServerRedirect } from 'amo/reducers/redirectTo';
-import {
-  dispatchClientMetadata,
-  getFakeConfig,
-  shallowUntilTarget,
-} from 'tests/unit/helpers';
+import { dispatchClientMetadata, shallowUntilTarget } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   const render = ({
@@ -36,10 +32,8 @@ describe(__filename, () => {
     sinon.assert.callCount(fakeDispatch, 1);
   });
 
-  it('renders a NotFoundPage if server redirect fails', () => {
-    const { store } = dispatchClientMetadata();
-    const _config = getFakeConfig({ disableSSR: true });
-    const root = render({ store, _config });
+  it('renders a NotFoundPage', () => {
+    const root = render();
 
     expect(root.find(NotFoundPage)).toHaveLength(1);
   });

--- a/tests/unit/amo/pages/TestSearchTools.js
+++ b/tests/unit/amo/pages/TestSearchTools.js
@@ -1,15 +1,30 @@
 import * as React from 'react';
 
+import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import SearchTools, { SearchToolsBase } from 'amo/pages/SearchTools';
 import { sendServerRedirect } from 'amo/reducers/redirectTo';
-import { dispatchClientMetadata, shallowUntilTarget } from 'tests/unit/helpers';
+import {
+  dispatchClientMetadata,
+  getFakeConfig,
+  shallowUntilTarget,
+} from 'tests/unit/helpers';
 
 describe(__filename, () => {
+  const render = ({
+    store = dispatchClientMetadata().store,
+    ...props
+  } = {}) => {
+    return shallowUntilTarget(
+      <SearchTools store={store} {...props} />,
+      SearchToolsBase,
+    );
+  };
+
   it('sends a server redirect to support old search tool URLs', () => {
     const { store } = dispatchClientMetadata();
     const fakeDispatch = sinon.spy(store, 'dispatch');
 
-    shallowUntilTarget(<SearchTools store={store} />, SearchToolsBase);
+    render({ store });
 
     sinon.assert.calledWith(
       fakeDispatch,
@@ -19,5 +34,13 @@ describe(__filename, () => {
       }),
     );
     sinon.assert.callCount(fakeDispatch, 1);
+  });
+
+  it('renders a NotFoundPage if server redirect fails', () => {
+    const { store } = dispatchClientMetadata();
+    const _config = getFakeConfig({ disableSSR: true });
+    const root = render({ store, _config });
+
+    expect(root.find(NotFoundPage)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Fixes #9248 

Returns `NotFoundPage` if the server redirect fails in the `SearchToolsBase` constructor. As described in the issue, this is replicated locally when `disableSSR: true` is set in `config/default.js`. 

Before:

![image](https://user-images.githubusercontent.com/15523645/113858451-f2a63200-97cd-11eb-9fee-470200a06830.png)

After:

![image](https://user-images.githubusercontent.com/15523645/113858461-f89c1300-97cd-11eb-9ea4-dbbd8e4c6333.png)


