### PR TITLE
Use installed add-on name when available, otherwise hide the add-on header when we don't have much information

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
   "bundlewatch": [
     {
       "path": "./dist/static/amo-!(i18n-)*.js",
-      "maxSize": "356 kB"
+      "maxSize": "357 kB"
     },
     {
       "path": "./dist/static/amo-i18n-*.js",

--- a/src/amo/installAddon.js
+++ b/src/amo/installAddon.js
@@ -209,6 +209,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
               status,
               canUninstall: clientAddon.canUninstall,
               version: clientAddon.version,
+              name: clientAddon.name,
             }),
           );
         },

--- a/src/amo/reducers/installations.js
+++ b/src/amo/reducers/installations.js
@@ -39,6 +39,7 @@ export type InstalledAddon = {
   status: InstalledAddonStatus,
   url?: $PropertyType<AddonType, 'url'>,
   version?: string,
+  name?: string,
 };
 
 export type InstallationsState = {
@@ -121,6 +122,7 @@ export default function installations(
           status: payload.status,
           url: payload.url,
           version: payload.version,
+          name: payload.name,
         },
       };
     case START_DOWNLOAD:

--- a/src/amo/sagas/addons.js
+++ b/src/amo/sagas/addons.js
@@ -24,6 +24,50 @@ import type {
   FetchAddonInfoAction,
 } from 'amo/reducers/addons';
 import type { Saga } from 'amo/types/sagas';
+import type { ExternalAddonType } from 'amo/types/addons';
+
+export const ADDON_STATUS_UNKNOWN_NON_PUBLIC = 'unknown-non-public';
+
+export const makeNonPublicAddon = (slug: string): ExternalAddonType => {
+  const defaultLocale = config.get('defaultLang');
+  return {
+    slug,
+    // This isn't going to be a numeric ID but that should still be fine.
+    id: (slug: any),
+    guid: slug,
+    name: {
+      [defaultLocale]: slug,
+    },
+    default_locale: defaultLocale,
+    homepage: null,
+    contributions_url: null,
+    url: '',
+    average_daily_users: 0,
+    weekly_downloads: 0,
+    tags: [],
+    support_url: null,
+    ratings: {
+      average: 0,
+      bayesian_average: 0,
+      count: 0,
+      grouped_counts: {
+        '1': 0,
+        '2': 0,
+        '3': 0,
+        '4': 0,
+        '5': 0,
+      },
+      text_count: 0,
+    },
+    // Assume extension.
+    type: ADDON_TYPE_EXTENSION,
+    promoted: null,
+    created: new Date(0),
+    last_updated: null,
+    // Mark the add-on as non-public.
+    status: ADDON_STATUS_UNKNOWN_NON_PUBLIC,
+  };
+};
 
 export function* fetchAddon({
   payload: { errorHandlerId, showGroupedRatings, slug, assumeNonPublic },
@@ -47,45 +91,7 @@ export function* fetchAddon({
 
     if ([401, 403, 404].includes(error.response?.status) && assumeNonPublic) {
       log.warn('Assuming we attempted to fetch a non-public add-on');
-      const defaultLocale = config.get('defaultLang');
-      const addon = {
-        slug,
-        // This isn't going to be a numeric ID but that should still be fine.
-        id: (slug: any),
-        guid: slug,
-        name: {
-          [defaultLocale]: slug,
-        },
-        default_locale: defaultLocale,
-        homepage: null,
-        contributions_url: null,
-        url: '',
-        average_daily_users: 0,
-        weekly_downloads: 0,
-        tags: [],
-        support_url: null,
-        ratings: {
-          average: 0,
-          bayesian_average: 0,
-          count: 0,
-          grouped_counts: {
-            '1': 0,
-            '2': 0,
-            '3': 0,
-            '4': 0,
-            '5': 0,
-          },
-          text_count: 0,
-        },
-        // Assume extension.
-        type: ADDON_TYPE_EXTENSION,
-        promoted: null,
-        created: new Date(0),
-        last_updated: null,
-        // Mark the add-on as non-public.
-        status: 'unknown-non-public',
-      };
-      yield put(loadAddon({ addon, slug }));
+      yield put(loadAddon({ addon: makeNonPublicAddon(slug), slug }));
     } else {
       yield put(errorHandler.createErrorAction(error));
     }

--- a/tests/unit/amo/reducers/test_installations.js
+++ b/tests/unit/amo/reducers/test_installations.js
@@ -30,6 +30,7 @@ describe(__filename, () => {
   it('adds an add-on to state', () => {
     const guid = 'my-addon@me.com';
     const version = '1.2.3.4';
+    const name = 'some name';
     expect(
       installations(
         undefined,
@@ -39,6 +40,7 @@ describe(__filename, () => {
           url: 'https://addons.cdn.mozilla.net/download/my-addon.xpi',
           status: UNINSTALLED,
           version,
+          name,
         }),
       ),
     ).toEqual({
@@ -51,6 +53,7 @@ describe(__filename, () => {
         status: UNINSTALLED,
         url: 'https://addons.cdn.mozilla.net/download/my-addon.xpi',
         version,
+        name,
       },
     });
   });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12537

~~:warning: depends on https://github.com/mozilla/addons-frontend/issues/12623~~