### PR TITLE
Change "Other" category in feedback form to point to "something_else" reason API

### DIFF
--- a/src/amo/components/AddonFeedbackForm/index.js
+++ b/src/amo/components/AddonFeedbackForm/index.js
@@ -11,7 +11,7 @@ import FeedbackForm, {
   CATEGORY_FEEDBACK_SPAM,
   CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
   CATEGORY_ILLEGAL,
-  CATEGORY_OTHER,
+  CATEGORY_SOMETHING_ELSE,
   CATEGORY_POLICY_VIOLATION,
 } from 'amo/components/FeedbackForm';
 import { withInstallHelpers } from 'amo/installAddon';
@@ -173,7 +173,7 @@ export class AddonFeedbackFormBase extends React.Component<InternalProps> {
       CATEGORY_POLICY_VIOLATION,
       CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
       CATEGORY_ILLEGAL,
-      CATEGORY_OTHER,
+      CATEGORY_SOMETHING_ELSE,
     ];
     if (addonType !== ADDON_TYPE_EXTENSION) {
       categories = categories.filter(

--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -82,7 +82,9 @@ export const CATEGORY_HATEFUL_VIOLENT_DECEPTIVE = 'hateful_violent_deceptive';
 // E
 export const CATEGORY_ILLEGAL = 'illegal';
 // F
-export const CATEGORY_OTHER = 'other';
+// Note that `other` category technically exists but only for add-ons, it's for
+// the previous abuse reporting mechanism.
+export const CATEGORY_OTHER = 'something_else';
 
 export const getCategories = (
   i18n: I18nType,

--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -84,7 +84,7 @@ export const CATEGORY_ILLEGAL = 'illegal';
 // F
 // Note that `other` category technically exists but only for add-ons, it's for
 // the previous abuse reporting mechanism.
-export const CATEGORY_OTHER = 'something_else';
+export const CATEGORY_SOMETHING_ELSE = 'something_else';
 
 export const getCategories = (
   i18n: I18nType,
@@ -134,7 +134,7 @@ export const getCategories = (
         ),
       },
       {
-        value: CATEGORY_OTHER,
+        value: CATEGORY_SOMETHING_ELSE,
         label: i18n.gettext('Something else'),
         help: i18n.gettext(
           'Anything that doesn’t fit into the other categories.',

--- a/src/amo/pages/CollectionFeedback/index.js
+++ b/src/amo/pages/CollectionFeedback/index.js
@@ -9,7 +9,7 @@ import FeedbackForm, {
   CATEGORY_FEEDBACK_SPAM,
   CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
   CATEGORY_ILLEGAL,
-  CATEGORY_OTHER,
+  CATEGORY_SOMETHING_ELSE,
 } from 'amo/components/FeedbackForm';
 import LoadingText from 'amo/components/LoadingText';
 import Card from 'amo/components/Card';
@@ -169,7 +169,7 @@ export class CollectionFeedbackBase extends React.Component<InternalProps> {
               CATEGORY_FEEDBACK_SPAM,
               CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
               CATEGORY_ILLEGAL,
-              CATEGORY_OTHER,
+              CATEGORY_SOMETHING_ELSE,
             ]}
             showLocation={false}
             onSubmit={this.onFormSubmitted}

--- a/src/amo/pages/RatingFeedback/index.js
+++ b/src/amo/pages/RatingFeedback/index.js
@@ -10,7 +10,7 @@ import { selectReview } from 'amo/reducers/reviews';
 import FeedbackForm, {
   CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
   CATEGORY_ILLEGAL,
-  CATEGORY_OTHER,
+  CATEGORY_SOMETHING_ELSE,
 } from 'amo/components/FeedbackForm';
 import LoadingText from 'amo/components/LoadingText';
 import Card from 'amo/components/Card';
@@ -168,7 +168,7 @@ export class RatingFeedbackBase extends React.Component<InternalProps> {
             categories={[
               CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
               CATEGORY_ILLEGAL,
-              CATEGORY_OTHER,
+              CATEGORY_SOMETHING_ELSE,
             ]}
             showLocation={false}
             onSubmit={this.onFormSubmitted}

--- a/src/amo/pages/UserFeedback/index.js
+++ b/src/amo/pages/UserFeedback/index.js
@@ -10,7 +10,7 @@ import FeedbackForm, {
   CATEGORY_FEEDBACK_SPAM,
   CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
   CATEGORY_ILLEGAL,
-  CATEGORY_OTHER,
+  CATEGORY_SOMETHING_ELSE,
 } from 'amo/components/FeedbackForm';
 import LoadingText from 'amo/components/LoadingText';
 import UserAvatar from 'amo/components/UserAvatar';
@@ -152,7 +152,7 @@ export class UserFeedbackBase extends React.Component<InternalProps> {
               CATEGORY_FEEDBACK_SPAM,
               CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
               CATEGORY_ILLEGAL,
-              CATEGORY_OTHER,
+              CATEGORY_SOMETHING_ELSE,
             ]}
             showLocation={false}
             onSubmit={this.onFormSubmitted}

--- a/tests/unit/amo/pages/TestAddonFeedback.js
+++ b/tests/unit/amo/pages/TestAddonFeedback.js
@@ -13,7 +13,7 @@ import {
 import {
   CATEGORY_HATEFUL_VIOLENT_DECEPTIVE,
   CATEGORY_ILLEGAL,
-  CATEGORY_OTHER,
+  CATEGORY_SOMETHING_ELSE,
 } from 'amo/components/FeedbackForm';
 import { extractId } from 'amo/pages/AddonFeedback';
 import { loadAddonAbuseReport, sendAddonAbuseReport } from 'amo/reducers/abuse';
@@ -357,7 +357,7 @@ describe(__filename, () => {
         reporterEmail: email,
         reporterName: name,
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         location: null,
         auth: true,
       }),

--- a/tests/unit/amo/pages/TestCollectionFeedback.js
+++ b/tests/unit/amo/pages/TestCollectionFeedback.js
@@ -14,7 +14,7 @@ import {
 } from 'amo/reducers/collectionAbuseReports';
 import {
   CATEGORY_FEEDBACK_SPAM,
-  CATEGORY_OTHER,
+  CATEGORY_SOMETHING_ELSE,
 } from 'amo/components/FeedbackForm';
 import { CLIENT_APP_FIREFOX } from 'amo/constants';
 import { extractId } from 'amo/pages/CollectionFeedback';
@@ -329,7 +329,7 @@ describe(__filename, () => {
         reporterEmail: signedInEmail,
         reporterName: signedInName,
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         auth: true,
       }),
     );
@@ -367,7 +367,7 @@ describe(__filename, () => {
         reporterEmail: '',
         reporterName: '',
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         auth: false,
       }),
     );

--- a/tests/unit/amo/pages/TestRatingFeedback.js
+++ b/tests/unit/amo/pages/TestRatingFeedback.js
@@ -10,7 +10,7 @@ import {
   setReview,
   setReviewWasFlagged,
 } from 'amo/actions/reviews';
-import { CATEGORY_OTHER } from 'amo/components/FeedbackForm';
+import { CATEGORY_SOMETHING_ELSE } from 'amo/components/FeedbackForm';
 import { CLIENT_APP_FIREFOX } from 'amo/constants';
 import { extractId } from 'amo/pages/RatingFeedback';
 import { clearError } from 'amo/reducers/errors';
@@ -360,7 +360,7 @@ describe(__filename, () => {
         reporterEmail: '',
         reporterName: '',
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         auth: false,
       }),
     );
@@ -391,7 +391,7 @@ describe(__filename, () => {
         reporterEmail: signedInEmail,
         reporterName: signedInName,
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         auth: true,
       }),
     );
@@ -427,7 +427,7 @@ describe(__filename, () => {
         reporterEmail: '',
         reporterName: '',
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         auth: false,
       }),
     );
