### PR TITLE
Use replaceStringsWithJSX() in FeedbackForm to get proper localized strings

### DIFF
--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -12,6 +12,7 @@ import Button from 'amo/components/Button';
 import Card from 'amo/components/Card';
 import Select from 'amo/components/Select';
 import SignedInUser from 'amo/components/SignedInUser';
+import { replaceStringsWithJSX } from 'amo/i18n/utils';
 import type { UserType } from 'amo/reducers/users';
 import type { AppState } from 'amo/store';
 import type { ElementEvent, HTMLElementEventHandler } from 'amo/types/dom';
@@ -364,8 +365,18 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
                       className="FeedbackForm-label"
                       htmlFor="feedbackLocation"
                     >
-                      {i18n.gettext('Place of the violation')}
-                      <span>({i18n.gettext('optional')})</span>
+                      {replaceStringsWithJSX({
+                        text: i18n.gettext(
+                          'Place of the violation %(spanStart)s(optional)%(spanEnd)s',
+                        ),
+                        replacements: [
+                          [
+                            'spanStart',
+                            'spanEnd',
+                            (text) => <span>{text}</span>,
+                          ],
+                        ],
+                      })}
                     </label>
                     <Select
                       className="FeedbackForm-location"
@@ -382,8 +393,14 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
                 )}
 
               <label className="FeedbackForm-label" htmlFor="feedbackText">
-                {i18n.gettext('Provide more details')}
-                <span>({i18n.gettext('optional')})</span>
+                {replaceStringsWithJSX({
+                  text: i18n.gettext(
+                    'Provide more details %(spanStart)s(optional)%(spanEnd)s',
+                  ),
+                  replacements: [
+                    ['spanStart', 'spanEnd', (text) => <span>{text}</span>],
+                  ],
+                })}
               </label>
               <Textarea
                 className="FeedbackForm-text"
@@ -442,12 +459,22 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
                 })}
                 htmlFor="feedbackName"
               >
-                {i18n.gettext('Your name')}
-                <span className="visually-hidden">
-                  {this.state.anonymous
-                    ? i18n.gettext('(optional)')
-                    : i18n.gettext('(required)')}
-                </span>
+                {replaceStringsWithJSX({
+                  text: this.state.anonymous
+                    ? i18n.gettext(
+                        'Your name %(spanStart)s(optional)%(spanEnd)s',
+                      )
+                    : i18n.gettext(
+                        'Your name %(spanStart)s(required)%(spanEnd)s',
+                      ),
+                  replacements: [
+                    [
+                      'spanStart',
+                      'spanEnd',
+                      (text) => <span className="visually-hidden">{text}</span>,
+                    ],
+                  ],
+                })}
               </label>
               <input
                 className={makeClassName('FeedbackForm-name', {
@@ -472,12 +499,22 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
                 })}
                 htmlFor="feedbackEmail"
               >
-                {i18n.gettext('Your email address')}
-                <span className="visually-hidden">
-                  {this.state.anonymous
-                    ? i18n.gettext('(optional)')
-                    : i18n.gettext('(required)')}
-                </span>
+                {replaceStringsWithJSX({
+                  text: this.state.anonymous
+                    ? i18n.gettext(
+                        'Your email address %(spanStart)s(optional)%(spanEnd)s',
+                      )
+                    : i18n.gettext(
+                        'Your email address %(spanStart)s(required)%(spanEnd)s',
+                      ),
+                  replacements: [
+                    [
+                      'spanStart',
+                      'spanEnd',
+                      (text) => <span className="visually-hidden">{text}</span>,
+                    ],
+                  ],
+                })}
               </label>
               <input
                 className={makeClassName('FeedbackForm-email', {

--- a/src/amo/components/FeedbackForm/styles.scss
+++ b/src/amo/components/FeedbackForm/styles.scss
@@ -45,8 +45,6 @@
 }
 
 .FeedbackForm-label > span {
-  @include margin-start(4px);
-
   color: $grey-50;
 }
 

--- a/tests/unit/amo/pages/TestAddonFeedback.js
+++ b/tests/unit/amo/pages/TestAddonFeedback.js
@@ -136,11 +136,11 @@ describe(__filename, () => {
       screen.getByText(`Report this add-on to Mozilla`),
     ).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).not.toBeDisabled();
     expect(nameInput.value).toBeEmpty();
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).not.toBeDisabled();
     expect(emailInput.value).toBeEmpty();
 
@@ -182,11 +182,11 @@ describe(__filename, () => {
       screen.getByText('Report this add-on to Mozilla'),
     ).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).toBeDisabled();
     expect(nameInput).toHaveValue(defaultUser.name);
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).toBeDisabled();
     expect(emailInput).toHaveValue(defaultUser.email);
 
