### PR TITLE
RE: Update Primary Hero loading skeleton to reflect a hero with an image

### DIFF
--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -267,7 +267,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           gradientsClassName,
           heightClassName,
           {
-            'HeroRecommendation--no-image': !featuredImage,
+            'HeroRecommendation--no-image': !featuredImage && !loading,
           },
         )}
       >
@@ -284,14 +284,18 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           {errorHandler.renderErrorIfPresent()}
 
           <div className="HeroRecommendation-content">
-            {featuredImage && (
-              <div className="HeroRecommendation-image-wrapper">
-                <img
-                  className="HeroRecommendation-image"
-                  alt=""
-                  src={featuredImage}
-                />
-              </div>
+            {loading ? (
+              <LoadingText width={40} />
+            ) : (
+              featuredImage && (
+                <div className="HeroRecommendation-image-wrapper">
+                  <img
+                    className="HeroRecommendation-image"
+                    alt=""
+                    src={featuredImage}
+                  />
+                </div>
+              )
             )}
             <div className="HeroRecommendation-info">
               {renderHeroTitle()}

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -289,7 +289,9 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
 
           <div className="HeroRecommendation-content">
             {loading ? (
-              <LoadingText width={40} />
+              <div className="HeroRecommendation-image-loading">
+                <LoadingText width={100} />
+              </div>
             ) : (
               featuredImage && (
                 <div className="HeroRecommendation-image-wrapper">

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -218,7 +218,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
     const renderHeroTitle = () => {
       // translators: If uppercase does not work in your locale,
       // change it to lowercase. This is used as a secondary heading.
-      let titleText = i18n.gettext('SPONSORED');
+      let titleText = null;
 
       const promotedCategory = _getPromotedCategory({
         addon,
@@ -226,20 +226,24 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
         forBadging: true,
       });
 
-      if (promotedCategory === RECOMMENDED) {
-        // translators: If uppercase does not work in your locale,
-        // change it to lowercase. This is used as a secondary heading.
-        titleText = i18n.gettext('RECOMMENDED');
-      } else if (promotedCategory === LINE) {
-        // translators: If uppercase does not work in your locale,
-        // change it to lowercase. This is used as a secondary heading.
-        titleText = i18n.gettext('BY FIREFOX');
+      if (!loading) {
+        if (promotedCategory === RECOMMENDED) {
+          // translators: If uppercase does not work in your locale,
+          // change it to lowercase. This is used as a secondary heading.
+          titleText = i18n.gettext('RECOMMENDED');
+        } else if (promotedCategory === LINE) {
+          // translators: If uppercase does not work in your locale,
+          // change it to lowercase. This is used as a secondary heading.
+          titleText = i18n.gettext('BY FIREFOX');
+        } else {
+          titleText = i18n.gettext('SPONSORED');
+        }
       }
 
       return (
         <div className="HeroRecommendation-title">
           <div className="HeroRecommendation-title-text">
-            {loading ? <LoadingText width={20} /> : titleText}
+            {titleText || <LoadingText width={20} />}
           </div>
           {![LINE, RECOMMENDED].includes(promotedCategory) && !loading ? (
             <a

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -55,6 +55,7 @@
   display: flex;
   flex-direction: column;
   line-height: $line-height-compressed;
+  min-width: 300px;
 
   @include respond-to(medium) {
     @include margin-start(24px);

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -47,7 +47,7 @@
   }
 
   .LoadingText {
-    height: 14em;
+    height: 100%;
   }
 }
 

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -41,6 +41,16 @@
   }
 }
 
+.HeroRecommendation-image-loading {
+  @include respond-to(medium) {
+    width: 40%;
+  }
+
+  .LoadingText {
+    height: 14em;
+  }
+}
+
 .HeroRecommendation-image-wrapper {
   @include respond-to(medium) {
     flex: 40%;

--- a/tests/unit/amo/components/TestHeroRecommendation.js
+++ b/tests/unit/amo/components/TestHeroRecommendation.js
@@ -326,7 +326,7 @@ describe(__filename, () => {
     const root = render();
 
     expect(root).toHaveClassName('HeroRecommendation--loading');
-    expect(root.find(LoadingText)).toHaveLength(4);
+    expect(root.find(LoadingText)).toHaveLength(5);
   });
 
   it('renders nothing if shelfData is null', () => {


### PR DESCRIPTION
Fixes #9049 

This pull request updates the primary hero loading skeleton to reflect a hero with an image.

https://user-images.githubusercontent.com/28129806/131353745-19785f98-07c2-4fb4-9292-9c25cbd547cc.mov

Please review when you have a moment. Thank you!