### PR TITLE
Remove obsolete and now inaccurate line in feedback form

### DIFF
--- a/src/amo/components/FeedbackForm/index.js
+++ b/src/amo/components/FeedbackForm/index.js
@@ -878,9 +878,7 @@ export class FeedbackFormBase extends React.Component<InternalProps, State> {
               <p className="FeedbackForm--help" id="feedbackText-help">
                 {i18n.gettext(`Please provide any additional information that
                   may help us to understand your report (including which policy
-                  you believe has been violated). While this information is not
-                  required, failure to include it may prevent us from
-                  addressing the reported content.`)}
+                  you believe has been violated).`)}
               </p>
             </Card>
 


### PR DESCRIPTION
That information _is_ required now, so that line no longer makes sense.

Fixes mozilla/addons#14988