### PR TITLE
Add ADU + ratings to the StaticAddonCard

### DIFF
--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -15,16 +15,19 @@ import type { I18nType } from 'amo/types/i18n';
 
 import './styles.scss';
 
-type PublicProps = {|
+type Props = {|
   addon: AddonType,
 |};
 
-type Props = {|
-  ...PublicProps,
+type InternalProps = {|
+  ...Props,
   i18n: I18nType,
 |};
 
-export const StaticAddonCardBase = ({ addon, i18n }: Props): React.Node => {
+export const StaticAddonCardBase = ({
+  addon,
+  i18n,
+}: InternalProps): React.Node => {
   if (!addon) {
     return null;
   }
@@ -35,9 +38,13 @@ export const StaticAddonCardBase = ({ addon, i18n }: Props): React.Node => {
 
   return (
     <div className="StaticAddonCard" data-addon-id={addon.id}>
-      <div className="AddonIcon">
-        <div className="AddonIconWrapper">
-          <img className="AddonIconImage" src={getAddonIconUrl(addon)} alt="" />
+      <div className="StaticAddonCard-icon">
+        <div className="StaticAddonCard-icon-wrapper">
+          <img
+            className="StaticAddonCard-icon-image"
+            src={getAddonIconUrl(addon)}
+            alt=""
+          />
         </div>
       </div>
 
@@ -45,26 +52,26 @@ export const StaticAddonCardBase = ({ addon, i18n }: Props): React.Node => {
 
       <AddonBadges addon={addon} />
 
-      <div className="AddonSummary">
+      <div className="StaticAddonCard-summary">
         <p
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={sanitizeHTML(nl2br(summary), ['a', 'br'])}
         />
       </div>
 
-      <div className="AddonMetadata">
+      <div className="StaticAddonCard-metadata">
         {averageRating && (
           <Rating rating={averageRating} readOnly styleSize="small" />
         )}
 
         {averageDailyUsers && (
-          <p className="AddonMetadata-adu">
+          <p className="StaticAddonCard-metadata-adu">
             Users: {i18n.formatNumber(averageDailyUsers)}
           </p>
         )}
       </div>
 
-      <div className="AddonFirefoxButton">
+      <div className="StaticAddonCard-firefox-button">
         <GetFirefoxButton
           addon={addon}
           buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
@@ -74,7 +81,7 @@ export const StaticAddonCardBase = ({ addon, i18n }: Props): React.Node => {
   );
 };
 
-const StaticAddonCard: React.ComponentType<PublicProps> = translate()(
+const StaticAddonCard: React.ComponentType<Props> = translate()(
   StaticAddonCardBase,
 );
 

--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -8,20 +8,30 @@ import AddonTitle from 'amo/components/AddonTitle';
 import GetFirefoxButton, {
   GET_FIREFOX_BUTTON_TYPE_ADDON,
 } from 'amo/components/GetFirefoxButton';
+import Rating from 'amo/components/Rating';
+import translate from 'amo/i18n/translate';
 import type { AddonType } from 'amo/types/addons';
+import type { I18nType } from 'amo/types/i18n';
 
 import './styles.scss';
 
-type Props = {|
+type PublicProps = {|
   addon: AddonType,
 |};
 
-const StaticAddonCard = ({ addon }: Props): React.Node => {
+type Props = {|
+  ...PublicProps,
+  i18n: I18nType,
+|};
+
+export const StaticAddonCardBase = ({ addon, i18n }: Props): React.Node => {
   if (!addon) {
     return null;
   }
 
   const summary = addon.summary ? addon.summary : addon.description;
+  const averageRating = addon.ratings ? addon.ratings.average : null;
+  const averageDailyUsers = addon.average_daily_users || null;
 
   return (
     <div className="StaticAddonCard" data-addon-id={addon.id}>
@@ -35,19 +45,37 @@ const StaticAddonCard = ({ addon }: Props): React.Node => {
 
       <AddonBadges addon={addon} />
 
-      <p
-        className="AddonSummary"
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={sanitizeHTML(nl2br(summary), ['a', 'br'])}
-      />
+      <div className="AddonSummary">
+        <p
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={sanitizeHTML(nl2br(summary), ['a', 'br'])}
+        />
+      </div>
 
-      <GetFirefoxButton
-        addon={addon}
-        buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
-        className="AddonFirefoxButton"
-      />
+      <div className="AddonMetadata">
+        {averageRating && (
+          <Rating rating={averageRating} readOnly styleSize="small" />
+        )}
+
+        {averageDailyUsers && (
+          <p className="AddonMetadata-adu">
+            Users: {i18n.formatNumber(averageDailyUsers)}
+          </p>
+        )}
+      </div>
+
+      <div className="AddonFirefoxButton">
+        <GetFirefoxButton
+          addon={addon}
+          buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+        />
+      </div>
     </div>
   );
 };
+
+const StaticAddonCard: React.ComponentType<PublicProps> = translate()(
+  StaticAddonCardBase,
+);
 
 export default StaticAddonCard;

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -31,17 +31,17 @@ $icon-size: 48px;
   }
 }
 
-.AddonIcon {
+.StaticAddonCard-icon {
   grid-column: 1;
   grid-row: 2;
 
-  .AddonIconWrapper {
+  .StaticAddonCard-icon-wrapper {
     height: $icon-size;
     overflow: hidden;
     width: $icon-size;
   }
 
-  .AddonIconImage {
+  .StaticAddonCard-icon-image {
     height: auto;
     width: 100%;
   }
@@ -72,7 +72,7 @@ $icon-size: 48px;
   }
 }
 
-.AddonSummary {
+.StaticAddonCard-summary {
   font-size: $font-size-s;
   grid-column: 1 / span 4;
   grid-row: 3;
@@ -87,7 +87,7 @@ $icon-size: 48px;
   }
 }
 
-.AddonMetadata {
+.StaticAddonCard-metadata {
   display: flex;
   font-size: $font-size-s;
   grid-column: 1 / span 4;
@@ -103,7 +103,7 @@ $icon-size: 48px;
   }
 }
 
-.AddonFirefoxButton {
+.StaticAddonCard-firefox-button {
   align-self: center;
   grid-column: 1 / span 4;
   grid-row: 5;

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -1,6 +1,6 @@
 @import '~amo/css/styles';
 
-$icon-size: 38px;
+$icon-size: 48px;
 
 .StaticAddonCard {
   background-color: $white;
@@ -8,7 +8,7 @@ $icon-size: 38px;
   box-shadow: 0 2px 6px rgba(58, 57, 68, 0.2);
   display: grid;
   grid-template-columns: ($icon-size + 8px) 2fr 1fr;
-  padding: 10px;
+  padding: 12px;
 
   @include respond-to(medium) {
     padding: 20px;
@@ -18,8 +18,12 @@ $icon-size: 38px;
 .AddonBadges {
   grid-column: 4;
   grid-row: 1;
-  margin-bottom: 14px;
+  margin-bottom: 10px;
   width: auto;
+
+  .PromotedBadge {
+    font-size: $font-size-s;
+  }
 
   @include respond-to(medium) {
     grid-column: 4;
@@ -48,11 +52,13 @@ $icon-size: 38px;
 }
 
 .AddonTitle {
+  align-self: center;
+  font-size: 20px;
+  font-weight: 700;
   grid-column: 2 / span 3;
   grid-row: 2;
   margin: 0;
 
-  &,
   & .AddonTitle-author,
   & .AddonTitle-author a,
   & .AddonTitle-author a:link {
@@ -72,20 +78,48 @@ $icon-size: 38px;
   grid-row: 3;
   line-height: 1.2;
 
+  p {
+    margin-bottom: 0;
+  }
+
   @include respond-to(medium) {
     grid-row: 2;
   }
 }
 
-.GetFirefoxButton {
-  align-self: center;
+.AddonMetadata {
+  display: flex;
+  font-size: $font-size-s;
   grid-column: 1 / span 4;
   grid-row: 4;
-  white-space: initial;
-  width: auto;
+  line-height: 1.2;
+
+  .Rating {
+    @include margin-end(12px);
+  }
 
   @include respond-to(medium) {
-    grid-column: 4;
     grid-row: 3;
+  }
+}
+
+.AddonFirefoxButton {
+  align-self: center;
+  grid-column: 1 / span 4;
+  grid-row: 5;
+  text-align: center;
+
+  .GetFirefoxButton {
+    margin-bottom: 0;
+    width: auto;
+  }
+
+  @include respond-to(medium) {
+    grid-row: 4;
+  }
+
+  @include respond-to(large) {
+    margin-top: -12px;
+    text-align: right;
   }
 }

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -45,7 +45,9 @@ describe(__filename, () => {
     expect(root.find(AddonBadges)).toHaveLength(1);
     expect(root.find(AddonBadges)).toHaveProp('addon', addon);
 
-    expect(root.find('.AddonSummary').html()).toContain(addon.summary);
+    expect(root.find('.StaticAddonCard-summary').html()).toContain(
+      addon.summary,
+    );
 
     expect(root.find(GetFirefoxButton)).toHaveLength(1);
     expect(root.find(GetFirefoxButton)).toHaveProp('addon', addon);
@@ -60,8 +62,12 @@ describe(__filename, () => {
 
     const root = render({ addon });
 
-    expect(root.find('.AddonSummary').html()).not.toContain(addon.summary);
-    expect(root.find('.AddonSummary').html()).toContain(addon.description);
+    expect(root.find('.StaticAddonCard-summary').html()).not.toContain(
+      addon.summary,
+    );
+    expect(root.find('.StaticAddonCard-summary').html()).toContain(
+      addon.description,
+    );
   });
 
   it('sanitizes the summary', () => {
@@ -77,9 +83,11 @@ describe(__filename, () => {
     });
 
     // Make sure an actual script tag was not created.
-    expect(root.find('.AddonSummary script')).toHaveLength(0);
+    expect(root.find('.StaticAddonCard-summary script')).toHaveLength(0);
     // Make sure the script has been removed.
-    expect(root.find('.AddonSummary').html()).not.toContain('<script>');
+    expect(root.find('.StaticAddonCard-summary').html()).not.toContain(
+      '<script>',
+    );
   });
 
   it('displays the number of users', () => {
@@ -91,8 +99,10 @@ describe(__filename, () => {
 
     const root = render({ addon });
 
-    expect(root.find('.AddonMetadata-adu')).toHaveLength(1);
-    expect(root.find('.AddonMetadata-adu').text()).toEqual('Users: 1,234,567');
+    expect(root.find('.StaticAddonCard-metadata-adu')).toHaveLength(1);
+    expect(root.find('.StaticAddonCard-metadata-adu').text()).toEqual(
+      'Users: 1,234,567',
+    );
   });
 
   it('hides the number of users when there is no data', () => {
@@ -103,7 +113,7 @@ describe(__filename, () => {
 
     const root = render({ addon });
 
-    expect(root.find('.AddonMetadata-adu')).toHaveLength(0);
+    expect(root.find('.StaticAddonCard-metadata-adu')).toHaveLength(0);
   });
 
   it('displays ratings', () => {

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -1,21 +1,28 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
 
 import AddonTitle from 'amo/components/AddonTitle';
 import AddonBadges from 'amo/components/AddonBadges';
-import StaticAddonCard from 'blog-utils/StaticAddonCard';
+import StaticAddonCard, {
+  StaticAddonCardBase,
+} from 'blog-utils/StaticAddonCard';
 import GetFirefoxButton, {
   GET_FIREFOX_BUTTON_TYPE_ADDON,
 } from 'amo/components/GetFirefoxButton';
+import Rating from 'amo/components/Rating';
 import {
   fakeAddon,
+  fakeI18n,
   createLocalizedString,
   createInternalAddonWithLang,
+  shallowUntilTarget,
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   const render = ({ addon }) => {
-    return shallow(<StaticAddonCard addon={addon} />);
+    return shallowUntilTarget(
+      <StaticAddonCard addon={addon} i18n={fakeI18n()} />,
+      StaticAddonCardBase,
+    );
   };
 
   it('renders nothing when add-on is falsey', () => {
@@ -73,5 +80,55 @@ describe(__filename, () => {
     expect(root.find('.AddonSummary script')).toHaveLength(0);
     // Make sure the script has been removed.
     expect(root.find('.AddonSummary').html()).not.toContain('<script>');
+  });
+
+  it('displays the number of users', () => {
+    const average_daily_users = 1234567;
+    const addon = createInternalAddonWithLang({
+      ...fakeAddon,
+      average_daily_users,
+    });
+
+    const root = render({ addon });
+
+    expect(root.find('.AddonMetadata-adu')).toHaveLength(1);
+    expect(root.find('.AddonMetadata-adu').text()).toEqual('Users: 1,234,567');
+  });
+
+  it('hides the number of users when there is no data', () => {
+    const addon = createInternalAddonWithLang({
+      ...fakeAddon,
+      average_daily_users: null,
+    });
+
+    const root = render({ addon });
+
+    expect(root.find('.AddonMetadata-adu')).toHaveLength(0);
+  });
+
+  it('displays ratings', () => {
+    const average = 4.3;
+    const addon = createInternalAddonWithLang({
+      ...fakeAddon,
+      ratings: { average },
+    });
+
+    const root = render({ addon });
+
+    expect(root.find(Rating)).toHaveLength(1);
+    expect(root.find(Rating)).toHaveProp('rating', average);
+    expect(root.find(Rating)).toHaveProp('readOnly', true);
+    expect(root.find(Rating)).toHaveProp('styleSize', 'small');
+  });
+
+  it('hides ratings when there is no data', () => {
+    const addon = createInternalAddonWithLang({
+      ...fakeAddon,
+      ratings: null,
+    });
+
+    const root = render({ addon });
+
+    expect(root.find(Rating)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Fixes #10338

---

Note: some of the style has been updated to look more like the latest mocks. This isn't strictly compliant with the mocks but it is consistent with the AMO frontend.

![Screen Shot 2021-04-12 at 10 48 21](https://user-images.githubusercontent.com/217628/114367338-a287f080-9b7c-11eb-8ac7-d01483003f3e.png)

![Screen Shot 2021-04-13 at 10 49 04](https://user-images.githubusercontent.com/217628/114367433-b9c6de00-9b7c-11eb-84f3-639242bd6257.png)

