### PR TITLE
Hide other site links in AMO header for blog

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -53,7 +53,6 @@ export class HeaderBase extends React.Component {
 
   renderMenuOrAuthButton() {
     const {
-      forBlog,
       i18n,
       isReviewer,
       loadedPageIsAnonymous,
@@ -61,7 +60,7 @@ export class HeaderBase extends React.Component {
       siteUser,
     } = this.props;
 
-    if (forBlog || loadedPageIsAnonymous) {
+    if (loadedPageIsAnonymous) {
       // The server has loaded a page that is marked as anonymous so we do not
       // want to render any menu or authentication button here so that
       // logged-in users are not confused.
@@ -250,19 +249,21 @@ export class HeaderBase extends React.Component {
             />
           ) : null}
 
-          <div className="Header-user-and-external-links">
-            {otherSiteLinks}
-
-            {this.renderMenuOrAuthButton()}
-          </div>
-
           {!forBlog && (
-            <SearchForm
-              className={makeClassName('Header-search-form', {
-                'Header-search-form--desktop': clientApp === CLIENT_APP_FIREFOX,
-              })}
-              pathname="/search/"
-            />
+            <>
+              <div className="Header-user-and-external-links">
+                {otherSiteLinks}
+
+                {this.renderMenuOrAuthButton()}
+              </div>
+              <SearchForm
+                className={makeClassName('Header-search-form', {
+                  'Header-search-form--desktop':
+                    clientApp === CLIENT_APP_FIREFOX,
+                })}
+                pathname="/search/"
+              />
+            </>
           )}
         </div>
       </header>

--- a/tests/unit/amo/components/TestHeader.js
+++ b/tests/unit/amo/components/TestHeader.js
@@ -311,6 +311,7 @@ describe(__filename, () => {
     expect(root.find('.Header-title')).toHaveProp('prependClientApp', false);
     expect(root.find('.Header-title')).toHaveProp('prependLang', false);
     expect(root.find('.Header-authenticate-button')).toHaveLength(0);
+    expect(root.find('.Header-user-and-external-links')).toHaveLength(0);
     expect(root.find(SearchForm)).toHaveLength(0);
     expect(root.find(SectionLinks)).toHaveProp('forBlog', true);
     expect(root.find(GetFirefoxBanner)).toHaveLength(0);


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #10997 

Added a check before rendering `otherSiteLinks` and `renderMenuOrAuthButton` method such that it will be rendered only if `forBlog` prop is false.

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
