### PR TITLE
Render noindex,follow meta when search page does not have any results

### DIFF
--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -131,8 +131,8 @@ export class SearchBase extends React.Component<InternalProps> {
     }
   }
 
-  renderHelmetTitle(): React.Node {
-    const { i18n, filters, pageTitle } = this.props;
+  renderHelmet(): React.Node {
+    const { i18n, filters, pageTitle, count } = this.props;
 
     let title = pageTitle;
 
@@ -235,6 +235,7 @@ export class SearchBase extends React.Component<InternalProps> {
     return (
       <Helmet>
         <title>{title}</title>
+        {count === 0 && <meta name="robots" content="noindex, follow" />}
       </Helmet>
     );
   }
@@ -291,7 +292,7 @@ export class SearchBase extends React.Component<InternalProps> {
 
     return (
       <div className="Search">
-        {this.renderHelmetTitle()}
+        {this.renderHelmet()}
 
         {errorHandler.renderErrorIfPresent()}
 

--- a/tests/unit/amo/components/TestSearch.js
+++ b/tests/unit/amo/components/TestSearch.js
@@ -433,6 +433,16 @@ describe(__filename, () => {
     expect(wrapper.find(NotFound)).toHaveLength(1);
   });
 
+  it('renders a robots meta when there is no results', () => {
+    const root = render({ count: 0 });
+
+    expect(root.find('meta[name="robots"]')).toHaveLength(1);
+    expect(root.find('meta[name="robots"]')).toHaveProp(
+      'content',
+      'noindex, follow',
+    );
+  });
+
   describe('errorHandler - extractId', () => {
     it('generates a unique ID based on the page filter', () => {
       const ownProps = {

--- a/tests/unit/amo/components/TestSearch.js
+++ b/tests/unit/amo/components/TestSearch.js
@@ -453,6 +453,16 @@ describe(__filename, () => {
     expect(root.find('meta[name="robots"]')).toHaveLength(0);
   });
 
+  it.each([undefined, false, true, '0'])(
+    'does not render a robots meta when count is %s',
+    (count) => {
+      // We shouldn't manually inject `count`.
+      const root = render({ count });
+
+      expect(root.find('meta[name="robots"]')).toHaveLength(0);
+    },
+  );
+
   describe('errorHandler - extractId', () => {
     it('generates a unique ID based on the page filter', () => {
       const ownProps = {

--- a/tests/unit/amo/components/TestSearch.js
+++ b/tests/unit/amo/components/TestSearch.js
@@ -86,6 +86,7 @@ describe(__filename, () => {
     expect(Object.keys(searchResults.props()).sort()).toEqual(
       ['count', 'filters', 'loading', 'paginator', 'results'].sort(),
     );
+    expect(root.find('meta[name="robots"]')).toHaveLength(0);
   });
 
   it('passes a Paginate component to the SearchResults component', () => {
@@ -203,6 +204,7 @@ describe(__filename, () => {
     const root = render({ errorHandler });
 
     expect(root.find(ErrorList)).toHaveLength(1);
+    expect(root.find('meta[name="robots"]')).toHaveLength(0);
   });
 
   it('renders an HTML title', () => {
@@ -434,13 +436,21 @@ describe(__filename, () => {
   });
 
   it('renders a robots meta when there is no results', () => {
-    const root = render({ count: 0 });
+    const { store } = dispatchSearchResults({ addons: [] });
+    const root = renderWithStore({ store });
 
     expect(root.find('meta[name="robots"]')).toHaveLength(1);
     expect(root.find('meta[name="robots"]')).toHaveProp(
       'content',
       'noindex, follow',
     );
+  });
+
+  it('does not render a robots meta when there are results', () => {
+    const { store } = dispatchSearchResults({ addons: [fakeAddon] });
+    const root = renderWithStore({ store });
+
+    expect(root.find('meta[name="robots"]')).toHaveLength(0);
   });
 
   describe('errorHandler - extractId', () => {


### PR DESCRIPTION
Fixes #10831

---

This should work with all search pages, including category pages and soon tag pages. FWIW, we use this `meta` tag for other pages.