### PR TITLE
Hide the GetFirefoxBanner on all pages from which an add-on can be installed

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -40,7 +40,7 @@ export class HeaderBase extends React.Component {
     clientApp: PropTypes.string.isRequired,
     handleLogOut: PropTypes.func.isRequired,
     i18n: PropTypes.object.isRequired,
-    isAddonDetailPage: PropTypes.bool,
+    isAddonInstallPage: PropTypes.bool,
     isHomePage: PropTypes.bool,
     isReviewer: PropTypes.bool.isRequired,
     loadedPageIsAnonymous: PropTypes.bool.isRequired,
@@ -173,7 +173,7 @@ export class HeaderBase extends React.Component {
       clientApp,
       withBlogUI,
       i18n,
-      isAddonDetailPage,
+      isAddonInstallPage,
       isHomePage,
       loadedPageIsAnonymous,
       location,
@@ -229,7 +229,7 @@ export class HeaderBase extends React.Component {
           'Header--loaded-page-is-anonymous': loadedPageIsAnonymous,
         })}
       >
-        {!isAddonDetailPage && variant === VARIANT_NEW ? (
+        {!isAddonInstallPage && variant === VARIANT_NEW ? (
           <GetFirefoxBanner />
         ) : null}
         <div className="Header-wrapper">

--- a/src/amo/components/Page/index.js
+++ b/src/amo/components/Page/index.js
@@ -24,7 +24,7 @@ import './styles.scss';
 type Props = {|
   children: React.Node,
   errorHandler?: ErrorHandlerType,
-  isAddonDetailPage?: boolean,
+  isAddonInstallPage?: boolean,
   isHomePage?: boolean,
   showWrongPlatformWarning?: boolean,
 |};
@@ -47,7 +47,7 @@ export const PageBase = ({
   children,
   clientApp,
   errorHandler,
-  isAddonDetailPage = false,
+  isAddonInstallPage = false,
   isHomePage = false,
   location,
   showWrongPlatformWarning = true,
@@ -81,7 +81,7 @@ export const PageBase = ({
       <InfoDialog />
 
       <Header
-        isAddonDetailPage={isAddonDetailPage}
+        isAddonInstallPage={isAddonInstallPage}
         isHomePage={isHomePage}
         location={location}
       />

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -444,7 +444,7 @@ export class AddonBase extends React.Component {
     return (
       <Page
         errorHandler={errorHandler}
-        isAddonDetailPage
+        isAddonInstallPage
         showWrongPlatformWarning={false}
       >
         <div

--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -141,7 +141,7 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
     }
 
     return (
-      <Page errorHandler={errorHandler}>
+      <Page errorHandler={errorHandler} isAddonInstallPage>
         <div className="AddonVersions">
           {addon && (
             <Helmet>

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -59,12 +59,12 @@ describe(__filename, () => {
   });
 
   it.each([true, false])(
-    'conditionally renders a GetFirefoxBanner component when isAddonDetailPage is %s',
-    (isAddonDetailPage) => {
-      const root = renderHeader({ isAddonDetailPage, variant: VARIANT_NEW });
+    'conditionally renders a GetFirefoxBanner component when isAddonInstallPage is %s',
+    (isAddonInstallPage) => {
+      const root = renderHeader({ isAddonInstallPage, variant: VARIANT_NEW });
 
       expect(root.find(GetFirefoxBanner)).toHaveLength(
-        isAddonDetailPage ? 0 : 1,
+        isAddonInstallPage ? 0 : 1,
       );
     },
   );

--- a/tests/unit/amo/components/TestPage.js
+++ b/tests/unit/amo/components/TestPage.js
@@ -38,14 +38,14 @@ describe(__filename, () => {
     expect(root.find(Header)).toHaveProp('isHomePage', isHomePage);
   });
 
-  it('passes isAddonDetailPage to Header', () => {
-    const isAddonDetailPage = true;
+  it('passes isAddonInstallPage to Header', () => {
+    const isAddonInstallPage = true;
 
-    const root = render({ isAddonDetailPage });
+    const root = render({ isAddonInstallPage });
 
     expect(root.find(Header)).toHaveProp(
-      'isAddonDetailPage',
-      isAddonDetailPage,
+      'isAddonInstallPage',
+      isAddonInstallPage,
     );
   });
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -452,7 +452,7 @@ describe(__filename, () => {
     const root = shallowRender({ errorHandler });
     const page = root.find(Page);
     expect(page).toHaveProp('errorHandler', errorHandler);
-    expect(page).toHaveProp('isAddonDetailPage', true);
+    expect(page).toHaveProp('isAddonInstallPage', true);
     expect(page).toHaveProp('showWrongPlatformWarning', false);
   });
 

--- a/tests/unit/amo/pages/TestAddonVersions.js
+++ b/tests/unit/amo/pages/TestAddonVersions.js
@@ -353,11 +353,12 @@ describe(__filename, () => {
     expect(root.find(CardList)).toHaveProp('header', <LoadingText />);
   });
 
-  it('passes the errorHandler to the Page component', () => {
+  it('passes the errorHandler and isAddonInstallPage to the Page component', () => {
     const errorHandler = createCapturedErrorHandler({ status: 404 });
 
     const root = render({ errorHandler });
     expect(root.find(Page)).toHaveProp('errorHandler', errorHandler);
+    expect(root.find(Page)).toHaveProp('isAddonInstallPage', true);
   });
 
   describe('latest version', () => {


### PR DESCRIPTION
Fixes #10399 

