### PR TITLE
Fix problem with double-encoded pathname

### DIFF
--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -165,9 +165,7 @@ export function callApi({
   adjustedEndpoint = adjustedEndpoint.endsWith('/')
     ? adjustedEndpoint
     : `${adjustedEndpoint}/`;
-  const apiURL = `${config.get('apiHost')}${encodeURI(
-    adjustedEndpoint,
-  )}${queryString}`;
+  const apiURL = `${config.get('apiHost')}${adjustedEndpoint}${queryString}`;
 
   // Flow expects headers['Content-type'] to be a string, but we sometimes
   // delete it at line 148, above.

--- a/tests/unit/amo/api/test_index.js
+++ b/tests/unit/amo/api/test_index.js
@@ -106,11 +106,12 @@ describe(__filename, () => {
       mockWindow.verify();
     });
 
-    it('encodes URL paths with encodeURI', async () => {
+    // See https://github.com/mozilla/addons-frontend/issues/11485.
+    it('does not encode URL paths', async () => {
       const endpoint = 'project-ă-ă-â-â-日本語';
       mockWindow
         .expects('fetch')
-        .withArgs(sinon.match(`/api/${apiVersion}/${encodeURI(endpoint)}/`))
+        .withArgs(sinon.match(`/api/${apiVersion}/${endpoint}/`))
         .returns(createApiResponse());
 
       await api.callApi({ endpoint });
@@ -125,9 +126,7 @@ describe(__filename, () => {
       mockWindow
         .expects('fetch')
         .withArgs(
-          sinon.match(
-            `/api/${apiVersion}/${encodeURI(endpoint)}/${expectedQueryString}`,
-          ),
+          sinon.match(`/api/${apiVersion}/${endpoint}/${expectedQueryString}`),
         )
         .returns(createApiResponse());
 


### PR DESCRIPTION
Fixes #11485 

I am fairly certain we don't need to encode the pathname. Node will do it for us on the server, and it doesn't seem to be needed on the client.

Does that make sense to you @diox? 