### PR TITLE
Open homepage shelf's footer_pathname URLs in a new tab

### DIFF
--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -58,6 +58,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
           footerLinkProps.href = footerLink.href;
           footerLinkProps.prependClientApp = false;
           footerLinkProps.prependLang = false;
+          footerLinkProps.target = '_blank';
         } else {
           // As a convenience, fix the query parameter.
           footerLinkProps.to = {

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -179,6 +179,9 @@ describe(__filename, () => {
     expect(root.find(AddonsCard).prop('footerLink').props.to).toEqual(
       undefined,
     );
+    expect(root.find(AddonsCard).prop('footerLink').props.target).toEqual(
+      '_blank',
+    );
   });
 
   it.each([true, false])(


### PR DESCRIPTION
Fixes #9996 

`footer_pathname` supports external URLs, which currently opens in the same tab. However, these URLs should have the same behavior as URLs in the secondary hero shelf (the page opens in a new tab).

This pull request updates the `LandingAddonsCard` component and its test.

@bobsilverberg, please review when you have a moment. Thank you!