### PR TITLE
Introduce new page for collection feedback

### DIFF
--- a/src/amo/components/Routes/index.js
+++ b/src/amo/components/Routes/index.js
@@ -17,6 +17,7 @@ import Collection from 'amo/pages/Collection';
 import CollectionEdit from 'amo/pages/CollectionEdit';
 import CollectionList from 'amo/pages/CollectionList';
 import AddonFeedback from 'amo/pages/AddonFeedback';
+import CollectionFeedback from 'amo/pages/CollectionFeedback';
 import UserFeedback from 'amo/pages/UserFeedback';
 import RatingFeedback from 'amo/pages/RatingFeedback';
 import NotAuthorizedPage from 'amo/pages/ErrorPages/NotAuthorizedPage';
@@ -183,6 +184,12 @@ const Routes = ({ _config = config }: Props = {}): React.Node => (
         exact
         path="/:lang/:application(firefox|android)/feedback/addon/:addonIdentifier/"
         component={AddonFeedback}
+      />,
+      <Route
+        key="collection-feedback"
+        exact
+        path="/:lang/:application(firefox|android)/feedback/collection/:authorId/:collectionSlug/"
+        component={CollectionFeedback}
       />,
       <Route
         key="user-feedback"

--- a/src/amo/pages/Collection/styles.scss
+++ b/src/amo/pages/Collection/styles.scss
@@ -59,9 +59,13 @@
   }
 }
 
