### PR TITLE
Removed "Latest Version" Block from Add-on Version History for Langpacks

### DIFF
--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -166,33 +166,53 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
                         'Be careful with old versions! These versions are displayed for testing and reference purposes.',
                       )}
                     </span>
-                    <span className="AddonVersions-warning-text">
-                      {i18n.gettext(
-                        'You should always use the latest version of an add-on.',
-                      )}
-                    </span>
+                    {addon?.type !== 'language' && (
+                      <span className="AddonVersions-warning-text">
+                        {i18n.gettext(
+                          'You should always use the latest version of an add-on.',
+                        )}
+                      </span>
+                    )}
                   </Notice>
                 </li>
-
-                <AddonVersionCard
-                  addon={addon}
-                  headerText={i18n.gettext('Latest version')}
-                  isCurrentVersion
-                  key="latestVersion"
-                  version={latestVersion}
-                />
-                {olderVersions.map((version, index) => {
-                  return (
+                {addon?.type === 'language' ? (
+                  <>
+                    {versions?.map((version, index) => {
+                      return (
+                        <AddonVersionCard
+                          addon={addon}
+                          headerText={
+                            index === 0 ? i18n.gettext('Versions') : null
+                          }
+                          key={version.id}
+                          version={version}
+                        />
+                      );
+                    })}
+                  </>
+                ) : (
+                  <>
                     <AddonVersionCard
                       addon={addon}
-                      headerText={
-                        index === 0 ? i18n.gettext('Older versions') : null
-                      }
-                      key={version.id}
-                      version={version}
+                      headerText={i18n.gettext('Latest version')}
+                      isCurrentVersion
+                      key="latestVersion"
+                      version={latestVersion}
                     />
-                  );
-                })}
+                    {olderVersions.map((version, index) => {
+                      return (
+                        <AddonVersionCard
+                          addon={addon}
+                          headerText={
+                            index === 0 ? i18n.gettext('Older versions') : null
+                          }
+                          key={version.id}
+                          version={version}
+                        />
+                      );
+                    })}
+                  </>
+                )}
               </ul>
             </CardList>
           </div>

--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -117,7 +117,7 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
 
     let latestVersion;
     let olderVersions: Array<AddonVersionType> = [];
-    if (addon && versions) {
+    if (addon && versions && addon?.type !== ADDON_TYPE_LANG) {
       latestVersion =
         versions.find((version) => version.id === addon.currentVersionId) ||
         null;

--- a/src/amo/pages/AddonVersions/index.js
+++ b/src/amo/pages/AddonVersions/index.js
@@ -35,6 +35,7 @@ import type {
 import type { I18nType } from 'amo/types/i18n';
 
 import './styles.scss';
+import { ADDON_TYPE_LANG } from '../../constants';
 
 type Props = {|
   // The `location` prop is used in `extractId()`.
@@ -166,7 +167,7 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
                         'Be careful with old versions! These versions are displayed for testing and reference purposes.',
                       )}
                     </span>
-                    {addon?.type !== 'language' && (
+                    {addon?.type !== ADDON_TYPE_LANG && (
                       <span className="AddonVersions-warning-text">
                         {i18n.gettext(
                           'You should always use the latest version of an add-on.',
@@ -175,7 +176,7 @@ export class AddonVersionsBase extends React.Component<InternalProps> {
                     )}
                   </Notice>
                 </li>
-                {addon?.type === 'language' ? (
+                {addon?.type === ADDON_TYPE_LANG ? (
                   <>
                     {versions?.map((version, index) => {
                       return (

--- a/tests/unit/amo/pages/TestAddonVersions.js
+++ b/tests/unit/amo/pages/TestAddonVersions.js
@@ -7,6 +7,7 @@ import {
   fetchVersions,
 } from 'amo/reducers/versions';
 import {
+  ADDON_TYPE_LANG,
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
@@ -531,6 +532,46 @@ describe(__filename, () => {
     ).not.toBeInTheDocument();
     expect(
       within(versionCards[3]).queryByRole('heading', {
+        name: 'Latest version',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays expected headings for langpacks', () => {
+    const version1 = { ...fakeVersion, id: 1 };
+    const addon = {
+      ...fakeAddon,
+      slug: defaultSlug,
+      type: ADDON_TYPE_LANG,
+      current_version: version1,
+    };
+    const version2 = { ...fakeVersion, id: 2 };
+    const version3 = { ...fakeVersion, id: 3 };
+
+    _loadAddon(addon);
+    _loadVersions({ versions: [version1, version2, version3] });
+
+    render();
+
+    const versionCards = allVersionCards();
+
+    expect(
+      within(versionCards[0]).getByRole('heading', {
+        name: 'Versions',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(versionCards[1]).queryByRole('heading', {
+        name: 'Versions',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(versionCards[2]).queryByRole('heading', {
+        name: 'Versions',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(document).queryByRole('heading', {
         name: 'Latest version',
       }),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
Fixes mozilla/addons#14942

Removes the 'latest version' block and replaces the 'older versions' block with a full version history for langpacks.

**Before**
![image](https://github.com/user-attachments/assets/df712d45-6d03-4f44-adf5-38d46f5f29af)

**After**
![image](https://github.com/user-attachments/assets/62dcf8ff-dd81-4830-9066-58ef4cb4802f)

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
