### PR TITLE
Never render the GetFirefoxBanner in the header when forBlog is true

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -224,7 +224,7 @@ export class HeaderBase extends React.Component {
           'Header--loaded-page-is-anonymous': loadedPageIsAnonymous,
         })}
       >
-        {!isAddonInstallPage ? <GetFirefoxBanner /> : null}
+        {!isAddonInstallPage && !forBlog ? <GetFirefoxBanner /> : null}
         <div className="Header-wrapper">
           <div className="Header-content">
             {isHomePage ? (

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -309,5 +309,6 @@ describe(__filename, () => {
     expect(root.find('.Header-download-button')).toHaveLength(0);
     expect(root.find(SearchForm)).toHaveLength(0);
     expect(root.find(SectionLinks)).toHaveProp('forBlog', true);
+    expect(root.find(GetFirefoxBanner)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10657