### PR TITLE
Added `rel=nofollow` to public links on AMO

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -98,6 +98,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
             className="AddonMoreInfo-homepage-link"
             href={homepage}
             title={addon.homepage && addon.homepage.url}
+            rel="nofollow"
           >
             {i18n.gettext('Homepage')}
           </a>
@@ -114,6 +115,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
             className="AddonMoreInfo-support-link"
             href={supportUrl}
             title={addon.support_url && addon.support_url.url}
+            rel="nofollow"
           >
             {i18n.gettext('Support site')}
           </a>

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -355,7 +355,9 @@ export class UserProfileBase extends React.Component<InternalProps> {
                     className="UserProfile-homepage"
                     term={i18n.gettext('Homepage')}
                   >
-                    <a href={user.homepage}>{i18n.gettext('Homepage')}</a>
+                    <a href={user.homepage} rel="nofollow">
+                      {i18n.gettext('Homepage')}
+                    </a>
                   </Definition>
                 ) : null}
                 {user && user.location ? (

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -148,6 +148,7 @@ describe(__filename, () => {
       'https://outgoing.mozilla.org/hamster',
     );
     expect(link).toHaveAttribute('title', 'http://hamsterdance.com/');
+    expect(link).toHaveAttribute('rel', 'nofollow');
   });
 
   it('does not render a support link if none exists', () => {
@@ -174,6 +175,7 @@ describe(__filename, () => {
       'https://outgoing.mozilla.org/hamster',
     );
     expect(link).toHaveAttribute('title', 'http://support.hamsterdance.com/');
+    expect(link).toHaveAttribute('rel', 'nofollow');
   });
 
   it('renders the email link of an add-on', () => {

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -297,10 +297,9 @@ describe(__filename, () => {
     const homepage = 'http://hamsterdance.com/';
     signInUserAndRenderUserProfile({ homepage });
 
-    expect(screen.getByRole('link', { name: 'Homepage' })).toHaveAttribute(
-      'href',
-      homepage,
-    );
+    const link = screen.getByRole('link', { name: 'Homepage' });
+    expect(link).toHaveAttribute('href', homepage);
+    expect(link).toHaveAttribute('rel', 'nofollow');
   });
 
   it("omits homepage if the user doesn't have one set", () => {


### PR DESCRIPTION
Fixes #12708

- Added `rel=nofollow` to homepage and support url on add-on's listing page, and developer user profile page
- Updated tests

### Question
- How do we also add `rel=nofollow` to any anchor links in the add-on summary field? 