### PR TITLE
Work around test timeout issues by using jest legacy fake timers and resetting after each test

### DIFF
--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -76,6 +76,10 @@ jest.mock('amo/localState', () =>
   }),
 );
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe(__filename, () => {
   let history;
   let store;
@@ -1190,7 +1194,7 @@ describe(__filename, () => {
     });
 
     it('displays a notification for 5 seconds after an add-on has been added', async () => {
-      jest.useFakeTimers();
+      jest.useFakeTimers({ legacyFakeTimers: true });
       renderWithCollectionForSignedInUser({ editing: true });
 
       expect(screen.queryByText('Added to collection')).not.toBeInTheDocument();
@@ -1215,7 +1219,7 @@ describe(__filename, () => {
     });
 
     it('displays a notification for 5 seconds after an add-on has been removed', async () => {
-      jest.useFakeTimers();
+      jest.useFakeTimers({ legacyFakeTimers: true });
       renderWithCollectionForSignedInUser({ editing: true });
 
       expect(

--- a/tests/unit/amo/pages/error-simulation/TestSimulateAsyncError.js
+++ b/tests/unit/amo/pages/error-simulation/TestSimulateAsyncError.js
@@ -1,9 +1,12 @@
 import { renderPage } from 'tests/unit/helpers';
 
-jest.useFakeTimers();
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 describe(__filename, () => {
   it('throws a simulated error', () => {
+    jest.useFakeTimers({ legacyFakeTimers: true });
     renderPage({ initialEntries: ['/en-US/firefox/simulate-async-error/'] });
 
     expect(() => jest.advanceTimersByTime(51)).toThrowError(


### PR DESCRIPTION
Fixes #11870 (hopefully)