### PR TITLE
Fix issue with notice icon alignment

### DIFF
--- a/src/amo/components/Notice/styles.scss
+++ b/src/amo/components/Notice/styles.scss
@@ -46,6 +46,14 @@
   width: 16px;
 }
 
+.Notice-genericWarning,
+.Notice-warning,
+.Notice-warningInfo {
+  .Notice-icon {
+    margin-top: 7px;
+  }
+}
+
 .Notice-light .Notice-icon {
   // Reduce the icon size for light notices so that the total
   // height of the notice adds up to $line-height-body.


### PR DESCRIPTION
Fixes #10588 

This actually fixes 3 instances where the Notice icon isn't aligned.

Before:

![Screen Shot 2021-05-18 at 10 43 24 AM](https://user-images.githubusercontent.com/142755/118673127-c1eeea80-b7c6-11eb-8427-6dc9abc7f72f.png)
![Screen Shot 2021-05-18 at 10 52 03 AM](https://user-images.githubusercontent.com/142755/118673566-1a25ec80-b7c7-11eb-9104-972c76d30733.png)
![Screen Shot 2021-05-18 at 10 51 15 AM](https://user-images.githubusercontent.com/142755/118673447-01b5d200-b7c7-11eb-8e1a-5063830216c7.png)

After:

![Screen Shot 2021-05-18 at 10 43 54 AM](https://user-images.githubusercontent.com/142755/118673123-c1565400-b7c6-11eb-80c6-38e1a7ac7624.png)
![Screen Shot 2021-05-18 at 10 42 41 AM](https://user-images.githubusercontent.com/142755/118673128-c2878100-b7c6-11eb-9c2e-57187dcf0581.png)
![Screen Shot 2021-05-18 at 10 41 23 AM](https://user-images.githubusercontent.com/142755/118673130-c2878100-b7c6-11eb-933e-0f1bf5096eeb.png)
