### PR TITLE
Cache-bust QR code images

### DIFF
--- a/src/amo/components/AddonQRCode/index.js
+++ b/src/amo/components/AddonQRCode/index.js
@@ -138,7 +138,7 @@ export class AddonQRCodeBase extends React.Component<InternalProps> {
         <img
           alt={altText}
           className="AddonQRCode-img"
-          src={`${config.get('staticPath')}${addon.id}.png?v=1`}
+          src={`${config.get('staticPath')}${addon.id}.png?v=2`}
         />
         <div className="AddonQRCode-label">{labelWithLink}</div>
       </div>

--- a/tests/unit/amo/components/TestAddonQRCode.js
+++ b/tests/unit/amo/components/TestAddonQRCode.js
@@ -106,7 +106,7 @@ describe(__filename, () => {
     );
     expect(root.find('.AddonQRCode-img')).toHaveProp(
       'src',
-      `${_config.get('staticPath')}${goodAddonId}.png?v=1`,
+      `${_config.get('staticPath')}${goodAddonId}.png?v=2`,
     );
   });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/10935

---

This is needed because the images have been updated in https://github.com/mozilla/addons-frontend/issues/10927