### PR TITLE
Implement filtering of theme searches by color

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
   "bundlewatch": [
     {
       "path": "./dist/static/amo-!(i18n-)*.js",
-      "maxSize": "363 kB"
+      "maxSize": "364 kB"
     },
     {
       "path": "./dist/static/amo-i18n-*.js",

--- a/src/amo/api/search.js
+++ b/src/amo/api/search.js
@@ -19,6 +19,7 @@ export type SearchFilters = {|
   author?: string,
   category?: string,
   clientApp?: string,
+  color?: string,
   compatibleWithVersion?: number | string,
   exclude_addons?: string,
   guid?: string,

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -400,7 +400,10 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                 >
                   <button
                     type="button"
-                    onClick={this.changeColorFilter.bind(null, filters.color || '')}
+                    onClick={this.changeColorFilter.bind(
+                      null,
+                      filters.color || '',
+                    )}
                   >
                     ✖
                   </button>

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -33,12 +33,7 @@ import ExpandableCard from 'amo/components/ExpandableCard';
 import Select from 'amo/components/Select';
 import type { AppState } from 'amo/store';
 import type { SearchFilters as SearchFiltersType } from 'amo/api/search';
-import type {
-  ElementEvent,
-  HTMLElementEventHandler,
-  SelectEvent,
-  TypedElementEvent,
-} from 'amo/types/dom';
+import type { SelectEvent, TypedElementEvent } from 'amo/types/dom';
 import type { I18nType } from 'amo/types/i18n';
 import type { ReactRouterHistoryType } from 'amo/types/router';
 
@@ -304,7 +299,10 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                           filters.color === colorFilter.color,
                       },
                     )}
-                    onClick={this.changeColorFilter.bind(null, colorFilter.color)}
+                    onClick={this.changeColorFilter.bind(
+                      null,
+                      colorFilter.color,
+                    )}
                   />
                 ))}
                 <li

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -134,12 +134,6 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
     this.doSearch(newFilters);
   };
 
-  onColorClick: HTMLElementEventHandler = (event: ElementEvent) => {
-    event.preventDefault();
-    const colorValue = event.currentTarget.getAttribute('data-color') || '';
-    this.changeColorFilter(colorValue);
-  };
-
   onCustomColorChange: (event: TypedElementEvent<HTMLInputElement>) => void = (
     event: TypedElementEvent<HTMLInputElement>,
   ) => {
@@ -310,8 +304,7 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                           filters.color === colorFilter.color,
                       },
                     )}
