### PR TITLE
Enable non-recommended extensions for Android on all envs

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -410,7 +410,7 @@ module.exports = {
 
   enableFeatureVPNPromo: true,
 
-  enableFeatureMoreAndroidExtensions: false,
+  enableFeatureMoreAndroidExtensions: true,
 
   extensionWorkshopUrl: 'https://extensionworkshop.com',
 


### PR DESCRIPTION
Compatibility filtering still applies, this should only really affect users of 119 Nightly/Beta for now, given
https://github.com/mozilla/addons-server/issues/21162

Follow-up for #12372 which only enabled it on dev.