### PR TITLE
Do not copy QRCode images when building blog-utils lib

### DIFF
--- a/webpack-common.js
+++ b/webpack-common.js
@@ -120,7 +120,10 @@ export function getRules({
   ];
 }
 
-export function getPlugins({ withBrowserWindow = true } = {}) {
+export function getPlugins({
+  withBrowserWindow = true,
+  withQRCodes = true,
+} = {}) {
   const clientConfig = getClientConfig(config);
 
   const plugins = [
@@ -146,21 +149,26 @@ export function getPlugins({ withBrowserWindow = true } = {}) {
       /locale$/,
       new RegExp(`^\\.\\/.*?\\/amo\\.js$`),
     ),
-    new CopyPlugin({
-      patterns: [
-        {
-          from: path.resolve(
-            __dirname,
-            'src',
-            'amo',
-            'components',
-            'AddonQRCode',
-            'img',
-          ),
-        },
-      ],
-    }),
   ];
+
+  if (withQRCodes) {
+    plugins.push(
+      new CopyPlugin({
+        patterns: [
+          {
+            from: path.resolve(
+              __dirname,
+              'src',
+              'amo',
+              'components',
+              'AddonQRCode',
+              'img',
+            ),
+          },
+        ],
+      }),
+    );
+  }
 
   if (withBrowserWindow) {
     plugins.push(

--- a/webpack.blog-utils.config.babel.js
+++ b/webpack.blog-utils.config.babel.js
@@ -30,7 +30,7 @@ const makeConfig = ({ target, externals = {} }) => ({
     rules: getRules({ fileLimit: 20000 }),
   },
   plugins: [
-    ...getPlugins({ withBrowserWindow: target === 'web' }),
+    ...getPlugins({ withBrowserWindow: target === 'web', withQRCodes: false }),
     new webpack.NormalModuleReplacementPlugin(
       /amo\/tracking/,
       'blog-utils/tracking.js',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14311

---

With this patch, we don't have the QR code images anymore:

```
$ ls -l dist/
total 3392
-rw-r--r--  1 williamdurand  staff   112B Oct  8 08:47 README.md
-rw-r--r--  1 williamdurand  staff   925K Oct  8 08:48 node.js
-rw-r--r--  1 williamdurand  staff   416B Oct  8 08:47 package.json
-rw-r--r--  1 williamdurand  staff   147K Oct  8 08:48 style.css
-rw-r--r--  1 williamdurand  staff   612K Oct  8 08:48 web.js
```