### PR TITLE
Avoid handling mouseenter/mouseleave if device doesn't support hover

### DIFF
--- a/src/amo/components/DropdownMenu/index.js
+++ b/src/amo/components/DropdownMenu/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+/* global window */
 import { oneLine } from 'common-tags';
 import * as React from 'react';
 import makeClassName from 'classnames';
@@ -20,12 +21,25 @@ type Props = {|
   className?: string,
 |};
 
+type DefaultProps = {|
+  _window: typeof window,
+|};
+
+type InternalProps = {|
+  ...Props,
+  ...DefaultProps,
+|};
+
 type State = {|
   buttonIsActive: boolean,
 |};
 
-export class DropdownMenuBase extends React.Component<Props, State> {
-  constructor(props: Props) {
+export class DropdownMenuBase extends React.Component<InternalProps, State> {
+  static defaultProps: DefaultProps = {
+    _window: typeof window !== 'undefined' ? window : null,
+  };
+
+  constructor(props: InternalProps) {
     super(props);
 
     this.state = { buttonIsActive: false };
@@ -54,11 +68,23 @@ export class DropdownMenuBase extends React.Component<Props, State> {
   };
 
   handleOnMouseEnter: () => void = () => {
-    this.setState({ buttonIsActive: true });
+    const { _window } = this.props;
+
+    // Check device is actually capable of proper hover handling because touch
+    // emulation can mess up with click event later.
+    // https://github.com/mozilla/addons-frontend/issues/11137#issuecomment-1039218104
+    if (_window && _window.matchMedia('(hover)').matches) {
+      this.setState({ buttonIsActive: true });
+    }
   };
 
   handleOnMouseLeave: () => void = () => {
-    this.setState({ buttonIsActive: false });
+    const { _window } = this.props;
+
+    // As above, check device is actually capable of hover through media query.
+    if (_window && _window.matchMedia('(hover)').matches) {
+      this.setState({ buttonIsActive: false });
+    }
   };
 
   render(): React.Node {

--- a/tests/unit/amo/components/TestDropdownMenu.js
+++ b/tests/unit/amo/components/TestDropdownMenu.js
@@ -93,9 +93,13 @@ describe(__filename, () => {
   });
 
   it('sets active on mouseEnter/clears on mouseLeave', () => {
+    const _window = {
+      matchMedia: sinon.stub().returns({ matches: true }),
+    };
+
     // We do this instead of a :hover with CSS to allow clearing the active
     // state after a click.
-    const root = mount(<DropdownMenu text="Menu" />);
+    const root = mount(<DropdownMenu text="Menu" _window={_window} />);
     const getMenu = () => root.find('.DropdownMenu');
 
     // User hovers on the menu.
@@ -103,6 +107,42 @@ describe(__filename, () => {
     expect(getMenu()).toHaveClassName('DropdownMenu--active');
 
     // User's mouse leaves the menu.
+    getMenu().simulate('mouseLeave', createFakeEvent());
+    expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
+  });
+
+  it('does not touch active on mouseleave/enter if device doesnt support hover', () => {
+    const _window = {
+      matchMedia: sinon.stub().returns({ matches: false }),
+    };
+
+    // We do this instead of a :hover with CSS to allow clearing the active
+    // state after a click.
+    const root = mount(<DropdownMenu text="Menu" _window={_window} />);
+    const getMenu = () => root.find('.DropdownMenu');
+
+    // User hovers on the menu.
+    getMenu().simulate('mouseEnter', createFakeEvent());
+    expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
+
+    // User's mouse leaves the menu (no changes).
+    getMenu().simulate('mouseLeave', createFakeEvent());
+    expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
+  });
+
+  it('does not touch active on mouseleave/enter if window is null', () => {
+    const _window = null;
+
+    // We do this instead of a :hover with CSS to allow clearing the active
+    // state after a click.
+    const root = mount(<DropdownMenu text="Menu" _window={_window} />);
+    const getMenu = () => root.find('.DropdownMenu');
+
+    // User hovers on the menu.
+    getMenu().simulate('mouseEnter', createFakeEvent());
+    expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
+
+    // User's mouse leaves the menu (no changes).
     getMenu().simulate('mouseLeave', createFakeEvent());
     expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
   });

--- a/tests/unit/amo/components/TestDropdownMenu.js
+++ b/tests/unit/amo/components/TestDropdownMenu.js
@@ -105,10 +105,13 @@ describe(__filename, () => {
     // User hovers on the menu.
     getMenu().simulate('mouseEnter', createFakeEvent());
     expect(getMenu()).toHaveClassName('DropdownMenu--active');
+    sinon.assert.calledWith(_window.matchMedia, '(hover)');
 
     // User's mouse leaves the menu.
+    _window.matchMedia.resetHistory();
     getMenu().simulate('mouseLeave', createFakeEvent());
     expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
+    sinon.assert.calledWith(_window.matchMedia, '(hover)');
   });
 
   it('does not touch active on mouseleave/enter if device doesnt support hover', () => {
@@ -124,18 +127,19 @@ describe(__filename, () => {
     // User hovers on the menu.
     getMenu().simulate('mouseEnter', createFakeEvent());
     expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
+    sinon.assert.calledWith(_window.matchMedia, '(hover)');
 
     // User's mouse leaves the menu (no changes).
+    _window.matchMedia.resetHistory();
     getMenu().simulate('mouseLeave', createFakeEvent());
     expect(getMenu()).not.toHaveClassName('DropdownMenu--active');
+    sinon.assert.calledWith(_window.matchMedia, '(hover)');
   });
 
   it('does not touch active on mouseleave/enter if window is null', () => {
-    const _window = null;
-
     // We do this instead of a :hover with CSS to allow clearing the active
     // state after a click.
-    const root = mount(<DropdownMenu text="Menu" _window={_window} />);
+    const root = mount(<DropdownMenu text="Menu" _window={null} />);
     const getMenu = () => root.find('.DropdownMenu');
 
     // User hovers on the menu.


### PR DESCRIPTION
This should fix the menu needing a double-tap to open on some mobile devices. I've tested it successfully on Desktop and Android, it fixes the issue for me without introducing regressions.

Fixes #11137