### PR TITLE
Expose Header in blog-utils library

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -49,9 +49,10 @@ export class HeaderBase extends React.Component {
     siteUser: PropTypes.object,
     userAgentInfo: PropTypes.object,
     variant: PropTypes.string,
+    withBlogUI: PropTypes.bool,
   };
 
-  static defaultProps = { _config: config };
+  static defaultProps = { _config: config, withBlogUI: false };
 
   handleLogOut = (event) => {
     event.preventDefault();
@@ -61,6 +62,7 @@ export class HeaderBase extends React.Component {
 
   renderMenuOrAuthButton() {
     const {
+      withBlogUI,
       i18n,
       isReviewer,
       loadedPageIsAnonymous,
@@ -68,7 +70,7 @@ export class HeaderBase extends React.Component {
       siteUser,
     } = this.props;
 
-    if (loadedPageIsAnonymous) {
+    if (withBlogUI || loadedPageIsAnonymous) {
       // The server has loaded a page that is marked as anonymous so we do not
       // want to render any menu or authentication button here so that
       // logged-in users are not confused.
@@ -169,6 +171,7 @@ export class HeaderBase extends React.Component {
     const {
       _config,
       clientApp,
+      withBlogUI,
       i18n,
       isAddonDetailPage,
       isHomePage,
@@ -239,12 +242,17 @@ export class HeaderBase extends React.Component {
           </div>
 
           {clientApp === CLIENT_APP_FIREFOX ? (
-            <SectionLinks className="Header-SectionLinks" location={location} />
+            <SectionLinks
+              className="Header-SectionLinks"
+              location={location}
+              withBlogUI={withBlogUI}
+            />
           ) : null}
 
           <div className="Header-user-and-external-links">
             {otherSiteLinks}
-            {variant !== VARIANT_NEW ? (
+
+            {!withBlogUI && variant !== VARIANT_NEW ? (
               <GetFirefoxButton
                 buttonType={GET_FIREFOX_BUTTON_TYPE_HEADER}
                 className="Header-download-button Header-button"
@@ -254,12 +262,14 @@ export class HeaderBase extends React.Component {
             {this.renderMenuOrAuthButton()}
           </div>
 
-          <SearchForm
-            className={makeClassName('Header-search-form', {
-              'Header-search-form--desktop': clientApp === CLIENT_APP_FIREFOX,
-            })}
-            pathname="/search/"
-          />
+          {!withBlogUI && (
+            <SearchForm
+              className={makeClassName('Header-search-form', {
+                'Header-search-form--desktop': clientApp === CLIENT_APP_FIREFOX,
+              })}
+              pathname="/search/"
+            />
+          )}
         </div>
       </header>
     );

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -31,6 +31,7 @@ import './styles.scss';
 
 type Props = {|
   className?: string,
+  withBlogUI?: boolean,
 |};
 
 type PropsFromState = {|
@@ -65,10 +66,10 @@ export class SectionLinksBase extends React.Component<InternalProps> {
   };
 
   render(): React.Node {
-    const { className, clientApp, i18n, viewContext } = this.props;
-    const isExploring = [VIEW_CONTEXT_EXPLORE, VIEW_CONTEXT_HOME].includes(
-      viewContext,
-    );
+    const { className, clientApp, withBlogUI, i18n, viewContext } = this.props;
+    const isExploring =
+      [VIEW_CONTEXT_EXPLORE, VIEW_CONTEXT_HOME].includes(viewContext) &&
+      !withBlogUI;
 
     let forBrowserNameText;
     if (clientApp === CLIENT_APP_FIREFOX) {
@@ -97,6 +98,22 @@ export class SectionLinksBase extends React.Component<InternalProps> {
 
     return (
       <ul className={makeClassName('SectionLinks', className)}>
+        {withBlogUI && (
+          <li>
+            <Link
+              className={makeClassName(
+                'SectionLinks-link',
+                'SectionLinks-blog',
+                'SectionLinks-link--active',
+              )}
+              href="/blog/"
+              prependClientApp={false}
+              prependLang={false}
+            >
+              {i18n.gettext('Blog')}
+            </Link>
+          </li>
+        )}
         <li>
           <Link
             className={makeClassName(
@@ -136,49 +153,51 @@ export class SectionLinksBase extends React.Component<InternalProps> {
             {i18n.gettext('Themes')}
           </Link>
         </li>
-        <li>
-          <DropdownMenu
-            className="SectionLinks-link SectionLinks-dropdown"
-            text={i18n.gettext('More…')}
-          >
-            {sectionsForBrowser.length > 0 && (
-              <DropdownMenuItem className="SectionLinks-subheader">
-                {forBrowserNameText}
-              </DropdownMenuItem>
-            )}
-            {sectionsForBrowser}
+        {!withBlogUI && (
+          <li>
+            <DropdownMenu
+              className="SectionLinks-link SectionLinks-dropdown"
+              text={i18n.gettext('More…')}
+            >
+              {sectionsForBrowser.length > 0 && (
+                <DropdownMenuItem className="SectionLinks-subheader">
+                  {forBrowserNameText}
+                </DropdownMenuItem>
+              )}
+              {sectionsForBrowser}
 
-            <DropdownMenuItem className="SectionLinks-subheader">
-              {i18n.gettext('Other Browser Sites')}
-            </DropdownMenuItem>
-            {clientApp !== CLIENT_APP_ANDROID ? (
-              <DropdownMenuItem>
-                <Link
-                  className={`SectionLinks-clientApp-${CLIENT_APP_ANDROID}`}
-                  data-clientapp={CLIENT_APP_ANDROID}
-                  onClick={this.setClientApp}
-                  prependClientApp={false}
-                  to={`/${CLIENT_APP_ANDROID}/`}
-                >
-                  {i18n.gettext('Add-ons for Android')}
-                </Link>
+              <DropdownMenuItem className="SectionLinks-subheader">
+                {i18n.gettext('Other Browser Sites')}
               </DropdownMenuItem>
-            ) : null}
-            {clientApp !== CLIENT_APP_FIREFOX ? (
-              <DropdownMenuItem>
-                <Link
-                  className={`SectionLinks-clientApp-${CLIENT_APP_FIREFOX}`}
-                  data-clientapp={CLIENT_APP_FIREFOX}
-                  onClick={this.setClientApp}
-                  prependClientApp={false}
-                  to={`/${CLIENT_APP_FIREFOX}/`}
-                >
-                  {i18n.gettext('Add-ons for Firefox')}
-                </Link>
-              </DropdownMenuItem>
-            ) : null}
-          </DropdownMenu>
-        </li>
+              {clientApp !== CLIENT_APP_ANDROID ? (
+                <DropdownMenuItem>
+                  <Link
+                    className={`SectionLinks-clientApp-${CLIENT_APP_ANDROID}`}
+                    data-clientapp={CLIENT_APP_ANDROID}
+                    onClick={this.setClientApp}
+                    prependClientApp={false}
+                    to={`/${CLIENT_APP_ANDROID}/`}
+                  >
+                    {i18n.gettext('Add-ons for Android')}
+                  </Link>
+                </DropdownMenuItem>
+              ) : null}
+              {clientApp !== CLIENT_APP_FIREFOX ? (
+                <DropdownMenuItem>
+                  <Link
+                    className={`SectionLinks-clientApp-${CLIENT_APP_FIREFOX}`}
+                    data-clientapp={CLIENT_APP_FIREFOX}
+                    onClick={this.setClientApp}
+                    prependClientApp={false}
+                    to={`/${CLIENT_APP_FIREFOX}/`}
+                  >
+                    {i18n.gettext('Add-ons for Firefox')}
+                  </Link>
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenu>
+          </li>
+        )}
       </ul>
     );
   }

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -15,6 +15,7 @@
 .SectionLinks-link:link {
   color: $grey-40;
   display: inline-block;
+  font-size: $font-size-m;
   font-weight: 400;
   margin: 0 8px;
   outline: none;

--- a/src/blog-utils/index.html
+++ b/src/blog-utils/index.html
@@ -27,9 +27,7 @@
 		</style>
 	</head>
 	<body>
-		<header>
-			<h1>addons-frontend-blog-utils</h1>
-		</header>
+		<header id="header"></header>
 
 		<div class="content">
 			<p>User-Agent switcher:</p>
@@ -54,6 +52,7 @@
 			}
 		});
 
+		document.querySelector('#header').outerHTML = AddonsFrontendBlogUtils.buildHeader();
 		document.querySelector('#footer').outerHTML = AddonsFrontendBlogUtils.buildFooter();
 	</script>
 </html>

--- a/src/blog-utils/index.js
+++ b/src/blog-utils/index.js
@@ -12,6 +12,7 @@ import { makeI18n } from 'amo/i18n/utils';
 import { setClientApp, setLang } from 'amo/reducers/api';
 import createStore from 'amo/store';
 import Footer from 'amo/components/Footer';
+import Header from 'amo/components/Header';
 import { createInternalAddon } from 'amo/reducers/addons';
 
 import StaticAddonCard from './StaticAddonCard';
@@ -50,6 +51,13 @@ export const buildFooter = (): string => {
   const lang = 'en-US';
 
   return render({ app, lang, component: <Footer noLangPicker /> });
+};
+
+export const buildHeader = (): string => {
+  const app = 'firefox';
+  const lang = 'en-US';
+
+  return render({ app, lang, component: <Header withBlogUI /> });
 };
 
 type BuildStaticAddonCardParams = {|

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -313,4 +313,15 @@ describe(__filename, () => {
       'Header-search-form--desktop',
     );
   });
+
+  it('can update its UI for the blog', () => {
+    const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
+
+    const root = renderHeader({ store, withBlogUI: true });
+
+    expect(root.find('.Header-authenticate-button')).toHaveLength(0);
+    expect(root.find('.Header-download-button')).toHaveLength(0);
+    expect(root.find(SearchForm)).toHaveLength(0);
+    expect(root.find(SectionLinks)).toHaveProp('withBlogUI', true);
+  });
 });

--- a/tests/unit/amo/components/TestSectionLinks.js
+++ b/tests/unit/amo/components/TestSectionLinks.js
@@ -178,4 +178,23 @@ describe(__filename, () => {
     sinon.assert.calledWith(dispatchSpy, setClientApp(CLIENT_APP_ANDROID));
     sinon.assert.calledWith(fakeHistory.push, `/en-US/${CLIENT_APP_ANDROID}/`);
   });
+
+  it('renders specific links for the blog', () => {
+    const root = render({ withBlogUI: true });
+
+    expect(root.find('.SectionLinks-blog')).toHaveLength(1);
+    expect(root.find('.SectionLinks-blog')).toHaveClassName(
+      'SectionLinks-link--active',
+    );
+    // Make sure that only the "Blog" link is active.
+    expect(root.find('.SectionLinks-link--active')).toHaveLength(1);
+    expect(root.find('.SectionLinks-blog')).toHaveProp('href', '/blog/');
+    expect(root.find('.SectionLinks-blog')).toHaveProp(
+      'prependClientApp',
+      false,
+    );
+    expect(root.find('.SectionLinks-blog')).toHaveProp('prependLang', false);
+    // TODO: there is a UI problem that makes the dropdown ugly.
+    expect(root.find('.SectionLinks-dropdown')).toHaveLength(0);
+  });
 });

--- a/tests/unit/blog-utils/test_index.js
+++ b/tests/unit/blog-utils/test_index.js
@@ -1,6 +1,6 @@
 import cheerio from 'cheerio';
 
-import { buildFooter, buildStaticAddonCard } from 'blog-utils';
+import { buildFooter, buildHeader, buildStaticAddonCard } from 'blog-utils';
 import { fakeAddon } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -54,6 +54,15 @@ describe(__filename, () => {
       });
 
       await expect(buildStaticAddonCard({ addonId })).rejects.toEqual(anError);
+    });
+  });
+
+  describe('buildHeader', () => {
+    it('returns the header HTML', () => {
+      const html = cheerio.load(buildHeader());
+
+      expect(html('.Header')).toHaveLength(1);
+      expect(html('.SectionLinks-blog')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10382

---

For some reasons, there is an issue with the "more..." dropdown and I don't know how to fix it. I think it's fine to hide it for now, we'll see with Product/UX later.

The dev page looks like this now:

![Screenshot_2021-04-14 blog-utils](https://user-images.githubusercontent.com/217628/114716900-cdb54000-9d34-11eb-89ed-557a1bd3fef3.png)


