### PR TITLE
RE: Fix title and footer text within homepage shelves (isHomepageCard props)

### DIFF
--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -37,7 +37,6 @@ type Props = {|
   type?: 'horizontal' | 'vertical',
   showFullSizePreview?: boolean,
   showMetadata?: boolean,
-  showPromotedBadge?: boolean,
   showSummary?: boolean,
 
   // These are all passed through to Card.

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -19,6 +19,7 @@ import './styles.scss';
 
 type DefaultProps = {|
   editing?: boolean,
+  isHomepageCard?: boolean,
   loading?: boolean,
   // When loading, this is the number of placeholders
   // that will be rendered.
@@ -44,6 +45,7 @@ type Props = {|
   footerLink?: Object | string | null,
   footerText?: string,
   header?: React.Node,
+  isHomepageCard?: boolean,
 
   // These are passed through to EditableCollectionAddon.
   deleteNote?: DeleteAddonNoteFunc,
@@ -58,6 +60,7 @@ type Props = {|
 export default class AddonsCard extends React.Component<Props> {
   static defaultProps: DefaultProps = {
     editing: false,
+    isHomepageCard: false,
     loading: false,
     placeholderCount: DEFAULT_API_PAGE_SIZE,
     showPromotedBadge: true,

--- a/src/amo/components/AddonsCard/index.js
+++ b/src/amo/components/AddonsCard/index.js
@@ -19,7 +19,7 @@ import './styles.scss';
 
 type DefaultProps = {|
   editing?: boolean,
-  isHomepageCard?: boolean,
+  isHomepageShelf?: boolean,
   loading?: boolean,
   // When loading, this is the number of placeholders
   // that will be rendered.
@@ -45,7 +45,6 @@ type Props = {|
   footerLink?: Object | string | null,
   footerText?: string,
   header?: React.Node,
-  isHomepageCard?: boolean,
 
   // These are passed through to EditableCollectionAddon.
   deleteNote?: DeleteAddonNoteFunc,
@@ -60,7 +59,7 @@ type Props = {|
 export default class AddonsCard extends React.Component<Props> {
   static defaultProps: DefaultProps = {
     editing: false,
-    isHomepageCard: false,
+    isHomepageShelf: false,
     loading: false,
     placeholderCount: DEFAULT_API_PAGE_SIZE,
     showPromotedBadge: true,

--- a/src/amo/components/Card/index.js
+++ b/src/amo/components/Card/index.js
@@ -13,10 +13,12 @@ export default class Card extends React.Component {
     footerLink: PropTypes.node,
     footerText: PropTypes.node,
     header: PropTypes.node,
+    isHomepageCard: PropTypes.bool,
     photonStyle: PropTypes.bool,
   };
 
   static defaultProps = {
+    isHomepageCard: false,
     // Photon is the name of the new Firefox design language. This flag
     // modifies the card style to left-align the header, add padding, and tweak
     // the styles to be in line with the new photon mocks while we migrate the
@@ -31,6 +33,7 @@ export default class Card extends React.Component {
       footer: footerNode,
       footerLink,
       footerText,
+      isHomepageCard,
       header,
       photonStyle,
     } = this.props;
@@ -63,12 +66,34 @@ export default class Card extends React.Component {
           'Card--no-footer': !footer,
         })}
       >
-        {header ? <header className="Card-header">{header}</header> : null}
+        {header ? (
+          <header
+            className={makeClassName('Card-header', {
+              'HomepageCard-header': isHomepageCard,
+            })}
+          >
+            <div className="Card-header-text">{header}</div>
+
+            {isHomepageCard && footer ? (
+              <footer className="HomepageCard-footer-in-header">
+                {footer}
+              </footer>
+            ) : null}
+          </header>
+        ) : null}
 
         {children ? <div className="Card-contents">{children}</div> : null}
 
         {footer ? (
-          <footer className={makeClassName('Card-footer', footerClass)}>
+          <footer
+            className={makeClassName(
+              'Card-footer',
+              {
+                'HomepageCard-footer': isHomepageCard,
+              },
+              footerClass,
+            )}
+          >
             {footer}
           </footer>
         ) : null}

--- a/src/amo/components/Card/index.js
+++ b/src/amo/components/Card/index.js
@@ -13,12 +13,12 @@ export default class Card extends React.Component {
     footerLink: PropTypes.node,
     footerText: PropTypes.node,
     header: PropTypes.node,
-    isHomepageCard: PropTypes.bool,
+    isHomepageShelf: PropTypes.bool,
     photonStyle: PropTypes.bool,
   };
 
   static defaultProps = {
-    isHomepageCard: false,
+    isHomepageShelf: false,
     // Photon is the name of the new Firefox design language. This flag
     // modifies the card style to left-align the header, add padding, and tweak
     // the styles to be in line with the new photon mocks while we migrate the
@@ -33,7 +33,7 @@ export default class Card extends React.Component {
       footer: footerNode,
       footerLink,
       footerText,
-      isHomepageCard,
+      isHomepageShelf,
       header,
       photonStyle,
     } = this.props;
@@ -69,15 +69,13 @@ export default class Card extends React.Component {
         {header ? (
           <header
             className={makeClassName('Card-header', {
-              'HomepageCard-header': isHomepageCard,
+              'Card-shelf-header': isHomepageShelf,
             })}
           >
             <div className="Card-header-text">{header}</div>
 
-            {isHomepageCard && footer ? (
-              <footer className="HomepageCard-footer-in-header">
-                {footer}
-              </footer>
+            {isHomepageShelf && footer ? (
+              <footer className="Card-shelf-footer-in-header">{footer}</footer>
             ) : null}
           </header>
         ) : null}
@@ -89,7 +87,7 @@ export default class Card extends React.Component {
             className={makeClassName(
               'Card-footer',
               {
-                'HomepageCard-footer': isHomepageCard,
+                'Card-shelf-footer': isHomepageShelf,
               },
               footerClass,
             )}

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -55,7 +55,7 @@ $footer-padding: 10px;
 
 .Card-footer-link,
 .Card-footer-text,
-.HomepageCard-footer-in-header {
+.Card-shelf-footer-in-header {
   a,
   a:active,
   a:hover,
@@ -88,19 +88,19 @@ $footer-padding: 10px;
   }
 }
 
-.HomepageCard-header {
+.Card-shelf-header {
   align-items: center;
   display: flex;
   justify-content: space-between;
 }
 
-.HomepageCard-footer {
+.Card-shelf-footer {
   @include respond-to(large) {
     display: none;
   }
 }
 
-.HomepageCard-footer-in-header {
+.Card-shelf-footer-in-header {
   @include respond-to(mediumOnly) {
     display: none;
   }

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -115,5 +115,4 @@ $footer-padding: 10px;
   a:visited {
     padding: 0;
   }
-
 }

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -105,6 +105,7 @@ $footer-padding: 10px;
     display: none;
   }
 
+  margin-left: 16px;
   padding: 0;
   text-align: right;
 

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -86,3 +86,27 @@ $footer-padding: 10px;
     padding: 5px 26px;
   }
 }
+
+.HomepageCard-header {
+  @extend .Card-header;
+
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.HomepageCard-footer {
+  @include respond-to(large) {
+    display: none;
+  }
+}
+
+.HomepageCard-footer-in-header {
+  @extend .Card-footer-link;
+  @include respond-to(mediumOnly) {
+    display: none;
+  }
+
+  padding: 0;
+  text-align: right;
+}

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -54,7 +54,8 @@ $footer-padding: 10px;
 }
 
 .Card-footer-link,
-.Card-footer-text {
+.Card-footer-text,
+.HomepageCard-footer-in-header {
   a,
   a:active,
   a:hover,
@@ -112,15 +113,7 @@ $footer-padding: 10px;
   a:hover,
   a:link,
   a:visited {
-    color: $link-color;
-    display: block;
-    font-weight: normal;
     padding: 0;
-    text-decoration: none;
   }
 
-  a:focus {
-    outline: 1px dotted $link-color;
-    outline: auto 5px -webkit-focus-ring-color;
-  }
 }

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -107,6 +107,14 @@ $footer-padding: 10px;
     display: none;
   }
 
-  padding: 0;
+  padding: 0px;
   text-align: right;
+
+  a,
+  a:active,
+  a:hover,
+  a:link,
+  a:visited {
+    padding: 0px;
+  }
 }

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -88,8 +88,6 @@ $footer-padding: 10px;
 }
 
 .HomepageCard-header {
-  @extend .Card-header;
-
   align-items: center;
   display: flex;
   justify-content: space-between;
@@ -102,7 +100,6 @@ $footer-padding: 10px;
 }
 
 .HomepageCard-footer-in-header {
-  @extend .Card-footer-link;
   @include respond-to(mediumOnly) {
     display: none;
   }
@@ -115,6 +112,15 @@ $footer-padding: 10px;
   a:hover,
   a:link,
   a:visited {
+    color: $link-color;
+    display: block;
+    font-weight: normal;
     padding: 0px;
+    text-decoration: none;
+  }
+
+  a:focus {
+    outline: 1px dotted $link-color;
+    outline: auto 5px -webkit-focus-ring-color;
   }
 }

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -104,7 +104,7 @@ $footer-padding: 10px;
     display: none;
   }
 
-  padding: 0px;
+  padding: 0;
   text-align: right;
 
   a,
@@ -115,7 +115,7 @@ $footer-padding: 10px;
     color: $link-color;
     display: block;
     font-weight: normal;
-    padding: 0px;
+    padding: 0;
     text-decoration: none;
   }
 

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -104,6 +104,7 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
           footerText={footerText}
           footerLink={footerLink}
           header={title}
+          isHomepageCard
           isTheme={hasThemes}
           key={shelfKey}
           placeholderCount={count}
@@ -115,7 +116,8 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
   return <div className="HomepageShelves">{shelvesContent}</div>;
 };
 
-const HomepageShelves: React.ComponentType<Props> =
-  translate()(HomepageShelvesBase);
+const HomepageShelves: React.ComponentType<Props> = translate()(
+  HomepageShelvesBase,
+);
 
 export default HomepageShelves;

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -104,7 +104,7 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
           footerText={footerText}
           footerLink={footerLink}
           header={title}
-          isHomepageCard
+          isHomepageShelf
           isTheme={hasThemes}
           key={shelfKey}
           placeholderCount={count}

--- a/src/amo/components/HomepageShelves/index.js
+++ b/src/amo/components/HomepageShelves/index.js
@@ -116,8 +116,7 @@ export const HomepageShelvesBase = (props: InternalProps): React.Node => {
   return <div className="HomepageShelves">{shelvesContent}</div>;
 };
 
-const HomepageShelves: React.ComponentType<Props> = translate()(
-  HomepageShelvesBase,
-);
+const HomepageShelves: React.ComponentType<Props> =
+  translate()(HomepageShelvesBase);
 
 export default HomepageShelves;

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -14,6 +14,7 @@ import type { AddonType } from 'amo/types/addons';
 import './styles.scss';
 
 type DefaultProps = {|
+  isHomepageCard?: boolean,
   placeholderCount: number,
 |};
 
@@ -31,6 +32,7 @@ type Props = {|
 
 export default class LandingAddonsCard extends React.Component<Props> {
   static defaultProps: DefaultProps = {
+    isHomepageCard: false,
     placeholderCount: LANDING_PAGE_EXTENSION_COUNT,
   };
 
@@ -42,6 +44,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
       footerLink,
       footerText,
       header,
+      isHomepageCard,
       isTheme,
       loading,
       placeholderCount,
@@ -83,6 +86,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
         })}
         footerLink={footerLinkHtml}
         header={header}
+        isHomepageCard={isHomepageCard}
         showPromotedBadge={false}
         type="horizontal"
         loading={loading}

--- a/src/amo/components/LandingAddonsCard/index.js
+++ b/src/amo/components/LandingAddonsCard/index.js
@@ -14,7 +14,7 @@ import type { AddonType } from 'amo/types/addons';
 import './styles.scss';
 
 type DefaultProps = {|
-  isHomepageCard?: boolean,
+  isHomepageShelf?: boolean,
   placeholderCount: number,
 |};
 
@@ -32,7 +32,7 @@ type Props = {|
 
 export default class LandingAddonsCard extends React.Component<Props> {
   static defaultProps: DefaultProps = {
-    isHomepageCard: false,
+    isHomepageShelf: false,
     placeholderCount: LANDING_PAGE_EXTENSION_COUNT,
   };
 
@@ -44,7 +44,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
       footerLink,
       footerText,
       header,
-      isHomepageCard,
+      isHomepageShelf,
       isTheme,
       loading,
       placeholderCount,
@@ -86,7 +86,7 @@ export default class LandingAddonsCard extends React.Component<Props> {
         })}
         footerLink={footerLinkHtml}
         header={header}
-        isHomepageCard={isHomepageCard}
+        isHomepageShelf={isHomepageShelf}
         showPromotedBadge={false}
         type="horizontal"
         loading={loading}

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -166,17 +166,12 @@ describe(__filename, () => {
     expect(root.find(CardList)).toHaveProp('header', header);
   });
 
-  it.each([true, false])(
-    'passes the isHomepageShelf prop through to Card',
-    (isHomepageShelf) => {
-      const root = render({ isHomepageShelf });
+  it('passes the isHomepageShelf prop through to Card', () => {
+    const isHomepageShelf = true;
+    const root = render({ isHomepageShelf });
 
-      expect(root.find(CardList)).toHaveProp(
-        'isHomepageShelf',
-        isHomepageShelf,
-      );
-    },
-  );
+    expect(root.find(CardList)).toHaveProp('isHomepageShelf', isHomepageShelf);
+  });
 
   it('passes the showPromotedBadge prop through to SearchResult', () => {
     const showPromotedBadge = false;

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -167,11 +167,14 @@ describe(__filename, () => {
   });
 
   it.each([true, false])(
-    'passes the isHomepageCard prop through to Card',
-    (isHomepageCard) => {
-      const root = render({ isHomepageCard });
+    'passes the isHomepageShelf prop through to Card',
+    (isHomepageShelf) => {
+      const root = render({ isHomepageShelf });
 
-      expect(root.find(CardList)).toHaveProp('isHomepageCard', isHomepageCard);
+      expect(root.find(CardList)).toHaveProp(
+        'isHomepageShelf',
+        isHomepageShelf,
+      );
     },
   );
 

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -166,6 +166,15 @@ describe(__filename, () => {
     expect(root.find(CardList)).toHaveProp('header', header);
   });
 
+  it.each([true, false])(
+    'passes the isHomepageCard prop through to Card',
+    (isHomepageCard) => {
+      const root = render({ isHomepageCard });
+
+      expect(root.find(CardList)).toHaveProp('isHomepageCard', isHomepageCard);
+    },
+  );
+
   it('passes the showPromotedBadge prop through to SearchResult', () => {
     const showPromotedBadge = false;
     const root = render({ addons: [fakeAddon], showPromotedBadge });

--- a/tests/unit/amo/components/TestCard.js
+++ b/tests/unit/amo/components/TestCard.js
@@ -43,30 +43,26 @@ describe(__filename, () => {
     expect(root).toHaveClassName('Card--no-header');
   });
 
-  it('does not use HomepageCard classes by default', () => {
+  it('does not use HomepageShelf classes by default', () => {
     const root = render({
       children: 'hello',
     });
-    expect(root.find('.Card-header')).not.toHaveClassName(
-      'HomepageCard-header',
-    );
-    expect(root.find('.Card-footer')).not.toHaveClassName(
-      'HomepageCard-footer',
-    );
-    expect(root).not.toHaveClassName('HomepageCard-footer-in-header');
+    expect(root.find('.Card-header')).not.toHaveClassName('Card-shelf-header');
+    expect(root.find('.Card-footer')).not.toHaveClassName('Card-shelf-footer');
+    expect(root).not.toHaveClassName('Card-shelf-footer-in-header');
   });
 
-  it('uses HomepageCard classes if isHomepageCard is true', () => {
+  it('uses HomepageShelf classes if isHomepageShelf is true', () => {
     const root = render({
       children: 'hello',
       footer: 'bar',
       header: 'foo',
-      isHomepageCard: true,
+      isHomepageShelf: true,
     });
-    expect(root.find('.Card-header')).toHaveClassName('HomepageCard-header');
-    expect(root.find('.Card-footer')).toHaveClassName('HomepageCard-footer');
-    expect(root.find('.HomepageCard-footer-in-header')).toHaveLength(1);
-    expect(root.find('.HomepageCard-footer-in-header')).toHaveText('bar');
+    expect(root.find('.Card-header')).toHaveClassName('Card-shelf-header');
+    expect(root.find('.Card-footer')).toHaveClassName('Card-shelf-footer');
+    expect(root.find('.Card-shelf-footer-in-header')).toHaveLength(1);
+    expect(root.find('.Card-shelf-footer-in-header')).toHaveText('bar');
   });
 
   it('shows footer text if supplied', () => {

--- a/tests/unit/amo/components/TestCard.js
+++ b/tests/unit/amo/components/TestCard.js
@@ -43,6 +43,32 @@ describe(__filename, () => {
     expect(root).toHaveClassName('Card--no-header');
   });
 
+  it('does not use HomepageCard classes by default', () => {
+    const root = render({
+      children: 'hello',
+    });
+    expect(root.find('.Card-header')).not.toHaveClassName(
+      'HomepageCard-header',
+    );
+    expect(root.find('.Card-footer')).not.toHaveClassName(
+      'HomepageCard-footer',
+    );
+    expect(root).not.toHaveClassName('HomepageCard-footer-in-header');
+  });
+
+  it('uses HomepageCard classes if isHomepageCard is true', () => {
+    const root = render({
+      children: 'hello',
+      footer: 'bar',
+      header: 'foo',
+      isHomepageCard: true,
+    });
+    expect(root.find('.Card-header')).toHaveClassName('HomepageCard-header');
+    expect(root.find('.Card-footer')).toHaveClassName('HomepageCard-footer');
+    expect(root.find('.HomepageCard-footer-in-header')).toHaveLength(1);
+    expect(root.find('.HomepageCard-footer-in-header')).toHaveText('bar');
+  });
+
   it('shows footer text if supplied', () => {
     const root = render({ footerText: 'foo' });
     expect(root.find('.Card-footer')).toHaveLength(1);

--- a/tests/unit/amo/components/TestHomepageShelves.js
+++ b/tests/unit/amo/components/TestHomepageShelves.js
@@ -149,6 +149,15 @@ describe(__filename, () => {
     },
   );
 
+  it('passes isHomepageCard to LandingAddonsCard', () => {
+    const root = render({
+      isHomepageCard: true,
+      shelves: [_createShelf()],
+    });
+
+    expect(root.find(LandingAddonsCard)).toHaveProp('isHomepageCard', true);
+  });
+
   it('generates a default footerText', () => {
     const title = 'Shelf Title';
     const root = render({

--- a/tests/unit/amo/components/TestHomepageShelves.js
+++ b/tests/unit/amo/components/TestHomepageShelves.js
@@ -149,13 +149,13 @@ describe(__filename, () => {
     },
   );
 
-  it('passes isHomepageCard to LandingAddonsCard', () => {
+  it('passes isHomepageShelf to LandingAddonsCard', () => {
     const root = render({
-      isHomepageCard: true,
+      isHomepageShelf: true,
       shelves: [_createShelf()],
     });
 
-    expect(root.find(LandingAddonsCard)).toHaveProp('isHomepageCard', true);
+    expect(root.find(LandingAddonsCard)).toHaveProp('isHomepageShelf', true);
   });
 
   it('generates a default footerText', () => {

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -63,17 +63,15 @@ describe(__filename, () => {
     );
   });
 
-  it.each([true, false])(
-    'passes isHomepageShelf to AddonsCard',
-    (isHomepageShelf) => {
-      const root = render({ isHomepageShelf });
+  it('passes isHomepageShelf to AddonsCard', () => {
+    const isHomepageShelf = true;
+    const root = render({ isHomepageShelf });
 
-      expect(root.find(AddonsCard)).toHaveProp(
-        'isHomepageShelf',
-        isHomepageShelf,
-      );
-    },
-  );
+    expect(root.find(AddonsCard)).toHaveProp(
+      'isHomepageShelf',
+      isHomepageShelf,
+    );
+  });
 
   it('sets the number of placeholders to render while loading', () => {
     const root = render({ loading: true });
@@ -196,10 +194,12 @@ describe(__filename, () => {
     );
   });
 
-  it('sets useThemePlaceholder to the value of isTheme on the AddonsCard', () => {
-    const isTheme = true;
-    const root = render({ isTheme });
+  it.each([true, false])(
+    'sets useThemePlaceholder to the value of isTheme on the AddonsCard',
+    (isTheme) => {
+      const root = render({ isTheme });
 
-    expect(root.find(AddonsCard)).toHaveProp('useThemePlaceholder', isTheme);
-  });
+      expect(root.find(AddonsCard)).toHaveProp('useThemePlaceholder', isTheme);
+    },
+  );
 });

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -64,13 +64,13 @@ describe(__filename, () => {
   });
 
   it.each([true, false])(
-    'passes isHomepageCard to AddonsCard',
-    (isHomepageCard) => {
-      const root = render({ isHomepageCard });
+    'passes isHomepageShelf to AddonsCard',
+    (isHomepageShelf) => {
+      const root = render({ isHomepageShelf });
 
       expect(root.find(AddonsCard)).toHaveProp(
-        'isHomepageCard',
-        isHomepageCard,
+        'isHomepageShelf',
+        isHomepageShelf,
       );
     },
   );
@@ -196,12 +196,10 @@ describe(__filename, () => {
     );
   });
 
-  it.each([true, false])(
-    'sets useThemePlaceholder to the value of isTheme on the AddonsCard',
-    (isTheme) => {
-      const root = render({ isTheme });
+  it('sets useThemePlaceholder to the value of isTheme on the AddonsCard', () => {
+    const isTheme = true;
+    const root = render({ isTheme });
 
-      expect(root.find(AddonsCard)).toHaveProp('useThemePlaceholder', isTheme);
-    },
-  );
+    expect(root.find(AddonsCard)).toHaveProp('useThemePlaceholder', isTheme);
+  });
 });

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -63,6 +63,18 @@ describe(__filename, () => {
     );
   });
 
+  it.each([true, false])(
+    'passes isHomepageCard to AddonsCard',
+    (isHomepageCard) => {
+      const root = render({ isHomepageCard });
+
+      expect(root.find(AddonsCard)).toHaveProp(
+        'isHomepageCard',
+        isHomepageCard,
+      );
+    },
+  );
+
   it('sets the number of placeholders to render while loading', () => {
     const root = render({ loading: true });
     expect(root).toHaveProp('placeholderCount', LANDING_PAGE_EXTENSION_COUNT);


### PR DESCRIPTION
Fixes #10373 
Fixes #10509

@bobsilverberg, as discussed, this pull request fixes the overlap between the header and footer_text within the homepage shelves by passing through a props (`isHomepageCard`) that `Card` can then utilize. If we proceed with this update, I'll work on updating the tests.

Please see screenshots below:
Homepage (width: 1024px)-
<img width="765" alt="Screen Shot 2021-06-09 at 5 02 31 PM" src="https://user-images.githubusercontent.com/28129806/121429326-c7ae9a80-c944-11eb-9887-989efd1f622b.png">

Homepage (width: 768px)- 
<img width="764" alt="Screen Shot 2021-06-09 at 5 02 44 PM" src="https://user-images.githubusercontent.com/28129806/121429340-cc734e80-c944-11eb-8f9f-12841c170d70.png">

Homepage (width: 425px)- 
<img width="418" alt="Screen Shot 2021-06-09 at 5 03 00 PM" src="https://user-images.githubusercontent.com/28129806/121429348-d1380280-c944-11eb-95a8-47f447ec1fe2.png">

Rating (included as it utilizes `Card` component)-
<img width="270" alt="Screen Shot 2021-06-09 at 5 03 49 PM" src="https://user-images.githubusercontent.com/28129806/121429364-d5642000-c944-11eb-9052-d7f36b7efbb5.png">

Review (included as it utilizes `Card` component)-
<img width="762" alt="Screen Shot 2021-06-09 at 5 03 56 PM" src="https://user-images.githubusercontent.com/28129806/121429379-da28d400-c944-11eb-924b-086ed15190bb.png">

Please review when you have a moment. Thank you!
