### PR TITLE
Send installed add-on version when available

### DIFF
--- a/src/amo/api/abuse.js
+++ b/src/amo/api/abuse.js
@@ -28,6 +28,7 @@ export type ReportAddonParams = {|
   message: string,
   reason: string | null,
   location: string | null,
+  addonVersion: string | null,
 |};
 
 export type ReportAddonResponse = {|
@@ -38,10 +39,11 @@ export type ReportAddonResponse = {|
   |},
   message: string | null,
   reporter: AbuseReporter | null,
-  reporterName: string | null,
-  reporterEmail: string | null,
+  reporter_name: string | null,
+  reporter_email: string | null,
   reason: string | null,
   location: string | null,
+  addon_version: string | null,
 |};
 
 export function reportAddon({
@@ -52,6 +54,7 @@ export function reportAddon({
   message,
   reason,
   location,
+  addonVersion,
 }: ReportAddonParams): Promise<ReportAddonResponse> {
   return callApi({
     auth: true,
@@ -64,6 +67,7 @@ export function reportAddon({
       message,
       reason,
       location,
+      addon_version: addonVersion,
     },
     apiState: api,
   });

--- a/src/amo/installAddon.js
+++ b/src/amo/installAddon.js
@@ -220,6 +220,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
               ...payload,
               status,
               canUninstall: clientAddon.canUninstall,
+              version: clientAddon.version,
             }),
           );
         },

