### PR TITLE
Add coverage for api/collections.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
     "intl-locales-supported": "^1.0.0",
     "jest": "^27.5.1",
     "jest-environment-jsdom": "^27.5.1",
+    "jest-extended": "^2.0.0",
     "jest-watch-typeahead": "^1.0.0",
     "lint-staged": "^12.0.0",
     "mini-css-extract-plugin": "^2.0.0",

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -3,6 +3,7 @@ import { setImmediate } from 'timers';
 import sinon from 'sinon';
 import config from 'config';
 import areIntlLocalesSupported from 'intl-locales-supported';
+import * as matchers from 'jest-extended';
 
 import '@testing-library/jest-dom/extend-expect';
 
@@ -47,6 +48,8 @@ global.fetch = (input) => {
     `API calls MUST be mocked. URL fetched: ${input.url || input}`,
   );
 };
+
+expect.extend(matchers);
 
 afterEach(() => {
   global.sinon.restore();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6796,7 +6796,7 @@ jest-config@^27.5.1:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.0.0, jest-diff@^27.5.1:
+jest-diff@^27.0.0, jest-diff@^27.2.5, jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -6849,7 +6849,15 @@ jest-environment-node@^27.5.1:
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
-jest-get-type@^27.5.1:
+jest-extended@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-2.0.0.tgz#8a6cef7369c2ef774bd966279a30cd73abe408dd"
+  integrity sha512-6AgjJQVaBEKGSK3FH90kOiRUWJsbzn9NWtW0pjGkAFIdH0oPilfkV/gHPJdVvJeBiqT3jMHw8TUg9pUGC1azDg==
+  dependencies:
+    jest-diff "^27.2.5"
+    jest-get-type "^27.0.6"
+
+jest-get-type@^27.0.6, jest-get-type@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
   integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==


### PR DESCRIPTION
This addresses some coverage that was missing for `api/collections.js` and also removes `sinon` from the test and uses a different ways of testing our api code which we should probably adopt for the other tests. It's fairly low priority, however, to make that change.