### PR TITLE
Allow ratings to be loaded when the API error is a 429

### DIFF
--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -71,6 +71,9 @@ export class RatingManagerBase extends React.Component<InternalProps> {
 
     if (
       errorHandler.hasError() &&
+      // A 429 can result when a user tries to post too many ratings and gets
+      // throttled. In that case we still want to try to load the rating,
+      // especially if the user navigated to a new add-on.
       errorHandler.capturedError.responseStatusCode !== 429
     ) {
       log.warn('Not loading data because of an error');

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -69,7 +69,10 @@ export class RatingManagerBase extends React.Component<InternalProps> {
   componentDidMount() {
     const { addon, dispatch, errorHandler, userId, userReview } = this.props;
 
-    if (errorHandler.hasError()) {
+    if (
+      errorHandler.hasError() &&
+      errorHandler.capturedError.responseStatusCode !== 429
+    ) {
       log.warn('Not loading data because of an error');
       return;
     }

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { createEvent, fireEvent } from '@testing-library/react';
 import defaultUserEvent from '@testing-library/user-event';
 
+import { createApiError } from 'amo/api';
 import {
   ADDON_TYPE_DICT,
   ADDON_TYPE_EXTENSION,
@@ -178,6 +179,31 @@ describe(__filename, () => {
 
     expect(dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: FETCH_LATEST_USER_REVIEW }),
+    );
+  });
+
+  it('dispatches fetchLatestUserReview if there was a 429 error', () => {
+    const addonId = 123;
+    const userId = 12889;
+    const addon = createInternalAddonWithLang({ ...fakeAddon, id: addonId });
+    dispatchSignInActionsWithStore({ store, userId });
+    createFailedErrorHandler({
+      id: errorHandlerId,
+      error: createApiError({ response: { status: 429 } }),
+      store,
+    });
+
+    const dispatch = jest.spyOn(store, 'dispatch');
+
+    render({ addon });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      fetchLatestUserReview({
+        addonId: addon.id,
+        addonSlug: addon.slug,
+        errorHandlerId,
+        userId,
+      }),
     );
   });
 


### PR DESCRIPTION
Fixes #11885 