### PR TITLE
Prevent callout icon from being cropped

### DIFF
--- a/src/amo/components/GetFirefoxButton/styles.scss
+++ b/src/amo/components/GetFirefoxButton/styles.scss
@@ -66,5 +66,6 @@ $callout-color: $yellow-50;
   background-image: url('../Notice/img/generic-info-mark.svg');
   height: 16px;
   margin: 0;
+  min-width: 16px;
   width: 16px;
 }


### PR DESCRIPTION
Fixes #10375 

Before:

![extension](https://user-images.githubusercontent.com/33448286/114689017-23083780-9cca-11eb-9c35-9f8ef3e5539a.png)

![themes](https://user-images.githubusercontent.com/33448286/114689382-7f6b5700-9cca-11eb-926a-28e40bf72a5c.png)

After:

![Screen Shot 2021-04-15 at 9 40 51 AM](https://user-images.githubusercontent.com/142755/114879136-ed994200-9dce-11eb-9ef7-56ace103acb0.png)

![Screen Shot 2021-04-15 at 9 40 23 AM](https://user-images.githubusercontent.com/142755/114879177-f2f68c80-9dce-11eb-93ce-c16c5a50836b.png)
