### PR TITLE
Add Tajik (tg) to languages.js

### DIFF
--- a/src/amo/languages.js
+++ b/src/amo/languages.js
@@ -579,6 +579,10 @@ export const unfilteredLanguages = {
     English: 'Telugu',
     native: '\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41',
   },
+  tg: {
+    English: 'Tajik',
+    native: '\u0422\u043e\u04b7\u0438\u043a\u04e3',
+  },
   th: {
     English: 'Thai',
     native: '\u0e44\u0e17\u0e22',


### PR DESCRIPTION
We plan to release this locale in Firefox 113, and this change will be needed to display the language pack in the [language-tools page](https://addons.mozilla.org/firefox/language-tools/).

Native name: Тоҷикӣ