### PR TITLE
Right align install button when there is no add-on description

### DIFF
--- a/src/amo/components/InstallButtonWrapper/styles.scss
+++ b/src/amo/components/InstallButtonWrapper/styles.scss
@@ -4,6 +4,10 @@
   display: flex;
   flex-direction: column;
 
+  @include respond-to(medium) {
+    @include margin-start(auto);
+  }
+
   .GetFirefoxButton {
     display: flex;
     flex-direction: column;
@@ -29,8 +33,6 @@
       .GetFirefoxButton-button {
         white-space: nowrap;
       }
-
-      @include margin-start(auto);
     }
   }
 }


### PR DESCRIPTION
Fixes #10648 

Before:

![Screen Shot 2021-06-04 at 11 16 26 AM](https://user-images.githubusercontent.com/142755/120824308-532fc200-c526-11eb-94bf-a7c9955cb138.png)

After:

![Screen Shot 2021-06-04 at 11 15 57 AM](https://user-images.githubusercontent.com/142755/120824250-4317e280-c526-11eb-9a0c-0b80413645fe.png)
