### PR TITLE
Retains focus inside flag review menu

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     // See: https://github.com/facebook/flow/issues/1609
     "SyntheticEvent": true,
     "SyntheticInputEvent": true,
+    "SyntheticKeyboardEvent": true,
     // See: https://github.com/facebook/flow/issues/5627
     "TimeoutID": true,
     // Standard DOM globals:

--- a/src/amo/components/FlagReview/index.js
+++ b/src/amo/components/FlagReview/index.js
@@ -19,6 +19,8 @@ type Props = {|
   reason: FlagReviewReasonType,
   review: UserReviewType,
   wasFlaggedText: string,
+  setFocusOnFirstItem?: Function,
+  btnRef?: Function,
 |};
 
 type PropsFromState = {|
@@ -46,8 +48,21 @@ export class FlagReviewBase extends React.Component<InternalProps> {
     );
   };
 
+  onKeyDown: (event: SyntheticKeyboardEvent<HTMLButtonElement>) => void = (
+    event: SyntheticKeyboardEvent<HTMLButtonElement>,
+  ) => {
+    const { setFocusOnFirstItem } = this.props;
+    if (setFocusOnFirstItem) {
+      if (!event.shiftKey && event.key === 'Tab') {
+        event.preventDefault();
+        setFocusOnFirstItem();
+      }
+    }
+  };
+
   renderControls(): React.Node {
-    const { errorHandler, flagState, buttonText, wasFlaggedText } = this.props;
+    const { errorHandler, flagState, buttonText, wasFlaggedText, btnRef } =
+      this.props;
 
     if (flagState) {
       if (flagState.inProgress && !errorHandler.hasError()) {
@@ -63,6 +78,8 @@ export class FlagReviewBase extends React.Component<InternalProps> {
         className="FlagReview-button"
         onClick={this.onClick}
         type="button"
+        ref={btnRef}
+        onKeyDown={this.onKeyDown}
       >
         {buttonText}
       </button>

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -43,8 +43,14 @@ type InternalProps = {|
 |};
 
 export class FlagReviewMenuBase extends React.Component<InternalProps> {
+  firstItemButtonRef: React.ElementRef<'button'> | null;
+
   static defaultProps: DefaultProps = {
     isDeveloperReply: false,
+  };
+
+  setFocusOnFirstItem: Function = (): void => {
+    this.firstItemButtonRef?.focus();
   };
 
   render(): React.Node {
@@ -87,6 +93,9 @@ export class FlagReviewMenuBase extends React.Component<InternalProps> {
             review={review}
             buttonText={i18n.gettext('This is spam')}
             wasFlaggedText={i18n.gettext('Flagged as spam')}
+            btnRef={(button: HTMLButtonElement | null) => {
+              this.firstItemButtonRef = button;
+            }}
           />
         </ListItem>,
         <ListItem
@@ -98,6 +107,9 @@ export class FlagReviewMenuBase extends React.Component<InternalProps> {
             review={review}
             buttonText={i18n.gettext('This contains inappropriate language')}
             wasFlaggedText={i18n.gettext('Flagged for inappropriate language')}
+            {...(isDeveloperReply && {
+              setFocusOnFirstItem: this.setFocusOnFirstItem,
+            })}
           />
         </ListItem>,
         // Only reviews (not developer responses) can be flagged as
@@ -116,6 +128,7 @@ export class FlagReviewMenuBase extends React.Component<InternalProps> {
               wasFlaggedText={i18n.gettext(
                 'Flagged as a bug report or support request',
               )}
+              setFocusOnFirstItem={this.setFocusOnFirstItem}
             />
           </ListItem>
         ),

--- a/tests/unit/amo/components/TestFlagReview.js
+++ b/tests/unit/amo/components/TestFlagReview.js
@@ -22,11 +22,14 @@ import {
 import ErrorList from 'amo/components/ErrorList';
 import LoadingText from 'amo/components/LoadingText';
 
+const setFocusOnFirstItem = jest.fn();
+
 describe(__filename, () => {
   let store;
 
   beforeEach(() => {
     store = dispatchSignInActions().store;
+    setFocusOnFirstItem.mockClear();
   });
 
   const render = (customProps = {}) => {
@@ -126,5 +129,27 @@ describe(__filename, () => {
 
     // It should still display a button so they can try again.
     expect(root.find('.FlagReview-button')).toHaveLength(1);
+  });
+
+  it('calls setFocusOnFirstItem on tab', () => {
+    const root = render({ setFocusOnFirstItem });
+    const flagReviewBtn = root.find('.FlagReview-button');
+    flagReviewBtn.simulate('keydown', {
+      shiftKey: false,
+      key: 'Tab',
+      preventDefault: () => {},
+    });
+    expect(setFocusOnFirstItem).toHaveBeenCalled();
+  });
+
+  it('does not calls setFocusOnFirstItem on `shift + tab`', () => {
+    const root = render({ setFocusOnFirstItem });
+    const flagReviewBtn = root.find('.FlagReview-button');
+    flagReviewBtn.simulate('keydown', {
+      shiftKey: true,
+      key: 'Tab',
+      preventDefault: () => {},
+    });
+    expect(setFocusOnFirstItem).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/amo/components/TestFlagReviewMenu.js
+++ b/tests/unit/amo/components/TestFlagReviewMenu.js
@@ -118,6 +118,35 @@ describe(__filename, () => {
       expect(items).toHaveLength(1);
       expect(items.at(0).html()).toContain('You cannot flag your own response');
     });
+
+    it('assigns setFocusOnFirstItem prop only on the last list item', () => {
+      const review = createInternalReview(fakeReview);
+      const { menu } = renderMenu({ review });
+
+      const items = menu.find(ListItem);
+      expect(items).toHaveLength(3);
+
+      expect(items.at(0).find(FlagReview)).not.toHaveProp(
+        'setFocusOnFirstItem',
+      );
+      expect(items.at(1).find(FlagReview)).not.toHaveProp(
+        'setFocusOnFirstItem',
+      );
+      expect(items.at(2).find(FlagReview)).toHaveProp('setFocusOnFirstItem');
+    });
+
+    it('assigns setFocusOnFirstItem prop only on the last list item when isDeveloperReply is true', () => {
+      const review = createInternalReview(fakeReview);
+      const { menu } = renderMenu({ review, isDeveloperReply: true });
+
+      const items = menu.find(ListItem);
+      expect(items).toHaveLength(2);
+
+      expect(items.at(0).find(FlagReview)).not.toHaveProp(
+        'setFocusOnFirstItem',
+      );
+      expect(items.at(1).find(FlagReview)).toHaveProp('setFocusOnFirstItem');
+    });
   });
 
   describe('prompts and FlagReview configuration', () => {


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #3630

Retains focus inside flag review menu upon pressing tab key on the last list item by focussing the first list item.

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->

Before:
1. When the last item is focused
![image](https://user-images.githubusercontent.com/31165776/132100945-9bf4b90a-3f5c-48dc-8e8c-c2a1296fb8a4.png)
2. On pressing tab key on last list item 
![image](https://user-images.githubusercontent.com/31165776/132100963-3ff16940-3d69-4dba-b1aa-8f92652315f9.png)

After:
1. When the last item is focused
![image](https://user-images.githubusercontent.com/31165776/132100945-9bf4b90a-3f5c-48dc-8e8c-c2a1296fb8a4.png)
2. On pressing tab key on last list item 
![image](https://user-images.githubusercontent.com/31165776/132101025-63b03422-0976-4b52-a44d-d2144ecf5ead.png)


