### PR TITLE
Adjust Rating stars spacing and size when writing a review

### DIFF
--- a/src/amo/components/AddonReviewManager/styles.scss
+++ b/src/amo/components/AddonReviewManager/styles.scss
@@ -23,6 +23,16 @@
       }
     }
   }
+
+  .Rating {
+    width: 100%;
+  }
+
+  @include respond-to(extraExtraLarge) {
+    .Rating {
+      width: inherit;
+    }
+  }
 }
 
 .AddonReviewManager-savedRating {

--- a/src/amo/components/AddonReviewManagerRating/styles.scss
+++ b/src/amo/components/AddonReviewManagerRating/styles.scss
@@ -1,5 +1,13 @@
+@import '~amo/css/styles';
+
 .AddonReviewManagerRating {
   align-items: center;
   display: flex;
   flex-flow: column wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+
+  @include respond-to(extraExtraLarge) {
+    flex-flow: row wrap;
+  }
 }


### PR DESCRIPTION
- On mobile, "Your star rating" and the stars should be on different lines, and the stars slightly bigger (larger target), with some margin to separate them from the textbox
  ![Screenshot 2022-07-25 at 13-39-17 wollinoss-magpiper-reingfiswollinoss-magpiper-reingfiswollinoss-magpiper-reingfis – Get this Extension for 🦊 Firefox (en-US)](https://user-images.githubusercontent.com/187006/180770235-a89ddd26-db0e-4152-9c5b-b18ca2f361bc.png)

- On larger screen sizes, "Your star rating" and the stars can be on the same line, with the regular small stars
  ![Screenshot 2022-07-25 at 13-38-58 wollinoss-magpiper-reingfiswollinoss-magpiper-reingfiswollinoss-magpiper-reingfis – Get this Extension for 🦊 Firefox (en-US)](https://user-images.githubusercontent.com/187006/180769714-5726d4bc-49a9-4ef4-8dcd-58d8a717d748.png)

Fixes https://github.com/mozilla/addons-frontend/issues/11746
