### PR TITLE
Increase default caching duration of pages to 360 seconds

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -32,7 +32,7 @@ We can't `Vary` on a specific cookie, only the whole header, which would include
 
 ### Cache duration
 
-We currently return `180` as the number of seconds to cache responses. The CDN might potentially serve stale responses while it's populating the cache, so sometimes clients might see a cached response that is a bit older than that.
+We currently return `360` as the number of seconds to cache responses. The CDN might potentially serve stale responses while it's populating the cache, so sometimes clients might see a cached response that is a bit older than that.
 
 ### API
 

--- a/src/amo/server/base.js
+++ b/src/amo/server/base.js
@@ -404,10 +404,10 @@ function baseServer(
           _log.debug(oneLine`${req.method} -> ${responseStatusCode},
             redirecting=${isRedirecting} anonymous=${!token}:
             response should be cached.`);
-          res.append('Cache-Control', 's-maxage=180');
+          res.append('Cache-Control', 's-maxage=360');
           // The following is for backwards-compatibility until we have
           // switched nginx to obey Cache-Control instead.
-          res.set('X-Accel-Expires', '180');
+          res.set('X-Accel-Expires', '360');
         } else {
           _log.debug(oneLine`${req.method} -> ${responseStatusCode},
             redirecting=${isRedirecting} anonymous=${!token}:

--- a/tests/unit/amo/server/test_base.js
+++ b/tests/unit/amo/server/test_base.js
@@ -203,7 +203,7 @@ describe(__filename, () => {
         store,
       }).get('/en-US/firefox/');
       expect(response.headers['cache-control']).toEqual(
-        'max-age=0, s-maxage=180',
+        'max-age=0, s-maxage=360',
       );
     });
 
@@ -636,9 +636,9 @@ describe(__filename, () => {
         sagaMiddleware,
         store,
       }).get('/en-US/firefox/');
-      expect(response.headers[X_ACCEL_EXPIRES_HEADER]).toEqual('180');
+      expect(response.headers[X_ACCEL_EXPIRES_HEADER]).toEqual('360');
       expect(response.headers['cache-control']).toEqual(
-        'max-age=0, s-maxage=180',
+        'max-age=0, s-maxage=360',
       );
     });
 
@@ -738,9 +738,9 @@ describe(__filename, () => {
 
       expect(response.status).toEqual(301);
       expect(response.headers.location).toEqual(newURL);
-      expect(response.headers[X_ACCEL_EXPIRES_HEADER]).toEqual('180');
+      expect(response.headers[X_ACCEL_EXPIRES_HEADER]).toEqual('360');
       expect(response.headers['cache-control']).toEqual(
-        'max-age=0, s-maxage=180',
+        'max-age=0, s-maxage=360',
       );
     });
   });


### PR DESCRIPTION
See https://github.com/mozilla/addons/issues/14798 (fixes the frontend part)

You can try it locally by observing non-authenticated HTTP responses for frontend pages are served with `cache-control: max-age=0, s-maxage=360` instead of `cache-control: max-age=0, s-maxage=180`
