### PR TITLE
Go back to 2 workers to run tests in CI for faster tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
       }
     },
     "test-ci": {
-      "command": "npm run version-check && npm run flow:check && bin/config-check.js && better-npm-run jest --color=false --coverage --runInBand",
+      "command": "npm run version-check && npm run flow:check && bin/config-check.js && better-npm-run jest --color=false --coverage --maxWorkers=2 --workerIdleMemoryLimit=1G",
       "env": {
         "NODE_ICU_DATA": "./node_modules/full-icu",
         "NODE_PATH": "./:./src",
@@ -148,7 +148,7 @@
       }
     },
     "test-ci-next": {
-      "command": "npm run version-check && npm run flow:check && bin/config-check.js && better-npm-run jest --color=false --coverage --runInBand",
+      "command": "npm run version-check && npm run flow:check && bin/config-check.js && better-npm-run jest --color=false --coverage --maxWorkers=2 --workerIdleMemoryLimit=1G",
       "env": {
         "NODE_ICU_DATA": "./node_modules/full-icu",
         "NODE_PATH": "./:./src",


### PR DESCRIPTION
with `--workerIdleMemoryLimit=1G` to work around jest memory consumption issues
