### PR TITLE
Yarn v2 config changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ node_modules
 # Optional npm cache directory
 .npm
 
+# yarn cache directory
+.yarn
+
 # Optional REPL history
 .node_repl_history
 

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -346,5 +346,6 @@
       "path": "./dist/static/amo-*.css",
       "maxSize": "32 kB"
     }
-  ]
+  ],
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
yarn v2 does things a little different - I didn't bother investigating if any of the new default were better, just tried to keep it as similar as possible to v1 - to get rid of the annoying extra cruft in my local folder.

/.yarn/ is where the downloads get cached
/.yarnrc.yml is where yarn settings are now.  it just has `nodeLinker: node-modules`, which is how yarn v1 works.