### PR TITLE
Resize the themes on homepage shelves (#10249)

### DIFF
--- a/src/amo/components/LandingAddonsCard/styles.scss
+++ b/src/amo/components/LandingAddonsCard/styles.scss
@@ -1,3 +1,3 @@
 .LandingAddonsCard-Themes .Card-contents .AddonsCard-list {
-  grid-template-columns: repeat(3, auto);
+  grid-template-columns: repeat(3, 33%);
 }

--- a/src/amo/pages/LandingPage/styles.scss
+++ b/src/amo/pages/LandingPage/styles.scss
@@ -4,14 +4,6 @@
   @include page-padding;
 }
 
-.LandingPage--theme {
-  .Card-contents {
-    .AddonsCard-list {
-      grid-template-columns: repeat(3, 33%);
-    }
-  }
-}
-
 .LandingPage-header {
   background-color: $white;
   border-radius: $border-radius-default;


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes mozilla/addons#10997

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes mozilla/addons#14043

Themes are now displayed at a size of ~370/48 when any number of themes are displayed in a shelf.

grid-template-columns was using repeat(3, auto) to size the themes, it has been modified to repeat(3, 33%).

I observed that a redundant style was being applied after making the above change. It has been removed.

Before:
![Screen Shot 2022-07-11 at 8 55 24 PM](https://user-images.githubusercontent.com/51471003/178302555-28084292-ee86-4077-aed8-31512e208245.png)

After:
![Screen Shot 2022-07-11 at 9 05 38 PM](https://user-images.githubusercontent.com/51471003/178302595-6edb4bdc-2848-454d-890f-d0091a8027ce.png)

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->