### PR TITLE
Fix loading of add-ons with only Android categories

### DIFF
--- a/src/amo/reducers/categories.js
+++ b/src/amo/reducers/categories.js
@@ -113,8 +113,10 @@ export default function reducer(
         // If the API returns data for an application we don't support,
         // we'll ignore it for now.
         if (category.application && category.application !== 'firefox') {
-          log.warn(oneLine`Category data for unknown clientApp
-              "${category.application}" received from API.`);
+          if (category.application !== 'android') {
+            log.warn(oneLine`Category data for unknown clientApp
+                "${category.application}" received from API.`);
+          }
           return;
         }
 

--- a/src/amo/reducers/utils.js
+++ b/src/amo/reducers/utils.js
@@ -24,8 +24,8 @@ export const selectLocalizedContent = (
 export const selectCategoryObject = (
   apiAddon: ExternalAddonType,
 ): CategoryEntry => {
-  if (apiAddon.categories && apiAddon.categories.firefox) {
-    return apiAddon.categories.firefox;
+  if (apiAddon.categories instanceof Array) {
+    return apiAddon.categories;
   }
-  return apiAddon.categories;
+  return apiAddon.categories.firefox;
 };

--- a/src/amo/reducers/utils.js
+++ b/src/amo/reducers/utils.js
@@ -27,5 +27,5 @@ export const selectCategoryObject = (
   if (apiAddon.categories instanceof Array) {
     return apiAddon.categories;
   }
-  return apiAddon.categories.firefox;
+  return apiAddon.categories?.firefox;
 };

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -613,6 +613,23 @@ describe(__filename, () => {
       expect(screen.queryByText('Related Categories')).not.toBeInTheDocument();
     });
 
+    it('does not render related categories when add-on only has Android categories', () => {
+      const addon = createInternalAddonWithLang({
+        ...fakeAddon,
+        // We are migrating away from per-app categories so if an Addon only
+        // has Android categories, ignore them completely, even on Android
+        // pages.
+        categories: { [CLIENT_APP_ANDROID]: ['some', 'thing'] },
+      });
+
+      store.dispatch(loadCategories({ results: categories }));
+      store.dispatch(setClientApp(CLIENT_APP_ANDROID));
+
+      render({ addon, store });
+
+      expect(screen.queryByText('Related Categories')).not.toBeInTheDocument();
+    });
+
     it('does not render related categories when there are no loaded categories', () => {
       const { slug: slug1 } = categories[3];
       const { slug: slug2 } = categories[4];


### PR DESCRIPTION
Follow-up fix for #12414

Some add-ons only have `"categories": {"android": [...]}` - those should be completely ignored (categories are not currently used on Android, and they'll be merged with Firefox soon)