### PR TITLE
Fix new CTA on 720px screen

### DIFF
--- a/src/amo/components/InstallButtonWrapper/styles.scss
+++ b/src/amo/components/InstallButtonWrapper/styles.scss
@@ -28,12 +28,25 @@
     display: flex;
     flex-direction: column;
 
-    @include respond-to(medium) {
-      justify-content: center;
-      width: fit-content;
+    .GetFirefoxButton-button,
+    .GetFirefoxButton-callout {
+      max-width: 100%;
+      text-align: center;
+      white-space: initial;
+      width: 100%;
+    }
 
-      .GetFirefoxButton-callout {
-        width: 100%;
+    @include respond-to(medium) {
+      width: fit-content;
+    }
+
+    @include respond-to(large) {
+      width: auto;
+    }
+
+    @include respond-to(extraLarge) {
+      .GetFirefoxButton-button {
+        white-space: nowrap;
       }
     }
   }


### PR DESCRIPTION
Fixes #10442

Before: 
![Screen Shot 2021-04-19 at 3 55 58 PM](https://user-images.githubusercontent.com/142755/115295441-c375b600-a127-11eb-8a16-14086df42621.png)

After:
![Screen Shot 2021-04-20 at 10 30 44 AM](https://user-images.githubusercontent.com/142755/115413850-88c15b80-a1c3-11eb-8cf4-ff17fc99e9b4.png)

Note that the reduced padding for the blue button at this specific resolution is something we're going to live with. It only affects screens from 720px - 730px.
