### PR TITLE
Fetch add-on with group ratings in feedback form

### DIFF
--- a/src/amo/pages/Feedback/index.js
+++ b/src/amo/pages/Feedback/index.js
@@ -64,6 +64,8 @@ export class FeedbackBase extends React.Component<InternalProps, State> {
     if (!addon && !addonIsLoading) {
       dispatch(
         fetchAddon({
+          // We need this in case users navigate back to the add-on detail page.
+          showGroupedRatings: true,
           slug: match.params.addonIdentifier,
           errorHandler,
           assumeNonPublic: true,

--- a/tests/unit/amo/pages/TestFeedback.js
+++ b/tests/unit/amo/pages/TestFeedback.js
@@ -108,6 +108,7 @@ describe(__filename, () => {
     expect(dispatch).toHaveBeenCalledWith(
       fetchAddon({
         errorHandler,
+        showGroupedRatings: true,
         slug: addonIdentifier,
         assumeNonPublic: true,
       }),


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12566

---

Not sure why we conditionally fetch an add-on with group ratings but
failing to do so will throw an error when we navigate back to an add-on
detail page after a reload. This isn't exactly a normal scenario but
that might happen given that the feedback page is available from a
detail page.