### PR TITLE
remove site status from AMO footer

### DIFF
--- a/src/amo/components/Footer/index.js
+++ b/src/amo/components/Footer/index.js
@@ -133,11 +133,6 @@ export class FooterBase extends React.Component<InternalProps> {
                   {i18n.gettext('Review Guide')}
                 </Link>
               </li>
-              <li>
-                <a href="https://status.mozilla.org/">
-                  {i18n.gettext('Site Status')}
-                </a>
-              </li>
             </ul>
           </section>
 


### PR DESCRIPTION
Fixes #11308 

This patch removes site status from the AMO footer.

BEFORE:
![Screenshot from 2022-02-26 13-41-19](https://user-images.githubusercontent.com/97871935/155840188-0ec78c4c-8b0f-44d2-a314-2d014d2527df.png)

AFTER: 
![Screenshot from 2022-02-26 13-41-03](https://user-images.githubusercontent.com/97871935/155840196-8381a823-d0f1-4b06-b09d-dc818aa68de8.png)

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
