### PR TITLE
Fix alignment of badge icons

### DIFF
--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -17,10 +17,10 @@
   }
 
   .Icon {
-    @include margin(0, 6px, 0, 0);
+    @include margin(2px, 6px, 0, 0);
 
     @include respond-to(large) {
-      @include margin(0, 0, 0, 6px);
+      @include margin(2px, 0, 0, 6px);
     }
 
     vertical-align: top;


### PR DESCRIPTION
Fixes mozilla/addons#14182 

Before:

![Screen Shot 2021-05-11 at 9 00 42 AM](https://user-images.githubusercontent.com/142755/117819317-6dcc8f00-b237-11eb-873a-7beb3d95a753.png)

After:

![Screen Shot 2021-05-11 at 9 00 06 AM](https://user-images.githubusercontent.com/142755/117819342-72914300-b237-11eb-85f3-6cb5de4de765.png)

![Screen Shot 2021-05-11 at 9 02 01 AM](https://user-images.githubusercontent.com/142755/117819489-9785b600-b237-11eb-8c55-65112feec2b4.png)
