### PR TITLE
Update docker images for Node on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
     working_directory: ~/addons-frontend
     docker:
       # This is the NodeJS version we run in production.
-      - image: cimg/node:14
+      - image: circleci/node:14
 
   defaults-next: &defaults-next
     working_directory: ~/addons-frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ references:
     working_directory: ~/addons-frontend
     docker:
       # This is the NodeJS version we run in production.
-      - image: circleci/node:14
+      - image: cimg/node:14
 
   defaults-next: &defaults-next
     working_directory: ~/addons-frontend
     docker:
       # This is the next NodeJS version we will support.
-      - image: circleci/node:16
+      - image: cimg/node:16.8
 
   defaults-release: &defaults-release
     machine:


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10897

---

It's been 24h and it's increasingly annoying to have red crosses everywhere on this GitHub repository so here we are... I pinned the Node 16 version to 16.8, which is not affected by the Node bug (which is a v8 bug actually).