### PR TITLE
Don't specify a python version for smoke tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ skipsdist = true
 envlist = smoke-tests, dennis-lint
 
 [testenv:smoke-tests]
-basepython = python3.7
 passenv = PYTEST_ADDOPTS
 deps =
   pytest>=5.0.1


### PR DESCRIPTION
Wwhatever the image provides is enough (should be python 3.x), especially given we only have a single dumb test