### PR TITLE
[BUG] #11824: Search bar hover display issue

### DIFF
--- a/src/amo/components/Header/index.js
+++ b/src/amo/components/Header/index.js
@@ -106,6 +106,7 @@ export class HeaderBase extends React.Component {
           >
             {i18n.gettext('Submit a New Add-on')}
           </Link>
+
         </DropdownMenuItem>
         <DropdownMenuItem>
           <Link

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -177,7 +177,10 @@
 
   .DropdownMenu-button {
     display: flex;
+    position: relative; /* Add this line to make the dropdown relative to its container */
     padding: 0;
+    overflow-y: auto;
+    max-height: 200px;
   }
 
   @include respond-to(medium) {


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes mozilla/addons#10997

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes mozilla/addons#14627 

The Bug is that, whenever someone hovers the search bar it display name which overlaps the search bar so to fix this I modified the code and tried different styles as well in the respective code files. 

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
