### PR TITLE
added strings for all the combinations of categories, tags, and queries

### DIFF
--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -54,26 +54,51 @@ export class SearchContextCardBase extends React.Component<InternalProps> {
     if (!loadingSearch) {
       switch (addonType) {
         case ADDON_TYPE_EXTENSION:
-          if (categoryName) {
-            if (query) {
-              searchText = i18n.sprintf(
-                i18n.ngettext(
-                  '%(count)s extension found for "%(query)s" in %(categoryName)s',
-                  '%(count)s extensions found for "%(query)s" in %(categoryName)s',
-                  count,
-                ),
-                { count: i18n.formatNumber(count), query, categoryName },
-              );
-            } else {
-              searchText = i18n.sprintf(
-                i18n.ngettext(
-                  '%(count)s extension found in %(categoryName)s',
-                  '%(count)s extensions found in %(categoryName)s',
-                  count,
-                ),
-                { count: i18n.formatNumber(count), categoryName },
-              );
-            }
+          if (categoryName && query && tag) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s extension found for "%(query)s" with tag %(tag)s in %(categoryName)s',
+                '%(count)s extensions found for "%(query)s" with tag %(tag)s in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), query, categoryName, tag },
+            );
+          } else if (categoryName && query) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s extension found for "%(query)s" in %(categoryName)s',
+                '%(count)s extensions found for "%(query)s" in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), query, categoryName },
+            );
+          } else if (categoryName && tag) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s extension found with tag %(tag)s in %(categoryName)s',
+                '%(count)s extensions found with tag %(tag)s in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), categoryName, tag },
+            );
+          } else if (categoryName) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s extension found in %(categoryName)s',
+                '%(count)s extensions found in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), categoryName },
+            );
+          } else if (query && tag) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s extension found for "%(query)s" with tag %(tag)s',
+                '%(count)s extensions found for "%(query)s" with tag %(tag)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), query, tag },
+            );
           } else if (query) {
             searchText = i18n.sprintf(
               i18n.ngettext(
@@ -104,26 +129,51 @@ export class SearchContextCardBase extends React.Component<InternalProps> {
           }
           break;
         case ADDON_TYPE_STATIC_THEME:
-          if (categoryName) {
-            if (query) {
-              searchText = i18n.sprintf(
-                i18n.ngettext(
-                  '%(count)s theme found for "%(query)s" in %(categoryName)s',
-                  '%(count)s themes found for "%(query)s" in %(categoryName)s',
-                  count,
-                ),
-                { count: i18n.formatNumber(count), query, categoryName },
-              );
-            } else {
-              searchText = i18n.sprintf(
-                i18n.ngettext(
-                  '%(count)s theme found in %(categoryName)s',
-                  '%(count)s themes found in %(categoryName)s',
-                  count,
-                ),
-                { count: i18n.formatNumber(count), categoryName },
-              );
-            }
+          if (categoryName && query && tag) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s theme found for "%(query)s" with tag %(tag)s in %(categoryName)s',
+                '%(count)s themes found for "%(query)s" with tag %(tag)s in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), query, categoryName, tag },
+            );
+          } else if (categoryName && query) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s theme found for "%(query)s" in %(categoryName)s',
+                '%(count)s themes found for "%(query)s" in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), query, categoryName },
+            );
+          } else if (categoryName && tag) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s theme found with tag %(tag)s in %(categoryName)s',
+                '%(count)s themes found with tag %(tag)s in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), categoryName, tag },
+            );
+          } else if (categoryName) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s theme found in %(categoryName)s',
+                '%(count)s themes found in %(categoryName)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), categoryName },
+            );
+          } else if (query && tag) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s theme found for "%(query)s" with tag %(tag)s',
+                '%(count)s themes found for "%(query)s" with tag %(tag)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), query, tag },
+            );
           } else if (query) {
             searchText = i18n.sprintf(
               i18n.ngettext(
@@ -154,7 +204,16 @@ export class SearchContextCardBase extends React.Component<InternalProps> {
           }
           break;
         default:
-          if (query) {
+          if (query && tag) {
+            searchText = i18n.sprintf(
+              i18n.ngettext(
+                '%(count)s result found for "%(query)s" with tag %(tag)s',
+                '%(count)s results found for "%(query)s" with tag %(tag)s',
+                count,
+              ),
+              { count: i18n.formatNumber(count), query, tag },
+            );
+          } else if (query) {
             searchText = i18n.sprintf(
               i18n.ngettext(
                 '%(count)s result found for "%(query)s"',

--- a/tests/unit/amo/components/TestSearchContextCard.js
+++ b/tests/unit/amo/components/TestSearchContextCard.js
@@ -491,6 +491,43 @@ describe(__filename, () => {
     );
   });
 
+  it('should render results with the tag, and the query string for tag query with a text query', () => {
+    const tag = 'foo';
+    const query = 'test';
+    dispatchSearchResults({
+      filters: {
+        tag,
+        query,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `2 results found for "${query}" with tag ${tag}`,
+    );
+  });
+
+  it('should render a singular result with the tag, and the query string for tag query with a text query', () => {
+    const tag = 'foo';
+    const query = 'test';
+    dispatchSearchResults({
+      addons: [fakeAddon],
+      filters: {
+        tag,
+        query,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `1 result found for "${query}" with tag ${tag}`,
+    );
+  });
+
   it('should render results with the tag for tag query', () => {
     const tag = 'foo';
     dispatchSearchResults({
@@ -521,6 +558,175 @@ describe(__filename, () => {
 
     expect(root.find('.SearchContextCard-header').text()).toEqual(
       `1 result found with tag ${tag}`,
+    );
+  });
+
+  it('should render results for addonType ADDON_TYPE_EXTENSION in a category with a query string and tag for tag query', () => {
+    const category = 'bookmarks';
+    const categoryName = 'Bookmarks';
+    const query = 'test';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_EXTENSION,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        category,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `2 extensions found for "${query}" with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render a singular result for addonType ADDON_TYPE_EXTENSION in a category with a query string and tag for tag query', () => {
+    const category = 'bookmarks';
+    const categoryName = 'Bookmarks';
+    const query = 'test';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_EXTENSION,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      addons: [fakeAddon],
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        category,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `1 extension found for "${query}" with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render results for addonType ADDON_TYPE_EXTENSION in a category and tag for tag query', () => {
+    const category = 'bookmarks';
+    const categoryName = 'Bookmarks';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_EXTENSION,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        category,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `2 extensions found with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render a singular result for addonType ADDON_TYPE_EXTENSION in a category and tag for tag query', () => {
+    const category = 'bookmarks';
+    const categoryName = 'Bookmarks';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_EXTENSION,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      addons: [fakeAddon],
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        category,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `1 extension found with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render results for addonType ADDON_TYPE_EXTENSION and tag and query string for tag query', () => {
+    const query = 'test';
+    const tag = 'foo';
+    dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `2 extensions found for "${query}" with tag ${tag}`,
+    );
+  });
+
+  it('should render a singular result for addonType ADDON_TYPE_EXTENSION and query string tag for tag query', () => {
+    const query = 'test';
+    const tag = 'foo';
+    dispatchSearchResults({
+      addons: [fakeAddon],
+      filters: {
+        addonType: ADDON_TYPE_EXTENSION,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `1 extension found for "${query}" with tag ${tag}`,
     );
   });
 
@@ -556,6 +762,175 @@ describe(__filename, () => {
 
     expect(root.find('.SearchContextCard-header').text()).toEqual(
       `1 extension found with tag ${tag}`,
+    );
+  });
+
+  it('should render results for addonType ADDON_TYPE_STATIC_THEME in a category with a query string and tag for tag query', () => {
+    const category = 'causes';
+    const categoryName = 'Causes';
+    const query = 'test';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_STATIC_THEME,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_STATIC_THEME,
+        category,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `2 themes found for "${query}" with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render a singular result for addonType ADDON_TYPE_STATIC_THEME in a category with a query string and tag for tag query', () => {
+    const category = 'causes';
+    const categoryName = 'Causes';
+    const query = 'test';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_STATIC_THEME,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      addons: [fakeAddon],
+      filters: {
+        addonType: ADDON_TYPE_STATIC_THEME,
+        category,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `1 theme found for "${query}" with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render results for addonType ADDON_TYPE_STATIC_THEME in a category and tag for tag query', () => {
+    const category = 'causes';
+    const categoryName = 'Causes';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_STATIC_THEME,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_STATIC_THEME,
+        category,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `2 themes found with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render a singular result for addonType ADDON_TYPE_STATIC_THEME in a category and tag for tag query', () => {
+    const category = 'causes';
+    const categoryName = 'Causes';
+    const tag = 'foo';
+    _fetchCategories();
+    _loadCategories({
+      results: [
+        {
+          ...fakeCategory,
+          type: ADDON_TYPE_STATIC_THEME,
+          name: categoryName,
+          slug: category,
+        },
+      ],
+    });
+    dispatchSearchResults({
+      addons: [fakeAddon],
+      filters: {
+        addonType: ADDON_TYPE_STATIC_THEME,
+        category,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `1 theme found with tag ${tag} in ${categoryName}`,
+    );
+  });
+
+  it('should render results for addonType ADDON_TYPE_STATIC_THEME and tag and query string for tag query', () => {
+    const query = 'test';
+    const tag = 'foo';
+    dispatchSearchResults({
+      filters: {
+        addonType: ADDON_TYPE_STATIC_THEME,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `2 themes found for "${query}" with tag ${tag}`,
+    );
+  });
+
+  it('should render a singular result for addonType ADDON_TYPE_STATIC_THEME and query string tag for tag query', () => {
+    const query = 'test';
+    const tag = 'foo';
+    dispatchSearchResults({
+      addons: [fakeAddon],
+      filters: {
+        addonType: ADDON_TYPE_STATIC_THEME,
+        query,
+        tag,
+      },
+      store: _store,
+    });
+
+    const root = render();
+
+    expect(root.find('.SearchContextCard-header').text()).toEqual(
+      `1 theme found for "${query}" with tag ${tag}`,
     );
   });
 


### PR DESCRIPTION
fixes #10847 
I flattened some of the multiple levels of `if` statements because they become hard to follow with a 3rd level for `if (tag)`