### PR TITLE
Allow HTML validation to kick in

### DIFF
--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -231,15 +231,8 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
 
   preventSubmit(): boolean {
     const { abuseIsLoading } = this.props;
-    const { anonymous, category, certification, name, email } = this.state;
 
-    return (
-      abuseIsLoading ||
-      !category ||
-      (this.isCertificationRequired() && !certification) ||
-      (!anonymous && (!name.trim().length || !email.trim().length)) ||
-      (this.isLocationRequired() && !this.state.location)
-    );
+    return abuseIsLoading;
   }
 
   renderReportSentConfirmation(): React.Node {

--- a/tests/unit/amo/pages/TestAddonFeedback.js
+++ b/tests/unit/amo/pages/TestAddonFeedback.js
@@ -645,14 +645,6 @@ describe(__filename, () => {
     ).toBeInTheDocument();
   });
 
-  it('disables the submit button when no reason selected', async () => {
-    render();
-
-    expect(
-      screen.getByRole('button', { name: 'Submit report' }),
-    ).toBeDisabled();
-  });
-
   it('renders errors', () => {
     const message = 'Some error message';
     createFailedErrorHandler({

--- a/tests/unit/amo/pages/TestCollectionFeedback.js
+++ b/tests/unit/amo/pages/TestCollectionFeedback.js
@@ -506,14 +506,6 @@ describe(__filename, () => {
     ).not.toBeInTheDocument();
   });
 
-  it('disables the submit button when no reason selected', async () => {
-    render();
-
-    expect(
-      screen.getByRole('button', { name: 'Submit report' }),
-    ).toBeDisabled();
-  });
-
   it('shows success message after submission', async () => {
     const collectionId = 456;
     const { store } = dispatchClientMetadata();

--- a/tests/unit/amo/pages/TestRatingFeedback.js
+++ b/tests/unit/amo/pages/TestRatingFeedback.js
@@ -438,14 +438,6 @@ describe(__filename, () => {
     ).not.toBeInTheDocument();
   });
 
-  it('disables the submit button when no reason selected', async () => {
-    render();
-
-    expect(
-      screen.getByRole('button', { name: 'Submit report' }),
-    ).toBeDisabled();
-  });
-
   it('shows success message after submission', async () => {
     const ratingId = 456;
     const { store } = dispatchClientMetadata();

--- a/tests/unit/amo/pages/TestUserFeedback.js
+++ b/tests/unit/amo/pages/TestUserFeedback.js
@@ -418,14 +418,6 @@ describe(__filename, () => {
     ).not.toBeInTheDocument();
   });
 
-  it('disables the submit button when no reason selected', async () => {
-    render();
-
-    expect(
-      screen.getByRole('button', { name: 'Submit report' }),
-    ).toBeDisabled();
-  });
-
   it('shows success message after submission', async () => {
     const userId = 456;
     const { store } = dispatchClientMetadata();


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-frontend/issues/12847

---

This relies on the builtin HTML validation to indicate which fields are required when a user attempts to submit a form without all the mandatory fields set.


### Examples

![Screenshot 2024-02-14 at 10 55 18](https://github.com/mozilla/addons-frontend/assets/217628/8c843b1f-bcfd-4dcc-a64d-30905bfc7a75)

![Screenshot 2024-02-14 at 10 55 41](https://github.com/mozilla/addons-frontend/assets/217628/6a10378c-33a7-4fbf-bb89-f74d6914b2be)