### PR TITLE
Add disclaimer next to message textarea in feedback form

### DIFF
--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -394,6 +394,13 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
                 onChange={this.onFieldChange}
                 value={this.state.text}
               />
+              <p className="FeedbackForm--help">
+                {i18n.gettext(`Please provide any additional information that
+                  may help us to understand your report (including which policy
+                  you believe has been violated). While this information is not
+                  required, failure to include it may prevent us from
+                  addressing the reported content.`)}
+              </p>
             </Card>
 
             <Card

--- a/src/amo/components/FeedbackForm/styles.scss
+++ b/src/amo/components/FeedbackForm/styles.scss
@@ -90,8 +90,11 @@ $icon-size: 32px;
 .FeedbackForm--help {
   color: $grey-50;
   display: block;
-  font-size: $font-size-xs;
-  margin-top: 4px;
+  margin-top: 0;
+}
+
+.FeedbackForm textarea {
+  margin-bottom: 4px;
 }
 
 .FeedbackForm input,


### PR DESCRIPTION
Fixes #12543

---

![image](https://github.com/mozilla/addons-frontend/assets/217628/1f3f9ac1-00d5-4963-aa02-a540852d6fe7)
