### PR TITLE
Always Vary on Accept-Language for pages that redirect based on language

### DIFF
--- a/src/amo/i18n/utils.js
+++ b/src/amo/i18n/utils.js
@@ -206,27 +206,24 @@ type GetLanguageParams = {|
 /*
  * Check validity of language:
  * - If invalid, fall-back to accept-language.
- * - Return object with lang and isLangFromHeader hint.
+ * - Return object with lang
  *
  */
 export function getLanguage({
   lang,
   acceptLanguage,
 }: GetLanguageParams = {}): {|
-  isLangFromHeader: boolean,
   lang: void | string,
 |} {
   let userLang = lang;
-  let isLangFromHeader = false;
   // If we don't have a supported userLang yet try accept-language.
   if (!isSupportedLang(normalizeLang(userLang)) && acceptLanguage) {
     userLang = getLangFromHeader(acceptLanguage);
-    isLangFromHeader = true;
   }
   // sanitizeLanguage will perform the following:
   // - mapping e.g. pt -> pt-PT.
   // - normalization e.g: en-us -> en-US.
-  return { lang: sanitizeLanguage(userLang), isLangFromHeader };
+  return { lang: sanitizeLanguage(userLang) };
 }
 
 // moment uses locales like "en-gb" whereas we use "en_GB".

--- a/src/amo/middleware/prefixMiddleware.js
+++ b/src/amo/middleware/prefixMiddleware.js
@@ -24,7 +24,7 @@ export function prefixMiddleware(req, res, next, { _config = config } = {}) {
   // Get language from URL or fall-back to detecting it from accept-language
   // header.
   const acceptLanguage = req.headers['accept-language'];
-  const { lang, isLangFromHeader } = getLanguage({
+  const { lang } = getLanguage({
     lang: URLPathParts[0],
     acceptLanguage,
   });
@@ -99,9 +99,7 @@ export function prefixMiddleware(req, res, next, { _config = config } = {}) {
   if (newURL !== req.originalUrl && !newURL.startsWith('//')) {
     // Collect vary headers to apply to the redirect
     // so we can make it cacheable.
-    if (isLangFromHeader) {
-      res.vary('accept-language');
-    }
+    res.vary('accept-language');
     if (isApplicationFromHeader) {
       res.vary('user-agent');
     }

--- a/tests/unit/amo/i18n/test_utils.js
+++ b/tests/unit/amo/i18n/test_utils.js
@@ -209,52 +209,44 @@ describe(__filename, () => {
     it('should return default lang if called without args', () => {
       const result = utils.getLanguage();
       expect(result.lang).toEqual(defaultLang);
-      expect(result.isLangFromHeader).toEqual(false);
     });
 
     it('should return default lang if no lang is provided', () => {
       const result = utils.getLanguage({ lang: '' });
       expect(result.lang).toEqual(defaultLang);
-      expect(result.isLangFromHeader).toEqual(false);
     });
 
     it('should return default lang if bad lang is provided', () => {
       const result = utils.getLanguage({ lang: 'bogus' });
       expect(result.lang).toEqual(defaultLang);
-      expect(result.isLangFromHeader).toEqual(false);
     });
 
     it('should return default lang if bad lang type provided', () => {
       const result = utils.getLanguage({ lang: 1 });
       expect(result.lang).toEqual(defaultLang);
-      expect(result.isLangFromHeader).toEqual(false);
     });
 
     it('should return lang if provided via the URL', () => {
       const result = utils.getLanguage({ lang: 'fr' });
       expect(result.lang).toEqual('fr');
-      expect(result.isLangFromHeader).toEqual(false);
     });
 
     it('should fall-back to accept-language', () => {
       const acceptLanguage = 'pt-br;q=0.5,en-us;q=0.3,en;q=0.2';
       const result = utils.getLanguage({ lang: 'bogus', acceptLanguage });
       expect(result.lang).toEqual('pt-BR');
-      expect(result.isLangFromHeader).toEqual(true);
     });
 
     it('should map lang from accept-language too', () => {
       const acceptLanguage = 'pt;q=0.5,en-us;q=0.3,en;q=0.2';
       const result = utils.getLanguage({ lang: 'wat', acceptLanguage });
       expect(result.lang).toEqual('pt-PT');
-      expect(result.isLangFromHeader).toEqual(true);
     });
 
     it('should fallback when nothing matches', () => {
       const acceptLanguage = 'awooga;q=0.5';
       const result = utils.getLanguage({ lang: 'wat', acceptLanguage });
       expect(result.lang).toEqual(defaultLang);
-      expect(result.isLangFromHeader).toEqual(true);
     });
   });
 

--- a/tests/unit/amo/middleware/test_prefixMiddleware.js
+++ b/tests/unit/amo/middleware/test_prefixMiddleware.js
@@ -66,7 +66,7 @@ describe(__filename, () => {
     prefixMiddleware(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
     sinon.assert.calledWith(fakeRes.redirect, 301, '/en-US/firefox/whatever');
     sinon.assert.calledWith(fakeRes.set, 'Cache-Control', ['max-age=31536000']);
-    sinon.assert.notCalled(fakeRes.vary);
+    sinon.assert.calledWith(fakeRes.vary, 'accept-language');
   });
 
   it('should prepend lang when missing but keep clientAppUrlException', () => {
@@ -81,7 +81,7 @@ describe(__filename, () => {
       '/en-US/validprefix/whatever',
     );
     sinon.assert.calledWith(fakeRes.set, 'Cache-Control', ['max-age=31536000']);
-    sinon.assert.notCalled(fakeRes.vary);
+    sinon.assert.calledWith(fakeRes.vary, 'accept-language');
   });
 
   it('should set lang when invalid, preserving clientApp URL exception', () => {
@@ -92,7 +92,7 @@ describe(__filename, () => {
     prefixMiddleware(fakeReq, fakeRes, fakeNext, { _config: fakeConfig });
     sinon.assert.calledWith(fakeRes.redirect, 301, '/en-US/developers/');
     sinon.assert.calledWith(fakeRes.set, 'Cache-Control', ['max-age=31536000']);
-    sinon.assert.notCalled(fakeRes.vary);
+    sinon.assert.calledWith(fakeRes.vary, 'accept-language');
   });
 
   it('should fallback to and vary on accept-language headers', () => {


### PR DESCRIPTION
Otherwise, the following could happen:
- Request comes in without `Accept-Language`, is cached by upstream without varying on `Accept-Language`
- Another request comes in with `Accept-Language`, upstream serves the previously cached response without knowing it shouldn't.

Required for https://github.com/mozilla/addons/issues/1344