### PR TITLE
pass errorHandler to Page from UserProfile; show AuthExpired for all 401s

### DIFF
--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -330,7 +330,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
       : i18n.gettext('User Profile');
 
     return (
-      <Page>
+      <Page errorHandler={errorHandler}>
         <div className="UserProfile">
           <UserProfileHead
             title={userProfileTitle}

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -31,6 +31,7 @@ import ErrorList from 'amo/components/ErrorList';
 import Icon from 'amo/components/Icon';
 import LoadingText from 'amo/components/LoadingText';
 import Rating from 'amo/components/Rating';
+import Page from 'amo/components/Page';
 import UserAvatar from 'amo/components/UserAvatar';
 import {
   createStubErrorHandler,
@@ -465,6 +466,13 @@ describe(__filename, () => {
       'errorHandler',
       errorHandler,
     );
+  });
+
+  it('passes the errorHandler to Page', () => {
+    const errorHandler = createStubErrorHandler();
+    const root = renderUserProfile({ errorHandler });
+
+    expect(root.find(Page).at(0)).toHaveProp('errorHandler', errorHandler);
   });
 
   it('renders AddonsByAuthorsCards without a user', () => {


### PR DESCRIPTION
fixes #11109?  It seems like a simple/simplistic fix, but appears to work 🤷 