--- a/src/amo/reducers/abuse.js
+++ b/src/amo/reducers/abuse.js
@@ -82,12 +82,13 @@ type LoadAddonAbuseReportAction = {|
 
 export function loadAddonAbuseReport({
   addon,
-  reporterEmail,
-  reporterName,
+  reporter_email,
+  reporter_name,
   message,
   reason,
   reporter,
   location,
+  addon_version,
 }: ReportAddonResponse): LoadAddonAbuseReportAction {
   invariant(addon, 'addon is required');
   invariant(typeof message !== 'undefined', 'message must be defined');
@@ -97,12 +98,13 @@ export function loadAddonAbuseReport({
     type: LOAD_ADDON_ABUSE_REPORT,
     payload: {
       addon,
-      reporterEmail,
-      reporterName,
+      reporter_email,
+      reporter_name,
       message,
       reason,
       reporter,
       location,
+      addon_version,
     },
   };
 }
@@ -115,6 +117,7 @@ type SendAddonAbuseReportParams = {|
   message: string,
   reason?: string | null,
   location?: string | null,
+  addonVersion?: string | null,
 |};
 
 export type SendAddonAbuseReportAction = {|
@@ -130,6 +133,7 @@ export function sendAddonAbuseReport({
   message,
   reason = null,
   location = null,
+  addonVersion = null,
 }: SendAddonAbuseReportParams): SendAddonAbuseReportAction {
   invariant(addonId, 'addonId is required');
   invariant(errorHandlerId, 'errorHandlerId is required');
@@ -145,6 +149,7 @@ export function sendAddonAbuseReport({
       message,
       reason,
       location,
+      addonVersion,
     },
   };
 }

--- a/src/amo/reducers/installations.js
+++ b/src/amo/reducers/installations.js
@@ -38,6 +38,7 @@ export type InstalledAddon = {
   needsRestart?: boolean,
   status: InstalledAddonStatus,
   url?: $PropertyType<AddonType, 'url'>,
+  version?: string,
 };
 
 export type InstallationsState = {
@@ -119,6 +120,7 @@ export default function installations(
           needsRestart: payload.needsRestart || false,
           status: payload.status,
           url: payload.url,
+          version: payload.version,
         },
       };
     case START_DOWNLOAD:

--- a/src/amo/sagas/abuse.js
+++ b/src/amo/sagas/abuse.js
@@ -28,6 +28,7 @@ export function* reportAddon({
     message,
     reason,
     location,
+    addonVersion,
   },
 }: SendAddonAbuseReportAction): Saga {
   const errorHandler = createErrorHandler(errorHandlerId);
@@ -45,20 +46,11 @@ export function* reportAddon({
       message,
       reason: reason || null,
       location: location || null,
+      addonVersion: addonVersion || null,
     };
     const response = yield call(reportAddonApi, params);
 
-    yield put(
-      loadAddonAbuseReport({
-        addon: response.addon,
-        reporterName: response.reporter_name,
-        reporterEmail: response.reporter_email,
-        message: response.message,
-        reason: response.reason,
-        reporter: response.reporter,
-        location: response.location,
-      }),
-    );
+    yield put(loadAddonAbuseReport(response));
   } catch (error) {
     log.warn(`Reporting add-on for abuse failed: ${error}`);
     yield put(errorHandler.createErrorAction(error));
@@ -78,10 +70,11 @@ export function* reportAddonViaFirefox({
           addon: { guid: addon.guid, id: addon.id, slug: addon.slug },
           message: null,
           reporter: null,
-          reporterEmail: null,
-          reporterName: null,
+          reporter_email: null,
+          reporter_name: null,
           reason: null,
           location: null,
+          addon_version: null,
         }),
       );
     }

--- a/tests/unit/amo/api/test_abuse.js
+++ b/tests/unit/amo/api/test_abuse.js
@@ -31,6 +31,7 @@ describe(__filename, () => {
       const reporterEmail = 'fox@moz.co';
       const addonId = 'cool-addon';
       const location = 'both';
+      const addonVersion = '1.2.3.4';
 
       mockApi
         .expects('callApi')
@@ -45,6 +46,7 @@ describe(__filename, () => {
             reporter_email: reporterEmail,
             reporter_name: reporterName,
             location,
+            addon_version: addonVersion,
           },
           apiState,
         })
@@ -64,6 +66,7 @@ describe(__filename, () => {
         reporterEmail,
         reporterName,
         location,
+        addonVersion,
       });
 
       mockApi.verify();

--- a/tests/unit/amo/reducers/test_abuse.js
+++ b/tests/unit/amo/reducers/test_abuse.js
@@ -103,6 +103,7 @@ describe(__filename, () => {
           reporterName: 'Foxy',
           reporterEmail: 'made_up@email',
           location: 'both',
+          addonVersion: '1.2.3',
         };
       });
 

--- a/tests/unit/amo/reducers/test_installations.js
+++ b/tests/unit/amo/reducers/test_installations.js
@@ -29,6 +29,7 @@ describe(__filename, () => {
 
   it('adds an add-on to state', () => {
     const guid = 'my-addon@me.com';
+    const version = '1.2.3.4';
     expect(
       installations(
         undefined,
@@ -37,6 +38,7 @@ describe(__filename, () => {
           guid,
           url: 'https://addons.cdn.mozilla.net/download/my-addon.xpi',
           status: UNINSTALLED,
+          version,
         }),
       ),
     ).toEqual({
@@ -48,6 +50,7 @@ describe(__filename, () => {
         needsRestart: false,
         status: UNINSTALLED,
         url: 'https://addons.cdn.mozilla.net/download/my-addon.xpi',
+        version,
       },
     });
   });

--- a/tests/unit/amo/sagas/test_abuse.js
+++ b/tests/unit/amo/sagas/test_abuse.js
@@ -148,10 +148,11 @@ describe(__filename, () => {
         addon: { guid: addon.guid, id: addon.id, slug: addon.slug },
         message: null,
         reporter: null,
-        reporterName: null,
-        reporterEmail: null,
+        reporter_name: null,
+        reporter_email: null,
         reason: null,
         location: null,
+        addon_version: null,
       });
 
       const loadAction = await sagaTester.waitFor(expectedLoadAction.type);


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12477

---

This PR allows add-on feedback reports to be sent with the installed add-on version when available.