### PR TITLE
Update flag review menu items

### DIFF
--- a/src/amo/components/FlagReview/index.js
+++ b/src/amo/components/FlagReview/index.js
@@ -22,6 +22,7 @@ type Props = {|
   review: UserReviewType,
   wasFlaggedText: string,
   disabled?: boolean,
+  disabledTitle: string,
 |};
 
 type PropsFromState = {|
@@ -50,8 +51,14 @@ export class FlagReviewBase extends React.Component<InternalProps> {
   };
 
   renderControls(): React.Node {
-    const { disabled, errorHandler, flagState, buttonText, wasFlaggedText } =
-      this.props;
+    const {
+      disabled,
+      disabledTitle,
+      errorHandler,
+      flagState,
+      buttonText,
+      wasFlaggedText,
+    } = this.props;
 
     if (flagState) {
       if (flagState.inProgress && !errorHandler.hasError()) {
@@ -68,6 +75,7 @@ export class FlagReviewBase extends React.Component<InternalProps> {
         onClick={this.onClick}
         type="button"
         disabled={!!disabled}
+        title={disabled ? disabledTitle : null}
       >
         {buttonText}
       </button>

--- a/src/amo/components/FlagReview/styles.scss
+++ b/src/amo/components/FlagReview/styles.scss
@@ -1,5 +1,9 @@
 @import '~amo/css/styles';
 
+.FlagReview-button {
+  padding: 0;
+}
+
 .FlagReview-button[disabled] {
   @include disabled;
 

--- a/src/amo/components/FlagReviewMenu/index.js
+++ b/src/amo/components/FlagReviewMenu/index.js
@@ -93,29 +93,15 @@ export class FlagReviewMenuBase extends React.Component<InternalProps> {
           <FlagReview
             reason={REVIEW_FLAG_REASON_SPAM}
             review={review}
-            buttonText={i18n.gettext('This is spam')}
+            buttonText={
+              enableFeatureFeedbackFormLinks
+                ? i18n.gettext('Spam')
+                : i18n.gettext('This is spam')
+            }
             wasFlaggedText={i18n.gettext('Flagged as spam')}
             disabled={disableItemsForUnauthenticatedUsers}
+            disabledTitle={i18n.gettext('Login required')}
           />
-        </ListItem>,
-        <ListItem
-          className="FlagReviewMenu-flag-language-item"
-          key="flag-language"
-        >
-          {enableFeatureFeedbackFormLinks ? (
-            <Link to={`/feedback/review/${review.id}/`}>
-              {i18n.gettext('This contains inappropriate language')}
-            </Link>
-          ) : (
-            <FlagReview
-              reason={REVIEW_FLAG_REASON_LANGUAGE}
-              review={review}
-              buttonText={i18n.gettext('This contains inappropriate language')}
-              wasFlaggedText={i18n.gettext(
-                'Flagged for inappropriate language',
-              )}
-            />
-          )}
         </ListItem>,
         // Only reviews (not developer responses) can be flagged as
         // misplaced bug reports or support requests.
@@ -127,16 +113,43 @@ export class FlagReviewMenuBase extends React.Component<InternalProps> {
             <FlagReview
               reason={REVIEW_FLAG_REASON_BUG_SUPPORT}
               review={review}
-              buttonText={i18n.gettext(
-                'This is a bug report or support request',
-              )}
-              wasFlaggedText={i18n.gettext(
-                'Flagged as a bug report or support request',
-              )}
+              buttonText={
+                enableFeatureFeedbackFormLinks
+                  ? i18n.gettext('Misplaced bug report or support request')
+                  : i18n.gettext('This is a bug report or support request')
+              }
+              wasFlaggedText={
+                enableFeatureFeedbackFormLinks
+                  ? i18n.gettext(`Flagged as misplaced bug report or support
+                      request`)
+                  : i18n.gettext('Flagged as a bug report or support request')
+              }
               disabled={disableItemsForUnauthenticatedUsers}
+              disabledTitle={i18n.gettext('Login required')}
             />
           </ListItem>
         ),
+        <ListItem
+          className="FlagReviewMenu-flag-language-item"
+          key="flag-language"
+        >
+          {enableFeatureFeedbackFormLinks ? (
+            <Link to={`/feedback/review/${review.id}/`}>
+              {i18n.gettext(`Content that is illegal or that violates AMO's
+                content policies`)}
+            </Link>
+          ) : (
+            <FlagReview
+              reason={REVIEW_FLAG_REASON_LANGUAGE}
+              review={review}
+              buttonText={i18n.gettext('This contains inappropriate language')}
+              wasFlaggedText={i18n.gettext(
+                'Flagged for inappropriate language',
+              )}
+              disabledTitle={i18n.gettext('Login required')}
+            />
+          )}
+        </ListItem>,
       ];
     }
 

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1473,37 +1473,6 @@ describe(__filename, () => {
     });
 
     describe('Tests for FlagReviewMenu', () => {
-      it('changes the "inappropriate language" menu item to a link pointing to the rating feedback form when enableFeatureFeedbackFormLinks is set', async () => {
-        const fakeConfig = getMockConfig({
-          enableFeatureFeedbackFormLinks: true,
-        });
-        config.get.mockImplementation((key) => {
-          return fakeConfig[key];
-        });
-        const review = createReviewAndSignInAsUnrelatedUser();
-        render({ review });
-
-        await openFlagMenu();
-
-        expect(
-          screen.getByRole('button', {
-            name: 'This is spam',
-          }),
-        ).not.toBeDisabled();
-        expect(
-          // It would have to be a 'button' if `enableFeatureFeedbackFormLinks`
-          // was set to `false`.
-          screen.getByRole('link', {
-            name: 'This contains inappropriate language',
-          }),
-        ).toBeInTheDocument();
-        expect(
-          screen.getByRole('button', {
-            name: 'This is a bug report or support request',
-          }),
-        ).not.toBeDisabled();
-      });
-
       it('can be configured with an openerClass', () => {
         const review = createReviewAndSignInAsUnrelatedUser();
         render({ review });
@@ -1535,6 +1504,27 @@ describe(__filename, () => {
         ).toBeInTheDocument();
       });
 
+      it('shows the menu for signed-in users', async () => {
+        dispatchSignInActionsWithStore({ store, userId: 999 });
+        render({ review: _setReview() });
+
+        await openFlagMenu();
+
+        expect(
+          screen.getByRole('button', { name: 'This is spam' }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', {
+            name: 'This is a bug report or support request',
+          }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', {
+            name: 'This contains inappropriate language',
+          }),
+        ).toBeInTheDocument();
+      });
+
       describe('when enableFeatureFeedbackFormLinks is enabled', () => {
         beforeEach(() => {
           const fakeConfig = getMockConfig({
@@ -1555,19 +1545,24 @@ describe(__filename, () => {
           ).not.toBeInTheDocument();
           expect(
             screen.getByRole('button', {
-              name: 'This is spam',
+              name: 'Spam',
             }),
           ).toBeDisabled();
-          expect(
-            screen.getByRole('link', {
-              name: 'This contains inappropriate language',
-            }),
-          ).toBeInTheDocument();
           expect(
             screen.getByRole('button', {
-              name: 'This is a bug report or support request',
+              name: 'Spam',
+            }),
+          ).toHaveAttribute('title', 'Login required');
+          expect(
+            screen.getByRole('button', {
+              name: 'Misplaced bug report or support request',
             }),
           ).toBeDisabled();
+          expect(
+            screen.getByRole('button', {
+              name: 'Misplaced bug report or support request',
+            }),
+          ).toHaveAttribute('title', 'Login required');
         });
 
         it('shows the menu for signed-in users', async () => {
@@ -1578,14 +1573,24 @@ describe(__filename, () => {
 
           expect(
             screen.getByRole('button', {
-              name: 'This is spam',
+              name: 'Spam',
             }),
           ).not.toBeDisabled();
           expect(
             screen.getByRole('button', {
-              name: 'This is a bug report or support request',
+              name: 'Spam',
+            }),
+          ).not.toHaveAttribute('title');
+          expect(
+            screen.getByRole('button', {
+              name: 'Misplaced bug report or support request',
             }),
           ).not.toBeDisabled();
+          expect(
+            screen.getByRole('button', {
+              name: 'Misplaced bug report or support request',
+            }),
+          ).not.toHaveAttribute('title');
         });
       });
 


### PR DESCRIPTION
Fixes #12605

---

We'll go with what we have in the doc. This PR also adds missing HTML
titles when the buttons are disabled to let users know why the buttons
are disabled.

## Screenshots

Signed-in users should see:

<img width="606" alt="Screenshot 2023-11-15 at 15 30 52" src="https://github.com/mozilla/addons-frontend/assets/217628/6876381c-c039-4a24-ba78-615bb5a15c27">

Signed-out users should see:

<img width="571" alt="Screenshot 2023-11-15 at 15 31 20" src="https://github.com/mozilla/addons-frontend/assets/217628/d1523455-e7c0-4c98-ae75-8fa86c89c1ba">
