### PR TITLE
Add overflow-wrap: break-word for Safari

### DIFF
--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -31,6 +31,8 @@ textarea {
 *::before,
 *::after {
   box-sizing: inherit;
+  // This is needed for Safari, which does not support `anywhere`.
+  overflow-wrap: break-word;
   // We use `anywhere` instead of `break-word` so that it works even when the
   // container does not have a well-defined width.
 


### PR DESCRIPTION
Fixes #10289
