### PR TITLE
Show the "not actively monitored" banner on Android as well

### DIFF
--- a/src/amo/components/InstallWarning/index.js
+++ b/src/amo/components/InstallWarning/index.js
@@ -8,7 +8,6 @@ import type { AppState } from 'amo/store';
 import { getPromotedBadgesLinkUrl } from 'amo/utils';
 import {
   ADDON_TYPE_EXTENSION,
-  CLIENT_APP_FIREFOX,
   EXCLUDE_WARNING_CATEGORIES,
 } from 'amo/constants';
 import translate from 'amo/i18n/translate';
@@ -86,7 +85,6 @@ export class InstallWarningBase extends React.Component<InternalProps> {
     return (
       !correctedLocation &&
       isFirefox({ userAgentInfo }) &&
-      clientApp === CLIENT_APP_FIREFOX &&
       addon.type === ADDON_TYPE_EXTENSION &&
       (!promotedCategory ||
         !EXCLUDE_WARNING_CATEGORIES.includes(promotedCategory))

--- a/tests/unit/amo/pages/TestAddonVersions.js
+++ b/tests/unit/amo/pages/TestAddonVersions.js
@@ -978,6 +978,15 @@ describe(__filename, () => {
         expect(getInstallWarning()).toBeInTheDocument();
       });
 
+      it('returns true if the userAgent is Firefox, clientApp Android and the add-on is an extension and is not promoted', () => {
+        dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID, store });
+        renderWithAddonAndVersions({
+          location: `/${lang}/${CLIENT_APP_ANDROID}/addon/${defaultSlug}/versions/`,
+        });
+
+        expect(getInstallWarning()).toBeInTheDocument();
+      });
+
       it('returns false if the add-on is not an extension', () => {
         renderWithAddonAndVersions({
           addon: {
@@ -1030,20 +1039,6 @@ describe(__filename, () => {
           userAgent: userAgentsByPlatform.mac.chrome41,
         });
         renderWithAddonAndVersions();
-
-        expect(
-          screen.queryByText(
-            `This add-on is not actively monitored for security by Mozilla. ` +
-              `Make sure you trust it before installing.`,
-          ),
-        ).not.toBeInTheDocument();
-      });
-
-      it('returns false if the clientApp is Android', () => {
-        dispatchClientMetadata({ clientApp: CLIENT_APP_ANDROID, store });
-        renderWithAddonAndVersions({
-          location: `/${lang}/${CLIENT_APP_ANDROID}/addon/${defaultSlug}/versions/`,
-        });
 
         expect(
           screen.queryByText(


### PR DESCRIPTION
Fixes mozilla/addons#2207

The change should be straightforward enough to be verified by the unit test alone, and the issue explains the context a bit more, but if you want to check locally:

1) Visit /en-US/android/ with a Firefox for Android User Agent (on Desktop, Firefox responsive mode with some custom UA should do the trick)
2) Follow the link to a non-recommended add-on
3) Notice the "not actively monitored" grey banner is present