### PR TITLE
Failing test with new user-event

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,4 +61,4 @@ We use [React Testing Library](https://github.com/testing-library/react-testing-
 - If a component is only used by a single parent, add tests for the component into the test suite for the parent, and render the component in the context of the parent.
 - For page components, use `renderPage` from `tests/unit/helpers`, otherwise use `render`.
 - `render` and `renderPage` will provide an instance of `history`, `i18n` and `store` to your component. Unless you need to interact with and/or assert about one of these in your test, you do not need to provide one to you call to `render`.
-- when interacting with UI elements, prefer `userEvent` over `fireEvent`. The latter seems to be neccesary when needing to listen for calls to `stopPropagation` and `preventDefault`.
+- when interacting with UI elements, prefer `userEvent` over `fireEvent`. The latter seems to be neccesary when needing to listen for calls to `stopPropagation` and `preventDefault`. Note that calls to `userEvent` functions should always be `await`ed.

--- a/package.json
+++ b/package.json
@@ -257,7 +257,6 @@
     "@babel/preset-react": "^7.17.12",
     "@babel/register": "^7.17.7",
     "@emotion/core": "^11.0.0",
-    "@testing-library/dom": "^8.11.3",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "@emotion/core": "^11.0.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^13.3.0",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.2.6",
     "autoprefixer": "^10.2.4",
     "babel-gettext-extractor": "^4.1.3",
     "babel-loader": "^8.0.4",

--- a/src/amo/components/AutoSearchInput/index.js
+++ b/src/amo/components/AutoSearchInput/index.js
@@ -247,6 +247,7 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
     event: ElementEvent,
     { suggestion }: {| suggestion: SuggestionType |},
   ) => {
+    console.log('----- in handleSuggestionSelected, this.props: ', this.props);
     event.preventDefault();
 
     if (this.props.loadingSuggestions) {
@@ -255,6 +256,9 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
     }
 
     this.setState({ autocompleteIsOpen: false, searchValue: '' });
+    console.log(
+      '----- in handleSuggestionSelected, calling this.props.onSuggestionSelected...',
+    );
     this.props.onSuggestionSelected(suggestion);
   };
 
