### PR TITLE
RE: Fix title and footer text within homepage shelves

### DIFF
--- a/src/amo/components/HomepageCard/index.js
+++ b/src/amo/components/HomepageCard/index.js
@@ -1,0 +1,72 @@
+import makeClassName from 'classnames';
+import { oneLine } from 'common-tags';
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import './styles.scss';
+
+export default class HomepageCard extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    footer: PropTypes.node,
+    footerLink: PropTypes.node,
+    footerText: PropTypes.node,
+    header: PropTypes.node,
+  };
+
+  render() {
+    const {
+      children,
+      className,
+      footer: footerNode,
+      footerLink,
+      footerText,
+      header,
+    } = this.props;
+
+    let footer;
+    let footerClass;
+
+    if (
+      (footerText && footerLink) ||
+      (footerLink && footerNode) ||
+      (footerText && footerNode)
+    ) {
+      throw new Error(oneLine`You can only specify exactly one of these props:
+        footer, footerLink or footerText.`);
+    } else if (footerText) {
+      footer = footerText;
+      footerClass = 'Card-footer-text';
+    } else if (footerLink) {
+      footer = footerLink;
+      footerClass = 'Card-footer-link';
+    } else {
+      footer = footerNode;
+    }
+
+    return (
+      <section
+        className={makeClassName('Card', className, {
+          'Card--no-footer': !footer,
+        })}
+      >
+        <header className="HomepageCard-header">
+          <div className="Card-header-text">{header}</div>
+
+          {footer ? (
+            <div className="HomepageCard-footer-in-header">{footer}</div>
+          ) : null}
+        </header>
+
+        {children ? <div className="Card-contents">{children}</div> : null}
+
+        {footer ? (
+          <footer className={makeClassName('HomepageCard-footer', footerClass)}>
+            {footer}
+          </footer>
+        ) : null}
+      </section>
+    );
+  }
+}

--- a/src/amo/components/HomepageCard/styles.scss
+++ b/src/amo/components/HomepageCard/styles.scss
@@ -1,0 +1,58 @@
+@import '~amo/css/styles';
+
+.HomepageCard-header {
+  @include addonSection();
+  @include font-bold();
+  @include text-align-start();
+
+  align-items: center;
+  border-top-left-radius: $border-radius-default;
+  border-top-right-radius: $border-radius-default;
+  display: flex;
+  font-size: $font-size-default;
+  justify-content: space-between;
+  margin-bottom: 1px;
+  margin-top: 0;
+}
+
+.HomepageCard-footer-in-header {
+  a,
+  a:active,
+  a:hover,
+  a:link,
+  a:visited {
+    color: $link-color;
+    display: block;
+    font-weight: normal;
+    padding: 0px;
+    text-decoration: none;
+  }
+
+  a:focus {
+    outline: 1px dotted $link-color;
+    outline: auto 5px -webkit-focus-ring-color;
+  }
+}
+
+.HomepageCard-footer-in-header {  
+  @include respond-to(mediumOnly) {
+    display: none;
+  }
+  @include respond-to(large) {
+    text-align: right;
+  }
+}
+
+.HomepageCard-footer {
+  @include addonSection();
+  @include respond-to(large) {
+    display: none;
+  }
+
+  border-bottom-left-radius: $border-radius-default;
+  border-bottom-right-radius: $border-radius-default;
+  margin-top: 1px;
+  overflow: inherit;
+  padding: 0;
+  text-align: center;
+}

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -1,8 +1,11 @@
 /* @flow */
+import makeClassName from 'classnames';
 import * as React from 'react';
 import config from 'config';
 
