### PR TITLE
Refactor add-on form, show add-on metadata

### DIFF
--- a/src/amo/api/abuse.js
+++ b/src/amo/api/abuse.js
@@ -25,7 +25,7 @@ export type ReportAddonParams = {|
   api: ApiState,
   reporterName: string | null,
   reporterEmail: string | null,
-  message: string,
+  message: string | null,
   reason: string | null,
   location: string | null,
   addonVersion: string | null,

--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -236,14 +236,10 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
   renderReportSentConfirmation(i18n: I18nType): React.Node {
     return (
       <div>
-        <Card
-          header={i18n.gettext('You sent a report about this add-on')}
-          className="FeedbackForm--Card"
-        >
-          <p className="ReportAbuseButton-first-paragraph">
-            {i18n.gettext(
-              `We have received your report. Thanks for letting us know.`,
-            )}
+        <Card header={i18n.gettext('You sent a report about this add-on')}>
+          <p className="FeedbackForm-success-first-paragraph">
+            {i18n.gettext(`We have received your report. Thanks for letting us
+              know.`)}
           </p>
         </Card>
       </div>

--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -3,7 +3,6 @@
 import invariant from 'invariant';
 import * as React from 'react';
 import Textarea from 'react-textarea-autosize';
-import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
@@ -13,8 +12,11 @@ import { getCurrentUser } from 'amo/reducers/users';
 import translate from 'amo/i18n/translate';
 import Button from 'amo/components/Button';
 import Card from 'amo/components/Card';
+import AddonTitle from 'amo/components/AddonTitle';
 import Notice from 'amo/components/Notice';
 import Select from 'amo/components/Select';
+import SignedInUser from 'amo/components/SignedInUser';
+import { getAddonIconUrl } from 'amo/imageUtils';
 import type { AddonAbuseState } from 'amo/reducers/abuse';
 import type { UserType } from 'amo/reducers/users';
 import type { AppState } from 'amo/store';
@@ -30,7 +32,6 @@ import './styles.scss';
 
 type Props = {|
   addon: AddonType | null,
-  addonId: string,
   errorHandler: ErrorHandlerType,
 |};
 
@@ -59,8 +60,8 @@ type FormValues = {|
   email: string,
   text: string,
   category: string | null,
-  legalAssertion: boolean,
-  violationLocation: string | null,
+  certification: boolean,
+  location: string | null,
 |};
 
 type State = {|
@@ -88,14 +89,14 @@ export const getCategories = (
           'It doesn’t work, breaks websites, or slows down Firefox',
         ),
         help: i18n.gettext(
-          "Example: Features are slow, hard to use, or don’t work; parts of websites won't load or look unusual",
+          "Example: Features are slow, hard to use, or don’t work; parts of websites won't load or look unusual.",
         ),
       },
       {
         value: 'feedback_spam',
         label: i18n.gettext('It’s SPAM'),
         help: i18n.gettext(
-          'Example: An application installed it without my permission',
+          'Example: The listing advertises unrelated products or services.',
         ),
       },
     ],
@@ -104,7 +105,7 @@ export const getCategories = (
         value: 'policy_violation',
         label: i18n.gettext('It violates Add-on Policies'),
         help: i18n.gettext(
-          'Example: I didn’t want it or It compromised my data without informing or asking me, or it changed my search engine or home page without informing or asking me.',
+          'Example: It compromised my data without informing or asking me, or it changed my search engine or home page without informing or asking me.',
         ),
       },
       {
@@ -112,7 +113,7 @@ export const getCategories = (
         label: i18n.gettext(
           'It contains hateful, violent, deceptive, or other inappropriate content',
         ),
-        help: i18n.gettext('Example: contains racist imagery'),
+        help: i18n.gettext('Example: It contains racist imagery.'),
       },
       {
         value: 'illegal',
@@ -120,14 +121,14 @@ export const getCategories = (
           'It violates the law or contains content that violates the law',
         ),
         help: i18n.gettext(
-          'Example: Copyright or Trademark Infringement, Fraud',
+          'Example: Copyright or Trademark Infringement, Fraud.',
         ),
       },
       {
         value: 'other',
         label: i18n.gettext('Something else'),
         help: i18n.gettext(
-          'Anything that doesn’t fit into the other categories',
+          'Anything that doesn’t fit into the other categories.',
         ),
       },
     ],
@@ -167,10 +168,15 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
   onFieldChange: (event: SyntheticEvent<HTMLInputElement>) => void = (
     event: SyntheticEvent<HTMLInputElement>,
   ) => {
-    const { name, value } = event.currentTarget;
+    const { name, value, checked } = event.currentTarget;
+
+    let newValue: boolean | string | null = value;
+    if (name === 'certification') {
+      newValue = checked;
+    }
 
     this.setState({
-      [name]: value,
+      [name]: newValue,
       successMessage: null,
     });
   };
@@ -179,9 +185,8 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
     event.preventDefault();
 
     const { addon, dispatch, errorHandler, installedAddon } = this.props;
-    const { email, name, text, category, violationLocation } = this.state;
+    const { email, name, text, category, location } = this.state;
 
-    invariant(text.trim().length, 'A report cannot be sent with no content.');
     invariant(addon, 'An add-on is required for a report.');
 
     dispatch(
@@ -194,7 +199,7 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
         reporterName: name,
         message: text,
         reason: category,
-        location: violationLocation,
+        location,
         addonVersion: installedAddon?.version || null,
       }),
     );
