### PR TITLE
Switch ubuntu image to 2004:current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,6 @@ jobs:
     <<: *defaults-release
     steps:
       - better_checkout
-      - run: pyenv global 3.11
       - run: pip install tox
       - run: TOXENV=dennis-lint tox
 
@@ -236,9 +235,6 @@ jobs:
       - run:
           name: Install dependencies
           command: sudo apt-get update; sudo apt-get install pigz
-      - run:
-          name: "Set Python Version"
-          command: pyenv global 3.11
       - run:
           name: "Install Tox"
           command: pip install tox
@@ -302,9 +298,6 @@ jobs:
       - run:
           name: Install dependencies
           command: sudo apt-get update; sudo apt-get install pigz
-      - run:
-          name: "Set Python Version"
-          command: pyenv global 3.11
       - run:
           name: "Install Tox"
           command: pip install tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ references:
 
   defaults-release: &defaults-release
     machine:
-      image: ubuntu-2004:2023.10.1
+      image: ubuntu-2004:current
     working_directory: ~/addons-frontend
 
   restore_build_cache: &restore_build_cache


### PR DESCRIPTION
2004:2023.10.1 is not deprecated yet, but might as well stay on the latest ubuntu-2004 for consistency/futureproofness

Relates to https://github.com/mozilla/addons/issues/1565