### PR TITLE
Replace "Occitan (Lengadocian)" with "Occitan"

### DIFF
--- a/src/amo/languages.js
+++ b/src/amo/languages.js
@@ -442,8 +442,8 @@ export const unfilteredLanguages = {
     native: 'Sepedi',
   },
   oc: {
-    English: 'Occitan (Lengadocian)',
-    native: 'occitan (lengadocian)',
+    English: 'Occitan',
+    native: 'occitan',
   },
   or: {
     English: 'Oriya',


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/11096

---

Lengadocian is just a variant of Occitan. In practice, the oc category on AMO includes dictionaries from other dialects such as Gascon and Aranese, so the "(Lengadocian)" qualifier is inaccurate.

See https://github.com/mdn/content/issues/11868 and https://github.com/mozilla/addons-server/pull/18624