@@ -206,8 +211,8 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
       name: '',
       text: '',
       category: null,
-      legalAssertion: false,
-      violationLocation: null,
+      certification: false,
+      location: null,
     };
 
     const { email, display_name: name } = currentUser || {};
@@ -221,14 +226,10 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
 
   preventSubmit(): boolean {
     const { loading } = this.props;
-    const { text, category, legalAssertion } = this.state;
+    const { category, certification } = this.state;
 
     return (
-      loading ||
-      !category ||
-      !text ||
-      (text && text.trim() === '') ||
-      !legalAssertion
+      loading || !category || (this.isCertificationRequired() && !certification)
     );
   }
 
@@ -249,8 +250,12 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
     );
   }
 
+  isCertificationRequired(): boolean {
+    return ['illegal'].includes(this.state.category);
+  }
+
   render(): React.Node {
-    const { addonId, abuseReport, currentUser, errorHandler, i18n, loading } =
+    const { abuseReport, addon, currentUser, errorHandler, i18n, loading } =
       this.props;
 
     let errorMessage;
@@ -288,14 +293,16 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
             >
               {category.label}
             </label>
-            <p className="FeedbackForm--help">{category.help}</p>
+            {category.help && (
+              <p className="FeedbackForm--help">{category.help}</p>
+            )}
           </li>,
         );
       });
     }
 
