### PR TITLE
Stop showing loading animation for themes when installed, this is no longer necessary

### DIFF
--- a/src/amo/components/AMInstallButton/index.js
+++ b/src/amo/components/AMInstallButton/index.js
@@ -122,13 +122,7 @@ export class AMInstallButtonBase extends React.Component<InternalProps> {
   };
 
   showLoadingAnimation(): boolean {
-    const { addon, status } = this.props;
-
-    if (ADDON_TYPE_STATIC_THEME === addon.type && status === INSTALLED) {
-      // We have to enable a static theme after having installed it, so we keep
-      // the animation visible to avoid flickering.
-      return true;
-    }
+    const { status } = this.props;
 
     return [
       DISABLING,

--- a/tests/unit/amo/components/TestAMInstallButton.js
+++ b/tests/unit/amo/components/TestAMInstallButton.js
@@ -284,27 +284,6 @@ describe(__filename, () => {
     },
   );
 
-  it('renders an Icon when add-on is a static theme and status is INSTALLED', () => {
-    render({
-      addon: createInternalAddonWithLang({
-        ...fakeTheme,
-        type: ADDON_TYPE_STATIC_THEME,
-      }),
-      status: INSTALLED,
-    });
-
-    expect(
-      screen.queryByClassName('AMInstallButton-button'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByClassName('AMInstallButton-loading-button'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByClassName('AMInstallButton-loader-container'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Remove')).toHaveClass('visually-hidden');
-  });
-
   it.each([
     [DOWNLOADING, 'Downloading'],
     [ENABLING, 'Enabling'],


### PR DESCRIPTION
Follow-up for #11600