### PR TITLE
Record experiment name and variation as GA dimensions

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -421,5 +421,6 @@ module.exports = {
     //
     // e.g., 20210531_amo_download_funnel_experiment: true,
     '20210714_amo_vpn_promo': false,
+    '20220908_amo_dimension_test': true,
   },
 };

--- a/src/amo/experiments/20220908_amo_dimension_test.js
+++ b/src/amo/experiments/20220908_amo_dimension_test.js
@@ -1,0 +1,15 @@
+/* @flow */
+import { NOT_IN_EXPERIMENT } from 'amo/withExperiment';
+import type { ExperimentConfig } from 'amo/withExperiment';
+
+export const VARIANT_A = 'a-branch';
+export const VARIANT_B = 'b-branch';
+
+export const EXPERIMENT_CONFIG: ExperimentConfig = {
+  id: '20220908_amo_dimension_test',
+  variants: [
+    { id: VARIANT_A, percentage: 0.45 },
+    { id: VARIANT_B, percentage: 0.45 },
+    { id: NOT_IN_EXPERIMENT, percentage: 0.1 },
+  ],
+};

--- a/src/amo/pages/LandingPage/index.js
+++ b/src/amo/pages/LandingPage/index.js
@@ -25,6 +25,7 @@ import {
   SEARCH_SORT_TRENDING,
 } from 'amo/constants';
 import { withErrorHandler } from 'amo/errorHandler';
+import { EXPERIMENT_CONFIG } from 'amo/experiments/20220908_amo_dimension_test';
 import {
   apiAddonType,
   apiAddonTypeIsValid,
@@ -32,6 +33,7 @@ import {
 } from 'amo/utils';
 import translate from 'amo/i18n/translate';
 import Button from 'amo/components/Button';
+import { withExperiment } from 'amo/withExperiment';
 
 import './styles.scss';
 
@@ -337,4 +339,5 @@ export default compose(
   connect(mapStateToProps),
   translate(),
   withErrorHandler({ id: 'LandingPage' }),
+  withExperiment({ experimentConfig: EXPERIMENT_CONFIG }),
 )(LandingPageBase);

--- a/src/amo/withExperiment.js
+++ b/src/amo/withExperiment.js
@@ -70,6 +70,9 @@ export const EXPERIMENT_ENROLLMENT_CATEGORY = 'AMO Experiment Enrollment -';
 // in the experiment.
 export const NOT_IN_EXPERIMENT = 'notInExperiment';
 export const EXPERIMENT_ID_REGEXP: RegExp = /\d{8}_amo_.+/;
+// The GA custom dimensions used for experimentId and variation.
+export const EXPERIMENT_ID_GA_DIMENSION = 'dimension8';
+export const EXPERIMENT_VARIATION_GA_DIMENSION = 'dimension9';
 
 // https://github.com/reactivestack/cookies/tree/f9beead40a6bebac475d9bf17c1da55418d26751/packages/react-cookie#setcookiename-value-options
 type CookieConfig = {|
@@ -290,6 +293,18 @@ export const withExperiment =
             experimentsToStore,
             cookieConfig || defaultCookieConfig,
           );
+        }
+
+        // If the user is enrolled in a branch, set the GA custom dimensions.
+        if (variant && variant !== NOT_IN_EXPERIMENT) {
+          _tracking.setDimension({
+            dimension: EXPERIMENT_ID_GA_DIMENSION,
+            value: id,
+          });
+          _tracking.setDimension({
+            dimension: EXPERIMENT_VARIATION_GA_DIMENSION,
+            value: variant,
+          });
         }
       }
 

--- a/tests/unit/amo/components/TestPage-VPNPromoBanner.js
+++ b/tests/unit/amo/components/TestPage-VPNPromoBanner.js
@@ -24,6 +24,7 @@ jest.mock('config');
 // We need this to avoid firing sendEvent during tests, which will throw.
 jest.mock('amo/tracking', () => ({
   sendEvent: jest.fn(),
+  setDimension: jest.fn(),
 }));
 
 describe(__filename, () => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -122,6 +122,7 @@ jest.mock('amo/addonManager', () => ({
 jest.mock('amo/tracking', () => ({
   ...jest.requireActual('amo/tracking'),
   sendEvent: jest.fn(),
+  setDimension: jest.fn(),
 }));
 
 jest.mock('config');

--- a/tests/unit/amo/pages/TestLandingPage.js
+++ b/tests/unit/amo/pages/TestLandingPage.js
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/react';
 
 import { setViewContext } from 'amo/actions/viewContext';
+import { EXPERIMENT_CONFIG } from 'amo/experiments/20220908_amo_dimension_test';
 import { GET_LANDING, getLanding, loadLanding } from 'amo/reducers/landing';
 import {
   ADDON_TYPE_EXTENSION,
@@ -13,7 +14,12 @@ import {
   SEARCH_SORT_TRENDING,
   SEARCH_SORT_TOP_RATED,
 } from 'amo/constants';
+import tracking from 'amo/tracking';
 import { getCanonicalURL, visibleAddonType } from 'amo/utils';
+import {
+  EXPERIMENT_ID_GA_DIMENSION,
+  EXPERIMENT_VARIATION_GA_DIMENSION,
+} from 'amo/withExperiment';
 import {
   changeLocation,
   createAddonsApiResult,
@@ -26,6 +32,12 @@ import {
   screen,
 } from 'tests/unit/helpers';
 
+jest.mock('amo/tracking', () => ({
+  ...jest.requireActual('amo/tracking'),
+  sendEvent: jest.fn(),
+  setDimension: jest.fn(),
+}));
+
 describe(__filename, () => {
   const clientApp = CLIENT_APP_FIREFOX;
   const lang = 'en-US';
@@ -37,6 +49,10 @@ describe(__filename, () => {
 
   beforeEach(() => {
     store = dispatchClientMetadata({ clientApp, lang }).store;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks().resetModules();
   });
 
   const render = ({ addonType = ADDON_TYPE_EXTENSION, location } = {}) => {
@@ -520,6 +536,22 @@ describe(__filename, () => {
         'href',
         getCanonicalURL({ locationPathname: getLocation() }),
       ),
+    );
+  });
+
+  // This is an integration test between LandingPage and withExperiment.
+  it('calls setDimension for the configured experiment', async () => {
+    render();
+
+    expect(tracking.setDimension).toHaveBeenCalledTimes(2);
+    expect(tracking.setDimension).toHaveBeenCalledWith({
+      dimension: EXPERIMENT_ID_GA_DIMENSION,
+      value: EXPERIMENT_CONFIG.id,
+    });
+    expect(tracking.setDimension).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dimension: EXPERIMENT_VARIATION_GA_DIMENSION,
+      }),
     );
   });
 });


### PR DESCRIPTION
Fixes #11819 

It includes a small experiment which simply allocates users into branches when they visit a landing page. We can use this to validate that everything works as expected in GA, after which we can remove that experiment.