### PR TITLE
Improve initialEntries hack

### DIFF
--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -580,13 +580,13 @@ describe(__filename, () => {
   it('dispatches a server redirect when slug is a numeric ID', () => {
     const dispatch = testServerRedirect({ slugInURL: addon.id });
     // 1. Initial LOAD_ADDON
-    // 2. @@router/LOCATION_CHANGE, which happens on every page load
-    // 3. SEND_SERVER_REDIRECT
-    // 4. FETCH_CATEGORIES (initiated by AddonMoreInfo)
-    // 5. FETCH_ADDONS_BY_AUTHORS (initiated by AddonsByAuthorsCard)
-    // 6. FETCH_RECOMMENDATIONS (initiated by AddonRecommendations)
-    // 7. @@router/LOCATION_CHANGE, which happens after rendering in the
+    // 2. @@router/LOCATION_CHANGE, which happens before rendering in the
     // test helper.
+    // 3. @@router/LOCATION_CHANGE, which happens on every page load
+    // 4. SEND_SERVER_REDIRECT
+    // 5. FETCH_CATEGORIES (initiated by AddonMoreInfo)
+    // 6. FETCH_ADDONS_BY_AUTHORS (initiated by AddonsByAuthorsCard)
+    // 7. FETCH_RECOMMENDATIONS (initiated by AddonRecommendations)
 
     expect(dispatch).toHaveBeenCalledTimes(7);
     expect(dispatch).toHaveBeenCalledWith(
@@ -594,6 +594,10 @@ describe(__filename, () => {
     );
     expect(dispatch).toHaveBeenNthCalledWith(
       2,
+      expect.objectContaining({ type: LOCATION_CHANGE }),
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(
+      3,
       expect.objectContaining({ type: LOCATION_CHANGE }),
     );
     expect(dispatch).toHaveBeenCalledWith(
@@ -607,10 +611,6 @@ describe(__filename, () => {
     );
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: FETCH_RECOMMENDATIONS }),
-    );
-    expect(dispatch).toHaveBeenNthCalledWith(
-      7,
-      expect.objectContaining({ type: LOCATION_CHANGE }),
     );
   });
 

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -53,14 +53,14 @@ describe(__filename, () => {
       fetchBlock({ guid: defaultGuid, errorHandlerId: getErrorHandlerId() }),
     );
     // dispatch is always called twice with LOCATION_CHANGE on render, once for
-    // the actual render, and a second time after render in the test helper.
+    // the actual render, and a second time before render in the test helper.
     expect(dispatch).toHaveBeenCalledTimes(3);
     expect(dispatch).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ type: LOCATION_CHANGE }),
     );
     expect(dispatch).toHaveBeenNthCalledWith(
-      3,
+      2,
       expect.objectContaining({ type: LOCATION_CHANGE }),
     );
   });

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1566,6 +1566,16 @@ export const render = (ui, options = {}) => {
       initialEntries: options.initialEntries || ['/'],
     });
   const store = options.store || dispatchClientMetadata().store;
+  if (options.initialEntries) {
+    // We need to update the router state with the initial entry.
+    const parts = options.initialEntries[0].split('?');
+    store.dispatch(
+      onLocationChanged({
+        pathname: parts[0],
+        search: parts.length > 1 ? `?${parts[1]}` : '',
+      }),
+    );
+  }
 
   const wrapper = ({ children }) => {
     return (
@@ -1578,10 +1588,6 @@ export const render = (ui, options = {}) => {
   };
 
   const result = libraryRender(ui, { wrapper });
-  if (options.initialEntries) {
-    // We need to update the router state with the initial entry.
-    history.push(options.initialEntries[0]);
-  }
   return { ...result, history, root: result.container.firstChild };
 };
 /* eslint-enable testing-library/no-node-access */


### PR DESCRIPTION
Fixes #11705 

I made a couple of improvements, I think:

1. We are not calling anything *after* rendering the component, but are instead calling something *before* rendering the component. This is important as we don't want to alter the component in any way after it has been rendered.
2. I am dispatching an action to update the state in the store, rather than calling `history.push` which could have additional side effects.

@diox Let me know what you think about this improvement.