### PR TITLE
add jsconfig.json to support webpack aliased imports in IDE import links.

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "amo/*": ["src/amo/*"]
+    }
+  },
+  "include": ["**/*"]
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/pull/12646

Adding a jsoncifg.json file to enable vscode to follow imports.

### How to test:

**Before: not working**
- checkout master and open with vscode. 
- (Command + click) (Ctrl + Click) on a file import in a .js file.
  - Expected: Cannot open file 

https://github.com/mozilla/addons-frontend/assets/19595165/211ee374-cc2a-439b-b027-7e91dda48c3c

**After: Working**
- checkout vscode-setup
- restart vscode to parse the settings and jsconfig files
- repeat step two from the previous set trying to open a file
  - Expected:  It should open the file.

https://github.com/mozilla/addons-frontend/assets/19595165/6900ac6f-5e7c-409d-ba65-29b31ef6e889

