### PR TITLE
use lang from api for addon fields in html

### DIFF
--- a/src/amo/components/AddonHead/index.js
+++ b/src/amo/components/AddonHead/index.js
@@ -57,7 +57,7 @@ export class AddonHeadBase extends React.Component<InternalProps> {
     invariant(addon, 'addon is required');
 
     const i18nValues = {
-      addonName: addon.name,
+      addonName: addon.name.content,
       locale: lang,
     };
 
@@ -130,8 +130,8 @@ export class AddonHeadBase extends React.Component<InternalProps> {
     return i18n.sprintf(
       i18n.gettext('Download %(addonName)s for Firefox. %(summary)s'),
       {
-        addonName: addon.name,
-        summary: addon.summary,
+        addonName: addon.name.content,
+        summary: addon.summary ? addon.summary.content : null,
       },
     );
   }

--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -122,12 +122,13 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
     }
 
     let supportEmail: React.Element<'li'> | null;
-    if (addon.support_email && /.+@.+/.test(addon.support_email)) {
+    if (addon.support_email && /.+@.+/.test(addon.support_email.content)) {
       supportEmail = (
         <li>
           <a
             className="AddonMoreInfo-support-email"
-            href={`mailto:${addon.support_email}`}
+            href={`mailto:${addon.support_email.content}`}
+            lang={addon.support_email.locale}
           >
             {i18n.gettext('Support Email')}
           </a>

--- a/src/amo/components/AddonTitle/index.js
+++ b/src/amo/components/AddonTitle/index.js
@@ -77,10 +77,10 @@ export const AddonTitleBase = ({
                 queryParamsForAttribution,
               )}
             >
-              {addon.name}
+              {addon.name.content}
             </Link>
           ) : (
-            addon.name
+            addon.name.content
           )}
           {authors.length > 0 && (
             <span className="AddonTitle-author">

--- a/src/amo/components/EditableCollectionAddon/index.js
+++ b/src/amo/components/EditableCollectionAddon/index.js
@@ -113,9 +113,11 @@ export class EditableCollectionAddonBase extends React.Component<InternalProps> 
           <img
             className="EditableCollectionAddon-icon"
             src={iconURL}
-            alt={addon.name}
+            alt={addon.name.content}
           />
-          <h2 className="EditableCollectionAddon-name">{addon.name}</h2>
+          <h2 className="EditableCollectionAddon-name" lang={addon.name.locale}>
+            {addon.name.content}
+          </h2>
         </div>
         <div className="EditableCollectionAddon-buttons">
           <div

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -184,7 +184,7 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
           ? {}
           : { rel: 'noopener noreferrer', target: '_blank' };
         if (addon) {
-          heading = addon.name;
+          heading = addon.name.content;
           link = (
             <Link
               className="HeroRecommendation-link"

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -196,7 +196,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
 
     const promptHTML = sanitizeHTML(
       i18n.sprintf(prompt, {
-        addonName: `<b lang="${addon.name.locale}">${addon.name.content}</b>`,
+        addonName: `<b>${addon.name.content}</b>`,
       }),
       ['b'],
     );

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -195,7 +195,9 @@ export class RatingManagerBase extends React.Component<InternalProps> {
     }
 
     const promptHTML = sanitizeHTML(
-      i18n.sprintf(prompt, { addonName: `<b>${addon.name}</b>` }),
+      i18n.sprintf(prompt, {
+        addonName: `<b lang="${addon.name.locale}">${addon.name.content}</b>`,
+      }),
       ['b'],
     );
 
@@ -206,6 +208,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
           <legend
             className="RatingManager-legend"
             dangerouslySetInnerHTML={promptHTML}
+            lang={addon.name.locale}
           />
           {/* eslint-enable react/no-danger */}
           <div className="RatingManager-ratingControl">

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -130,7 +130,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
           to={this.getAddonLink(addon, addonInstallSource)}
           onClick={this.onClickAddon}
         >
-          {addon.name}
+          {addon.name.content}
         </Link>
       );
     }
@@ -164,7 +164,10 @@ export class SearchResultBase extends React.Component<InternalProps> {
     if (showSummary) {
       const summaryProps = {};
       if (addon) {
-        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(addon.summary);
+        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(
+          addon.summary ? addon.summary.content : '',
+        );
+        summaryProps.lang = addon.summary ? addon.summary.locale : null;
       } else {
         summaryProps.children = <LoadingText />;
       }
@@ -188,7 +191,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
                   'SearchResult-icon--loading': !addon,
                 })}
                 src={imageURL}
-                alt={addon ? `${addon.name}` : ''}
+                alt={addon ? `${addon.name.content}` : ''}
               />
             ) : (
               <p className="SearchResult-notheme">

--- a/src/amo/components/ThemeImage/index.js
+++ b/src/amo/components/ThemeImage/index.js
@@ -31,7 +31,7 @@ export const ThemeImageBase = ({
     'A ThemeImage can only be rendered for a static theme',
   );
   const label = i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
-    title: addon.name,
+    title: addon.name.content,
   });
 
   return (

--- a/src/amo/installAddon.js
+++ b/src/amo/installAddon.js
@@ -42,6 +42,7 @@ import type { AppState } from 'amo/store';
 import type { AddonVersionType } from 'amo/reducers/versions';
 import type { AddonType } from 'amo/types/addons';
 import type { DispatchFunc } from 'amo/types/redux';
+import type { LocalizedStringWithLocale } from 'amo/types/api';
 
 type AddonInstallType = {|
   maxProgress: number,
@@ -60,7 +61,7 @@ type MakeProgressHandlerParams = {|
   _tracking: typeof tracking,
   dispatch: DispatchFunc,
   guid: string,
-  name: string,
+  name: LocalizedStringWithLocale,
   type: string,
 |};
 
@@ -142,7 +143,7 @@ type WithInstallHelpersInternalProps = {|
 
 type UninstallParams = {|
   guid: string,
-  name: string,
+  name: LocalizedStringWithLocale,
   type: string,
 |};
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -318,7 +318,11 @@ export class AddonBase extends React.Component {
   renderDevCommentsCard = () => {
     const { addon, i18n } = this.props;
 
-    if (!addon || !addon.developer_comments) {
+    if (
+      !addon ||
+      !addon.developer_comments ||
+      !addon.developer_comments.content
+    ) {
       return null;
     }
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -179,7 +179,7 @@ export class AddonBase extends React.Component {
 
     const label = addon
       ? i18n.sprintf(i18n.gettext('Preview of %(title)s'), {
-          title: addon.name,
+          title: addon.name.content,
         })
       : null;
 
@@ -283,13 +283,19 @@ export class AddonBase extends React.Component {
           title = i18n.gettext('About this add-on');
       }
 
-      const description = addon.description ? addon.description : addon.summary;
-      showAbout = description !== addon.summary;
+      const description = addon.description
+        ? addon.description.content
+        : addon.summary.content;
+      const descriptionLang = addon.description
+        ? addon.description.locale
+        : addon.summary.locale;
+      showAbout = description !== addon.summary.content;
 
       if (!description || !description.length) {
         return null;
       }
       descriptionProps.dangerouslySetInnerHTML = sanitizeUserHTML(description);
+      descriptionProps.lang = descriptionLang;
     } else {
       title = <LoadingText width={40} />;
       descriptionProps.children = <LoadingText width={100} />;
@@ -316,7 +322,7 @@ export class AddonBase extends React.Component {
       return null;
     }
 
-    const devComments = sanitizeUserHTML(addon.developer_comments);
+    const devComments = sanitizeUserHTML(addon.developer_comments.content);
     const showMoreCardName = 'Addon-developer-comments';
 
     /* eslint-disable react/no-danger */
@@ -330,6 +336,7 @@ export class AddonBase extends React.Component {
         <div
           className="Addon-developer-comments-contents"
           dangerouslySetInnerHTML={devComments}
+          lang={addon.developer_comments.locale}
         />
       </ShowMoreCard>
     );
@@ -429,13 +436,18 @@ export class AddonBase extends React.Component {
     if (addon) {
       // Themes lack a summary so we do the inverse :-/
       // TODO: We should file an API bug about this...
-      const summary = addon.summary ? addon.summary : addon.description;
-
+      const summary = addon.summary
+        ? addon.summary.content
+        : addon.description.content;
+      const summaryLang = addon.summary
+        ? addon.summary.locale
+        : addon.description.locale;
       if (summary && summary.length) {
         summaryProps.dangerouslySetInnerHTML = sanitizeHTML(nl2br(summary), [
           'a',
           'br',
         ]);
+        summaryProps.lang = summaryLang;
         showSummary = true;
       }
     } else {

--- a/src/amo/pages/AddonInfo/index.js
+++ b/src/amo/pages/AddonInfo/index.js
@@ -173,7 +173,7 @@ export class AddonInfoBase extends React.Component<InternalProps> {
     }
 
     if (addon) {
-      header = i18n.sprintf(title, { addonName: addon.name });
+      header = i18n.sprintf(title, { addonName: addon.name.content });
     }
 
     if (

--- a/src/amo/pages/AddonReviewList/index.js
+++ b/src/amo/pages/AddonReviewList/index.js
@@ -197,7 +197,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
     return i18n.sprintf(
       i18n.gettext(`Reviews and ratings for %(addonName)s. Find out what other
         users think about %(addonName)s and add it to your Firefox Browser.`),
-      { addonName: addon.name },
+      { addonName: addon.name.content },
     );
   }
 
@@ -260,7 +260,7 @@ export class AddonReviewListBase extends React.Component<InternalProps> {
 
     const header = addon
       ? i18n.sprintf(i18n.gettext('Reviews for %(addonName)s'), {
-          addonName: addon.name,
+          addonName: addon.name.content,
         })
       : '';
 

--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -134,7 +134,7 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
           versions.length,
         ),
         {
-          addonName: addon.name,
+          addonName: addon.name.content,
           total: i18n.formatNumber(versions.length),
         },
       );

--- a/src/amo/reducers/addons.js
+++ b/src/amo/reducers/addons.js
@@ -9,7 +9,10 @@ import type {
   UnloadAddonReviewsAction,
   UpdateRatingCountsAction,
 } from 'amo/actions/reviews';
-import { selectLocalizedContent } from 'amo/reducers/utils';
+import {
+  selectLocalizedContent,
+  selectLocalizedContentWithLocale,
+} from 'amo/reducers/utils';
 import { SET_LANG } from 'amo/reducers/api';
 import type { ExternalAddonInfoType } from 'amo/api/addonInfo';
 import type { AppState } from 'amo/store';
@@ -201,8 +204,8 @@ export function createInternalAddon(
     contributions_url: apiAddon.contributions_url,
     created: apiAddon.created,
     default_locale: apiAddon.default_locale,
-    description: selectLocalizedContent(apiAddon.description, lang),
-    developer_comments: selectLocalizedContent(
+    description: selectLocalizedContentWithLocale(apiAddon.description, lang),
+    developer_comments: selectLocalizedContentWithLocale(
       apiAddon.developer_comments,
       lang,
     ),
@@ -220,7 +223,7 @@ export function createInternalAddon(
     last_updated: apiAddon.last_updated,
     latest_unlisted_version: apiAddon.latest_unlisted_version,
     locale_disambiguation: apiAddon.locale_disambiguation,
-    name: selectLocalizedContent(apiAddon.name, lang),
+    name: selectLocalizedContentWithLocale(apiAddon.name, lang),
     previews: apiAddon.previews
       ? createInternalPreviews(apiAddon.previews, lang)
       : undefined,
@@ -230,8 +233,11 @@ export function createInternalAddon(
     review_url: apiAddon.review_url,
     slug: apiAddon.slug,
     status: apiAddon.status,
-    summary: selectLocalizedContent(apiAddon.summary, lang),
-    support_email: selectLocalizedContent(apiAddon.support_email, lang),
+    summary: selectLocalizedContentWithLocale(apiAddon.summary, lang),
+    support_email: selectLocalizedContentWithLocale(
+      apiAddon.support_email,
+      lang,
+    ),
     support_url: selectLocalizedUrlWithOutgoing(apiAddon.support_url, lang),
     tags: apiAddon.tags,
     target_locale: apiAddon.target_locale,

--- a/src/amo/reducers/utils.js
+++ b/src/amo/reducers/utils.js
@@ -17,3 +17,25 @@ export const selectLocalizedContent = (
 
   return field[lang];
 };
+
+export const selectLocalizedContentWithLocale = (
+  field: LocalizedString,
+  lang: string,
+) => {
+  invariant(lang, 'lang must not be empty');
+  if (!field) {
+    return null;
+  }
+
+  if (!field[lang]) {
+    return {
+      content: field[field._default],
+      locale: field._default,
+    };
+  }
+
+  return {
+    content: field[lang],
+    locale: lang,
+  };
+};

--- a/src/amo/types/addons.js
+++ b/src/amo/types/addons.js
@@ -9,6 +9,7 @@ import type {
   LocalizedUrlWithOutgoing,
   LocalizedString,
   UrlWithOutgoing,
+  LocalizedStringWithLocale,
 } from 'amo/types/api';
 
 export type AddonStatusType =
@@ -164,13 +165,13 @@ export type PartialExternalAddonType = {|
 export type AddonType = {|
   ...ExternalAddonType,
   // normalized l10n fields
-  description: string | null,
-  developer_comments: string | null,
+  description: LocalizedStringWithLocale | null,
+  developer_comments: LocalizedStringWithLocale | null,
   homepage: UrlWithOutgoing | null,
-  name: string,
+  name: LocalizedStringWithLocale,
   previews?: Array<PreviewType>,
-  summary: string | null,
-  support_email: string | null,
+  summary: LocalizedStringWithLocale | null,
+  support_email: LocalizedStringWithLocale | null,
   support_url: UrlWithOutgoing | null,
   // Here are some custom properties for our internal representation.
   currentVersionId: VersionIdType | null,

--- a/src/amo/types/api.js
+++ b/src/amo/types/api.js
@@ -22,6 +22,11 @@ export type LocalizedString = {
   [locale: string]: string,
 };
 
+export type LocalizedStringWithLocale = {
+  locale: string,
+  content: string,
+};
+
 export type UrlWithOutgoing = {|
   outgoing: string,
   url: string,

--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -33,7 +33,17 @@ export const StaticAddonCardBase = ({
     return null;
   }
 
-  const summary = addon.summary ? addon.summary : addon.description;
+  let summary;
+  let summaryLang;
+
+  if (addon.summary) {
+    summary = addon.summary.content;
+    summaryLang = addon.summary.locale;
+  } else if (addon.description) {
+    summary = addon.description.content;
+    summaryLang = addon.description.locale;
+  }
+
   const isTheme = addon.type === ADDON_TYPE_STATIC_THEME;
 
   return (
@@ -65,6 +75,7 @@ export const StaticAddonCardBase = ({
 
       <div className="StaticAddonCard-summary">
         <p
+          lang={summaryLang}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={sanitizeHTML(nl2br(summary), ['a', 'br'])}
         />

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -21,6 +21,7 @@ import {
   createInternalAddonWithLang,
   createLocalizedString,
   createStubErrorHandler,
+  DEFAULT_LANG_IN_TESTS,
   dispatchClientMetadata,
   dispatchSignInActions,
   fakeAddon,
@@ -185,6 +186,7 @@ describe(__filename, () => {
 
     const link = screen.getByText('Support Email');
     expect(link).toHaveAttribute('href', 'mailto:ba@bar.com');
+    expect(link).toHaveAttribute('lang', DEFAULT_LANG_IN_TESTS);
   });
 
   const _loadVersions = (versionProps = {}) => {

--- a/tests/unit/amo/components/TestAddonTitle.js
+++ b/tests/unit/amo/components/TestAddonTitle.js
@@ -89,7 +89,7 @@ describe(__filename, () => {
     render({ addon });
 
     // This makes sure only the add-on name is displayed.
-    expect(screen.getByRole('heading')).toHaveTextContent(addon.name);
+    expect(screen.getByRole('heading')).toHaveTextContent(addon.name.content);
     expect(
       screen.queryByClassName('AddonTitle-author'),
     ).not.toBeInTheDocument();
@@ -174,10 +174,9 @@ describe(__filename, () => {
     render({ addon, linkToAddon: true });
 
     expect(screen.getAllByRole('link')).toHaveLength(2);
-    expect(screen.getByRole('link', { name: addon.name })).toHaveAttribute(
-      'href',
-      `/en-US/android${getAddonURL(addon.slug)}`,
-    );
+    expect(
+      screen.getByRole('link', { name: addon.name.content }),
+    ).toHaveAttribute('href', `/en-US/android${getAddonURL(addon.slug)}`);
     expect(
       screen.getByRole('link', { name: addon.authors[0].name }),
     ).toHaveAttribute('href', `/en-US/android/user/${addon.authors[0].id}/`);
@@ -194,7 +193,9 @@ describe(__filename, () => {
     render({ addon, as: 'span' });
 
     expect(screen.queryByRole('heading')).not.toBeInTheDocument();
-    expect(screen.getAllByTagName('span')[0]).toHaveTextContent(addon.name);
+    expect(screen.getAllByTagName('span')[0]).toHaveTextContent(
+      addon.name.content,
+    );
   });
 
   it('accepts some query params for attribution to append to the add-on URL', () => {
@@ -207,7 +208,9 @@ describe(__filename, () => {
       queryParamsForAttribution,
     });
 
-    expect(screen.getByRole('link', { name: addon.name })).toHaveAttribute(
+    expect(
+      screen.getByRole('link', { name: addon.name.content }),
+    ).toHaveAttribute(
       'href',
       `/en-US/android${getAddonURL(addon.slug)}?some=value`,
     );

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -14,6 +14,7 @@ import {
   createHistory,
   createInternalAddonWithLang,
   createLocalizedString,
+  DEFAULT_LANG_IN_TESTS,
   dispatchClientMetadata,
   fakeAddon,
   fakeAuthor,
@@ -107,6 +108,12 @@ describe(__filename, () => {
     expect(
       screen.getByRole('heading', { name: addons[1].name.content }),
     ).toHaveClass('EditableCollectionAddon-name');
+    expect(
+      screen.getByRole('heading', { name: addons[0].name.content }),
+    ).toHaveAttribute('lang', addons[0].locale);
+    expect(
+      screen.getByRole('heading', { name: addons[1].name.content }),
+    ).toHaveAttribute('lang', addons[1].locale);
   });
 
   it('passes expected functions to editable add-ons', async () => {
@@ -447,6 +454,10 @@ describe(__filename, () => {
       });
 
       expect(screen.getByText(summary)).toBeInTheDocument();
+      expect(screen.getByText(summary)).toHaveAttribute(
+        'lang',
+        DEFAULT_LANG_IN_TESTS,
+      );
     });
 
     it('can hide the summary section', () => {

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -460,6 +460,21 @@ describe(__filename, () => {
       );
     });
 
+    it('does not render the summary nor the lang attribute if it is empty', () => {
+      renderWithResult({
+        addonProps: {
+          summary: createLocalizedString(''),
+        },
+      });
+
+      expect(
+        screen.getByClassName('SearchResult-summary'),
+      ).toBeEmptyDOMElement();
+      expect(
+        screen.queryByClassName('SearchResult-summary').getAttribute('lang'),
+      ).not.toBeInTheDocument();
+    });
+
     it('can hide the summary section', () => {
       const summary = 'Summary for an add-on';
       renderWithResult({

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -88,12 +88,12 @@ describe(__filename, () => {
 
     expect(screen.getByRole('list')).toBeInTheDocument();
     expect(screen.getAllByRole('listitem')).toHaveLength(2);
-    expect(screen.getByRole('link', { name: addons[0].name })).toHaveClass(
-      'SearchResult-link',
-    );
-    expect(screen.getByRole('link', { name: addons[1].name })).toHaveClass(
-      'SearchResult-link',
-    );
+    expect(
+      screen.getByRole('link', { name: addons[0].name.content }),
+    ).toHaveClass('SearchResult-link');
+    expect(
+      screen.getByRole('link', { name: addons[1].name.content }),
+    ).toHaveClass('SearchResult-link');
   });
 
   it('renders editable add-ons when supplied and requested', () => {
@@ -101,12 +101,12 @@ describe(__filename, () => {
 
     expect(screen.getByRole('list')).toBeInTheDocument();
     expect(screen.getAllByRole('listitem')).toHaveLength(2);
-    expect(screen.getByRole('heading', { name: addons[0].name })).toHaveClass(
-      'EditableCollectionAddon-name',
-    );
-    expect(screen.getByRole('heading', { name: addons[1].name })).toHaveClass(
-      'EditableCollectionAddon-name',
-    );
+    expect(
+      screen.getByRole('heading', { name: addons[0].name.content }),
+    ).toHaveClass('EditableCollectionAddon-name');
+    expect(
+      screen.getByRole('heading', { name: addons[1].name.content }),
+    ).toHaveClass('EditableCollectionAddon-name');
   });
 
   it('passes expected functions to editable add-ons', async () => {
@@ -177,10 +177,10 @@ describe(__filename, () => {
     render({ addons, loading: true });
 
     expect(
-      screen.getByRole('link', { name: addons[0].name }),
+      screen.getByRole('link', { name: addons[0].name.content }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: addons[1].name }),
+      screen.getByRole('link', { name: addons[1].name.content }),
     ).toBeInTheDocument();
   });
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -72,7 +72,7 @@ describe(__filename, () => {
     render({ addons });
 
     expect(
-      screen.getByRole('link', { name: addons[0].name }),
+      screen.getByRole('link', { name: addons[0].name.content }),
     ).toBeInTheDocument();
   });
 
@@ -86,10 +86,9 @@ describe(__filename, () => {
       'utm_medium=referral',
       `utm_content=${addonInstallSource}`,
     ].join('&');
-    expect(screen.getByRole('link', { name: addons[0].name })).toHaveAttribute(
-      'href',
-      expectedLink,
-    );
+    expect(
+      screen.getByRole('link', { name: addons[0].name.content }),
+    ).toHaveAttribute('href', expectedLink);
   });
 
   it('passes isHomepageShelf to AddonsCard', () => {

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -35,6 +35,7 @@ import {
   createInternalAddonWithLang,
   createInternalVersionWithLang,
   createLocalizedString,
+  DEFAULT_LANG_IN_TESTS,
   dispatchClientMetadata,
   dispatchSignInActionsWithStore,
   fakeAddon,
@@ -416,6 +417,10 @@ describe(__filename, () => {
       renderWithReview();
 
       expect(screen.getByClassName('RatingManager-legend')).toBeInTheDocument();
+      expect(screen.getByClassName('RatingManager-legend')).toHaveAttribute(
+        'lang',
+        DEFAULT_LANG_IN_TESTS,
+      );
       expect(
         screen.getByClassName('RatingManager-UserRating'),
       ).toBeInTheDocument();

--- a/tests/unit/amo/components/TestSearchResults.js
+++ b/tests/unit/amo/components/TestSearchResults.js
@@ -94,9 +94,9 @@ describe(__filename, () => {
     });
 
     expect(
-      screen.getByRole('link', { name: results[0].name }),
+      screen.getByRole('link', { name: results[0].name.content }),
     ).toBeInTheDocument();
-    expect(screen.getByAltText(results[0].name)).toHaveAttribute(
+    expect(screen.getByAltText(results[0].name.content)).toHaveAttribute(
       'src',
       headerImageFull,
     );
@@ -115,10 +115,9 @@ describe(__filename, () => {
       'utm_medium=referral',
       `utm_content=${INSTALL_SOURCE_SEARCH}`,
     ].join('&');
-    expect(screen.getByRole('link', { name: results[0].name })).toHaveAttribute(
-      'href',
-      expectedLink,
-    );
+    expect(
+      screen.getByRole('link', { name: results[0].name.content }),
+    ).toHaveAttribute('href', expectedLink);
   });
 
   it('sets add-on install source to recommended when approrpriate', () => {
@@ -134,10 +133,9 @@ describe(__filename, () => {
       'utm_medium=referral',
       `utm_content=${INSTALL_SOURCE_FEATURED}`,
     ].join('&');
-    expect(screen.getByRole('link', { name: results[0].name })).toHaveAttribute(
-      'href',
-      expectedLink,
-    );
+    expect(
+      screen.getByRole('link', { name: results[0].name.content }),
+    ).toHaveAttribute('href', expectedLink);
   });
 
   it('passes a paginator as footer prop to the AddonsCard if supplied', () => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -80,6 +80,7 @@ import {
   createFakeErrorHandler,
   createLocalizedString,
   createExperimentCookie,
+  DEFAULT_LANG_IN_TESTS,
   dispatchClientMetadata,
   dispatchSignInActionsWithStore,
   fakeAddon,
@@ -671,6 +672,7 @@ describe(__filename, () => {
     expect(
       within(addonSummary).queryByTagName('script'),
     ).not.toBeInTheDocument();
+    expect(addonSummary).toHaveAttribute('lang', DEFAULT_LANG_IN_TESTS);
   });
 
   it('adds <br> tags for newlines in a summary', () => {
@@ -695,6 +697,10 @@ describe(__filename, () => {
     expect(
       within(addonDescription).queryByTagName('script'),
     ).not.toBeInTheDocument();
+    expect(screen.getByClassName('AddonDescription-contents')).toHaveAttribute(
+      'lang',
+      DEFAULT_LANG_IN_TESTS,
+    );
   });
 
   // This is a test helper that can be used to test the integration between
@@ -858,6 +864,9 @@ describe(__filename, () => {
 
     expect(screen.getByText('Developer comments')).toBeInTheDocument();
     expect(screen.getByText(developerComments)).toBeInTheDocument();
+    expect(
+      screen.getByClassName('Addon-developer-comments-contents'),
+    ).toHaveAttribute('lang', DEFAULT_LANG_IN_TESTS);
   });
 
   it('passes the expected contentId to ShowMoreCard for developer comments', async () => {

--- a/tests/unit/amo/reducers/test_addons.js
+++ b/tests/unit/amo/reducers/test_addons.js
@@ -875,7 +875,7 @@ describe(__filename, () => {
   });
 
   describe('createInternalAddon', () => {
-    it('coverts localized strings into simple strings', () => {
+    it('coverts localized strings into localized strings with locale', () => {
       const description = 'Some description';
       const developer_comments = 'developer comments';
       const homepage = {
@@ -913,12 +913,17 @@ describe(__filename, () => {
       );
 
       expect(addon.description.content).toEqual(description);
+      expect(addon.description.locale).toEqual(lang);
       expect(addon.developer_comments.content).toEqual(developer_comments);
+      expect(addon.developer_comments.locale).toEqual(lang);
       expect(addon.homepage).toEqual(homepage);
       expect(addon.name.content).toEqual(name);
+      expect(addon.name.locale).toEqual(lang);
       expect(addon.previews).toEqual(createInternalPreviews(previews, lang));
       expect(addon.summary.content).toEqual(summary);
+      expect(addon.summary.locale).toEqual(lang);
       expect(addon.support_email.content).toEqual(support_email);
+      expect(addon.support_email.locale).toEqual(lang);
       expect(addon.support_url).toEqual(support_url);
     });
   });

--- a/tests/unit/amo/reducers/test_addons.js
+++ b/tests/unit/amo/reducers/test_addons.js
@@ -912,13 +912,13 @@ describe(__filename, () => {
         lang,
       );
 
-      expect(addon.description).toEqual(description);
-      expect(addon.developer_comments).toEqual(developer_comments);
+      expect(addon.description.content).toEqual(description);
+      expect(addon.developer_comments.content).toEqual(developer_comments);
       expect(addon.homepage).toEqual(homepage);
-      expect(addon.name).toEqual(name);
+      expect(addon.name.content).toEqual(name);
       expect(addon.previews).toEqual(createInternalPreviews(previews, lang));
-      expect(addon.summary).toEqual(summary);
-      expect(addon.support_email).toEqual(support_email);
+      expect(addon.summary.content).toEqual(summary);
+      expect(addon.support_email.content).toEqual(support_email);
       expect(addon.support_url).toEqual(support_url);
     });
   });

--- a/tests/unit/amo/reducers/test_utils.js
+++ b/tests/unit/amo/reducers/test_utils.js
@@ -1,4 +1,7 @@
-import { selectLocalizedContent } from 'amo/reducers/utils';
+import {
+  selectLocalizedContent,
+  selectLocalizedContentWithLocale,
+} from 'amo/reducers/utils';
 
 describe(__filename, () => {
   describe('selectLocalizedContent', () => {
@@ -31,6 +34,42 @@ describe(__filename, () => {
           requestedLang,
         ),
       ).toEqual(expected);
+    });
+  });
+
+  describe('selectLocalizedContentWithLocale', () => {
+    it('returns null if field is falsey', () => {
+      expect(selectLocalizedContentWithLocale(null, 'en-US')).toEqual(null);
+    });
+
+    it('returns a translation if found', () => {
+      const expected = 'expected string';
+      const unexpected = 'unexpected string';
+      const lang = 'en-US';
+
+      expect(
+        selectLocalizedContentWithLocale(
+          { [lang]: expected, fr: unexpected },
+          lang,
+        ),
+      ).toEqual({ locale: lang, content: expected });
+    });
+
+    it('returns a translation from the default lang if not found', () => {
+      const expected = 'expected string';
+      const defaultLang = 'en-US';
+      const requestedLang = 'fr';
+
+      expect(
+        selectLocalizedContentWithLocale(
+          {
+            [defaultLang]: expected,
+            fr: null,
+            _default: defaultLang,
+          },
+          requestedLang,
+        ),
+      ).toEqual({ locale: defaultLang, content: expected });
     });
   });
 });

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -10,6 +10,7 @@ import {
   fakeAddon,
   createLocalizedString,
   createInternalAddonWithLang,
+  DEFAULT_LANG_IN_TESTS,
   dispatchClientMetadata,
   render as defaultRender,
   screen,
@@ -114,6 +115,10 @@ describe(__filename, () => {
     expect(
       screen.getByClassName('StaticAddonCard-summary'),
     ).not.toHaveTextContent('<script>');
+    expect(screen.getByText(plainText)).toHaveAttribute(
+      'lang',
+      DEFAULT_LANG_IN_TESTS,
+    );
   });
 
   it('displays the number of users', () => {

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -71,7 +71,7 @@ describe(__filename, () => {
       }),
     ).toHaveTextContent('Recommended');
 
-    expect(screen.getByText(addon.summary)).toBeInTheDocument();
+    expect(screen.getByText(addon.summary.content)).toBeInTheDocument();
 
     // GetFirefoxButton
     expect(
@@ -91,7 +91,7 @@ describe(__filename, () => {
 
     render({ addon });
 
-    expect(screen.getByText(addon.description)).toBeInTheDocument();
+    expect(screen.getByText(addon.description.content)).toBeInTheDocument();
   });
 
   it('sanitizes the summary', () => {


### PR DESCRIPTION
Fixes #3049 

Create a new type LocalizedStringWithLocale and new function SelectLocalizedContentWithLocale so that the AddonType (internal Addon) fields that previously use SelectLocalizedContent now contains a 'locale' field. Everywhere in the code where any of these 5 fields (summary, name, description, support_email, developer_comments) exist, the surrounding HTML will contain a lang tag (if applicable).
