### PR TITLE
chore(): remove duplicate deps in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,8 +257,6 @@
     "@babel/eslint-parser": "^7.23.3",
     "@babel/preset-env": "^7.23.3",
     "@babel/preset-flow": "^7.23.3",
-    "@babel/preset-react": "^7.22.5",
-    "@babel/preset-flow": "^7.22.15",
     "@babel/preset-react": "^7.23.3",
     "@babel/register": "^7.22.15",
     "@emotion/core": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,7 +1019,7 @@
     core-js-compat "^3.31.0"
     semver "^6.3.1"
 
-"@babel/preset-flow@^7.22.15":
+"@babel/preset-flow@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.23.3.tgz#8084e08b9ccec287bd077ab288b286fab96ffab1"
   integrity sha512-7yn6hl8RIv+KNk6iIrGZ+D06VhVY35wLVf23Cz/mMu1zOr7u4MMP4j0nZ9tLf8+4ZFpnib8cFYgB/oYg9hfswA==


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12637

Removes duplicated dependencies in package.json. I've verified the resolved version is not changed in yarn.lock so there is no impact on bundled code.


