### PR TITLE
Add link to add-on name in StaticAddonCard

### DIFF
--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -61,7 +61,7 @@ export const StaticAddonCardBase = ({
         </div>
       )}
 
-      <AddonTitle addon={addon} />
+      <AddonTitle addon={addon} linkToAddon />
 
       <AddonBadges addon={addon} />
 

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -72,6 +72,10 @@ $icon-size: 48px;
   grid-row: 2;
   margin: 0;
 
+  a {
+    text-decoration: none;
+  }
+
   .StaticAddonCard--is-theme & {
     grid-column: 1 / span 3;
   }

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -41,6 +41,7 @@ describe(__filename, () => {
 
     expect(root.find(AddonTitle)).toHaveLength(1);
     expect(root.find(AddonTitle)).toHaveProp('addon', addon);
+    expect(root.find(AddonTitle)).toHaveProp('linkToAddon', true);
 
     expect(root.find(AddonBadges)).toHaveLength(1);
     expect(root.find(AddonBadges)).toHaveProp('addon', addon);


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10684

---

After:

![Screenshot 2021-06-16 at 17-44-27 blog-utils](https://user-images.githubusercontent.com/217628/122251368-baf0f000-ceca-11eb-8cd6-f1f7eefd243f.png)