-.Collection-delete-button {
+.Collection-delete-button,
+.Collection-report-button {
   margin-top: 24px;
+  width: 100%;
+}
 
+.Collection-delete-button {
   .ConfirmButton-default-button {
     width: 100%;
   }

--- a/src/amo/pages/CollectionFeedback/index.js
+++ b/src/amo/pages/CollectionFeedback/index.js
@@ -1,0 +1,211 @@
+/* @flow */
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { Helmet } from 'react-helmet';
+import invariant from 'invariant';
+
+import FeedbackForm, {
+  CATEGORY_FEEDBACK_SPAM,
+  CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
+  CATEGORY_ILLEGAL,
+  CATEGORY_OTHER,
+} from 'amo/components/FeedbackForm';
+import LoadingText from 'amo/components/LoadingText';
+import Card from 'amo/components/Card';
+import log from 'amo/logger';
+import translate from 'amo/i18n/translate';
+import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
+import Page from 'amo/components/Page';
+import {
+  fetchCurrentCollection,
+  getCurrentCollection,
+} from 'amo/reducers/collections';
+import { sendCollectionAbuseReport } from 'amo/reducers/collectionAbuseReports';
+import { withFixedErrorHandler } from 'amo/errorHandler';
+import type { AppState } from 'amo/store';
+import type { ErrorHandlerType } from 'amo/types/errorHandler';
+import type { DispatchFunc } from 'amo/types/redux';
+import type { ReactRouterMatchType } from 'amo/types/router';
+import type { I18nType } from 'amo/types/i18n';
+import type { FeedbackFormValues } from 'amo/components/FeedbackForm';
+import type { CollectionType } from 'amo/reducers/collections';
+
+import './styles.scss';
+
+type Props = {|
+  match: {|
+    ...ReactRouterMatchType,
+    params: {| authorId: number, collectionSlug: string |},
+  |},
+|};
+
+type PropsFromState = {|
+  collection: CollectionType | null,
+  isCollectionLoading: boolean,
+  hasSubmitted: boolean,
+  isSubmitting: boolean,
+|};
+
+type InternalProps = {|
+  ...Props,
+  ...PropsFromState,
+  i18n: I18nType,
+  dispatch: DispatchFunc,
+  errorHandler: ErrorHandlerType,
+|};
+
+export class CollectionFeedbackBase extends React.Component<InternalProps> {
+  constructor(props: InternalProps) {
+    super(props);
+
+    const { collection, dispatch, errorHandler, isCollectionLoading, match } =
+      props;
+    const { params } = match;
+
+    if (errorHandler.hasError()) {
+      log.warn('Not loading data because of an error.');
+      return;
+    }
+
+    if (!collection && !isCollectionLoading) {
+      dispatch(
+        fetchCurrentCollection({
+          errorHandlerId: errorHandler.id,
+          userId: params.authorId,
+          slug: params.collectionSlug,
+        }),
+      );
+    }
+  }
+
+  onFormSubmitted: (values: FeedbackFormValues) => void = (values) => {
+    const { dispatch, errorHandler, collection } = this.props;
+    const { anonymous, email, name, text, category } = values;
+
+    invariant(collection, 'collection is required');
+
+    dispatch(
+      sendCollectionAbuseReport({
+        // Only authenticate the API call when the report isn't submitted
+        // anonymously.
+        auth: anonymous === false,
+        errorHandlerId: errorHandler.id,
+        message: text,
+        collectionId: collection.id,
+        reason: category,
+        reporterEmail: anonymous ? '' : email,
+        reporterName: anonymous ? '' : name,
+      }),
+    );
+  };
+
+  render(): React.Node {
+    const { collection, errorHandler, hasSubmitted, i18n, isSubmitting } =
+      this.props;
+
+    if (
+      errorHandler.hasError() &&
+      errorHandler.capturedError.responseStatusCode === 404
+    ) {
+      return <NotFoundPage />;
+    }
+
+    return (
+      <Page>
+        <div className="CollectionFeedback-page">
+          <Helmet>
+            <title>
+              {i18n.gettext(
+                'Submit feedback or report a collection to Mozilla',
+              )}
+            </title>
+            <meta name="robots" content="noindex, follow" />
+          </Helmet>
+
+          <FeedbackForm
+            errorHandler={errorHandler}
+            contentHeader={
+              <Card className="CollectionFeedback-header">
+                <h1 className="CollectionFeedback-header-name">
+                  {collection ? collection.name : <LoadingText />}
+                  <span className="CollectionFeedback-header-creator">
+                    {collection ? (
+                      i18n.sprintf(i18n.gettext('by %(authorName)s'), {
+                        authorName: collection.authorName,
+                      })
+                    ) : (
+                      <LoadingText />
+                    )}
+                  </span>
+                </h1>
+
+                <div className="CollectionFeedback-header-metadata">
+                  <p className="CollectionFeedback-header-metadata-addons">
+                    <span>{i18n.gettext('Add-ons')}</span>
+                    {collection ? collection.numberOfAddons : <LoadingText />}
+                  </p>
+                  <p className="CollectionFeedback-header-metadata-last-updated">
+                    <span>{i18n.gettext('Last updated')}</span>
+                    {collection ? (
+                      i18n.moment(collection.lastUpdatedDate).format('ll')
+                    ) : (
+                      <LoadingText />
+                    )}
+                  </p>
+                </div>
+              </Card>
+            }
+            abuseIsLoading={isSubmitting}
+            abuseSubmitted={hasSubmitted}
+            categoryHeader={i18n.gettext('Report this collection to Mozilla')}
+            feedbackTitle={i18n.gettext(
+              'Send some feedback about the collection',
+            )}
+            reportTitle={i18n.gettext(
+              "Report the collection because it's illegal or incompliant",
+            )}
+            categories={[
+              CATEGORY_FEEDBACK_SPAM,
+              CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
+              CATEGORY_ILLEGAL,
+              CATEGORY_OTHER,
+            ]}
+            showLocation={false}
+            onSubmit={this.onFormSubmitted}
+          />
+        </div>
+      </Page>
+    );
+  }
+}
+
+function mapStateToProps(state: AppState): PropsFromState {
+  const { collections, collectionAbuseReports } = state;
+
+  const { loading } = collections.current;
+  const collection = getCurrentCollection(collections);
+  const abuseReport =
+    (collection && collectionAbuseReports.byCollectionId[collection.id]) || {};
+
+  return {
+    collection,
+    isCollectionLoading: loading,
+    isSubmitting: abuseReport.isSubmitting || false,
+    hasSubmitted: abuseReport.hasSubmitted || false,
+  };
+}
+
+export const extractId = (ownProps: InternalProps): string => {
+  const { params } = ownProps.match;
+
+  return `${params.authorId}-${params.collectionSlug}`;
+};
+
+const CollectionFeedback: React.ComponentType<Props> = compose(
+  translate(),
+  connect(mapStateToProps),
+  withFixedErrorHandler({ fileName: __filename, extractId }),
+)(CollectionFeedbackBase);
+
+export default CollectionFeedback;

--- a/src/amo/pages/CollectionFeedback/styles.scss
+++ b/src/amo/pages/CollectionFeedback/styles.scss
@@ -1,0 +1,74 @@
+@import '~amo/css/styles';
+
+.CollectionFeedback-page {
+  @include page-padding;
+}
+
+.CollectionFeedback-header > .Card-contents {
+  align-items: center;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+}
+
+.CollectionFeedback-header-name {
+  @include font-regular;
+
+  color: $black;
+  font-size: $font-size-heading-xs;
+  grid-column: 1 / span 2;
+  margin: 0;
+
+  @include respond-to(large) {
+    grid-column: 1;
+  }
+}
+
+.CollectionFeedback-header-creator {
+  @include font-light;
+
+  display: block;
+  padding-top: 3px;
+
+  &,
+  a,
+  a:link {
+    font-size: $font-size-l;
+  }
+}
+
+.CollectionFeedback-header-metadata {
+  grid-column: 1 / span 2;
+  grid-row: 2;
+  text-align: start;
+
+  .CollectionFeedback-header-metadata-addons {
+    margin: 8px 0 0;
+  }
+
+  .CollectionFeedback-header-metadata-last-updated {
+    margin: 0;
+  }
+
+  span {
+    @include margin-end(4px);
+
+    color: $grey-50;
+    display: inline-block;
+
+    @include respond-to(large) {
+      @include margin-end(0);
+
+      display: block;
+    }
+  }
+
+  @include respond-to(large) {
+    grid-row: 1;
+    grid-column: 2;
+    text-align: end;
+
+    .CollectionFeedback-header-metadata-addons {
+      margin-top: 0;
+    }
+  }
+}

--- a/tests/unit/amo/pages/TestCollectionFeedback.js
+++ b/tests/unit/amo/pages/TestCollectionFeedback.js
@@ -4,25 +4,22 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/react';
 
 import {
-  sendUserAbuseReport,
-  loadUserAbuseReport,
-} from 'amo/reducers/userAbuseReports';
+  FETCH_CURRENT_COLLECTION,
+  fetchCurrentCollection,
+  loadCurrentCollection,
+} from 'amo/reducers/collections';
 import {
-  CATEGORY_FEEDBACK_SPAM,
-  CATEGORY_OTHER,
-} from 'amo/components/FeedbackForm';
+  sendCollectionAbuseReport,
+  loadCollectionAbuseReport,
+} from 'amo/reducers/collectionAbuseReports';
+import { CATEGORY_FEEDBACK_SPAM } from 'amo/components/FeedbackForm';
 import { CLIENT_APP_FIREFOX } from 'amo/constants';
