### PR TITLE
12033: Fixed overlapping header content onto dropdown menu at medium size

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -45,6 +45,7 @@
     align-self: end;
     grid-row: 1 / 2;
     margin: 48px 0 0;
+    width: 50%;
 
     &,
     .Header--loaded-page-is-anonymous & {


### PR DESCRIPTION
Fixes #12033

This patch adds responsiveness to the margin of the logo in the header at medium size. This is to not overlap the user drop down menu in order to keep it clickable at this scale.

Before:
<img width="909" alt="Screenshot 2023-05-05 at 10 36 37 AM" src="https://user-images.githubusercontent.com/63402349/236488867-37db71ea-ae87-433e-add6-283d99d40675.png">

After:
<img width="903" alt="Screenshot 2023-05-05 at 10 35 01 AM" src="https://user-images.githubusercontent.com/63402349/236488905-de9edeab-5960-47ce-99e8-8b9e8921e8e1.png">
