### PR TITLE
Use user `name` instead of `display_name` when submitting the feedback form

### DIFF
--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -215,7 +215,9 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
       location: null,
     };
 
-    const { email, display_name: name } = currentUser || {};
+    // `name` is either the `display_name` when set or `Firefox user XYZ`
+    // (auto-generated) when the user hasn't chosen a display name yet.
+    const { email, name } = currentUser || {};
 
     return {
       ...defaultFormValues,

--- a/tests/unit/amo/pages/TestAddonFeedback.js
+++ b/tests/unit/amo/pages/TestAddonFeedback.js
@@ -330,7 +330,7 @@ describe(__filename, () => {
   it('dispatches sendAddonAbuseReport action with all fields on submit for a signed-in user', async () => {
     const name = 'some user name';
     const email = 'some user email';
-    signInUserWithProps({ display_name: name, email });
+    signInUserWithProps({ name, email });
     const dispatch = jest.spyOn(store, 'dispatch');
     render();
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12610