### PR TITLE
Clean up line-heights

### DIFF
--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -2,7 +2,7 @@
 
 .AddonReviewCard {
   .Rating {
-    height: $default-line-height;
+    height: $font-size-l;
   }
 
   &:not(.AddonReviewCard-slim) .UserReview-body {
@@ -59,7 +59,7 @@
   color: $blue-50;
   font-size: $font-size-s;
   height: auto;
-  line-height: $default-line-height;
+  line-height: $line-height-body;
   padding: 0;
 
   &.Button.Button--neutral:hover {

--- a/src/amo/components/AddonReviewManagerRating/styles.scss
+++ b/src/amo/components/AddonReviewManagerRating/styles.scss
@@ -22,7 +22,7 @@
     flex-direction: row;
 
     .Rating {
-      height: $default-line-height;
+      height: $font-size-l;
       margin: 0;
       width: auto;
 

--- a/src/amo/components/AddonSummaryCard/styles.scss
+++ b/src/amo/components/AddonSummaryCard/styles.scss
@@ -44,7 +44,7 @@
     @include font-bold();
 
     font-size: $font-size-l;
-    line-height: $default-line-height;
+    line-height: $line-height-body;
     margin: 0;
     padding: 0;
 

--- a/src/amo/components/AddonTitle/styles.scss
+++ b/src/amo/components/AddonTitle/styles.scss
@@ -6,7 +6,6 @@
   color: $black;
   font-size: $font-size-heading-s;
   grid-column: 1 / span 2;
-  line-height: 1.1;
   margin: 0 0 $padding-page-l;
   width: 100%;
 

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -23,7 +23,6 @@ textarea {
   box-shadow: none;
   color: $black;
   font-size: $font-size-m;
-  line-height: 1.4;
   padding: 4px;
 }
 
@@ -43,7 +42,7 @@ body {
 
   color: $body-font-color;
   font-size: $font-size-default;
-  line-height: $default-line-height;
+  line-height: $line-height-body;
 }
 
 #react-view {
@@ -56,11 +55,11 @@ h2 {
 
   color: $primary-font-color;
   font-weight: 600;
+  line-height: $line-height-compressed;
 }
 
 h1 {
   font-size: $font-size-heading-m;
-  line-height: 1;
 }
 
 h2 {
@@ -71,7 +70,7 @@ h3 {
   @include font-bold();
 
   font-size: 14px;
-  line-height: 19px;
+  line-height: $line-height-compressed;
 }
 
 a:link {
@@ -91,7 +90,6 @@ strong {
 .caption {
   color: $primary-font-color;
   font-size: 10px;
-  line-height: 11px;
 }
 
 .date-time {

--- a/src/amo/components/AutoSearchInput/styles.scss
+++ b/src/amo/components/AutoSearchInput/styles.scss
@@ -14,7 +14,6 @@
   border-radius: $border-radius-s;
   color: $black;
   height: 27px;
-  line-height: 27px;
   outline: 0;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -3,7 +3,7 @@
 .Badge {
   color: $grey-90;
   font-size: $font-size-m;
-  line-height: 1.2;
+  line-height: $line-height-compressed;
   margin: 0 0 6px;
 
   @include respond-to(large) {

--- a/src/amo/components/Button/styles.scss
+++ b/src/amo/components/Button/styles.scss
@@ -22,7 +22,7 @@ $default-font-size: 13px;
   display: inline-flex;
   height: 32px;
   justify-content: center;
-  line-height: 1.3;
+  line-height: $line-height-compressed;
   margin: 0;
   padding: 0 8px;
   text-decoration: none;

--- a/src/amo/components/DropdownMenuItem/styles.scss
+++ b/src/amo/components/DropdownMenuItem/styles.scss
@@ -3,7 +3,6 @@
 .DropdownMenuItem-section {
   color: $grey-50;
   font-size: $font-size-s;
-  line-height: 1.6;
   margin: 16px 0 0;
 }
 
@@ -16,7 +15,6 @@
     color: $grey-90;
     cursor: pointer;
     font-size: $font-size-m;
-    line-height: 1.6;
     margin: 0;
     padding: 0;
     text-decoration: none;

--- a/src/amo/components/GetFirefoxBanner/styles.scss
+++ b/src/amo/components/GetFirefoxBanner/styles.scss
@@ -11,7 +11,6 @@
   color: $grey-90;
   font-size: $font-size-s;
   left: 50%;
-  line-height: 1.5;
   padding: 12px 40px;
   position: fixed;
   text-align: center;

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -30,7 +30,6 @@
 .Header-content {
   grid-column: 1 / span 4;
   grid-row: 2 / 4;
-  line-height: 1;
   margin: 0 0 36px;
   text-align: center;
   width: 100%;

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -54,6 +54,7 @@
 .HeroRecommendation-info {
   display: flex;
   flex-direction: column;
+  line-height: $line-height-compressed;
 
   @include respond-to(medium) {
     @include margin-start(24px);
@@ -78,7 +79,6 @@
   display: inline;
   font-size: $font-size-s;
   letter-spacing: 0.1em;
-  line-height: 1.143;
   margin: 0;
   opacity: 0.5;
 
@@ -122,7 +122,6 @@
 
   color: $white;
   font-size: $font-size-heading-s;
-  line-height: 1.188;
   margin: 14px 0 0 0;
 
   @include respond-to(extraExtraLarge) {
@@ -134,7 +133,7 @@
   @include font-light();
 
   font-size: $font-size-s;
-  line-height: 1.666;
+  line-height: $line-height-body;
   margin: 18px 0 24px 0;
 
   @include respond-to(medium) {
@@ -191,7 +190,6 @@
   border: 4px solid $white;
   display: inline-block;
   font-size: $font-size-l;
-  line-height: 1.25;
   padding: 12px 24px;
   text-align: center;
   // The theme styles will add a hover effect.

--- a/src/amo/components/LoadingText/styles.scss
+++ b/src/amo/components/LoadingText/styles.scss
@@ -27,7 +27,6 @@
   background: $grey-30;
   display: inline-block;
   height: 1rem;
-  line-height: 1;
   margin: 0;
   vertical-align: middle;
 }

--- a/src/amo/components/MetadataCard/styles.scss
+++ b/src/amo/components/MetadataCard/styles.scss
@@ -21,13 +21,11 @@
   max-width: 25%;
 
   dd {
-    line-height: 1.4;
     margin: 0;
     min-height: 18px;
   }
 
   dt {
     color: $grey-50;
-    line-height: 1.4;
   }
 }

--- a/src/amo/components/Notice/styles.scss
+++ b/src/amo/components/Notice/styles.scss
@@ -13,7 +13,7 @@
     background-color: transparent;
     display: flex;
     justify-content: center;
-    line-height: $default-line-height;
+    line-height: $line-height-body;
     padding: 0;
   }
 
@@ -47,7 +47,7 @@
 
 .Notice-light .Notice-icon {
   // Reduce the icon size for light notices so that the total
-  // height of the notice adds up to $default-line-height.
+  // height of the notice adds up to $line-height-body.
 
   background-size: 11px 11px;
   height: 11px;
@@ -82,7 +82,7 @@
   &.Button--micro:link {
     border: none;
     font-size: $font-size-s;
-    line-height: 1.1;
+    line-height: $line-height-compressed;
     margin-bottom: 4px;
     margin-top: 4px;
     padding: 6px;

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -7,7 +7,7 @@
   grid-gap: 12px;
   grid-template-columns: max-content auto max-content;
   // This controls whitespace and should also match the bar height.
-  line-height: 16px;
+  line-height: 1;
 }
 
 .RatingsByStar-star {

--- a/src/amo/components/ScreenShots/styles.scss
+++ b/src/amo/components/ScreenShots/styles.scss
@@ -19,7 +19,6 @@ $screenshot-width: 320px;
 .ScreenShots-list {
   display: flex;
   height: $screenshot-height;
-  line-height: 0;
   list-style-type: none;
   margin: 0;
   overflow-x: scroll;

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -122,7 +122,7 @@ $icon-default-size: 32px;
   flex-grow: 1;
   flex-wrap: wrap;
   font-size: $font-size-m;
-  line-height: 1.2;
+  line-height: $line-height-compressed;
   margin: 0;
   padding: 0;
   text-decoration: none;

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -28,7 +28,6 @@
   @include font-regular();
 
   font-size: $font-size-hero-m;
-  line-height: 1.5;
   margin-top: 0;
   padding: 0 10px 10px 10px;
 
@@ -41,7 +40,7 @@
   @include font-medium();
 
   font-size: $font-size-hero-message-headline;
-  line-height: 1.333;
+  line-height: $line-height-compressed;
   margin: 0;
 
   .LoadingText {
@@ -68,7 +67,6 @@
   display: flex;
   flex-direction: column;
   font-size: $font-size-hero-m;
-  line-height: 1.5;
   padding: $padding-page 0;
   padding-top: 0;
 

--- a/src/amo/components/Select/styles.scss
+++ b/src/amo/components/Select/styles.scss
@@ -11,7 +11,7 @@
   border: 0;
   border-radius: $border-radius-s;
   display: block;
-  line-height: 1.2;
+  line-height: $line-height-compressed;
   overflow: hidden;
   padding-bottom: 10px;
   padding-top: 10px;

--- a/src/amo/components/TooltipMenu/styles.scss
+++ b/src/amo/components/TooltipMenu/styles.scss
@@ -15,7 +15,7 @@
 .TooltipMenu-opener {
   color: $blue-50;
   cursor: pointer;
-  line-height: 1.6;
+  line-height: $line-height-body;
   margin: 0;
   padding: 0;
 }
@@ -81,7 +81,7 @@
 
         color: $grey-90;
         font-size: $font-size-m;
-        line-height: 1.6;
+        line-height: $line-height-body;
       }
     }
 

--- a/src/amo/components/UserProfileEditNotifications/styles.scss
+++ b/src/amo/components/UserProfileEditNotifications/styles.scss
@@ -4,7 +4,7 @@ $input-height: 16px;
 
 .UserProfileEditNotifications {
   .UserProfileEditNotification {
-    line-height: $input-height;
+    line-height: $line-height-compressed;
 
     label {
       @include padding-start(12px);

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -21,8 +21,11 @@ $showmorecard-gradient-color: #f4f9ff;
 // Fonts
 $default-font-family: 'Clear Sans', Helvetica, Arial, sans-serif;
 
+// Line-Height Variables
+$line-height-body: 1.5;
+$line-height-compressed: 1.2;
+
 // Font-Size Variables
-$default-line-height: 1.5;
 $font-size-default: 16px;
 $font-size-xs: 12px;
 $font-size-s: 14px;

--- a/src/amo/pages/AddonReviewList/styles.scss
+++ b/src/amo/pages/AddonReviewList/styles.scss
@@ -50,11 +50,15 @@
   flex-grow: 1;
   // This creates vertical space when items are wrapped on very
   // small-width screens.
-
-  line-height: 36px;
-  margin: auto;
+  margin: 6px auto 6px auto;
 
   @include margin-start(0);
+
+  @include respond-to(medium) {
+    margin: auto;
+
+    @include margin-start(0);
+  }
 }
 
 .AddonReviewList-filterByScore {

--- a/src/amo/pages/AddonVersions/styles.scss
+++ b/src/amo/pages/AddonVersions/styles.scss
@@ -42,7 +42,6 @@
 }
 
 .AddonVersions-warning-text {
-  line-height: $default-line-height;
   margin: 0;
 }
 

--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -165,7 +165,6 @@
 
 .Home-heroHeader-title {
   font-size: $font-size-heading-s;
-  line-height: 1;
   margin: $padding-page-l 0 20px;
 
   @include respond-to(medium) {
@@ -176,12 +175,10 @@
 .Home-heroHeader-subtitle {
   font-size: 20px;
   font-weight: normal;
-  line-height: 1.15;
   margin: $padding-page 0 $padding-page-l;
 
   @include respond-to(medium) {
     font-size: $font-size-heading-s;
-    line-height: 1;
   }
 }
 

--- a/src/amo/pages/LandingPage/styles.scss
+++ b/src/amo/pages/LandingPage/styles.scss
@@ -51,7 +51,6 @@
   @include font-regular();
 
   font-size: $font-size-s;
-  line-height: 1.5;
   margin: 0;
   max-width: 600px;
 

--- a/src/amo/pages/UserProfile/styles.scss
+++ b/src/amo/pages/UserProfile/styles.scss
@@ -73,7 +73,7 @@ $avatar-size: 64px;
 }
 
 .UserProfile-rating-average .Rating {
-  height: $default-line-height;
+  height: $font-size-l;
   justify-content: start;
 }
 

--- a/src/amo/pages/UserProfileEdit/styles.scss
+++ b/src/amo/pages/UserProfileEdit/styles.scss
@@ -30,8 +30,8 @@ $font-size-aside: 10px;
       @include font-bold();
 
       font-size: $font-size-default;
-      line-height: 2;
       list-style-type: none;
+      margin-top: $padding-page;
     }
   }
 }


### PR DESCRIPTION
Fixes #10251

This changes the default line-height for body to `1.5` and the line-height used for everything else to `1.2`. I only had to keep once instance of a specific line-height other than those two, and that is for `.RatingsByStar-graph` in order to make the rows the right height.
