### PR TITLE
allow ratings and users search parameters to be passed to the search api

### DIFF
--- a/src/amo/searchUtils.js
+++ b/src/amo/searchUtils.js
@@ -9,6 +9,10 @@ import {
 import log from 'amo/logger';
 import { USER_AGENT_OS_IOS } from 'amo/reducers/api';
 
+// TODO: we need to specify these API params in `paramsToFilter` so that the
+// app uses them when making API calls but ideally we'd revisit the filter
+// names when we need to use the filters in our code (because `foo__lte` isn't
+// a great name).
 export function generateThresholdParams(param) {
   return ['__gt', '__lt', '__lte', '__gte', ''].reduce((object, key) => {
     return { ...object, [`${param}${key}`]: `${param}${key}` };

--- a/src/amo/searchUtils.js
+++ b/src/amo/searchUtils.js
@@ -9,7 +9,7 @@ import {
 import log from 'amo/logger';
 import { USER_AGENT_OS_IOS } from 'amo/reducers/api';
 
-export function generate_threshold_params({ param }) {
+export function generateThresholdParams(param) {
   return ['__gt', '__lt', '__lte', '__gte', ''].reduce((object, key) => {
     return { ...object, [`${param}${key}`]: `${param}${key}` };
   }, {});
@@ -27,11 +27,11 @@ export const paramsToFilter = {
   page_size: 'page_size',
   promoted: 'promoted',
   q: 'query',
-  ...generate_threshold_params({ param: 'ratings' }),
+  ...generateThresholdParams('ratings'),
   sort: 'sort',
   tag: 'tag',
   type: 'addonType',
-  ...generate_threshold_params({ param: 'users' }),
+  ...generateThresholdParams('users'),
 };
 
 export function addVersionCompatibilityToFilters({

--- a/src/amo/searchUtils.js
+++ b/src/amo/searchUtils.js
@@ -9,6 +9,12 @@ import {
 import log from 'amo/logger';
 import { USER_AGENT_OS_IOS } from 'amo/reducers/api';
 
+export function generate_threshold_params({ param }) {
+  return ['__gt', '__lt', '__lte', '__gte', ''].reduce((object, key) => {
+    return { ...object, [`${param}${key}`]: `${param}${key}` };
+  }, {});
+}
+
 export const paramsToFilter = {
   app: 'clientApp',
   appversion: 'compatibleWithVersion',
@@ -21,9 +27,11 @@ export const paramsToFilter = {
   page_size: 'page_size',
   promoted: 'promoted',
   q: 'query',
+  ...generate_threshold_params({ param: 'ratings' }),
   sort: 'sort',
   tag: 'tag',
   type: 'addonType',
+  ...generate_threshold_params({ param: 'users' }),
 };
 
 export function addVersionCompatibilityToFilters({

--- a/tests/unit/amo/test_searchUtils.js
+++ b/tests/unit/amo/test_searchUtils.js
@@ -284,11 +284,9 @@ describe(__filename, () => {
 
   describe('paramsToFilter', () => {
     it('generates all the required threshold parameters for ratings and users', () => {
-      expect(paramsToFilter).toEqual({
-        ...paramsToFilter,
-        ...generateThresholdParams('ratings'),
-        ...generateThresholdParams('users'),
-      });
+      expect(paramsToFilter).toMatchObject({ ratings__gt: 'ratings__gt' });
+      expect(paramsToFilter).toMatchObject({ users__lte: 'users__lte' });
+      expect(paramsToFilter).toMatchObject({ users: 'users' });
     });
   });
 });

--- a/tests/unit/amo/test_searchUtils.js
+++ b/tests/unit/amo/test_searchUtils.js
@@ -13,6 +13,8 @@ import {
   convertQueryParamsToFilters,
   fixFiltersForClientApp,
   fixFiltersFromLocation,
+  generate_threshold_params,
+  paramsToFilter,
 } from 'amo/searchUtils';
 import {
   dispatchClientMetadata,
@@ -263,6 +265,30 @@ describe(__filename, () => {
       const filters = { clientApp: CLIENT_APP_ANDROID, lang: 'fr', page };
 
       expect(fixFiltersFromLocation(filters)).toEqual({ page });
+    });
+  });
+
+  describe('generate_threshold_params', () => {
+    it('generates all the required threshold parameters for a given param', () => {
+      const generated = generate_threshold_params({ param: 'foo' });
+
+      expect(generated).toEqual({
+        foo__gt: 'foo__gt',
+        foo__lt: 'foo__lt',
+        foo__gte: 'foo__gte',
+        foo__lte: 'foo__lte',
+        foo: 'foo',
+      });
+    });
+  });
+
+  describe('paramsToFilter', () => {
+    it('generates all the required threshold parameters for ratings and users', () => {
+      expect(paramsToFilter).toEqual({
+        ...paramsToFilter,
+        ...generate_threshold_params({ param: 'ratings' }),
+        ...generate_threshold_params({ param: 'users' }),
+      });
     });
   });
 });

--- a/tests/unit/amo/test_searchUtils.js
+++ b/tests/unit/amo/test_searchUtils.js
@@ -13,7 +13,7 @@ import {
   convertQueryParamsToFilters,
   fixFiltersForClientApp,
   fixFiltersFromLocation,
-  generate_threshold_params,
+  generateThresholdParams,
   paramsToFilter,
 } from 'amo/searchUtils';
 import {
@@ -268,9 +268,9 @@ describe(__filename, () => {
     });
   });
 
-  describe('generate_threshold_params', () => {
+  describe('generateThresholdParams', () => {
     it('generates all the required threshold parameters for a given param', () => {
-      const generated = generate_threshold_params({ param: 'foo' });
+      const generated = generateThresholdParams('foo');
 
       expect(generated).toEqual({
         foo__gt: 'foo__gt',
@@ -286,8 +286,8 @@ describe(__filename, () => {
     it('generates all the required threshold parameters for ratings and users', () => {
       expect(paramsToFilter).toEqual({
         ...paramsToFilter,
-        ...generate_threshold_params({ param: 'ratings' }),
-        ...generate_threshold_params({ param: 'users' }),
+        ...generateThresholdParams('ratings'),
+        ...generateThresholdParams('users'),
       });
     });
   });


### PR DESCRIPTION
fixes #10835 - seems to work from a quick test.  Not sure if there needs to be anything else added?