### PR TITLE
 Get add-on icon URL form API's icons object with specific icon size

### DIFF
--- a/src/amo/imageUtils.js
+++ b/src/amo/imageUtils.js
@@ -1,24 +1,25 @@
 import fallbackIcon from 'amo/img/icons/default.svg';
 
+//
 // returns icon url from icons objects,
-// or returns icon_url value if icons does't exists
+// or returns icon_url value if icons does not exists
 //
 // fallback icon will be returned if the addon has no icon.
 //
 // iconSize values are 32 | 64 | 128
-export function getAddonIconUrl(addon, iconSize) {
-  const defaultIconSize = 64;
+export function getAddonIconUrl(addon, size) {
+  const iconSizes = [32, 64, 128];
+  const iconSizeIsNotValid = size && !iconSizes.includes(size);
 
-  const addonIconsExists = addon?.icons;
-
-  if (addonIconsExists) {
-    const iconFromIcons = addon.icons?.[iconSize || defaultIconSize];
-
-    return iconFromIcons || fallbackIcon;
+  if (iconSizeIsNotValid) {
+    throw new Error(`size must be one of: ${iconSizes.toString()}`);
   }
 
-  // autocomplete API does't return icons object, returns icon_url only
-  return addon?.icon_url || fallbackIcon;
+  const defaultIconSize = iconSizes[1];
+
+  const iconFromIcons = addon?.icons?.[size] || addon?.icons?.[defaultIconSize];
+
+  return iconFromIcons || addon?.icon_url || fallbackIcon;
 }
 
 export const getPreviewImage = (addon, { full = true } = {}) => {

--- a/src/amo/imageUtils.js
+++ b/src/amo/imageUtils.js
@@ -8,14 +8,7 @@ import fallbackIcon from 'amo/img/icons/default.svg';
 //
 // iconSize values are 32 | 64 | 128
 export function getAddonIconUrl(addon, size) {
-  const iconSizes = [32, 64, 128];
-  const iconSizeIsNotValid = size && !iconSizes.includes(size);
-
-  if (iconSizeIsNotValid) {
-    throw new Error(`size must be one of: ${iconSizes.toString()}`);
-  }
-
-  const defaultIconSize = iconSizes[1];
+  const defaultIconSize = 64;
 
   const iconFromIcons = addon?.icons?.[size] || addon?.icons?.[defaultIconSize];
 

--- a/src/amo/imageUtils.js
+++ b/src/amo/imageUtils.js
@@ -1,7 +1,24 @@
 import fallbackIcon from 'amo/img/icons/default.svg';
 
-export function getAddonIconUrl(addon) {
-  return addon ? addon.icon_url : fallbackIcon;
+// returns icon url from icons objects,
+// or returns icon_url value if icons does't exists
+//
+// fallback icon will be returned if the addon has no icon.
+//
+// iconSize values are 32 | 64 | 128
+export function getAddonIconUrl(addon, iconSize) {
+  const defaultIconSize = 64;
+
+  const addonIconsExists = addon?.icons;
+
+  if (addonIconsExists) {
+    const iconFromIcons = addon.icons?.[iconSize || defaultIconSize];
+
+    return iconFromIcons || fallbackIcon;
+  }
+
+  // autocomplete API does't return icons object, returns icon_url only
+  return addon?.icon_url || fallbackIcon;
 }
 
 export const getPreviewImage = (addon, { full = true } = {}) => {

--- a/src/amo/reducers/addons.js
+++ b/src/amo/reducers/addons.js
@@ -212,6 +212,7 @@ export function createInternalAddon(
     has_privacy_policy: apiAddon.has_privacy_policy,
     homepage: selectLocalizedUrlWithOutgoing(apiAddon.homepage, lang),
     icon_url: apiAddon.icon_url,
+    icons: apiAddon.icons,
     id: apiAddon.id,
     is_disabled: apiAddon.is_disabled,
     is_experimental: apiAddon.is_experimental,

--- a/src/amo/types/addons.js
+++ b/src/amo/types/addons.js
@@ -36,6 +36,12 @@ export type AddonAuthorType = {|
   picture_url: string,
 |};
 
+export type AddonIconsType = {
+  '32'?: string,
+  '64'?: string,
+  '128'?: string,
+};
+
 export type ExternalLanguageToolType = {|
   current_version: ExternalAddonVersionType,
   default_locale: string,
@@ -115,6 +121,7 @@ export type ExternalAddonType = {|
   has_privacy_policy?: boolean,
   homepage: LocalizedUrlWithOutgoing | null,
   icon_url?: string,
+  icons?: AddonIconsType,
   id: number,
   is_disabled?: boolean,
   is_experimental?: boolean,

--- a/tests/unit/amo/components/TestAddonSummaryCard.js
+++ b/tests/unit/amo/components/TestAddonSummaryCard.js
@@ -46,7 +46,7 @@ describe(__filename, () => {
 
       expect(screen.getByAltText('Add-on icon')).toHaveAttribute(
         'src',
-        addon.icon_url,
+        addon.icons[64],
       );
     });
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -937,12 +937,12 @@ describe(__filename, () => {
   it('renders an amo icon image', () => {
     const addonName = 'some-addon-name';
     addon.name = createLocalizedString(addonName);
-    addon.icon_url = 'https://addons.mozilla.org/foo.jpg';
+    addon.icons[64] = 'https://addons.mozilla.org/foo.jpg';
     renderWithAddon();
 
     expect(screen.getByAltText(`Preview of ${addonName}`)).toHaveAttribute(
       'src',
-      addon.icon_url,
+      addon.icons[64],
     );
   });
 

--- a/tests/unit/amo/test_imageUtils.js
+++ b/tests/unit/amo/test_imageUtils.js
@@ -10,17 +10,17 @@ const iconsUrlsExample = {
 
 describe(__filename, () => {
   describe('getAddonIconUrl', () => {
-    it('return default icon size if requested size is invalid', () => {
+    it('return requested icon size url', () => {
       const addonIconUrl = getAddonIconUrl(
-        { icons: { 64: iconsUrlsExample.regular } },
+        { icons: { 32: iconsUrlsExample.regular } },
 
-        25,
+        32,
       );
 
       expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
     });
 
-    it('return icon urls from icons object', () => {
+    it('return default icon size url if no size is requested', () => {
       const addonIcon = getAddonIconUrl({
         icons: { 64: iconsUrlsExample.regular },
       });
@@ -28,74 +28,30 @@ describe(__filename, () => {
       expect(addonIcon).toEqual(iconsUrlsExample.regular);
     });
 
-    it('return small(32px) url icon', () => {
-      const smallIconUrl = iconsUrlsExample.small;
-
-      const addonIconUrl = getAddonIconUrl(
+    it('return default icon size url if requested size url is undefined', () => {
+      const addonIcon = getAddonIconUrl(
         {
-          icons: { 32: smallIconUrl },
+          icons: { 64: iconsUrlsExample.regular },
         },
 
         32,
       );
 
-      expect(addonIconUrl).toEqual(smallIconUrl);
+      expect(addonIcon).toEqual(iconsUrlsExample.regular);
     });
 
-    it('return regular(64px) icon url', () => {
-      const regularIconUrl = iconsUrlsExample.regular;
-
-      const addonIcon = getAddonIconUrl({
-        icons: { 64: regularIconUrl },
+    it('return icon_url if default icon size url is undefined', () => {
+      const addonIconUrl = getAddonIconUrl({
+        icon_url: iconsUrlsExample.regular,
       });
 
-      expect(addonIcon).toEqual(regularIconUrl);
-    });
-
-    it('return large(128px) icon url', () => {
-      const largeIconUrl = iconsUrlsExample.large;
-
-      const addonIconUrl = getAddonIconUrl(
-        {
-          icons: { 64: largeIconUrl },
-        },
-
-        64,
-      );
-
-      expect(addonIconUrl).toEqual(largeIconUrl);
-    });
-
-    it('return icon_url if icons is undefined', () => {
-      const addonIconUrl = getAddonIconUrl(
-        {
-          icon_url: iconsUrlsExample.regular,
-        },
-
-        64,
-      );
-
       expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
     });
 
-    it('return default icon size if requested icon size(large, small) is undefined', () => {
-      const addonIconUrl = getAddonIconUrl(
-        {
-          icons: { 64: iconsUrlsExample.regular },
-        },
-
-        64,
-      );
-
-      expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
-    });
-
-    it('return fallback icon if requested icon size is undefined', () => {
-      const addonIconUrl = getAddonIconUrl(
-        { icons: { 32: iconsUrlsExample.small } },
-
-        64,
-      );
+    it('return fallback icon url if icon_url is undefined', () => {
+      const addonIconUrl = getAddonIconUrl({
+        icons: { 32: iconsUrlsExample.small },
+      });
 
       expect(addonIconUrl).toEqual(fallbackIcon);
     });

--- a/tests/unit/amo/test_imageUtils.js
+++ b/tests/unit/amo/test_imageUtils.js
@@ -1,19 +1,67 @@
 import { getAddonIconUrl, getPreviewImage } from 'amo/imageUtils';
-import {
-  createInternalAddonWithLang,
-  fakeAddon,
-  fakePreview,
-} from 'tests/unit/helpers';
+import { createInternalAddonWithLang, fakePreview } from 'tests/unit/helpers';
 import fallbackIcon from 'amo/img/icons/default.svg';
 
-describe(__filename, () => {
-  const allowedIcon = 'https://addons.mozilla.org/webdev-64.png';
+const iconsUrlsExample = {
+  small: 'https://addons.mozilla.org/get-icon-exampele-sml-32.png',
+  regular: 'https://addons.mozilla.org/get-icon-example-reg-64.png',
+  large: 'https://addons.mozilla.org/get-icon-example-lrg-128.png',
+};
 
+describe(__filename, () => {
   describe('getAddonIconUrl', () => {
-    it('return icon url as in fake addon', () => {
-      expect(getAddonIconUrl({ ...fakeAddon, icon_url: allowedIcon })).toEqual(
-        allowedIcon,
+    it('return icon urls from icons object', () => {
+      const addonIcon = getAddonIconUrl({
+        icons: { 64: iconsUrlsExample.regular },
+      });
+
+      expect(addonIcon).toEqual(iconsUrlsExample.regular);
+    });
+
+    it('return small(32px) url icon', () => {
+      const smallIconUrl = iconsUrlsExample.small;
+
+      const addonIconUrl = getAddonIconUrl(
+        {
+          icons: { 32: smallIconUrl },
+        },
+        32,
       );
+
+      expect(addonIconUrl).toEqual(smallIconUrl);
+    });
+
+    it('return regular(64px) icon url', () => {
+      const regularIconUrl = iconsUrlsExample.regular;
+
+      const addonIcon = getAddonIconUrl({
+        icons: { 64: regularIconUrl },
+      });
+
+      expect(addonIcon).toEqual(regularIconUrl);
+    });
+    it('return large(128px) icon url', () => {
+      const largeIconUrl = iconsUrlsExample.large;
+
+      const addonIconUrl = getAddonIconUrl(
+        {
+          icons: { 64: largeIconUrl },
+        },
+        64,
+      );
+
+      expect(addonIconUrl).toEqual(largeIconUrl);
+    });
+
+    it('return icon_url if icons object does not exist', () => {
+      const addonIconUrl = getAddonIconUrl(
+        {
+          icon_url: iconsUrlsExample.regular,
+        },
+        64,
+      );
+
+      expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
     });
 
     it('return fallback icon in case of null addon value', () => {

--- a/tests/unit/amo/test_imageUtils.js
+++ b/tests/unit/amo/test_imageUtils.js
@@ -10,12 +10,14 @@ const iconsUrlsExample = {
 
 describe(__filename, () => {
   describe('getAddonIconUrl', () => {
-    it('throw error if requested icon size is invalid', () => {
-      const getIconWithInvalidSize = () => getAddonIconUrl({}, 25);
+    it('return default icon size if requested size is invalid', () => {
+      const addonIconUrl = getAddonIconUrl(
+        { icons: { 64: iconsUrlsExample.regular } },
 
-      expect(getIconWithInvalidSize).toThrowErrorMatchingInlineSnapshot(
-        `"size must be one of: 32,64,128"`,
+        25,
       );
+
+      expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
     });
 
     it('return icon urls from icons object', () => {

--- a/tests/unit/amo/test_imageUtils.js
+++ b/tests/unit/amo/test_imageUtils.js
@@ -10,6 +10,14 @@ const iconsUrlsExample = {
 
 describe(__filename, () => {
   describe('getAddonIconUrl', () => {
+    it('throw error if requested icon size is invalid', () => {
+      const getIconWithInvalidSize = () => getAddonIconUrl({}, 25);
+
+      expect(getIconWithInvalidSize).toThrowErrorMatchingInlineSnapshot(
+        `"size must be one of: 32,64,128"`,
+      );
+    });
+
     it('return icon urls from icons object', () => {
       const addonIcon = getAddonIconUrl({
         icons: { 64: iconsUrlsExample.regular },
@@ -25,6 +33,7 @@ describe(__filename, () => {
         {
           icons: { 32: smallIconUrl },
         },
+
         32,
       );
 
@@ -40,6 +49,7 @@ describe(__filename, () => {
 
       expect(addonIcon).toEqual(regularIconUrl);
     });
+
     it('return large(128px) icon url', () => {
       const largeIconUrl = iconsUrlsExample.large;
 
@@ -47,21 +57,45 @@ describe(__filename, () => {
         {
           icons: { 64: largeIconUrl },
         },
+
         64,
       );
 
       expect(addonIconUrl).toEqual(largeIconUrl);
     });
 
-    it('return icon_url if icons object does not exist', () => {
+    it('return icon_url if icons is undefined', () => {
       const addonIconUrl = getAddonIconUrl(
         {
           icon_url: iconsUrlsExample.regular,
         },
+
         64,
       );
 
       expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
+    });
+
+    it('return default icon size if requested icon size(large, small) is undefined', () => {
+      const addonIconUrl = getAddonIconUrl(
+        {
+          icons: { 64: iconsUrlsExample.regular },
+        },
+
+        64,
+      );
+
+      expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
+    });
+
+    it('return fallback icon if requested icon size is undefined', () => {
+      const addonIconUrl = getAddonIconUrl(
+        { icons: { 32: iconsUrlsExample.small } },
+
+        64,
+      );
+
+      expect(addonIconUrl).toEqual(fallbackIcon);
     });
 
     it('return fallback icon in case of null addon value', () => {

--- a/tests/unit/amo/test_imageUtils.js
+++ b/tests/unit/amo/test_imageUtils.js
@@ -13,7 +13,6 @@ describe(__filename, () => {
     it('return requested icon size url', () => {
       const addonIconUrl = getAddonIconUrl(
         { icons: { 32: iconsUrlsExample.regular } },
-
         32,
       );
 
@@ -21,23 +20,22 @@ describe(__filename, () => {
     });
 
     it('return default icon size url if no size is requested', () => {
-      const addonIcon = getAddonIconUrl({
+      const addonIconUrl = getAddonIconUrl({
         icons: { 64: iconsUrlsExample.regular },
       });
 
-      expect(addonIcon).toEqual(iconsUrlsExample.regular);
+      expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
     });
 
     it('return default icon size url if requested size url is undefined', () => {
-      const addonIcon = getAddonIconUrl(
+      const addonIconUrl = getAddonIconUrl(
         {
           icons: { 64: iconsUrlsExample.regular },
         },
-
         32,
       );
 
-      expect(addonIcon).toEqual(iconsUrlsExample.regular);
+      expect(addonIconUrl).toEqual(iconsUrlsExample.regular);
     });
 
     it('return icon_url if default icon size url is undefined', () => {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -163,6 +163,11 @@ export const fakeAddon = Object.freeze({
   },
   id: 1234,
   icon_url: 'https://addons.mozilla.org/user-media/webdev-64.png',
+  icons: {
+    32: 'https://addons.mozilla.org/user-media/webdev-32.png',
+    64: 'https://addons.mozilla.org/user-media/webdev-64.png',
+    128: 'https://addons.mozilla.org/user-media/webdev-128.png',
+  },
   is_disabled: false,
   is_experimental: false,
   is_source_public: true,


### PR DESCRIPTION
Fixes #11349

Use API's `icons` object for add-on icon URL, and be able to pick a specific icon size(32, 64, 128). 

## Context
Currently, all add-ons icon URLs are coming from API's `icon_url` field.
The need is to switch to getting them from API's `icons` object.

### `icons` object example:
```JSON

"icons": {
  "32": "https://addons.allizom.org/static-server/img/addon-icons/default-32.2b26add4b394.png",
  "64": "https://addons.allizom.org/static-server/img/addon-icons/default-64.d144b50f2bb8.png",
  "128": "https://addons.allizom.org/static-server/img/addon-icons/default-128.452018499894.png"
}
````

`getAddonIconUrl` is the function responsible for getting all add-ons icons, 
it is used to get autocomplete add-ons icons too.

**Autocomplete** API **doesn't return `icons` objects**, only returns `icon_url`.







