### PR TITLE
Issue 12034: Fixed search bar overlapping name

### DIFF
--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -239,11 +239,16 @@
     max-width: 250px;
   }
 
+  @include respond-to(large) {
+    grid-row: 2 / 3;
+  }
+
   @include respond-to(extraLarge) {
     align-self: center;
     margin: 0;
     max-width: 284px;
     width: 100%;
+    grid-row: 3 / 3;
   }
 
   &.Header-search-form--desktop {

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -239,10 +239,6 @@
     max-width: 250px;
   }
 
-  @include respond-to(large) {
-    grid-row: 2 / 3;
-  }
-
   @include respond-to(extraLarge) {
     align-self: center;
     margin: 0;


### PR DESCRIPTION
Fixes #12034

When the screen size is extraLarge, lower the row of the search bar once more. This ensures no overlap occurs.

Before:
<img width="1143" alt="Screenshot 2023-05-05 at 1 56 38 PM" src="https://user-images.githubusercontent.com/63402349/236533794-17739191-74d4-4ea1-b81a-f158594e4691.png">

After:
<img width="1138" alt="Screenshot 2023-05-05 at 1 56 22 PM" src="https://user-images.githubusercontent.com/63402349/236533791-113c95a4-dabe-49c8-b804-a1f3f8225497.png">

