### PR TITLE
Add rel=nofollow to links to add-on misc info pages we're not indexing

### DIFF
--- a/src/amo/components/AddonMoreInfo/index.js
+++ b/src/amo/components/AddonMoreInfo/index.js
@@ -166,6 +166,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
               `/addon/${addon.slug}/license/`,
               getQueryParametersForAttribution(location),
             ),
+            rel: 'nofollow',
           }
         : { href: license.url, prependClientApp: false, prependLang: false };
       const licenseName = license.name || i18n.gettext('Custom License');
@@ -227,6 +228,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
             `/addon/${addon.slug}/privacy/`,
             getQueryParametersForAttribution(location),
           )}
+          rel="nofollow"
         >
           {i18n.gettext('Read the privacy policy for this add-on')}
         </Link>
@@ -238,6 +240,7 @@ export class AddonMoreInfoBase extends React.Component<InternalProps> {
             `/addon/${addon.slug}/eula/`,
             getQueryParametersForAttribution(location),
           )}
+          rel="nofollow"
         >
           {i18n.gettext('Read the license agreement for this add-on')}
         </Link>

--- a/src/amo/components/ReportAbuseButton/index.js
+++ b/src/amo/components/ReportAbuseButton/index.js
@@ -64,6 +64,7 @@ export class ReportAbuseButtonBase extends React.Component<InternalProps> {
             buttonType="neutral"
             className="ReportAbuseButton-show-more"
             disabled={loading}
+            rel="nofollow"
             puffy
             {...reportButtonProps}
           >

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -262,6 +262,7 @@ describe(__filename, () => {
       'href',
       `/en-US/android/addon/${addon.slug}/license/`,
     );
+    expect(link).toHaveAttribute('rel', 'nofollow');
   });
 
   it('renders a default name when the license name is null', () => {
@@ -341,6 +342,7 @@ describe(__filename, () => {
       'href',
       '/en-US/android/addon/chill-out/privacy/',
     );
+    expect(link).toHaveAttribute('rel', 'nofollow');
   });
 
   it('does not render a EULA if none exists', () => {
@@ -365,6 +367,7 @@ describe(__filename, () => {
       'href',
       '/en-US/android/addon/chill-out/eula/',
     );
+    expect(link).toHaveAttribute('rel', 'nofollow');
   });
 
   it('does not link to stats if user is not author of the add-on', () => {

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -526,11 +526,8 @@ describe(__filename, () => {
     it('allows a user to report an add-on for abuse', async () => {
       render();
 
-      expect(
-        screen.getByRole('link', {
-          name: 'Report this add-on',
-        }),
-      ).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: 'Report this add-on' });
+      expect(link).toHaveAttribute('rel', 'nofollow');
     });
 
     it('shows a success message when feedback has been submitted', () => {


### PR DESCRIPTION
Fixes mozilla/addons#14874

## Description

As mentioned in the issue, the following links don't need to be followed by search engines and should have a `nofollow` set to avoid search engines spending crawl budget on them:
- Feedback page (link: Report this add-on)
- Privacy Policy page (link: Read the privacy policy for this add-on - if there is one for that add-on)
- EULA page (link: Read the license agreement for this add-on - if there is one for that add-on)
- (custom) License page (link: {license name})

## Testing

Unit tests should be enough, but you can load an individual add-on detail page on your local machine to test this if you want. Note that you'll need to use one which has the relevant links enabled (so if you want everything, you need it to have a privacy policy, an EULA and a custom license set on the current version)