### PR TITLE
flatten categorylist to not use clientapp

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -414,7 +414,6 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
 const mapStateToProps = (state: AppState, ownProps: Props): PropsFromState => {
   const { addon, i18n } = ownProps;
   const { categories } = state.categories;
-  const { clientApp } = state.api;
 
   let currentVersion = null;
   let relatedCategories = null;
@@ -435,9 +434,9 @@ const mapStateToProps = (state: AppState, ownProps: Props): PropsFromState => {
     });
   }
 
-  if (addon && addon.categories && addon.type && categories && clientApp) {
-    const appCategories = categories[clientApp][addon.type];
-    const addonCategories = addon.categories[clientApp] || [];
+  if (addon && addon.categories && addon.type && categories) {
+    const appCategories = categories[addon.type];
+    const addonCategories = addon.categories || [];
 
     relatedCategories = addonCategories.reduce((result, slug) => {
       if (typeof appCategories[slug] !== 'undefined') {

--- a/src/amo/components/AddonSuggestions/index.js
+++ b/src/amo/components/AddonSuggestions/index.js
@@ -143,7 +143,7 @@ const getCategory = (
     },
   ];
 
-  const categories = addon?.categories?.firefox || [];
+  const categories = addon?.categories || [];
   if (categories.length) {
     for (const category of categoryHierarchy) {
       if (categories.includes(category.slug)) {

--- a/src/amo/components/Categories/index.js
+++ b/src/amo/components/Categories/index.js
@@ -39,7 +39,6 @@ type Props = {|
 
 type PropsFromState = {|
   categoriesState: $PropertyType<CategoriesState, 'categories'>,
-  clientApp: string,
   loading: boolean,
 |};
 
@@ -81,7 +80,6 @@ export class CategoriesBase extends React.Component<InternalProps> {
       addonType,
       categoriesState,
       className,
-      clientApp,
       errorHandler,
       i18n,
       loading,
@@ -89,12 +87,8 @@ export class CategoriesBase extends React.Component<InternalProps> {
     invariant(addonType, 'addonType is undefined');
 
     let categories: Array<mixed> = [];
-    if (
-      categoriesState &&
-      categoriesState[clientApp] &&
-      categoriesState[clientApp][addonType]
-    ) {
-      categories = Object.values(categoriesState[clientApp][addonType]);
+    if (categoriesState && categoriesState[addonType]) {
+      categories = Object.values(categoriesState[addonType]);
     }
     const classNameProp = classnames('Categories', className);
 
@@ -162,7 +156,6 @@ export class CategoriesBase extends React.Component<InternalProps> {
 function mapStateToProps(state: AppState): PropsFromState {
   return {
     categoriesState: state.categories.categories,
-    clientApp: state.api.clientApp,
     loading: state.categories.loading,
   };
 }

--- a/src/amo/components/SearchContextCard/index.js
+++ b/src/amo/components/SearchContextCard/index.js
@@ -277,22 +277,17 @@ function mapStateToProps(state: AppState): PropsFromState {
 
   if (currentCategory) {
     const categoriesState = state.categories.categories;
-    const { clientApp } = state.api;
 
-    if (categoriesState && clientApp) {
-      const appTypes = categoriesState[clientApp];
+    if (categoriesState) {
+      if (
+        filters &&
+        filters.addonType &&
+        typeof filters.addonType === 'string'
+      ) {
+        const { addonType } = filters;
+        const categories = categoriesState[addonType];
 
-      if (appTypes) {
-        if (
-          filters &&
-          filters.addonType &&
-          typeof filters.addonType === 'string'
-        ) {
-          const { addonType } = filters;
-          const categories = appTypes[addonType];
-
-          categoryName = getCategoryName(categories, currentCategory);
-        }
+        categoryName = getCategoryName(categories, currentCategory);
       }
     }
   }

--- a/src/amo/pages/CategoryPage/index.js
+++ b/src/amo/pages/CategoryPage/index.js
@@ -112,15 +112,10 @@ const mapStateToProps = (state: AppState, ownProps: Props): PropsFromState => {
 
   const addonType = apiAddonType(visibleAddonType);
   const categoriesState = state.categories.categories;
-  const { clientApp } = state.api;
 
-  if (categoriesState && clientApp) {
-    const appTypes = categoriesState[clientApp];
-
-    if (appTypes) {
-      const categories = appTypes[addonType];
-      categoryName = getCategoryName(categories, categorySlug);
-    }
+  if (categoriesState) {
+    const categories = categoriesState[addonType];
+    categoryName = getCategoryName(categories, categorySlug);
   }
 
   const filtersFromLocation = convertQueryParamsToFilters(location.query);

--- a/src/amo/reducers/addons.js
+++ b/src/amo/reducers/addons.js
@@ -9,7 +9,10 @@ import type {
   UnloadAddonReviewsAction,
   UpdateRatingCountsAction,
 } from 'amo/actions/reviews';
-import { selectLocalizedContent } from 'amo/reducers/utils';
+import {
+  selectLocalizedContent,
+  selectCategoryObject,
+} from 'amo/reducers/utils';
 import { SET_LANG } from 'amo/reducers/api';
 import type { ExternalAddonInfoType } from 'amo/api/addonInfo';
 import type { AppState } from 'amo/store';
@@ -197,7 +200,7 @@ export function createInternalAddon(
   const addon: AddonType = {
     authors: apiAddon.authors,
     average_daily_users: apiAddon.average_daily_users,
-    categories: apiAddon.categories,
+    categories: selectCategoryObject(apiAddon),
     contributions_url: apiAddon.contributions_url,
     created: apiAddon.created,
     default_locale: apiAddon.default_locale,

--- a/src/amo/reducers/categories.js
+++ b/src/amo/reducers/categories.js
@@ -1,6 +1,5 @@
 /* @flow */
 import { oneLine } from 'common-tags';
-import config from 'config';
 import invariant from 'invariant';
 
 import { validAddonTypes } from 'amo/constants';
@@ -14,7 +13,7 @@ export type ExternalCategory = {|
   id: string,
   name: string,
   slug: string,
-  application: string,
+  application: string | null,
   misc: boolean,
   type: string,
   weight: number,
@@ -24,9 +23,7 @@ export type ExternalCategory = {|
 export type CategoryEntry = {| [addonSlug: string]: ExternalCategory |};
 
 export type CategoryMapType = {|
-  [appName: string]: {
-    [addonType: string]: CategoryEntry,
-  },
+  [addonType: string]: CategoryEntry,
 |};
 
 export type CategoriesState = {|
@@ -78,20 +75,16 @@ export function loadCategories({
 }
 
 type EmptyCategoryListType = {|
-  [appName: string]: {|
-    [addonType: string]: Array<ExternalCategory>,
-  |},
+  [addonType: string]: Array<ExternalCategory>,
 |};
 
 export function createEmptyCategoryList(): EmptyCategoryListType {
-  return config.get('validClientApplications').reduce((object, appName) => {
-    return {
-      ...object,
-      [appName]: validAddonTypes.reduce((appObject, addonType: string) => {
-        return { ...appObject, [addonType]: [] };
-      }, {}),
-    };
-  }, {});
+  return validAddonTypes.reduce<EmptyCategoryListType>(
+    (appObject, addonType: string) => {
+      return { ...appObject, [addonType]: [] };
+    },
+    {},
+  );
 }
 
 type Action = FetchCategoriesAction | LoadCategoriesAction;
@@ -111,43 +104,35 @@ export default function reducer(
 
       payload.results.forEach((category) => {
         // This category has no data, so skip it.
-        if (!category || !category.application) {
+        if (!category) {
           // eslint-disable-next-line amo/only-log-strings
-          log.warn('category or category.application was falsey: %o', category);
+          log.warn('category was falsey: %o', category);
           return;
         }
 
         // If the API returns data for an application we don't support,
         // we'll ignore it for now.
-        if (!categoryList[category.application]) {
+        if (category.application && category.application !== 'firefox') {
           log.warn(oneLine`Category data for unknown clientApp
               "${category.application}" received from API.`);
           return;
         }
 
-        if (!categoryList[category.application][category.type]) {
+        if (!categoryList[category.type]) {
           log.warn(oneLine`add-on category for unknown add-on type
-              "${category.type}" for clientApp "${category.type}" received
-              from API.`);
+              "${category.type}" received from API.`);
           return;
         }
 
-        categoryList[category.application][category.type].push(category);
+        categoryList[category.type].push(category);
       });
 
       const categories: CategoryMapType = {};
-      Object.keys(categoryList).forEach((appName) => {
-        categories[appName] = {};
-
-        Object.keys(categoryList[appName]).forEach((addonType) => {
-          // $FlowIgnore: flow can't be sure that the reduce result match ExternalCategory definition, let's trust the test coverage here.
-          categories[appName][addonType] = categoryList[appName][addonType]
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .reduce(
-              (object, value) => ({ ...object, [value.slug]: value }),
-              {},
-            );
-        });
+      Object.keys(categoryList).forEach((addonType) => {
+        // $FlowIgnore: flow can't be sure that the reduce result match ExternalCategory definition, let's trust the test coverage here.
+        categories[addonType] = categoryList[addonType]
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .reduce((object, value) => ({ ...object, [value.slug]: value }), {});
       });
 
       return {

--- a/src/amo/reducers/utils.js
+++ b/src/amo/reducers/utils.js
@@ -2,6 +2,9 @@ import invariant from 'invariant';
 
 import type { LocalizedString } from 'amo/types/api';
 
+import type { CategoryEntry } from './categories';
+import type { ExternalAddonType } from '../types/addons';
+
 export const selectLocalizedContent = (
   field: LocalizedString,
   lang: string,
@@ -16,4 +19,13 @@ export const selectLocalizedContent = (
   }
 
   return field[lang];
+};
+
+export const selectCategoryObject = (
+  apiAddon: ExternalAddonType,
+): CategoryEntry => {
+  if (apiAddon.categories && apiAddon.categories.firefox) {
+    return apiAddon.categories.firefox;
+  }
+  return apiAddon.categories;
 };

--- a/src/amo/types/addons.js
+++ b/src/amo/types/addons.js
@@ -106,7 +106,7 @@ export type GroupedRatingsType = {|
 export type ExternalAddonType = {|
   authors?: Array<AddonAuthorType>,
   average_daily_users: number,
-  categories?: Object,
+  categories?: Object | Array<string>,
   contributions_url: UrlWithOutgoing | null,
   created: Date,
   // If you make an API request as an admin for an incomplete

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -580,7 +580,7 @@ describe(__filename, () => {
       const { slug: slug2, name: name2 } = categories[4];
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
-        categories: { [CLIENT_APP_FIREFOX]: [slug1, slug2] },
+        categories: [slug1, slug2],
       });
 
       store.dispatch(loadCategories({ results: categories }));
@@ -649,7 +649,7 @@ describe(__filename, () => {
     it('does not render a related category if add-on does not have that category', () => {
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
-        categories: { [CLIENT_APP_ANDROID]: ['does-not-exist'] },
+        categories: ['does-not-exist'],
       });
 
       store.dispatch(loadCategories({ results: categories }));
@@ -662,7 +662,7 @@ describe(__filename, () => {
     it('does not render a related category if add-on does not have any category at all', () => {
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
-        categories: {},
+        categories: [],
       });
       store.dispatch(loadCategories({ results: categories }));
 
@@ -675,7 +675,7 @@ describe(__filename, () => {
       const { slug } = categories[0];
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
-        categories: { [CLIENT_APP_ANDROID]: [slug] },
+        categories: [slug],
         type: ADDON_TYPE_STATIC_THEME,
       });
 
@@ -691,7 +691,7 @@ describe(__filename, () => {
       (type) => {
         const addon = createInternalAddonWithLang({
           ...fakeAddon,
-          categories: { [CLIENT_APP_ANDROID]: [categories[0].slug] },
+          categories: [categories[0].slug],
           type,
         });
         store.dispatch(loadCategories({ results: categories }));

--- a/tests/unit/amo/pages/TestSearchPage.js
+++ b/tests/unit/amo/pages/TestSearchPage.js
@@ -1074,7 +1074,7 @@ describe(__filename, () => {
         results: [
           {
             ...fakeCategory,
-            application: CLIENT_APP_ANDROID,
+            application: CLIENT_APP_FIREFOX, // Unified categories ignore android applications
             type: ADDON_TYPE_EXTENSION,
             name: categoryName,
             slug: category,

--- a/tests/unit/amo/reducers/test_categories.js
+++ b/tests/unit/amo/reducers/test_categories.js
@@ -95,11 +95,12 @@ describe(__filename, () => {
         },
         {
           ...fakeCategory,
-          application: CLIENT_APP_ANDROID,
+          application: CLIENT_APP_FIREFOX,
           name: 'I should also not appear',
           slug: 'i-should-also-not-appear',
           type: 'FAKE_TYPE',
         },
+        {},
       ];
 
       state = categories(initialState, loadCategories({ results }));

--- a/tests/unit/amo/reducers/test_categories.js
+++ b/tests/unit/amo/reducers/test_categories.js
@@ -174,83 +174,45 @@ describe(__filename, () => {
       state = categories(initialState, loadCategories({ results }));
 
       expect(state.categories).toEqual({
-        firefox: {
-          [ADDON_TYPE_DICT]: {},
-          [ADDON_TYPE_EXTENSION]: {
-            'alert-update': {
-              ...fakeCategory,
-              application: CLIENT_APP_FIREFOX,
-              name: 'Alerts & Update',
-              slug: 'alert-update',
-              type: ADDON_TYPE_EXTENSION,
-            },
-            security: {
-              ...fakeCategory,
-              application: CLIENT_APP_FIREFOX,
-              name: 'Security',
-              slug: 'security',
-              type: ADDON_TYPE_EXTENSION,
-            },
+        [ADDON_TYPE_DICT]: {},
+        [ADDON_TYPE_EXTENSION]: {
+          'alert-update': {
+            ...fakeCategory,
+            application: CLIENT_APP_FIREFOX,
+            name: 'Alerts & Update',
+            slug: 'alert-update',
+            type: ADDON_TYPE_EXTENSION,
           },
-          [ADDON_TYPE_LANG]: {},
-          [ADDON_TYPE_STATIC_THEME]: {
-            anime: {
-              ...fakeCategory,
-              application: CLIENT_APP_FIREFOX,
-              name: 'Anime',
-              slug: 'anime',
-              type: ADDON_TYPE_STATIC_THEME,
-            },
-            naturé: {
-              ...fakeCategory,
-              application: CLIENT_APP_FIREFOX,
-              name: 'Naturé',
-              slug: 'naturé',
-              type: ADDON_TYPE_STATIC_THEME,
-            },
-            painting: {
-              ...fakeCategory,
-              application: CLIENT_APP_FIREFOX,
-              name: 'Painting',
-              slug: 'painting',
-              type: ADDON_TYPE_STATIC_THEME,
-            },
+          security: {
+            ...fakeCategory,
+            application: CLIENT_APP_FIREFOX,
+            name: 'Security',
+            slug: 'security',
+            type: ADDON_TYPE_EXTENSION,
           },
         },
-        android: {
-          [ADDON_TYPE_DICT]: {},
-          [ADDON_TYPE_EXTENSION]: {
-            'alert-update': {
-              ...fakeCategory,
-              application: CLIENT_APP_ANDROID,
-              name: 'Alerts & Update',
-              slug: 'alert-update',
-              type: ADDON_TYPE_EXTENSION,
-            },
-            blogging: {
-              ...fakeCategory,
-              application: CLIENT_APP_ANDROID,
-              name: 'Blogging',
-              slug: 'blogging',
-              type: ADDON_TYPE_EXTENSION,
-            },
-            Games: {
-              ...fakeCategory,
-              application: CLIENT_APP_ANDROID,
-              name: 'Games',
-              slug: 'Games',
-              type: ADDON_TYPE_EXTENSION,
-            },
+        [ADDON_TYPE_LANG]: {},
+        [ADDON_TYPE_STATIC_THEME]: {
+          anime: {
+            ...fakeCategory,
+            application: CLIENT_APP_FIREFOX,
+            name: 'Anime',
+            slug: 'anime',
+            type: ADDON_TYPE_STATIC_THEME,
           },
-          [ADDON_TYPE_LANG]: {},
-          [ADDON_TYPE_STATIC_THEME]: {
-            painting: {
-              ...fakeCategory,
-              application: CLIENT_APP_ANDROID,
-              name: 'Painting',
-              slug: 'painting',
-              type: ADDON_TYPE_STATIC_THEME,
-            },
+          naturé: {
+            ...fakeCategory,
+            application: CLIENT_APP_FIREFOX,
+            name: 'Naturé',
+            slug: 'naturé',
+            type: ADDON_TYPE_STATIC_THEME,
+          },
+          painting: {
+            ...fakeCategory,
+            application: CLIENT_APP_FIREFOX,
+            name: 'Painting',
+            slug: 'painting',
+            type: ADDON_TYPE_STATIC_THEME,
           },
         },
       });


### PR DESCRIPTION
Fixes #12414 

This removes the need for the clientapp in category list since we are unifying categories. It also handles the unified api categories as well as legacy category object from the api addon type in the reducer.