### PR TITLE
Remove yellow banner on /android/ pages on android

### DIFF
--- a/src/amo/utils/compatibility.js
+++ b/src/amo/utils/compatibility.js
@@ -289,7 +289,6 @@ export const getMobileHomepageLink = (lang: string): string =>
 
 export const correctedLocationForPlatform = ({
   clientApp,
-  isHomePage = false,
   lang,
   location,
   userAgentInfo,
@@ -311,11 +310,8 @@ export const correctedLocationForPlatform = ({
 
   if (
     // Android browser on desktop site.
-    (isFirefoxForAndroid(userAgentInfo) && clientApp === CLIENT_APP_FIREFOX) ||
-    // Android browser on page other than Home or Search.
-    (isFirefoxForAndroid(userAgentInfo) &&
-      !isHomePage &&
-      !location.pathname.includes('/search/'))
+    isFirefoxForAndroid(userAgentInfo) &&
+    clientApp === CLIENT_APP_FIREFOX
   ) {
     // Redirect to `android` home page.
     return getMobileHomepageLink(lang);

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -168,6 +168,16 @@ describe(__filename, () => {
     ).toBeInTheDocument();
   });
 
+  it('does not generate a message on android when on /android/ pages that are not home or search', () => {
+    _correctedLocationForPlatform.mockReturnValue(null);
+    _isFirefoxForAndroid.mockReturnValue(true);
+    render({ location: '/android/extensions/categories' });
+
+    expect(
+      screen.queryByClassName('WrongPlatformWarning'),
+    ).not.toBeInTheDocument();
+  });
+
   it('generates the expected message when being directed to other than the mobile home page, from the detail page', () => {
     const newLocation = '/some/location/';
     _correctedLocationForPlatform.mockReturnValue(newLocation);

--- a/tests/unit/amo/utils/test_compatibility.js
+++ b/tests/unit/amo/utils/test_compatibility.js
@@ -721,7 +721,7 @@ describe(__filename, () => {
       ).toEqual(getMobileHomepageLink(lang));
     });
 
-    it('returns a link to the mobile homepage when on Firefox for Android and clientApp is android for most pages', () => {
+    it('returns null when on Firefox for Android and clientApp is android for most pages', () => {
       const lang = 'fr';
       expect(
         _correctedLocationForPlatform({
@@ -731,7 +731,7 @@ describe(__filename, () => {
           location: createFakeLocation({ pathname: '/some/path' }),
           userAgentInfo: UAParser(userAgentsByPlatform.android.firefox40Mobile),
         }),
-      ).toEqual(getMobileHomepageLink(lang));
+      ).toEqual(null);
     });
 
     it('returns null when on Firefox for Android and clientApp is android for the home page', () => {


### PR DESCRIPTION
Fixes #12496 

Previously, the banner showed up everywhere on android that wasn't home or search. This removes that condition, so it won't show up anywhere on android while one /android/ pages.