### PR TITLE
Add font-display: block on the (preloaded) font subset

### DIFF
--- a/src/fonts/inter.scss
+++ b/src/fonts/inter.scss
@@ -25,6 +25,7 @@
 }
 
 @font-face {
+  font-display: block;
   font-family: 'Inter';
   font-style: normal;
   font-weight: 300 600;


### PR DESCRIPTION
In Chrome, if you have a "bad" connection, font-display: auto behaves like font-display: swap, causing potentially a flash of content but also a layout shift and that can mess with the LCP because Inter is generally wider than the fallback font. Since we're preloading the font, the behavior we really want is font-display: block for the subset.

Should improve and potentially fix #10444, #10445, #10446