### PR TITLE
Replace 'Learn more about permissions' button with 'Learn more' link

### DIFF
--- a/src/amo/components/PermissionsCard/index.js
+++ b/src/amo/components/PermissionsCard/index.js
@@ -2,9 +2,9 @@
 import * as React from 'react';
 import { compose } from 'redux';
 
-import translate from 'amo/i18n/translate';
 import Link from 'amo/components/Link';
 import ShowMoreCard from 'amo/components/ShowMoreCard';
+import translate from 'amo/i18n/translate';
 import type { AddonVersionType } from 'amo/reducers/versions';
 import type { I18nType } from 'amo/types/i18n';
 
@@ -55,10 +55,10 @@ export class PermissionsCardBase extends React.Component<InternalProps> {
     }
 
     const header = (
-      <div className="PermissionCard-header">
+      <div className="PermissionsCard-header">
         {i18n.gettext('Permissions')}
         <Link
-          className="PermissionCard-learn-more"
+          className="PermissionsCard-learn-more"
           href="https://support.mozilla.org/kb/permission-request-messages-firefox-extensions"
           target="_blank"
           externalDark

--- a/src/amo/components/PermissionsCard/index.js
+++ b/src/amo/components/PermissionsCard/index.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { compose } from 'redux';
 
 import translate from 'amo/i18n/translate';
-import Button from 'amo/components/Button';
+import Link from 'amo/components/Link';
 import ShowMoreCard from 'amo/components/ShowMoreCard';
 import type { AddonVersionType } from 'amo/reducers/versions';
 import type { I18nType } from 'amo/types/i18n';
@@ -54,9 +54,25 @@ export class PermissionsCardBase extends React.Component<InternalProps> {
       return null;
     }
 
+    const header = (
+      <div className="PermissionCard-header">
+        {i18n.gettext('Permissions')}
+        <Link
+          className="PermissionCard-learn-more"
+          href="https://support.mozilla.org/kb/permission-request-messages-firefox-extensions"
+          target="_blank"
+          externalDark
+          prependClientApp={false}
+          prependLang={false}
+        >
+          {i18n.gettext('Learn more')}
+        </Link>
+      </div>
+    );
+
     return (
       <ShowMoreCard
-        header={i18n.gettext('Permissions')}
+        header={header}
         contentId={version.id}
         className="PermissionsCard"
         id="AddonDescription-permissions-card"
@@ -82,16 +98,6 @@ export class PermissionsCardBase extends React.Component<InternalProps> {
             </ul>
           </>
         ) : null}
-        <Button
-          buttonType="neutral"
-          className="PermissionCard-learn-more"
-          href="https://support.mozilla.org/kb/permission-request-messages-firefox-extensions"
-          target="_blank"
-          externalDark
-          puffy
-        >
-          {i18n.gettext('Learn more about permissions')}
-        </Button>
       </ShowMoreCard>
     );
   }

--- a/src/amo/components/PermissionsCard/styles.scss
+++ b/src/amo/components/PermissionsCard/styles.scss
@@ -1,12 +1,12 @@
 @import '~amo/css/styles';
 
-.PermissionCard-header {
+.PermissionsCard-header {
   width: 100%;
   display: flex;
   justify-content: space-between;
 }
 
-.PermissionCard-learn-more {
+.PermissionsCard-learn-more {
   .Icon {
     @include margin-start(12px);
   }

--- a/src/amo/components/PermissionsCard/styles.scss
+++ b/src/amo/components/PermissionsCard/styles.scss
@@ -1,9 +1,9 @@
 @import '~amo/css/styles';
 
 .PermissionsCard-header {
-  width: 100%;
   display: flex;
   justify-content: space-between;
+  width: 100%;
 }
 
 .PermissionsCard-learn-more {

--- a/src/amo/components/PermissionsCard/styles.scss
+++ b/src/amo/components/PermissionsCard/styles.scss
@@ -1,9 +1,12 @@
 @import '~amo/css/styles';
 
-.PermissionCard-learn-more {
-  margin: 16px auto 0;
+.PermissionCard-header {
   width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
 
+.PermissionCard-learn-more {
   .Icon {
     @include margin-start(12px);
   }

--- a/tests/unit/amo/components/TestPermissionsCard.js
+++ b/tests/unit/amo/components/TestPermissionsCard.js
@@ -96,8 +96,8 @@ describe(__filename, () => {
       const header = shallow(root.prop('header'));
 
       expect(root).toHaveClassName('PermissionsCard');
-      expect(header).toHaveClassName('PermissionCard-header');
-      expect(header.find(Link)).toHaveClassName('PermissionCard-learn-more');
+      expect(header).toHaveClassName('PermissionsCard-header');
+      expect(header.find(Link)).toHaveClassName('PermissionsCard-learn-more');
       expect(header.find(Link)).toHaveProp('externalDark', true);
     });
 

--- a/tests/unit/amo/components/TestPermissionsCard.js
+++ b/tests/unit/amo/components/TestPermissionsCard.js
@@ -1,5 +1,8 @@
+import { shallow } from 'enzyme';
 import * as React from 'react';
 
+import Link from 'amo/components/Link';
+import Permission from 'amo/components/Permission';
 import PermissionsCard, {
   PermissionsCardBase,
 } from 'amo/components/PermissionsCard';
@@ -11,8 +14,6 @@ import {
   fakeVersion,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
-import Button from 'amo/components/Button';
-import Permission from 'amo/components/Permission';
 
 describe(__filename, () => {
   let store;
@@ -87,14 +88,17 @@ describe(__filename, () => {
       expect(root).toHaveProp('contentId', id);
     });
 
-    it('renders learn more button', () => {
+    it('renders learn more link in header', () => {
       const permission = 'bookmarks';
       const root = render({
         version: createVersionWithPermissions({ required: [permission] }),
       });
+      const header = shallow(root.prop('header'));
+
       expect(root).toHaveClassName('PermissionsCard');
-      expect(root.find(Button)).toHaveClassName('PermissionCard-learn-more');
-      expect(root.find(Button)).toHaveProp('externalDark', true);
+      expect(header).toHaveClassName('PermissionCard-header');
+      expect(header.find(Link)).toHaveClassName('PermissionCard-learn-more');
+      expect(header.find(Link)).toHaveProp('externalDark', true);
     });
 
     it('renders required permissions only', () => {


### PR DESCRIPTION
Fixes #9411 

As requested in this [comment](https://github.com/mozilla/addons-frontend/issues/9411#issuecomment-704338725), this PR replaces the button in the PermissionsCard with a link in its header that says 'Learn more'.

Before:

![image](https://user-images.githubusercontent.com/15523645/114197102-38a0f880-997c-11eb-8b2b-3590d9e51c47.png)

After:

![image](https://user-images.githubusercontent.com/15523645/114197151-42c2f700-997c-11eb-8997-6c59c4c1c474.png)
