### PR TITLE
Fix spacing between badges

### DIFF
--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -9,7 +9,7 @@
   @include respond-to(large) {
     display: flex;
     flex-direction: row-reverse;
-    margin: 0 0 12px;
+    margin: 0 0 6px;
 
     .Addon-theme & {
       flex-direction: row;


### PR DESCRIPTION
Fixes #10547

UI Change: Equal spacing between badges.

**Before**

![Screen Shot 2021-05-07 at 03 11 25](https://user-images.githubusercontent.com/12775813/117369068-02ef2100-aee2-11eb-9879-9dc28a56dd17.png)


**After**

![Screen Shot 2021-05-07 at 03 12 05](https://user-images.githubusercontent.com/12775813/117369077-07b3d500-aee2-11eb-9194-b5c9f947964f.png)