-    const violationLocationOptions = [
-      { children: i18n.gettext('--Select a location--'), value: '' },
+    const locationOptions = [
+      { children: i18n.gettext('Select place'), value: '' },
       {
         children: i18n.gettext("On the add-on's page on this website"),
         value: 'amo',
@@ -308,19 +315,19 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
 
     return (
       <div className="FeedbackForm">
-        <Helmet>
-          <title>
-            {i18n.sprintf(
-              i18n.gettext(
-                'Submit feedback or report for %(type)s %(identifier)s',
-              ),
-              {
-                type: i18n.gettext('Add-on'),
-                identifier: addonId,
-              },
-            )}
-          </title>
-        </Helmet>
+        <Card className="FeedbackForm-header">
+          <div className="FeedbackForm-header-icon">
+            <div className="FeedbackForm-header-icon-wrapper">
+              <img
+                className="FeedbackForm-header-icon-image"
+                src={getAddonIconUrl(addon)}
+                alt=""
+              />
+            </div>
+          </div>
+
+          <AddonTitle addon={addon} />
+        </Card>
 
         {abuseSubmitted ? (
           this.renderReportSentConfirmation(i18n)
@@ -333,125 +340,120 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
                 <Notice type="success">{this.state.successMessage}</Notice>
               )}
             </div>
-            <div>
-              <Card
-                className="FeedbackForm--Card"
-                header={i18n.gettext('Send some feedback about an add-on')}
-              >
-                <ul>{categoryInputs.feedback}</ul>
-              </Card>
-              <Card
-                className="FeedbackForm--Card"
-                header={i18n.gettext(
-                  "Report an add-on to Mozilla because it's illegal or incompliant",
+
+            <Card
+              className="FeedbackForm--Card"
+              header={i18n.gettext('Report this add-on to Mozilla')}
+            >
+              <h3>{i18n.gettext('Send some feedback about the add-on')}</h3>
+              <ul>{categoryInputs.feedback}</ul>
+
+              <h3>
+                {i18n.gettext(
+                  "Report the add-on because it's illegal or incompliant",
                 )}
-              >
-                <ul>{categoryInputs.report}</ul>
-              </Card>
+              </h3>
+              <ul>{categoryInputs.report}</ul>
+            </Card>
 
-              <Card
-                className="FeedbackForm--Card"
-                header={i18n.gettext('Tell us more')}
+            <Card
+              className="FeedbackForm--Card"
+              header={i18n.gettext('Provide more information')}
+            >
+              <label className="FeedbackForm--label" htmlFor="feedbackLocation">
+                {i18n.gettext('Place of the violation')}
+                <span>({i18n.gettext('optional')})</span>
+              </label>
+              <Select
+                className="FeedbackForm-location"
+                id="feedbackLocation"
+                name="location"
+                onChange={this.onFieldChange}
+                value={this.state.location}
               >
-                <label
-                  className="FeedbackForm--label"
-                  htmlFor="feedbackLocation"
-                >
-                  {i18n.gettext('Where is the offending content')}
-                </label>
-                <Select
-                  className="FeedbackForm-violationLocation"
-                  id="feedbackLocation"
-                  name="violationLocation"
-                  onChange={this.onFieldChange}
-                  value={this.state.violationLocation}
-                >
-                  {violationLocationOptions.map((option) => {
-                    return <option key={option.value} {...option} />;
-                  })}
-                </Select>
+                {locationOptions.map((option) => {
+                  return <option key={option.value} {...option} />;
+                })}
+              </Select>
 
-                <label className="FeedbackForm--label" htmlFor="feedbackText">
-                  {i18n.gettext('Give details of your feedback or report')}
-                </label>
-                <Textarea
-                  className="FeedbackForm-text"
-                  id="feedbackText"
-                  name="text"
-                  onChange={this.onFieldChange}
-                  value={this.state.text}
-                />
-                <input
-                  type="checkbox"
-                  className="FeedbackForm-legalAssertion"
-                  id="feedbackLegalAssertion"
-                  name="legalAssertion"
-                  onChange={this.onFieldChange}
-                  required="true"
-                />
-                <label
-                  className="FeedbackForm--label"
-                  htmlFor="feedbackLegalAssertion"
-                >
-                  {i18n.gettext(
-                    'I hereby certify, under penalty of perjury, my bona fide belief ' +
-                      'that the allegations in this report are complete and accurate. ' +
-                      'For allegations of trademark or copyright infringement, I further ' +
-                      'certify that I am either the affected rightsholder, or have been ' +
-                      "authorized to act on that rightsholder's behalf.",
-                  )}
-                </label>
-              </Card>
+              <label className="FeedbackForm--label" htmlFor="feedbackText">
+                {i18n.gettext('Provide more details')}
+                <span>({i18n.gettext('optional')})</span>
+              </label>
+              <Textarea
+                className="FeedbackForm-text"
+                id="feedbackText"
+                name="text"
+                onChange={this.onFieldChange}
+                value={this.state.text}
+              />
+            </Card>
 
-              <Card
-                className="FeedbackForm--Card"
-                header={i18n.gettext('Your details')}
-              >
-                <p className="FeedbackForm-details-aside">
-                  {currentUser
-                    ? i18n.gettext(
-                        'We will notify you by email with any updates about your report.',
-                      )
-                    : i18n.gettext(
-                        'To receive updates about your report enter your name and email address.',
-                      )}
+            <Card
+              className="FeedbackForm--Card"
+              header={i18n.gettext('Contact information')}
+            >
+              {currentUser && <SignedInUser user={currentUser} />}
+
+              <label className="FeedbackForm--label" htmlFor="feedbackName">
+                {i18n.gettext('Your name')}
+                {!currentUser && <span>({i18n.gettext('optional')})</span>}
+              </label>
+              <input
+                className="FeedbackForm-name"
+                id="feedbackName"
+                name="name"
+                disabled={currentUser}
+                onChange={this.onFieldChange}
+                value={this.state.name || (currentUser && currentUser.name)}
+              />
+
+              <label className="FeedbackForm--label" htmlFor="feedbackEmail">
+                {i18n.gettext('Your email address')}
+                {!currentUser && <span>({i18n.gettext('optional')})</span>}
+              </label>
+              <input
+                className="FeedbackForm-email"
+                id="feedbackEmail"
+                name="email"
+                disabled={currentUser}
+                onChange={this.onFieldChange}
+                value={this.state.email || (currentUser && currentUser.email)}
+              />
+
+              {this.isCertificationRequired() && (
+                <p>
+                  <input
+                    type="checkbox"
+                    className="FeedbackForm-certification"
+                    id="feedbackCertification"
+                    name="certification"
+                    onChange={this.onFieldChange}
+                    checked={!!this.state.certification}
+                    required={this.isCertificationRequired()}
+                  />
+                  <label
+                    className="FeedbackForm--label"
+                    htmlFor="feedbackCertification"
+                  >
+                    {i18n.gettext(`By submitting this report I certify, under
+                    penalty of perjury, that the allegations it contains are
+                    complete and accurate, to the best of my knowledge.`)}
+                  </label>
                 </p>
-                <label className="FeedbackForm--label" htmlFor="feedbackName">
-                  {i18n.gettext('Your Full Name')}
-                </label>
-                <input
-                  className="FeedbackForm-name"
-                  id="feedbackName"
-                  name="name"
-                  disabled={currentUser}
-                  onChange={this.onFieldChange}
-                  value={this.state.name || (currentUser && currentUser.name)}
-                />
+              )}
+            </Card>
 
-                <label className="FeedbackForm--label" htmlFor="feedbackEmail">
-                  {i18n.gettext('Your Email Address')}
-                </label>
-                <input
-                  className="FeedbackForm-email"
-                  id="feedbackEmail"
-                  name="email"
-                  disabled={currentUser}
-                  onChange={this.onFieldChange}
-                  value={this.state.email || (currentUser && currentUser.email)}
-                />
-              </Card>
-
-              <div className="FeedbackForm-buttons-wrapper">
-                <Button
-                  buttonType="action"
-                  className="FeedbackForm-submit-button FeedbackForm-button"
-                  disabled={this.preventSubmit()}
-                  puffy
-                  type="submit"
-                >
-                  {submitButtonText}
-                </Button>
-              </div>
+            <div className="FeedbackForm-buttons-wrapper">
+              <Button
+                buttonType="action"
+                className="FeedbackForm-submit-button FeedbackForm-button"
+                disabled={this.preventSubmit()}
+                puffy
+                type="submit"
+              >
+                {submitButtonText}
+              </Button>
             </div>
           </form>
         )}

--- a/src/amo/components/FeedbackForm/styles.scss
+++ b/src/amo/components/FeedbackForm/styles.scss
@@ -1,43 +1,53 @@
 @import '~amo/css/styles';
 
-$font-size-aside: $font-size-xs;
+$icon-size: 32px;
 
-.FeedbackForm {
-  @include page-padding;
+.FeedbackForm-header > .Card-contents {
+  align-items: center;
+  display: grid;
+  grid-template-columns: ($icon-size + 16px) 1fr;
 
-  @include respond-to(large) {
-    display: flex;
-    justify-content: flex-start;
+  .FeedbackForm-header-icon {
+    grid-column: 1;
   }
 
-  > div {
+  .FeedbackForm-header-icon-wrapper {
+    height: $icon-size;
+    overflow: hidden;
+    width: $icon-size;
+  }
+
+  .FeedbackForm-header-icon-image {
+    height: auto;
     width: 100%;
+  }
+
+  .AddonTitle {
+    font-size: $font-size-heading-xs;
+    grid-column: 2;
+    margin-bottom: 0;
+
+    .AddonTitle-author {
+      &,
+      a,
+      a:link {
+        font-size: $font-size-l;
+      }
+    }
   }
 }
 
-.FeedbackForm-form-messages .Notice,
-.FeedbackForm--Card {
+.FeedbackForm .Card {
   margin-bottom: $padding-page;
+}
 
+.FeedbackForm-form {
   ul {
     @include padding-start(0);
   }
-}
 
-.FeedbackForm-details-aside {
-  color: $grey-50;
-  font-size: $font-size-aside;
-  margin-top: 0;
-
-  @include respond-to(large) {
-    @include margin(0, 0, 0, $padding-page);
-
-    float: right;
-    width: 35%;
-
-    [dir='rtl'] & {
-      float: left;
-    }
+  h3:first-child {
+    margin-top: 0;
   }
 }
 
@@ -45,16 +55,23 @@ $font-size-aside: $font-size-xs;
   display: block;
 }
 
+.FeedbackForm--label > span {
+  @include margin-start(4px);
+
+  color: $grey-50;
+}
+
 input[type='radio'] + .FeedbackForm--label,
 input[type='checkbox'] + .FeedbackForm--label {
+  @include padding-start(0.5em);
+
   display: revert;
-  padding-inline-start: 1em;
 }
 
 .FeedbackForm--help {
   color: $grey-50;
   display: block;
-  font-size: $font-size-aside;
+  font-size: $font-size-xs;
   margin-top: 4px;
 }
 
@@ -85,14 +102,21 @@ input[type='checkbox'] + .FeedbackForm--label {
 
 .FeedbackForm-name,
 .FeedbackForm-email,
-.FeedbackForm-violationLocation,
-.FeedbackForm-text {
+.FeedbackForm-location,
+.FeedbackForm-text,
+.FeedbackForm .SignedInUser {
   margin-bottom: 16px;
 }
 
 .FeedbackForm-text {
-  min-height: 3rem;
-  resize: vertical;
+  // The max height ensures that the textarea won't expand beyond 600
+  // characters and instead shows a scrollbar.
+  max-height: 230px;
+
+  // This is the height of two lines of text.
+  min-height: 51px;
+  resize: none;
+  width: 100%;
 }
 
 .FeedbackForm-category--li {

--- a/src/amo/components/FeedbackForm/styles.scss
+++ b/src/amo/components/FeedbackForm/styles.scss
@@ -141,3 +141,7 @@ input[type='checkbox'] + .FeedbackForm--label {
     margin-bottom: 0;
   }
 }
+
+.FeedbackForm-success-first-paragraph {
+  margin-top: 6px;
+}

--- a/src/amo/components/SignedInUser/index.js
+++ b/src/amo/components/SignedInUser/index.js
@@ -1,0 +1,36 @@
+/* @flow */
+import * as React from 'react';
+import { compose } from 'redux';
+
+import translate from 'amo/i18n/translate';
+import Icon from 'amo/components/Icon';
+import type { UserType } from 'amo/reducers/users';
+import type { I18nType } from 'amo/types/i18n';
+
+import './styles.scss';
+
+type Props = {|
+  user: UserType,
+|};
+
+type InternalProps = {|
+  ...Props,
+  i18n: I18nType,
+|};
+
+const SignedInUserBase = (props: InternalProps) => (
+  <div className="SignedInUser">
+    <Icon name="user-fill" />
+    <span className="SignedInUser-text">
+      {props.i18n.sprintf(props.i18n.gettext('Signed in as %(username)s'), {
+        username: props.user.name,
+      })}
+    </span>
+  </div>
+);
+
+const SignedInUser: React.ComponentType<Props> = compose(translate())(
+  SignedInUserBase,
+);
+
+export default SignedInUser;

--- a/src/amo/components/SignedInUser/styles.scss
+++ b/src/amo/components/SignedInUser/styles.scss
@@ -1,0 +1,10 @@
+@import '~amo/css/styles';
+
+.SignedInUser {
+  display: inline-flex;
+  align-items: center;
+}
+
+.SignedInUser-text {
+  @include margin-start(4px);
+}

--- a/src/amo/pages/Feedback/styles.scss
+++ b/src/amo/pages/Feedback/styles.scss
@@ -1,0 +1,5 @@
+@import '~amo/css/styles';
+
+.Feedback-page {
+  @include page-padding;
+}

--- a/src/amo/reducers/abuse.js
+++ b/src/amo/reducers/abuse.js
@@ -114,7 +114,7 @@ type SendAddonAbuseReportParams = {|
   errorHandlerId: string,
   reporterEmail?: string | null,
   reporterName?: string | null,
-  message: string,
+  message: string | null,
   reason?: string | null,
   location?: string | null,
   addonVersion?: string | null,
@@ -130,14 +130,13 @@ export function sendAddonAbuseReport({
   errorHandlerId,
   reporterEmail = null,
   reporterName = null,
-  message,
+  message = null,
   reason = null,
   location = null,
   addonVersion = null,
 }: SendAddonAbuseReportParams): SendAddonAbuseReportAction {
   invariant(addonId, 'addonId is required');
   invariant(errorHandlerId, 'errorHandlerId is required');
-  invariant(message, 'message is required');
 
   return {
     type: SEND_ADDON_ABUSE_REPORT,

--- a/src/amo/reducers/addons.js
+++ b/src/amo/reducers/addons.js
@@ -70,6 +70,7 @@ type FetchAddonParams = {|
   errorHandler: ErrorHandlerType,
   showGroupedRatings?: boolean,
   slug: string,
+  assumeNonPublic?: boolean,
 |};
 
 export type FetchAddonAction = {|
@@ -78,6 +79,7 @@ export type FetchAddonAction = {|
     errorHandlerId: string,
     showGroupedRatings?: boolean,
     slug: string,
+    assumeNonPublic?: boolean,
   |},
 |};
 
@@ -85,6 +87,7 @@ export function fetchAddon({
   errorHandler,
   showGroupedRatings = false,
   slug,
+  assumeNonPublic = false,
 }: FetchAddonParams): FetchAddonAction {
   if (!errorHandler) {
     throw new Error('errorHandler cannot be empty');
@@ -94,7 +97,12 @@ export function fetchAddon({
   }
   return {
     type: FETCH_ADDON,
-    payload: { errorHandlerId: errorHandler.id, showGroupedRatings, slug },
+    payload: {
+      errorHandlerId: errorHandler.id,
+      showGroupedRatings,
+      slug,
+      assumeNonPublic,
+    },
   };
 }
 

--- a/src/amo/sagas/abuse.js
+++ b/src/amo/sagas/abuse.js
@@ -50,6 +50,17 @@ export function* reportAddon({
     };
     const response = yield call(reportAddonApi, params);
 
+    // Update the response for non-public add-ons so that the rest of our
+    // (redux) logic isn't confused by the lack of information.
+    if (!response.addon.id && !response.addon.slug) {
+      const { addon } = response;
+      response.addon = {
+        ...addon,
+        guid: addon.guid,
+        slug: addon.guid,
+      };
+    }
+
     yield put(loadAddonAbuseReport(response));
   } catch (error) {
     log.warn(`Reporting add-on for abuse failed: ${error}`);

--- a/tests/unit/amo/components/TestSignedInUser.js
+++ b/tests/unit/amo/components/TestSignedInUser.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import SignedInUser from 'amo/components/SignedInUser';
+import { getCurrentUser } from 'amo/reducers/users';
+import { dispatchSignInActions, render, screen } from 'tests/unit/helpers';
+
+describe(__filename, () => {
+  const getUser = (userProps = {}) => {
+    const { state } = dispatchSignInActions({ userProps });
+    return getCurrentUser(state.users);
+  };
+
+  it('renders the user name', () => {
+    const username = 'some username';
+
+    render(<SignedInUser user={getUser({ username })} />);
+
+    expect(screen.getByText(`Signed in as ${username}`)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/amo/reducers/test_abuse.js
+++ b/tests/unit/amo/reducers/test_abuse.js
@@ -131,15 +131,6 @@ describe(__filename, () => {
           sendAddonAbuseReport(partialParams);
         }).toThrow('errorHandlerId is required');
       });
-
-      it('requires a message', () => {
-        expect(() => {
-          const partialParams = { ...defaultParams };
-          delete partialParams.message;
-
-          sendAddonAbuseReport(partialParams);
-        }).toThrow('message is required');
-      });
     });
 
     describe('loadAddonAbuseReport', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12478

---

This PR updates the UI and adds some of the add-on metadata we need on this page. The "stepper" thingy is omitted on purpose for now. I'll also address the "anonymous" part in https://github.com/mozilla/addons-frontend/issues/12532. ~~As for the legal certification at the bottom, I'm still waiting on confirmation to know when that is required.~~

As described at the bottom of this description, the required certification checkbox now appears for reasons D and E only. Most fields are also optional, in fact only the reason (named `category` in the code, for now) is required.

## Screenshots

User is signed in, add-on is listed:

![image](https://github.com/mozilla/addons-frontend/assets/217628/e1e41a34-5c77-47cc-b63d-1476b2d4f4c2)

User is signed in, add-on is a theme:

![image](https://github.com/mozilla/addons-frontend/assets/217628/8e4e80d9-676a-4811-8933-ee418cd084ac)

User is signed out, add-on is listed:

![image](https://github.com/mozilla/addons-frontend/assets/217628/a7777ea9-806e-4fd4-80fd-e699493646b9)

Add-on is unlisted:

![image](https://github.com/mozilla/addons-frontend/assets/217628/438f051b-514d-4e90-9647-a77196c29aeb)

Mobile view:

![image](https://github.com/mozilla/addons-frontend/assets/217628/7e0977b0-dea7-4656-b0d8-ea2378d49ddd)

The certification only appears when the right reason is selected (D and E, currently):

![image](https://github.com/mozilla/addons-frontend/assets/217628/3f832e6c-c7be-492d-8a5d-9674b6ef10b9)
