### PR TITLE
RE: Fix addon_type property for homepage shelves

### DIFF
--- a/src/amo/reducers/home.js
+++ b/src/amo/reducers/home.js
@@ -146,7 +146,7 @@ export type ExternalResultShelfType = {|
   title: LocalizedString,
   url: string,
   endpoint: string,
-  addonType: AddonTypeType,
+  addon_type: AddonTypeType,
   criteria: string,
   footer: ExternalHeroCallToActionType | null,
   addons: Array<ExternalAddonType>,
@@ -313,7 +313,7 @@ export const createInternalShelf = (
     title: selectLocalizedContent(result.title, lang),
     url: result.url,
     endpoint: result.endpoint,
-    addonType: result.addonType,
+    addonType: result.addon_type,
     criteria: result.criteria,
     footer: result.footer
       ? createInternalHeroCallToAction(result.footer, lang)

--- a/tests/unit/amo/components/TestHomepageShelves.js
+++ b/tests/unit/amo/components/TestHomepageShelves.js
@@ -115,9 +115,9 @@ describe(__filename, () => {
     [true, HOMESHELVES_ENDPOINT_SEARCH, ADDON_TYPE_STATIC_THEME],
   ])(
     'passes isTheme as %s when endpoint is %s with addon type %s',
-    (isTheme, endpoint, addonType) => {
+    (isTheme, endpoint, addon_type) => {
       const root = render({
-        shelves: [_createShelf({ endpoint, addonType })],
+        shelves: [_createShelf({ endpoint, addon_type })],
       });
 
       expect(root.find(LandingAddonsCard)).toHaveProp('isTheme', isTheme);
@@ -134,9 +134,9 @@ describe(__filename, () => {
     [3, HOMESHELVES_ENDPOINT_SEARCH, ADDON_TYPE_STATIC_THEME],
   ])(
     'passes placeholderCount as %s when endpoint is %s with addon type %s',
-    (placeholderCount, endpoint, addonType) => {
+    (placeholderCount, endpoint, addon_type) => {
       const root = render({
-        shelves: [_createShelf({ endpoint, addonType })],
+        shelves: [_createShelf({ endpoint, addon_type })],
       });
 
       expect(root.find(LandingAddonsCard)).toHaveProp(

--- a/tests/unit/amo/reducers/test_home.js
+++ b/tests/unit/amo/reducers/test_home.js
@@ -463,7 +463,7 @@ describe(__filename, () => {
 
       expect(createInternalShelf(shelf, lang)).toEqual({
         addons: [createInternalAddon(addon, lang)],
-        addonType: shelf.addonType,
+        addon_type: shelf.addon_type,
         criteria: shelf.criteria,
         endpoint: shelf.endpoint,
         footer: createInternalHeroCallToAction(shelf.footer, lang),


### PR DESCRIPTION
Fixes #10496

@bobsilverberg, the addon_type property was lost in `createInternalShelf()`. I had not updated `ExternalResultShelfType` correctly - `addon_type` instead of `addonType`. Please review when you have a moment. Thank you!