### PR TITLE
Update wrong platform copy in add-on details pages when client app is "android"

### DIFF
--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -115,27 +115,6 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
           ],
         ],
       });
-    } else if (addon && newLocation) {
-      // User with desktop browser looking at detail page on mobile site.
-      message = replaceStringsWithJSX({
-        text: i18n.gettext(`This listing is not intended for this platform.
-          %(linkStart)sBrowse add-ons for Firefox for desktop%(linkEnd)s.`),
-        replacements: [
-          [
-            'linkStart',
-            'linkEnd',
-            (text) => (
-              <Link
-                to={newLocation}
-                prependClientApp={false}
-                prependLang={false}
-              >
-                {text}
-              </Link>
-            ),
-          ],
-        ],
-      });
     } else if (newLocation) {
       const overrideQueryParams = {
         // If there is a UTM campaign set on the visited AMO URL, pass it to

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -178,11 +178,31 @@ describe(__filename, () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'Browse add-ons for Firefox for desktop',
+        name: 'Firefox for Android',
+      }),
+    ).toHaveAttribute(
+      'href',
+      `https://play.google.com/store/apps/details?${[
+        'id=org.mozilla.firefox',
+        `referrer=${encodeURIComponent(
+          [
+            'utm_campaign=amo-fx-cta',
+            'utm_content=banner-download-button',
+            'utm_medium=referral',
+            'utm_source=addons.mozilla.org',
+          ].join('&'),
+        )}`,
+      ].join('&')}`,
+    );
+    expect(screen.getByText(/To use Android extensions/)).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'visit our desktop site',
       }),
     ).toHaveAttribute('href', newLocation);
     expect(
-      screen.getByText(/This listing is not intended for this platform./),
+      screen.getByText(/To explore Firefox for desktop add-ons, please/),
     ).toBeInTheDocument();
   });
 

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -358,11 +358,11 @@ describe(__filename, () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('link', {
-        name: 'Browse add-ons for Firefox for desktop',
+        name: 'visit our desktop site',
       }),
     ).toHaveAttribute('href', '/a/different/location/');
     expect(
-      screen.getByText(/This listing is not intended for this platform./),
+      screen.getByText(/To explore Firefox for desktop add-ons, please/),
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
We already had the right message for non add-on detail pages, so removing the message specific to the add-on detail page is enough to address the issue.

This causes us to show what we want, which is, on android add-on detail pages visited from a Desktop browser, a link to download Firefox for Android and a link to switch to the desktop version of the page.

![Screenshot 2024-05-21 at 15-59-42 Test pt nume – Get this Extension for 🦊 Firefox Android (en-US)](https://github.com/mozilla/addons-frontend/assets/187006/99a274d8-8283-4d9c-8777-1c96ac6806ec)


Fixes mozilla/addons#2205