### PR TITLE
Use variable utm_campaign for attribution

### DIFF
--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -13,7 +13,6 @@ import {
   DOWNLOAD_FIREFOX_BASE_URL,
   DOWNLOAD_FIREFOX_EXPERIMENTAL_URL,
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
-  DOWNLOAD_FIREFOX_UTM_TERM,
   LINE,
   RECOMMENDED,
   SPONSORED,
@@ -60,31 +59,23 @@ type InternalProps = {|
   i18n: I18nType,
 |};
 
-// As we expect to continue to experiment with this button, maintain the
-// ability to create a term that contains a variant.
-export const getDownloadTerm = ({
+export const getDownloadCampaign = ({
   addonId,
-  variant,
 }: {|
   addonId?: number,
-  variant?: string | null,
 |} = {}): string => {
-  let term = DOWNLOAD_FIREFOX_UTM_TERM;
+  let campaign = DOWNLOAD_FIREFOX_UTM_CAMPAIGN;
 
   if (addonId) {
-    term = `${term}-${addonId}`;
+    campaign = `${campaign}-${addonId}`;
   }
 
-  if (variant) {
-    term = `${term}-${variant}`;
-  }
-
-  return term;
+  return campaign;
 };
 
 export type GetDownloadLinkParams = {|
   _encode?: typeof encode,
-  _getDownloadTerm?: typeof getDownloadTerm,
+  _getDownloadCampaign?: typeof getDownloadCampaign,
   addon?: AddonType,
   overrideQueryParams?: {| [name: string]: string | null |},
   variant?: string | null,
@@ -92,7 +83,7 @@ export type GetDownloadLinkParams = {|
 
 export const getDownloadLink = ({
   _encode = encode,
-  _getDownloadTerm = getDownloadTerm,
+  _getDownloadCampaign = getDownloadCampaign,
   addon,
   overrideQueryParams = {},
   variant,
@@ -113,9 +104,8 @@ export const getDownloadLink = ({
     };
   }
   return `${baseURL}${makeQueryStringWithUTM({
-    utm_campaign: DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
+    utm_campaign: _getDownloadCampaign({ addonId: addon && addon.id }),
     utm_content: addon && addon.guid ? `rta:${_encode(addon.guid)}` : '',
-    utm_term: _getDownloadTerm({ addonId: addon && addon.id, variant }),
     ...queryParams,
   })}`;
 };

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -313,8 +313,7 @@ export const AMO_REQUEST_ID_HEADER = 'amo-request-id';
 
 export const DEFAULT_UTM_SOURCE = 'addons.mozilla.org';
 export const DEFAULT_UTM_MEDIUM = 'referral';
-export const DOWNLOAD_FIREFOX_UTM_CAMPAIGN = 'non-fx-button';
-export const DOWNLOAD_FIREFOX_UTM_TERM = 'amo-fx-cta';
+export const DOWNLOAD_FIREFOX_UTM_CAMPAIGN = 'amo-fx-cta';
 
 // Promoted categories
 export const LINE = 'line';

--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -88,7 +88,7 @@ export const StaticAddonCardBase = ({
         <GetFirefoxButton
           addon={addon}
           overrideQueryParams={{
-            utm_term: `amo-blog-fx-cta-${addon.id}`,
+            utm_campaign: `amo-blog-fx-cta-${addon.id}`,
             experiment: null,
             variation: null,
           }}

--- a/tests/unit/amo/components/TestGetFirefoxBanner.js
+++ b/tests/unit/amo/components/TestGetFirefoxBanner.js
@@ -19,7 +19,6 @@ import {
   DOWNLOAD_FIREFOX_BASE_URL,
   DOWNLOAD_FIREFOX_EXPERIMENTAL_URL,
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
-  DOWNLOAD_FIREFOX_UTM_TERM,
 } from 'amo/constants';
 import {
   createFakeEvent,
@@ -110,7 +109,6 @@ describe(__filename, () => {
         `utm_campaign=${DOWNLOAD_FIREFOX_UTM_CAMPAIGN}`,
         `utm_content=${GET_FIREFOX_BANNER_UTM_CONTENT}`,
         `utm_medium=referral&utm_source=addons.mozilla.org`,
-        `utm_term=${DOWNLOAD_FIREFOX_UTM_TERM}-${VARIANT_CURRENT}`,
       ].join('&');
       expect(root.find(Button)).toHaveProp('href', expectedHref);
     });
@@ -125,7 +123,6 @@ describe(__filename, () => {
         `utm_campaign=${DOWNLOAD_FIREFOX_UTM_CAMPAIGN}`,
         `utm_content=${GET_FIREFOX_BANNER_UTM_CONTENT}`,
         `utm_medium=referral&utm_source=addons.mozilla.org`,
-        `utm_term=${DOWNLOAD_FIREFOX_UTM_TERM}-${VARIANT_NEW}`,
       ].join('&');
       expect(root.find(Button)).toHaveProp('href', expectedHref);
     });
@@ -137,7 +134,6 @@ describe(__filename, () => {
         `${DOWNLOAD_FIREFOX_BASE_URL}?utm_campaign=${DOWNLOAD_FIREFOX_UTM_CAMPAIGN}`,
         `utm_content=${GET_FIREFOX_BANNER_UTM_CONTENT}`,
         `utm_medium=referral&utm_source=addons.mozilla.org`,
-        `utm_term=${DOWNLOAD_FIREFOX_UTM_TERM}`,
       ].join('&');
       expect(root.find(Button)).toHaveProp('href', expectedHref);
     });

--- a/tests/unit/amo/components/TestGetFirefoxButton.js
+++ b/tests/unit/amo/components/TestGetFirefoxButton.js
@@ -11,14 +11,13 @@ import GetFirefoxButton, {
   GET_FIREFOX_BUTTON_CLICK_CATEGORY,
   GetFirefoxButtonBase,
   getDownloadLink,
-  getDownloadTerm,
+  getDownloadCampaign,
 } from 'amo/components/GetFirefoxButton';
 import {
   CLIENT_APP_FIREFOX,
   DOWNLOAD_FIREFOX_BASE_URL,
   DOWNLOAD_FIREFOX_EXPERIMENTAL_URL,
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
-  DOWNLOAD_FIREFOX_UTM_TERM,
   LINE,
   RECOMMENDED,
   SPONSORED,
@@ -305,30 +304,15 @@ describe(__filename, () => {
     });
   });
 
-  describe('getDownloadTerm', () => {
-    it('returns a term without an addonId or variant', () => {
-      expect(getDownloadTerm()).toEqual(DOWNLOAD_FIREFOX_UTM_TERM);
+  describe('getDownloadCampaign', () => {
+    it('returns a campaign without an addonId', () => {
+      expect(getDownloadCampaign()).toEqual(DOWNLOAD_FIREFOX_UTM_CAMPAIGN);
     });
 
-    it('returns a term with an addonId', () => {
+    it('returns a campaign with an addonId', () => {
       const addonId = 12345;
-      expect(getDownloadTerm({ addonId })).toEqual(
-        `${DOWNLOAD_FIREFOX_UTM_TERM}-${addonId}`,
-      );
-    });
-
-    it('returns a term with a variant', () => {
-      const variant = 'some-variant';
-      expect(getDownloadTerm({ variant })).toEqual(
-        `${DOWNLOAD_FIREFOX_UTM_TERM}-${variant}`,
-      );
-    });
-
-    it('returns a term with both an addonId and a variant', () => {
-      const addonId = 12345;
-      const variant = 'some-variant';
-      expect(getDownloadTerm({ addonId, variant })).toEqual(
-        `${DOWNLOAD_FIREFOX_UTM_TERM}-${addonId}-${variant}`,
+      expect(getDownloadCampaign({ addonId })).toEqual(
+        `${DOWNLOAD_FIREFOX_UTM_CAMPAIGN}-${addonId}`,
       );
     });
   });
@@ -391,41 +375,32 @@ describe(__filename, () => {
       expect(link.includes('utm_content')).toEqual(false);
     });
 
-    it('calls getDownloadTerm with a variant and add-on to populate utm_term', () => {
+    it('calls getDownloadCampaign with an add-on to populate utm_campaign', () => {
       const addonId = 123;
       const addon = createInternalAddonWithLang({ ...fakeAddon, id: addonId });
-      const term = 'some_utm_term';
-      const variant = VARIANT_NEW;
-      const _getDownloadTerm = sinon.stub().returns(term);
+      const campaign = 'some_campaign';
+      const _getDownloadCampaign = sinon.stub().returns(campaign);
 
-      const link = getDownloadLink({ _getDownloadTerm, addon, variant });
+      const link = getDownloadLink({ _getDownloadCampaign, addon });
 
-      sinon.assert.calledWith(_getDownloadTerm, { addonId, variant });
-      expect(link.includes(`utm_term=${term}`)).toEqual(true);
+      sinon.assert.calledWith(_getDownloadCampaign, { addonId });
+      expect(link.includes(`utm_campaign=${campaign}`)).toEqual(true);
     });
 
-    it('calls getDownloadTerm without an add-on or variant to populate utm_term', () => {
+    it('calls getDownloadCampaign without an add-on to populate utm_campaign', () => {
       const addon = undefined;
-      const term = 'some_utm_term';
-      const variant = undefined;
-      const _getDownloadTerm = sinon.stub().returns(term);
+      const campaign = 'some_campaign';
+      const _getDownloadCampaign = sinon.stub().returns(campaign);
 
-      const link = getDownloadLink({
-        _getDownloadTerm,
-        addon,
-        variant,
-      });
+      const link = getDownloadLink({ _getDownloadCampaign, addon });
 
-      sinon.assert.calledWith(_getDownloadTerm, {
-        addonId: undefined,
-        variant: undefined,
-      });
-      expect(link.includes(`utm_term=${term}`)).toEqual(true);
+      sinon.assert.calledWith(_getDownloadCampaign, { addonId: undefined });
+      expect(link.includes(`utm_campaign=${campaign}`)).toEqual(true);
     });
 
     // Note: This is a sanity test for the entire URL string. Each of the
     // individual tests above test separate pieces of logic.
-    it('returns the expected URL for the new variant and an add-on', () => {
+    it('returns the expected URL for an add-on', () => {
       const addonId = 123;
       const addon = createInternalAddonWithLang({ ...fakeAddon, id: addonId });
 
@@ -433,10 +408,9 @@ describe(__filename, () => {
         `${DOWNLOAD_FIREFOX_EXPERIMENTAL_URL}?experiment=${EXPERIMENT_CONFIG.id}`,
         `variation=${VARIANT_NEW}`,
         `xv=amo`,
-        `utm_campaign=${DOWNLOAD_FIREFOX_UTM_CAMPAIGN}`,
+        `utm_campaign=${DOWNLOAD_FIREFOX_UTM_CAMPAIGN}-${addonId}`,
         `utm_content=rta%3A${encode(addon.guid)}`,
         `utm_medium=referral&utm_source=addons.mozilla.org`,
-        `utm_term=${DOWNLOAD_FIREFOX_UTM_TERM}-${addonId}-${VARIANT_NEW}`,
       ].join('&');
 
       expect(

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -162,7 +162,7 @@ describe(__filename, () => {
     const root = render({ addon });
 
     expect(root.find(GetFirefoxButton)).toHaveProp('overrideQueryParams', {
-      utm_term: `amo-blog-fx-cta-${addon.id}`,
+      utm_campaign: `amo-blog-fx-cta-${addon.id}`,
       experiment: null,
       variation: null,
     });


### PR DESCRIPTION
Fixes #10786 

This also removes logic that would have appended the `variant` to the `utm_campaign` param as we no longer need to do that. As long as we pass the `variant` in `variation`, then it will get stored in a usable format in both GA and telemetry.