### PR TITLE
Load locale bundle using dynamic import rather than locale-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
     "babel-gettext-extractor": "^4.1.3",
     "babel-loader": "^8.0.4",
     "babel-plugin-dynamic-import-node": "^2.2.0",
-    "bundle-loader": "^0.5.5",
     "bundlewatch": "^0.3.3",
     "chalk": "^4.0.0",
     "characterset": "^1.3.0",

--- a/src/amo/client/base.js
+++ b/src/amo/client/base.js
@@ -77,12 +77,10 @@ export default async function createClient(
   let i18nData = {};
   try {
     if (locale !== langToLocale(_config.get('defaultLang'))) {
-      i18nData = await new Promise((resolve) => {
-        // eslint-disable-next-line max-len, global-require, import/no-dynamic-require
-        require(`bundle-loader?name=[name]-i18n-[folder]!../../locale/${locale}/amo.js`)(
-          resolve,
-        );
-      });
+      i18nData = await import(
+        /* webpackChunkName: "amo-i18n-[request]" */
+        `../../locale/${locale}/amo.js`
+      );
     }
   } catch (e) {
     log.info(oneLine`Locale not found or required for locale: "${locale}".

--- a/yarn.lock
+++ b/yarn.lock
@@ -3424,13 +3424,6 @@ buffer@^5.4.3:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-bundle-loader@^0.5.5:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/bundle-loader/-/bundle-loader-0.5.6.tgz#6c9042e62f1c89941458805a3a479d10f34c71fd"
-  integrity sha512-SUgX+u/LJzlJiuoIghuubZ66eflehnjmqSfh/ib9DTe08sxRJ5F/MhHSjp7GfSJivSp8NWgez4PVNAUuMg7vSg==
-  dependencies:
-    loader-utils "^1.1.0"
-
 bundlewatch@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/bundlewatch/-/bundlewatch-0.3.3.tgz#6226f2317a8183cfccdd1ea016bdf10373c9498c"


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/11601

https://webpack.js.org/api/module-methods/#dynamic-expressions-in-import

## Details

## Bundle locale filenames

- before: `amo-i18n-en_US-eb9305cb9fedfb0e1c62.js`
- after: `amo-i18n-en_US-amo-js-de725749b6745cf38ee9.js`

## Main Bundle size

- before:
  - uncompressed:1.2 MB (1203076 bytes)
  - brotli 9: 318 kB (318058 bytes)
- after:
  - uncompressed: 1.19 MB (1192066 bytes)
  - brotli 9: 318 kB (317617 bytes)
- gains:
  - uncompressed: 11kB (11010 bytes, 0.91%)
  - brotli 9: 441 bytes

## Main bundle diff

### `require.ensure` bundle-loader output (one for each locale bundle)

```diff
<       5129: function (e, t, n) {
<         var r,
<           o = [];
<         (e.exports = function (e) {
<           o ? o.push(e) : e(r);
<         }),
<           n
<             .e(5859)
<             .then(
<               function (e) {
<                 r = n(9571);
<                 var t = o;
<                 o = null;
<                 for (var i = 0, a = t.length; i < a; i++) t[i](r);
<               }.bind(null, n)
<             )
<             .catch(n.oe);
<       },
```

### Locale bundle import

```diff
<           h !== M(s.get("defaultLang")) &&
<             (v = await new Promise((e) => {
<               o(5349)(`./${h}/amo.js`)(e);
<             }));
---
>           h !== M(s.get("defaultLang")) && (v = await a(5619)(`./${h}/amo.js`));
```