+import AddonsCard from 'amo/components/AddonsCard';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
+import Link from 'amo/components/Link';
 import LoadingText from 'amo/components/LoadingText';
 import {
   ADDON_TYPE_STATIC_THEME,
@@ -12,9 +15,12 @@ import {
   LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
 import translate from 'amo/i18n/translate';
+import { convertFiltersToQueryParams } from 'amo/searchUtils';
 import { checkInternalURL } from 'amo/utils';
 import type { ResultShelfType } from 'amo/reducers/home';
 import type { I18nType } from 'amo/types/i18n';
+
+import './styles.scss';
 
 type Props = {|
   loading: boolean,
@@ -96,17 +102,47 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
             : `/search/${criteria}`;
       }
 
+      let footerLinkHtml = null;
+      const footerLinkProps = {};
+
+      if (addons && addons.length >= count) {
+        if (footerLink && typeof footerLink === 'object') {
+          // If an href has been passed, use that for the Link.
+          if (footerLink.href) {
+            footerLinkProps.href = footerLink.href;
+            footerLinkProps.prependClientApp = false;
+            footerLinkProps.prependLang = false;
+            footerLinkProps.target = '_blank';
+          } else {
+            // As a convenience, fix the query parameter.
+            footerLinkProps.to = {
+              ...footerLink,
+              query: convertFiltersToQueryParams(footerLink),
+            };
+          }
+        } else {
+          // It's just a string, so pass it into the `to` prop.
+          footerLinkProps.to = footerLink;
+        }
+
+        footerLinkHtml = <Link {...footerLinkProps}>{footerText}</Link>;
+      }
+
       return (
-        <LandingAddonsCard
+        <AddonsCard
           addonInstallSource={addonInstallSource}
           addons={addons}
-          className={`Home-${shelfKey}`}
-          footerText={footerText}
-          footerLink={footerLink}
+          className={makeClassName(`Home-${shelfKey}`, {
+            'HomepageShelvesCard-Themes': hasThemes,
+          })}
+          footerLink={footerLinkHtml}
           header={title}
-          isTheme={hasThemes}
           key={shelfKey}
+          loading={loading}
           placeholderCount={count}
+          showPromotedBadge={false}
+          type="horizontal"
+          useThemePlaceholder={hasThemes}
         />
       );
     });

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -3,7 +3,7 @@ import makeClassName from 'classnames';
 import config from 'config';
 import * as React from 'react';
 
-import CardList from 'amo/components/CardList';
+import Card from 'amo/components/Card';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import LoadingText from 'amo/components/LoadingText';
@@ -168,9 +168,10 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
       }
 
       return (
-        <CardList
+        <Card
           className={makeClassName(
             `Home-${shelfKey}`,
+            'CardList',
             'horizontal' && 'AddonsCard--horizontal',
             {
               'HomepageShelvesCard-Themes': hasThemes,
@@ -183,7 +184,7 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
           {addonElements.length ? (
             <ul className="AddonsCard-list">{addonElements}</ul>
           ) : null}
-        </CardList>
+        </Card>
       );
     });
   }

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -115,7 +115,8 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
   return <div className="HomepageShelves">{shelvesContent}</div>;
 };
 
-const HomepageShelves: React.ComponentType<Props> =
-  translate()(HomepageShelvesBase);
+const HomepageShelves: React.ComponentType<Props> = translate()(
+  HomepageShelvesBase,
+);
 
 export default HomepageShelves;

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -3,7 +3,7 @@ import makeClassName from 'classnames';
 import config from 'config';
 import * as React from 'react';
 
-import Card from 'amo/components/Card';
+import HomepageCard from 'amo/components/HomepageCard';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import Link from 'amo/components/Link';
 import LoadingText from 'amo/components/LoadingText';
@@ -168,11 +168,10 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
       }
 
       return (
-        <Card
+        <HomepageCard
           className={makeClassName(
             `Home-${shelfKey}`,
-            'CardList',
-            'horizontal' && 'AddonsCard--horizontal',
+            'HomepageShelves-HomepageCard',
             {
               'HomepageShelvesCard-Themes': hasThemes,
             },
@@ -184,7 +183,7 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
           {addonElements.length ? (
             <ul className="AddonsCard-list">{addonElements}</ul>
           ) : null}
-        </Card>
+        </HomepageCard>
       );
     });
   }

