### PR TITLE
Update wrong platform notice and get firefox banner for Android

### DIFF
--- a/src/amo/components/GetFirefoxBanner/styles.scss
+++ b/src/amo/components/GetFirefoxBanner/styles.scss
@@ -4,6 +4,10 @@
   @include respond-to(extraLarge) {
     border-radius: 0 0 $border-radius-m $border-radius-m;
     width: 890px;
+
+    .Notice-content {
+      max-width: 590px;
+    }
   }
 
   border-radius: 0;

--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -9,8 +9,10 @@ import { encode } from 'universal-base64url';
 import Button from 'amo/components/Button';
 import {
   ADDON_TYPE_STATIC_THEME,
+  CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
   DOWNLOAD_FIREFOX_BASE_URL,
+  DOWNLOAD_FIREFOX_FOR_ANDROID_URL,
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
 } from 'amo/constants';
 import translate from 'amo/i18n/translate';
@@ -69,6 +71,7 @@ export type GetDownloadLinkParams = {|
   _encode?: typeof encode,
   _getDownloadCampaign?: typeof getDownloadCampaign,
   addon?: AddonType,
+  clientApp?: string,
   overrideQueryParams?: {| [name: string]: string | null |},
   variant?: string | null,
 |};
@@ -77,8 +80,13 @@ export const getDownloadLink = ({
   _encode = encode,
   _getDownloadCampaign = getDownloadCampaign,
   addon,
+  clientApp,
   overrideQueryParams = {},
 }: GetDownloadLinkParams): string => {
+  if (clientApp === CLIENT_APP_ANDROID) {
+    return DOWNLOAD_FIREFOX_FOR_ANDROID_URL;
+  }
+
   return `${DOWNLOAD_FIREFOX_BASE_URL}${makeQueryStringWithUTM({
     utm_campaign: _getDownloadCampaign({ addonId: addon && addon.id }),
     utm_content: addon && addon.guid ? `rta:${_encode(addon.guid)}` : '',

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -5,14 +5,16 @@ import * as React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
+import Link from 'amo/components/Link';
+import { replaceStringsWithJSX } from 'amo/i18n/utils';
 import translate from 'amo/i18n/translate';
-import { sanitizeHTML } from 'amo/utils';
 import {
   correctedLocationForPlatform,
   getMobileHomepageLink,
   isFirefoxForAndroid,
   isFirefoxForIOS,
 } from 'amo/utils/compatibility';
+import { getDownloadLink } from 'amo/components/GetFirefoxButton';
 import Notice, { warningInfoType } from 'amo/components/Notice';
 import type { AppState } from 'amo/store';
 import type { AddonType } from 'amo/types/addons';
@@ -84,9 +86,8 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
 
     if (_isFirefoxForIOS(userAgentInfo)) {
       // Firefox for iOS.
-      message = i18n.gettext(
-        `Add-ons are not compatible with Firefox for iOS. Try installing them on Firefox for desktop.`,
-      );
+      message = i18n.gettext(`Add-ons are not compatible with Firefox for iOS.
+        Try installing them on Firefox for desktop.`);
     } else if (
       _isFirefoxForAndroid(userAgentInfo) &&
       addon?.isAndroidCompatible
@@ -95,37 +96,88 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
       message = null;
     } else if (newLocation === getMobileHomepageLink(lang)) {
       // Redirecting to mobile home page.
-      message = i18n.sprintf(
-        i18n.gettext(
-          `To find add-ons compatible with Firefox for Android,
-               <a href="%(newLocation)s">click here</a>.`,
-        ),
-        { newLocation },
-      );
+      message = replaceStringsWithJSX({
+        text: i18n.gettext(`To find extensions compatible with Firefox for
+          Android, %(linkStart)sclick here%(linkEnd)s.`),
+        replacements: [
+          [
+            'linkStart',
+            'linkEnd',
+            (text) => (
+              <Link
+                to={newLocation}
+                prependClientApp={false}
+                prependLang={false}
+              >
+                {text}
+              </Link>
+            ),
+          ],
+        ],
+      });
     } else if (addon && newLocation) {
       // User with desktop browser looking at detail page on mobile site.
-      message = i18n.sprintf(
-        `This listing is not intended for this platform.
-        <a href="%(newLocation)s">Browse add-ons for Firefox on desktop</a>.`,
-        { newLocation },
-      );
+      message = replaceStringsWithJSX({
+        text: i18n.gettext(`This listing is not intended for this platform.
+          %(linkStart)sBrowse add-ons for Firefox for desktop%(linkEnd)s.`),
+        replacements: [
+          [
+            'linkStart',
+            'linkEnd',
+            (text) => (
+              <Link
+                to={newLocation}
+                prependClientApp={false}
+                prependLang={false}
+              >
+                {text}
+              </Link>
+            ),
+          ],
+        ],
+      });
     } else if (newLocation) {
       // Redirecting to new page on the desktop site.
-      message = i18n.sprintf(
-        `To find add-ons compatible with Firefox on desktop,
-               <a href="%(newLocation)s">visit our desktop site</a>.`,
-        { newLocation },
-      );
+      message = replaceStringsWithJSX({
+        text: i18n.gettext(`To use Android extensions, you'll need
+          %(downloadLinkStart)sFirefox for Android%(downloadLinkEnd)s. To
+          explore Firefox for desktop add-ons, please %(linkStart)svisit our
+          desktop site%(linkEnd)s.`),
+        replacements: [
+          [
+            'downloadLinkStart',
+            'downloadLinkEnd',
+            (text) => (
+              <Link
+                href={getDownloadLink({ clientApp })}
+                prependClientApp={false}
+                prependLang={false}
+              >
+                {text}
+              </Link>
+            ),
+          ],
+          [
+            'linkStart',
+            'linkEnd',
+            (text) => (
+              <Link
+                to={newLocation}
+                prependClientApp={false}
+                prependLang={false}
+              >
+                {text}
+              </Link>
+            ),
+          ],
+        ],
+      });
     }
 
     return message ? (
       <div className={makeClassName('WrongPlatformWarning', className)}>
         <Notice id="WrongPlatformWarning-Notice" type={warningInfoType}>
-          <span
-            className="WrongPlatformWarning-message"
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={sanitizeHTML(message, ['a'])}
-          />
+          <span className="WrongPlatformWarning-message">{message}</span>
         </Notice>
       </div>
     ) : null;

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -25,6 +25,8 @@ export const DOWNLOAD_FIREFOX_BASE_URL =
   'https://www.mozilla.org/firefox/download/thanks/';
 export const PROMOTED_ADDONS_SUMO_URL =
   'https://support.mozilla.org/kb/add-on-badges';
+export const DOWNLOAD_FIREFOX_FOR_ANDROID_URL =
+  'https://play.google.com/store/apps/details?id=org.mozilla.firefox';
 
 // Addon States.
 export const DISABLED = 'DISABLED';

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -155,7 +155,9 @@ describe(__filename, () => {
       mobileLink,
     );
     expect(
-      screen.getByText(/To find add-ons compatible with Firefox for Android,/),
+      screen.getByText(
+        /To find extensions compatible with Firefox for Android,/,
+      ),
     ).toBeInTheDocument();
   });
 
@@ -176,7 +178,7 @@ describe(__filename, () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'Browse add-ons for Firefox on desktop',
+        name: 'Browse add-ons for Firefox for desktop',
       }),
     ).toHaveAttribute('href', newLocation);
     expect(
@@ -195,7 +197,7 @@ describe(__filename, () => {
       }),
     ).toHaveAttribute('href', newLocation);
     expect(
-      screen.getByText(/To find add-ons compatible with Firefox on desktop,/),
+      screen.getByText(/To explore Firefox for desktop add-ons, please/),
     ).toBeInTheDocument();
   });
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -103,7 +103,7 @@ jest.mock('amo/utils/compatibility', () => ({
   ...jest.requireActual('amo/utils/compatibility'),
   correctedLocationForPlatform: jest
     .fn()
-    .mockReturnValue('a/different/location/'),
+    .mockReturnValue('/a/different/location/'),
   getClientCompatibility: jest.fn().mockReturnValue({
     compatible: true,
     reason: null,
@@ -358,9 +358,9 @@ describe(__filename, () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
-        name: 'Browse add-ons for Firefox on desktop',
+        name: 'Browse add-ons for Firefox for desktop',
       }),
-    ).toHaveAttribute('href', 'a/different/location/');
+    ).toHaveAttribute('href', '/a/different/location/');
     expect(
       screen.getByText(/This listing is not intended for this platform./),
     ).toBeInTheDocument();


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12664

---

![Screenshot 2023-12-01 at 16-53-05 Add-ons for Firefox Android (en-US)](https://github.com/mozilla/addons-frontend/assets/217628/e453a6b4-88cd-4a38-b996-c8678abea7f5)

<img width="1624" alt="Screenshot 2023-12-01 at 16 54 05" src="https://github.com/mozilla/addons-frontend/assets/217628/64b1a4d8-3520-405e-bf22-b8aaa96d98a9">



