### PR TITLE
Sync validClientAppUrlExceptions with SUPPORTED_NONAPPS

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -339,6 +339,7 @@ module.exports = {
     '__frontend_version__',
     '__version__',
     'about',
+    'abuse',
     'admin',
     'apps',
     'blocklist',


### PR DESCRIPTION
This allows /abuse/ to work on local envs to work without needing to mess with nginx config. On dev/stage/prod we'll still need to change that nginx config but that will only become relevant when we start testing/deploying it in those envs.

Supports https://github.com/mozilla/addons-server/issues/21290