### PR TITLE
Update `format` property in po2json.parseFileSync() call

### DIFF
--- a/bin/build-locales
+++ b/bin/build-locales
@@ -48,7 +48,7 @@ poFiles.forEach((pofile) => {
   const json = po2json.parseFileSync(pofile, {
     stringify: true,
     pretty: true,
-    format: 'jed1.x',
+    format: 'jed',
     fuzzy: config.get('po2jsonFuzzyOutput'),
   });
   const localeObject = JSON.parse(json);


### PR DESCRIPTION
https://github.com/mikeedwards/po2json/commit/e5db448c changed the `format` property:
- `jed` no longer means compatible with jed < 1.1.0, it now means what `jed1.x` used to mean
- `jed1.x` no longer exists as a result

Fixes https://github.com/mozilla/addons-frontend/issues/11414
Fixes https://github.com/mozilla/addons-frontend/issues/11427