### PR TITLE
Use mozAddonManager.sendAbuseReport() to submit add-on abuse reports

### DIFF
--- a/src/amo/addonManager.js
+++ b/src/amo/addonManager.js
@@ -34,6 +34,11 @@ export type MozAddonManagerType = {|
   addEventListener: (eventName: string, handler: Function) => void,
   createInstall: ({| url: string, hash?: string | null |}) => Promise<any>,
   getAddonByID: (guid: string) => Promise<FirefoxAddon>,
+  sendAbuseReport: (
+    addonId: string,
+    data: { [key: string]: string | null },
+    options?: { authorization?: string | null },
+  ) => Promise<any>,
 |};
 
 type PrivilegedNavigatorType = {|
@@ -254,4 +259,23 @@ export function enable(
     }
     throw new Error(SET_ENABLE_NOT_AVAILABLE);
   });
+}
+
+export function canSendAbuseReports({
+  _mozAddonManager = window.navigator.mozAddonManager,
+}: OptionalParams = {}): boolean {
+  return typeof _mozAddonManager?.sendAbuseReport === 'function';
+}
+
+export function sendAbuseReport(
+  addonId: string,
+  data: { [key: string]: string | null },
+  options?: { authorization?: string | null },
+  { _mozAddonManager = window.navigator.mozAddonManager }: OptionalParams = {},
+): Promise<any> {
+  if (canSendAbuseReports({ _mozAddonManager })) {
+    return _mozAddonManager.sendAbuseReport(addonId, data, options);
+  }
+
+  return Promise.reject(new Error('cannot send abuse reports via Firefox'));
 }

--- a/src/amo/api/abuse.js
+++ b/src/amo/api/abuse.js
@@ -25,15 +25,18 @@ export type AbuseReporter = {|
 export type ReportAddonParams = {|
   addonId: string,
   api: ApiState,
-  reporterName: string | null,
-  reporterEmail: string | null,
+  reporter_name: string | null,
+  reporter_email: string | null,
   message: string | null,
   reason: string | null,
   location: string | null,
-  addonVersion: string | null,
+  addon_version: string | null,
   auth: boolean,
 |};
 
+// We are using snake case in this type because it makes it easier to share
+// the same set of parameters between the `mozAddonManager.sendAbuseReport()`
+// method and the direct API call (`reportAddon()` below).
 export type ReportAddonResponse = {|
   addon: {|
     guid: string,
@@ -52,12 +55,12 @@ export type ReportAddonResponse = {|
 export function reportAddon({
   addonId,
   api,
-  reporterName,
-  reporterEmail,
+  reporter_name,
+  reporter_email,
   message,
   reason,
   location,
-  addonVersion,
+  addon_version,
   auth,
 }: ReportAddonParams): Promise<ReportAddonResponse> {
   return callApi({
@@ -66,12 +69,12 @@ export function reportAddon({
     method: 'POST',
     body: {
       addon: addonId,
-      reporter_email: reporterEmail,
-      reporter_name: reporterName,
+      reporter_email,
+      reporter_name,
       message,
       reason,
       location,
-      addon_version: addonVersion,
+      addon_version,
       lang: api.lang,
     },
     apiState: api,

--- a/tests/unit/amo/api/test_abuse.js
+++ b/tests/unit/amo/api/test_abuse.js
@@ -33,11 +33,11 @@ describe(__filename, () => {
       const apiState = dispatchClientMetadata().store.getState().api;
       const message = 'I do not like this!';
       const reason = 'does_not_work';
-      const reporterName = 'Foxy';
-      const reporterEmail = 'fox@moz.co';
+      const reporter_name = 'Foxy';
+      const reporter_email = 'fox@moz.co';
       const addonId = 'cool-addon';
       const location = 'both';
-      const addonVersion = '1.2.3.4';
+      const addon_version = '1.2.3.4';
 
       mockApi
         .expects('callApi')
@@ -49,10 +49,10 @@ describe(__filename, () => {
             addon: addonId,
             message,
             reason,
-            reporter_email: reporterEmail,
-            reporter_name: reporterName,
+            reporter_email,
+            reporter_name,
             location,
-            addon_version: addonVersion,
+            addon_version,
             lang: DEFAULT_LANG_IN_TESTS,
           },
           apiState,
@@ -70,10 +70,10 @@ describe(__filename, () => {
         api: apiState,
         message,
         reason,
-        reporterEmail,
-        reporterName,
+        reporter_email,
+        reporter_name,
         location,
-        addonVersion,
+        addon_version,
         auth: true,
       });
 

--- a/tests/unit/amo/test_addonManager.js
+++ b/tests/unit/amo/test_addonManager.js
@@ -45,6 +45,7 @@ describe(__filename, () => {
       createInstall: sinon.stub().returns(Promise.resolve(fakeInstallObj)),
       getAddonByID: sinon.stub(),
       addEventListener: sinon.stub(),
+      sendAbuseReport: sinon.stub(),
     };
   });
 
@@ -369,6 +370,38 @@ describe(__filename, () => {
         .then(unexpectedSuccess, (err) => {
           expect(err.message).toEqual(SET_ENABLE_NOT_AVAILABLE);
         });
+    });
+  });
+
+  describe('sendAbuseReport', () => {
+    it('rejects when mozAddonManager.sendAbuseReport is not available', () => {
+      delete fakeMozAddonManager.sendAbuseReport;
+
+      return addonManager
+        .sendAbuseReport(
+          'addon-id',
+          /* data */ {},
+          /* options */ {},
+          {
+            _mozAddonManager: fakeMozAddonManager,
+          },
+        )
+        .then(unexpectedSuccess, (err) =>
+          expect(err.message).toEqual('cannot send abuse reports via Firefox'),
+        );
+    });
+
+    it('calls mozAddonManager.sendAbuseReport when available', async () => {
+      fakeMozAddonManager.sendAbuseReport.returns(Promise.resolve('ok'));
+
+      const res = await addonManager.sendAbuseReport(
+        'addon-id',
+        /* data */ {},
+        /* options */ {},
+        { _mozAddonManager: fakeMozAddonManager },
+      );
+
+      expect(res).toEqual('ok');
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14807

---

When the Firefox API isn't available, we fallback to a direct HTTP call to the API (as it is currently).