@@ -474,7 +474,10 @@ describe(__filename, () => {
     render({ id: ratingId }, store);
 
     store.dispatch(
-      setReviewWasFlagged({ reviewId: ratingId, reason: CATEGORY_OTHER }),
+      setReviewWasFlagged({
+        reviewId: ratingId,
+        reason: CATEGORY_SOMETHING_ELSE,
+      }),
     );
 
     expect(

--- a/tests/unit/amo/pages/TestUserFeedback.js
+++ b/tests/unit/amo/pages/TestUserFeedback.js
@@ -9,7 +9,7 @@ import {
 } from 'amo/reducers/userAbuseReports';
 import {
   CATEGORY_FEEDBACK_SPAM,
-  CATEGORY_OTHER,
+  CATEGORY_SOMETHING_ELSE,
 } from 'amo/components/FeedbackForm';
 import { CLIENT_APP_FIREFOX } from 'amo/constants';
 import {
@@ -371,7 +371,7 @@ describe(__filename, () => {
         reporterEmail: signedInEmail,
         reporterName: signedInName,
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         auth: true,
       }),
     );
@@ -407,7 +407,7 @@ describe(__filename, () => {
         reporterEmail: '',
         reporterName: '',
         message: '',
-        reason: CATEGORY_OTHER,
+        reason: CATEGORY_SOMETHING_ELSE,
         auth: false,
       }),
     );


### PR DESCRIPTION
Fixes #12752

It needs to be deployed together with the fix for https://github.com/mozilla/addons-server/issues/21662, otherwise the new `something_else` category would be invalid.