### PR TITLE
Do not render related categories for add-ons that are not extensions/themes

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -434,8 +434,9 @@ const mapStateToProps = (state: AppState, ownProps: Props): PropsFromState => {
 
   if (addon && addon.categories && addon.type && categories && clientApp) {
     const appCategories = categories[clientApp][addon.type];
+    const addonCategories = addon.categories[clientApp] || [];
 
-    relatedCategories = addon.categories[clientApp].reduce((result, slug) => {
+    relatedCategories = addonCategories.reduce((result, slug) => {
       if (typeof appCategories[slug] !== 'undefined') {
         result.push(appCategories[slug]);
       }

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -10,7 +10,11 @@ import Card from 'amo/components/Card';
 import DefinitionList, { Definition } from 'amo/components/DefinitionList';
 import Link from 'amo/components/Link';
 import LoadingText from 'amo/components/LoadingText';
-import { STATS_VIEW } from 'amo/constants';
+import {
+  ADDON_TYPE_EXTENSION,
+  ADDON_TYPE_STATIC_THEME,
+  STATS_VIEW,
+} from 'amo/constants';
 import { withErrorHandler } from 'amo/errorHandler';
 import translate from 'amo/i18n/translate';
 import { fetchCategories } from 'amo/reducers/categories';
@@ -170,6 +174,29 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
       );
     }
 
+    let categories = null;
+    if (
+      [ADDON_TYPE_EXTENSION, ADDON_TYPE_STATIC_THEME].includes(addon.type) &&
+      relatedCategories &&
+      relatedCategories.length > 0
+    ) {
+      categories = relatedCategories.map((category) => {
+        return (
+          <li key={category.slug}>
+            <Link
+              className="AddonMoreInfo-related-category-link"
+              to={getCategoryResultsPathname({
+                addonType: category.type,
+                slug: category.slug,
+              })}
+            >
+              {i18n.gettext(category.name)}
+            </Link>
+          </li>
+        );
+      });
+    }
+
     return this.renderDefinitions({
       homepage,
       supportUrl,
@@ -211,24 +238,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
           {i18n.gettext('Read the license agreement for this add-on')}
         </Link>
       ) : null,
-      relatedCategories:
-        relatedCategories && relatedCategories.length > 0
-          ? relatedCategories.map((category) => {
-              return (
-                <li key={category.slug}>
-                  <Link
-                    className="AddonMoreInfo-related-category-link"
-                    to={getCategoryResultsPathname({
-                      addonType: category.type,
-                      slug: category.slug,
-                    })}
-                  >
-                    {i18n.gettext(category.name)}
-                  </Link>
-                </li>
-              );
-            })
-          : null,
+      relatedCategories: categories,
       versionHistoryLink: (
         <li>
           <Link

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -724,6 +724,20 @@ describe(__filename, () => {
       ).toHaveLength(0);
     });
 
+    it('does not render a related category if add-on does not have any category at all', () => {
+      const addon = createInternalAddonWithLang({
+        ...fakeAddon,
+        categories: {},
+      });
+      store.dispatch(loadCategories({ results: categories }));
+
+      const root = render({ addon, store });
+
+      expect(
+        root.find('.AddonMoreInfo-related-categories').find(Link),
+      ).toHaveLength(0);
+    });
+
     it('does not render a related category when add-on type does not have this category', () => {
       const { slug } = categories[0];
       const addon = createInternalAddonWithLang({

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -608,6 +608,20 @@ describe(__filename, () => {
         slug: 'anime',
         type: ADDON_TYPE_STATIC_THEME,
       },
+      {
+        ...fakeCategory,
+        application: CLIENT_APP_ANDROID,
+        name: 'Alerts & Update',
+        slug: 'alert-update',
+        type: ADDON_TYPE_DICT,
+      },
+      {
+        ...fakeCategory,
+        application: CLIENT_APP_ANDROID,
+        name: 'Alerts & Update',
+        slug: 'alert-update',
+        type: ADDON_TYPE_LANG,
+      },
     ];
 
     it('renders related categories', () => {
@@ -726,6 +740,24 @@ describe(__filename, () => {
         root.find('.AddonMoreInfo-related-categories').find(Link),
       ).toHaveLength(0);
     });
+
+    it.each([ADDON_TYPE_DICT, ADDON_TYPE_LANG])(
+      'does not render related categories for addonType=%s',
+      (type) => {
+        const addon = createInternalAddonWithLang({
+          ...fakeAddon,
+          categories: { [CLIENT_APP_ANDROID]: [categories[0].slug] },
+          type,
+        });
+        store.dispatch(loadCategories({ results: categories }));
+
+        const root = render({ addon, store });
+
+        expect(
+          root.find('.AddonMoreInfo-related-categories').find(Link),
+        ).toHaveLength(0);
+      },
+    );
 
     it('renders errors when API error occurs', () => {
       const errorHandler = new ErrorHandler({


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10829

---

We can reproduce the bug (without this patch) by loading:

- http://localhost:3000/en-US/firefox/addon/akan-ns%C9%9Bmfuaasekyer%C9%9B/
- http://localhost:3000/en-US/firefox/addon/asturianu-language-pack/

The fix is to not render categories for add-ons that are not extensions or themes given that we only have category pages for extensions and themes. We could also render the categories without links but that wouldn't be super useful so it is best to hide them.

The second commit handles add-ons without any categories at all, e.g.:

- http://127.0.0.1:3000/en-US/firefox/addon/xuxen/