### PR TITLE
Fix header display name overlap with searchbar (#11824)

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -118,7 +118,7 @@
   }
 
   @include respond-to(extraLarge) {
-    grid-column: 2 / -1;
+    grid-column: 1 / -1;
     grid-row: 1 / 2;
   }
 


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes #11824

## Before:
![image](https://user-images.githubusercontent.com/68125677/216846993-f503f717-4ea6-407a-a301-e6fce6a00a09.png)
## After:
![image](https://user-images.githubusercontent.com/68125677/216847003-26019749-c28b-431d-a8a4-55d1cb0b1afc.png)
## With right-to-left language
![image](https://user-images.githubusercontent.com/68125677/216847571-f0c484ac-8a61-4fad-967f-a2c1013b6cf3.png)
## Side Note
Tested with usernames containing 50 characters (limit)


<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
