### PR TITLE
reformat auth expired explanation paragraph to a single l10n-able string

### DIFF
--- a/src/amo/components/Errors/AuthExpired/index.js
+++ b/src/amo/components/Errors/AuthExpired/index.js
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
-import Button from 'amo/components/Button';
 import ErrorComponent from 'amo/components/Errors/ErrorComponent';
+import Link from 'amo/components/Link';
+import { replaceStringsWithJSX } from 'amo/i18n/utils';
 import translate from 'amo/i18n/translate';
 import { logOutUser } from 'amo/reducers/users';
 import type { I18nType } from 'amo/types/i18n';
@@ -39,25 +40,30 @@ export class AuthExpiredBase extends React.Component<InternalProps> {
   render(): React.Node {
     const { _window, i18n } = this.props;
 
-    const reloadButton = (
-      <Button
-        className="ReloadPageButton"
-        buttonType="none"
-        onClick={() => _window.location.reload()}
-      >
-        {i18n.gettext('Reload the page')}
-      </Button>
-    );
+    const paragraph = replaceStringsWithJSX({
+      text: i18n.gettext(`
+        Login authentication has expired. %(startLink)sReload the page%(endLink)s
+        to continue without authentication, or login again using the Log In
+        link at the top of the page.`),
+      replacements: [
+        [
+          'startLink',
+          'endLink',
+          (text) => (
+            <Link
+              className="ReloadPageLink"
+              onClick={() => _window.location.reload()}
+            >
+              {text}
+            </Link>
+          ),
+        ],
+      ],
+    });
 
     return (
       <ErrorComponent code={401} header={i18n.gettext('Login Expired')}>
-        <p>
-          {i18n.gettext(`Login authentication has expired.`)}
-          {reloadButton}
-          {i18n.gettext(`
-            to continue without authentication, or login again using the Log In
-            link at the top of the page.`)}
-        </p>
+        <p>{paragraph}</p>
       </ErrorComponent>
     );
   }

--- a/src/amo/components/Errors/AuthExpired/index.js
+++ b/src/amo/components/Errors/AuthExpired/index.js
@@ -53,6 +53,9 @@ export class AuthExpiredBase extends React.Component<InternalProps> {
             <Link
               className="ReloadPageLink"
               onClick={() => _window.location.reload()}
+              href="#"
+              prependClientApp={false}
+              prependLang={false}
             >
               {text}
             </Link>

--- a/src/amo/components/Errors/AuthExpired/styles.scss
+++ b/src/amo/components/Errors/AuthExpired/styles.scss
@@ -1,6 +1,6 @@
 @import '~amo/css/styles';
 
-.ReloadPageButton {
+.ReloadPageLink {
   color: $link-color;
   text-decoration: underline;
   cursor: pointer;

--- a/tests/unit/amo/components/Errors/TestAuthExpired.js
+++ b/tests/unit/amo/components/Errors/TestAuthExpired.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import Button from 'amo/components/Button';
+import Link from 'amo/components/Link';
 import ErrorComponent from 'amo/components/Errors/ErrorComponent';
 import AuthExpired, {
   AuthExpiredBase,
@@ -53,15 +53,15 @@ describe(__filename, () => {
     sinon.assert.calledWith(dispatchSpy, logOutUserAction());
   });
 
-  it('renders a reload button', () => {
+  it('renders a reload link', () => {
     const _window = { location: { reload: sinon.stub() } };
     const root = render({ _window });
 
-    const button = root.find(Button);
-    expect(button.childAt(0).text()).toContain('Reload the page');
-    expect(button.prop('onClick')).toBeDefined();
+    const link = root.find(Link);
+    expect(link.childAt(0).text()).toContain('Reload the page');
+    expect(link.prop('onClick')).toBeDefined();
 
-    const action = button.prop('onClick');
+    const action = link.prop('onClick');
     // Simulate the callback on button press.
     action();
 


### PR DESCRIPTION
fixes #11107 