### PR TITLE
Only set an experiment cookie and send an enrollment event on the client

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -46,6 +46,6 @@ module.exports = {
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
 
   experiments: {
-    '20210404_download_cta_experiment': false,
+    '20210404_download_cta_experiment': true,
   },
 };

--- a/src/amo/withExperiment.js
+++ b/src/amo/withExperiment.js
@@ -26,6 +26,13 @@ import { getDisplayName } from 'amo/utils';
  *        in the experiment, assign a percentage to the special
  *        `NOT_IN_EXPERIMENT` variant.
  *
+ *  Note: Experiments are only executed on the client. The component will
+ *        initially be rendered with `variant === null`. Therefore the
+ *        version of the component that will be the least disruptive should
+ *        be generated when `variant === null`. Once a variant is determined
+ *        on the client, the layout of the component will change to match that
+ *        of the variant.
+ *
  *  Example:
  *
  *     withExperiment({
@@ -164,9 +171,7 @@ export const withExperiment = ({
 
     static displayName = `WithExperiment(${getDisplayName(WrappedComponent)})`;
 
-    constructor(props: withExperimentInternalProps) {
-      super(props);
-
+    componentDidMount() {
       const {
         _getVariant,
         _isExperimentEnabled,

--- a/tests/unit/amo/test_withExperiment.js
+++ b/tests/unit/amo/test_withExperiment.js
@@ -35,8 +35,7 @@ describe(__filename, () => {
   };
 
   const renderWithExperiment = ({
-    // By default all tests are run on the client.
-    configOverrides = { server: false },
+    configOverrides = {},
     cookies = fakeCookies(),
     experimentProps,
     props,
@@ -50,6 +49,7 @@ describe(__filename, () => {
         },
         ...configOverrides,
       }),
+      _tracking: createFakeTracking(),
       id,
       ...experimentProps,
     };
@@ -179,7 +179,6 @@ describe(__filename, () => {
         [experimentId]: true,
         [anotherExperimentId]: true,
       },
-      server: false,
     };
     const variantId = 'some-variant-id';
     const cookies = fakeCookies({
@@ -215,7 +214,6 @@ describe(__filename, () => {
         [experimentId]: true,
         [anotherExperimentId]: false,
       },
-      server: false,
     };
     const variantId = 'some-variant-id';
     const cookies = fakeCookies({


### PR DESCRIPTION
Fixes #10188 and re-enables the experiment on dev