### PR TITLE
Remove fastclick: it's obsolete and causing issues with <select>

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "dompurify": "2.3.5",
     "express": "4.17.2",
     "express-http-context": "1.2.4",
-    "fastclick": "1.0.6",
     "filesize": "8.0.7",
     "focus-visible": "5.2.0",
     "fs-extra": "10.0.0",

--- a/src/amo/client/base.js
+++ b/src/amo/client/base.js
@@ -1,7 +1,6 @@
 import 'amo/polyfill';
 import { oneLine } from 'common-tags';
 import config from 'config';
-import FastClick from 'fastclick';
 import { createBrowserHistory } from 'history';
 import * as React from 'react';
 import { render } from 'react-dom';
@@ -15,7 +14,6 @@ import tracking from 'amo/tracking';
 export default async function createClient(
   createStore,
   {
-    _FastClick = FastClick,
     _config = config,
     _createBrowserHistory = createBrowserHistory,
     _tracking = tracking,
@@ -32,8 +30,6 @@ export default async function createClient(
     log.info(oneLine`StrictMode is enabled, which causes double redux action
       dispatching. See: https://github.com/mozilla/addons-frontend/issues/6424`);
   }
-
-  _FastClick.attach(document.body);
 
   const initialStateContainer = document.getElementById('redux-store-state');
   let initialState;

--- a/tests/unit/amo/client/test_base.js
+++ b/tests/unit/amo/client/test_base.js
@@ -8,20 +8,11 @@ import { createFakeTracking } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   describe('createClient()', () => {
-    let fakeFastClick;
-
-    beforeEach(() => {
-      fakeFastClick = {
-        attach: sinon.stub(),
-      };
-    });
-
     const _createClient = ({
-      _FastClick = fakeFastClick,
       createStore = createAmoStore,
       ...others
     } = {}) => {
-      return createClient(createStore, { _FastClick, ...others });
+      return createClient(createStore, { ...others });
     };
 
     it('returns an object with a `renderApp` function', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5207,11 +5207,6 @@ fast-safe-stringify@^2.0.2, fast-safe-stringify@^2.0.7:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
   integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
 
-fastclick@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/fastclick/-/fastclick-1.0.6.tgz#161625b27b1a5806405936bda9a2c1926d06be6a"
-  integrity sha1-FhYlsnsaWAZAWTa9qaLBkm0Gvmo=
-
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"


### PR DESCRIPTION
On my Android device, this fixes issues with `<select>` and doesn't regress tapping on links. Please test on yours.

Fixes https://github.com/mozilla/addons-frontend/issues/11135