### PR TITLE
Reduce gap for Username dropdown menu

### DIFF
--- a/src/amo/components/DropdownMenu/styles.scss
+++ b/src/amo/components/DropdownMenu/styles.scss
@@ -77,7 +77,7 @@
   max-width: 245px;
   padding: 4px 24px 20px;
   position: absolute;
-  top: 30px;
+  top: 25px;
   white-space: nowrap;
   width: auto;
   z-index: 10;

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -102,8 +102,4 @@
     color: $grey-40;
     font-size: $font-size-default;
   }
-
-  .DropdownMenu-items {
-    top: 22px;
-  }
 }


### PR DESCRIPTION
Fixes #10520 

This both reduces the size of the gap for the Username menu, and also slightly increases the size of the gap for the More... menu.

Before:

![Screen Shot 2021-05-10 at 2 16 22 PM](https://user-images.githubusercontent.com/142755/117705794-7de26100-b19a-11eb-8deb-9548b2018216.png)

After:

![Screen Shot 2021-05-10 at 2 15 42 PM](https://user-images.githubusercontent.com/142755/117705779-791dad00-b19a-11eb-9e24-feff4893e508.png)
