### PR TITLE
Make TestUsersUnsubscribe forward compatible with future dependencies

### DIFF
--- a/tests/unit/amo/pages/TestUsersUnsubscribe.js
+++ b/tests/unit/amo/pages/TestUsersUnsubscribe.js
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import { encode } from 'universal-base64url';
 
+import { CLIENT_APP_FIREFOX } from 'amo/constants';
 import {
   abortUnsubscribeNotification,
   finishUnsubscribeNotification,
@@ -59,7 +60,7 @@ describe(__filename, () => {
   };
 
   beforeEach(() => {
-    store = dispatchClientMetadata().store;
+    store = dispatchClientMetadata({ clientApp: CLIENT_APP_FIREFOX }).store;
   });
 
   it('renders loading indicators when the user is not unsubscribed yet', () => {


### PR DESCRIPTION
Fixes #11690

Fun one. It's a single failure, but it's kinda interesting:

The `when user is successfully unsubscribed › renders a link to edit the user profile` test was failing, expecting a link to edit your profile to be present... and it was... but with a different app in the URL that what we're expecting - `android` instead of `firefox`. We're not checking what the `<title>` says, but it was set to `Unsubscribe – Add-ons for Firefox Android (en-US)` - so the whole page was being rendered with `android` as the app. We're setting `initialEntries to `[/en-US/firefox/users/unsubscribe/...]` at the start, but I guess the `dispatchClientMetadata()` call in `beforeEach()` overrides that asynchronously ?

Since that's inconsistent with the URL, I fixed it by initializing the store with `CLIENT_APP_FIREFOX`, but I expect we'll see more of this in other tests.