-import {
-  FETCH_USER_ACCOUNT,
-  fetchUserAccount,
-  loadUserAccount,
-} from 'amo/reducers/users';
-import { extractId } from 'amo/pages/UserFeedback';
+import { extractId } from 'amo/pages/CollectionFeedback';
 import { clearError } from 'amo/reducers/errors';
 import { createApiError } from 'amo/api';
 import {
-  createUserAccountResponse,
   createFailedErrorHandler,
+  createFakeCollectionDetail,
   createFakeErrorHandler,
   dispatchClientMetadata,
   dispatchSignInActionsWithStore,
@@ -49,50 +46,58 @@ describe(__filename, () => {
     jest.clearAllMocks().resetModules();
   });
 
-  const getErrorHandlerId = (userId) =>
-    `src/amo/pages/UserFeedback/index.js-${userId}`;
+  const getErrorHandlerId = (authorId, collectionSlug) =>
+    `src/amo/pages/CollectionFeedback/index.js-${authorId}-${collectionSlug}`;
 
   const signInUserWithProps = (
     props = {},
     store = dispatchClientMetadata().store,
   ) => {
-    const { id, ...userProps } = props;
+    const { id: userId, ...userProps } = props;
 
-    return dispatchSignInActionsWithStore({ userId: id, userProps, store });
+    return dispatchSignInActionsWithStore({ userId, userProps, store });
   };
 
   const renderWithoutLoading = ({
-    userId,
+    authorId,
+    slug,
     lang = 'en-US',
     clientApp = CLIENT_APP_FIREFOX,
     store = dispatchClientMetadata({ lang, clientApp }).store,
   }) => {
     const renderOptions = {
-      initialEntries: [`/${lang}/${clientApp}/feedback/user/${userId}/`],
+      initialEntries: [
+        `/${lang}/${clientApp}/feedback/collection/${authorId}/${slug}/`,
+      ],
       store,
     };
     return defaultRender(renderOptions);
   };
 
-  const render = (userProps = {}, store = dispatchClientMetadata().store) => {
-    const user = createUserAccountResponse(userProps);
-    store.dispatch(loadUserAccount({ user }));
+  const render = (detailProps = {}, store = dispatchClientMetadata().store) => {
+    const detail = createFakeCollectionDetail(detailProps);
+    store.dispatch(loadCurrentCollection({ detail }));
 
-    return renderWithoutLoading({ userId: user.id, store });
+    return renderWithoutLoading({
+      authorId: detail.author.id,
+      slug: detail.slug,
+      store,
+    });
   };
 
   describe('error handling', () => {
     it('renders errors', () => {
-      const userId = 1234;
+      const authorId = 1234;
+      const collectionSlug = 'some-collection-slug';
       const message = 'Some error message';
       const { store } = dispatchClientMetadata();
       createFailedErrorHandler({
-        id: getErrorHandlerId(userId),
+        id: getErrorHandlerId(authorId, collectionSlug),
         message,
         store,
       });
 
-      render({ id: userId }, store);
+      render({ authorId, slug: collectionSlug }, store);
 
       expect(screen.getByText(message)).toBeInTheDocument();
 
@@ -105,49 +110,61 @@ describe(__filename, () => {
     });
 
     it('scrolls to the top of the page when an error is rendered', async () => {
-      const userId = 1234;
+      const authorId = 1234;
+      const collectionSlug = 'some-collection-slug';
       const { store } = dispatchClientMetadata();
 
-      render({ id: userId }, store);
+      render({ authorId, slug: collectionSlug }, store);
 
-      createFailedErrorHandler({ id: getErrorHandlerId(userId), store });
+      createFailedErrorHandler({
+        id: getErrorHandlerId(authorId, collectionSlug),
+        store,
+      });
 
       await waitFor(() => expect(window.scroll).toHaveBeenCalledWith(0, 0));
     });
 
     it('clears the error handler when unmounting', () => {
-      const userId = 1234;
+      const authorId = 1234;
+      const collectionSlug = 'some-collection-slug';
       const { store } = dispatchClientMetadata();
       const dispatch = jest.spyOn(store, 'dispatch');
-      createFailedErrorHandler({ id: getErrorHandlerId(userId), store });
-      const { unmount } = render({ id: userId }, store);
+      const errorHandlerId = getErrorHandlerId(authorId, collectionSlug);
+      createFailedErrorHandler({ id: errorHandlerId, store });
+      const { unmount } = render({ authorId, slug: collectionSlug }, store);
 
       unmount();
 
-      expect(dispatch).toHaveBeenCalledWith(
-        clearError(getErrorHandlerId(userId)),
-      );
+      expect(dispatch).toHaveBeenCalledWith(clearError(errorHandlerId));
     });
 
-    it('does not fetch the user when there is an error', () => {
-      const userId = 1234;
+    it('does not fetch the current collection when there is an error', () => {
+      const authorId = 1234;
+      const collectionSlug = 'some-collection-slug';
       const { store } = dispatchClientMetadata();
-      createFailedErrorHandler({ id: getErrorHandlerId(userId), store });
+      createFailedErrorHandler({
+        id: getErrorHandlerId(authorId, collectionSlug),
+        store,
+      });
       const dispatch = jest.spyOn(store, 'dispatch');
 
-      renderWithoutLoading({ userId, store });
+      renderWithoutLoading({ authorId, slug: collectionSlug, store });
 
       expect(dispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({
-          type: FETCH_USER_ACCOUNT,
+          type: FETCH_CURRENT_COLLECTION,
         }),
       );
     });
 
     describe('extractId', () => {
       it('returns a unique ID based on params', () => {
-        const userId = 8;
-        expect(extractId({ match: { params: { userId } } })).toEqual('8');
+        const authorId = 8;
+        const collectionSlug = 'some-collection-slug';
+
+        expect(
+          extractId({ match: { params: { authorId, collectionSlug } } }),
+        ).toEqual('8-some-collection-slug');
       });
     });
   });
@@ -163,7 +180,8 @@ describe(__filename, () => {
   });
 
   it('renders a 404 page when the API returned a 404', () => {
-    const userId = 1234;
+    const authorId = 1234;
+    const collectionSlug = 'some-collection-slug';
     const { store } = dispatchClientMetadata();
     createFailedErrorHandler({
       error: createApiError({
@@ -171,44 +189,48 @@ describe(__filename, () => {
         apiURL: 'https://some/api/endpoint',
         jsonResponse: { message: 'not found' },
       }),
-      id: getErrorHandlerId(userId),
+      id: getErrorHandlerId(authorId, collectionSlug),
       store,
     });
 
-    render({ id: userId }, store);
+    render({ authorId, slug: collectionSlug }, store);
 
     expect(
       screen.getByText('Oops! We can’t find that page'),
     ).toBeInTheDocument();
   });
 
-  it('dispatches fetchUserAccount when the user is not loaded yet', () => {
-    const userId = 1234;
+  it('dispatches fetchCurrentCollection when the collection is not loaded yet', () => {
+    const authorId = 1234;
+    const collectionSlug = 'some-slug';
     const { store } = dispatchClientMetadata();
     const dispatch = jest.spyOn(store, 'dispatch');
     const errorHandler = createFakeErrorHandler({
-      id: getErrorHandlerId(userId),
+      id: getErrorHandlerId(authorId, collectionSlug),
     });
 
-    renderWithoutLoading({ userId, store });
+    renderWithoutLoading({ authorId, slug: collectionSlug, store });
 
     expect(dispatch).toHaveBeenCalledWith(
-      fetchUserAccount({
+      fetchCurrentCollection({
         errorHandlerId: errorHandler.id,
-        userId: `${userId}`,
+        userId: `${authorId}`,
+        slug: collectionSlug,
       }),
     );
   });
 
   it('renders the feedback form for a signed out user', () => {
-    const username = 'some user name';
+    const name = 'some collection name';
 
-    render({ username });
+    render({ name });
 
     // Header.
-    expect(screen.getByText(username)).toBeInTheDocument();
+    expect(screen.getByText(name)).toBeInTheDocument();
 
-    expect(screen.getByText(`Report this user to Mozilla`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`Report this collection to Mozilla`),
+    ).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
     expect(screen.getByLabelText('Your name')).not.toBeDisabled();
@@ -216,7 +238,7 @@ describe(__filename, () => {
     expect(screen.getByLabelText('Your email address')).not.toBeDisabled();
     expect(screen.getByLabelText('Your email address').value).toBeEmpty();
 
-    // This should never be shown for users.
+    // This should never be shown for collections.
     expect(
       screen.queryByRole('combobox', {
         name: 'Place of the violation (optional)',
@@ -230,40 +252,42 @@ describe(__filename, () => {
   });
 
   it('renders the feedback form for a signed in user', () => {
-    const signedInUsername = 'signed-in-username';
+    const signedInCollectionname = 'signed-in-username';
     const signedInEmail = 'signed-in-email';
     const store = signInUserWithProps({
-      display_name: signedInUsername,
+      username: signedInCollectionname,
       email: signedInEmail,
     });
-    const username = 'some user name';
+    const name = 'some collection name';
 
-    render({ username }, store);
+    render({ name }, store);
 
     // Header.
-    expect(screen.getByText(username)).toBeInTheDocument();
+    expect(screen.getByText(name)).toBeInTheDocument();
 
-    expect(screen.getByText(`Report this user to Mozilla`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`Report this collection to Mozilla`),
+    ).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
     const nameInput = screen.getByLabelText('Your name');
     expect(nameInput).toBeDisabled();
-    expect(nameInput).toHaveValue(signedInUsername);
+    expect(nameInput).toHaveValue(signedInCollectionname);
 
     const emailInput = screen.getByLabelText('Your email address');
     expect(emailInput).toBeDisabled();
     expect(emailInput).toHaveValue(signedInEmail);
 
-    // This should never be shown for users.
+    // This should never be shown for collections.
     expect(
       screen.queryByRole('combobox', {
         name: 'Place of the violation (optional)',
       }),
     ).not.toBeInTheDocument();
 
-    // SignedInUser component should be visible.
+    // SignedInCollection component should be visible.
     expect(
-      screen.getByText(`Signed in as ${signedInUsername}`),
+      screen.getByText(`Signed in as ${signedInCollectionname}`),
     ).toBeInTheDocument();
 
     // We shouldn't show the confirmation message.
@@ -272,7 +296,61 @@ describe(__filename, () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders the different categories for a user', () => {
+  it('restores the name when the user toggles the anonymous checkbox', async () => {
+    const reporterName = 'some reporter name';
+    render();
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Your name' }),
+      reporterName,
+    );
+
+    const nameInput = screen.getByLabelText('Your name');
+    expect(nameInput).toHaveValue(reporterName);
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'File report anonymously',
+      }),
+    );
+    expect(nameInput).toHaveValue('');
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'File report anonymously',
+      }),
+    );
+    expect(nameInput).toHaveValue(reporterName);
+  });
+
+  it('restores the email when the user toggles the anonymous checkbox', async () => {
+    const reporterEmail = 'reporter@example.com';
+    render();
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Your email address' }),
+      reporterEmail,
+    );
+
+    const emailInput = screen.getByLabelText('Your email address');
+    expect(emailInput).toHaveValue(reporterEmail);
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        email: 'File report anonymously',
+      }),
+    );
+    expect(emailInput).toHaveValue('');
+
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'File report anonymously',
+      }),
+    );
+    expect(emailInput).toHaveValue(reporterEmail);
+  });
+
+  it('renders the different categories for a collection', () => {
     render();
 
     // A
@@ -310,11 +388,14 @@ describe(__filename, () => {
     expect(screen.getByText(/^Anything that doesn’t/)).toBeInTheDocument();
   });
 
-  it('dispatches sendUserAbuseReport with all fields on submit', async () => {
-    const userId = 9999;
+  it('dispatches sendCollectionAbuseReport with all fields on submit', async () => {
+    const authorId = 1234;
+    const collectionId = 98765;
+    const collectionSlug = 'some-collection-slug';
     const { store } = dispatchClientMetadata();
     const dispatch = jest.spyOn(store, 'dispatch');
-    render({ id: userId }, store);
+
+    render({ authorId, slug: collectionSlug, id: collectionId }, store);
 
     await userEvent.click(screen.getByRole('radio', { name: 'It’s spam' }));
     await userEvent.click(
@@ -327,80 +408,13 @@ describe(__filename, () => {
     );
 
     expect(dispatch).toHaveBeenCalledWith(
-      sendUserAbuseReport({
-        userId,
-        errorHandlerId: getErrorHandlerId(userId),
+      sendCollectionAbuseReport({
+        collectionId,
+        errorHandlerId: getErrorHandlerId(authorId, collectionSlug),
         reporterEmail: '',
         reporterName: '',
         message: '',
         reason: CATEGORY_FEEDBACK_SPAM,
-        auth: false,
-      }),
-    );
-  });
-
-  it('dispatches sendUserAbuseReport action with all fields on submit for a signed-in user', async () => {
-    const signedInName = 'signed-in-username';
-    const signedInEmail = 'signed-in-email';
-    const store = signInUserWithProps({
-      display_name: signedInName,
-      email: signedInEmail,
-    });
-    const dispatch = jest.spyOn(store, 'dispatch');
-    const userId = 10;
-    render({ id: userId }, store);
-
-    await userEvent.click(
-      screen.getByRole('radio', { name: 'Something else' }),
-    );
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Submit report' }),
-    );
-
-    expect(dispatch).toHaveBeenCalledWith(
-      sendUserAbuseReport({
-        userId,
-        errorHandlerId: getErrorHandlerId(userId),
-        reporterEmail: signedInEmail,
-        reporterName: signedInName,
-        message: '',
-        reason: CATEGORY_OTHER,
-        auth: true,
-      }),
-    );
-  });
-
-  it('dispatches sendUserAbuseReport action with all fields on submit for a signed-in user who files the report anonymously', async () => {
-    const signedInName = 'signed-in-username';
-    const signedInEmail = 'signed-in-email';
-    const store = signInUserWithProps({
-      display_name: signedInName,
-      email: signedInEmail,
-    });
-    const dispatch = jest.spyOn(store, 'dispatch');
-    const userId = 10;
-    render({ id: userId }, store);
-
-    await userEvent.click(
-      screen.getByRole('radio', { name: 'Something else' }),
-    );
-    await userEvent.click(
-      screen.getByRole('checkbox', {
-        name: 'File report anonymously',
-      }),
-    );
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Submit report' }),
-    );
-
-    expect(dispatch).toHaveBeenCalledWith(
-      sendUserAbuseReport({
-        userId,
-        errorHandlerId: getErrorHandlerId(userId),
-        reporterEmail: '',
-        reporterName: '',
-        message: '',
-        reason: CATEGORY_OTHER,
         auth: false,
       }),
     );
@@ -441,14 +455,12 @@ describe(__filename, () => {
   });
 
   it('shows success message after submission', async () => {
-    const userId = 456;
+    const collectionId = 456;
     const { store } = dispatchClientMetadata();
 
-    render({ id: userId }, store);
+    render({ id: collectionId }, store);
 
-    store.dispatch(
-      loadUserAbuseReport({ userId, message: 'some message', reporter: null }),
-    );
+    store.dispatch(loadCollectionAbuseReport({ collectionId }));
 
     expect(
       await screen.findByText(
@@ -457,7 +469,7 @@ describe(__filename, () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.queryByText('Report this user to Mozilla'),
+      screen.queryByText('Report this collection to Mozilla'),
     ).not.toBeInTheDocument();
 
     expect(window.scrollTo).toHaveBeenCalledWith(0, 0);


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12512

~~:warning: depends on https://github.com/mozilla/addons-frontend/issues/12594~~

---

- The report button is only visible to users who are not owners of the collection
- There is a "confirmation" message that replaces the report button after the form has been submitted (and the user has navigated back to the collection). This is similar to the other reporting features we already have

## Screenshots

![image](https://github.com/mozilla/addons-frontend/assets/217628/6047e29b-bfe7-428e-a66f-472954654cf6)

![image](https://github.com/mozilla/addons-frontend/assets/217628/5dec2aa6-f717-44e1-992b-e58e308a0f88)

![image](https://github.com/mozilla/addons-frontend/assets/217628/bb39bbbe-92fc-4021-affe-c28c37a8484d)

### Link in the collection page:

![image](https://github.com/mozilla/addons-frontend/assets/217628/0327a05d-5c33-4fa3-961b-785eed450f85)

When the form has been submitted, navigating (back) to the collection page will show a confirmation message:

<img width="522" alt="Screenshot 2023-11-15 at 12 15 10" src="https://github.com/mozilla/addons-frontend/assets/217628/28ec46a1-4e17-48a5-825c-4397c59811fb">