-                    data-color={colorFilter.color}
-                    onClick={this.onColorClick}
+                    onClick={this.changeColorFilter.bind(null, colorFilter.color)}
                   />
                 ))}
                 <li

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -24,11 +24,7 @@ import {
 import { withErrorHandler } from 'amo/errorHandler';
 import log from 'amo/logger';
 import translate from 'amo/i18n/translate';
-import {
-  colorFilters,
-  convertFiltersToQueryParams,
-  paramsToFilter,
-} from 'amo/searchUtils';
+import { convertFiltersToQueryParams, paramsToFilter } from 'amo/searchUtils';
 import ExpandableCard from 'amo/components/ExpandableCard';
 import Select from 'amo/components/Select';
 import type { AppState } from 'amo/store';
@@ -60,6 +56,8 @@ type InternalProps = {|
 |};
 
 type SelectOption = {| children: string, value: string |};
+
+type ColorFilter = {| id: string, color: string, label: string |};
 
 export class SearchFiltersBase extends React.Component<InternalProps> {
   onSelectElementChange: (event: SelectEvent) => boolean = (
@@ -117,9 +115,16 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
     return false;
   };
 
-  changeColorFilter: (colorValue: string) => void = (colorValue: string) => {
+  changeColorFilter: (
+    colorValue: string,
+    event: TypedElementEvent<HTMLInputElement>,
+  ) => void = (
+    colorValue: string,
+    event: TypedElementEvent<HTMLInputElement>,
+  ) => {
     const { filters } = this.props;
     const newFilters = { ...filters };
+    event.preventDefault();
     if (filters.color === colorValue) {
       delete newFilters.color;
     } else if (colorValue) {
@@ -134,7 +139,7 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
   ) => {
     const colorValue = event.target.value;
     if (colorValue && colorValue.startsWith('#')) {
-      this.changeColorFilter(colorValue.substr(1));
+      this.changeColorFilter(colorValue.substr(1), event);
     }
   };
 
@@ -214,6 +219,58 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
     ];
   }
 
+  colorFilters(): Array<ColorFilter> {
+    const { i18n } = this.props;
+
+    return [
+      {
+        id: 'black',
+        color: '000000',
+        label: i18n.gettext('Black'),
+      },
+      {
+        id: 'gray',
+        color: '808080',
+        label: i18n.gettext('Gray'),
+      },
+      {
+        id: 'white',
+        color: 'ffffff',
+        label: i18n.gettext('White'),
+      },
+      {
+        id: 'red',
+        color: 'ff0000',
+        label: i18n.gettext('Red'),
+      },
+      {
+        id: 'yellow',
+        color: 'ffff00',
+        label: i18n.gettext('Yellow'),
+      },
+      {
+        id: 'green',
+        color: '00ff00',
+        label: i18n.gettext('Green'),
+      },
+      {
+        id: 'cyan',
+        color: '00ffff',
+        label: i18n.gettext('Cyan'),
+      },
+      {
+        id: 'blue',
+        color: '0000ff',
+        label: i18n.gettext('Blue'),
+      },
+      {
+        id: 'magenta',
+        color: 'ff00ff',
+        label: i18n.gettext('Magenta'),
+      },
+    ];
+  }
+
   render(): React.Node {
     const { clientApp, filters, i18n } = this.props;
 
@@ -225,7 +282,7 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
       : [''];
     const selectedSort = selectedSortFields[0];
     const selectedCustomColor = filters.color
-      ? colorFilters
+      ? this.colorFilters()
           .map((colorFilter) => {
             return colorFilter.color;
           })
@@ -287,10 +344,10 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                 {i18n.gettext('Theme Color')}
               </label>
               <ul className="SearchFilters-ThemeColors">
-                {colorFilters.map((colorFilter) => (
-                  // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events
+                {this.colorFilters().map((colorFilter) => (
                   <li
                     key={colorFilter.id}
+                    title={colorFilter.label}
                     className={makeClassName(
                       'SearchFilter-ThemeColors-ColorItem',
                       `SearchFilter-ThemeColors-ColorItem--${colorFilter.id}`,
@@ -299,11 +356,20 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                           filters.color === colorFilter.color,
                       },
                     )}
-                    onClick={this.changeColorFilter.bind(
-                      null,
-                      colorFilter.color,
-                    )}
-                  />
+                  >
+                    <button
+                      aria-describedby={colorFilter.id}
+                      type="button"
+                      onClick={this.changeColorFilter.bind(
+                        null,
+                        colorFilter.color,
+                      )}
+                    >
+                      <span id={colorFilter.id} className="visually-hidden">
+                        {colorFilter.label}
+                      </span>
+                    </button>
+                  </li>
                 ))}
                 <li
                   className={makeClassName(

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -374,7 +374,7 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                 <li
                   className={makeClassName(
                     'SearchFilter-ThemeColors-ColorItem',
-                    `SearchFilter-ThemeColors-ColorItem--custom`,
+                    'SearchFilter-ThemeColors-ColorItem--custom',
                     {
                       'SearchFilter-ThemeColors-ColorItem--active':
                         selectedCustomColor === true,
@@ -386,6 +386,24 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                     type="color"
                     onChange={this.onCustomColorChange}
                   />
+                </li>
+                <li
+                  title={i18n.gettext('Clear')}
+                  className={makeClassName(
+                    'SearchFilter-ThemeColors-ColorItem',
+                    'SearchFilter-ThemeColors-ColorItem--clear',
+                    {
+                      'SearchFilter-ThemeColors-ColorItem--hidden':
+                        filters.color === undefined,
+                    },
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={this.changeColorFilter.bind(null, filters.color)}
+                  >
+                    ✖
+                  </button>
                 </li>
               </ul>
             </div>

--- a/src/amo/components/SearchFilters/index.js
+++ b/src/amo/components/SearchFilters/index.js
@@ -400,7 +400,7 @@ export class SearchFiltersBase extends React.Component<InternalProps> {
                 >
                   <button
                     type="button"
-                    onClick={this.changeColorFilter.bind(null, filters.color)}
+                    onClick={this.changeColorFilter.bind(null, filters.color || '')}
                   >
                     ✖
                   </button>

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -28,8 +28,8 @@
     outline: 2px solid transparent; /* originally had a 1px border instead, but it was too subtle */
     border: 1px solid $grey-40;
     margin-right: 4px;
-    width: 34px;
-    height: 34px;
+    width: 32px;
+    height: 32px;
     display: inline-block;
     border-radius: 50%;
     vertical-align: top;
@@ -47,6 +47,21 @@
       padding: 0;
       border-radius: 50%;
       border: 0;
+    }
+
+    &.SearchFilter-ThemeColors-ColorItem--hidden {
+      visibility: hidden;
+    }
+
+    &.SearchFilter-ThemeColors-ColorItem--clear {
+      border: 0;
+      margin-right: 0;
+      width: 29px;
+
+      button {
+        opacity: 100%;
+        font-size: 125%;
+      }
     }
   }
 }

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -38,7 +38,8 @@
       outline-color: $action-active-color;
     }
 
-    button, input[type='color'] {
+    button,
+    input[type='color'] {
       cursor: pointer;
       width: 100%;
       height: 100%;

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -6,7 +6,7 @@
 }
 
 .SearchFilters-select {
-  margin: 0 0 5px;
+  margin: 0 0 7px;
 }
 
 .SearchFilters-Recommended-label {
@@ -21,7 +21,7 @@
 
 .SearchFilters-ThemeColors {
   display: inline-block;
-  margin: 0;
+  margin: 0 0 7px;
   padding: 0;
 
   .SearchFilter-ThemeColors-ColorItem {

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -34,6 +34,14 @@
     border-radius: 50%;
     vertical-align: top;
 
+    &:hover {
+      outline-color: $action-hover-color;
+    }
+
+    &:has(button:focus,input:focus) {
+      outline-color: $action-active-color;
+    }
+
     &.SearchFilter-ThemeColors-ColorItem--active {
       outline-color: $action-active-color;
     }

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -59,7 +59,7 @@
       width: 29px;
 
       button {
-        opacity: 100%;
+        opacity: 1;
         font-size: 125%;
       }
     }

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -38,7 +38,7 @@
       outline-color: $action-hover-color;
     }
 
-    &:has(button:focus,input:focus) {
+    &:has(button:focus, input:focus) {
       outline-color: $action-active-color;
     }
 

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -18,3 +18,84 @@
 #SearchFilters-Recommended {
   @include margin-end(10px);
 }
+
+.SearchFilters-ThemeColors {
+  display: inline-block;
+  margin: 0;
+  padding: 0;
+
+  .SearchFilter-ThemeColors-ColorItem {
+    cursor: pointer;
+    outline: 2px solid transparent; /* originally had a 1px border instead, but it was too subtle */
+    border: 1px solid $grey-40;
+    margin-right: 4px;
+    width: 34px;
+    height: 34px;
+    display: inline-block;
+    border-radius: 50%;
+
+    &.SearchFilter-ThemeColors-ColorItem--active {
+      outline-color: $action-active-color;
+    }
+
+    input[type='color'] {
+      width: 100%;
+      height: 100%;
+      opacity: 0; /* hidden, but captures clicks  to trigger the color dialog */
+      padding: 0;
+      border-radius: 50%;
+      border: 0;
+    }
+  }
+}
+
+.SearchFilter-ThemeColors-ColorItem--custom {
+  background: linear-gradient(
+    90deg,
+    hsl(0deg, 100%, 50%),
+    hsl(45deg, 100%, 50%),
+    hsl(90deg, 100%, 50%),
+    hsl(135deg, 100%, 50%),
+    hsl(180deg, 100%, 50%),
+    hsl(225deg, 100%, 50%),
+    hsl(270deg, 100%, 50%),
+    hsl(315deg, 100%, 50%),
+    hsl(360deg, 100%, 50%)
+  );
+}
+
+.SearchFilter-ThemeColors-ColorItem--black {
+  background-color: $black;
+}
+
+.SearchFilter-ThemeColors-ColorItem--gray {
+  background-color: $grey-50;
+}
+
+.SearchFilter-ThemeColors-ColorItem--white {
+  background-color: $white-100;
+}
+
+.SearchFilter-ThemeColors-ColorItem--red {
+  background-color: $red-50;
+}
+
+.SearchFilter-ThemeColors-ColorItem--yellow {
+  background-color: $yellow-50;
+}
+
+.SearchFilter-ThemeColors-ColorItem--green {
+  background-color: $green-50;
+}
+
+.SearchFilter-ThemeColors-ColorItem--cyan {
+  background-color: $teal-50;
+}
+
+.SearchFilter-ThemeColors-ColorItem--blue {
+  background-color: $blue-50;
+}
+
+.SearchFilter-ThemeColors-ColorItem--magenta {
+  background-color: $magenta-50;
+}

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -25,7 +25,6 @@
   padding: 0;
 
   .SearchFilter-ThemeColors-ColorItem {
-    cursor: pointer;
     outline: 2px solid transparent; /* originally had a 1px border instead, but it was too subtle */
     border: 1px solid $grey-40;
     margin-right: 4px;
@@ -39,10 +38,11 @@
       outline-color: $action-active-color;
     }
 
-    input[type='color'] {
+    button, input[type='color'] {
+      cursor: pointer;
       width: 100%;
       height: 100%;
-      opacity: 0; /* hidden, but captures clicks to trigger the color dialog */
+      opacity: 0; /* hidden, but captures clicks to trigger the color change */
       padding: 0;
       border-radius: 50%;
       border: 0;

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -33,6 +33,7 @@
     height: 34px;
     display: inline-block;
     border-radius: 50%;
+    vertical-align: top;
 
     &.SearchFilter-ThemeColors-ColorItem--active {
       outline-color: $action-active-color;
@@ -41,7 +42,7 @@
     input[type='color'] {
       width: 100%;
       height: 100%;
-      opacity: 0; /* hidden, but captures clicks  to trigger the color dialog */
+      opacity: 0; /* hidden, but captures clicks to trigger the color dialog */
       padding: 0;
       border-radius: 50%;
       border: 0;

--- a/src/amo/searchUtils.js
+++ b/src/amo/searchUtils.js
@@ -40,45 +40,6 @@ export const paramsToFilter = {
   ...generateThresholdParams('users'),
 };
 
-export const colorFilters = [
-  {
-    id: 'black',
-    color: '000000',
-  },
-  {
-    id: 'gray',
-    color: '808080',
-  },
-  {
-    id: 'white',
-    color: 'ffffff',
-  },
-  {
-    id: 'red',
-    color: 'ff0000',
-  },
-  {
-    id: 'yellow',
-    color: 'ffff00',
-  },
-  {
-    id: 'green',
-    color: '00ff00',
-  },
-  {
-    id: 'cyan',
-    color: '00ffff',
-  },
-  {
-    id: 'blue',
-    color: '0000ff',
-  },
-  {
-    id: 'magenta',
-    color: 'ff00ff',
-  },
-];
-
 export function addVersionCompatibilityToFilters({
   filters,
   userAgentInfo,

--- a/src/amo/searchUtils.js
+++ b/src/amo/searchUtils.js
@@ -25,6 +25,7 @@ export const paramsToFilter = {
   appversion: 'compatibleWithVersion',
   author: 'author',
   category: 'category',
+  color: 'color',
   exclude_addons: 'exclude_addons',
   guid: 'guid',
   page: 'page',
@@ -38,6 +39,45 @@ export const paramsToFilter = {
   type: 'addonType',
   ...generateThresholdParams('users'),
 };
+
+export const colorFilters = [
+  {
+    id: 'black',
+    color: '000000',
+  },
+  {
+    id: 'gray',
+    color: '808080',
+  },
+  {
+    id: 'white',
+    color: 'ffffff',
+  },
+  {
+    id: 'red',
+    color: 'ff0000',
+  },
+  {
+    id: 'yellow',
+    color: 'ffff00',
+  },
+  {
+    id: 'green',
+    color: '00ff00',
+  },
+  {
+    id: 'cyan',
+    color: '00ffff',
+  },
+  {
+    id: 'blue',
+    color: '0000ff',
+  },
+  {
+    id: 'magenta',
+    color: 'ff00ff',
+  },
+];
 
 export function addVersionCompatibilityToFilters({
   filters,

--- a/tests/unit/amo/pages/TestSearchPage.js
+++ b/tests/unit/amo/pages/TestSearchPage.js
@@ -726,7 +726,9 @@ describe(__filename, () => {
       const pushSpy = jest.spyOn(history, 'push');
 
       await userEvent.click(
-        screen.getByClassName('SearchFilter-ThemeColors-ColorItem--green'),
+        within(
+          screen.getByClassName('SearchFilter-ThemeColors-ColorItem--green'),
+        ).getByRole('button'),
       );
 
       expect(pushSpy).toHaveBeenCalledWith({

--- a/tests/unit/amo/pages/TestSearchPage.js
+++ b/tests/unit/amo/pages/TestSearchPage.js
@@ -1,7 +1,7 @@
 // We shouldn't use `cleanup()` but this test file uses it anyway in
 // `testWithFilters()`, which should be refactored eventually...
 // eslint-disable-next-line testing-library/no-manual-cleanup
-import { cleanup, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { setViewContext } from 'amo/actions/viewContext';
@@ -41,6 +41,7 @@ import {
   getSearchErrorHandlerId,
   renderPage as defaultRender,
   screen,
+  within,
 } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -692,6 +693,69 @@ describe(__filename, () => {
           page: '1',
           promoted: RECOMMENDED,
           query,
+        }),
+      });
+    });
+
+    it('shows the color filter when filtering by Theme Add-on type', async () => {
+      render({ type: ADDON_TYPE_STATIC_THEME });
+
+      expect(
+        screen.getByClassName('SearchFilters-ThemeColors'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the color filter when filtering by Extension Add-on type', async () => {
+      render({ type: ADDON_TYPE_EXTENSION });
+
+      expect(
+        screen.queryByClassName('SearchFilters-ThemeColors'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show the color filter when not filtering by Add-on type', async () => {
+      render();
+
+      expect(
+        screen.queryByClassName('SearchFilters-ThemeColors'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('changes the URL to filter by corresponding color when a color is clicked on', async () => {
+      await render({ type: ADDON_TYPE_STATIC_THEME });
+      const pushSpy = jest.spyOn(history, 'push');
+
+      await userEvent.click(
+        screen.getByClassName('SearchFilter-ThemeColors-ColorItem--green'),
+      );
+
+      expect(pushSpy).toHaveBeenCalledWith({
+        pathname: defaultLocation,
+        query: convertFiltersToQueryParams({
+          color: '00ff00',
+          addonType: ADDON_TYPE_STATIC_THEME,
+        }),
+      });
+    });
+
+    it('changes the URL to filter by color when a custom color is entered in the input type=color', async () => {
+      await render({ type: ADDON_TYPE_STATIC_THEME });
+      const pushSpy = jest.spyOn(history, 'push');
+
+      fireEvent.change(
+        within(
+          screen.getByClassName('SearchFilter-ThemeColors-ColorItem--custom'),
+        ).getByTagName('input'),
+        {
+          target: { value: '#336699' },
+        },
+      );
+
+      expect(pushSpy).toHaveBeenCalledWith({
+        pathname: defaultLocation,
+        query: convertFiltersToQueryParams({
+          color: '336699',
+          addonType: ADDON_TYPE_STATIC_THEME,
         }),
       });
     });


### PR DESCRIPTION
Fixes mozilla/addons#14971

### Description

Adds ability to filter search by color when searching through themes (need to select the `Add-on Type` or be on a theme category page, which filters by type behind the scenes).

The API side has been implemented years ago in https://github.com/mozilla/addons/issues/6257 but never used. It's not 100% perfect, we could tweak it, but should be good enough for a first iteration.

### Testing

Using dev as the backend server (`yarn amo:dev`) it should work out of the box. Filter your search to only show themes and then choose a color. The last circle with the gradient allows any arbitrary color to be selected, making it possible to find pink or orange themes for instance.