@@ -358,6 +362,10 @@ export class AutoSearchInputBase extends React.Component<InternalProps, State> {
 }
 
 const mapStateToProps = (state: AppState): PropsFromState => {
+  console.log(
+    '--- in mapStateToProps, state.autocomplete: ',
+    state.autocomplete,
+  );
   return {
     suggestions: state.autocomplete.suggestions,
     loadingSuggestions: state.autocomplete.loading,

--- a/tests/unit/amo/components/TestAMInstallButton.js
+++ b/tests/unit/amo/components/TestAMInstallButton.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createEvent, fireEvent, waitFor } from '@testing-library/react';
+import { createEvent, fireEvent } from '@testing-library/react';
 
 import AMInstallButton from 'amo/components/AMInstallButton';
 import {
@@ -162,9 +162,7 @@ describe(__filename, () => {
 
     await fireEvent(button, clickEvent);
 
-    await waitFor(() => {
-      expect(install).toHaveBeenCalledTimes(1);
-    });
+    expect(install).toHaveBeenCalledTimes(1);
     expect(enable).not.toHaveBeenCalled();
     expect(preventDefaultWatcher).toHaveBeenCalled();
     expect(stopPropagationWatcher).toHaveBeenCalled();

--- a/tests/unit/amo/components/TestAddAddonToCollection.js
+++ b/tests/unit/amo/components/TestAddAddonToCollection.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import AddAddonToCollection, {
   extractId,
@@ -47,9 +47,11 @@ jest.mock('amo/api/collections', () => {
 
 describe(__filename, () => {
   let store;
+  let userEvent;
 
   beforeEach(() => {
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   const getProps = (customProps = {}) => {
@@ -249,7 +251,7 @@ describe(__filename, () => {
       expect(screen.queryByRole('group')).not.toBeInTheDocument();
     });
 
-    it('dispatches the expected action when a user selects a collection', () => {
+    it('dispatches the expected action when a user selects a collection', async () => {
       const addon = createInternalAddonWithLang({ ...fakeAddon, id: 234 });
       const secondName = 'second';
       const userId = 10;
@@ -266,7 +268,7 @@ describe(__filename, () => {
 
       render({ addon });
 
-      userEvent.selectOptions(screen.getByRole('combobox'), secondName);
+      await userEvent.selectOptions(screen.getByRole('combobox'), secondName);
 
       expect(dispatch).toHaveBeenCalledWith(
         addAddonToCollection({
@@ -328,7 +330,7 @@ describe(__filename, () => {
       );
     });
 
-    it('shows a notice that you added to a collection', () => {
+    it('shows a notice that you added to a collection', async () => {
       const addon = createInternalAddonWithLang(fakeAddon);
       const firstName = 'a collection';
       const userId = 10;
@@ -346,14 +348,14 @@ describe(__filename, () => {
 
       render({ addon });
 
-      userEvent.selectOptions(screen.getByRole('combobox'), firstName);
+      await userEvent.selectOptions(screen.getByRole('combobox'), firstName);
 
       expect(screen.getByClassName('Notice-success')).toHaveTextContent(
         `Added to ${firstName}`,
       );
     });
 
-    it('shows notices for each target collection', () => {
+    it('shows notices for each target collection', async () => {
       const addon = createInternalAddonWithLang(fakeAddon);
       const firstName = 'a collection';
       const secondName = 'b collection';
@@ -374,14 +376,14 @@ describe(__filename, () => {
 
       render({ addon });
 
-      userEvent.selectOptions(screen.getByRole('combobox'), firstName);
-      userEvent.selectOptions(screen.getByRole('combobox'), secondName);
+      await userEvent.selectOptions(screen.getByRole('combobox'), firstName);
+      await userEvent.selectOptions(screen.getByRole('combobox'), secondName);
 
       expect(screen.getByText(`Added to ${firstName}`)).toBeInTheDocument();
       expect(screen.getByText(`Added to ${secondName}`)).toBeInTheDocument();
     });
 
-    it('uses expected name in the notice when the collection name is missing', () => {
+    it('uses expected name in the notice when the collection name is missing', async () => {
       const addon = createInternalAddonWithLang(fakeAddon);
       const userId = 10;
 
@@ -399,19 +401,19 @@ describe(__filename, () => {
 
       render({ addon });
 
-      userEvent.selectOptions(screen.getByRole('combobox'), '(no name)');
+      await userEvent.selectOptions(screen.getByRole('combobox'), '(no name)');
 
       expect(screen.getByText('Added to (no name)')).toBeInTheDocument();
     });
 
-    it('does nothing when you select the prompt', () => {
+    it('does nothing when you select the prompt', async () => {
       signInAndDispatchCollections();
       const dispatch = jest.spyOn(store, 'dispatch');
       render();
 
       dispatch.mockClear();
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox'),
         'Select a collection…',
       );
@@ -419,7 +421,7 @@ describe(__filename, () => {
       expect(dispatch).not.toBeCalled();
     });
 
-    it('lets you create a new collection by navigating to the collection page', () => {
+    it('lets you create a new collection by navigating to the collection page', async () => {
       const clientApp = CLIENT_APP_FIREFOX;
       const lang = DEFAULT_LANG_IN_TESTS;
       const id = 234;
@@ -435,7 +437,7 @@ describe(__filename, () => {
       const pushSpy = jest.spyOn(history, 'push');
       render({ addon, history });
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox'),
         'Create new collection',
       );

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { createEvent, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent, {
+  PointerEventsCheckLevel,
+} from '@testing-library/user-event';
 
 import {
   SAVED_RATING,
@@ -48,6 +50,7 @@ import {
 describe(__filename, () => {
   let i18n;
   let store;
+  let userEvent;
 
   // This is a review with only a rating, no text.
   const fakeRatingOnly = Object.freeze({
@@ -59,6 +62,11 @@ describe(__filename, () => {
   beforeEach(() => {
     i18n = fakeI18n();
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup({
+      // This is needed for one test which was triggering a library error about
+      // pointer events not being available.
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
   });
 
   const render = ({
@@ -248,65 +256,27 @@ describe(__filename, () => {
     });
   };
 
-  const openFlagMenu = async ({ isLoggedIn = true, isReply = false } = {}) => {
+  const openFlagMenu = async ({ isReply = false } = {}) =>
     userEvent.click(
       screen.getByRole('button', {
         name: isReply ? 'Flag this developer response' : 'Flag this review',
       }),
     );
-    if (isLoggedIn) {
-      expect(
-        await screen.findByRole('button', { name: 'This is spam' }),
-      ).toBeInTheDocument();
-    } else {
-      expect(
-        await screen.findByRole('link', { name: /Log in/ }),
-      ).toBeInTheDocument();
-    }
-  };
 
-  const clickDeleteRating = async ({ slim = false } = {}) => {
+  const clickDeleteRating = async () =>
     userEvent.click(screen.getByRole('button', { name: 'Delete rating' }));
-    if (slim) {
-      expect(
-        await screen.findByRole('button', { name: 'Keep rating' }),
-      ).toBeInTheDocument();
-    } else {
-      expect(
-        await screen.findByText('Do you really want to delete this rating?'),
-      ).toBeInTheDocument();
-    }
-  };
 
-  const clickDeleteReview = async ({ slim = false } = {}) => {
+  const clickDeleteReview = async () =>
     userEvent.click(screen.getByRole('button', { name: 'Delete review' }));
-    if (slim) {
-      expect(
-        await screen.findByRole('button', { name: 'Keep review' }),
-      ).toBeInTheDocument();
-    } else {
-      expect(
-        await screen.findByRole('button', { name: 'Cancel' }),
-      ).toBeInTheDocument();
-    }
-  };
 
-  const clickEditReply = () =>
+  const clickEditReply = async () =>
     userEvent.click(screen.getByRole('link', { name: 'Edit reply' }));
 
-  const clickEditReview = async () => {
+  const clickEditReview = async () =>
     userEvent.click(screen.getByRole('link', { name: 'Edit review' }));
-    expect(
-      await screen.findByRole('button', { name: 'Cancel' }),
-    ).toBeInTheDocument();
-  };
 
-  const clickReplyToReview = async () => {
+  const clickReplyToReview = async () =>
     userEvent.click(screen.getByRole('link', { name: 'Reply to this review' }));
-    expect(
-      await screen.findByRole('button', { name: 'Cancel' }),
-    ).toBeInTheDocument();
-  };
 
   const getDefaultErrorHandlerId = (reviewId) => `AddonReviewCard-${reviewId}`;
 
@@ -498,7 +468,7 @@ describe(__filename, () => {
     });
     render({ review, slim: true });
 
-    await clickDeleteRating({ slim: true });
+    await clickDeleteRating();
 
     expect(
       screen.getByRole('button', { name: 'Keep rating' }),
@@ -512,7 +482,7 @@ describe(__filename, () => {
     const review = signInAndDispatchSavedReview();
     render({ review, slim: true });
 
-    await clickDeleteReview({ slim: true });
+    await clickDeleteReview();
 
     expect(
       screen.getByRole('button', { name: 'Keep review' }),
@@ -526,7 +496,7 @@ describe(__filename, () => {
     const review = signInAndDispatchSavedReview();
     render({ review, slim: true });
 
-    await clickDeleteReview({ slim: true });
+    await clickDeleteReview();
 
     expect(
       screen.queryByText('Do you really want to delete this review?'),
@@ -611,7 +581,7 @@ describe(__filename, () => {
     render({ review });
 
     await clickDeleteReview();
-    userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
     createFailedErrorHandler({
       id: getDefaultErrorHandlerId(review.id),
@@ -812,21 +782,19 @@ describe(__filename, () => {
   it('configures a reply-to-review text form when editing', async () => {
     const { reply } = renderNestedReplyForSignedInDeveloper();
 
-    userEvent.click(screen.getByRole('link', { name: 'Edit reply' }));
+    await userEvent.click(screen.getByRole('link', { name: 'Edit reply' }));
 
-    const textArea = await screen.findByPlaceholderText(
+    const textArea = screen.getByPlaceholderText(
       'Write a reply to this review.',
     );
     expect(textArea).toHaveValue(reply.body);
 
-    userEvent.type(textArea, 'Updated reply');
+    await userEvent.type(textArea, 'Updated reply');
 
-    userEvent.click(screen.getByRole('button', { name: 'Update reply' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Update reply' }));
 
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: 'Updating reply' }),
-      ).toHaveClass('Button--disabled'),
+    expect(screen.getByRole('button', { name: 'Updating reply' })).toHaveClass(
+      'Button--disabled',
     );
   });
 
@@ -837,7 +805,7 @@ describe(__filename, () => {
     render({ addon, review, siteUserCanReply: true });
 
     await clickReplyToReview();
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(dispatch).toHaveBeenCalledWith(
       hideReplyToReviewForm({
@@ -863,8 +831,10 @@ describe(__filename, () => {
     );
     expect(textArea).toHaveValue('');
 
-    userEvent.type(textArea, replyBody);
-    userEvent.click(screen.getByRole('button', { name: 'Publish reply' }));
+    await userEvent.type(textArea, replyBody);
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Publish reply' }),
+    );
 
     expect(dispatch).toHaveBeenCalledWith(
       sendReplyToReview({
@@ -874,11 +844,9 @@ describe(__filename, () => {
       }),
     );
 
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: 'Publishing reply' }),
-      ).toHaveClass('Button--disabled'),
-    );
+    expect(
+      screen.getByRole('button', { name: 'Publishing reply' }),
+    ).toHaveClass('Button--disabled');
     expect(
       screen.queryByRole('button', { name: 'Publish reply' }),
     ).not.toBeInTheDocument();
@@ -899,11 +867,13 @@ describe(__filename, () => {
     render({ addon, review, siteUserCanReply: true });
 
     await clickReplyToReview();
-    userEvent.type(
+    await userEvent.type(
       screen.getByPlaceholderText('Write a reply to this review.'),
-      '{selectall}{del}Body of the review',
+      'Body of the review',
     );
-    userEvent.click(screen.getByRole('button', { name: 'Publish reply' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Publish reply' }),
+    );
 
     createFailedErrorHandler({
       id: getDefaultErrorHandlerId(review.id),
@@ -1017,7 +987,7 @@ describe(__filename, () => {
       render({ review });
 
       await clickEditReview();
-      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(dispatch).toHaveBeenCalledWith(
         hideEditReviewForm({
@@ -1034,11 +1004,9 @@ describe(__filename, () => {
 
       await clickDeleteRating();
 
-      await waitFor(() =>
-        expect(
-          screen.queryByRole('button', { name: 'Write a review' }),
-        ).not.toBeInTheDocument(),
-      );
+      expect(
+        screen.queryByRole('button', { name: 'Write a review' }),
+      ).not.toBeInTheDocument();
     });
 
     it('hides the write review button for ratings when not logged in', async () => {
@@ -1255,7 +1223,7 @@ describe(__filename, () => {
         screen.getByRole('heading', { name: 'Developer response' }),
       ).toBeInTheDocument();
 
-      clickEditReply();
+      await clickEditReply();
 
       expect(dispatch).toHaveBeenCalledWith(
         showReplyToReviewForm({
@@ -1263,11 +1231,9 @@ describe(__filename, () => {
         }),
       );
 
-      await waitFor(() =>
-        expect(
-          screen.queryByRole('heading', { name: 'Developer response' }),
-        ).not.toBeInTheDocument(),
-      );
+      expect(
+        screen.queryByRole('heading', { name: 'Developer response' }),
+      ).not.toBeInTheDocument();
     });
 
     it('does not include a user name in the byline', () => {
@@ -1298,10 +1264,12 @@ describe(__filename, () => {
         screen.getByRole('heading', { name: 'Developer response' }),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByRole('button', { name: 'Delete reply' }));
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete reply' }),
+      );
 
       expect(
-        await screen.findByText('Do you really want to delete this reply?'),
+        screen.getByText('Do you really want to delete this reply?'),
       ).toBeInTheDocument();
 
       const button = screen.getByRole('button', {
@@ -1338,10 +1306,12 @@ describe(__filename, () => {
       ).toBeInTheDocument();
     });
 
-    it('renders the expected delete confirm button text when slim=true', () => {
+    it('renders the expected delete confirm button text when slim=true', async () => {
       renderNestedReplyForSignedInDeveloper({ slim: true });
 
-      userEvent.click(screen.getByRole('button', { name: 'Delete reply' }));
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete reply' }),
+      );
 
       expect(
         screen.getByRole('button', { name: 'Delete reply' }),
@@ -1447,16 +1417,14 @@ describe(__filename, () => {
       render({ review });
 
       await openFlagMenu();
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', {
           name: 'This is a bug report or support request',
         }),
-        undefined,
-        { skipPointerEventsCheck: true },
       );
 
       expect(
-        await within(screen.getByRole('tooltip')).findByRole('alert'),
+        within(screen.getByRole('tooltip')).getByRole('alert'),
       ).toBeInTheDocument();
     });
 
@@ -1503,7 +1471,7 @@ describe(__filename, () => {
       it('requires you to be signed in', async () => {
         render({ review: _setReview() });
 
-        await openFlagMenu({ isLoggedIn: false });
+        await openFlagMenu();
 
         // Only the button item should be rendered.
         expect(
@@ -1519,7 +1487,7 @@ describe(__filename, () => {
       it('prompts you to flag a developer response after login', async () => {
         renderNestedReply();
 
-        await openFlagMenu({ isLoggedIn: false, isReply: true });
+        await openFlagMenu({ isReply: true });
 
         expect(
           screen.getByRole('link', { name: 'Log in to flag this response' }),
@@ -1692,7 +1660,7 @@ describe(__filename, () => {
 
       await clickEditReview();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', {
           name: `Update your rating to ${newScore} out of 5`,
         }),
@@ -1717,13 +1685,15 @@ describe(__filename, () => {
 
       await clickEditReview();
 
-      userEvent.type(
-        screen.getByPlaceholderText(
-          'Write about your experience with this add-on.',
-        ),
-        `{selectall}{del}${newBody}`,
+      const input = screen.getByPlaceholderText(
+        'Write about your experience with this add-on.',
       );
-      userEvent.click(screen.getByRole('button', { name: 'Update review' }));
+      await userEvent.clear(input);
+      await userEvent.type(input, newBody);
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Update review' }),
+      );
 
       expect(dispatch).toHaveBeenCalledWith(
         updateAddonReview({
@@ -1836,20 +1806,22 @@ describe(__filename, () => {
       });
       render({ review });
 
-      userEvent.click(screen.getByRole('button', { name: 'Write a review' }));
-      await waitFor(() =>
-        expect(
-          screen.queryByRole('button', { name: 'Write a review' }),
-        ).not.toBeInTheDocument(),
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Write a review' }),
       );
+      expect(
+        screen.queryByRole('button', { name: 'Write a review' }),
+      ).not.toBeInTheDocument();
 
-      userEvent.type(
+      await userEvent.type(
         screen.getByPlaceholderText(
           'Write about your experience with this add-on.',
         ),
         body,
       );
-      userEvent.click(screen.getByRole('button', { name: 'Submit review' }));
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Submit review' }),
+      );
 
       expect(dispatch).toHaveBeenCalledWith(
         showEditReviewForm({ reviewId: review.id }),

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -910,9 +910,11 @@ describe(__filename, () => {
       store,
     });
 
-    expect(
-      screen.getByRole('button', { name: 'Publish reply' }),
-    ).not.toHaveClass('Button--disabled');
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Publish reply' }),
+      ).not.toHaveClass('Button--disabled'),
+    );
     expect(
       screen.queryByRole('button', { name: 'Publishing reply' }),
     ).not.toBeInTheDocument();

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createEvent, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import { DEFAULT_API_PAGE_SIZE } from 'amo/api';
 import AddonsCard from 'amo/components/AddonsCard';
@@ -27,9 +27,11 @@ import {
 describe(__filename, () => {
   let addons;
   let store;
+  let userEvent;
 
   beforeEach(() => {
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   const render = ({ history, location, lang, ...customProps } = {}) => {
@@ -123,15 +125,15 @@ describe(__filename, () => {
       saveNote,
     });
 
-    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
-    userEvent.type(await screen.findByRole('textbox'), 'Some new notes');
-    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await userEvent.type(screen.getByRole('textbox'), 'Some new notes');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
     expect(saveNote).toHaveBeenCalled();
 
-    userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
     expect(deleteNote).toHaveBeenCalled();
 
-    userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
     expect(removeAddon).toHaveBeenCalled();
   });
 
@@ -379,45 +381,39 @@ describe(__filename, () => {
       ).toBeInTheDocument();
     });
 
-    it('links the li element to the detail page', () => {
+    it('links the li element to the detail page', async () => {
       const history = createHistory();
       renderWithResult({ props: { history } });
 
       const pushSpy = jest.spyOn(history, 'push');
-      const li = screen.getByRole('listitem');
-      const clickEvent = createEvent.click(li);
-
-      fireEvent(li, clickEvent);
+      await userEvent.click(screen.getByRole('listitem'));
 
       expect(pushSpy).toHaveBeenCalledWith(`/en-US/android/addon/${slug}/`);
     });
 
-    it('calls the custom onClick handler for the li element, passing the addon', () => {
+    it('calls the custom onClick handler for the li element, passing the addon', async () => {
       const onClick = jest.fn();
       renderWithResult({ props: { onAddonClick: onClick } });
 
-      const li = screen.getByRole('listitem');
-      userEvent.click(li);
+      await userEvent.click(screen.getByRole('listitem'));
 
       expect(onClick).toHaveBeenCalledWith(createAddon());
     });
 
-    it('does not call the custom onClick handler for the li element without an addon', () => {
+    it('does not call the custom onClick handler for the li element without an addon', async () => {
       const onClick = jest.fn();
       render({ loading: true, onAddonClick: onClick, placeholderCount: 1 });
 
-      const li = screen.getByRole('listitem');
-      userEvent.click(li);
+      await userEvent.click(screen.getByRole('listitem'));
 
       expect(onClick).not.toHaveBeenCalled();
     });
 
-    it('calls the custom onClick handler for the anchor element, passing the addon', () => {
+    it('calls the custom onClick handler for the anchor element, passing the addon', async () => {
       const onClick = jest.fn();
       renderWithResult({ props: { onAddonClick: onClick } });
 
-      const link = screen.getByRole('link', { name });
-      userEvent.click(link);
+      await userEvent.click(screen.getByRole('link', { name }));
 
       expect(onClick).toHaveBeenCalledWith(createAddon());
     });

--- a/tests/unit/amo/components/TestAutoSearchInput.js
+++ b/tests/unit/amo/components/TestAutoSearchInput.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import AutoSearchInput, {
   SEARCH_TERM_MIN_LENGTH,
@@ -32,11 +31,13 @@ import {
 
 describe(__filename, () => {
   let store;
+  let userEvent;
   const defaultInputName = 'query';
   const errorHandlerId = `src/amo/components/AutoSearchInput/index.js-${defaultInputName}`;
 
   beforeEach(() => {
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   const render = ({
@@ -62,8 +63,11 @@ describe(__filename, () => {
     );
   };
 
-  const typeInSearch = (term = '') =>
-    userEvent.type(screen.getByRole('searchbox'), `{selectall}{del}${term}`);
+  const typeInSearch = async (term = '') => {
+    const input = screen.getByRole('searchbox');
+    await userEvent.clear(input);
+    await userEvent.type(input, term);
+  };
 
   describe('search input', () => {
     it('renders an initial query', () => {
@@ -93,7 +97,7 @@ describe(__filename, () => {
         location: `/?${defaultInputName}=${query}`,
       });
 
-      typeInSearch(typedQuery);
+      await typeInSearch(typedQuery);
 
       expect(screen.getByRole('searchbox')).toHaveValue(typedQuery);
 
@@ -121,50 +125,50 @@ describe(__filename, () => {
       expect(screen.getByRole('searchbox')).toHaveAttribute('name', inputName);
     });
 
-    it('handles submitting a search', () => {
+    it('handles submitting a search', async () => {
       const onSearch = jest.fn();
       render({ onSearch });
 
       const query = 'panda themes';
-      typeInSearch(query);
+      await typeInSearch(query);
 
-      userEvent.click(screen.getByRole('button', { name: 'Search' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Search' }));
       expect(onSearch).toHaveBeenCalledWith({
         query,
       });
     });
 
-    it('trims spaces from the input', () => {
+    it('trims spaces from the input', async () => {
       const onSearch = jest.fn();
       render({ onSearch });
 
       const query = 'panda themes';
-      typeInSearch('     ');
+      await typeInSearch('     ');
 
-      userEvent.click(screen.getByRole('button', { name: 'Search' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Search' }));
 
       expect(onSearch).toHaveBeenCalledWith({ query: '' });
 
       onSearch.mockClear();
 
-      typeInSearch(`   ${query}   `);
+      await typeInSearch(`   ${query}   `);
 
-      userEvent.click(screen.getByRole('button', { name: 'Search' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Search' }));
 
       expect(onSearch).toHaveBeenCalledWith({ query });
     });
 
-    it('blurs the input when submitting a search', () => {
+    it('blurs the input when submitting a search', async () => {
       render();
 
       const query = 'panda themes';
-      typeInSearch(query);
+      await typeInSearch(query);
 
       // eslint-disable-next-line testing-library/no-node-access
       const inputElement = document.getElementById('AutoSearchInput-query');
       const blur = jest.spyOn(inputElement, 'blur');
 
-      userEvent.click(screen.getByRole('button', { name: 'Search' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Search' }));
 
       expect(blur).toHaveBeenCalled();
     });
@@ -190,12 +194,12 @@ describe(__filename, () => {
   });
 
   describe('fetching search suggestions', () => {
-    it('fetches search suggestions', () => {
+    it('fetches search suggestions', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const query = 'ad blocker';
       render();
 
-      typeInSearch(query);
+      await typeInSearch(query);
 
       expect(dispatch).toHaveBeenCalledWith(
         autocompleteStart({
@@ -205,12 +209,12 @@ describe(__filename, () => {
       );
     });
 
-    it('fetches suggestions without a page', () => {
+    it('fetches suggestions without a page', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const query = 'ad blocker';
       render({ location: '/?page=3' });
 
-      typeInSearch(query);
+      await typeInSearch(query);
 
       expect(dispatch).toHaveBeenCalledWith(
         autocompleteStart({
@@ -221,12 +225,12 @@ describe(__filename, () => {
       );
     });
 
-    it('does not pass a `random` sort filter', () => {
+    it('does not pass a `random` sort filter', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const query = 'ad blocker';
       render({ location: `/?sort=${SEARCH_SORT_RANDOM}` });
 
-      typeInSearch(query);
+      await typeInSearch(query);
 
       expect(dispatch).toHaveBeenCalledWith(
         autocompleteStart({
@@ -237,13 +241,13 @@ describe(__filename, () => {
       );
     });
 
-    it('does pass a sort filter that is not `random`', () => {
+    it('does pass a sort filter that is not `random`', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const query = 'ad blocker';
       const sort = SEARCH_SORT_POPULAR;
       render({ location: `/?sort=${sort}` });
 
-      typeInSearch(query);
+      await typeInSearch(query);
 
       expect(dispatch).toHaveBeenCalledWith(
         autocompleteStart({
@@ -253,13 +257,13 @@ describe(__filename, () => {
       );
     });
 
-    it('preserves existing search filters on the query string', () => {
+    it('preserves existing search filters on the query string', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const query = 'ad blocker';
       const type = ADDON_TYPE_EXTENSION;
       render({ location: `/?type=${type}` });
 
-      typeInSearch(query);
+      await typeInSearch(query);
 
       expect(dispatch).toHaveBeenCalledWith(
         autocompleteStart({
@@ -269,11 +273,11 @@ describe(__filename, () => {
       );
     });
 
-    it('does not fetch suggestions for a really short value', () => {
+    it('does not fetch suggestions for a really short value', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       render();
 
-      typeInSearch('t'.repeat(SEARCH_TERM_MIN_LENGTH - 1));
+      await typeInSearch('t'.repeat(SEARCH_TERM_MIN_LENGTH - 1));
 
       expect(dispatch).toHaveBeenCalledWith(autocompleteCancel());
       expect(dispatch).not.toHaveBeenCalledWith(
@@ -288,7 +292,7 @@ describe(__filename, () => {
       });
       render();
 
-      typeInSearch('panda themes');
+      await typeInSearch('panda themes');
 
       expect(screen.getByClassName('AutoSearchInput')).toHaveClass(
         'AutoSearchInput--autocompleteIsOpen',
@@ -303,11 +307,11 @@ describe(__filename, () => {
       render();
 
       // We need to type in the search field to show results.
-      typeInSearch('something');
+      await typeInSearch('something');
       // Tab away from search field.
-      userEvent.tab();
+      await userEvent.tab();
       // Tab back to search field.
-      userEvent.tab({ shift: true });
+      await userEvent.tab({ shift: true });
 
       expect(screen.getByClassName('AutoSearchInput')).toHaveClass(
         'AutoSearchInput--autocompleteIsOpen',
@@ -324,26 +328,26 @@ describe(__filename, () => {
       render();
 
       // We need to type in the search field to show results.
-      typeInSearch('something');
+      await typeInSearch('something');
       expect(screen.getByClassName('AutoSearchInput')).toHaveClass(
         'AutoSearchInput--autocompleteIsOpen',
       );
 
       // Typing escape should close the menu.
-      typeInSearch('{esc}');
+      await typeInSearch('{esc}');
       expect(screen.getByClassName('AutoSearchInput')).not.toHaveClass(
         'AutoSearchInput--autocompleteIsOpen',
       );
     });
 
-    it('cancels pending requests on autosuggest cancel', () => {
+    it('cancels pending requests on autosuggest cancel', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       render();
 
-      typeInSearch('something');
+      await typeInSearch('something');
       dispatch.mockClear();
 
-      typeInSearch('{esc}');
+      await typeInSearch('{esc}');
       expect(dispatch).toHaveBeenCalledWith(autocompleteCancel());
     });
   });
@@ -354,18 +358,18 @@ describe(__filename, () => {
       const onSuggestionSelected = jest.fn();
       render({ onSuggestionSelected });
 
-      typeInSearch('test');
+      await typeInSearch('test');
 
       await dispatchAutocompleteResults({ results: [fakeResult], store });
 
-      userEvent.click(screen.getByRole('option'));
+      await userEvent.click(screen.getByRole('option'));
 
       expect(onSuggestionSelected).toHaveBeenCalledWith(
         createInternalSuggestionWithLang(fakeResult),
       );
     });
 
-    it('does not execute callback when selecting a placeholder', () => {
+    it('does not execute callback when selecting a placeholder', async () => {
       const onSuggestionSelected = jest.fn();
       store.dispatch(
         autocompleteStart({
@@ -375,9 +379,9 @@ describe(__filename, () => {
       );
       render({ onSuggestionSelected });
 
-      typeInSearch('test');
+      await typeInSearch('test');
 
-      userEvent.click(screen.getAllByRole('option')[0]);
+      await userEvent.click(screen.getAllByRole('option')[0]);
 
       expect(onSuggestionSelected).not.toHaveBeenCalled();
     });
@@ -385,19 +389,17 @@ describe(__filename, () => {
     it('closes suggestion menu when selecting a suggestion', async () => {
       render();
 
-      typeInSearch('test');
+      await typeInSearch('test');
 
       await dispatchAutocompleteResults({
         results: [createFakeAutocompleteResult()],
         store,
       });
 
-      userEvent.click(screen.getByRole('option'));
+      await userEvent.click(screen.getByRole('option'));
 
-      await waitFor(() =>
-        expect(screen.getByClassName('AutoSearchInput')).not.toHaveClass(
-          'AutoSearchInput--autocompleteIsOpen',
-        ),
+      expect(screen.getByClassName('AutoSearchInput')).not.toHaveClass(
+        'AutoSearchInput--autocompleteIsOpen',
       );
     });
 
@@ -405,7 +407,7 @@ describe(__filename, () => {
       const query = 'test';
       render();
 
-      typeInSearch(query);
+      await typeInSearch(query);
       expect(screen.getByRole('searchbox')).toHaveValue(query);
 
       await dispatchAutocompleteResults({
@@ -413,11 +415,9 @@ describe(__filename, () => {
         store,
       });
 
-      userEvent.click(screen.getByRole('option'));
+      await userEvent.click(screen.getByRole('option'));
 
-      await waitFor(() =>
-        expect(screen.getByRole('searchbox')).toHaveValue(''),
-      );
+      expect(screen.getByRole('searchbox')).toHaveValue('');
     });
   });
 
@@ -432,7 +432,7 @@ describe(__filename, () => {
     });
     render({ selectSuggestionText });
 
-    typeInSearch('test');
+    await typeInSearch('test');
 
     await dispatchAutocompleteResults({ results: [fakeResult], store });
 
@@ -460,7 +460,7 @@ describe(__filename, () => {
       const secondResult = createFakeAutocompleteResult({ name: secondName });
       render();
 
-      typeInSearch('test');
+      await typeInSearch('test');
 
       await dispatchAutocompleteResults({
         results: [firstResult, secondResult],
@@ -473,7 +473,7 @@ describe(__filename, () => {
       expect(screen.getByAltText(secondName)).toBeInTheDocument();
     });
 
-    it('configures search suggestions in a loading state', () => {
+    it('configures search suggestions in a loading state', async () => {
       store.dispatch(
         autocompleteStart({
           errorHandlerId,
@@ -483,7 +483,7 @@ describe(__filename, () => {
 
       render();
 
-      typeInSearch('test');
+      await typeInSearch('test');
 
       // Exactly 10 placeholders are returned.
       expect(screen.getAllByRole('alert')).toHaveLength(10);
@@ -519,7 +519,7 @@ describe(__filename, () => {
       });
       render();
 
-      typeInSearch('test');
+      await typeInSearch('test');
 
       await dispatchAutocompleteResults({ results: [result], store });
 
@@ -530,7 +530,7 @@ describe(__filename, () => {
       const result = createFakeAutocompleteResult({ promoted: null });
       render();
 
-      typeInSearch('test');
+      await typeInSearch('test');
 
       await dispatchAutocompleteResults({ results: [result], store });
 

--- a/tests/unit/amo/components/TestButton.js
+++ b/tests/unit/amo/components/TestButton.js
@@ -10,7 +10,7 @@ describe(__filename, () => {
     return defaultRender(<Button {...props} />);
   }
 
-  it('renders a button', () => {
+  it('renders a button', async () => {
     const onClick = jest.fn();
     render({
       children: 'My button!',
@@ -22,7 +22,7 @@ describe(__filename, () => {
     expect(button).toHaveTextContent('My button!');
     expect(button).toHaveClass('Foo');
 
-    userEvent.click(button);
+    await userEvent.setup().click(button);
     expect(onClick).toHaveBeenCalled();
   });
 

--- a/tests/unit/amo/components/TestConfirmButton.js
+++ b/tests/unit/amo/components/TestConfirmButton.js
@@ -1,12 +1,16 @@
 import * as React from 'react';
-import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import ConfirmButton, { extractId } from 'amo/components/ConfirmButton';
 import { render as defaultRender, screen } from 'tests/unit/helpers';
 
 describe(__filename, () => {
   const defaultChildText = 'the default text of this button';
+  let userEvent;
+
+  beforeEach(() => {
+    userEvent = defaultUserEvent.setup();
+  });
 
   const render = ({
     children = defaultChildText,
@@ -31,12 +35,11 @@ describe(__filename, () => {
     render(otherProps);
 
     // Click to open ConfirmationDialog.
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole('button', {
         name: defaultChildText,
       }),
     );
-    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(2));
   };
 
   it('renders a button', () => {
@@ -71,13 +74,13 @@ describe(__filename, () => {
 
     expect(screen.queryByText('some warning message')).not.toBeInTheDocument();
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole('button', {
         name: defaultChildText,
       }),
     );
 
-    expect(await screen.findByText('some warning message')).toBeInTheDocument();
+    expect(screen.getByText('some warning message')).toBeInTheDocument();
   });
 
   it('configures ConfirmationDialog', async () => {
@@ -115,16 +118,16 @@ describe(__filename, () => {
     const button = screen.getByRole('button', {
       name: defaultChildText,
     });
-    userEvent.click(button);
-    await waitFor(() => expect(button).not.toBeInTheDocument());
+    await userEvent.click(button);
+    expect(button).not.toBeInTheDocument();
   });
 
   it('hides ConfirmationDialog on cancel', async () => {
     await renderWithDialog();
 
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(1));
+    expect(screen.getAllByRole('button')).toHaveLength(1);
   });
 
   it('handles onConfirm callback and hides ConfirmationDialog on confirm', async () => {
@@ -133,9 +136,9 @@ describe(__filename, () => {
 
     expect(screen.getAllByRole('button')).toHaveLength(2);
 
-    userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
-    await waitFor(() => expect(screen.getAllByRole('button')).toHaveLength(1));
+    expect(screen.getAllByRole('button')).toHaveLength(1);
     expect(onConfirm).toHaveBeenCalled();
   });
 

--- a/tests/unit/amo/components/TestConfirmationDialog.js
+++ b/tests/unit/amo/components/TestConfirmationDialog.js
@@ -1,10 +1,16 @@
 import * as React from 'react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import ConfirmationDialog from 'amo/components/ConfirmationDialog';
 import { render as defaultRender, screen } from 'tests/unit/helpers';
 
 describe(__filename, () => {
+  let userEvent;
+
+  beforeEach(() => {
+    userEvent = defaultUserEvent.setup();
+  });
+
   function render(props = {}) {
     return defaultRender(<ConfirmationDialog {...props} />);
   }
@@ -52,17 +58,21 @@ describe(__filename, () => {
     expect(confirmButton).not.toHaveClass('Button--puffy');
   });
 
-  it('calls onConfirm() when user clicks Confirm', () => {
+  it('calls onConfirm() when user clicks Confirm', async () => {
     const onConfirm = jest.fn();
     render({ onConfirm });
-    userEvent.click(screen.getByClassName('ConfirmationDialog-confirm-button'));
+    await userEvent.click(
+      screen.getByClassName('ConfirmationDialog-confirm-button'),
+    );
     expect(onConfirm).toHaveBeenCalled();
   });
 
-  it('calls onCancel() when user clicks Cancel', () => {
+  it('calls onCancel() when user clicks Cancel', async () => {
     const onCancel = jest.fn();
     render({ onCancel });
-    userEvent.click(screen.getByClassName('ConfirmationDialog-cancel-button'));
+    await userEvent.click(
+      screen.getByClassName('ConfirmationDialog-cancel-button'),
+    );
     expect(onCancel).toHaveBeenCalled();
   });
 

--- a/tests/unit/amo/components/TestDismissibleTextForm.js
+++ b/tests/unit/amo/components/TestDismissibleTextForm.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createEvent, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import DismissibleTextForm from 'amo/components/DismissibleTextForm';
 import {
@@ -14,6 +14,7 @@ import {
 
 describe(__filename, () => {
   let store;
+  let userEvent;
 
   const renderProps = (customProps = {}) => {
     return {
@@ -36,6 +37,7 @@ describe(__filename, () => {
 
   beforeEach(() => {
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   it('can be configured with a custom class', () => {
@@ -79,11 +81,11 @@ describe(__filename, () => {
     expect(getTextBox()).toHaveValue('Some text to edit');
   });
 
-  it('calls back when dismissing the textarea', () => {
+  it('calls back when dismissing the textarea', async () => {
     const onDismiss = jest.fn();
     render({ onDismiss });
 
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(onDismiss).toHaveBeenCalled();
   });
@@ -91,18 +93,18 @@ describe(__filename, () => {
   it('clears the form onDismiss', async () => {
     render({ onDismiss: jest.fn() });
 
-    userEvent.type(getTextBox(), 'Example text');
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-    await waitFor(() => expect(getTextBox()).toHaveValue(''));
+    await userEvent.type(getTextBox(), 'Example text');
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(getTextBox()).toHaveValue('');
   });
 
-  it('calls back when submitting the form', () => {
+  it('calls back when submitting the form', async () => {
     const onSubmit = jest.fn();
     render({ onSubmit });
     const enteredText = 'Some review text';
 
-    userEvent.type(getTextBox(), enteredText);
-    userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    await userEvent.type(getTextBox(), enteredText);
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -169,18 +171,18 @@ describe(__filename, () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).not.toBeDisabled();
   });
 
-  it('enables the submit button after text has been entered', () => {
+  it('enables the submit button after text has been entered', async () => {
     render({ text: '' });
 
-    userEvent.type(getTextBox(), 'Typing some text...');
+    await userEvent.type(getTextBox(), 'Typing some text...');
 
     expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled();
   });
 
-  it('disables the submit button when updating with whitespaces', () => {
+  it('disables the submit button when updating with whitespaces', async () => {
     render({ text: 'Some Text' });
 
-    userEvent.type(getTextBox(), '   ');
+    await userEvent.type(getTextBox(), '   ');
 
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
   });
@@ -287,19 +289,19 @@ describe(__filename, () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
   });
 
-  it('enables the delete button after text has been entered', () => {
+  it('enables the delete button after text has been entered', async () => {
     render({ onDelete: jest.fn(), text: '' });
 
-    userEvent.type(getTextBox(), 'Typing some text...');
+    await userEvent.type(getTextBox(), 'Typing some text...');
 
     expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled();
   });
 
-  it('calls back when clicking the delete button', () => {
+  it('calls back when clicking the delete button', async () => {
     const onDelete = jest.fn();
     render({ onDelete });
 
-    userEvent.type(getTextBox(), 'Some review text');
+    await userEvent.type(getTextBox(), 'Some review text');
 
     // Submit the form.
     const button = screen.getByRole('button', { name: 'Delete' });
@@ -415,52 +417,52 @@ describe(__filename, () => {
       expect(getTextBox()).toHaveValue(text);
     });
 
-    it('saves to LocalState when typing', () => {
+    it('saves to LocalState when typing', async () => {
       const saveSpy = jest.fn(() => Promise.resolve());
       render({
         _createLocalState: () => createFakeLocalState({ save: saveSpy }),
       });
 
       const text = 'Example text';
-      userEvent.type(getTextBox(), text);
+      await userEvent.type(getTextBox(), text);
 
       expect(saveSpy).toHaveBeenCalledWith({ text });
     });
 
-    it('clears LocalState onDismiss', () => {
+    it('clears LocalState onDismiss', async () => {
       const clearSpy = jest.fn(() => Promise.resolve());
       render({
         _createLocalState: () => createFakeLocalState({ clear: clearSpy }),
         onDismiss: jest.fn(),
       });
 
-      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(clearSpy).toHaveBeenCalled();
     });
 
-    it('clears LocalState onDelete', () => {
+    it('clears LocalState onDelete', async () => {
       const clearSpy = jest.fn(() => Promise.resolve());
       render({
         _createLocalState: () => createFakeLocalState({ clear: clearSpy }),
         onDelete: jest.fn(),
       });
 
-      userEvent.type(getTextBox(), 'something');
-      userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await userEvent.type(getTextBox(), 'something');
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
       expect(clearSpy).toHaveBeenCalled();
     });
 
-    it('clears LocalState onSubmit', () => {
+    it('clears LocalState onSubmit', async () => {
       const clearSpy = jest.fn(() => Promise.resolve());
       render({
         _createLocalState: () => createFakeLocalState({ clear: clearSpy }),
         onSubmit: jest.fn(),
       });
 
-      userEvent.type(getTextBox(), 'something');
-      userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      await userEvent.type(getTextBox(), 'something');
+      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
       expect(clearSpy).toHaveBeenCalled();
     });

--- a/tests/unit/amo/components/TestDropdownMenu.js
+++ b/tests/unit/amo/components/TestDropdownMenu.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import DropdownMenu from 'amo/components/DropdownMenu';
 import DropdownMenuItem from 'amo/components/DropdownMenuItem';
@@ -12,13 +11,18 @@ describe(__filename, () => {
   let _window = {
     matchMedia: jest.fn().mockReturnValue({ matches: false }),
   };
+  let userEvent;
+
+  beforeEach(() => {
+    userEvent = defaultUserEvent.setup();
+  });
 
   const getMenu = () => screen.getByClassName('DropdownMenu');
   const getMenuButton = (name = defaultMenuText) =>
     screen.getByRole('button', { name });
   const getItem = () => screen.getByRole('listitem');
 
-  const clickMenu = (name = defaultMenuText) =>
+  const clickMenu = async (name = defaultMenuText) =>
     userEvent.click(getMenuButton(name));
 
   const render = ({ children, text = defaultMenuText, ...props } = {}) => {
@@ -29,14 +33,14 @@ describe(__filename, () => {
     );
   };
 
-  it('renders a menu', () => {
+  it('renders a menu', async () => {
     render();
 
     expect(screen.getByClassName('DropdownMenu')).toBeInTheDocument();
     expect(getMenu()).toHaveTextContent(defaultMenuText);
     expect(screen.getByClassName('Icon-inverted-caret')).toBeInTheDocument();
 
-    clickMenu();
+    await clickMenu();
 
     expect(screen.queryByRole('list')).not.toBeInTheDocument();
     expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
@@ -45,9 +49,9 @@ describe(__filename, () => {
   it('renders items passed as children', async () => {
     render({ children: <DropdownMenuItem>A section</DropdownMenuItem> });
 
-    clickMenu();
+    await clickMenu();
 
-    expect(await screen.findByRole('list')).toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
     expect(screen.getAllByRole('listitem')).toHaveLength(1);
   });
 
@@ -56,14 +60,12 @@ describe(__filename, () => {
     expect(getMenu()).not.toHaveClass('DropdownMenu--active');
 
     // User clicks the menu main button.
-    clickMenu();
-    await waitFor(() => expect(getMenu()).toHaveClass('DropdownMenu--active'));
+    await clickMenu();
+    expect(getMenu()).toHaveClass('DropdownMenu--active');
 
     // User clicks the menu main button, again.
-    clickMenu();
-    await waitFor(() =>
-      expect(getMenu()).not.toHaveClass('DropdownMenu--active'),
-    );
+    await clickMenu();
+    expect(getMenu()).not.toHaveClass('DropdownMenu--active');
   });
 
   it('resets the menu state on blur', async () => {
@@ -76,14 +78,12 @@ describe(__filename, () => {
     );
 
     // User clicks the menu main button.
-    clickMenu();
-    await waitFor(() => expect(getMenu()).toHaveClass('DropdownMenu--active'));
+    await clickMenu();
+    expect(getMenu()).toHaveClass('DropdownMenu--active');
 
     // User clicks somewhere else.
-    userEvent.click(screen.getByRole('heading'));
-    await waitFor(() =>
-      expect(getMenu()).not.toHaveClass('DropdownMenu--active'),
-    );
+    await userEvent.click(screen.getByRole('heading'));
+    expect(getMenu()).not.toHaveClass('DropdownMenu--active');
   });
 
   it('resets the menu state on click', async () => {
@@ -99,14 +99,12 @@ describe(__filename, () => {
     });
 
     // User clicks the menu main button to open it.
-    clickMenu();
-    await waitFor(() => expect(getMenu()).toHaveClass('DropdownMenu--active'));
+    await clickMenu();
+    expect(getMenu()).toHaveClass('DropdownMenu--active');
 
     // User clicks a link.
-    userEvent.click(screen.getByRole('link'));
-    await waitFor(() =>
-      expect(getMenu()).not.toHaveClass('DropdownMenu--active'),
-    );
+    await userEvent.click(screen.getByRole('link'));
+    expect(getMenu()).not.toHaveClass('DropdownMenu--active');
   });
 
   it('sets active on mouseEnter/clears on mouseLeave', async () => {
@@ -114,45 +112,43 @@ describe(__filename, () => {
     render();
 
     // User hovers on the menu.
-    userEvent.hover(getMenu());
-    await waitFor(() => expect(getMenu()).toHaveClass('DropdownMenu--active'));
+    await userEvent.hover(getMenu());
+    expect(getMenu()).toHaveClass('DropdownMenu--active');
     expect(_window.matchMedia).toHaveBeenCalledWith('(hover)');
 
     _window.matchMedia.mockClear();
 
     // User's mouse leaves the menu.
-    userEvent.unhover(getMenu());
-    await waitFor(() =>
-      expect(getMenu()).not.toHaveClass('DropdownMenu--active'),
-    );
+    await userEvent.unhover(getMenu());
+    expect(getMenu()).not.toHaveClass('DropdownMenu--active');
     expect(_window.matchMedia).toHaveBeenCalledWith('(hover)');
   });
 
-  it('does not touch active on mouseleave/enter if device doesnt support hover', () => {
+  it('does not touch active on mouseleave/enter if device doesnt support hover', async () => {
     _window.matchMedia = jest.fn().mockReturnValue({ matches: false });
     render();
 
     // User hovers on the menu.
-    userEvent.hover(getMenu());
+    await userEvent.hover(getMenu());
     expect(getMenu()).not.toHaveClass('DropdownMenu--active');
     expect(_window.matchMedia).toHaveBeenCalledWith('(hover)');
 
     // User's mouse leaves the menu (no changes).
-    userEvent.unhover(getMenu());
+    await userEvent.unhover(getMenu());
     expect(getMenu()).not.toHaveClass('DropdownMenu--active');
     expect(_window.matchMedia).toHaveBeenCalledWith('(hover)');
   });
 
-  it('does not touch active on mouseleave/enter if window is null', () => {
+  it('does not touch active on mouseleave/enter if window is null', async () => {
     _window = null;
     render();
 
     // User hovers on the menu.
-    userEvent.hover(getMenu());
+    await userEvent.hover(getMenu());
     expect(getMenu()).not.toHaveClass('DropdownMenu--active');
 
     // User's mouse leaves the menu (no changes).
-    userEvent.unhover(getMenu());
+    await userEvent.unhover(getMenu());
     expect(getMenu()).not.toHaveClass('DropdownMenu--active');
   });
 
@@ -166,8 +162,8 @@ describe(__filename, () => {
   describe('Tests for DropdownMenuItem', () => {
     const renderWithItems = async (children) => {
       render({ children });
-      clickMenu();
-      expect(await screen.findByRole('listitem')).toBeInTheDocument();
+      await clickMenu();
+      expect(screen.getByRole('listitem')).toBeInTheDocument();
     };
 
     it('renders a section when only `children` prop is supplied', async () => {
@@ -222,7 +218,7 @@ describe(__filename, () => {
       expect(item).toHaveClass('DropdownMenuItem');
       expect(item).toHaveClass('DropdownMenuItem-link');
 
-      userEvent.click(screen.getByRole('button', { name: buttonText }));
+      await userEvent.click(screen.getByRole('button', { name: buttonText }));
       expect(onClick).toHaveBeenCalled();
     });
 

--- a/tests/unit/amo/components/TestErrorList.js
+++ b/tests/unit/amo/components/TestErrorList.js
@@ -57,7 +57,7 @@ describe(__filename, () => {
 
   it.each(API_ERRORS_SESSION_EXPIRY)(
     'renders a reload button for session expiry error: %s',
-    (code) => {
+    async (code) => {
       const _window = { location: { reload: jest.fn() } };
       render({
         _window,
@@ -68,9 +68,9 @@ describe(__filename, () => {
       // Make sure the Signature error message is replaced with a new message.
       expect(screen.getByText('Your session has expired')).toBeInTheDocument();
 
-      userEvent.click(
-        screen.getByRole('button', { name: 'Reload To Continue' }),
-      );
+      await userEvent
+        .setup()
+        .click(screen.getByRole('button', { name: 'Reload To Continue' }));
 
       // The button should reload the location.
       expect(_window.location.reload).toHaveBeenCalled();

--- a/tests/unit/amo/components/TestExpandableCard.js
+++ b/tests/unit/amo/components/TestExpandableCard.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import ExpandableCard, { extractId } from 'amo/components/ExpandableCard';
 import {
@@ -35,18 +34,15 @@ describe(__filename, () => {
 
   it('toggles when clicked', async () => {
     render();
+    const userEvent = defaultUserEvent.setup();
 
     // This toggles to make expanded true.
-    userEvent.click(screen.getByRole('switch'));
-    await waitFor(() =>
-      expect(getCard()).toHaveClass('ExpandableCard--expanded'),
-    );
+    await userEvent.click(screen.getByRole('switch'));
+    expect(getCard()).toHaveClass('ExpandableCard--expanded');
 
     // This toggles to make expanded false.
-    userEvent.click(screen.getByRole('switch'));
-    await waitFor(() =>
-      expect(getCard()).not.toHaveClass('ExpandableCard--expanded'),
-    );
+    await userEvent.click(screen.getByRole('switch'));
+    expect(getCard()).not.toHaveClass('ExpandableCard--expanded');
   });
 
   it('renders with a className', () => {

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 import { encode } from 'universal-base64url';
 
 import {
@@ -83,6 +83,7 @@ const INVALID_TYPE = 'not-a-real-type';
 describe(__filename, () => {
   let addon;
   let store;
+  let userEvent;
   let _addonManager;
   let _getClientCompatibility;
 
@@ -90,6 +91,7 @@ describe(__filename, () => {
     _getClientCompatibility = jest.fn().mockReturnValue({ compatible: true });
     addon = { ...fakeAddon };
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   afterEach(() => {
@@ -670,10 +672,10 @@ describe(__filename, () => {
         ).toBeInTheDocument();
       });
 
-      it('sends a tracking event when the button is clicked', () => {
+      it('sends a tracking event when the button is clicked', async () => {
         render();
 
-        userEvent.click(getFirefoxButton());
+        await userEvent.click(getFirefoxButton());
 
         expect(tracking.sendEvent).toHaveBeenCalledTimes(1);
         expect(tracking.sendEvent).toHaveBeenCalledWith({
@@ -1155,11 +1157,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Enable' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Enable' }));
 
-        await waitFor(() => {
-          expect(_addonManager.enable).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.enable).toHaveBeenCalledWith(addon.guid);
 
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
           action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
@@ -1189,11 +1189,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Enable' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Enable' }));
 
-        await waitFor(() => {
-          expect(_addonManager.enable).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.enable).toHaveBeenCalledWith(addon.guid);
 
         expect(dispatch).toHaveBeenCalledWith(
           setInstallState({
@@ -1227,11 +1225,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Enable' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Enable' }));
 
-        await waitFor(() => {
-          expect(_addonManager.enable).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.enable).toHaveBeenCalledWith(addon.guid);
 
         expect(dispatch).not.toHaveBeenCalledWith(
           setInstallState({
@@ -1257,15 +1253,13 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
-        await waitFor(() => {
-          expect(_addonManager.install).toHaveBeenCalledWith(
-            addon.current_version.file.url,
-            expect.any(Function),
-            { hash: addon.current_version.file.hash },
-          );
-        });
+        expect(_addonManager.install).toHaveBeenCalledWith(
+          addon.current_version.file.url,
+          expect.any(Function),
+          { hash: addon.current_version.file.hash },
+        );
       });
 
       it('uses a version instead of the currentVersion when one exists in props', async () => {
@@ -1292,15 +1286,13 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
-        await waitFor(() => {
-          expect(_addonManager.install).toHaveBeenCalledWith(
-            versionInstallURL,
-            expect.any(Function),
-            { hash: versionHash },
-          );
-        });
+        expect(_addonManager.install).toHaveBeenCalledWith(
+          versionInstallURL,
+          expect.any(Function),
+          { hash: versionHash },
+        );
       });
 
       it('tracks the start of an addon install', async () => {
@@ -1320,11 +1312,9 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
-        await waitFor(() => {
-          expect(_addonManager.install).toHaveBeenCalled();
-        });
+        expect(_addonManager.install).toHaveBeenCalled();
 
         expect(fakeTracking.sendEvent).toHaveBeenCalledTimes(1);
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
@@ -1351,15 +1341,11 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
-        await waitFor(() => {
-          expect(_addonManager.install).toHaveBeenCalled();
-        });
+        expect(_addonManager.install).toHaveBeenCalled();
 
-        await waitFor(() =>
-          expect(fakeTracking.sendEvent).toHaveBeenCalledTimes(2),
-        );
+        expect(fakeTracking.sendEvent).toHaveBeenCalledTimes(2);
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
           action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
           category: getAddonEventCategory(
@@ -1393,11 +1379,9 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
-        await waitFor(() => {
-          expect(_addonManager.install).toHaveBeenCalled();
-        });
+        expect(_addonManager.install).toHaveBeenCalled();
 
         expect(fakeTracking.sendEvent).toHaveBeenCalledTimes(1);
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
@@ -1425,15 +1409,11 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
-        await waitFor(() => {
-          expect(_addonManager.install).toHaveBeenCalled();
-        });
+        expect(_addonManager.install).toHaveBeenCalled();
 
-        await waitFor(() =>
-          expect(fakeTracking.sendEvent).toHaveBeenCalledTimes(2),
-        );
+        expect(fakeTracking.sendEvent).toHaveBeenCalledTimes(2);
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
           action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
           category: getAddonEventCategory(
@@ -1465,7 +1445,7 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
         expect(dispatch).toHaveBeenCalledWith({
           type: START_DOWNLOAD,
@@ -1487,19 +1467,15 @@ describe(__filename, () => {
 
         await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
-        await waitFor(() => {
-          expect(_addonManager.install).toHaveBeenCalled();
-        });
+        expect(_addonManager.install).toHaveBeenCalled();
 
-        await waitFor(() =>
-          expect(dispatch).toHaveBeenCalledWith(
-            setInstallError({
-              error: FATAL_INSTALL_ERROR,
-              guid: addon.guid,
-            }),
-          ),
+        expect(dispatch).toHaveBeenCalledWith(
+          setInstallError({
+            error: FATAL_INSTALL_ERROR,
+            guid: addon.guid,
+          }),
         );
       });
     });
@@ -1516,11 +1492,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Remove' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Remove' }));
 
-        await waitFor(() => {
-          expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
 
         expect(dispatch).toHaveBeenCalledWith(
           setInstallState({ guid: addon.guid, status: UNINSTALLING }),
@@ -1544,11 +1518,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Remove' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Remove' }));
 
-        await waitFor(() => {
-          expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
 
         expect(dispatch).toHaveBeenCalledWith(
           setInstallState({ guid: addon.guid, status: UNINSTALLING }),
@@ -1574,11 +1546,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Remove' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Remove' }));
 
-        await waitFor(() => {
-          expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
 
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
           action: getAddonTypeForTracking(ADDON_TYPE_EXTENSION),
@@ -1604,11 +1574,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Remove' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Remove' }));
 
-        await waitFor(() => {
-          expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
 
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
           action: getAddonTypeForTracking(ADDON_TYPE_STATIC_THEME),
@@ -1634,11 +1602,9 @@ describe(__filename, () => {
           ).toBeInTheDocument();
         });
 
-        userEvent.click(screen.getByRole('link', { name: 'Remove' }));
+        await userEvent.click(screen.getByRole('link', { name: 'Remove' }));
 
-        await waitFor(() => {
-          expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
-        });
+        expect(_addonManager.uninstall).toHaveBeenCalledWith(addon.guid);
 
         expect(fakeTracking.sendEvent).toHaveBeenCalledWith({
           action: TRACKING_TYPE_INVALID,

--- a/tests/unit/amo/components/TestNotice.js
+++ b/tests/unit/amo/components/TestNotice.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/react';
 
 import Notice from 'amo/components/Notice';
@@ -15,9 +15,11 @@ describe(__filename, () => {
   const clientApp = CLIENT_APP_FIREFOX;
   const lang = 'en-US';
   let store;
+  let userEvent;
 
   beforeEach(() => {
     store = dispatchClientMetadata({ clientApp, lang }).store;
+    userEvent = defaultUserEvent.setup();
   });
 
   const render = ({ children, ...props } = {}) => {
@@ -69,13 +71,13 @@ describe(__filename, () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('renders an action button', () => {
+  it('renders an action button', async () => {
     const actionOnClick = jest.fn();
     const actionText = 'some text';
     render({ actionOnClick, actionText });
 
     const button = screen.getByRole('button', { name: actionText });
-    userEvent.click(button);
+    await userEvent.click(button);
 
     expect(actionOnClick).toHaveBeenCalled();
   });
@@ -108,11 +110,11 @@ describe(__filename, () => {
     );
   });
 
-  it('calls back when you dismiss a notice', () => {
+  it('calls back when you dismiss a notice', async () => {
     const onDismiss = jest.fn();
     render({ dismissible: true, onDismiss });
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole('button', { name: 'Dismiss this notice' }),
     );
 
@@ -128,21 +130,21 @@ describe(__filename, () => {
   });
 
   // eslint-disable-next-line jest/expect-expect
-  it('does not require a dismissal callback', () => {
+  it('does not require a dismissal callback', async () => {
     render({ dismissible: true, onDismiss: undefined });
 
     // Make sure this doesn't throw.
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole('button', { name: 'Dismiss this notice' }),
     );
   });
 
-  it('changes UI state when dismissing a notice', () => {
+  it('changes UI state when dismissing a notice', async () => {
     const dispatch = jest.spyOn(store, 'dispatch');
     const id = 'example-id';
     render({ id, dismissible: true });
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole('button', { name: 'Dismiss this notice' }),
     );
 

--- a/tests/unit/amo/components/TestOverlayCard.js
+++ b/tests/unit/amo/components/TestOverlayCard.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import { extractId } from 'amo/components/Overlay';
 import OverlayCard from 'amo/components/OverlayCard';
@@ -14,9 +14,11 @@ import {
 describe(__filename, () => {
   const id = 'OverlayCard';
   let store;
+  let userEvent;
 
   beforeEach(() => {
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   function render({ overlayChildren, ...props } = {}) {
@@ -112,11 +114,11 @@ describe(__filename, () => {
       expect(screen.getByText(text)).toBeInTheDocument();
     });
 
-    it('calls onEscapeOverlay when clicking the background', () => {
+    it('calls onEscapeOverlay when clicking the background', async () => {
       const onEscapeOverlay = jest.fn();
       render({ onEscapeOverlay });
 
-      userEvent.click(screen.getByRole('presentation'));
+      await userEvent.click(screen.getByRole('presentation'));
 
       expect(onEscapeOverlay).toHaveBeenCalled();
     });
@@ -126,12 +128,10 @@ describe(__filename, () => {
 
       expect(screen.getByClassName('Overlay')).toHaveClass('Overlay--visible');
 
-      userEvent.click(screen.getByRole('presentation'));
+      await userEvent.click(screen.getByRole('presentation'));
 
-      await waitFor(() =>
-        expect(screen.getByClassName('Overlay')).not.toHaveClass(
-          'Overlay--visible',
-        ),
+      expect(screen.getByClassName('Overlay')).not.toHaveClass(
+        'Overlay--visible',
       );
     });
 

--- a/tests/unit/amo/components/TestRating.js
+++ b/tests/unit/amo/components/TestRating.js
@@ -1,16 +1,17 @@
 import * as React from 'react';
-import userEvent from '@testing-library/user-event';
-import {
-  cleanup,
-  createEvent,
-  fireEvent,
-  waitFor,
-} from '@testing-library/react';
+import defaultUserEvent from '@testing-library/user-event';
+import { cleanup, createEvent, fireEvent } from '@testing-library/react';
 
 import Rating from 'amo/components/Rating';
 import { fakeI18n, render as defaultRender, screen } from 'tests/unit/helpers';
 
 describe(__filename, () => {
+  let userEvent;
+
+  beforeEach(() => {
+    userEvent = defaultUserEvent.setup();
+  });
+
   const render = (props = {}) => {
     return defaultRender(<Rating {...props} />);
   };
@@ -41,9 +42,9 @@ describe(__filename, () => {
     return screen.getByClassName(`Rating-rating-${rating}`);
   };
 
-  const selectRating = (ratingNumber) => {
+  const selectRating = async (ratingNumber) => {
     const star = getStarButton({ rating: ratingNumber });
-    userEvent.click(star);
+    await userEvent.click(star);
   };
 
   it('classifies as editable by default', () => {
@@ -76,17 +77,20 @@ describe(__filename, () => {
     );
   });
 
-  it.each([1, 2, 3, 4, 5])('lets you select a %s star rating', (rating) => {
-    const onSelectRating = jest.fn();
-    renderWithEmptyRating({ onSelectRating });
-    selectRating(rating);
-    expect(onSelectRating).toHaveBeenCalledWith(rating);
-  });
+  it.each([1, 2, 3, 4, 5])(
+    'lets you select a %s star rating',
+    async (rating) => {
+      const onSelectRating = jest.fn();
+      renderWithEmptyRating({ onSelectRating });
+      await selectRating(rating);
+      expect(onSelectRating).toHaveBeenCalledWith(rating);
+    },
+  );
 
-  it('does not let you select a star while loading', () => {
+  it('does not let you select a star while loading', async () => {
     const onSelectRating = jest.fn();
     render({ onSelectRating, rating: undefined });
-    selectRating(1);
+    await selectRating(1);
     expect(onSelectRating).not.toHaveBeenCalled();
   });
 
@@ -236,14 +240,12 @@ describe(__filename, () => {
     renderWithEmptyRating();
 
     const hoverStar = getStarButton({ rating: 4 });
-    userEvent.hover(hoverStar);
+    await userEvent.hover(hoverStar);
 
     // The first 4 should be selected:
     for (const star of [1, 2, 3, 4]) {
-      await waitFor(() =>
-        expect(getStarButton({ rating: star })).toHaveClass(
-          'Rating-selected-star',
-        ),
+      expect(getStarButton({ rating: star })).toHaveClass(
+        'Rating-selected-star',
       );
     }
 
@@ -258,53 +260,51 @@ describe(__filename, () => {
     render({ rating: currentRating });
 
     const hoverStar = getStarButton({ currentRating, rating: 1 });
-    userEvent.hover(hoverStar);
+    await userEvent.hover(hoverStar);
 
-    await waitFor(() =>
-      expect(
-        getStarButton({ currentRating, rating: currentRating }),
-      ).not.toHaveClass('Rating-selected-star'),
-    );
+    expect(
+      getStarButton({ currentRating, rating: currentRating }),
+    ).not.toHaveClass('Rating-selected-star');
   });
 
-  it('finishes hovering on mouseLeave', () => {
+  it('finishes hovering on mouseLeave', async () => {
     renderWithEmptyRating();
 
     const rating = 3;
     const hoverStar = getStarButton({ rating });
-    userEvent.hover(hoverStar);
-    userEvent.unhover(hoverStar);
+    await userEvent.hover(hoverStar);
+    await userEvent.unhover(hoverStar);
 
     expect(getStarButton({ rating })).not.toHaveClass('Rating-selected-star');
   });
 
   describe('readOnly=true', () => {
-    it('prevents you from selecting ratings', () => {
+    it('prevents you from selecting ratings', async () => {
       const onSelectRating = jest.fn();
       renderWithRating({ onSelectRating, readOnly: true });
       const star = getStar({ rating: 1 });
-      userEvent.click(star);
+      await userEvent.click(star);
       expect(onSelectRating).not.toHaveBeenCalled();
     });
 
-    it('does nothing when you hover over stars', () => {
+    it('does nothing when you hover over stars', async () => {
       const _setState = jest.fn();
       renderWithRating({ readOnly: true, _setState });
 
       const rating = 3;
       const hoverStar = getStar({ rating });
-      userEvent.hover(hoverStar);
+      await userEvent.hover(hoverStar);
       expect(_setState).not.toHaveBeenCalled();
     });
 
-    it('does nothing when finishing a hover action', () => {
+    it('does nothing when finishing a hover action', async () => {
       const _setState = jest.fn();
       renderWithRating({ readOnly: true, _setState });
 
       const rating = 3;
       const hoverStar = getStar({ rating });
-      userEvent.hover(hoverStar);
-      userEvent.unhover(hoverStar);
+      await userEvent.hover(hoverStar);
+      await userEvent.unhover(hoverStar);
       expect(_setState).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { createEvent, fireEvent, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { createEvent, fireEvent } from '@testing-library/react';
+import defaultUserEvent from '@testing-library/user-event';
 
 import {
   ADDON_TYPE_DICT,
@@ -59,6 +59,7 @@ jest.mock('amo/constants', () => ({
 
 describe(__filename, () => {
   let store;
+  let userEvent;
   const defaultAddonName = 'My Add-On';
   const defaultAddonId = 123;
   const defaultUserId = 456;
@@ -66,6 +67,7 @@ describe(__filename, () => {
 
   beforeEach(() => {
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   afterEach(() => {
@@ -320,28 +322,27 @@ describe(__filename, () => {
     it('allows a user to delete a review', async () => {
       renderWithReview();
 
-      userEvent.click(screen.getByRole('button', { name: 'Delete review' }));
-
-      // eslint-disable-next-line testing-library/prefer-find-by
-      await waitFor(() =>
-        expect(
-          screen.getByTextAcrossTags(
-            `Are you sure you want to delete your review of ${defaultAddonName}?`,
-          ),
-        ).toBeInTheDocument(),
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete review' }),
       );
+
+      expect(
+        screen.getByTextAcrossTags(
+          `Are you sure you want to delete your review of ${defaultAddonName}?`,
+        ),
+      ).toBeInTheDocument();
 
       // This verifies that AddonReviewManagerRating receives the expected
       // rating from RatingManager.
       expect(screen.getAllByTitle('Rated 3 out of 5')).toHaveLength(6);
 
-      userEvent.click(screen.getByRole('button', { name: 'Delete review' }));
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete review' }),
+      );
 
       // This verifies that AddonReviewManagerRating receives the expected
       // rating from RatingManager while a deletion is happening.
-      await waitFor(() =>
-        expect(screen.getAllByTitle('Rated 3 out of 5')).toHaveLength(6),
-      );
+      expect(screen.getAllByTitle('Rated 3 out of 5')).toHaveLength(6);
     });
 
     it('prompts to delete a rating when beginningToDeleteReview', async () => {
@@ -353,31 +354,29 @@ describe(__filename, () => {
         },
       });
 
-      userEvent.click(screen.getByRole('button', { name: 'Delete rating' }));
-
-      // eslint-disable-next-line testing-library/prefer-find-by
-      await waitFor(() =>
-        expect(
-          screen.getByTextAcrossTags(
-            `Are you sure you want to delete your rating of ${defaultAddonName}?`,
-          ),
-        ).toBeInTheDocument(),
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete rating' }),
       );
+
+      expect(
+        screen.getByTextAcrossTags(
+          `Are you sure you want to delete your rating of ${defaultAddonName}?`,
+        ),
+      ).toBeInTheDocument();
     });
 
     it('still prompts to delete a review while deletingReview', async () => {
       renderWithReview();
 
-      userEvent.click(screen.getByRole('button', { name: 'Delete review' }));
-
-      // eslint-disable-next-line testing-library/prefer-find-by
-      await waitFor(() =>
-        expect(
-          screen.getByTextAcrossTags(
-            `Are you sure you want to delete your review of ${defaultAddonName}?`,
-          ),
-        ).toBeInTheDocument(),
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete review' }),
       );
+
+      expect(
+        screen.getByTextAcrossTags(
+          `Are you sure you want to delete your review of ${defaultAddonName}?`,
+        ),
+      ).toBeInTheDocument();
     });
 
     it('shows AddonReviewCard with a saved review', () => {
@@ -395,40 +394,28 @@ describe(__filename, () => {
         screen.getByClassName('RatingManager-UserRating'),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByRole('link', { name: 'Edit review' }));
+      await userEvent.click(screen.getByRole('link', { name: 'Edit review' }));
 
-      await waitFor(() =>
-        expect(
-          screen.queryByClassName('RatingManager-legend'),
-        ).not.toBeInTheDocument(),
-      );
-      await waitFor(() =>
-        expect(
-          screen.queryByClassName('RatingManager-UserRating'),
-        ).not.toBeInTheDocument(),
-      );
+      expect(
+        screen.queryByClassName('RatingManager-legend'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByClassName('RatingManager-UserRating'),
+      ).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-      // eslint-disable-next-line testing-library/prefer-find-by
-      await waitFor(() =>
-        expect(
-          screen.getByClassName('RatingManager-legend'),
-        ).toBeInTheDocument(),
-      );
-      // eslint-disable-next-line testing-library/prefer-find-by
-      await waitFor(() =>
-        expect(
-          screen.getByClassName('RatingManager-UserRating'),
-        ).toBeInTheDocument(),
-      );
+      expect(screen.getByClassName('RatingManager-legend')).toBeInTheDocument();
+      expect(
+        screen.getByClassName('RatingManager-UserRating'),
+      ).toBeInTheDocument();
     });
 
-    it('submits a new rating', () => {
+    it('submits a new rating', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const { addon } = renderWithReview({ review: null });
 
-      userEvent.click(screen.getByTitle('Rate this add-on 1 out of 5'));
+      await userEvent.click(screen.getByTitle('Rate this add-on 1 out of 5'));
 
       expect(dispatch).toHaveBeenCalledWith(
         createAddonReview({
@@ -440,11 +427,11 @@ describe(__filename, () => {
       );
     });
 
-    it('updates an existing rating', () => {
+    it('updates an existing rating', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const { review } = renderWithReview();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', {
           name: 'Update your rating to 1 out of 5',
         }),
@@ -529,22 +516,20 @@ describe(__filename, () => {
 
       expect(preventDefaultWatcher).toHaveBeenCalled();
 
-      userEvent.type(
+      await userEvent.type(
         screen.getByPlaceholderText(
           'Explain how this add-on is violating our policies.',
         ),
         message,
       );
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Send abuse report' }),
       );
 
-      await waitFor(() =>
-        expect(
-          screen.getByRole('button', { name: 'Sending abuse report' }),
-        ).toHaveClass('Button--disabled'),
-      );
+      expect(
+        screen.getByRole('button', { name: 'Sending abuse report' }),
+      ).toHaveClass('Button--disabled');
 
       expect(dispatch).toHaveBeenCalledWith(
         sendAddonAbuseReport({
@@ -554,35 +539,29 @@ describe(__filename, () => {
         }),
       );
 
-      userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
 
       // Dismiss should have been ignored.
-      await waitFor(() =>
-        expect(screen.getByClassName('ReportAbuseButton')).toHaveClass(
-          'ReportAbuseButton--is-expanded',
-        ),
+      expect(screen.getByClassName('ReportAbuseButton')).toHaveClass(
+        'ReportAbuseButton--is-expanded',
       );
     });
 
     it('hides the form when Dismiss is clicked', async () => {
       render();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Report this add-on for abuse' }),
       );
 
-      await waitFor(() =>
-        expect(screen.getByClassName('ReportAbuseButton')).toHaveClass(
-          'ReportAbuseButton--is-expanded',
-        ),
+      expect(screen.getByClassName('ReportAbuseButton')).toHaveClass(
+        'ReportAbuseButton--is-expanded',
       );
 
-      userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
 
-      await waitFor(() =>
-        expect(screen.getByClassName('ReportAbuseButton')).not.toHaveClass(
-          'ReportAbuseButton--is-expanded',
-        ),
+      expect(screen.getByClassName('ReportAbuseButton')).not.toHaveClass(
+        'ReportAbuseButton--is-expanded',
       );
     });
 
@@ -630,16 +609,14 @@ describe(__filename, () => {
         const dispatch = jest.spyOn(store, 'dispatch');
         render({ addon });
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByRole('button', {
             name: 'Report this add-on for abuse',
           }),
         );
 
-        await waitFor(() =>
-          expect(screen.getByClassName('ReportAbuseButton')).toHaveClass(
-            'ReportAbuseButton--is-expanded',
-          ),
+        expect(screen.getByClassName('ReportAbuseButton')).toHaveClass(
+          'ReportAbuseButton--is-expanded',
         );
 
         expect(dispatch).not.toHaveBeenCalledWith(
@@ -705,15 +682,15 @@ describe(__filename, () => {
       ).not.toHaveClass('Button--disabled');
     });
 
-    it('does not allow dispatch if there is no content in the textarea', () => {
+    it('does not allow dispatch if there is no content in the textarea', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       render();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Report this add-on for abuse' }),
       );
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Send abuse report' }),
       );
 
@@ -725,22 +702,22 @@ describe(__filename, () => {
       );
     });
 
-    it('does not allow dispatch if textarea is whitespace', () => {
+    it('does not allow dispatch if textarea is whitespace', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       render();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Report this add-on for abuse' }),
       );
 
-      userEvent.type(
+      await userEvent.type(
         screen.getByPlaceholderText(
           'Explain how this add-on is violating our policies.',
         ),
         '     ',
       );
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Send abuse report' }),
       );
 
@@ -772,24 +749,24 @@ describe(__filename, () => {
       // The AddonReviewManagerRating is only rendered when the "Delete review"
       // dialog is open, and it is assigned a custom className by
       // RatingManager.
-      userEvent.click(screen.getByRole('button', { name: 'Delete review' }));
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete review' }),
+      );
 
-      await waitFor(() =>
-        expect(screen.getByClassName('AddonReviewManagerRating')).toHaveClass(
-          'RatingManager-AddonReviewManagerRating',
-        ),
+      expect(screen.getByClassName('AddonReviewManagerRating')).toHaveClass(
+        'RatingManager-AddonReviewManagerRating',
       );
     });
 
     it('sets readOnly correctly when onSelectRating is undefined', async () => {
       renderWithReview();
 
-      userEvent.click(screen.getByRole('button', { name: 'Delete review' }));
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Delete review' }),
+      );
 
       // When Rating is in readOnly mode, the title for all stars is as below.
-      await waitFor(() =>
-        expect(screen.getAllByTitle('Rated 3 out of 5')).toHaveLength(6),
-      );
+      expect(screen.getAllByTitle('Rated 3 out of 5')).toHaveLength(6);
     });
   });
 });

--- a/tests/unit/amo/components/TestScreenShots.js
+++ b/tests/unit/amo/components/TestScreenShots.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import ScreenShots from 'amo/components/ScreenShots';
 import { render as defaultRender, screen } from 'tests/unit/helpers';
@@ -8,6 +8,7 @@ const HEIGHT = 400;
 const WIDTH = 200;
 
 describe(__filename, () => {
+  let userEvent;
   const testPreviews = [
     {
       title: 'A screenshot',
@@ -29,10 +30,14 @@ describe(__filename, () => {
     },
   ];
 
+  beforeEach(() => {
+    userEvent = defaultUserEvent.setup();
+  });
+
   const render = (previews = testPreviews) =>
     defaultRender(<ScreenShots previews={previews} />);
 
-  it('renders the previews', () => {
+  it('renders the previews', async () => {
     render();
 
     const imgs = Array.from(screen.getAllByTagName('img'));
@@ -51,7 +56,7 @@ describe(__filename, () => {
       expect(preview).toHaveAttribute('alt', testPreviews[index].title);
     });
 
-    userEvent.click(screen.getByAltText(testPreviews[0].title));
+    await userEvent.click(screen.getByAltText(testPreviews[0].title));
 
     // Verifying the output of PHOTO_SWIPE_OPTIONS.
     // closeEl: true,
@@ -96,19 +101,25 @@ describe(__filename, () => {
   Commenting this out for now.
   See https://github.com/mozilla/addons-frontend/issues/11482.
 
-  it('scrolls to the active item on close', () => {
+  it('scrolls to the active item on close', async () => {
     const { unmount } = render();
-
+    
     // eslint-disable-next-line testing-library/no-node-access
     const list = document.querySelector('.ScreenShots-list');
     const scrollLeft = jest.spyOn(list, 'scrollLeft', 'set');
-
-    userEvent.click(screen.getByAltText(testPreviews[0].title));
-    userEvent.keyboard('[Escape]');
-    userEvent.keyboard('{esc}');
+    
+    // This clicks the Escape key.
+    fireEvent.keyDown(screen.getByAltText(testPreviews[0].title), {
+      key: 'Escape',
+      keyCode: 27,
+      which: 27,
+    });
+    await userEvent.click(screen.getByAltText(testPreviews[0].title));
+    await userEvent.keyboard('[Escape]');
+    await userEvent.keyboard('{esc}');
     unmount();
-
-    expect(scrollLeft).toHaveBeenCalled();
+    
+    await waitFor(() => expect(scrollLeft).toHaveBeenCalled());
   });
   */
 });

--- a/tests/unit/amo/components/TestShowMoreCard.js
+++ b/tests/unit/amo/components/TestShowMoreCard.js
@@ -54,13 +54,13 @@ describe(__filename, () => {
     mockClientHeight(DEFAULT_MAX_HEIGHT + 1);
     render();
 
-    userEvent.click(screen.getByRole('link', { name: 'Expand to read more' }));
+    await userEvent
+      .setup()
+      .click(screen.getByRole('link', { name: 'Expand to read more' }));
 
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('link', { name: 'Expand to read more' }),
-      ).not.toBeInTheDocument(),
-    );
+    expect(
+      screen.queryByRole('link', { name: 'Expand to read more' }),
+    ).not.toBeInTheDocument();
     expect(screen.getByClassName('ShowMoreCard')).toHaveClass(
       'ShowMoreCard--expanded',
     );

--- a/tests/unit/amo/components/TestVPNPromoBanner.js
+++ b/tests/unit/amo/components/TestVPNPromoBanner.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Route } from 'react-router-dom';
-import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import VPNPromoBanner, {
   IMPRESSION_COUNT_KEY,
@@ -46,11 +45,13 @@ import {
 describe(__filename, () => {
   let history;
   let store;
+  let userEvent;
   const addonId = 123;
   const slug = 'some-slug';
 
   beforeEach(() => {
     store = dispatchClientMetadata().store;
+    userEvent = defaultUserEvent.setup();
   });
 
   const createCookies = () => {
@@ -169,26 +170,23 @@ describe(__filename, () => {
     ).toHaveAttribute('href', href);
   });
 
-  const clickCta = () => {
+  const clickCta = async () =>
     userEvent.click(screen.getByRole('link', { name: 'Get Mozilla VPN' }));
-  };
 
-  const clickDismiss = () => {
-    userEvent.click(screen.getByRole('button'));
-  };
+  const clickDismiss = async () => userEvent.click(screen.getByRole('button'));
 
-  it('clears the impression count when the cta is clicked', () => {
+  it('clears the impression count when the cta is clicked', async () => {
     const _localStorage = createFakeLocalStorage();
     render({ _localStorage });
-    clickCta();
+    await clickCta();
 
     expect(_localStorage.removeItem).toHaveBeenCalledWith(IMPRESSION_COUNT_KEY);
   });
 
-  it('reads and updates the experiment cookie when the cta is clicked', () => {
+  it('reads and updates the experiment cookie when the cta is clicked', async () => {
     const cookies = createCookies();
     render({ cookies });
-    clickCta();
+    await clickCta();
 
     expect(cookies.get).toHaveBeenCalledWith(EXPERIMENT_COOKIE_NAME);
     expect(cookies.set).toHaveBeenCalledWith(
@@ -208,27 +206,25 @@ describe(__filename, () => {
       screen.getByRole('link', { name: 'Get Mozilla VPN' }),
     ).toBeInTheDocument();
 
-    clickCta();
+    await clickCta();
 
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('link', { name: 'Get Mozilla VPN' }),
-      ).not.toBeInTheDocument(),
-    );
+    expect(
+      screen.queryByRole('link', { name: 'Get Mozilla VPN' }),
+    ).not.toBeInTheDocument();
   });
 
-  it('clears the impression count when the dismiss button is clicked', () => {
+  it('clears the impression count when the dismiss button is clicked', async () => {
     const _localStorage = createFakeLocalStorage();
     render({ _localStorage });
-    clickDismiss();
+    await clickDismiss();
 
     expect(_localStorage.removeItem).toHaveBeenCalledWith(IMPRESSION_COUNT_KEY);
   });
 
-  it('reads and updates the experiment cookie when the dismiss button is clicked', () => {
+  it('reads and updates the experiment cookie when the dismiss button is clicked', async () => {
     const cookies = createCookies();
     render({ cookies });
-    clickDismiss();
+    await clickDismiss();
 
     expect(cookies.get).toHaveBeenCalledWith(EXPERIMENT_COOKIE_NAME);
     expect(cookies.set).toHaveBeenCalledWith(
@@ -248,13 +244,11 @@ describe(__filename, () => {
       screen.getByRole('link', { name: 'Get Mozilla VPN' }),
     ).toBeInTheDocument();
 
-    clickDismiss();
+    await clickDismiss();
 
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('link', { name: 'Get Mozilla VPN' }),
-      ).not.toBeInTheDocument(),
-    );
+    expect(
+      screen.queryByRole('link', { name: 'Get Mozilla VPN' }),
+    ).not.toBeInTheDocument();
   });
 
   it('throws an exception if something other than a number is stored', () => {
@@ -268,14 +262,14 @@ describe(__filename, () => {
   });
 
   describe('tracking', () => {
-    it('sends a tracking event when the cta is clicked', () => {
+    it('sends a tracking event when the cta is clicked', async () => {
       const impressionCount = '5';
       const _localStorage = createFakeLocalStorage({
         getItem: jest.fn().mockReturnValue(impressionCount),
       });
       const _tracking = createFakeTracking();
       render({ _tracking, _localStorage });
-      clickCta();
+      await clickCta();
 
       expect(_tracking.sendEvent).toHaveBeenCalledWith({
         action: VPN_PROMO_CLICK_ACTION,
@@ -286,14 +280,14 @@ describe(__filename, () => {
       expect(_tracking.sendEvent).toHaveBeenCalledTimes(2);
     });
 
-    it('sends a tracking event when the dismiss button is clicked', () => {
+    it('sends a tracking event when the dismiss button is clicked', async () => {
       const impressionCount = '5';
       const _localStorage = createFakeLocalStorage({
         getItem: jest.fn().mockReturnValue(impressionCount),
       });
       const _tracking = createFakeTracking();
       render({ _tracking, _localStorage });
-      clickDismiss();
+      await clickDismiss();
 
       expect(_tracking.sendEvent).toHaveBeenCalledWith({
         action: VPN_PROMO_DISMISS_ACTION,

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -2,7 +2,7 @@ import { LOCATION_CHANGE } from 'connected-react-router';
 import config from 'config';
 import serialize from 'serialize-javascript';
 import { cleanup, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import { createAddonReview, setLatestReview } from 'amo/actions/reviews';
 import { setViewContext } from 'amo/actions/viewContext';
@@ -144,6 +144,7 @@ describe(__filename, () => {
   let store;
   let addon;
   let history;
+  let userEvent;
 
   const getLocation = ({ page, slug = defaultSlug } = {}) => {
     return `/${lang}/${clientApp}/addon/${slug}/${
@@ -177,6 +178,7 @@ describe(__filename, () => {
     });
 
     store = dispatchClientMetadata({ clientApp, lang, regionCode: 'US' }).store;
+    userEvent = defaultUserEvent.setup();
   });
 
   afterEach(() => {
@@ -713,14 +715,14 @@ describe(__filename, () => {
     expect(card).not.toHaveClass('ShowMoreCard--expanded');
 
     // Click the link to expand the ShowMoreCard.
-    userEvent.click(
+    await userEvent.click(
       within(card).getByRole('link', {
         name: 'Expand to read more',
       }),
     );
 
     // It should be expanded now.
-    await waitFor(() => expect(card).toHaveClass('ShowMoreCard--expanded'));
+    expect(card).toHaveClass('ShowMoreCard--expanded');
 
     // Update with the same version id, which should change nothing.
     _loadAddon();
@@ -891,7 +893,7 @@ describe(__filename, () => {
     ).toBeInTheDocument();
   });
 
-  it('configures the RatingManager', () => {
+  it('configures the RatingManager', async () => {
     dispatchSignInActionsWithStore({ store, userId: authorUserId });
     store.dispatch(
       setLatestReview({
@@ -903,7 +905,7 @@ describe(__filename, () => {
     const dispatch = jest.spyOn(store, 'dispatch');
     renderWithAddon();
 
-    userEvent.click(screen.getByTitle('Rate this add-on 1 out of 5'));
+    await userEvent.click(screen.getByTitle('Rate this add-on 1 out of 5'));
 
     expect(dispatch).toHaveBeenCalledWith(
       createAddonReview({
@@ -1764,11 +1766,9 @@ describe(__filename, () => {
       renderWithAddon();
       tracking.sendEvent.mockClear();
 
-      userEvent.click(screen.getByTitle(url));
+      await userEvent.click(screen.getByTitle(url));
 
-      await waitFor(() => {
-        expect(tracking.sendEvent).toHaveBeenCalledTimes(1);
-      });
+      expect(tracking.sendEvent).toHaveBeenCalledTimes(1);
       expect(tracking.sendEvent).toHaveBeenCalledWith({
         action: CONTRIBUTE_BUTTON_CLICK_ACTION,
         category: CONTRIBUTE_BUTTON_CLICK_CATEGORY,

--- a/tests/unit/amo/pages/TestAddonInfo.js
+++ b/tests/unit/amo/pages/TestAddonInfo.js
@@ -405,10 +405,10 @@ describe(__filename, () => {
 
   it('does not render an HTML title when there is no add-on', async () => {
     render();
-    await waitFor(() => expect(getElement('title')).toBeInTheDocument());
-
-    expect(getElement('title')).toHaveTextContent(
-      `Add-ons for Firefox (${lang})`,
+    await waitFor(() =>
+      expect(getElement('title')).toHaveTextContent(
+        `Add-ons for Firefox (${lang})`,
+      ),
     );
   });
 
@@ -417,12 +417,10 @@ describe(__filename, () => {
     render();
 
     await waitFor(() =>
-      expect(getElement('meta[name="robots"]')).toBeInTheDocument(),
-    );
-
-    expect(getElement('meta[name="robots"]')).toHaveAttribute(
-      'content',
-      'noindex, follow',
+      expect(getElement('meta[name="robots"]')).toHaveAttribute(
+        'content',
+        'noindex, follow',
+      ),
     );
   });
 

--- a/tests/unit/amo/pages/TestAddonReviewList.js
+++ b/tests/unit/amo/pages/TestAddonReviewList.js
@@ -1,5 +1,5 @@
 import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import {
   fetchReview,
@@ -42,6 +42,7 @@ describe(__filename, () => {
   let store;
   let addon;
   let history;
+  let userEvent;
 
   const getLocation = ({ page, reviewId, score, slug = defaultSlug } = {}) => {
     let queryString = '?';
@@ -64,6 +65,7 @@ describe(__filename, () => {
   beforeEach(() => {
     store = dispatchClientMetadata({ clientApp, lang }).store;
     addon = { ...fakeAddon, slug: defaultSlug };
+    userEvent = defaultUserEvent.setup();
   });
 
   const render = ({
@@ -884,11 +886,11 @@ describe(__filename, () => {
       expect(getSelector()).toHaveProperty('disabled', false);
     });
 
-    it('lets you select all reviews', () => {
+    it('lets you select all reviews', async () => {
       renderWithAddonAndReviews();
 
       const pushSpy = jest.spyOn(history, 'push');
-      userEvent.selectOptions(getSelector(), SHOW_ALL_REVIEWS);
+      await userEvent.selectOptions(getSelector(), SHOW_ALL_REVIEWS);
 
       expect(pushSpy).toHaveBeenCalledWith(
         `/en-US/firefox/addon/${defaultSlug}/reviews/`,
@@ -901,11 +903,11 @@ describe(__filename, () => {
       [3, 'Show only three-star reviews'],
       [2, 'Show only two-star reviews'],
       [1, 'Show only one-star reviews'],
-    ])('lets you select only %s star reviews', (score, option) => {
+    ])('lets you select only %s star reviews', async (score, option) => {
       renderWithAddonAndReviews();
 
       const pushSpy = jest.spyOn(history, 'push');
-      userEvent.selectOptions(getSelector(), option);
+      await userEvent.selectOptions(getSelector(), option);
 
       expect(pushSpy).toHaveBeenCalledWith(
         `/en-US/firefox/addon/${defaultSlug}/reviews/?score=${score}`,

--- a/tests/unit/amo/pages/TestAddonVersions.js
+++ b/tests/unit/amo/pages/TestAddonVersions.js
@@ -256,30 +256,32 @@ describe(__filename, () => {
   it('generates an empty header when no add-on is loaded', async () => {
     render();
 
-    await waitFor(() => expect(getElement('title')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(getElement('title')).toHaveTextContent(
+        'Add-ons for Firefox (en-US)',
+      ),
+    );
 
     expect(
       screen.getByClassName('AddonSummaryCard-header-text'),
     ).toHaveTextContent('');
-    expect(getElement('title')).toHaveTextContent(
-      'Add-ons for Firefox (en-US)',
-    );
   });
 
   it('generates an empty header when no versions have loaded', async () => {
     _loadAddon();
     render();
 
-    await waitFor(() => expect(getElement('title')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(getElement('title')).toHaveTextContent(
+        'Add-ons for Firefox (en-US)',
+      ),
+    );
 
     expect(
       within(
         screen.getByClassName('AddonSummaryCard-header-text'),
       ).getByClassName('visually-hidden'),
     ).toHaveTextContent('');
-    expect(getElement('title')).toHaveTextContent(
-      'Add-ons for Firefox (en-US)',
-    );
   });
 
   it('generates a header with add-on name and version count when versions have loaded', async () => {

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -149,10 +149,10 @@ describe(__filename, () => {
     store.dispatch(loadBlock({ block }));
     render();
 
-    await waitFor(() => expect(getElement('title')).toBeInTheDocument());
-
-    expect(getElement('title')).toHaveTextContent(
-      `${title} – Add-ons for Firefox (${lang})`,
+    await waitFor(() =>
+      expect(getElement('title')).toHaveTextContent(
+        `${title} – Add-ons for Firefox (${lang})`,
+      ),
     );
     expect(screen.getByText(title)).toBeInTheDocument();
   });
@@ -272,12 +272,10 @@ describe(__filename, () => {
     render();
 
     await waitFor(() =>
-      expect(getElement('meta[name="robots"]')).toBeInTheDocument(),
-    );
-
-    expect(getElement('meta[name="robots"]')).toHaveAttribute(
-      'content',
-      'noindex, follow',
+      expect(getElement('meta[name="robots"]')).toHaveAttribute(
+        'content',
+        'noindex, follow',
+      ),
     );
   });
 

--- a/tests/unit/amo/pages/TestCategoriesPage.js
+++ b/tests/unit/amo/pages/TestCategoriesPage.js
@@ -64,12 +64,10 @@ describe(__filename, () => {
     render();
 
     await waitFor(() =>
-      expect(getElement('link[rel="canonical"]')).toBeInTheDocument(),
-    );
-
-    expect(getElement('link[rel="canonical"]')).toHaveAttribute(
-      'href',
-      getCanonicalURL({ locationPathname: getLocation() }),
+      expect(getElement('link[rel="canonical"]')).toHaveAttribute(
+        'href',
+        getCanonicalURL({ locationPathname: getLocation() }),
+      ),
     );
   });
 
@@ -82,12 +80,10 @@ describe(__filename, () => {
       render({ addonType });
 
       await waitFor(() =>
-        expect(getElement('meta[property="og:title"]')).toBeInTheDocument(),
-      );
-
-      expect(getElement(`meta[property="og:title"]`)).toHaveAttribute(
-        'content',
-        `All ${expectedMatch} categories – Add-ons for Firefox (en-US)`,
+        expect(getElement(`meta[property="og:title"]`)).toHaveAttribute(
+          'content',
+          `All ${expectedMatch} categories – Add-ons for Firefox (en-US)`,
+        ),
       );
     },
   );

--- a/tests/unit/amo/pages/TestCategoryPage.js
+++ b/tests/unit/amo/pages/TestCategoryPage.js
@@ -1,5 +1,5 @@
 import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import {
   ADDON_TYPE_EXTENSION,
@@ -31,6 +31,7 @@ import {
 describe(__filename, () => {
   let history;
   let store;
+  let userEvent;
   const lang = 'en-US';
   const clientApp = CLIENT_APP_FIREFOX;
   const defaultAddonType = ADDON_TYPE_EXTENSION;
@@ -40,6 +41,7 @@ describe(__filename, () => {
 
   beforeEach(() => {
     store = dispatchClientMetadata({ clientApp, lang }).store;
+    userEvent = defaultUserEvent.setup();
   });
 
   function render({
@@ -197,13 +199,13 @@ describe(__filename, () => {
   );
 
   describe('Tests for Search', () => {
-    it('forces recommended add-ons to the top when a category is specified and a new sort filter is selected', () => {
+    it('forces recommended add-ons to the top when a category is specified and a new sort filter is selected', async () => {
       const sort = SEARCH_SORT_POPULAR;
 
       render({ location: `${defaultLocation}?sort=${sort}` });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Sort by' }),
         'Trending',
       );
@@ -216,7 +218,7 @@ describe(__filename, () => {
       });
     });
 
-    it('removes category and addonType from the URL if category is in filters', () => {
+    it('removes category and addonType from the URL if category is in filters', async () => {
       const sort = SEARCH_SORT_POPULAR;
 
       render({
@@ -224,7 +226,7 @@ describe(__filename, () => {
       });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Sort by' }),
         'Trending',
       );

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -1,6 +1,6 @@
 import { LOCATION_CHANGE } from 'connected-react-router';
 import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import {
@@ -84,6 +84,7 @@ describe(__filename, () => {
   const errorHandlerId = 'Home';
   let store;
   let history;
+  let userEvent;
 
   const getLocation = ({
     clientApp = defaultClientApp,
@@ -95,6 +96,7 @@ describe(__filename, () => {
       clientApp: defaultClientApp,
       lang: defaultLang,
     }).store;
+    userEvent = defaultUserEvent.setup();
   });
 
   afterEach(() => {
@@ -225,14 +227,14 @@ describe(__filename, () => {
       ).not.toBeInTheDocument();
     });
 
-    it('sends a tracking event when the cta is clicked', () => {
+    it('sends a tracking event when the cta is clicked', async () => {
       const strippedUrl = '/a/different/url';
       stripLangFromAmoUrl.mockReturnValue(strippedUrl);
       const cta = { text: 'cta text', url: '/some/url', outgoing: '/out/url' };
       renderWithHomeData({ secondaryProps: { cta } });
 
       tracking.sendEvent.mockClear();
-      userEvent.click(screen.getByRole('link', { name: cta.text }));
+      await userEvent.click(screen.getByRole('link', { name: cta.text }));
 
       expect(tracking.sendEvent).toHaveBeenCalledTimes(1);
       expect(tracking.sendEvent).toHaveBeenCalledWith({
@@ -350,13 +352,15 @@ describe(__filename, () => {
         },
       );
 
-      it('sends a tracking event when the cta is clicked', () => {
+      it('sends a tracking event when the cta is clicked', async () => {
         const strippedUrl = '/a/different/url';
         stripLangFromAmoUrl.mockReturnValue(strippedUrl);
         renderWithHomeData({ secondaryProps: secondaryPropsWithModules });
 
         tracking.sendEvent.mockClear();
-        userEvent.click(screen.getByRole('link', { name: module1.cta.text }));
+        await userEvent.click(
+          screen.getByRole('link', { name: module1.cta.text }),
+        );
 
         expect(stripLangFromAmoUrl).toHaveBeenCalledWith({
           urlString: expect.stringContaining(
@@ -1024,11 +1028,11 @@ describe(__filename, () => {
         ['external', withExternalShelfData],
       ])(
         'sends a tracking event when the cta is clicked for %s',
-        (feature, shelfData) => {
+        async (feature, shelfData) => {
           renderWithHomeData(shelfData);
           tracking.sendEvent.mockClear();
 
-          userEvent.click(
+          await userEvent.click(
             screen.getByRole('link', { name: 'Get the extension' }),
           );
 
@@ -1325,14 +1329,12 @@ describe(__filename, () => {
 
     // Without the waitFor, the meta tags have not rendered into the head yet.
     await waitFor(() =>
-      expect(getElement('meta[name="description"]')).toBeInTheDocument(),
-    );
-
-    expect(getElement('meta[name="description"]')).toHaveAttribute(
-      'content',
-      `Download Firefox extensions and themes. They’re like apps for your ` +
-        `browser. They can block annoying ads, protect passwords, change ` +
-        `browser appearance, and more.`,
+      expect(getElement('meta[name="description"]')).toHaveAttribute(
+        'content',
+        `Download Firefox extensions and themes. They’re like apps for your ` +
+          `browser. They can block annoying ads, protect passwords, change ` +
+          `browser appearance, and more.`,
+      ),
     );
   });
 

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -492,12 +492,10 @@ describe(__filename, () => {
       render({ addonType });
 
       await waitFor(() =>
-        expect(getElement('meta[name="description"]')).toBeInTheDocument(),
-      );
-
-      expect(getElement('meta[name="description"]')).toHaveAttribute(
-        'content',
-        expect.stringContaining(description),
+        expect(getElement('meta[name="description"]')).toHaveAttribute(
+          'content',
+          expect.stringContaining(description),
+        ),
       );
     },
   );
@@ -506,12 +504,10 @@ describe(__filename, () => {
     render();
 
     await waitFor(() =>
-      expect(getElement('link[rel="canonical"]')).toBeInTheDocument(),
-    );
-
-    expect(getElement('link[rel="canonical"]')).toHaveAttribute(
-      'href',
-      getCanonicalURL({ locationPathname: getLocation() }),
+      expect(getElement('link[rel="canonical"]')).toHaveAttribute(
+        'href',
+        getCanonicalURL({ locationPathname: getLocation() }),
+      ),
     );
   });
 });

--- a/tests/unit/amo/pages/TestLanguageTools.js
+++ b/tests/unit/amo/pages/TestLanguageTools.js
@@ -326,12 +326,10 @@ describe(__filename, () => {
     render();
 
     await waitFor(() =>
-      expect(getElement('meta[name="description"]')).toBeInTheDocument(),
-    );
-
-    expect(getElement('meta[name="description"]')).toHaveAttribute(
-      'content',
-      expect.stringContaining('Download Firefox dictionaries and language'),
+      expect(getElement('meta[name="description"]')).toHaveAttribute(
+        'content',
+        expect.stringContaining('Download Firefox dictionaries and language'),
+      ),
     );
   });
 
@@ -339,12 +337,12 @@ describe(__filename, () => {
     render();
 
     await waitFor(() =>
-      expect(getElement('link[rel="canonical"]')).toBeInTheDocument(),
-    );
-
-    expect(getElement('link[rel="canonical"]')).toHaveAttribute(
-      'href',
-      getCanonicalURL({ locationPathname: `/${lang}/firefox/language-tools/` }),
+      expect(getElement('link[rel="canonical"]')).toHaveAttribute(
+        'href',
+        getCanonicalURL({
+          locationPathname: `/${lang}/firefox/language-tools/`,
+        }),
+      ),
     );
   });
 });

--- a/tests/unit/amo/pages/TestSearchPage.js
+++ b/tests/unit/amo/pages/TestSearchPage.js
@@ -1,5 +1,5 @@
 import { cleanup, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import { createApiError } from 'amo/api/index';
@@ -44,12 +44,14 @@ import {
 describe(__filename, () => {
   let history;
   let store;
+  let userEvent;
   const lang = 'en-US';
   const clientApp = CLIENT_APP_FIREFOX;
   const defaultLocation = `/${lang}/${clientApp}/search/`;
 
   beforeEach(() => {
     store = dispatchClientMetadata({ clientApp, lang }).store;
+    userEvent = defaultUserEvent.setup();
   });
 
   const getLocation = ({ category, query, tag, type }) => {
@@ -413,7 +415,7 @@ describe(__filename, () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       await renderWithResults({ page, query });
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Sort by' }),
         'Relevance',
       );
@@ -431,16 +433,14 @@ describe(__filename, () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       await renderWithResults({ page, query });
 
-      userEvent.type(screen.getByRole('searchbox'), '{selectall}{del}');
-      userEvent.click(screen.getByRole('button', { name: 'Search' }));
+      await userEvent.clear(screen.getByRole('searchbox'));
+      await userEvent.click(screen.getByRole('button', { name: 'Search' }));
 
-      await waitFor(() =>
-        expect(dispatch).toHaveBeenCalledWith(
-          searchStart({
-            errorHandlerId: getSearchErrorHandlerId(),
-            filters: {},
-          }),
-        ),
+      expect(dispatch).toHaveBeenCalledWith(
+        searchStart({
+          errorHandlerId: getSearchErrorHandlerId(),
+          filters: {},
+        }),
       );
     });
 
@@ -458,11 +458,11 @@ describe(__filename, () => {
     it('renders a robots meta tag when there are no results', async () => {
       render();
 
-      await waitFor(() => expect(getElement('title')).toBeInTheDocument());
-
-      expect(getElement('meta[name="robots"]')).toHaveAttribute(
-        'content',
-        'noindex, follow',
+      await waitFor(() =>
+        expect(getElement('meta[name="robots"]')).toHaveAttribute(
+          'content',
+          'noindex, follow',
+        ),
       );
     });
 
@@ -642,7 +642,7 @@ describe(__filename, () => {
       await renderWithResults({ query });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Add-on Type' }),
         'Extension',
       );
@@ -663,7 +663,7 @@ describe(__filename, () => {
       await renderWithResults({ query });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Sort by' }),
         'Trending',
       );
@@ -684,7 +684,7 @@ describe(__filename, () => {
       await renderWithResults({ query });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Badging' }),
         'Recommended',
       );
@@ -756,7 +756,7 @@ describe(__filename, () => {
       await renderWithResults({ filterProps: { type }, query });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Add-on Type' }),
         'All',
       );
@@ -777,7 +777,7 @@ describe(__filename, () => {
       await renderWithResults({ filterProps: { type }, query });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Add-on Type' }),
         'Extension',
       );
@@ -792,7 +792,7 @@ describe(__filename, () => {
       await renderWithResults({ filterProps: { promoted, sort } });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Badging' }),
         'Any',
       );
@@ -810,7 +810,7 @@ describe(__filename, () => {
       await renderWithResults({ page, query });
       const pushSpy = jest.spyOn(history, 'push');
 
-      userEvent.selectOptions(
+      await userEvent.selectOptions(
         screen.getByRole('combobox', { name: 'Add-on Type' }),
         'Extension',
       );

--- a/tests/unit/amo/pages/TestTagPage.js
+++ b/tests/unit/amo/pages/TestTagPage.js
@@ -42,17 +42,19 @@ describe(__filename, () => {
     return renderResult;
   }
 
-  it('removes tag from the query params if tag is in filters', () => {
+  it('removes tag from the query params if tag is in filters', async () => {
     const tag = 'myTag';
     const location = `/${lang}/${clientApp}/tag/${tag}/`;
 
     render({ location: `${location}?tag=${tag}` });
     const pushSpy = jest.spyOn(history, 'push');
 
-    userEvent.selectOptions(
-      screen.getByRole('combobox', { name: 'Sort by' }),
-      'Trending',
-    );
+    await userEvent
+      .setup()
+      .selectOptions(
+        screen.getByRole('combobox', { name: 'Sort by' }),
+        'Trending',
+      );
 
     expect(pushSpy).toHaveBeenCalledWith({
       pathname: location,

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -1,6 +1,6 @@
 import config from 'config';
 import { waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import defaultUserEvent from '@testing-library/user-event';
 
 import {
   fetchUserReviews,
@@ -76,10 +76,12 @@ describe(__filename, () => {
   const clientApp = CLIENT_APP_FIREFOX;
   let history;
   let store;
+  let userEvent;
   const defaultUserId = fakeAuthors[0].id;
 
   beforeEach(() => {
     store = dispatchClientMetadata({ clientApp, lang }).store;
+    userEvent = defaultUserEvent.setup();
   });
 
   afterEach(() => {
@@ -1086,19 +1088,19 @@ describe(__filename, () => {
           store,
         });
 
-        userEvent.click(await screen.findByRole('link', { name: 'Next' }));
+        await userEvent.click(
+          await screen.findByRole('link', { name: 'Next' }),
+        );
 
-        await waitFor(() =>
-          expect(dispatch).toHaveBeenCalledWith(
-            fetchAddonsByAuthors({
-              addonType: ADDON_TYPE_EXTENSION,
-              authorIds: [defaultUserId],
-              errorHandlerId: createErrorHandlerId(),
-              page: '2',
-              pageSize: String(EXTENSIONS_BY_AUTHORS_PAGE_SIZE),
-              sort: SEARCH_SORT_POPULAR,
-            }),
-          ),
+        expect(dispatch).toHaveBeenCalledWith(
+          fetchAddonsByAuthors({
+            addonType: ADDON_TYPE_EXTENSION,
+            authorIds: [defaultUserId],
+            errorHandlerId: createErrorHandlerId(),
+            page: '2',
+            pageSize: String(EXTENSIONS_BY_AUTHORS_PAGE_SIZE),
+            sort: SEARCH_SORT_POPULAR,
+          }),
         );
 
         // Verify that the AddonsByAuthors card for Themes did not dispatch.
@@ -1148,14 +1150,12 @@ describe(__filename, () => {
         renderUserProfile({ location: getLocation({ search }) });
 
         await waitFor(() =>
-          expect(getElement('link[rel="canonical"]')).toBeInTheDocument(),
-        );
-
-        expect(getElement('link[rel="canonical"]')).toHaveAttribute(
-          'href',
-          `${config.get('baseURL')}${getLocation({
-            search: expectedQueryString,
-          })}`,
+          expect(getElement('link[rel="canonical"]')).toHaveAttribute(
+            'href',
+            `${config.get('baseURL')}${getLocation({
+              search: expectedQueryString,
+            })}`,
+          ),
         );
 
         expect(getElement('meta[property="og:url"]')).toHaveAttribute(
@@ -1171,12 +1171,10 @@ describe(__filename, () => {
       renderUserProfile();
 
       await waitFor(() =>
-        expect(getElement('meta[property="og:title"]')).toBeInTheDocument(),
-      );
-
-      expect(getElement('meta[property="og:title"]')).toHaveAttribute(
-        'content',
-        `User Profile – Add-ons for Firefox (${lang})`,
+        expect(getElement('meta[property="og:title"]')).toHaveAttribute(
+          'content',
+          `User Profile – Add-ons for Firefox (${lang})`,
+        ),
       );
     });
 
@@ -1185,12 +1183,10 @@ describe(__filename, () => {
       signInUserAndRenderUserProfile({ display_name: displayName });
 
       await waitFor(() =>
-        expect(getElement('meta[property="og:title"]')).toBeInTheDocument(),
-      );
-
-      expect(getElement('meta[property="og:title"]')).toHaveAttribute(
-        'content',
-        `User Profile for ${displayName} – Add-ons for Firefox (${lang})`,
+        expect(getElement('meta[property="og:title"]')).toHaveAttribute(
+          'content',
+          `User Profile for ${displayName} – Add-ons for Firefox (${lang})`,
+        ),
       );
     });
   });
@@ -1221,7 +1217,7 @@ describe(__filename, () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const userId = renderForOtherThanSignedInUser();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Report this user for abuse' }),
       );
 
@@ -1231,10 +1227,8 @@ describe(__filename, () => {
         }),
       );
 
-      await waitFor(() =>
-        expect(screen.getByClassName('ReportUserAbuse')).toHaveClass(
-          'ReportUserAbuse--is-expanded',
-        ),
+      expect(screen.getByClassName('ReportUserAbuse')).toHaveClass(
+        'ReportUserAbuse--is-expanded',
       );
 
       // The initial button should no longer be visible.
@@ -1243,10 +1237,10 @@ describe(__filename, () => {
       ).not.toBeInTheDocument();
     });
 
-    it('renders the form in a pre-submitted state', () => {
+    it('renders the form in a pre-submitted state', async () => {
       renderForOtherThanSignedInUser();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Report this user for abuse' }),
       );
 
@@ -1258,15 +1252,15 @@ describe(__filename, () => {
       ).toBeInTheDocument();
     });
 
-    it('hides more content when the cancel button is clicked', () => {
+    it('hides more content when the cancel button is clicked', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       const userId = renderForOtherThanSignedInUser();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Report this user for abuse' }),
       );
 
-      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
       expect(dispatch).toHaveBeenCalledWith(
         hideUserAbuseReportUI({
@@ -1283,17 +1277,17 @@ describe(__filename, () => {
       const message = 'This user is funny';
       const userId = renderForOtherThanSignedInUser();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Report this user for abuse' }),
       );
 
-      userEvent.type(
+      await userEvent.type(
         screen.getByPlaceholderText(
           'Explain how this user is violating our policies.',
         ),
         message,
       );
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole('button', { name: 'Send abuse report' }),
       );
 
@@ -1305,11 +1299,9 @@ describe(__filename, () => {
         }),
       );
 
-      await waitFor(() =>
-        expect(
-          screen.getByRole('button', { name: 'Sending abuse report' }),
-        ).toBeDisabled(),
-      );
+      expect(
+        screen.getByRole('button', { name: 'Sending abuse report' }),
+      ).toBeDisabled();
     });
 
     it('shows a success message and hides the button if report was sent', () => {

--- a/tests/unit/amo/pages/TestUsersUnsubscribe.js
+++ b/tests/unit/amo/pages/TestUsersUnsubscribe.js
@@ -72,9 +72,9 @@ describe(__filename, () => {
   it('renders an HTML title', async () => {
     render();
 
-    await waitFor(() => expect(getElement('title')).toBeInTheDocument());
-
-    expect(getElement('title')).toHaveTextContent('Unsubscribe');
+    await waitFor(() =>
+      expect(getElement('title')).toHaveTextContent('Unsubscribe'),
+    );
   });
 
   it('dispatches unsubscribeNotification on mount', () => {

--- a/tests/unit/amo/test_errorHandler.js
+++ b/tests/unit/amo/test_errorHandler.js
@@ -168,11 +168,11 @@ describe(__filename, () => {
       expect(dispatch).toHaveBeenCalledWith(expectedAction);
     });
 
-    it('configures an error handler for action dispatching', () => {
+    it('configures an error handler for action dispatching', async () => {
       const dispatch = jest.spyOn(store, 'dispatch');
       render();
 
-      userEvent.click(getInput());
+      await userEvent.setup().click(getInput());
 
       expect(dispatch).toHaveBeenCalledWith(
         setError({

--- a/tests/unit/amo/test_withUIState.js
+++ b/tests/unit/amo/test_withUIState.js
@@ -1,6 +1,5 @@
 /* eslint-disable  react/prop-types, max-classes-per-file */
 import * as React from 'react';
-import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import withUIState, { generateId } from 'amo/withUIState';
@@ -64,13 +63,13 @@ describe(__filename, () => {
       render();
 
       // Test that closing the overlay is hooked up to uiState.
-      userEvent.click(screen.getByRole('button', { name: buttonText }));
+      await userEvent
+        .setup()
+        .click(screen.getByRole('button', { name: buttonText }));
 
-      await waitFor(() =>
-        expect(
-          screen.queryByRole('button', { name: buttonText }),
-        ).not.toBeInTheDocument(),
-      );
+      expect(
+        screen.queryByRole('button', { name: buttonText }),
+      ).not.toBeInTheDocument();
     });
 
     const propValue = 'Some prop from state';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,10 +1825,10 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
-"@testing-library/user-event@14.2.6":
-  version "14.2.6"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.6.tgz#9ba313a212994eea66e018520e23542ac3eb6fbe"
-  integrity sha512-l/4W4x3Lm24wkWNkPasXqvEzG+a6n2X872XCUjhyfbNqcoOapaWyCxC5Fz+E4r7JPu8gysQKSSCrK0OO2x+D+A==
+"@testing-library/user-event@^14.2.6":
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.3.0.tgz#0a6750b94b40e4739706d41e8efc2ccf64d2aad9"
+  integrity sha512-P02xtBBa8yMaLhK8CzJCIns8rqwnF6FxhR9zs810flHOBXUYCFjLd8Io1rQrAkQRWEmW2PGdZIEdMxf/KLsqFA==
 
 "@tootallnate/once@1":
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,12 +1825,10 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
-"@testing-library/user-event@^13.5.0":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@14.2.6":
+  version "14.2.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.2.6.tgz#9ba313a212994eea66e018520e23542ac3eb6fbe"
+  integrity sha512-l/4W4x3Lm24wkWNkPasXqvEzG+a6n2X872XCUjhyfbNqcoOapaWyCxC5Fz+E4r7JPu8gysQKSSCrK0OO2x+D+A==
 
 "@tootallnate/once@1":
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,20 +1787,6 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@testing-library/dom@^8.11.3":
-  version "8.11.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.3.tgz#38fd63cbfe14557021e88982d931e33fb7c1a808"
-  integrity sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^5.0.0"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
-    lz-string "^1.4.4"
-    pretty-format "^27.0.2"
-
 "@testing-library/dom@^8.5.0":
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.14.0.tgz#c9830a21006d87b9ef6e1aae306cf49b0283e28e"


### PR DESCRIPTION
There is one test (well two really, but they are from the same `it.each`) that is failing regularly with the update to the latest `user-event` combined with the changes that implement the `await`s. It generally doesn't fail when you run just the `TestPage.js` suite (although sometimes it still does), but it seems to consistently fail when you run the whole suite.

I have spent a number of hours on this and I still have no idea what's causing it. I did identify a situation that exists when the test fails, but I don't know why that situation does not exist when the test passes. It's like somehow other tests are interfering with this test, or maybe it's just an intermittent problem and the fact that it happens when you run the whole suite is a red herring.

This draft PR includes the changes for updating to the latest `user-event`, as well as a commit with a bunch of debugging I was using to try to figure out what is happening.