### PR TITLE
Fix add-on rating stars in feedback form

### DIFF
--- a/src/amo/components/AddonFeedbackForm/index.js
+++ b/src/amo/components/AddonFeedbackForm/index.js
@@ -141,7 +141,7 @@ export class AddonFeedbackFormBase extends React.Component<InternalProps> {
 
               {!this.isAddonNonPublic() && (
                 <div className="AddonFeedbackForm-header-metadata">
-                  <p className="AddonFeedbackForm-header-metadata-adu">
+                  <div className="AddonFeedbackForm-header-metadata-adu">
                     <Icon name="user-fill" />
                     {addon ? (
                       i18n.sprintf(
@@ -155,8 +155,8 @@ export class AddonFeedbackFormBase extends React.Component<InternalProps> {
                     ) : (
                       <LoadingText />
                     )}
-                  </p>
-                  <p className="AddonFeedbackForm-header-metadata-rating">
+                  </div>
+                  <div className="AddonFeedbackForm-header-metadata-rating">
                     {addon ? (
                       <Rating
                         rating={addon.ratings.average}
@@ -166,7 +166,7 @@ export class AddonFeedbackFormBase extends React.Component<InternalProps> {
                     ) : (
                       <LoadingText />
                     )}
-                  </p>
+                  </div>
                 </div>
               )}
             </Card>


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12599

---

The `Rating` component renders a `div` element, which cannot be placed
inside a `p`, though React is happy to force that to happen on the
client side while browsers "fix" this mistake in the HTML returned by
the server. That explains the short flash of content (with the stars
moving from the middle of the header to the right side in LTR mode).

I don't think we can write a good test for this...