### PR TITLE
Refactor withExperiment HOC to make it more predictable

### DIFF
--- a/src/amo/withExperiment.js
+++ b/src/amo/withExperiment.js
@@ -217,7 +217,7 @@ export const withExperiment =
       setupExperiment(props) {
         const { _getVariant, dispatch, isUserExcluded, storedVariants } = props;
 
-        // If the experiment is not enable, we return a null variant.
+        // If the experiment is not enabled, we return a null variant.
         if (!this.isEnabled()) {
           return null;
         }

--- a/src/amo/withExperiment.js
+++ b/src/amo/withExperiment.js
@@ -79,7 +79,6 @@ type CookieConfig = {|
 |};
 
 type ExperimentVariant = {| id: string, percentage: number |};
-type RegisteredExpermients = {| [experimentId: string]: string |};
 
 export type ExperimentConfig = {|
   cookieConfig?: CookieConfig,
@@ -185,6 +184,8 @@ export const withExperiment =
     invariant(variants, 'variants is required');
 
     class WithExperiment extends React.Component<WithExperimentInternalProps> {
+      variant: string | null;
+
       static defaultProps = {
         _getVariant: getVariant,
         _isExperimentEnabled: isExperimentEnabled,
@@ -194,66 +195,71 @@ export const withExperiment =
         WrappedComponent,
       )})`;
 
-      experimentSetup(props) {
-        const {
-          _getVariant,
-          _isExperimentEnabled,
-          dispatch,
-          isUserExcluded,
-          storedVariants,
-        } = props;
+      constructor(props: WithExperimentInternalProps) {
+        super(props);
 
-        let variant = null;
+        this.variant = this.setupExperiment(props);
+      }
 
-        const isEnabled = _isExperimentEnabled({ _config, id });
-        const registeredExperiments = this.getExperiments();
-        const experimentInCookie = this.cookieIncludesExperiment(
-          registeredExperiments,
-        );
-        const addExperimentToCookie = !experimentInCookie;
-        const variantFromStore = storedVariants[id];
+      isEnabled() {
+        return this.props._isExperimentEnabled({ _config, id });
+      }
 
-        // Always use the variant from the cookie, if it exists.
-        if (experimentInCookie) {
-          variant = registeredExperiments[id];
+      readVariantFromCookie() {
+        if (this.cookieIncludesExperiment()) {
+          return this.getExperimentsFromCookie()[id];
         }
 
-        if (isEnabled && !variant) {
+        return null;
+      }
+
+      // Returns a variant.
+      setupExperiment(props) {
+        const { _getVariant, dispatch, isUserExcluded, storedVariants } = props;
+
+        // If the experiment is not enable, we return a null variant.
+        if (!this.isEnabled()) {
+          return null;
+        }
+
+        // Always use the variant from the cookie, if it exists.
+        let variant = this.readVariantFromCookie();
+
+        if (!variant) {
+          const variantFromStore = storedVariants[id];
           // Look for a variant in the Redux store.
           if (variantFromStore) {
             variant = variantFromStore;
           }
-          // Otherwise if the user is to be excluded, use the NOT_IN_EXPERIMENT variant.
+          // Otherwise if the user is to be excluded, use the NOT_IN_EXPERIMENT
+          // variant.
           else if (isUserExcluded) {
             variant = NOT_IN_EXPERIMENT;
+          } else {
+            variant = _getVariant({ variants });
           }
 
           // Do we need to store the variant in the cookie?
-          if (addExperimentToCookie) {
-            // Determine the variant if we don't already have one.
-            variant = variant || _getVariant({ variants });
-
+          if (!this.cookieIncludesExperiment() && !variantFromStore) {
             // Store the variant in the Redux store for use during
-            // componentDidMount.
+            // `componentDidMount()` and only when the user does not yet have a
+            // variant in a cookie. In this case, the `experiments` state would
+            // be empty, which is a bit unusual as we normally have consistent
+            // states.
             dispatch(storeExperimentVariant({ id, variant }));
           }
         }
 
-        return {
-          // We only need to add the experiment to the cookie if we have a
-          // variant.
-          addExperimentToCookie: addExperimentToCookie && variant,
-          registeredExperiments,
-          variant,
-        };
+        return variant;
       }
 
       componentDidMount() {
+        const { variant } = this;
         const { _isExperimentEnabled, cookies } = this.props;
 
-        const { addExperimentToCookie, registeredExperiments, variant } =
-          this.experimentSetup(this.props);
-
+        const addExperimentToCookie =
+          variant && !this.cookieIncludesExperiment();
+        const registeredExperiments = this.getExperimentsFromCookie();
         const experimentsToStore = { ...registeredExperiments };
 
         // Clear any disabled experiments from the cookie.
@@ -287,30 +293,30 @@ export const withExperiment =
         }
       }
 
-      getExperiments() {
-        const { cookies } = this.props;
-
-        return cookies.get(EXPERIMENT_COOKIE_NAME) || {};
+      getExperimentsFromCookie() {
+        return this.props.cookies.get(EXPERIMENT_COOKIE_NAME) || {};
       }
 
-      cookieIncludesExperiment(registeredExperiments: RegisteredExpermients) {
-        return Object.keys(registeredExperiments).includes(id);
+      cookieIncludesExperiment() {
+        return Object.keys(this.getExperimentsFromCookie()).includes(id);
       }
 
       render() {
-        const { _isExperimentEnabled, ...props } = this.props;
+        // We extract only the props we want to pass to the wrapper component.
+        const { _getVariant, _isExperimentEnabled, ...otherProps } = this.props;
 
-        const { variant } = this.experimentSetup(this.props);
-        const isEnabled = _isExperimentEnabled({ _config, id });
+        // We should always read the variant from the cookie, unless it has not
+        // been set yet, in which case the attribute should have it.
+        const variant = this.readVariantFromCookie() || this.variant;
 
         const exposedProps: WithExperimentInjectedProps = {
           experimentId: id,
-          isExperimentEnabled: isEnabled,
+          isExperimentEnabled: this.isEnabled(),
           isUserInExperiment: Boolean(variant && variant !== NOT_IN_EXPERIMENT),
           variant,
         };
 
-        return <WrappedComponent {...exposedProps} {...props} />;
+        return <WrappedComponent {...exposedProps} {...otherProps} />;
       }
     }
 

--- a/tests/unit/amo/test_withExperiment.js
+++ b/tests/unit/amo/test_withExperiment.js
@@ -275,6 +275,7 @@ describe(__filename, () => {
       experimentProps: { id: experimentId },
     });
 
+    sinon.assert.calledOnce(cookies.set);
     sinon.assert.calledWith(
       cookies.set,
       EXPERIMENT_COOKIE_NAME,
@@ -300,8 +301,10 @@ describe(__filename, () => {
       props: { _getVariant },
     });
 
+    sinon.assert.calledOnce(_getVariant);
     sinon.assert.calledWith(_getVariant, { variants });
 
+    sinon.assert.calledOnce(cookies.set);
     sinon.assert.calledWith(
       cookies.set,
       EXPERIMENT_COOKIE_NAME,
@@ -443,6 +446,7 @@ describe(__filename, () => {
       store,
     });
 
+    sinon.assert.calledOnce(fakeDispatch);
     sinon.assert.calledWith(
       fakeDispatch,
       storeExperimentVariant({ id, variant: variantId }),
@@ -473,6 +477,7 @@ describe(__filename, () => {
       props: { _getVariant },
     });
 
+    sinon.assert.calledOnce(cookies.set);
     sinon.assert.calledWith(
       cookies.set,
       EXPERIMENT_COOKIE_NAME,
@@ -514,6 +519,7 @@ describe(__filename, () => {
       props: { _getVariant },
     });
 
+    sinon.assert.calledOnce(_tracking.sendEvent);
     sinon.assert.calledWith(
       _tracking.sendEvent,
       sinon.match({
@@ -574,6 +580,7 @@ describe(__filename, () => {
       props: { _getVariant },
     });
 
+    sinon.assert.calledOnce(cookies.set);
     sinon.assert.calledWith(
       cookies.set,
       EXPERIMENT_COOKIE_NAME,
@@ -609,6 +616,7 @@ describe(__filename, () => {
     });
 
     const root = render({ cookies, experimentProps: { id } });
+
     expect(root).toHaveProp('isUserInExperiment', false);
   });
 
@@ -621,6 +629,7 @@ describe(__filename, () => {
     };
 
     const root = render({ configOverrides, experimentProps: { id } });
+
     expect(root).toHaveProp('isUserInExperiment', false);
   });
 
@@ -631,6 +640,7 @@ describe(__filename, () => {
     };
 
     const root = render({ configOverrides });
+
     expect(root).toHaveProp('isExperimentEnabled', false);
   });
 
@@ -638,6 +648,7 @@ describe(__filename, () => {
     const configOverrides = { experiments: null };
 
     const root = render({ configOverrides });
+
     expect(root).toHaveProp('isExperimentEnabled', false);
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10812
Fixes https://github.com/mozilla/addons-frontend/issues/10811

---

Let's start with the good thing: no tests broken! 🎉 There are a bunch of changes to simplify the HOC with the main goal of avoiding the call to `experimentSetup` (renamed to put the verb first) in `render()`. I added some assertions to make sure we don't dispatch too many actions (never a good idea).

I confirmed this patch fixes the addons-server local dev issue mentioned by @wagnerand on Matrix. I tried it locally and it looks good as well but I'll ask QA to verify everything extensively on -dev.

On addons-server local dev, there is a third issue (see #10810) but it is not required to make the frontend work in this environment. The only problem with #10810 is that we don't have cookies set and therefore we don't take part in any experiment. I'll fix that later in a different patch.