### PR TITLE
Fix problem with rounded corners on add-on reviews

### DIFF
--- a/src/amo/components/UserReview/styles.scss
+++ b/src/amo/components/UserReview/styles.scss
@@ -13,7 +13,7 @@
 
   .Card-contents {
     background: transparent;
-    padding: 0;
+    padding: 0 0 2px 0;
   }
 
   .ShowMoreCard.UserReview-emptyBody {


### PR DESCRIPTION
Fixes #10405 

This adds a bit more space between the bottom of the review text and the textual links, but I think that's acceptable to fix the rounded corners cutting off part of the text issue.

Before:

![Screen Shot 2021-07-05 at 1 36 51 PM](https://user-images.githubusercontent.com/142755/124504892-54a71100-dd96-11eb-9681-073ed3ceb0cd.png)

After:

![Screen Shot 2021-07-05 at 1 35 49 PM](https://user-images.githubusercontent.com/142755/124504902-5a9cf200-dd96-11eb-9c7c-0ab9f09a6e5e.png)
