### PR TITLE
l10n - Update Santali native name to correct Ol Chiki script in languages.js

### DIFF
--- a/src/amo/languages.js
+++ b/src/amo/languages.js
@@ -495,7 +495,7 @@ export const unfilteredLanguages = {
   },
   sat: {
     English: 'Santali',
-    native: '\u0938\u0902\u0924\u093e\u0932\u0940',
+    native: '\u1c65\u1c5f\u1c71\u1c5b\u1c5f\u1c72\u1c64',
   },
   sah: {
     English: 'Sakha',


### PR DESCRIPTION
Santali locale is being added to Beta/Release cycle. It was already enabled for langpacks, but the locale name [here](https://addons.mozilla.org/en-US/firefox/language-tools/) doesn't match the language name for the language pack / what is shown in Firefox.

![image](https://github.com/mozilla/addons-frontend/assets/38174554/37f4fef5-6e14-4cd5-9e66-9e7752d6b833)

This change updates the display name to match the language name in Firefox:
Locale: sat
Native (current): संताली
Native (update): ᱥᱟᱱᱛᱟᱲᱤ