### PR TITLE
Add canonical / alternate links for mozilla collections (and only those)

### DIFF
--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -1,4 +1,5 @@
 /* @flow */
+import config from 'config';
 import deepEqual from 'deep-eql';
 import invariant from 'invariant';
 import * as React from 'react';
@@ -589,9 +590,10 @@ export class CollectionBase extends React.Component<InternalProps> {
           )}
           {
             /* Only include canonical/alternate links if this is a mozilla collection */
-            collection && collection.authorUsername === 'mozilla' && (
-              <HeadLinks />
-            )
+            collection &&
+              collection.authorId === config.get('mozillaUserId') && (
+                <HeadLinks />
+              )
           }
 
           {errorHandler.renderErrorIfPresent()}

--- a/src/amo/pages/Collection/index.js
+++ b/src/amo/pages/Collection/index.js
@@ -11,6 +11,7 @@ import Button from 'amo/components/Button';
 import CollectionAddAddon from 'amo/components/CollectionAddAddon';
 import CollectionControls from 'amo/components/CollectionControls';
 import CollectionDetailsCard from 'amo/components/CollectionDetailsCard';
+import HeadLinks from 'amo/components/HeadLinks';
 import NotFoundPage from 'amo/pages/ErrorPages/NotFoundPage';
 import Link from 'amo/components/Link';
 import Page from 'amo/components/Page';
@@ -586,6 +587,12 @@ export class CollectionBase extends React.Component<InternalProps> {
               <meta name="description" content={this.getPageDescription()} />
             </Helmet>
           )}
+          {
+            /* Only include canonical/alternate links if this is a mozilla collection */
+            collection && collection.authorUsername === 'mozilla' && (
+              <HeadLinks />
+            )
+          }
 
           {errorHandler.renderErrorIfPresent()}
 

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -1151,7 +1151,7 @@ describe(__filename, () => {
 
   it('renders canonical and alternate links for mozilla collections', async () => {
     renderWithCollection({
-      detailProps: { authorId: mozillaUserId, authorUsername: 'mozilla' },
+      detailProps: { authorId: mozillaUserId },
       userId: mozillaUserId,
     });
 


### PR DESCRIPTION
Non-mozilla collections are disallowed in robots.txt

Fixes mozilla/addons#14887