### PR TITLE
Pass variant instead of trying to recompute it

### DIFF
--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -6,10 +6,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import Button from 'amo/components/Button';
-import {
-  VARIANT_CURRENT,
-  VARIANT_NEW,
-} from 'amo/experiments/20210531_download_funnel_experiment';
+import { VARIANT_NEW } from 'amo/experiments/20210531_download_funnel_experiment';
 import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_FIREFOX,
@@ -42,7 +39,7 @@ export type Props = {|
   className?: string,
   forIncompatibleAddon?: boolean,
   overrideQueryParams?: {| [name: string]: string | null |},
-  useNewVersion?: boolean,
+  variant?: string | null,
 |};
 
 export type DefaultProps = {|
@@ -135,19 +132,17 @@ export const GetFirefoxButtonBase = ({
   _getPromotedCategory = getPromotedCategory,
   _tracking = tracking,
   addon,
-  forIncompatibleAddon,
   className,
   clientApp,
+  forIncompatibleAddon,
   i18n,
   overrideQueryParams = {},
-  useNewVersion = false,
   userAgentInfo,
+  variant,
 }: InternalProps): null | React.Node => {
   if (isFirefox({ userAgentInfo }) && !forIncompatibleAddon) {
     return null;
   }
-
-  const variant = useNewVersion ? VARIANT_NEW : VARIANT_CURRENT;
 
   const onButtonClick = () => {
     _tracking.sendEvent({

--- a/src/amo/components/InstallButtonWrapper/index.js
+++ b/src/amo/components/InstallButtonWrapper/index.js
@@ -16,10 +16,7 @@ import {
   INCOMPATIBLE_UNSUPPORTED_PLATFORM,
   UNKNOWN,
 } from 'amo/constants';
-import {
-  VARIANT_NEW,
-  EXPERIMENT_CONFIG,
-} from 'amo/experiments/20210531_download_funnel_experiment';
+import { EXPERIMENT_CONFIG } from 'amo/experiments/20210531_download_funnel_experiment';
 import translate from 'amo/i18n/translate';
 import { findInstallURL, withInstallHelpers } from 'amo/installAddon';
 import { getVersionById } from 'amo/reducers/versions';
@@ -189,7 +186,7 @@ export const InstallButtonWrapperBase = (props: InternalProps): React.Node => {
                 className={className ? `GetFirefoxButton--${className}` : ''}
                 forIncompatibleAddon={forIncompatibleAddon}
                 overrideQueryParams={overrideQueryParams}
-                useNewVersion={variant === VARIANT_NEW}
+                variant={variant}
               />
             ) : null}
           </>

--- a/tests/unit/amo/components/TestGetFirefoxBanner.js
+++ b/tests/unit/amo/components/TestGetFirefoxBanner.js
@@ -139,6 +139,20 @@ describe(__filename, () => {
       expect(root.find(Button)).toHaveProp('href', expectedHref);
     });
 
+    it('sends a tracking event when the button is clicked without a variant', () => {
+      const _tracking = createFakeTracking();
+      const root = render({ _tracking, store });
+
+      const event = createFakeEvent();
+      root.find(Button).simulate('click', event);
+
+      sinon.assert.calledWith(_tracking.sendEvent, {
+        action: GET_FIREFOX_BANNER_CLICK_ACTION,
+        category: GET_FIREFOX_BUTTON_CLICK_CATEGORY,
+      });
+      sinon.assert.calledOnce(_tracking.sendEvent);
+    });
+
     it('sends a tracking event when the button is clicked', () => {
       const _tracking = createFakeTracking();
       const variant = VARIANT_NEW;

--- a/tests/unit/amo/components/TestGetFirefoxButton.js
+++ b/tests/unit/amo/components/TestGetFirefoxButton.js
@@ -278,23 +278,21 @@ describe(__filename, () => {
       const guid = 'some-guid';
       const addon = createInternalAddonWithLang({ ...fakeAddon, guid });
 
-      it.each([true, false])(
-        'sends a tracking event when the button is clicked and useNewVersion is %s',
-        (useNewVersion) => {
+      it.each([VARIANT_NEW, VARIANT_CURRENT])(
+        'sends a tracking event when the button is clicked and variant is %s',
+        (variant) => {
           const _tracking = createFakeTracking();
           const root = render({
             _tracking,
             addon,
             store,
-            useNewVersion,
+            variant,
           });
 
           const event = createFakeEvent();
           root.find('.GetFirefoxButton-button').simulate('click', event);
 
-          const category = `${GET_FIREFOX_BUTTON_CLICK_CATEGORY}-${
-            useNewVersion ? VARIANT_NEW : VARIANT_CURRENT
-          }`;
+          const category = `${GET_FIREFOX_BUTTON_CLICK_CATEGORY}-${variant}`;
           sinon.assert.calledWith(_tracking.sendEvent, {
             action: GET_FIREFOX_BUTTON_CLICK_ACTION,
             category,

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -7,7 +7,6 @@ import InstallButtonWrapper, {
 import {
   EXPERIMENT_CONFIG,
   VARIANT_CURRENT,
-  VARIANT_NEW,
 } from 'amo/experiments/20210531_download_funnel_experiment';
 import { setInstallState } from 'amo/reducers/installations';
 import AMInstallButton from 'amo/components/AMInstallButton';
@@ -551,21 +550,6 @@ describe(__filename, () => {
 
     expect(root.find('.InstallButtonWrapper-download')).toHaveLength(0);
   });
-
-  it.each([VARIANT_CURRENT, VARIANT_NEW, null])(
-    'passes the expected value for useNewVersion to GetFirefoxButton when variant is %s',
-    (variant) => {
-      _dispatchClientMetadata({
-        userAgent: userAgentsByPlatform.mac.chrome41,
-      });
-      const root = render({ variant });
-
-      expect(root.find(GetFirefoxButton)).toHaveProp(
-        'useNewVersion',
-        variant === VARIANT_NEW,
-      );
-    },
-  );
 
   it('passes the expected overrideQueryParams to GetFirefoxButton if an experiment is active', () => {
     _dispatchClientMetadata({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10724

---

We shouldn't try to recompute the variant of an experiment because the variant
is optional. When the experiment is disabled, there is no variant and
everything related to the experiment should take that into account. This patch
makes sure we pass the variant and deal with it correctly.