### PR TITLE
Align items in autocomplete results

### DIFF
--- a/src/amo/components/SearchSuggestion/styles.scss
+++ b/src/amo/components/SearchSuggestion/styles.scss
@@ -1,6 +1,7 @@
 @import '~amo/css/styles';
 
 .SearchSuggestion {
+  align-items: center;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -38,6 +39,5 @@
 .SearchSuggestion-icon-arrow {
   display: none;
   height: 16px;
-  margin-top: 1px;
   width: 16px;
 }


### PR DESCRIPTION
Fixes #10505

UI Change: Will horizontal align the items in autocomplete results.

**Before**  

![Screen Shot 2021-05-06 at 17 54 21](https://user-images.githubusercontent.com/12775813/117297784-3c993b00-ae94-11eb-9786-b832c4858686.png)

**After**  

![Screen Shot 2021-05-06 at 17 55 06](https://user-images.githubusercontent.com/12775813/117297796-3f942b80-ae94-11eb-8b4c-eb444b469a02.png)


