### PR TITLE
Use Node 18.19 everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
     working_directory: ~/addons-frontend
     docker:
       # This is the NodeJS version we run in production.
-      - image: cimg/node:18.18
+      - image: cimg/node:18.19
 
   defaults-next: &defaults-next
     working_directory: ~/addons-frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Build
 #
-FROM node:18-slim AS builder
+FROM node:18.19-slim AS builder
 
 WORKDIR /srv/node
 COPY package.json yarn.lock /srv/node/
@@ -11,7 +11,7 @@ RUN yarn install --pure-lockfile
 #
 # Install
 #
-FROM node:18-slim
+FROM node:18.19-slim
 
 ARG app_uid=9500
 ARG app_dir=/app


### PR DESCRIPTION
At least we get the same output in PRs and the main branch now:

```
PASS ./dist/static/amo-35683fa25eab81ca105d.js: 357.42KB < 360KB (gzip)
```