### PR TITLE
Update CSP config to follow docs for Google Analytics 4 + Universal Analytics

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -151,9 +151,6 @@ module.exports = {
         `${baseUrlProd}${mediaPath}`,
         `${baseUrlProd}${staticPath}`,
         `${baseUrlProd}${serverStaticPath}`,
-        // For backwards-compatibility, allow images to be served from the old
-        // dedicated domain for statics and user uploaded content:
-        'https://addons.cdn.mozilla.net/',
         ga4AnalyticsHost,
         ga4TagManagerHost,
       ],
@@ -163,8 +160,8 @@ module.exports = {
       // Script is limited to the static path
       scriptSrc: [
         `${baseUrlProd}${staticPath}`,
-        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
-        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       styleSrc: [
         `${baseUrlProd}${staticPath}`,

--- a/config/default.js
+++ b/config/default.js
@@ -4,7 +4,17 @@
 
 import path from 'path';
 
-import { analyticsHost, ga4ConnectHost, ga4Host, prodDomain, apiProdHost, baseUrlProd, mediaPath, serverStaticPath, staticPath } from './lib/shared';
+import {
+  apiProdHost,
+  baseUrlProd,
+  ga4AdditionalAnalyticsHost,
+  ga4AnalyticsHost,
+  ga4TagManagerHost,
+  mediaPath,
+  prodDomain,
+  serverStaticPath,
+  staticPath,
+} from './lib/shared';
 
 const basePath = path.resolve(__dirname, '../');
 
@@ -124,7 +134,12 @@ module.exports = {
       defaultSrc: ["'none'"],
       baseUri: ["'self'"],
       childSrc: ["'none'"],
-      connectSrc: [analyticsHost, ga4ConnectHost, apiProdHost],
+      connectSrc: [
+        apiProdHost,
+        ga4AnalyticsHost,
+        ga4AdditionalAnalyticsHost,
+        ga4TagManagerHost,
+      ],
       fontSrc: [
         `${baseUrlProd}${staticPath}`,
       ],
@@ -139,6 +154,8 @@ module.exports = {
         // For backwards-compatibility, allow images to be served from the old
         // dedicated domain for statics and user uploaded content:
         'https://addons.cdn.mozilla.net/',
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       manifestSrc: ["'none'"],
       mediaSrc: ["'none'"],
@@ -146,8 +163,8 @@ module.exports = {
       // Script is limited to the static path
       scriptSrc: [
         `${baseUrlProd}${staticPath}`,
-        `${analyticsHost}/analytics.js`,
-        `${ga4Host}/gtag/js`,
+        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
+        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
       ],
       styleSrc: [
         `${baseUrlProd}${staticPath}`,

--- a/config/dev.js
+++ b/config/dev.js
@@ -42,8 +42,8 @@ module.exports = {
       ],
       scriptSrc: [
         `${baseUrlDev}${staticPath}`,
-        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
-        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       styleSrc: [
         `${baseUrlDev}${staticPath}`,

--- a/config/dev.js
+++ b/config/dev.js
@@ -1,5 +1,15 @@
 // Config for the -dev server.
-import { analyticsHost, apiDevHost, baseUrlDev, devDomain, ga4ConnectHost, ga4Host, mediaPath, serverStaticPath, staticPath } from './lib/shared';
+import {
+  apiDevHost,
+  baseUrlDev,
+  devDomain,
+  ga4AdditionalAnalyticsHost,
+  ga4AnalyticsHost,
+  ga4TagManagerHost,
+  mediaPath,
+  serverStaticPath,
+  staticPath,
+} from './lib/shared';
 
 module.exports = {
   baseURL: baseUrlDev,
@@ -13,9 +23,10 @@ module.exports = {
     useDefaults: false,
     directives: {
       connectSrc: [
-        analyticsHost,
-        ga4ConnectHost,
         apiDevHost,
+        ga4AnalyticsHost,
+        ga4AdditionalAnalyticsHost,
+        ga4TagManagerHost,
       ],
       fontSrc: [
         `${baseUrlDev}${staticPath}`,
@@ -26,11 +37,13 @@ module.exports = {
         `${baseUrlDev}${mediaPath}`,
         `${baseUrlDev}${staticPath}`,
         `${baseUrlDev}${serverStaticPath}`,
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       scriptSrc: [
         `${baseUrlDev}${staticPath}`,
-        `${analyticsHost}/analytics.js`,
-        `${ga4Host}/gtag/js`,
+        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
+        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
       ],
       styleSrc: [
         `${baseUrlDev}${staticPath}`,

--- a/config/development.js
+++ b/config/development.js
@@ -1,5 +1,11 @@
 // Config specific to local development
-import { baseUrlDev, analyticsHost, apiDevHost, ga4ConnectHost, ga4Host } from './lib/shared';
+import {
+  apiDevHost,
+  baseUrlDev,
+  ga4AdditionalAnalyticsHost,
+  ga4AnalyticsHost,
+  ga4TagManagerHost,
+} from './lib/shared';
 
 const webpackServerHost = process.env.WEBPACK_SERVER_HOST || '127.0.0.1';
 const webpackServerPort = process.env.WEBPACK_SERVER_PORT || 3001;
@@ -42,12 +48,13 @@ module.exports = {
       connectSrc: [
         "'self'",
         baseUrlDev,
-        analyticsHost,
-        ga4ConnectHost,
         apiDevHost,
         webpackDevServer,
         // This is needed for pino-devtools.
         `${webpackServerHost}:3010`,
+        ga4AnalyticsHost,
+        ga4AdditionalAnalyticsHost,
+        ga4TagManagerHost,
       ],
       fontSrc: [
         webpackDevServer,
@@ -57,6 +64,8 @@ module.exports = {
         'data:',
         baseUrlDev,
         webpackDevServer,
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       scriptSrc: [
         "'self'",
@@ -64,8 +73,8 @@ module.exports = {
         "'unsafe-inline'",
         baseUrlDev,
         webpackDevServer,
-        `${analyticsHost}/analytics.js`,
-        `${ga4Host}/gtag/js`,
+        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
+        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
       ],
       styleSrc: [
         "'self'",

--- a/config/development.js
+++ b/config/development.js
@@ -73,8 +73,8 @@ module.exports = {
         "'unsafe-inline'",
         baseUrlDev,
         webpackDevServer,
-        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
-        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       styleSrc: [
         "'self'",

--- a/config/lib/shared.js
+++ b/config/lib/shared.js
@@ -10,10 +10,11 @@ export const baseUrlDev = apiDevHost;
 export const baseUrlProd = apiProdHost;
 export const baseUrlStage = apiStageHost;
 
-export const analyticsHost = 'https://www.google-analytics.com';
-export const ga4Host = 'https://www.googletagmanager.com';
-// See https://github.com/mozilla/bedrock/issues/11768
-export const ga4ConnectHost = 'https://*.google-analytics.com';
+// https://github.com/mozilla/addons/issues/14799#issuecomment-2127359422
+// These match Google's recommendations for CSP with GA4.
+export const ga4TagManagerHost = 'https://*.googletagmanager.com';
+export const ga4AnalyticsHost = 'https://*.google-analytics.com';
+export const ga4AdditionalAnalyticsHost = 'https://*.analytics.google.com';
 
 export const staticPath = '/static-frontend/';
 export const serverStaticPath = '/static-server/';  // addons-server statics.

--- a/config/stage.js
+++ b/config/stage.js
@@ -1,5 +1,15 @@
 // Config for the stage server.
-import { analyticsHost, apiStageHost, baseUrlStage, ga4ConnectHost, ga4Host, mediaPath, serverStaticPath, stageDomain, staticPath } from './lib/shared';
+import {
+  apiStageHost,
+  baseUrlStage,
+  ga4AdditionalAnalyticsHost,
+  ga4AnalyticsHost,
+  ga4TagManagerHost,
+  mediaPath,
+  serverStaticPath,
+  stageDomain,
+  staticPath,
+} from './lib/shared';
 
 module.exports = {
   baseURL: baseUrlStage,
@@ -12,9 +22,10 @@ module.exports = {
     useDefaults: false,
     directives: {
       connectSrc: [
-        analyticsHost,
-        ga4ConnectHost,
         apiStageHost,
+        ga4AnalyticsHost,
+        ga4AdditionalAnalyticsHost,
+        ga4TagManagerHost,
       ],
       fontSrc: [
         `${baseUrlStage}${staticPath}`,
@@ -25,11 +36,13 @@ module.exports = {
         `${baseUrlStage}${mediaPath}`,
         `${baseUrlStage}${staticPath}`,
         `${baseUrlStage}${serverStaticPath}`,
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       scriptSrc: [
         `${baseUrlStage}${staticPath}`,
-        `${analyticsHost}/analytics.js`,
-        `${ga4Host}/gtag/js`,
+        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
+        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
       ],
       styleSrc: [
         `${baseUrlStage}${staticPath}`,

--- a/config/stage.js
+++ b/config/stage.js
@@ -41,8 +41,8 @@ module.exports = {
       ],
       scriptSrc: [
         `${baseUrlStage}${staticPath}`,
-        ga4AnalyticsHost,  // https://www.google-analytics.com/analytics.js
-        ga4TagManagerHost, // https://www.googletagmanager.com/gtag/js
+        ga4AnalyticsHost,
+        ga4TagManagerHost,
       ],
       styleSrc: [
         `${baseUrlStage}${staticPath}`,


### PR DESCRIPTION
- https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics
- https://developers.google.com/tag-platform/security/guides/csp#universal_analytics_google_analytics

Cf mozilla/addons#14799 (fixes frontend side)

To test this locally, run with the various configs (`yarn amo:dev` will test the development config, but for dev/stage/prod production builds you'll need to follow https://github.com/mozilla/addons-frontend/blob/master/README.md#running-builds-locally)