### PR TITLE
Pass app to recommendations API endpoint

### DIFF
--- a/src/amo/api/recommendations.js
+++ b/src/amo/api/recommendations.js
@@ -26,6 +26,6 @@ export const getRecommendations = ({
     apiState: api,
     auth: true,
     endpoint: 'addons/recommendations/',
-    params: { guid, recommended },
+    params: { app: api.clientApp, guid, recommended },
   });
 };

--- a/tests/unit/amo/api/test_recommendations.js
+++ b/tests/unit/amo/api/test_recommendations.js
@@ -8,6 +8,7 @@ describe(__filename, () => {
     const apiState = dispatchClientMetadata().store.getState().api;
 
     const params = {
+      app: apiState.clientApp,
       guid: 'addon-guid',
       recommended: true,
     };


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10912

---

The issue cannot be reproduced with all add-ons but it is reproducible with uBlock on -prod and for -dev/localdev, I used http://127.0.0.1:3000/en-US/android/addon/enhancer-for-youtube-2/.

This patch fixes the issue linked above because we update the Redux state when we load the recommendations. It is usually not a problem except in this particular case: while the "app" in URLs is usually interchangeable, it matters for Fenix because [only URLs with `/android/` will trigger the Interceptor](https://github.com/mozilla-mobile/fenix/blob/e00079aeafec60e18fcaa9080a656c698c0266ef/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt#L172). Note that this is a tricky bug because it only occurs for add-ons recommended by TAAR on the add-on detail page of one of these recommendations.