### PR TITLE
Allow loading of images on the main domain

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -1,5 +1,5 @@
 // Config specific to local development
-import { addonsServerDevCDN, analyticsHost, apiDevHost } from './lib/shared';
+import { baseUrlDev, analyticsHost, apiDevHost } from './lib/shared';
 
 const webpackServerHost = process.env.WEBPACK_SERVER_HOST || '127.0.0.1';
 const webpackServerPort = 3001;
@@ -24,7 +24,7 @@ module.exports = {
   trackingEnabled: false,
   loggingLevel: 'debug',
 
-  amoCDN: addonsServerDevCDN,
+  amoCDN: baseUrlDev,
 
   isDeployed: false,
   isDevelopment: true,
@@ -47,7 +47,7 @@ module.exports = {
     directives: {
       connectSrc: [
         "'self'",
-        addonsServerDevCDN,
+        baseUrlDev,
         analyticsHost,
         apiDevHost,
         webpackDevServer,
@@ -60,14 +60,14 @@ module.exports = {
       imgSrc: [
         "'self'",
         'data:',
-        addonsServerDevCDN,
+        baseUrlDev,
         webpackDevServer,
       ],
       scriptSrc: [
         "'self'",
         // webpack injects inline JS
         "'unsafe-inline'",
-        addonsServerDevCDN,
+        baseUrlDev,
         webpackDevServer,
         `${analyticsHost}/analytics.js`,
       ],

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "amo:dev": {
       "command": "better-npm-run start-dev-proxy",
       "env": {
-        "AMO_CDN": "https://addons-dev-cdn.allizom.org",
         "PROXY_API_HOST": "https://addons-dev.allizom.org"
       }
     },

--- a/src/amo/utils/index.js
+++ b/src/amo/utils/index.js
@@ -258,7 +258,7 @@ export function isAddonAuthor({
 export function isAllowedOrigin(
   urlString: string,
   {
-    allowedOrigins = [config.get('amoCDN')],
+    allowedOrigins = [config.get('amoCDN'), config.get('baseURL')],
   }: {| allowedOrigins?: Array<string> |} = {},
 ): boolean {
   let parsedURL;


### PR DESCRIPTION
That fixes dev (and local instances running against dev data) which  had been broken following https://github.com/mozilla/addons/issues/8524