### PR TITLE
Ignore and remove some folders for the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN buildDeps=' \
     yarn install --pure-lockfile && \
     # cleanup
     # apt-get purge -y $buildDeps && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    yarn cache clean
 
 COPY . /srv/code/
 WORKDIR /srv/code


### PR DESCRIPTION
Part of #11647.

I built the docker image locally to test size impact.

Before:
```
% docker image ls baseline
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
baseline     latest    2a80f9b89c3a   57 seconds ago   2.87GB
```

After:
```
% docker image ls clear_yarn_cache_ignore_file
REPOSITORY                     TAG       IMAGE ID       CREATED          SIZE
clear_yarn_cache_ignore_file   latest    9adaf897347f   18 seconds ago   1.55GB
```

What this patch does not clear is `node_modules` and I am not sure we should. But I noticed that there are two of them:
* `/srv/code/node_modules/`
* `src/node/node_modules/`
Presumably, we don't need both of them?