### PR TITLE
Downgrade a log statement from warn to debug

### DIFF
--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -249,7 +249,7 @@ export function fetchAddon({
   const { clientApp, userAgentInfo } = api;
   const appVersion = userAgentInfo.browser.version;
   if (!appVersion) {
-    log.warn(
+    log.debug(
       `Failed to parse appversion for client app ${clientApp || '[empty]'}`,
     );
   }


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10493

---

This log statement does not seem very useful in production because we call the
API anyway and parsing `appversion` is handled by a 3rd party library.