### PR TITLE
Prevent More... menu from overlapping search box

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -249,7 +249,7 @@
 
   &.Header-search-form--desktop {
     @include respond-to(medium) {
-      max-width: 160px;
+      max-width: 140px;
     }
 
     @include respond-to(large) {


### PR DESCRIPTION
Fixes #10488 

We already reduced the size of this input on smaller screens, and reducing it a bit more fixes this. It's still a bit tight, as can be seen from the screenshot, but this really only happens on a 500px wide screen. Anything smaller and the input moves to the top of the screen. If we want to make this less "tight", we could reduce the size of the input even more, but that would impact all screens between 500px and 720px, so I think it's better to avoid that.

Before:

![Screen Shot 2021-05-06 at 12 31 11 PM](https://user-images.githubusercontent.com/142755/117334015-87508e00-ae67-11eb-8cfd-a2604bce095d.png)

After:

![Screen Shot 2021-05-06 at 12 32 02 PM](https://user-images.githubusercontent.com/142755/117333990-7f90e980-ae67-11eb-9947-b1945af53e09.png)
