### PR TITLE
Allow installAddon.setCurrentStatus() to set status for non-public add-ons

### DIFF
--- a/src/amo/installAddon.js
+++ b/src/amo/installAddon.js
@@ -190,20 +190,8 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
       return Promise.resolve();
     }
 
-    if (!currentVersion) {
-      _log.debug('no currentVersion, aborting setCurrentStatus()');
-      return Promise.resolve();
-    }
-
     const { guid, type } = addon;
-    const { file } = currentVersion;
-
-    if (!file) {
-      _log.debug('no file, aborting setCurrentStatus()');
-      return Promise.resolve();
-    }
-
-    const payload = { guid, url: file.url };
+    const payload = { guid, url: currentVersion?.file?.url };
 
     _log.info('Setting add-on status');
     return _addonManager

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -950,19 +950,6 @@ describe(__filename, () => {
         );
       });
 
-      it('does nothing when currentVersion is `null`', () => {
-        const _log = getFakeLogger();
-
-        const dispatch = jest.spyOn(store, 'dispatch');
-
-        render({ _log });
-
-        expect(dispatch).not.toHaveBeenCalled();
-        expect(_log.debug).toHaveBeenCalledWith(
-          'no currentVersion, aborting setCurrentStatus()',
-        );
-      });
-
       it('sets the canUninstall prop', async () => {
         const installURL = addon.current_version.file.url;
         const canUninstall = false;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12623