@@ -777,19 +777,19 @@ describe(__filename, () => {
       // By default, name/email fields are required and marked as such (for
       // accessibility reasons). These fields can be disabled when the current
       // user is signed-in.
-      let nameInput = screen.getByLabelText('Your name(required)');
+      let nameInput = screen.getByLabelText('Your name (required)');
       expect(nameInput).toBeInTheDocument();
       expect(nameInput.disabled).toEqual(withSignedInUser);
 
-      let emailInput = screen.getByLabelText('Your email address(required)');
+      let emailInput = screen.getByLabelText('Your email address (required)');
       expect(emailInput).toBeInTheDocument();
       expect(emailInput.disabled).toEqual(withSignedInUser);
 
       expect(
-        screen.queryByLabelText('Your name(optional)'),
+        screen.queryByLabelText('Your name (optional)'),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByLabelText('Your email address(optional)'),
+        screen.queryByLabelText('Your email address (optional)'),
       ).not.toBeInTheDocument();
 
       await userEvent.click(
@@ -801,17 +801,17 @@ describe(__filename, () => {
       // When the user wants to file a report anonymously, we disable the
       // name/email fields and mark them as optional for accessibility reasons.
       expect(
-        screen.queryByLabelText('Your name(required)'),
+        screen.queryByLabelText('Your name (required)'),
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByLabelText('Your email address(required)'),
+        screen.queryByLabelText('Your email address (required)'),
       ).not.toBeInTheDocument();
 
-      nameInput = screen.getByLabelText('Your name(optional)');
+      nameInput = screen.getByLabelText('Your name (optional)');
       expect(nameInput).toBeInTheDocument();
       expect(nameInput).toBeDisabled();
 
-      emailInput = screen.getByLabelText('Your email address(optional)');
+      emailInput = screen.getByLabelText('Your email address (optional)');
       expect(emailInput).toBeInTheDocument();
       expect(emailInput).toBeDisabled();
     },

--- a/tests/unit/amo/pages/TestCollectionFeedback.js
+++ b/tests/unit/amo/pages/TestCollectionFeedback.js
@@ -236,11 +236,11 @@ describe(__filename, () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).not.toBeDisabled();
     expect(nameInput.value).toBeEmpty();
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).not.toBeDisabled();
     expect(emailInput.value).toBeEmpty();
 
@@ -276,11 +276,11 @@ describe(__filename, () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).toBeDisabled();
     expect(nameInput).toHaveValue(signedInCollectionname);
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).toBeDisabled();
     expect(emailInput).toHaveValue(signedInEmail);
 
@@ -382,7 +382,7 @@ describe(__filename, () => {
       reporterName,
     );
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).toHaveValue(reporterName);
 
     await userEvent.click(
@@ -409,7 +409,7 @@ describe(__filename, () => {
       reporterEmail,
     );
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).toHaveValue(reporterEmail);
 
     await userEvent.click(

--- a/tests/unit/amo/pages/TestRatingFeedback.js
+++ b/tests/unit/amo/pages/TestRatingFeedback.js
@@ -222,11 +222,11 @@ describe(__filename, () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).not.toBeDisabled();
     expect(nameInput.value).toBeEmpty();
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).not.toBeDisabled();
     expect(emailInput.value).toBeEmpty();
 
@@ -267,11 +267,11 @@ describe(__filename, () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).toBeDisabled();
     expect(nameInput).toHaveValue(signedInName);
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).toBeDisabled();
     expect(emailInput).toHaveValue(signedInEmail);
 

--- a/tests/unit/amo/pages/TestUserFeedback.js
+++ b/tests/unit/amo/pages/TestUserFeedback.js
@@ -211,11 +211,11 @@ describe(__filename, () => {
     expect(screen.getByText(`Report this user to Mozilla`)).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).not.toBeDisabled();
     expect(nameInput.value).toBeEmpty();
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).not.toBeDisabled();
     expect(emailInput.value).toBeEmpty();
 
@@ -249,11 +249,11 @@ describe(__filename, () => {
     expect(screen.getByText(`Report this user to Mozilla`)).toBeInTheDocument();
     expect(screen.getByText('Submit report')).toBeInTheDocument();
 
-    const nameInput = screen.getByLabelText('Your name(required)');
+    const nameInput = screen.getByLabelText('Your name (required)');
     expect(nameInput).toBeDisabled();
     expect(nameInput).toHaveValue(signedInUsername);
 
-    const emailInput = screen.getByLabelText('Your email address(required)');
+    const emailInput = screen.getByLabelText('Your email address (required)');
     expect(emailInput).toBeDisabled();
     expect(emailInput).toHaveValue(signedInEmail);
 


### PR DESCRIPTION
Fixes #12640