### PR TITLE
Update download firefox button text for ERTAMO

### DIFF
--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -12,15 +12,10 @@ import {
   CLIENT_APP_FIREFOX,
   DOWNLOAD_FIREFOX_BASE_URL,
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
-  LINE,
-  RECOMMENDED,
-  SPONSORED,
-  VERIFIED,
 } from 'amo/constants';
 import translate from 'amo/i18n/translate';
 import tracking from 'amo/tracking';
 import { makeQueryStringWithUTM } from 'amo/utils';
-import { getPromotedCategory } from 'amo/utils/addons';
 import { isFirefox } from 'amo/utils/compatibility';
 import type { UserAgentInfoType } from 'amo/reducers/api';
 import type { AppState } from 'amo/store';
@@ -41,7 +36,6 @@ export type Props = {|
 
 export type DefaultProps = {|
   _encode: typeof encode,
-  _getPromotedCategory: typeof getPromotedCategory,
   _tracking: typeof tracking,
 |};
 
@@ -97,7 +91,6 @@ export const getDownloadLink = ({
 
 export const GetFirefoxButtonBase = ({
   _encode = encode,
-  _getPromotedCategory = getPromotedCategory,
   _tracking = tracking,
   addon,
   className,
@@ -121,15 +114,7 @@ export const GetFirefoxButtonBase = ({
     });
   };
 
-  const promotedCategory = _getPromotedCategory({
-    addon,
-    clientApp,
-    forBadging: true,
-  });
-
-  const supportsRTAMO =
-    [LINE, RECOMMENDED, SPONSORED, VERIFIED].includes(promotedCategory) &&
-    clientApp === CLIENT_APP_FIREFOX;
+  const supportsRTAMO = clientApp === CLIENT_APP_FIREFOX;
 
   let downloadTextForRTAMO =
     addon.type === ADDON_TYPE_STATIC_THEME


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/11562

---

Technically, we should have added a check for `version.channel` (that
must be `'listed'`) but we don't check the channel anywhere currently. I
tried to add support for it but failed because I couldn't retrieve the
current version object for some reasons...