### PR TITLE
Remove obsolete/useless `Verified` badging filter in search

### DIFF
--- a/src/amo/components/Search/index.js
+++ b/src/amo/components/Search/index.js
@@ -23,7 +23,6 @@ import {
   SEARCH_SORT_TOP_RATED,
   SEARCH_SORT_TRENDING,
   VIEW_CONTEXT_HOME,
-  VERIFIED_FILTER,
 } from 'amo/constants';
 import { withFixedErrorHandler } from 'amo/errorHandler';
 import translate from 'amo/i18n/translate';
@@ -171,17 +170,6 @@ export class SearchBase extends React.Component<InternalProps> {
               break;
             default:
               title = i18n.gettext('Reviewed add-ons');
-          }
-        } else if (filters.promoted === VERIFIED_FILTER) {
-          switch (filters.addonType) {
-            case ADDON_TYPE_EXTENSION:
-              title = i18n.gettext('Verified extensions');
-              break;
-            case ADDON_TYPE_STATIC_THEME:
-              title = i18n.gettext('Verified themes');
-              break;
-            default:
-              title = i18n.gettext('Verified add-ons');
           }
         }
       } else if (filters && filters.sort) {

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -19,7 +19,6 @@ import {
   SEARCH_SORT_TOP_RATED,
   SEARCH_SORT_TRENDING,
   SEARCH_SORT_UPDATED,
-  VERIFIED_FILTER,
 } from 'amo/constants';
 import { withErrorHandler } from 'amo/errorHandler';
 import log from 'amo/logger';
@@ -181,10 +180,6 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
       {
         children: i18n.gettext('By Firefox'),
         value: LINE,
-      },
-      {
-        children: i18n.gettext('Verified'),
-        value: VERIFIED_FILTER,
       },
       {
         children: i18n.gettext('All Reviewed'),

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -346,7 +346,6 @@ export const EXCLUDE_WARNING_CATEGORIES = [
   VERIFIED,
 ];
 export const REVIEWED_FILTER = 'badged';
-export const VERIFIED_FILTER = `${SPONSORED},${VERIFIED}`;
 
 export type PromotedCategoryType =
   | typeof LINE

--- a/tests/unit/amo/pages/TestSearchPage.js
+++ b/tests/unit/amo/pages/TestSearchPage.js
@@ -24,7 +24,6 @@ import {
   SEARCH_SORT_TOP_RATED,
   SEARCH_SORT_POPULAR,
   SET_VIEW_CONTEXT,
-  VERIFIED_FILTER,
   VIEW_CONTEXT_HOME,
 } from 'amo/constants';
 import { fetchCategories, loadCategories } from 'amo/reducers/categories';
@@ -534,18 +533,6 @@ describe(__filename, () => {
       [
         { type: ADDON_TYPE_LANG, promoted: REVIEWED_FILTER },
         'Reviewed add-ons',
-      ],
-      [
-        { type: ADDON_TYPE_EXTENSION, promoted: VERIFIED_FILTER },
-        'Verified extensions',
-      ],
-      [
-        { type: ADDON_TYPE_STATIC_THEME, promoted: VERIFIED_FILTER },
-        'Verified themes',
-      ],
-      [
-        { type: ADDON_TYPE_LANG, promoted: VERIFIED_FILTER },
-        'Verified add-ons',
       ],
       [
         { type: ADDON_TYPE_EXTENSION, sort: SEARCH_SORT_TRENDING },


### PR DESCRIPTION
Fixes mozilla/addons#14926