### PR TITLE
Do not prepend clientApp/locale in URLs of the Header when rendered for the blog

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -49,10 +49,10 @@ export class HeaderBase extends React.Component {
     siteUser: PropTypes.object,
     userAgentInfo: PropTypes.object,
     variant: PropTypes.string,
-    withBlogUI: PropTypes.bool,
+    forBlog: PropTypes.bool,
   };
 
-  static defaultProps = { _config: config, withBlogUI: false };
+  static defaultProps = { _config: config, forBlog: false };
 
   handleLogOut = (event) => {
     event.preventDefault();
@@ -62,7 +62,7 @@ export class HeaderBase extends React.Component {
 
   renderMenuOrAuthButton() {
     const {
-      withBlogUI,
+      forBlog,
       i18n,
       isReviewer,
       loadedPageIsAnonymous,
@@ -70,7 +70,7 @@ export class HeaderBase extends React.Component {
       siteUser,
     } = this.props;
 
-    if (withBlogUI || loadedPageIsAnonymous) {
+    if (forBlog || loadedPageIsAnonymous) {
       // The server has loaded a page that is marked as anonymous so we do not
       // want to render any menu or authentication button here so that
       // logged-in users are not confused.
@@ -171,7 +171,7 @@ export class HeaderBase extends React.Component {
     const {
       _config,
       clientApp,
-      withBlogUI,
+      forBlog,
       i18n,
       isAddonDetailPage,
       isHomePage,
@@ -182,7 +182,12 @@ export class HeaderBase extends React.Component {
     } = this.props;
 
     const headerLink = (
-      <Link className="Header-title" to="/">
+      <Link
+        className="Header-title"
+        to="/"
+        prependClientApp={!forBlog}
+        prependLang={!forBlog}
+      >
         <span className="visually-hidden">
           {
             // translators: "Firefox" should not be translated. :-)
@@ -245,14 +250,14 @@ export class HeaderBase extends React.Component {
             <SectionLinks
               className="Header-SectionLinks"
               location={location}
-              withBlogUI={withBlogUI}
+              forBlog={forBlog}
             />
           ) : null}
 
           <div className="Header-user-and-external-links">
             {otherSiteLinks}
 
-            {!withBlogUI && variant !== VARIANT_NEW ? (
+            {!forBlog && variant !== VARIANT_NEW ? (
               <GetFirefoxButton
                 buttonType={GET_FIREFOX_BUTTON_TYPE_HEADER}
                 className="Header-download-button Header-button"
@@ -262,7 +267,7 @@ export class HeaderBase extends React.Component {
             {this.renderMenuOrAuthButton()}
           </div>
 
-          {!withBlogUI && (
+          {!forBlog && (
             <SearchForm
               className={makeClassName('Header-search-form', {
                 'Header-search-form--desktop': clientApp === CLIENT_APP_FIREFOX,

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -31,7 +31,7 @@ import './styles.scss';
 
 type Props = {|
   className?: string,
-  withBlogUI?: boolean,
+  forBlog?: boolean,
 |};
 
 type PropsFromState = {|
@@ -66,10 +66,10 @@ export class SectionLinksBase extends React.Component<InternalProps> {
   };
 
   render(): React.Node {
-    const { className, clientApp, withBlogUI, i18n, viewContext } = this.props;
+    const { className, clientApp, forBlog, i18n, viewContext } = this.props;
     const isExploring =
       [VIEW_CONTEXT_EXPLORE, VIEW_CONTEXT_HOME].includes(viewContext) &&
-      !withBlogUI;
+      !forBlog;
 
     let forBrowserNameText;
     if (clientApp === CLIENT_APP_FIREFOX) {
@@ -98,7 +98,7 @@ export class SectionLinksBase extends React.Component<InternalProps> {
 
     return (
       <ul className={makeClassName('SectionLinks', className)}>
-        {withBlogUI && (
+        {forBlog && (
           <li>
             <Link
               className={makeClassName(
@@ -153,7 +153,7 @@ export class SectionLinksBase extends React.Component<InternalProps> {
             {i18n.gettext('Themes')}
           </Link>
         </li>
-        {!withBlogUI && (
+        {!forBlog && (
           <li>
             <DropdownMenu
               className="SectionLinks-link SectionLinks-dropdown"

--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -96,6 +96,11 @@ export class SectionLinksBase extends React.Component<InternalProps> {
       );
     }
 
+    const linkProps = {
+      prependClientApp: !forBlog,
+      prependLang: !forBlog,
+    };
+
     return (
       <ul className={makeClassName('SectionLinks', className)}>
         {forBlog && (
@@ -103,7 +108,7 @@ export class SectionLinksBase extends React.Component<InternalProps> {
             <Link
               className={makeClassName(
                 'SectionLinks-link',
-                'SectionLinks-blog',
+                'SectionLinks-link-blog',
                 'SectionLinks-link--active',
               )}
               href="/blog/"
@@ -118,22 +123,29 @@ export class SectionLinksBase extends React.Component<InternalProps> {
           <Link
             className={makeClassName(
               'SectionLinks-link',
-              'SectionLinks-explore',
+              'SectionLinks-link-explore',
               {
                 'SectionLinks-link--active': isExploring,
               },
             )}
             to="/"
+            {...linkProps}
           >
             {i18n.gettext('Explore')}
           </Link>
         </li>
         <li>
           <Link
-            className={makeClassName('SectionLinks-link', {
-              'SectionLinks-link--active': viewContext === ADDON_TYPE_EXTENSION,
-            })}
+            className={makeClassName(
+              'SectionLinks-link',
+              'SectionLinks-link-extension',
+              {
+                'SectionLinks-link--active':
+                  viewContext === ADDON_TYPE_EXTENSION,
+              },
+            )}
             to={`/${visibleAddonType(ADDON_TYPE_EXTENSION)}/`}
+            {...linkProps}
           >
             {i18n.gettext('Extensions')}
           </Link>
@@ -149,6 +161,7 @@ export class SectionLinksBase extends React.Component<InternalProps> {
               },
             )}
             to={`/${visibleAddonType(ADDON_TYPE_STATIC_THEME)}/`}
+            {...linkProps}
           >
             {i18n.gettext('Themes')}
           </Link>

--- a/src/blog-utils/index.js
+++ b/src/blog-utils/index.js
@@ -61,7 +61,7 @@ export const buildHeader = (): string => {
   const app = 'firefox';
   const lang = 'en-US';
 
-  return render({ app, lang, component: <Header withBlogUI /> });
+  return render({ app, lang, component: <Header forBlog /> });
 };
 
 type BuildStaticAddonCardParams = {|

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -319,6 +319,8 @@ describe(__filename, () => {
 
     const root = renderHeader({ store, forBlog: true });
 
+    expect(root.find('.Header-title')).toHaveProp('prependClientApp', false);
+    expect(root.find('.Header-title')).toHaveProp('prependLang', false);
     expect(root.find('.Header-authenticate-button')).toHaveLength(0);
     expect(root.find('.Header-download-button')).toHaveLength(0);
     expect(root.find(SearchForm)).toHaveLength(0);

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -317,11 +317,11 @@ describe(__filename, () => {
   it('can update its UI for the blog', () => {
     const { store } = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX });
 
-    const root = renderHeader({ store, withBlogUI: true });
+    const root = renderHeader({ store, forBlog: true });
 
     expect(root.find('.Header-authenticate-button')).toHaveLength(0);
     expect(root.find('.Header-download-button')).toHaveLength(0);
     expect(root.find(SearchForm)).toHaveLength(0);
-    expect(root.find(SectionLinks)).toHaveProp('withBlogUI', true);
+    expect(root.find(SectionLinks)).toHaveProp('forBlog', true);
   });
 });

--- a/tests/unit/amo/components/TestSectionLinks.js
+++ b/tests/unit/amo/components/TestSectionLinks.js
@@ -182,18 +182,49 @@ describe(__filename, () => {
   it('renders specific links for the blog', () => {
     const root = render({ forBlog: true });
 
-    expect(root.find('.SectionLinks-blog')).toHaveLength(1);
-    expect(root.find('.SectionLinks-blog')).toHaveClassName(
+    expect(root.find('.SectionLinks-link-blog')).toHaveLength(1);
+    expect(root.find('.SectionLinks-link-blog')).toHaveClassName(
       'SectionLinks-link--active',
     );
     // Make sure that only the "Blog" link is active.
     expect(root.find('.SectionLinks-link--active')).toHaveLength(1);
-    expect(root.find('.SectionLinks-blog')).toHaveProp('href', '/blog/');
-    expect(root.find('.SectionLinks-blog')).toHaveProp(
+    expect(root.find('.SectionLinks-link-blog')).toHaveProp('href', '/blog/');
+    expect(root.find('.SectionLinks-link-blog')).toHaveProp(
       'prependClientApp',
       false,
     );
-    expect(root.find('.SectionLinks-blog')).toHaveProp('prependLang', false);
+    expect(root.find('.SectionLinks-link-blog')).toHaveProp(
+      'prependLang',
+      false,
+    );
+
+    expect(root.find('.SectionLinks-link-explore')).toHaveProp(
+      'prependClientApp',
+      false,
+    );
+    expect(root.find('.SectionLinks-link-explore')).toHaveProp(
+      'prependLang',
+      false,
+    );
+
+    expect(root.find('.SectionLinks-link-extension')).toHaveProp(
+      'prependClientApp',
+      false,
+    );
+    expect(root.find('.SectionLinks-link-extension')).toHaveProp(
+      'prependLang',
+      false,
+    );
+
+    expect(root.find('.SectionLinks-link-theme')).toHaveProp(
+      'prependClientApp',
+      false,
+    );
+    expect(root.find('.SectionLinks-link-theme')).toHaveProp(
+      'prependLang',
+      false,
+    );
+
     // TODO: there is a UI problem that makes the dropdown ugly.
     expect(root.find('.SectionLinks-dropdown')).toHaveLength(0);
   });

--- a/tests/unit/amo/components/TestSectionLinks.js
+++ b/tests/unit/amo/components/TestSectionLinks.js
@@ -180,7 +180,7 @@ describe(__filename, () => {
   });
 
   it('renders specific links for the blog', () => {
-    const root = render({ withBlogUI: true });
+    const root = render({ forBlog: true });
 
     expect(root.find('.SectionLinks-blog')).toHaveLength(1);
     expect(root.find('.SectionLinks-blog')).toHaveClassName(

--- a/tests/unit/blog-utils/test_index.js
+++ b/tests/unit/blog-utils/test_index.js
@@ -66,7 +66,7 @@ describe(__filename, () => {
       const html = cheerio.load(buildHeader());
 
       expect(html('.Header')).toHaveLength(1);
-      expect(html('.SectionLinks-blog')).toHaveLength(1);
+      expect(html('.SectionLinks-link-blog')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10406

---

I renamed the special prop in the first commit because I find it a bit easier to read when used.