### PR TITLE
Add gap between promoted badge and add-on name

### DIFF
--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -122,10 +122,10 @@ $icon-default-size: 32px;
   flex-grow: 1;
   flex-wrap: wrap;
   font-size: $font-size-default;
-  gap: 6px;
   line-height: $line-height-compressed;
   margin: 0;
   padding: 0;
+  row-gap: 6px;
   text-decoration: none;
   width: 100%;
 

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -122,6 +122,7 @@ $icon-default-size: 32px;
   flex-grow: 1;
   flex-wrap: wrap;
   font-size: $font-size-default;
+  gap: 6px;
   line-height: $line-height-compressed;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Fixes #10590 

Before:

![Screen Shot 2021-05-18 at 12 18 28 PM](https://user-images.githubusercontent.com/142755/118687633-3cbe0280-b7d3-11eb-8684-19594ac70497.png)

After:

![Screen Shot 2021-05-18 at 12 17 17 PM](https://user-images.githubusercontent.com/142755/118687636-3d569900-b7d3-11eb-8d0e-141c4c0ea41b.png)

~~Note that this will also add a 6px gap between the name and the badge when the badge does not wrap to the next line, but I think that's a reasonable tradeoff.~~ - fixed by using `row-gap` instead of `gap`.