### PR TITLE
Rename `Feedback` page component to `AddonFeedback`

### DIFF
--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -16,7 +16,7 @@ import CategoryPage from 'amo/pages/CategoryPage';
 import Collection from 'amo/pages/Collection';
 import CollectionEdit from 'amo/pages/CollectionEdit';
 import CollectionList from 'amo/pages/CollectionList';
-import Feedback from 'amo/pages/Feedback';
+import AddonFeedback from 'amo/pages/AddonFeedback';
 import NotAuthorizedPage from 'amo/pages/ErrorPages/NotAuthorizedPage';
 import UnavailableForLegalReasonsPage from 'amo/pages/ErrorPages/UnavailableForLegalReasonsPage';
 import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
@@ -179,7 +179,7 @@ const Routes = ({ _config = config }: Props = {}): React.Node => (
       <Route
         exact
         path="/:lang/:application(firefox|android)/feedback/addon/:addonIdentifier/"
-        component={Feedback}
+        component={AddonFeedback}
       />
     )}
 

--- a/src/amo/pages/AddonFeedback/index.js
+++ b/src/amo/pages/AddonFeedback/index.js
@@ -44,7 +44,7 @@ type InternalProps = {|
 
 type State = {||};
 
-export class FeedbackBase extends React.Component<InternalProps, State> {
+export class AddonFeedbackBase extends React.Component<InternalProps, State> {
   constructor(props: InternalProps) {
     super(props);
     this.loadDataIfNeeded();
@@ -79,7 +79,7 @@ export class FeedbackBase extends React.Component<InternalProps, State> {
 
     return (
       <Page>
-        <div className="Feedback-page">
+        <div className="AddonFeedback-page">
           <Helmet>
             <title>
               {i18n.gettext('Submit feedback or report an add-on to Mozilla')}
@@ -111,10 +111,10 @@ export const extractId = (ownProps: InternalProps): string => {
   return ownProps.match.params.addonIdentifier;
 };
 
-const Feedback: React.ComponentType<Props> = compose(
+const AddonFeedback: React.ComponentType<Props> = compose(
   translate(),
   connect(mapStateToProps),
   withFixedErrorHandler({ fileName: __filename, extractId }),
-)(FeedbackBase);
+)(AddonFeedbackBase);
 
-export default Feedback;
+export default AddonFeedback;

--- a/src/amo/pages/AddonFeedback/styles.scss
+++ b/src/amo/pages/AddonFeedback/styles.scss
@@ -1,5 +1,5 @@
 @import '~amo/css/styles';
 
-.Feedback-page {
+.AddonFeedback-page {
   @include page-padding;
 }

--- a/tests/unit/amo/pages/TestAddonFeedback.js
+++ b/tests/unit/amo/pages/TestAddonFeedback.js
@@ -10,7 +10,7 @@ import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_FIREFOX,
 } from 'amo/constants';
-import { extractId } from 'amo/pages/Feedback';
+import { extractId } from 'amo/pages/AddonFeedback';
 import { loadAddonAbuseReport, sendAddonAbuseReport } from 'amo/reducers/abuse';
 import { loadAddon, fetchAddon } from 'amo/reducers/addons';
 import { clearError } from 'amo/reducers/errors';
@@ -73,7 +73,7 @@ describe(__filename, () => {
   }
 
   const getErrorHandlerId = (addonId) =>
-    `src/amo/pages/Feedback/index.js-${addonId}`;
+    `src/amo/pages/AddonFeedback/index.js-${addonId}`;
 
   const renderWithoutLoadingAddon = (addonIdentifier) => {
     const renderOptions = {


### PR DESCRIPTION
Fixes #12564

---

~~:warning: depends on https://github.com/mozilla/addons-frontend/pull/12560~~