### PR TITLE
Use utm_term to pass the addonId and variant to mozilla.org on download URLs

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -424,6 +424,6 @@ module.exports = {
     // See: https://github.com/mozilla/addons-frontend/pull/9125#issuecomment-580683288
     //
     // e.g., 20200204_installWarning: true,
-    '20210404_download_cta_experiment': false,
+    '20210404_download_cta_experiment': true,
   },
 };

--- a/src/amo/components/GetFirefoxBanner/index.js
+++ b/src/amo/components/GetFirefoxBanner/index.js
@@ -5,11 +5,14 @@ import { compose } from 'redux';
 
 import Button from 'amo/components/Button';
 import {
-  getDownloadCampaign,
+  getDownloadTerm,
   getDownloadCategory,
 } from 'amo/components/GetFirefoxButton';
 import Notice from 'amo/components/Notice';
-import { DOWNLOAD_FIREFOX_BASE_URL } from 'amo/constants';
+import {
+  DOWNLOAD_FIREFOX_BASE_URL,
+  DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
+} from 'amo/constants';
 import { VARIANT_NEW } from 'amo/experiments/20210404_download_cta_experiment';
 import tracking from 'amo/tracking';
 import { makeQueryStringWithUTM } from 'amo/utils';
@@ -84,8 +87,9 @@ export const GetFirefoxBannerBase = ({
               buttonType="none"
               className="GetFirefoxBanner-button"
               href={`${DOWNLOAD_FIREFOX_BASE_URL}${makeQueryStringWithUTM({
-                utm_campaign: getDownloadCampaign({ variant: VARIANT_NEW }),
+                utm_campaign: DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
                 utm_content: GET_FIREFOX_BANNER_UTM_CONTENT,
+                utm_term: getDownloadTerm({ variant: VARIANT_NEW }),
               })}`}
               key="GetFirefoxBanner-button"
               onClick={onButtonClick}

--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -16,6 +16,7 @@ import {
   CLIENT_APP_FIREFOX,
   DOWNLOAD_FIREFOX_BASE_URL,
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
+  DOWNLOAD_FIREFOX_UTM_TERM,
   RECOMMENDED,
 } from 'amo/constants';
 import translate from 'amo/i18n/translate';
@@ -69,20 +70,24 @@ type InternalProps = {|
   i18n: I18nType,
 |};
 
-export const getDownloadCampaign = ({
-  // eslint-disable-next-line no-unused-vars
+export const getDownloadTerm = ({
   addonId,
-  // eslint-disable-next-line no-unused-vars
   variant,
 }: {|
   addonId?: number,
   variant?: string,
 |} = {}): string => {
-  // TODO: add `addonId` and `variant` when they are provided BUT note that
-  // changing the `utm_campaign` is currently NOT possible because it breaks
-  // RTAMO.
+  let term = DOWNLOAD_FIREFOX_UTM_TERM;
 
-  return DOWNLOAD_FIREFOX_UTM_CAMPAIGN;
+  if (addonId) {
+    term = `${term}-${addonId}`;
+  }
+
+  if (variant) {
+    term = `${term}-${variant}`;
+  }
+
+  return term;
 };
 
 export const getDownloadCategory = (variant: string): string =>
@@ -124,8 +129,8 @@ export const GetFirefoxButtonBase = ({
   let calloutText;
   let micro = false;
   let puffy = false;
-  let utmCampaign;
   let utmContent;
+  let utmTerm;
 
   switch (buttonType) {
     case GET_FIREFOX_BUTTON_TYPE_ADDON: {
@@ -159,16 +164,15 @@ export const GetFirefoxButtonBase = ({
             : i18n.gettext(`You'll need Firefox to use this extension`);
       }
       puffy = true;
-      utmCampaign = getDownloadCampaign({ addonId: addon.id, variant });
-
       utmContent = addon.guid ? `rta:${_encode(addon.guid)}` : '';
+      utmTerm = getDownloadTerm({ addonId: addon.id, variant });
       break;
     }
     case GET_FIREFOX_BUTTON_TYPE_HEADER: {
       buttonText = i18n.gettext('Download Firefox');
       micro = true;
-      utmCampaign = getDownloadCampaign({ variant });
       utmContent = 'header-download-button';
+      utmTerm = getDownloadTerm({ variant });
       break;
     }
     default:
@@ -189,8 +193,9 @@ export const GetFirefoxButtonBase = ({
         className,
       )}
       href={`${DOWNLOAD_FIREFOX_BASE_URL}${makeQueryStringWithUTM({
-        utm_campaign: utmCampaign,
+        utm_campaign: DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
         utm_content: utmContent,
+        utm_term: utmTerm,
       })}`}
       micro={micro}
       onClick={onButtonClick}

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -313,6 +313,7 @@ export const AMO_REQUEST_ID_HEADER = 'amo-request-id';
 export const DEFAULT_UTM_SOURCE = 'addons.mozilla.org';
 export const DEFAULT_UTM_MEDIUM = 'referral';
 export const DOWNLOAD_FIREFOX_UTM_CAMPAIGN = 'non-fx-button';
+export const DOWNLOAD_FIREFOX_UTM_TERM = 'amo-fx-cta';
 
 // Promoted categories
 export const LINE = 'line';

--- a/src/amo/utils/index.js
+++ b/src/amo/utils/index.js
@@ -15,6 +15,7 @@ import {
   API_ADDON_TYPES_MAPPING,
   DEFAULT_UTM_MEDIUM,
   DEFAULT_UTM_SOURCE,
+  DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
   PROMOTED_ADDONS_SUMO_URL,
   VISIBLE_ADDON_TYPES_MAPPING,
 } from 'amo/constants';
@@ -42,21 +43,24 @@ export function getAddonURL(slug: string): string {
 }
 
 export const makeQueryStringWithUTM = ({
-  utm_source = DEFAULT_UTM_SOURCE,
-  utm_medium = DEFAULT_UTM_MEDIUM,
-  utm_campaign = 'non-fx-button',
+  utm_campaign = DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
   utm_content = null,
+  utm_medium = DEFAULT_UTM_MEDIUM,
+  utm_source = DEFAULT_UTM_SOURCE,
+  utm_term = null,
 }: {|
-  utm_source?: string,
-  utm_medium?: string,
   utm_campaign?: string | null,
   utm_content?: string | null,
+  utm_medium?: string,
+  utm_source?: string,
+  utm_term?: string | null,
 |}): string => {
   return makeQueryString({
-    utm_source,
-    utm_medium,
     utm_campaign,
     utm_content,
+    utm_medium,
+    utm_source,
+    utm_term,
   });
 };
 

--- a/tests/unit/amo/components/TestGetFirefoxBanner.js
+++ b/tests/unit/amo/components/TestGetFirefoxBanner.js
@@ -14,6 +14,7 @@ import Notice from 'amo/components/Notice';
 import {
   DOWNLOAD_FIREFOX_BASE_URL,
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
+  DOWNLOAD_FIREFOX_UTM_TERM,
 } from 'amo/constants';
 import { makeQueryStringWithUTM } from 'amo/utils';
 import {
@@ -98,8 +99,9 @@ describe(__filename, () => {
 
       const expectedHref = `${DOWNLOAD_FIREFOX_BASE_URL}${makeQueryStringWithUTM(
         {
-          utm_content: GET_FIREFOX_BANNER_UTM_CONTENT,
           utm_campaign: DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
+          utm_content: GET_FIREFOX_BANNER_UTM_CONTENT,
+          utm_term: `${DOWNLOAD_FIREFOX_UTM_TERM}-${VARIANT_NEW}`,
         },
       )}`;
       expect(root.find(Button)).toHaveProp('href', expectedHref);


### PR DESCRIPTION
Fixes #10479 