### PR TITLE
Render 'More...' link (header) for the blog and add link to the blog in the submenu

### DIFF
--- a/src/amo/components/SectionLinks/index.js
+++ b/src/amo/components/SectionLinks/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import config from 'config';
 import makeClassName from 'classnames';
 import * as React from 'react';
 import { compose } from 'redux';
@@ -39,15 +40,24 @@ type PropsFromState = {|
   viewContext: ViewContextType,
 |};
 
+type DefaultProps = {|
+  _config: typeof config,
+|};
+
 type InternalProps = {|
   ...Props,
   ...PropsFromState,
+  ...DefaultProps,
   dispatch: DispatchFunc,
-  i18n: I18nType,
   history: ReactRouterHistoryType,
+  i18n: I18nType,
 |};
 
 export class SectionLinksBase extends React.Component<InternalProps> {
+  static defaultProps: DefaultProps = {
+    _config: config,
+  };
+
   setClientApp: HTMLElementEventHandler = (event: ElementEvent) => {
     event.preventDefault();
 
@@ -66,7 +76,14 @@ export class SectionLinksBase extends React.Component<InternalProps> {
   };
 
   render(): React.Node {
-    const { className, clientApp, forBlog, i18n, viewContext } = this.props;
+    const {
+      _config,
+      className,
+      clientApp,
+      forBlog,
+      i18n,
+      viewContext,
+    } = this.props;
     const isExploring =
       [VIEW_CONTEXT_EXPLORE, VIEW_CONTEXT_HOME].includes(viewContext) &&
       !forBlog;
@@ -94,6 +111,24 @@ export class SectionLinksBase extends React.Component<InternalProps> {
           </Link>
         </DropdownMenuItem>,
       );
+
+      if (_config.get('enableFeatureLinkToNewBlog') || forBlog) {
+        sectionsForBrowser.push(
+          <DropdownMenuItem key="blog">
+            <Link
+              className={makeClassName(
+                'SectionLinks-dropdownlink',
+                'SectionLinks-dropdownlink-blog',
+              )}
+              href="/blog/"
+              prependClientApp={false}
+              prependLang={false}
+            >
+              {i18n.gettext('Blog')}
+            </Link>
+          </DropdownMenuItem>,
+        );
+      }
     }
 
     const linkProps = {
@@ -103,22 +138,6 @@ export class SectionLinksBase extends React.Component<InternalProps> {
 
     return (
       <ul className={makeClassName('SectionLinks', className)}>
-        {forBlog && (
-          <li>
-            <Link
-              className={makeClassName(
-                'SectionLinks-link',
-                'SectionLinks-link-blog',
-                'SectionLinks-link--active',
-              )}
-              href="/blog/"
-              prependClientApp={false}
-              prependLang={false}
-            >
-              {i18n.gettext('Blog')}
-            </Link>
-          </li>
-        )}
         <li>
           <Link
             className={makeClassName(
@@ -166,51 +185,49 @@ export class SectionLinksBase extends React.Component<InternalProps> {
             {i18n.gettext('Themes')}
           </Link>
         </li>
-        {!forBlog && (
-          <li>
-            <DropdownMenu
-              className="SectionLinks-link SectionLinks-dropdown"
-              text={i18n.gettext('More…')}
-            >
-              {sectionsForBrowser.length > 0 && (
-                <DropdownMenuItem className="SectionLinks-subheader">
-                  {forBrowserNameText}
-                </DropdownMenuItem>
-              )}
-              {sectionsForBrowser}
-
+        <li>
+          <DropdownMenu
+            className="SectionLinks-link SectionLinks-dropdown"
+            text={i18n.gettext('More…')}
+          >
+            {sectionsForBrowser.length > 0 && (
               <DropdownMenuItem className="SectionLinks-subheader">
-                {i18n.gettext('Other Browser Sites')}
+                {forBrowserNameText}
               </DropdownMenuItem>
-              {clientApp !== CLIENT_APP_ANDROID ? (
-                <DropdownMenuItem>
-                  <Link
-                    className={`SectionLinks-clientApp-${CLIENT_APP_ANDROID}`}
-                    data-clientapp={CLIENT_APP_ANDROID}
-                    onClick={this.setClientApp}
-                    prependClientApp={false}
-                    to={`/${CLIENT_APP_ANDROID}/`}
-                  >
-                    {i18n.gettext('Add-ons for Android')}
-                  </Link>
-                </DropdownMenuItem>
-              ) : null}
-              {clientApp !== CLIENT_APP_FIREFOX ? (
-                <DropdownMenuItem>
-                  <Link
-                    className={`SectionLinks-clientApp-${CLIENT_APP_FIREFOX}`}
-                    data-clientapp={CLIENT_APP_FIREFOX}
-                    onClick={this.setClientApp}
-                    prependClientApp={false}
-                    to={`/${CLIENT_APP_FIREFOX}/`}
-                  >
-                    {i18n.gettext('Add-ons for Firefox')}
-                  </Link>
-                </DropdownMenuItem>
-              ) : null}
-            </DropdownMenu>
-          </li>
-        )}
+            )}
+            {sectionsForBrowser}
+
+            <DropdownMenuItem className="SectionLinks-subheader">
+              {i18n.gettext('Other Browser Sites')}
+            </DropdownMenuItem>
+            {clientApp !== CLIENT_APP_ANDROID ? (
+              <DropdownMenuItem>
+                <Link
+                  className={`SectionLinks-clientApp-${CLIENT_APP_ANDROID}`}
+                  data-clientapp={CLIENT_APP_ANDROID}
+                  onClick={this.setClientApp}
+                  prependClientApp={false}
+                  to={`/${CLIENT_APP_ANDROID}/`}
+                >
+                  {i18n.gettext('Add-ons for Android')}
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+            {clientApp !== CLIENT_APP_FIREFOX ? (
+              <DropdownMenuItem>
+                <Link
+                  className={`SectionLinks-clientApp-${CLIENT_APP_FIREFOX}`}
+                  data-clientapp={CLIENT_APP_FIREFOX}
+                  onClick={this.setClientApp}
+                  prependClientApp={false}
+                  to={`/${CLIENT_APP_FIREFOX}/`}
+                >
+                  {i18n.gettext('Add-ons for Firefox')}
+                </Link>
+              </DropdownMenuItem>
+            ) : null}
+          </DropdownMenu>
+        </li>
       </ul>
     );
   }

--- a/src/blog-utils/index.html
+++ b/src/blog-utils/index.html
@@ -10,6 +10,10 @@
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/inter-ui/3.18.0/inter.min.css" integrity="sha512-LmuBiKMv0sdyc1LQk0LPrsjj3KSoVgVpAXUoFGY8Ye5Zi1mff0it3I42dkh3/NGQgtkqiHcdWOcHGUmOzYLETQ==" crossorigin="anonymous" />
 		<link href="/style.css" rel="stylesheet" type="text/css">
 		<style>
+			* {
+				box-sizing: border-box;
+			}
+
 			body {
 				font-family: Inter;
 			}
@@ -21,8 +25,7 @@
 
 			.content {
 				margin: 1em auto;
-				max-width: 900px;
-				padding: 1em;
+				max-width: 625px;
 			}
 		</style>
 	</head>

--- a/src/blog-utils/index.js
+++ b/src/blog-utils/index.js
@@ -17,6 +17,8 @@ import { createInternalAddon } from 'amo/reducers/addons';
 
 import StaticAddonCard from './StaticAddonCard';
 
+import './styles.scss';
+
 const AMO_BASE_URL = 'https://addons.mozilla.org';
 
 type RenderParams = {|

--- a/src/blog-utils/styles.scss
+++ b/src/blog-utils/styles.scss
@@ -1,0 +1,8 @@
+.DropdownMenu {
+  // This is added as a global style on AMO but we don't use all of the AMO CSS
+  // in this library so this is why we have to declare some style here.
+  button {
+    background: none;
+    border: none;
+  }
+}

--- a/tests/unit/amo/components/TestSectionLinks.js
+++ b/tests/unit/amo/components/TestSectionLinks.js
@@ -18,6 +18,7 @@ import {
   createFakeHistory,
   dispatchClientMetadata,
   fakeI18n,
+  getFakeConfig,
   shallowUntilTarget,
 } from 'tests/unit/helpers';
 import DropdownMenu from 'amo/components/DropdownMenu';
@@ -179,25 +180,9 @@ describe(__filename, () => {
     sinon.assert.calledWith(fakeHistory.push, `/en-US/${CLIENT_APP_ANDROID}/`);
   });
 
-  it('renders specific links for the blog', () => {
+  it('renders links without clientApp/locale for the blog', () => {
     const root = render({ forBlog: true });
 
-    expect(root.find('.SectionLinks-link-blog')).toHaveLength(1);
-    expect(root.find('.SectionLinks-link-blog')).toHaveClassName(
-      'SectionLinks-link--active',
-    );
-    // Make sure that only the "Blog" link is active.
-    expect(root.find('.SectionLinks-link--active')).toHaveLength(1);
-    expect(root.find('.SectionLinks-link-blog')).toHaveProp('href', '/blog/');
-    expect(root.find('.SectionLinks-link-blog')).toHaveProp(
-      'prependClientApp',
-      false,
-    );
-    expect(root.find('.SectionLinks-link-blog')).toHaveProp(
-      'prependLang',
-      false,
-    );
-
     expect(root.find('.SectionLinks-link-explore')).toHaveProp(
       'prependClientApp',
       false,
@@ -224,8 +209,32 @@ describe(__filename, () => {
       'prependLang',
       false,
     );
+  });
 
-    // TODO: there is a UI problem that makes the dropdown ugly.
-    expect(root.find('.SectionLinks-dropdown')).toHaveLength(0);
+  it('adds a link to the blog in the "More..." dropdown submenu for the blog', () => {
+    // The "More..." link is not rendered on Android.
+    _store.dispatch(setClientApp(CLIENT_APP_FIREFOX));
+
+    const root = render({ forBlog: true });
+
+    expect(
+      root.find('.SectionLinks-dropdownlink').findWhere((element) => {
+        return element.prop('href') === '/blog/';
+      }),
+    ).toHaveLength(1);
+  });
+
+  it('renders a link to the new blog when the feature flag is active', () => {
+    // The "More..." link is not rendered on Android.
+    _store.dispatch(setClientApp(CLIENT_APP_FIREFOX));
+    const _config = getFakeConfig({ enableFeatureLinkToNewBlog: true });
+
+    const root = render({ _config });
+
+    expect(
+      root.find('.SectionLinks-dropdownlink').findWhere((element) => {
+        return element.prop('href') === '/blog/';
+      }),
+    ).toHaveLength(1);
   });
 });

--- a/tests/unit/blog-utils/test_index.js
+++ b/tests/unit/blog-utils/test_index.js
@@ -66,7 +66,7 @@ describe(__filename, () => {
       const html = cheerio.load(buildHeader());
 
       expect(html('.Header')).toHaveLength(1);
-      expect(html('.SectionLinks-link-blog')).toHaveLength(1);
+      expect(html('.SectionLinks-dropdownlink-blog')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Fixes #10407 

---

Note: the `buildHeader()` function only returns HTML and we use JS to open/close the dropdown, so this won't work on the dev page. The `blog-utils` library does not provide any "production" JS code, which is why there is no JS in this patch. I have some JS to animate the dropdown in `addons-blog`. Maybe it could be moved in this project in the future but that will require some more webpack config and a few changes. I think this is something we will want to do in the future, if we keep the blog after the pilot.