### PR TITLE
Add support for themes in StaticAddonCard

### DIFF
--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -1,6 +1,8 @@
 /* @flow */
 import * as React from 'react';
+import makeClassName from 'classnames';
 
+import { ADDON_TYPE_STATIC_THEME } from 'amo/constants';
 import { getAddonIconUrl } from 'amo/imageUtils';
 import { nl2br, sanitizeHTML } from 'amo/utils';
 import AddonBadges from 'amo/components/AddonBadges';
@@ -9,6 +11,7 @@ import GetFirefoxButton, {
   GET_FIREFOX_BUTTON_TYPE_ADDON,
 } from 'amo/components/GetFirefoxButton';
 import Rating from 'amo/components/Rating';
+import ThemeImage from 'amo/components/ThemeImage';
 import translate from 'amo/i18n/translate';
 import type { AddonType } from 'amo/types/addons';
 import type { I18nType } from 'amo/types/i18n';
@@ -35,18 +38,30 @@ export const StaticAddonCardBase = ({
   const summary = addon.summary ? addon.summary : addon.description;
   const averageRating = addon.ratings ? addon.ratings.average : null;
   const averageDailyUsers = addon.average_daily_users || null;
+  const isTheme = addon.type === ADDON_TYPE_STATIC_THEME;
 
   return (
-    <div className="StaticAddonCard" data-addon-id={addon.id}>
-      <div className="StaticAddonCard-icon">
-        <div className="StaticAddonCard-icon-wrapper">
-          <img
-            className="StaticAddonCard-icon-image"
-            src={getAddonIconUrl(addon)}
-            alt=""
-          />
+    <div
+      className={makeClassName('StaticAddonCard', {
+        'StaticAddonCard--is-theme': isTheme,
+      })}
+      data-addon-id={addon.id}
+    >
+      {isTheme ? (
+        <div className="StaticAddonCard-theme-preview">
+          <ThemeImage addon={addon} roundedCorners />
         </div>
-      </div>
+      ) : (
+        <div className="StaticAddonCard-icon">
+          <div className="StaticAddonCard-icon-wrapper">
+            <img
+              className="StaticAddonCard-icon-image"
+              src={getAddonIconUrl(addon)}
+              alt=""
+            />
+          </div>
+        </div>
+      )}
 
       <AddonTitle addon={addon} />
 

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -24,6 +24,10 @@ $icon-size: 48px;
   margin-bottom: 10px;
   width: auto;
 
+  .StaticAddonCard--is-theme & {
+    grid-row: 2;
+  }
+
   .PromotedBadge {
     font-size: $font-size-s;
   }
@@ -32,6 +36,12 @@ $icon-size: 48px;
     grid-column: 4;
     margin: 0 0 0 auto;
   }
+}
+
+.StaticAddonCard-theme-preview {
+  grid-column: 1 / span 4;
+  grid-row: 1;
+  margin-bottom: 20px;
 }
 
 .StaticAddonCard-icon {
@@ -62,6 +72,10 @@ $icon-size: 48px;
   grid-row: 2;
   margin: 0;
 
+  .StaticAddonCard--is-theme & {
+    grid-column: 1 / span 3;
+  }
+
   & .AddonTitle-author,
   & .AddonTitle-author a,
   & .AddonTitle-author a:link {
@@ -72,6 +86,11 @@ $icon-size: 48px;
   @include respond-to(medium) {
     grid-column: 2 / span 2;
     grid-row: 1;
+
+    .StaticAddonCard--is-theme & {
+      grid-column: 1 / span 3;
+      grid-row: 2;
+    }
   }
 }
 
@@ -87,6 +106,10 @@ $icon-size: 48px;
   @include respond-to(medium) {
     grid-row: 2;
   }
+
+  .StaticAddonCard--is-theme & {
+    grid-row: 3;
+  }
 }
 
 .StaticAddonCard-metadata {
@@ -101,6 +124,10 @@ $icon-size: 48px;
 
   @include respond-to(medium) {
     grid-row: 3;
+
+    .StaticAddonCard--is-theme & {
+      grid-row: 4;
+    }
   }
 }
 
@@ -110,6 +137,10 @@ $icon-size: 48px;
   grid-row: 5;
   text-align: center;
   width: 100%;
+
+  .StaticAddonCard--is-theme & {
+    grid-row: 5;
+  }
 
   &,
   .GetFirefoxButton-button,

--- a/src/blog-utils/index.html
+++ b/src/blog-utils/index.html
@@ -41,6 +41,9 @@
 
 			<p>AMO info (not a recommended extension)</p>
 			<div class="addon-card" data-addon-id="1000795"></div>
+
+			<p>A static theme</p>
+			<div class="addon-card" data-addon-id="2597127"></div>
 		</div>
 
 		<footer id="footer"></footer>

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { ADDON_TYPE_STATIC_THEME } from 'amo/constants';
 import AddonTitle from 'amo/components/AddonTitle';
 import AddonBadges from 'amo/components/AddonBadges';
 import StaticAddonCard, {
@@ -9,6 +10,7 @@ import GetFirefoxButton, {
   GET_FIREFOX_BUTTON_TYPE_ADDON,
 } from 'amo/components/GetFirefoxButton';
 import Rating from 'amo/components/Rating';
+import ThemeImage from 'amo/components/ThemeImage';
 import {
   fakeAddon,
   fakeI18n,
@@ -144,5 +146,19 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find(Rating)).toHaveLength(0);
+  });
+
+  it('renders a theme image preview when add-on is a theme', () => {
+    const addon = createInternalAddonWithLang({
+      ...fakeAddon,
+      type: ADDON_TYPE_STATIC_THEME,
+    });
+
+    const root = render({ addon });
+
+    expect(root).toHaveClassName('StaticAddonCard--is-theme');
+    expect(root.find(ThemeImage)).toHaveLength(1);
+    expect(root.find(ThemeImage)).toHaveProp('addon', addon);
+    expect(root.find('.StaticAddonCard-icon')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10525

---

## Screenshots

<img width="356" alt="Screen Shot 2021-05-03 at 11 50 32" src="https://user-images.githubusercontent.com/217628/116863419-908ef000-ac06-11eb-9059-521c8d0ab938.png">

<img width="670" alt="Screen Shot 2021-05-03 at 11 50 06" src="https://user-images.githubusercontent.com/217628/116863421-91c01d00-ac06-11eb-8b65-5ddb6188c13c.png">
