### PR TITLE
Remove obsolete references to nginx caching

### DIFF
--- a/src/amo/server/base.js
+++ b/src/amo/server/base.js
@@ -405,9 +405,6 @@ function baseServer(
             redirecting=${isRedirecting} anonymous=${!token}:
             response should be cached.`);
           res.append('Cache-Control', 's-maxage=360');
-          // The following is for backwards-compatibility until we have
-          // switched nginx to obey Cache-Control instead.
-          res.set('X-Accel-Expires', '360');
         } else {
           _log.debug(oneLine`${req.method} -> ${responseStatusCode},
             redirecting=${isRedirecting} anonymous=${!token}:

--- a/tests/unit/amo/server/test_base.js
+++ b/tests/unit/amo/server/test_base.js
@@ -88,8 +88,6 @@ const NotFoundApp = () => (
   </div>
 );
 
-const X_ACCEL_EXPIRES_HEADER = 'x-accel-expires'; // Has to be in lowercase
-
 // eslint-disable-next-line jest/no-export
 export class ServerTestHelper {
   constructor() {
@@ -636,7 +634,6 @@ describe(__filename, () => {
         sagaMiddleware,
         store,
       }).get('/en-US/firefox/');
-      expect(response.headers[X_ACCEL_EXPIRES_HEADER]).toEqual('360');
       expect(response.headers['cache-control']).toEqual(
         'max-age=0, s-maxage=360',
       );
@@ -652,7 +649,6 @@ describe(__filename, () => {
       })
         .get('/en-US/firefox/')
         .set('cookie', `${defaultConfig.get('cookieName')}="foo"`);
-      expect(response.headers).not.toContain(X_ACCEL_EXPIRES_HEADER);
       expect(response.headers['cache-control']).toEqual(
         'max-age=0, s-maxage=0',
       );
@@ -666,7 +662,6 @@ describe(__filename, () => {
         sagaMiddleware,
         store,
       }).post('/en-US/firefox/');
-      expect(response.headers).not.toContain(X_ACCEL_EXPIRES_HEADER);
       expect(response.headers['cache-control']).toEqual(
         'max-age=0, s-maxage=0',
       );
@@ -677,7 +672,6 @@ describe(__filename, () => {
         '/en-US/firefox/simulation-of-a-non-existent-page/',
       );
       expect(response.statusCode).toEqual(404);
-      expect(response.headers).not.toContain(X_ACCEL_EXPIRES_HEADER);
       expect(response.headers['cache-control']).toEqual(
         'max-age=0, s-maxage=0',
       );
@@ -692,7 +686,6 @@ describe(__filename, () => {
         '/en-US/firefox/',
       );
       expect(response.statusCode).toEqual(500);
-      expect(response.headers).not.toContain(X_ACCEL_EXPIRES_HEADER);
       expect(response.headers['cache-control']).toEqual('max-age=0');
     });
 
@@ -738,7 +731,6 @@ describe(__filename, () => {
 
       expect(response.status).toEqual(301);
       expect(response.headers.location).toEqual(newURL);
-      expect(response.headers[X_ACCEL_EXPIRES_HEADER]).toEqual('360');
       expect(response.headers['cache-control']).toEqual(
         'max-age=0, s-maxage=360',
       );


### PR DESCRIPTION
## Context

Caching has been done through the CDN for a long time (and before that nginx had been upgraded & set up to support caching through the standard Cache-Control header anyway)

## Testing

Our local environments don't use the CDN (or nginx, unless you set up addons-server, and even then you don't have the same setup as prod) so you'll have to trust me that this is truly obsolete. But you can check that responses from addons-frontend nodejs no longer contain the `X-Accel-Expires` header. It should change absolutely nothing.

Fixes mozilla/addons#14814