### PR TITLE
Use new download button version in StaticAddonCard (blog-utils)

### DIFF
--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -75,6 +75,7 @@ export const StaticAddonCardBase = ({
         <GetFirefoxButton
           addon={addon}
           buttonType={GET_FIREFOX_BUTTON_TYPE_ADDON}
+          useNewVersion
         />
       </div>
     </div>

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -6,7 +6,9 @@ $icon-size: 48px;
   background-color: $white;
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(58, 57, 68, 0.2);
+  box-sizing: border-box;
   display: grid;
+  font-size: $font-size-s;
   grid-template-columns: ($icon-size + 8px) 2fr 1fr;
   padding: 12px;
 
@@ -73,7 +75,6 @@ $icon-size: 48px;
 }
 
 .StaticAddonCard-summary {
-  font-size: $font-size-s;
   grid-column: 1 / span 4;
   grid-row: 3;
   line-height: 1.2;
@@ -89,7 +90,6 @@ $icon-size: 48px;
 
 .StaticAddonCard-metadata {
   display: flex;
-  font-size: $font-size-s;
   grid-column: 1 / span 4;
   grid-row: 4;
   line-height: 1.2;
@@ -108,18 +108,23 @@ $icon-size: 48px;
   grid-column: 1 / span 4;
   grid-row: 5;
   text-align: center;
+  width: 100%;
 
-  .GetFirefoxButton {
+  &,
+  .GetFirefoxButton-button,
+  .GetFirefoxButton-callout {
+    box-sizing: border-box;
+  }
+
+  .GetFirefoxButton-button {
     margin-bottom: 0;
-    width: auto;
+  }
+
+  .GetFirefoxButton-callout {
+    margin-top: 0;
   }
 
   @include respond-to(medium) {
-    grid-row: 4;
-  }
-
-  @include respond-to(large) {
-    margin-top: -12px;
-    text-align: right;
+    margin-top: 10px;
   }
 }

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -55,6 +55,7 @@ describe(__filename, () => {
       'buttonType',
       GET_FIREFOX_BUTTON_TYPE_ADDON,
     );
+    expect(root.find(GetFirefoxButton)).toHaveProp('useNewVersion', true);
   });
 
   it('displays the description if there is no summary', () => {


### PR DESCRIPTION
Fixes #10353

---

![Screen Shot 2021-04-14 at 09 16 33](https://user-images.githubusercontent.com/217628/114513266-4e434600-9c3a-11eb-91bf-66f75f74c3cc.png)

![Screen Shot 2021-04-14 at 09 16 37](https://user-images.githubusercontent.com/217628/114513273-4f747300-9c3a-11eb-8bfd-22fc60207ed4.png)

![Screen Shot 2021-04-14 at 09 16 50](https://user-images.githubusercontent.com/217628/114513274-500d0980-9c3a-11eb-9424-df9bb4e708cf.png)

![Screenshot_2021-04-13 blog-utils](https://user-images.githubusercontent.com/217628/114513278-50a5a000-9c3a-11eb-8cc2-83743f54cc20.png)
