### PR TITLE
Make LanguagePicker less "compact"

### DIFF
--- a/src/amo/components/LanguagePicker/styles.scss
+++ b/src/amo/components/LanguagePicker/styles.scss
@@ -1,3 +1,7 @@
 .LanguagePicker-header {
   margin: 0 0 5px;
 }
+
+.LanguagePicker-selector {
+  padding: 2px;
+}


### PR DESCRIPTION
Fixes #10524 

This adds `2px` of padding. We can make it even roomier by adding more padding.

Before:

![Screen Shot 2021-05-06 at 11 49 16 AM](https://user-images.githubusercontent.com/142755/117328154-5cfbd200-ae61-11eb-800b-92822cc482c4.png)

After:

![Screen Shot 2021-05-06 at 11 49 01 AM](https://user-images.githubusercontent.com/142755/117328179-62f1b300-ae61-11eb-863d-67bec80be674.png)
