### PR TITLE
Install the react-router-dom-v5-compat package

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "react-redux": "8.0.4",
     "react-router": "5.3.3",
     "react-router-dom": "5.3.3",
+    "react-router-dom-v5-compat": "6.4.1",
     "react-super-responsive-table": "5.2.1",
     "react-textarea-autosize": "8.3.4",
     "react-transition-group": "4.4.5",

--- a/src/amo/components/Root/index.js
+++ b/src/amo/components/Root/index.js
@@ -1,9 +1,10 @@
 /* @flow */
+import config from 'config';
 import * as React from 'react';
 import { CookiesProvider, Cookies } from 'react-cookie';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import config from 'config';
+import { CompatRouter } from 'react-router-dom-v5-compat';
 
 import I18nProvider from 'amo/i18n/Provider';
 import type { I18nType } from 'amo/types/i18n';
@@ -31,14 +32,16 @@ const Root = ({
     <I18nProvider i18n={i18n}>
       <Provider store={store} key="provider">
         <Router history={history}>
-          <CookiesProvider cookies={cookies}>
-            {/* $FlowFixMe: https://github.com/facebook/react/issues/12553 */}
-            {_config.get('enableStrictMode') ? (
-              <React.StrictMode>{children}</React.StrictMode>
-            ) : (
-              children
-            )}
-          </CookiesProvider>
+          <CompatRouter>
+            <CookiesProvider cookies={cookies}>
+              {/* $FlowFixMe: https://github.com/facebook/react/issues/12553 */}
+              {_config.get('enableStrictMode') ? (
+                <React.StrictMode>{children}</React.StrictMode>
+              ) : (
+                children
+              )}
+            </CookiesProvider>
+          </CompatRouter>
         </Router>
       </Provider>
     </I18nProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,7 +1464,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.13":
+"@babel/runtime@^7.12.13", "@babel/runtime@^7.7.6":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -2012,6 +2012,11 @@
     redux "^4.1.2"
     redux-thunk "^2.4.1"
     reselect "^4.1.5"
+
+"@remix-run/router@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.1.tgz#88d7ac31811ab0cef14aaaeae2a0474923b278bc"
+  integrity sha512-eBV5rvW4dRFOU1eajN7FmYxjAIVz/mRHgUE9En9mBn6m3mulK3WTR5C3iQhL9MZ14rWAq+xOlEaCkDiW0/heOg==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.20"
@@ -6114,6 +6119,13 @@ history@4.10.1, history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
+history@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -9733,6 +9745,14 @@ react-redux@8.0.4:
     react-is "^18.0.0"
     use-sync-external-store "^1.0.0"
 
+react-router-dom-v5-compat@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.4.1.tgz#981ac810451ad6602fcc1ba679f36b627d10fd7a"
+  integrity sha512-qMcObRRYEpCm2v0PEhepfo5LWgN6seQkwSehNfOYbZvjS8DOrHbH6IjPggWt+lu9+wL4pYz+FvoCG8LNQehQ6A==
+  dependencies:
+    history "^5.3.0"
+    react-router "6.4.1"
+
 react-router-dom@5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.3.tgz#8779fc28e6691d07afcaf98406d3812fe6f11199"
@@ -9761,6 +9781,13 @@ react-router@5.3.3:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-router@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.4.1.tgz#dd9cc4dfa264751d143a4b6c9d4faa60ab3ce26c"
+  integrity sha512-OJASKp5AykDWFewgWUim1vlLr7yfD4vO/h+bSgcP/ix8Md+LMHuAjovA74MQfsfhQJGGN1nHRhwS5qQQbbBt3A==
+  dependencies:
+    "@remix-run/router" "1.0.1"
 
 react-side-effect@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
Fixes #11860 

We should hold off merging this until https://github.com/mozilla/addons-frontend/issues/11847 is verified on dev, so we're not stuck trying to figure what caused a problem, if one is found.
