### PR TITLE
 Include Add-on name and Add-on Icon in each review under "My reviews" on User Profile

### DIFF
--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -80,12 +80,11 @@ export function createInternalReview(
   review: ExternalReviewType | ExternalReviewReplyType,
   lang: string = '',
 ): UserReviewType {
-  const effectiveLang = lang || 'en-US';
   return {
     reviewAddon: {
       iconUrl: review.addon.icon_url,
       id: review.addon.id,
-      name: selectLocalizedContent(review.addon.name, effectiveLang),
+      name: selectLocalizedContent(review.addon.name, lang),
       slug: review.addon.slug,
     },
     body: review.body,
@@ -95,9 +94,7 @@ export function createInternalReview(
     isDeveloperReply: review.is_developer_reply,
     isLatest: review.is_latest,
     score: review.score || null,
-    reply: review.reply
-      ? createInternalReview(review.reply, effectiveLang)
-      : null,
+    reply: review.reply ? createInternalReview(review.reply, lang) : null,
     userId: review.user.id,
     userName: review.user.name,
     userUrl: review.user.url,

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -7,6 +7,7 @@ import type {
   ExternalReviewType,
 } from 'amo/api/reviews';
 import type { UserId } from 'amo/reducers/users';
+import { selectLocalizedContent } from 'amo/reducers/utils';
 
 export const CREATE_ADDON_REVIEW: 'CREATE_ADDON_REVIEW' = 'CREATE_ADDON_REVIEW';
 export const SHOW_EDIT_REVIEW_FORM: 'SHOW_EDIT_REVIEW_FORM' =
@@ -55,7 +56,7 @@ export const UPDATE_RATING_COUNTS: 'UPDATE_RATING_COUNTS' =
 export type ReviewAddonType = {|
   iconUrl: string,
   id: number,
-  name: Object,
+  name: string,
   slug: string,
 |};
 
@@ -82,7 +83,7 @@ export function createInternalReview(
     reviewAddon: {
       iconUrl: review.addon.icon_url,
       id: review.addon.id,
-      name: review.addon.name,
+      name: selectLocalizedContent(review.addon.name, 'en-US'),
       slug: review.addon.slug,
     },
     body: review.body,

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -55,7 +55,7 @@ export const UPDATE_RATING_COUNTS: 'UPDATE_RATING_COUNTS' =
 export type ReviewAddonType = {|
   iconUrl: string,
   id: number,
-  name: string,
+  name: Object,
   slug: string,
 |};
 

--- a/src/amo/actions/reviews.js
+++ b/src/amo/actions/reviews.js
@@ -78,12 +78,14 @@ export type UserReviewType = {|
 
 export function createInternalReview(
   review: ExternalReviewType | ExternalReviewReplyType,
+  lang: string = '',
 ): UserReviewType {
+  const effectiveLang = lang || 'en-US';
   return {
     reviewAddon: {
       iconUrl: review.addon.icon_url,
       id: review.addon.id,
-      name: selectLocalizedContent(review.addon.name, 'en-US'),
+      name: selectLocalizedContent(review.addon.name, effectiveLang),
       slug: review.addon.slug,
     },
     body: review.body,
@@ -93,7 +95,9 @@ export function createInternalReview(
     isDeveloperReply: review.is_developer_reply,
     isLatest: review.is_latest,
     score: review.score || null,
-    reply: review.reply ? createInternalReview(review.reply) : null,
+    reply: review.reply
+      ? createInternalReview(review.reply, effectiveLang)
+      : null,
     userId: review.user.id,
     userName: review.user.name,
     userUrl: review.user.url,

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -8,12 +8,13 @@ import type { FlagReviewReasonType } from 'amo/constants';
 import type { ApiState } from 'amo/reducers/api';
 import type { ErrorHandlerType } from 'amo/types/errorHandler';
 import type { PaginatedApiResponse } from 'amo/types/api';
+import type { LocalizedString } from 'amo/types/api';
 
 type ExternalReviewTypeBase = {|
   addon: {|
     icon_url: string,
     id: number,
-    name: string,
+    name: LocalizedString,
     slug: string,
   |},
   body: string,

--- a/src/amo/api/reviews.js
+++ b/src/amo/api/reviews.js
@@ -7,8 +7,7 @@ import { callApi } from 'amo/api';
 import type { FlagReviewReasonType } from 'amo/constants';
 import type { ApiState } from 'amo/reducers/api';
 import type { ErrorHandlerType } from 'amo/types/errorHandler';
-import type { PaginatedApiResponse } from 'amo/types/api';
-import type { LocalizedString } from 'amo/types/api';
+import type { PaginatedApiResponse, LocalizedString } from 'amo/types/api';
 
 type ExternalReviewTypeBase = {|
   addon: {|

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -552,7 +552,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           {this.props.isUserProfile &&
             addonName &&
             addonIconURL &&
-            this.isReply() && (
+            !this.isReply() && (
               <div className="AddonReviewCard-addonInfo">
                 <img src={addonIconURL} alt={`Icon for ${addonName}`} />
                 <span>

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -359,11 +359,8 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     } = this.props;
 
     let byLine;
-    const addonIconURL = review ? review.reviewAddon.iconUrl : null;
-    const addonName =
-      review?.reviewAddon?.name?.['en-US'] ||
-      review?.reviewAddon?.name?.[review?.reviewAddon?.name?._default] ||
-      null;
+    const addonIconURL = review?.reviewAddon?.iconUrl || null;
+    const addonName = review?.reviewAddon?.name || null;
     const noAuthor = shortByLine || this.isReply();
     const showUserProfileLink = !noAuthor && hasUsersEditPermission;
 
@@ -552,19 +549,20 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
         <div className="AddonReviewCard-container">
           {errorHandler.renderErrorIfPresent()}
           {/* Div to display Addon's name and icon */}
-          {this.props.isUserProfile && addonName && addonIconURL && (
-            <div className="AddonReviewCard-addonInfo">
-              <img src={addonIconURL} alt={`Icon for ${addonName}`} />
-              <span>
-                <span className="AddonReviewCard-addonReviewLabel">
-                  Review of{' '}
+          {this.props.isUserProfile &&
+            addonName &&
+            addonIconURL &&
+            this.isReply() && (
+              <div className="AddonReviewCard-addonInfo">
+                <img src={addonIconURL} alt={`Icon for ${addonName}`} />
+                <span>
+                  <span className="AddonReviewCard-addonReviewLabel">
+                    Review of{' '}
+                  </span>
+                  <span className="AddonReviewCard-addonName">{addonName}</span>
                 </span>
-                <span className="AddonReviewCard-addonNameBold">
-                  {addonName}
-                </span>
-              </span>
-            </div>
-          )}
+              </div>
+            )}
 
           {review && review.isDeleted && (
             <Notice type="error" className="AddonReviewCard-non-public-notice">

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -554,10 +554,13 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
             addonIconURL &&
             !this.isReply() && (
               <div className="AddonReviewCard-addonInfo">
-                <img src={addonIconURL} alt={`Icon for ${addonName}`} />
+                <img
+                  src={addonIconURL}
+                  alt={i18n.sprintf(i18n.gettext('Icon for %1$s'), addonName)}
+                />
                 <span>
                   <span className="AddonReviewCard-addonReviewLabel">
-                    Review of{' '}
+                    {i18n.sprintf(i18n.gettext('Review of %1$s'), addonName)}
                   </span>
                   <span className="AddonReviewCard-addonName">{addonName}</span>
                 </span>

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -556,11 +556,15 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
               <div className="AddonReviewCard-addonInfo">
                 <img
                   src={addonIconURL}
-                  alt={i18n.sprintf(i18n.gettext('Icon for %1$s'), addonName)}
+                  alt={i18n.sprintf(i18n.gettext('Icon for %1$s'), {
+                    '%1$s': addonName,
+                  })}
                 />
                 <span>
                   <span className="AddonReviewCard-addonReviewLabel">
-                    {i18n.sprintf(i18n.gettext('Review of %1$s'), addonName)}
+                    {i18n.sprintf(i18n.gettext('Review of %1$s'), {
+                      '%1$s': addonName,
+                    })}
                   </span>
                   <span className="AddonReviewCard-addonName">{addonName}</span>
                 </span>

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -359,7 +359,10 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
     let byLine;
     const addonIconURL = review ? review.reviewAddon.iconUrl : null;
-    const addonName = review ? review.reviewAddon.name['en-US'] : null;
+    const addonName = review
+      ? review.reviewAddon.name['en-US'] ||
+        review.reviewAddon.name[review.reviewAddon.name._default]
+      : null;
     const noAuthor = shortByLine || this.isReply();
     const showUserProfileLink = !noAuthor && hasUsersEditPermission;
 

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -360,10 +360,10 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
     let byLine;
     const addonIconURL = review ? review.reviewAddon.iconUrl : null;
-    const addonName = review
-      ? review.reviewAddon.name['en-US'] ||
-        review.reviewAddon.name[review.reviewAddon.name._default]
-      : null;
+    const addonName =
+      review?.reviewAddon?.name?.['en-US'] ||
+      review?.reviewAddon?.name?.[review?.reviewAddon?.name?._default] ||
+      null;
     const noAuthor = shortByLine || this.isReply();
     const showUserProfileLink = !noAuthor && hasUsersEditPermission;
 

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -358,6 +358,8 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
     } = this.props;
 
     let byLine;
+    const addonIconURL = review ? review.reviewAddon.iconUrl : null;
+    const addonName = review ? review.reviewAddon.name['en-US'] : null;
     const noAuthor = shortByLine || this.isReply();
     const showUserProfileLink = !noAuthor && hasUsersEditPermission;
 
@@ -545,6 +547,21 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       >
         <div className="AddonReviewCard-container">
           {errorHandler.renderErrorIfPresent()}
+          {/* Div to display Addon's name and icon */}
+          {addonName && addonIconURL && (
+            <div className="AddonReviewCard-addonInfo">
+              <img src={addonIconURL} alt={`Icon for ${addonName}`} />
+              <span>
+                <span className="AddonReviewCard-addonReviewLabel">
+                  Review of{' '}
+                </span>
+                <span className="AddonReviewCard-addonNameBold">
+                  {addonName}
+                </span>
+              </span>
+            </div>
+          )}
+
           {review && review.isDeleted && (
             <Notice type="error" className="AddonReviewCard-non-public-notice">
               {i18n.gettext(

--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -67,6 +67,7 @@ type Props = {|
   isReplyToReviewId?: number,
   review?: UserReviewType | null,
   siteUserCanReply: ?boolean,
+  isUserProfile?: boolean,
 |};
 
 type PropsFromState = {|
@@ -551,7 +552,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
         <div className="AddonReviewCard-container">
           {errorHandler.renderErrorIfPresent()}
           {/* Div to display Addon's name and icon */}
-          {addonName && addonIconURL && (
+          {this.props.isUserProfile && addonName && addonIconURL && (
             <div className="AddonReviewCard-addonInfo">
               <img src={addonIconURL} alt={`Icon for ${addonName}`} />
               <span>

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -28,7 +28,7 @@
   margin-left: 10px;
 }
 
-.AddonReviewCard-addonNameBold {
+.AddonReviewCard-addonName {
   font-weight: bold;
 }
 

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -27,7 +27,7 @@
 
 .AddonReviewCard-addonReviewLabel {
   font-weight: normal;
-  margin-left: 4px;
+  margin-left: 3px;
 }
 
 .AddonReviewCard-addonName {
@@ -43,7 +43,6 @@
 .AddonReviewCard-addonInfo img {
   max-width: 20px;
   max-height: 20px;
-  margin-left: -23px;
 }
 
 .AddonReviewCard-authorByLine {

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -3,6 +3,8 @@
 .AddonReviewCard {
   .Rating {
     height: $font-size-l;
+    margin-top: auto;
+    padding: auto;
   }
 
   &:not(.AddonReviewCard-slim) .UserReview-body {
@@ -25,7 +27,7 @@
 
 .AddonReviewCard-addonReviewLabel {
   font-weight: normal;
-  margin-left: 10px;
+  margin-left: 4px;
 }
 
 .AddonReviewCard-addonName {
@@ -35,16 +37,13 @@
 .AddonReviewCard-addonInfo {
   display: flex;
   align-items: center;
-  background-color: #f2f2f2;
-  padding: 10px;
-  border-radius: 5px;
-  margin-bottom: 10px;
+  padding: auto;
 }
 
 .AddonReviewCard-addonInfo img {
-  max-width: 40px;
-  max-height: 40px;
-  margin-right: 10px;
+  max-width: 20px;
+  max-height: 20px;
+  margin-left: -23px;
 }
 
 .AddonReviewCard-authorByLine {

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -23,6 +23,30 @@
   }
 }
 
+.AddonReviewCard-addonReviewLabel {
+  font-weight: normal;
+  margin-left: 10px;
+}
+
+.AddonReviewCard-addonNameBold {
+  font-weight: bold;
+}
+
+.AddonReviewCard-addonInfo {
+  display: flex;
+  align-items: center;
+  background-color: #f2f2f2;
+  padding: 10px;
+  border-radius: 5px;
+  margin-bottom: 10px;
+}
+
+.AddonReviewCard-addonInfo img {
+  max-width: 40px;
+  max-height: 40px;
+  margin-right: 10px;
+}
+
 .AddonReviewCard-authorByLine {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -249,6 +249,7 @@ export class UserProfileBase extends React.Component<InternalProps> {
                   review={review}
                   shortByLine
                   siteUserCanReply={false}
+                  isUserProfile
                 />
               </li>
             );

--- a/src/amo/reducers/reviews.js
+++ b/src/amo/reducers/reviews.js
@@ -3,6 +3,7 @@ import { oneLine } from 'common-tags';
 import invariant from 'invariant';
 import { LOCATION_CHANGE } from 'redux-first-history';
 
+import { SET_LANG } from 'amo/reducers/api';
 import {
   BEGIN_DELETE_ADDON_REVIEW,
   CANCEL_DELETE_ADDON_REVIEW,
@@ -160,6 +161,7 @@ export type ReviewsState = {|
   loadingForSlug: {
     [slug: string]: boolean,
   },
+  lang: string,
 |};
 
 export const initialState: ReviewsState = {
@@ -172,6 +174,7 @@ export const initialState: ReviewsState = {
   view: {},
   flashMessage: undefined,
   loadingForSlug: {},
+  lang: '',
 };
 
 export function selectReviews({
@@ -517,7 +520,7 @@ export default function reviewsReducer(
     }
     case SET_REVIEW: {
       const { payload } = action;
-      const review = createInternalReview(payload);
+      const review = createInternalReview(payload, state.lang);
 
       const newState = _addReviewToState({ state, review });
       return changeViewState({
@@ -544,7 +547,7 @@ export default function reviewsReducer(
           ...state.byId,
           [review.id]: {
             ...review,
-            reply: createInternalReview(action.payload.reply),
+            reply: createInternalReview(action.payload.reply, state.lang),
           },
         },
       };
@@ -592,7 +595,7 @@ export default function reviewsReducer(
     case SET_ADDON_REVIEWS: {
       const { payload } = action;
       const reviews = payload.reviews.map((review) =>
-        createInternalReview(review),
+        createInternalReview(review, state.lang),
       );
 
       return {
@@ -619,7 +622,7 @@ export default function reviewsReducer(
     case SET_USER_REVIEWS: {
       const { payload } = action;
       const reviews = payload.reviews.map((review) =>
-        createInternalReview(review),
+        createInternalReview(review, state.lang),
       );
 
       return {
@@ -721,6 +724,11 @@ export default function reviewsReducer(
         },
       };
     }
+    case SET_LANG:
+      return {
+        ...state,
+        lang: action.payload.lang,
+      };
     default:
       return state;
   }

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1334,6 +1334,29 @@ describe(__filename, () => {
     });
   });
 
+  describe('Tests for AddonReviewCard-addonInfo', () => {
+    it('displays addon icon and name when isUserProfile is true and isReply is false', () => {
+      const review = _setReview({
+        reviewAddon: {
+          ...fakeReview.reviewAddon,
+          IconUrl: 'http://sample.url/icon.png',
+          name: 'Sample Addon',
+        },
+      });
+
+      render({ review, isUserProfile: true, isReply: false });
+      expect(
+        screen.getByClassName('AddonReviewCard-addonInfo'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByClassName('AddonReviewCard-addonReviewLabel'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByClassName('AddonReviewCard-addonName'),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('Tests for UserRating', () => {
     it('renders a Rating', () => {
       render({ review: _setReview({ score: 2 }) });

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1853,37 +1853,5 @@ describe(__filename, () => {
         ).toEqual(id.toString());
       });
     });
-
-    describe('AddonName extraction and display in AddonReviewCard', () => {
-      it('displays the addonName extracted from "en-US" key', () => {
-        const addonName = 'Test Addon';
-        const review = _setReview({
-          reviewAddon: {
-            name: {
-              'en-US': addonName,
-            },
-          },
-        });
-        render({ review });
-
-        expect(screen.getByText(`Review of ${addonName}`)).toBeInTheDocument();
-      });
-
-      it('displays the addonName from the default key if "en-US" is not present', () => {
-        const addonName = 'Test Addon';
-        const review = _setReview({
-          reviewAddon: {
-            name: {
-              '_default': {
-                'FR': addonName,
-              },
-            },
-          },
-        });
-        render({ review });
-
-        expect(screen.getByText(`Review of ${addonName}`)).toBeInTheDocument();
-      });
-    });
   });
 });

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1853,5 +1853,37 @@ describe(__filename, () => {
         ).toEqual(id.toString());
       });
     });
+
+    describe('AddonName extraction and display in AddonReviewCard', () => {
+      it('displays the addonName extracted from "en-US" key', () => {
+        const addonName = 'Test Addon';
+        const review = _setReview({
+          reviewAddon: {
+            name: {
+              'en-US': addonName,
+            },
+          },
+        });
+        render({ review });
+
+        expect(screen.getByText(`Review of ${addonName}`)).toBeInTheDocument();
+      });
+
+      it('displays the addonName from the default key if "en-US" is not present', () => {
+        const addonName = 'Test Addon';
+        const review = _setReview({
+          reviewAddon: {
+            name: {
+              '_default': {
+                'FR': addonName,
+              },
+            },
+          },
+        });
+        render({ review });
+
+        expect(screen.getByText(`Review of ${addonName}`)).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1355,6 +1355,27 @@ describe(__filename, () => {
         screen.getByClassName('AddonReviewCard-addonName'),
       ).toBeInTheDocument();
     });
+
+    it('does not display addon icon and name when isUserProfile is false and isReply is false', () => {
+      const review = _setReview({
+        reviewAddon: {
+          ...fakeReview.reviewAddon,
+          IconUrl: 'http://sample.url/icon.png',
+          name: 'Sample Addon',
+        },
+      });
+
+      render({ review, isUserProfile: false, isReply: false });
+      expect(
+        screen.queryByClassName('AddonReviewCard-addonInfo'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByClassName('AddonReviewCard-addonReviewLabel'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByClassName('AddonReviewCard-addonName'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('Tests for UserRating', () => {

--- a/tests/unit/amo/reducers/test_addons.js
+++ b/tests/unit/amo/reducers/test_addons.js
@@ -1,8 +1,4 @@
-import {
-  createInternalReview,
-  unloadAddonReviews,
-  updateRatingCounts,
-} from 'amo/actions/reviews';
+import { unloadAddonReviews, updateRatingCounts } from 'amo/actions/reviews';
 import { ADDON_TYPE_EXTENSION } from 'amo/constants';
 import addons, {
   createGroupedRatings,
@@ -24,6 +20,7 @@ import addons, {
 } from 'amo/reducers/addons';
 import { setLang } from 'amo/reducers/api';
 import {
+  createInternalReviewWithLang,
   createFakeAddon,
   createInternalAddonWithLang,
   createLocalizedString,
@@ -376,7 +373,7 @@ describe(__filename, () => {
     function _updateRatingCounts({
       addonId = 321,
       oldReview = null,
-      newReview = createInternalReview({ ...fakeReview }),
+      newReview = createInternalReviewWithLang({ ...fakeReview }),
     } = {}) {
       return updateRatingCounts({ addonId, oldReview, newReview });
     }
@@ -396,7 +393,7 @@ describe(__filename, () => {
     }
 
     function reviewWithScore(score) {
-      return createInternalReview({ ...fakeReview, score });
+      return createInternalReviewWithLang({ ...fakeReview, score });
     }
 
     function average(numbers) {
@@ -548,7 +545,7 @@ describe(__filename, () => {
         _updateRatingCounts({
           addonId: addon.id,
           oldReview: null,
-          newReview: createInternalReview({
+          newReview: createInternalReviewWithLang({
             ...fakeReview,
             body: null,
             score: 5,
@@ -574,7 +571,7 @@ describe(__filename, () => {
         _updateRatingCounts({
           addonId: addon.id,
           oldReview: null,
-          newReview: createInternalReview({
+          newReview: createInternalReviewWithLang({
             ...fakeReview,
             body: 'Fantastic add-on',
             score: 5,
@@ -598,12 +595,12 @@ describe(__filename, () => {
         state,
         _updateRatingCounts({
           addonId: addon.id,
-          oldReview: createInternalReview({
+          oldReview: createInternalReviewWithLang({
             ...fakeReview,
             body: null,
             score: 5,
           }),
-          newReview: createInternalReview({
+          newReview: createInternalReviewWithLang({
             ...fakeReview,
             body: 'Fantastic add-on',
             score: 5,
@@ -629,8 +626,8 @@ describe(__filename, () => {
         state,
         _updateRatingCounts({
           addonId: addon.id,
-          oldReview: createInternalReview({ ...fakeReview }),
-          newReview: createInternalReview({ ...fakeReview }),
+          oldReview: createInternalReviewWithLang({ ...fakeReview }),
+          newReview: createInternalReviewWithLang({ ...fakeReview }),
         }),
       );
 
@@ -648,7 +645,7 @@ describe(__filename, () => {
         _updateRatingCounts({
           addonId: addon.id,
           oldReview: null,
-          newReview: createInternalReview({
+          newReview: createInternalReviewWithLang({
             ...fakeReview,
             body: 'This add-on is nice',
             score: 5,
@@ -677,8 +674,14 @@ describe(__filename, () => {
         state,
         _updateRatingCounts({
           addonId: addon.id,
-          oldReview: createInternalReview({ ...fakeReview, score: oldScore }),
-          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+          oldReview: createInternalReviewWithLang({
+            ...fakeReview,
+            score: oldScore,
+          }),
+          newReview: createInternalReviewWithLang({
+            ...fakeReview,
+            score: newScore,
+          }),
         }),
       );
 
@@ -703,7 +706,10 @@ describe(__filename, () => {
         _updateRatingCounts({
           addonId: addon.id,
           oldReview: null,
-          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+          newReview: createInternalReviewWithLang({
+            ...fakeReview,
+            score: newScore,
+          }),
         }),
       );
 
@@ -724,7 +730,10 @@ describe(__filename, () => {
         _updateRatingCounts({
           addonId: addon.id,
           oldReview: null,
-          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+          newReview: createInternalReviewWithLang({
+            ...fakeReview,
+            score: newScore,
+          }),
         }),
       );
 
@@ -746,12 +755,12 @@ describe(__filename, () => {
         state,
         _updateRatingCounts({
           addonId: addon.id,
-          oldReview: createInternalReview({
+          oldReview: createInternalReviewWithLang({
             ...fakeReview,
             body: null,
             score: 5,
           }),
-          newReview: createInternalReview({
+          newReview: createInternalReviewWithLang({
             ...fakeReview,
             body: 'Fantastic add-on',
             score: 5,
@@ -780,7 +789,10 @@ describe(__filename, () => {
         _updateRatingCounts({
           addonId: addon.id,
           oldReview: null,
-          newReview: createInternalReview({ ...fakeReview, score: newScore }),
+          newReview: createInternalReviewWithLang({
+            ...fakeReview,
+            score: newScore,
+          }),
         }),
       );
 

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -43,6 +43,7 @@ import reviewsReducer, {
 } from 'amo/reducers/reviews';
 import { DEFAULT_API_PAGE_SIZE } from 'amo/api';
 import { fakeAddon, fakeReview } from 'tests/unit/helpers';
+import { selectLocalizedContent } from 'amo/reducers/utils';
 
 describe(__filename, () => {
   function setFakeReview({
@@ -124,7 +125,7 @@ describe(__filename, () => {
       reviewAddon: {
         iconUrl: fakeReview.addon.icon_url,
         id: fakeReview.addon.id,
-        name: fakeReview.addon.name,
+        name: selectLocalizedContent(fakeReview.addon.name, 'en-US'),
         slug: fakeReview.addon.slug,
       },
       body: fakeReview.body,

--- a/tests/unit/amo/reducers/test_reviews.js
+++ b/tests/unit/amo/reducers/test_reviews.js
@@ -4,7 +4,6 @@ import {
   SAVED_RATING,
   beginDeleteAddonReview,
   cancelDeleteAddonReview,
-  createInternalReview,
   deleteAddonReview,
   fetchReview,
   fetchReviewPermissions,
@@ -42,7 +41,11 @@ import reviewsReducer, {
   storeReviewObjects,
 } from 'amo/reducers/reviews';
 import { DEFAULT_API_PAGE_SIZE } from 'amo/api';
-import { fakeAddon, fakeReview } from 'tests/unit/helpers';
+import {
+  fakeAddon,
+  fakeReview,
+  createInternalReviewWithLang,
+} from 'tests/unit/helpers';
 import { selectLocalizedContent } from 'amo/reducers/utils';
 
 describe(__filename, () => {
@@ -179,7 +182,7 @@ describe(__filename, () => {
 
       sinon.assert.calledWith(_addReviewToState, {
         state: initialState,
-        review: createInternalReview(review),
+        review: createInternalReviewWithLang(review),
       });
     });
 
@@ -195,7 +198,7 @@ describe(__filename, () => {
     it('calls _addReviewToState()', () => {
       const _addReviewToState = sinon.spy();
 
-      const review = createInternalReview(fakeReview);
+      const review = createInternalReviewWithLang(fakeReview);
       reviewsReducer(undefined, setInternalReview(review), {
         _addReviewToState,
       });
@@ -222,7 +225,9 @@ describe(__filename, () => {
 
     expect(newState.byId[review.id].body).toEqual('Original review body');
     expect(newState.byId[review.id].reply.body).toEqual('A developer reply');
-    expect(newState.byId[review.id].reply).toEqual(createInternalReview(reply));
+    expect(newState.byId[review.id].reply).toEqual(
+      createInternalReviewWithLang(reply),
+    );
   });
 
   it('cannot store a reply to a non-existant review', () => {
@@ -337,8 +342,12 @@ describe(__filename, () => {
         reviews: [review1, review2],
       });
       const state = reviewsReducer(undefined, action);
-      expect(state.byId[review1.id]).toEqual(createInternalReview(review1));
-      expect(state.byId[review2.id]).toEqual(createInternalReview(review2));
+      expect(state.byId[review1.id]).toEqual(
+        createInternalReviewWithLang(review1),
+      );
+      expect(state.byId[review2.id]).toEqual(
+        createInternalReviewWithLang(review2),
+      );
     });
 
     it('stores review counts', () => {
@@ -604,8 +613,8 @@ describe(__filename, () => {
         reviews: reviewsData.reviews,
       });
 
-      expect(expanded[0]).toEqual(createInternalReview(review1));
-      expect(expanded[1]).toEqual(createInternalReview(review2));
+      expect(expanded[0]).toEqual(createInternalReviewWithLang(review1));
+      expect(expanded[1]).toEqual(createInternalReviewWithLang(review2));
     });
 
     it('throws an error if the review does not exist', () => {
@@ -696,8 +705,8 @@ describe(__filename, () => {
   describe('storeReviewObjects', () => {
     it('stores review objects by ID', () => {
       const reviews = [
-        createInternalReview({ ...fakeReview, id: 1 }),
-        createInternalReview({ ...fakeReview, id: 2 }),
+        createInternalReviewWithLang({ ...fakeReview, id: 1 }),
+        createInternalReviewWithLang({ ...fakeReview, id: 2 }),
       ];
       expect(storeReviewObjects({ state: initialState, reviews })).toEqual({
         [reviews[0].id]: reviews[0],
@@ -706,8 +715,8 @@ describe(__filename, () => {
     });
 
     it('preserves existing reviews', () => {
-      const review1 = createInternalReview({ ...fakeReview, id: 1 });
-      const review2 = createInternalReview({ ...fakeReview, id: 2 });
+      const review1 = createInternalReviewWithLang({ ...fakeReview, id: 1 });
+      const review2 = createInternalReviewWithLang({ ...fakeReview, id: 2 });
 
       const state = initialState;
       const byId = storeReviewObjects({ state, reviews: [review1] });
@@ -724,7 +733,9 @@ describe(__filename, () => {
     });
 
     it('throws an error for falsy IDs', () => {
-      const reviews = [createInternalReview({ ...fakeReview, id: undefined })];
+      const reviews = [
+        createInternalReviewWithLang({ ...fakeReview, id: undefined }),
+      ];
       expect(() => {
         storeReviewObjects({ state: initialState, reviews });
       }).toThrow(/Cannot store review because review.id is falsy/);
@@ -1042,8 +1053,12 @@ describe(__filename, () => {
         }),
       );
 
-      expect(state.byId[review1.id]).toEqual(createInternalReview(review1));
-      expect(state.byId[review2.id]).toEqual(createInternalReview(review2));
+      expect(state.byId[review1.id]).toEqual(
+        createInternalReviewWithLang(review1),
+      );
+      expect(state.byId[review2.id]).toEqual(
+        createInternalReviewWithLang(review2),
+      );
     });
 
     it('stores multiple reviews for a user ID', () => {
@@ -1100,7 +1115,7 @@ describe(__filename, () => {
       expect(getReviewsByUserId(state, userId)).toEqual({
         pageSize,
         reviewCount: reviews.length,
-        reviews: reviews.map(createInternalReview),
+        reviews: reviews.map(createInternalReviewWithLang),
       });
     });
   });
@@ -1209,7 +1224,7 @@ describe(__filename, () => {
     }
 
     it('stores an internal review object', () => {
-      const review = createInternalReview({ ...fakeReview, id: 1 });
+      const review = createInternalReviewWithLang({ ...fakeReview, id: 1 });
       const state = _addReviewToState({ review });
 
       expect(state.byId[review.id]).toEqual(review);
@@ -1228,7 +1243,7 @@ describe(__filename, () => {
         }),
       );
 
-      const review = createInternalReview({
+      const review = createInternalReviewWithLang({
         ...fakeReview,
         id: reviewId2,
         body: 'This add-on is fantastic',
@@ -1259,7 +1274,7 @@ describe(__filename, () => {
         }),
       );
 
-      const review = createInternalReview({
+      const review = createInternalReviewWithLang({
         ...fakeReview,
         id: reviewId2,
         body: undefined,
@@ -1289,7 +1304,7 @@ describe(__filename, () => {
       );
       expect(prevState.byUserId[userId]).toBeDefined();
 
-      const review = createInternalReview({
+      const review = createInternalReviewWithLang({
         ...fakeReview,
         user: {
           ...fakeReview.user,
@@ -1326,7 +1341,7 @@ describe(__filename, () => {
       );
 
       // Upgrade the rating to a review.
-      const review = createInternalReview({
+      const review = createInternalReviewWithLang({
         ...fakeReview,
         body: 'This add-on is pretty good',
         user: externalReviewUser,
@@ -1353,7 +1368,7 @@ describe(__filename, () => {
       );
       state = _addReviewToState({
         state,
-        review: createInternalReview({
+        review: createInternalReviewWithLang({
           ...fakeReview,
           addon: {
             ...fakeReview.addon,
@@ -1380,7 +1395,7 @@ describe(__filename, () => {
       );
       state = _addReviewToState({
         state,
-        review: createInternalReview({
+        review: createInternalReviewWithLang({
           ...fakeReview,
           addon: {
             ...fakeReview.addon,
@@ -1416,7 +1431,7 @@ describe(__filename, () => {
       );
       state = _addReviewToState({
         state,
-        review: createInternalReview({
+        review: createInternalReviewWithLang({
           ...fakeReview,
           addon: {
             ...fakeReview.addon,

--- a/tests/unit/amo/sagas/test_reviews.js
+++ b/tests/unit/amo/sagas/test_reviews.js
@@ -11,7 +11,6 @@ import {
   STARTED_SAVE_REVIEW,
   unloadAddonReviews,
   createAddonReview,
-  createInternalReview,
   deleteAddonReview,
   fetchLatestUserReview,
   fetchReview,
@@ -43,6 +42,7 @@ import reviewsSaga, { FLASH_SAVED_MESSAGE_DURATION } from 'amo/sagas/reviews';
 import { DEFAULT_API_PAGE_SIZE } from 'amo/api';
 import apiReducer from 'amo/reducers/api';
 import {
+  createInternalReviewWithLang,
   apiResponsePage,
   createExternalReview,
   createStubErrorHandler,
@@ -565,7 +565,7 @@ describe(__filename, () => {
       const expectedAction = updateRatingCounts({
         addonId,
         oldReview: undefined,
-        newReview: createInternalReview(submittedReview),
+        newReview: createInternalReviewWithLang(submittedReview),
       });
       const action = await sagaTester.waitFor(expectedAction.type);
       expect(action).toEqual(expectedAction);
@@ -635,8 +635,8 @@ describe(__filename, () => {
 
       const expectedAction = updateRatingCounts({
         addonId,
-        oldReview: createInternalReview(oldReview),
-        newReview: createInternalReview(newReview),
+        oldReview: createInternalReviewWithLang(oldReview),
+        newReview: createInternalReviewWithLang(newReview),
       });
       const action = await sagaTester.waitFor(expectedAction.type);
 

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -54,6 +54,7 @@ import App from 'amo/components/App';
 import { ErrorHandler } from 'amo/errorHandler';
 import { makeI18n } from 'amo/i18n/utils';
 import { createGroupedRatings, createInternalAddon } from 'amo/reducers/addons';
+import { createInternalReview } from 'amo/actions/reviews';
 import {
   autocompleteLoad,
   autocompleteStart,
@@ -1305,6 +1306,13 @@ export const fakeEventData = Object.freeze({
   click: 'some-click-data',
   conversion: 'some-conversion-data',
 });
+
+export const createInternalReviewWithLang = (
+  review,
+  lang = DEFAULT_LANG_IN_TESTS,
+) => {
+  return createInternalReview(review, lang);
+};
 
 export const createInternalAddonWithLang = (
   addon,


### PR DESCRIPTION
Fixes mozilla/addons#2050 

This patch includes the Add-on Name and Add-on Icon in each review under "My reviews", on the User Profile.

Before:
<img width="865" alt="Screenshot 2023-09-25 at 11 03 43 AM" src="https://github.com/mozilla/addons-frontend/assets/63154973/af4f6d5c-8c08-438e-b88e-df898224e7d9">

After:
<img width="875" alt="Screenshot 2023-09-25 at 11 02 14 AM" src="https://github.com/mozilla/addons-frontend/assets/63154973/166502c1-1ae6-4f02-b593-2fc78089efe1">