### PR TITLE
Show add-on metadata in the add-on feedback form page

### DIFF
--- a/src/amo/components/AddonFeedbackForm/index.js
+++ b/src/amo/components/AddonFeedbackForm/index.js
@@ -3,6 +3,7 @@ import invariant from 'invariant';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import makeClassName from 'classnames';
 
 import { ADDON_TYPE_EXTENSION } from 'amo/constants';
 import FeedbackForm, {
@@ -18,6 +19,9 @@ import { sendAddonAbuseReport } from 'amo/reducers/abuse';
 import translate from 'amo/i18n/translate';
 import Card from 'amo/components/Card';
 import AddonTitle from 'amo/components/AddonTitle';
+import Icon from 'amo/components/Icon';
+import Rating from 'amo/components/Rating';
+import LoadingText from 'amo/components/LoadingText';
 import { getAddonIconUrl } from 'amo/imageUtils';
 import type { AddonAbuseState } from 'amo/reducers/abuse';
 import type { AppState } from 'amo/store';
@@ -114,7 +118,11 @@ export class AddonFeedbackFormBase extends React.Component<InternalProps> {
     }
 
     return (
-      <div className="AddonFeedbackForm">
+      <div
+        className={makeClassName('AddonFeedbackForm', {
+          'AddonFeedbackForm--no-metadata': this.isAddonNonPublic(),
+        })}
+      >
         <FeedbackForm
           errorHandler={errorHandler}
           contentHeader={
@@ -130,6 +138,37 @@ export class AddonFeedbackFormBase extends React.Component<InternalProps> {
               </div>
 
               <AddonTitle addon={addon} />
+
+              {!this.isAddonNonPublic() && (
+                <div className="AddonFeedbackForm-header-metadata">
+                  <p className="AddonFeedbackForm-header-metadata-adu">
+                    <Icon name="user-fill" />
+                    {addon ? (
+                      i18n.sprintf(
+                        i18n.ngettext(
+                          '%(total)s user',
+                          '%(total)s users',
+                          addon.average_daily_users,
+                        ),
+                        { total: i18n.formatNumber(addon.average_daily_users) },
+                      )
+                    ) : (
+                      <LoadingText />
+                    )}
+                  </p>
+                  <p className="AddonFeedbackForm-header-metadata-rating">
+                    {addon ? (
+                      <Rating
+                        rating={addon.ratings.average}
+                        readOnly
+                        styleSize="small"
+                      />
+                    ) : (
+                      <LoadingText />
+                    )}
+                  </p>
+                </div>
+              )}
             </Card>
           }
           abuseIsLoading={loading}

--- a/src/amo/components/AddonFeedbackForm/styles.scss
+++ b/src/amo/components/AddonFeedbackForm/styles.scss
@@ -5,7 +5,7 @@ $icon-size: 32px;
 .AddonFeedbackForm-header > .Card-contents {
   align-items: center;
   display: grid;
-  grid-template-columns: ($icon-size + 16px) 1fr;
+  grid-template-columns: ($icon-size + 16px) 2fr 1fr;
 
   .AddonFeedbackForm-header-icon {
     grid-column: 1;
@@ -24,8 +24,12 @@ $icon-size: 32px;
 
   .AddonTitle {
     font-size: $font-size-heading-xs;
-    grid-column: 2;
+    grid-column: 2 / span 2;
     margin-bottom: 0;
+
+    @include respond-to(large) {
+      grid-column: 2;
+    }
 
     .AddonTitle-author {
       &,
@@ -34,5 +38,40 @@ $icon-size: 32px;
         font-size: $font-size-l;
       }
     }
+  }
+
+  .AddonFeedbackForm-header-metadata {
+    color: $grey-50;
+    grid-column: 2 / span 2;
+    grid-row: 2;
+
+    @include respond-to(large) {
+      grid-row: 1;
+      grid-column: 3;
+    }
+  }
+
+  .AddonFeedbackForm-header-metadata-adu,
+  .AddonFeedbackForm-header-metadata-rating {
+    align-items: center;
+    display: flex;
+    margin: 8px 0;
+    justify-content: start;
+
+    @include respond-to(large) {
+      justify-content: end;
+    }
+  }
+
+  .AddonFeedbackForm-header-metadata-adu {
+    .Icon {
+      @include margin-end(4px);
+    }
+  }
+}
+
+.AddonFeedbackForm--no-metadata {
+  .AddonFeedbackForm-header > .Card-contents .AddonTitle {
+    grid-column: 2 / span 2;
   }
 }

--- a/tests/unit/amo/pages/TestAddonFeedback.js
+++ b/tests/unit/amo/pages/TestAddonFeedback.js
@@ -124,6 +124,8 @@ describe(__filename, () => {
     // Add-on header.
     expect(screen.getByText('some add-on name')).toBeInTheDocument();
     expect(screen.getByText(authors[0].name)).toBeInTheDocument();
+    // We should render the `Rating` component too.
+    expect(screen.getByClassName('Rating')).toBeInTheDocument();
 
     expect(screen.getByText('Submit report')).toBeInTheDocument();
     expect(
@@ -143,6 +145,30 @@ describe(__filename, () => {
       screen.queryByClassName('ReportAbuseButton-first-paragraph'),
     ).not.toBeInTheDocument();
   });
+
+  it.each([
+    [0, '0 users'],
+    [1, '1 user'],
+    [123, '123 users'],
+  ])(
+    'renders the average daily users - average_daily_users=%d',
+    (averageDailyUsers, expectedText) => {
+      render({ average_daily_users: averageDailyUsers });
+
+      expect(screen.getByText(expectedText)).toBeInTheDocument();
+    },
+  );
+
+  it.each([{ is_disabled: true }, { status: 'unknown-non-public' }])(
+    'does not render metadata for a non-public add-on - %o',
+    (addonProps) => {
+      render(addonProps);
+
+      expect(
+        screen.queryByClassName('AddonFeedbackForm-header-metadata'),
+      ).not.toBeInTheDocument();
+    },
+  );
 
   it('renders feedback form for logged in user with disabled but prefilled name and email', () => {
     signInUserWithProps();


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12592

---

![image](https://github.com/mozilla/addons-frontend/assets/217628/72dded22-bee8-42ce-86aa-a84dc23549c1)

![image](https://github.com/mozilla/addons-frontend/assets/217628/ed3a7108-b746-4738-880d-2f67f31bc951)

![Screen Shot 2023-11-13 at 15 03 24](https://github.com/mozilla/addons-frontend/assets/217628/da5d5645-ec9c-425e-9d12-03d993d50d9a)