### PR TITLE
Fix problem on Collections page when a collection is loading

### DIFF
--- a/src/amo/components/UserCollection/index.js
+++ b/src/amo/components/UserCollection/index.js
@@ -31,7 +31,7 @@ export const UserCollectionBase = (props: InternalProps): React.Node => {
   const linkProps = {};
   let numberText;
 
-  if (loading) {
+  if (loading || numberOfAddons === null) {
     linkProps.href = '';
   } else {
     invariant(authorId, 'authorId is required');

--- a/src/amo/components/UserCollection/index.js
+++ b/src/amo/components/UserCollection/index.js
@@ -14,9 +14,9 @@ import './styles.scss';
 type Props = {|
   authorId?: number,
   id: number,
-  loading?: boolean,
   name?: string,
-  numberOfAddons?: number,
+  // numberOfAddons is null when the collection is in a loading state.
+  numberOfAddons: number | null,
   slug?: string,
 |};
 
@@ -26,12 +26,12 @@ type InternalProps = {|
 |};
 
 export const UserCollectionBase = (props: InternalProps): React.Node => {
-  const { authorId, id, loading, name, numberOfAddons, slug, i18n } = props;
+  const { authorId, id, name, numberOfAddons, slug, i18n } = props;
 
   const linkProps = {};
   let numberText;
 
-  if (loading || numberOfAddons === null) {
+  if (numberOfAddons === null) {
     linkProps.href = '';
   } else {
     invariant(authorId, 'authorId is required');
@@ -52,7 +52,11 @@ export const UserCollectionBase = (props: InternalProps): React.Node => {
     <li className="UserCollection" key={id}>
       <Link className="UserCollection-link" {...linkProps}>
         <h2 className="UserCollection-name">
-          {loading ? <LoadingText /> : collectionName({ name, i18n })}
+          {numberOfAddons === null ? (
+            <LoadingText />
+          ) : (
+            collectionName({ name, i18n })
+          )}
         </h2>
         <p className="UserCollection-number">{numberText || <LoadingText />}</p>
       </Link>

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -117,7 +117,7 @@ export const computeNewCollectionPage = ({
   const { numberOfAddons, pageSize } = collection;
 
   let page = '1';
-  if (pageSize) {
+  if (pageSize && numberOfAddons) {
     const lastPage = Math.ceil((numberOfAddons - 1) / Number(pageSize));
 
     // If we are not on the last page, we can just return the current page.
@@ -434,6 +434,7 @@ export class CollectionBase extends React.Component<InternalProps> {
     const paginator =
       collection &&
       collection.pageSize &&
+      collection.numberOfAddons &&
       collection.numberOfAddons > Number(collection.pageSize) ? (
         <Paginate
           LinkComponent={Link}

--- a/src/amo/pages/CollectionList/index.js
+++ b/src/amo/pages/CollectionList/index.js
@@ -87,7 +87,8 @@ export class CollectionListBase extends React.Component<InternalProps> {
       // Create 4 "loading" components.
       for (let count = 0; count < 4; count++) {
         collectionElements.push(
-          <UserCollection id={count} key={count} loading />,
+          // numberOfAddons is null when the collection is in a loading state.
+          <UserCollection id={count} key={count} numberOfAddons={null} />,
         );
       }
     }

--- a/src/amo/reducers/collections.js
+++ b/src/amo/reducers/collections.js
@@ -72,7 +72,7 @@ export type CollectionType = {
   id: number,
   lastUpdatedDate: string,
   name: string,
-  numberOfAddons: number,
+  numberOfAddons: number | null,
   pageSize: string | null,
   slug: string,
 };

--- a/tests/unit/amo/components/TestUserCollection.js
+++ b/tests/unit/amo/components/TestUserCollection.js
@@ -71,6 +71,10 @@ describe(__filename, () => {
 
     expect(root.find('.UserCollection')).toHaveLength(1);
     expect(root.find('.UserCollection-link')).toHaveProp('href', '');
+    expect(root.find('.UserCollection-name').find(LoadingText)).toHaveLength(1);
+    expect(root.find('.UserCollection-number').find(LoadingText)).toHaveLength(
+      1,
+    );
   });
 
   it('renders singular text for a collection with 1 add-on', () => {
@@ -86,22 +90,6 @@ describe(__filename, () => {
 
     expect(root.find('.UserCollection-number').children()).toHaveText(
       `${props.numberOfAddons} add-on`,
-    );
-  });
-
-  it('renders loading text when loading is true', () => {
-    const props = {
-      id: 99,
-      loading: true,
-    };
-
-    const root = render(props);
-
-    expect(root.find('.UserCollection')).toHaveLength(1);
-    expect(root.find('.UserCollection-link')).toHaveProp('href', '');
-    expect(root.find('.UserCollection-name').find(LoadingText)).toHaveLength(1);
-    expect(root.find('.UserCollection-number').find(LoadingText)).toHaveLength(
-      1,
     );
   });
 });

--- a/tests/unit/amo/components/TestUserCollection.js
+++ b/tests/unit/amo/components/TestUserCollection.js
@@ -57,6 +57,22 @@ describe(__filename, () => {
     );
   });
 
+  it('can render a collection that is loading', () => {
+    const props = {
+      authorId: 1234,
+      id: 1,
+      name: 'collection name',
+      // When a collection is in a loading state, numberOfAddons is null.
+      numberOfAddons: null,
+      slug: 'some-slug',
+    };
+
+    const root = render(props);
+
+    expect(root.find('.UserCollection')).toHaveLength(1);
+    expect(root.find('.UserCollection-link')).toHaveProp('href', '');
+  });
+
   it('renders singular text for a collection with 1 add-on', () => {
     const props = {
       authorId: 1234,

--- a/tests/unit/amo/pages/TestCollectionList.js
+++ b/tests/unit/amo/pages/TestCollectionList.js
@@ -188,7 +188,7 @@ describe(__filename, () => {
     expect(userCollections).toHaveLength(4);
     for (let count = 0; count < 4; count++) {
       expect(userCollections.at(count)).toHaveProp('id', count);
-      expect(userCollections.at(count)).toHaveProp('loading', true);
+      expect(userCollections.at(count)).toHaveProp('numberOfAddons', null);
     }
   });
 


### PR DESCRIPTION
Fixes #10886 

The problem in the issue occurs when a user navigates quickly from a collection detail page back to the same page (but with a different sort sequence), and then to the Collections list. The first navigation causes the detail for the collection to be re-fetched, but because of the quick navigation, the details for that collection are still loading when we try to render the Collections list. The code assumes this will not be the case, hence the error.

The fix is to update the code for `UserCollection` to make it smart enough to deal with a collection that is currently being loaded.