### PR TITLE
Render full size theme preview in collection page

### DIFF
--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -495,6 +495,7 @@ export class CollectionBase extends React.Component<InternalProps> {
               placeholderCount={this.addonPlaceholderCount}
               removeAddon={this.removeAddon}
               saveNote={this.saveNote}
+              showFullSizePreview
             />
           )}
           {placeholderText && (

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -634,6 +634,7 @@ describe(__filename, () => {
 
     expect(wrapper.find('.Collection-wrapper')).toHaveLength(1);
     expect(wrapper.find(AddonsCard)).toHaveProp('editing', false);
+    expect(wrapper.find(AddonsCard)).toHaveProp('showFullSizePreview', true);
   });
 
   it('sets a default placeholder count', () => {


### PR DESCRIPTION
Collection page displays add-on results in a wide layout similar to search, so we want the full size theme preview and not the small thumbnail.

Fixes #10326