### PR TITLE
Revert "Bump node from 18.19-slim to 20.12-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Build
 #
-FROM node:20.12-slim AS builder
+FROM node:18.19-slim AS builder
 
 WORKDIR /srv/node
 COPY package.json yarn.lock /srv/node/
@@ -12,7 +12,7 @@ RUN yarn install --pure-lockfile
 #
 # Install
 #
-FROM node:20.12-slim
+FROM node:18.19-slim
 
 ARG app_uid=9500
 ARG app_dir=/app


### PR DESCRIPTION
Reverts mozilla/addons-frontend#12920