### PR TITLE
Add config to filter out/consider non-recommended/line extensions for Android incompatible

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -45,12 +45,9 @@ module.exports = {
   isDeployed: true,
   isDevelopment: false,
 
-  // For all Firefox 57+ (Quantum) UAs, send the `appversion` in all API
-  // search requests. This will return only compatible add-ons, which is
-  // good for UX (it prevents a lot of incompatible old add-ons).
-  // Disable this in development when working with stage data, which is
-  // very out-of-date and mostly not 57+ compatible.
-  restrictSearchResultsToAppVersion: true,
+  // Force Android pages to only show/allow install of recommended/line add-ons
+  // instead of showing/allowing all marked as compatible.
+  restrictAndroidToRecommended: true,
 
   // The node server host and port.
   serverHost: '127.0.0.1',
@@ -107,7 +104,7 @@ module.exports = {
     'langs',
     'loggingLevel',
     'mozillaUserId',
-    'restrictSearchResultsToAppVersion',
+    'restrictAndroidToRecommended',
     'rtlLangs',
     'staticPath',
     'trackingEnabled',

--- a/config/dev.js
+++ b/config/dev.js
@@ -41,4 +41,7 @@ module.exports = {
   allowErrorSimulation: true,
 
   extensionWorkshopUrl: 'https://extensionworkshop-dev.allizom.org',
+
+  // For testing until we remove that restriction in stage&prod too
+  restrictAndroidToRecommended: false,
 };

--- a/config/development-local.js
+++ b/config/development-local.js
@@ -18,4 +18,7 @@ module.exports = {
 
   // See: https://github.com/mozilla/addons-frontend/issues/10545
   enableTrailingSlashesMiddleware: false,
+
+  // For testing until we remove that restriction in stage&prod too
+  restrictAndroidToRecommended: false,
 };

--- a/config/development.js
+++ b/config/development.js
@@ -14,11 +14,8 @@ module.exports = {
   proxyPort: 3000,
   proxyEnabled: true,
 
-  // Setting this to false returns add-ons that are not compatible but means
-  // developers can pull from a much larger dataset on the local/-dev/-stage
-  // servers. Set this to true to only get compatible add-ons (this is what
-  // happens in production) but get a lot fewer add-ons in search results.
-  restrictSearchResultsToAppVersion: false,
+  // For testing until we remove that restriction in stage&prod too
+  restrictAndroidToRecommended: false,
 
   fxaConfig: 'local',
   trackingEnabled: false,

--- a/src/amo/api/index.js
+++ b/src/amo/api/index.js
@@ -12,7 +12,6 @@ import log from 'amo/logger';
 import {
   addVersionCompatibilityToFilters,
   convertFiltersToQueryParams,
-  fixFiltersForClientApp,
 } from 'amo/searchUtils';
 import { addQueryParams } from 'amo/utils/url';
 import type { ApiState } from 'amo/reducers/api';
@@ -298,7 +297,6 @@ export function logOutFromServer({
 }
 
 export type AutocompleteParams = {|
-  _fixFiltersForClientApp?: typeof fixFiltersForClientApp,
   api: ApiState,
   filters: {|
     query: string,
@@ -307,13 +305,12 @@ export type AutocompleteParams = {|
 |};
 
 export function autocomplete({
-  _fixFiltersForClientApp = fixFiltersForClientApp,
   api,
   filters,
 }: AutocompleteParams): Promise<Array<ExternalSuggestion>> {
   const filtersWithAppVersion = addVersionCompatibilityToFilters({
-    filters: _fixFiltersForClientApp({ api, filters }),
-    userAgentInfo: api.userAgentInfo,
+    filters: filters,
+    api: api,
   });
 
   return callApi({

--- a/src/amo/api/search.js
+++ b/src/amo/api/search.js
@@ -6,7 +6,6 @@ import { callApi } from 'amo/api';
 import {
   addVersionCompatibilityToFilters,
   convertFiltersToQueryParams,
-  fixFiltersForClientApp,
 } from 'amo/searchUtils';
 import log from 'amo/logger';
 import type { ApiState } from 'amo/reducers/api';
@@ -31,21 +30,19 @@ export type SearchFilters = {|
 |};
 
 export type SearchParams = {|
-  _fixFiltersForClientApp?: typeof fixFiltersForClientApp,
   api: ApiState,
   auth?: boolean,
   filters: SearchFilters,
 |};
 
 export function search({
-  _fixFiltersForClientApp = fixFiltersForClientApp,
   api,
   auth = false,
   filters = {},
 }: SearchParams): Promise<PaginatedApiResponse<ExternalAddonType>> {
   const newFilters = addVersionCompatibilityToFilters({
-    filters: _fixFiltersForClientApp({ api, filters }),
-    userAgentInfo: api.userAgentInfo,
+    filters: filters,
+    api: api,
   });
 
   // The API says: 'The "sort" parameter "random" can only be specified when

--- a/src/amo/utils/compatibility.js
+++ b/src/amo/utils/compatibility.js
@@ -22,7 +22,6 @@ import {
   RECOMMENDED,
 } from 'amo/constants';
 import log from 'amo/logger';
-import { getPromotedCategory } from 'amo/utils/addons';
 import type { AddonVersionType } from 'amo/reducers/versions';
 import type { UserAgentInfoType } from 'amo/reducers/api';
 import type { AddonType } from 'amo/types/addons';
@@ -115,16 +114,13 @@ export const isAndroidInstallable = ({
 }: {
   addon: AddonType | null,
 }): boolean => {
-  // Only extensions that are recommended on android are considered compatible.
+  // if restrictAndroidToRecommended config is true, only extensions that are
+  // recommended/line on android are considered compatible.
   // See https://github.com/mozilla/addons-frontend/issues/9713.
+  // FIXME pass config to do that
   return (
     !!addon &&
-    addon.type === ADDON_TYPE_EXTENSION &&
-    getPromotedCategory({
-      addon,
-      clientApp: CLIENT_APP_ANDROID,
-    }) === RECOMMENDED
-  );
+    addon.type === ADDON_TYPE_EXTENSION);
 };
 
 export type IsCompatibleWithUserAgentParams = {|


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12372
Fixes https://github.com/mozilla/addons-frontend/issues/12379

TODO:
- [ ] Restore restriction on recommended in `isAndroidInstallable` if `restrictAndroidToRecommended` is `true` in config
- [ ] Update & add tests