### PR TITLE
Implement eslint-plugin-testing-library

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,15 @@
     "amo",
     "plugin:amo/recommended"
   ],
+  "plugins": ["testing-library"],
+  "overrides": [
+    {
+      //Enable eslint-plugin-testing-library rules only for test files.
+      "files": ["**/tests/**/*.js"],
+      "extends": ["plugin:testing-library/react"],
+      "rules": {"testing-library/render-result-naming-convention": "off"}
+    },
+  ],
   "globals": {
     "CLIENT_CONFIG": true,
     "document": true,

--- a/package.json
+++ b/package.json
@@ -276,6 +276,7 @@
     "eslint-plugin-amo": "^1.13.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-testing-library": "^5.0.5",
     "file-loader": "^6.0.0",
     "flow-bin": "^0.171.0",
     "glob": "^7.1.1",

--- a/tests/unit/amo/components/TestIcon.js
+++ b/tests/unit/amo/components/TestIcon.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import Icon from 'amo/components/Icon';
-import { render } from 'tests/unit/helpers';
+import { render, screen } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   it('maps the name to a className', () => {
@@ -20,19 +20,19 @@ describe(__filename, () => {
 
   it('renders alt-text as a visually hidden span', () => {
     const alt = 'Alt text!';
-    const { getByText } = render(<Icon alt={alt} name="bar" />);
-    expect(getByText(alt)).toHaveClass('visually-hidden');
+    render(<Icon alt={alt} name="bar" />);
+    expect(screen.getByText(alt)).toHaveClass('visually-hidden');
   });
 
   it('renders alt text and children', () => {
     const alt = 'Alt text!';
     const childText = 'Some child text';
-    const { getByText } = render(
+    render(
       <Icon alt={alt} name="bar">
         <span>{childText}</span>
       </Icon>,
     );
-    expect(getByText(alt)).toHaveClass('visually-hidden');
-    expect(getByText(childText)).toBeInTheDocument();
+    expect(screen.getByText(alt)).toHaveClass('visually-hidden');
+    expect(screen.getByText(childText)).toBeInTheDocument();
   });
 });

--- a/tests/unit/amo/components/TestIconPromotedBadge.js
+++ b/tests/unit/amo/components/TestIconPromotedBadge.js
@@ -70,7 +70,6 @@ describe(__filename, () => {
 
     // Icon will render a <span> with a class of
     // 'visually-hidden' if an `alt` prop was passed.
-    screen.debug();
     expect(screen.queryByClassName('visually-hidden')).toHaveLength(0);
   });
 

--- a/tests/unit/amo/components/TestIconXMark.js
+++ b/tests/unit/amo/components/TestIconXMark.js
@@ -19,7 +19,6 @@ describe(__filename, () => {
   it('can pass an alt to Icon', () => {
     const alt = 'click to close';
     render({ alt });
-    screen.debug();
 
     expect(screen.getByText(alt)).toBeInTheDocument();
   });

--- a/tests/unit/amo/components/TestPermission.js
+++ b/tests/unit/amo/components/TestPermission.js
@@ -39,7 +39,6 @@ describe(__filename, () => {
   it('renders the description', () => {
     const description = 'It can access your bookmarks';
     render({ description });
-    screen.debug();
 
     expect(screen.getByText(description)).toBeInTheDocument();
   });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1478,6 +1478,7 @@ export const createExperimentData = ({
   return { [id]: variantId };
 };
 
+/* eslint-disable testing-library/no-node-access */
 const queryByClassName = (container, className) => {
   return container.querySelectorAll(`.${className}`);
 };
@@ -1534,3 +1535,4 @@ export const render = (ui, options = {}) => {
   const result = libraryRender(ui, { wrapper });
   return { ...result, root: result.container.firstChild };
 };
+/* eslint-enable testing-library/no-node-access */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,10 +1876,23 @@
     "@typescript-eslint/types" "5.1.0"
     "@typescript-eslint/visitor-keys" "5.1.0"
 
+"@typescript-eslint/scope-manager@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.12.1.tgz#58734fd45d2d1dec49641aacc075fba5f0968817"
+  integrity sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/visitor-keys" "5.12.1"
+
 "@typescript-eslint/types@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.1.0.tgz#a8a75ddfc611660de6be17d3ad950302385607a9"
   integrity sha512-sEwNINVxcB4ZgC6Fe6rUyMlvsB2jvVdgxjZEjQUQVlaSPMNamDOwO6/TB98kFt4sYYfNhdhTPBEQqNQZjMMswA==
+
+"@typescript-eslint/types@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.12.1.tgz#46a36a28ff4d946821b58fe5a73c81dc2e12aa89"
+  integrity sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==
 
 "@typescript-eslint/typescript-estree@5.1.0":
   version "5.1.0"
@@ -1894,12 +1907,45 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.12.1.tgz#6a9425b9c305bcbc38e2d1d9a24c08e15e02b722"
+  integrity sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/visitor-keys" "5.12.1"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@^5.10.2":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.12.1.tgz#447c24a05d9c33f9c6c64cb48f251f2371eef920"
+  integrity sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.12.1"
+    "@typescript-eslint/types" "5.12.1"
+    "@typescript-eslint/typescript-estree" "5.12.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/visitor-keys@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.1.0.tgz#e01a01b27eb173092705ae983aa1451bd1842630"
   integrity sha512-uqNXepKBg81JVwjuqAxYrXa1Ql/YDzM+8g/pS+TCPxba0wZttl8m5DkrasbfnmJGHs4lQ2jTbcZ5azGhI7kK+w==
   dependencies:
     "@typescript-eslint/types" "5.1.0"
+    eslint-visitor-keys "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.12.1.tgz#f722da106c8f9695ae5640574225e45af3e52ec3"
+  integrity sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==
+  dependencies:
+    "@typescript-eslint/types" "5.12.1"
     eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.11.0":
@@ -4920,6 +4966,13 @@ eslint-plugin-react@7.26.1:
     resolve "^2.0.0-next.3"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.5"
+
+eslint-plugin-testing-library@5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.0.5.tgz#5757961ec20a6ca8b0992d2c5487db1b51612d8d"
+  integrity sha512-0j355vJpJCE/2g+aayIgJRUB6jBVqpD5ztMLGcadR1PgrgGPnPxN1HJuOAsAAwiMo27GwRnpJB8KOQzyNuNZrw==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.2"
 
 eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
Fixes #11322 

We could think about adding this to [`eslint-config-amo`](https://github.com/mozilla/eslint-config-amo), but perhaps that is premature.
