### PR TITLE
Set 'Access-Control-Allow-Origin: *' on /__version__

### DIFF
--- a/src/amo/utils/server.js
+++ b/src/amo/utils/server.js
@@ -48,6 +48,8 @@ export const viewFrontendVersionHandler = ({
       } else {
         const versionJson = await fs.readJson(version);
 
+        // Allow anyone to fetch this file.
+        res.header('Access-Control-Allow-Origin', '*');
         res.json({
           ...versionJson,
           experiments,

--- a/tests/unit/amo/utils/test_server.js
+++ b/tests/unit/amo/utils/test_server.js
@@ -24,6 +24,7 @@ describe(__filename, () => {
         expect(res.get('content-type')).toEqual(
           'application/json; charset=utf-8',
         );
+        expect(res.get('access-control-allow-origin')).toEqual('*');
         expect(res._getJSON()).toMatchObject(versionJson);
 
         done();


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10822

---

This can be tested locally with [amo-info](https://addons.mozilla.org/en-US/firefox/addon/amo-info/) or `curl -I`.