### PR TITLE
Address code coverage issues with addonManager and installAddon

### DIFF
--- a/src/amo/addonManager.js
+++ b/src/amo/addonManager.js
@@ -73,6 +73,7 @@ export function hasAddonManager({
   navigator,
 }: { navigator: PrivilegedNavigatorType } = {}): boolean {
   if (typeof window === 'undefined') {
+    /* istanbul ignore next */
     return false;
   }
 

--- a/src/amo/components/AMInstallButton/index.js
+++ b/src/amo/components/AMInstallButton/index.js
@@ -23,7 +23,6 @@ import {
   UNKNOWN,
 } from 'amo/constants';
 import translate from 'amo/i18n/translate';
-import { findInstallURL } from 'amo/installAddon';
 import log from 'amo/logger';
 import tracking, {
   getAddonTypeForTracking,
@@ -236,9 +235,7 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
 
     const installURL =
       currentVersion && currentVersion.file
-        ? findInstallURL({
-            file: currentVersion.file,
-          })
+        ? currentVersion.file.url
         : undefined;
 
     const buttonIsDisabled =

--- a/src/amo/components/InstallButtonWrapper/index.js
+++ b/src/amo/components/InstallButtonWrapper/index.js
@@ -17,7 +17,7 @@ import {
 } from 'amo/constants';
 import { EXPERIMENT_CONFIG } from 'amo/experiments/20210531_amo_download_funnel_experiment';
 import translate from 'amo/i18n/translate';
-import { findInstallURL, withInstallHelpers } from 'amo/installAddon';
+import { withInstallHelpers } from 'amo/installAddon';
 import { getVersionById } from 'amo/reducers/versions';
 import { getClientCompatibility, isFirefox } from 'amo/utils/compatibility';
 import { withExperiment } from 'amo/withExperiment';
@@ -34,7 +34,6 @@ import './styles.scss';
 
 export type Props = {|
   _getClientCompatibility?: typeof getClientCompatibility,
-  _findInstallURL?: typeof findInstallURL,
   addon: AddonType | null,
   className?: string,
   defaultButtonText?: string,
@@ -64,7 +63,6 @@ type InternalProps = {|
 
 export const InstallButtonWrapperBase = (props: InternalProps): React.Node => {
   const {
-    _findInstallURL = findInstallURL,
     _getClientCompatibility = getClientCompatibility,
     addon,
     canUninstall,
@@ -123,13 +121,8 @@ export const InstallButtonWrapperBase = (props: InternalProps): React.Node => {
     }
   }
 
-  const file = currentVersion ? currentVersion.file : null;
-
-  const installURL = file
-    ? _findInstallURL({
-        file,
-      })
-    : undefined;
+  const installURL =
+    currentVersion && currentVersion.file ? currentVersion.file.url : undefined;
 
   const showDownloadLink = !isCompatible && installURL;
 

--- a/src/amo/installAddon.js
+++ b/src/amo/installAddon.js
@@ -37,7 +37,7 @@ import { getVersionById } from 'amo/reducers/versions';
 import { getDisplayName } from 'amo/utils';
 import { getFileHash } from 'amo/utils/addons';
 import type { AppState } from 'amo/store';
-import type { AddonVersionType, AddonFileType } from 'amo/reducers/versions';
+import type { AddonVersionType } from 'amo/reducers/versions';
 import type { AddonType } from 'amo/types/addons';
 import type { DispatchFunc } from 'amo/types/redux';
 
@@ -112,27 +112,6 @@ export function makeProgressHandler({
     }
   };
 }
-
-type FindInstallUrlParams = {|
-  file: AddonFileType,
-|};
-
-/**
- * This is a helper to find the correct install URL for the user agent's
- * platform.
- */
-export const findInstallURL = ({
-  file,
-}: FindInstallUrlParams): string | void => {
-  const installURL = file && file.url;
-
-  if (!installURL) {
-    log.debug('findInstallURL() could not find a url');
-    return undefined;
-  }
-
-  return installURL;
-};
 
 type WithInstallHelpersProps = {|
   addon: AddonType | null,
@@ -247,9 +226,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       return Promise.resolve();
     }
 
-    const installURL = findInstallURL({ file });
-
-    const payload = { guid, url: installURL };
+    const payload = { guid, url: file.url };
 
     _log.info('Setting add-on status');
     return _addonManager
@@ -359,15 +336,11 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
         label: guid,
       });
 
-      const installURL = findInstallURL({ file });
+      const installURL = file.url;
 
       resolve(installURL);
     })
       .then((installURL) => {
-        if (!installURL) {
-          throw new Error('installURL is invalid (empty or undefined)');
-        }
-
         const hash = getFileHash({
           addon,
           installURL,

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -29,6 +29,7 @@ import {
   createInternalVersionWithLang,
   dispatchClientMetadata,
   fakeAddon,
+  fakeFile,
   fakeI18n,
   fakeInstalledAddon,
   fakeVersion,
@@ -395,15 +396,11 @@ describe(__filename, () => {
   });
 
   it('displays a download link when the browser is not compatible', () => {
-    const _findInstallURL = sinon
-      .stub()
-      .returns('https://a.m.o/files/addon.xpi');
     const _getClientCompatibility = sinon.stub().returns({
       compatible: false,
     });
 
     const root = render({
-      _findInstallURL,
       _getClientCompatibility,
       version: createInternalVersionWithLang(fakeAddon.current_version),
     });
@@ -412,15 +409,11 @@ describe(__filename, () => {
   });
 
   it('does not display a download link when the browser is compatible and showLinkInsteadOfButton is false', () => {
-    const _findInstallURL = sinon
-      .stub()
-      .returns('https://a.m.o/files/addon.xpi');
     const _getClientCompatibility = sinon.stub().returns({
       compatible: true,
     });
 
     const root = render({
-      _findInstallURL,
       _getClientCompatibility,
       version: createInternalVersionWithLang(fakeAddon.current_version),
       showLinkInsteadOfButton: false,
@@ -430,15 +423,11 @@ describe(__filename, () => {
   });
 
   it('displays a download link when the browser is compatible and showLinkInsteadOfButton is true', () => {
-    const _findInstallURL = sinon
-      .stub()
-      .returns('https://a.m.o/files/addon.xpi');
     const _getClientCompatibility = sinon.stub().returns({
       compatible: true,
     });
 
     const root = render({
-      _findInstallURL,
       _getClientCompatibility,
       version: createInternalVersionWithLang(fakeAddon.current_version),
       showLinkInsteadOfButton: true,
@@ -448,15 +437,11 @@ describe(__filename, () => {
   });
 
   it('does not display a button when the browser is compatible and showLinkInsteadOfButton is true', () => {
-    const _findInstallURL = sinon
-      .stub()
-      .returns('https://a.m.o/files/addon.xpi');
     const _getClientCompatibility = sinon.stub().returns({
       compatible: true,
     });
 
     const root = render({
-      _findInstallURL,
       _getClientCompatibility,
       version: createInternalVersionWithLang(fakeAddon.current_version),
       showLinkInsteadOfButton: true,
@@ -481,15 +466,11 @@ describe(__filename, () => {
   });
 
   it('does not add a special classname when a download link is displayed', () => {
-    const _findInstallURL = sinon
-      .stub()
-      .returns('https://a.m.o/files/addon.xpi');
     const _getClientCompatibility = sinon.stub().returns({
       compatible: false,
     });
 
     const root = render({
-      _findInstallURL,
       _getClientCompatibility,
       version: createInternalVersionWithLang(fakeAddon.current_version),
     });
@@ -499,54 +480,45 @@ describe(__filename, () => {
     );
   });
 
-  it('calls findInstallURL to determine the installURL for the add-on', () => {
-    const _findInstallURL = sinon.spy();
-    const version = createInternalVersionWithLang(fakeAddon.current_version);
-
-    render({ _findInstallURL, version });
-
-    sinon.assert.calledWith(_findInstallURL, {
-      file: version.file,
-    });
-  });
-
-  it('does not call findInstallURL if there is no currentVersion', () => {
-    const _findInstallURL = sinon.spy();
-
-    render({ _findInstallURL, version: null });
-
-    sinon.assert.notCalled(_findInstallURL);
-  });
-
-  it('uses the installURL in the download link', () => {
-    const installURL = 'https://a.m.o/files/addon.xpi';
-    const _findInstallURL = sinon.stub().returns(installURL);
+  it('uses the file url in the download link', () => {
     const _getClientCompatibility = sinon.stub().returns({
       compatible: false,
     });
+    const fileURL = 'https://a.m.o/files/addon.xpi';
 
     const root = render({
-      _findInstallURL,
       _getClientCompatibility,
-      version: createInternalVersionWithLang(fakeAddon.current_version),
+      version: createInternalVersionWithLang({
+        ...fakeAddon.current_version,
+        files: [{ ...fakeFile, url: fileURL }],
+      }),
     });
 
     expect(root.find('.InstallButtonWrapper-download-link')).toHaveProp(
       'href',
-      installURL,
+      fileURL,
     );
   });
 
-  it('does not display a download link when there is no installURL', () => {
-    const _findInstallURL = sinon.stub().returns(null);
+  it('does not display a download link when there is no currentVersion', () => {
     const _getClientCompatibility = sinon.stub().returns({
       compatible: false,
     });
+    const root = render({ _getClientCompatibility, version: null });
 
+    expect(root.find('.InstallButtonWrapper-download')).toHaveLength(0);
+  });
+
+  it('does not display a download link when currentVersion has no file', () => {
+    const _getClientCompatibility = sinon.stub().returns({
+      compatible: false,
+    });
     const root = render({
-      _findInstallURL,
       _getClientCompatibility,
-      version: createInternalVersionWithLang(fakeAddon.current_version),
+      version: createInternalVersionWithLang({
+        ...fakeAddon.current_version,
+        files: [],
+      }),
     });
 
     expect(root.find('.InstallButtonWrapper-download')).toHaveLength(0);


### PR DESCRIPTION
Fixes #10762 

It turns out that after the changes landed in https://github.com/mozilla/addons-frontend/commit/f259dfd0bb05015f28dc0cb9cce3a3dfdcfea8d9, we no longer need the `findInstallURL` helper at all, nor do we need the code that checks that `installURL` exists in `install` in `installAddon` because Flow guarantees that it will exist at that point.