--- a/src/amo/components/HomepageShelves/styles.scss
+++ b/src/amo/components/HomepageShelves/styles.scss
@@ -1,3 +1,148 @@
+@import '~amo/css/styles';
+
+$footer-padding: 10px;
+
 .HomepageShelvesCard-Themes .Card-contents .AddonsCard-list {
   grid-template-columns: repeat(3, auto);
+}
+
+.HomepageShelves-HomepageCard {
+  margin: $padding-page 0;
+
+  .Card-contents {
+    background: none;
+    padding: 0;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+
+    > li {
+      background: $white;
+      margin-bottom: 1px;
+      padding: $padding-page;
+
+      &:last-of-type {
+        margin-bottom: 0;
+      }
+
+      @include respond-to(large) {
+        padding: $padding-page-l;
+      }
+    }
+  }
+
+  @include respond-to(large) {
+    margin: $padding-page-l 0;
+    position: relative;
+
+    .Card-contents {
+      background: $white;
+      border-bottom-left-radius: $border-radius-default;
+      border-bottom-right-radius: $border-radius-default;
+      padding: 12px 6px;
+    }
+
+    .Card-footer-text,
+    .Card-footer-link {
+      @include end(0);
+      @include text-align-end();
+
+      background: none;
+      border: 0;
+      position: absolute;
+      top: 0;
+    }
+
+    ul.AddonsCard-list {
+      display: grid;
+      grid-auto-flow: column dense;
+      grid-template-columns: repeat(4, 25%);
+
+      .SearchResult {
+        grid-column: auto;
+        margin: 0 6px 1px;
+        // Prevents content overflow.
+        min-width: 0;
+        padding: 0;
+      }
+
+      .SearchResult-wrapper {
+        display: inline-block;
+        height: 100%;
+        padding: 12px 24px;
+        transition: background-color $transition-short ease-in-out;
+        width: 100%;
+      }
+
+      .SearchResult-result {
+        display: grid;
+        grid-column-gap: 8px;
+        grid-template-columns: 32px auto;
+      }
+
+      .SearchResult-icon-wrapper {
+        grid-column: 1 / 2;
+        grid-row: 1 / 3;
+      }
+
+      .SearchResult-contents {
+        grid-column: 2 / 2;
+        grid-row: 1 / 2;
+        margin: 0;
+        // Prevents content overflow.
+        min-width: 0;
+        width: auto;
+      }
+
+      .SearchResult-metadata,
+      .SearchResult-metadata .SearchResult-author,
+      .SearchResult-summary {
+        display: none;
+      }
+
+      .SearchResult-users {
+        @include margin-start(-3.5px);
+
+        grid-column: 2 / 2;
+        grid-row: 2 / 2;
+      }
+
+      .SearchResult-users,
+      .SearchResult-metadata {
+        height: 24px;
+      }
+
+      .SearchResult--theme {
+        // stylelint-disable max-nesting-depth
+        .SearchResult-result {
+          display: block;
+        }
+
+        .SearchResult-icon-wrapper {
+          border-radius: $border-radius-default;
+          margin: 0 0 5px;
+          width: 100%;
+        }
+        // stylelint-enable max-nesting-depth
+      }
+
+      .SearchResult-wrapper:focus,
+      .SearchResult-wrapper:hover {
+        background-color: $grey-10;
+        border-radius: $border-radius-default;
+
+        // stylelint-disable max-nesting-depth
+        .SearchResult-users {
+          display: none;
+        }
+
+        .SearchResult-metadata {
+          display: block;
+        }
+        // stylelint-enable max-nesting-depth
+      }
+    }
+  }
 }

--- a/src/amo/components/HomepageShelves/styles.scss
+++ b/src/amo/components/HomepageShelves/styles.scss
@@ -1,0 +1,3 @@
+.HomepageShelvesCard-Themes .Card-contents .AddonsCard-list {
+  grid-template-columns: repeat(3, auto);
+}


### PR DESCRIPTION
Fixes #10373 

This pull request fixes the overlap between the header and footer_text within the homepage shelves.

@bobsilverberg , I updated this with a flexbox as you had suggested, instead of using `max-width` in my initial attempts. I think this takes care of it, but, just in case, here's my thought process.

`Card-footer-` only appeared in three stylesheets:
1. `AddonsCard`
2. `Card`
3. `ShowMoreCard`

The rule that causes the footer link to appear as if it is in the Card header is located in the `AddonsCard` stylesheet. Therefore, I updated the style for `.Card-footer-link` and `.Card-footer-text` to `display: none`.

Within the stylesheet for the `Card` component, I made the following updates:
- Updated `Card-header` to become a flexbox
- Added classname of `Card-text-wrapper`, which has the same properties as `Card-footer-link` and `Card-footer-text`, and adheres to the following breakpoint rules:
  - `mediumOnly` => `display: none`
  - `large` => `text-align: right`

No changes to `ShowMoreCard`'s stylesheet was made, as none of the updates should affect this component.

While running tests, it showed that the `Addon` component was also affected, as it was displaying "Read 1 review" within the header. I updated its stylesheet to have this `display: none`, but the test still received the length of 2. I tried to console log to check that it's counting the two `div`s within the `header` tag, but could not figure it out. How do I go about checking this test? Would the length really be two even if `display` is ` none`?

Please see the screenshots of a homepage shelf below at the two breakpoints.
mediumOnly breakpoint:
<img width="556" alt="Screen Shot 2021-05-11 at 8 00 52 PM" src="https://user-images.githubusercontent.com/28129806/117898843-de08fe00-b293-11eb-9253-4daeffc80ef8.png">

large breakpoint:
<img width="738" alt="Screen Shot 2021-05-11 at 8 00 18 PM" src="https://user-images.githubusercontent.com/28129806/117898866-e6f9cf80-b293-11eb-95d4-8c21816467e1.png">

Please review when you have a moment. Thank you!

