### PR TITLE
Remove code handling categories with an application

### DIFF
--- a/src/amo/reducers/categories.js
+++ b/src/amo/reducers/categories.js
@@ -13,7 +13,6 @@ export type ExternalCategory = {|
   id: string,
   name: string,
   slug: string,
-  application: string | null,
   misc: boolean,
   type: string,
   weight: number,
@@ -107,16 +106,6 @@ export default function reducer(
         if (!category) {
           // eslint-disable-next-line amo/only-log-strings
           log.warn('category was falsey: %o', category);
-          return;
-        }
-
-        // If the API returns data for an application we don't support,
-        // we'll ignore it for now.
-        if (category.application && category.application !== 'firefox') {
-          if (category.application !== 'android') {
-            log.warn(oneLine`Category data for unknown clientApp
-                "${category.application}" received from API.`);
-          }
           return;
         }
 

--- a/src/amo/reducers/utils.js
+++ b/src/amo/reducers/utils.js
@@ -24,8 +24,5 @@ export const selectLocalizedContent = (
 export const selectCategoryObject = (
   apiAddon: ExternalAddonType,
 ): CategoryEntry => {
-  if (apiAddon.categories instanceof Array) {
-    return apiAddon.categories;
-  }
-  return apiAddon.categories?.firefox;
+  return apiAddon.categories;
 };

--- a/src/amo/types/addons.js
+++ b/src/amo/types/addons.js
@@ -108,7 +108,7 @@ export type GroupedRatingsType = {|
 export type ExternalAddonType = {|
   authors?: Array<AddonAuthorType>,
   average_daily_users: number,
-  categories?: Object | Array<string>,
+  categories?: Array<string>,
   contributions_url: UrlWithOutgoing | null,
   created: Date,
   // If you make an API request as an admin for an incomplete

--- a/tests/unit/amo/components/TestAddonMoreInfo.js
+++ b/tests/unit/amo/components/TestAddonMoreInfo.js
@@ -524,56 +524,30 @@ describe(__filename, () => {
     const categories = [
       {
         ...fakeCategory,
-        application: CLIENT_APP_ANDROID,
         name: 'Alerts & Update',
         slug: 'alert-update',
         type: ADDON_TYPE_EXTENSION,
       },
       {
         ...fakeCategory,
-        application: CLIENT_APP_ANDROID,
-        name: 'Blogging',
-        slug: 'blogging',
-        type: ADDON_TYPE_EXTENSION,
-      },
-      {
-        ...fakeCategory,
-        application: CLIENT_APP_ANDROID,
-        name: 'Games',
-        slug: 'Games',
-        type: ADDON_TYPE_EXTENSION,
-      },
-      {
-        ...fakeCategory,
-        application: CLIENT_APP_FIREFOX,
-        name: 'Alerts & Update',
-        slug: 'alert-update',
-        type: ADDON_TYPE_EXTENSION,
-      },
-      {
-        ...fakeCategory,
-        application: CLIENT_APP_FIREFOX,
         name: 'Security',
         slug: 'security',
         type: ADDON_TYPE_EXTENSION,
       },
       {
         ...fakeCategory,
-        application: CLIENT_APP_FIREFOX,
         name: 'Anime',
         slug: 'anime',
         type: ADDON_TYPE_STATIC_THEME,
       },
       {
         ...fakeCategory,
-        application: CLIENT_APP_ANDROID,
         name: 'Alerts & Update',
         slug: 'alert-update',
         type: ADDON_TYPE_DICT,
       },
       {
         ...fakeCategory,
-        application: CLIENT_APP_ANDROID,
         name: 'Alerts & Update',
         slug: 'alert-update',
         type: ADDON_TYPE_LANG,
@@ -581,8 +555,8 @@ describe(__filename, () => {
     ];
 
     it('renders related categories', () => {
-      const { slug: slug1, name: name1 } = categories[3];
-      const { slug: slug2, name: name2 } = categories[4];
+      const { slug: slug1, name: name1 } = categories[0];
+      const { slug: slug2, name: name2 } = categories[1];
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
         categories: [slug1, slug2],
@@ -607,7 +581,7 @@ describe(__filename, () => {
     it('does not render related categories when add-on has no category', () => {
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
-        categories: { [CLIENT_APP_FIREFOX]: [] },
+        categories: [],
       });
 
       store.dispatch(loadCategories({ results: categories }));
@@ -624,7 +598,7 @@ describe(__filename, () => {
         // We are migrating away from per-app categories so if an Addon only
         // has Android categories, ignore them completely, even on Android
         // pages.
-        categories: { [CLIENT_APP_ANDROID]: ['some', 'thing'] },
+        categories: ['some', 'thing'],
       });
 
       store.dispatch(loadCategories({ results: categories }));
@@ -640,7 +614,7 @@ describe(__filename, () => {
       const { slug: slug2 } = categories[4];
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
-        categories: { [CLIENT_APP_FIREFOX]: [slug1, slug2] },
+        categories: [slug1, slug2],
       });
 
       store.dispatch(loadCategories({ results: [] }));
@@ -654,10 +628,8 @@ describe(__filename, () => {
     it('does not render related categories when categories for add-on do not exist in clientApp', () => {
       const addon = createInternalAddonWithLang({
         ...fakeAddon,
-        categories: {
-          // 'blogging' and 'games' only exist for CLIENT_APP_ANDROID
-          [CLIENT_APP_FIREFOX]: ['blogging', 'games'],
-        },
+        // 'blogging' and 'games' only exist for CLIENT_APP_ANDROID
+        categories: ['blogging', 'games'],
       });
 
       store.dispatch(loadCategories({ results: categories }));

--- a/tests/unit/amo/pages/TestAddon-AddonSuggestions.js
+++ b/tests/unit/amo/pages/TestAddon-AddonSuggestions.js
@@ -79,7 +79,7 @@ describe(__filename, () => {
   beforeEach(() => {
     addon = {
       ...fakeAddon,
-      categories: { firefox: [addonCategory] },
+      categories: [addonCategory],
       slug: defaultSlug,
     };
     fakeConfig = getMockConfig({
@@ -289,7 +289,7 @@ describe(__filename, () => {
       const dispatch = jest.spyOn(store, 'dispatch');
 
       renderWithAddon({
-        addonToLoad: { ...addon, categories: { firefox: [] } },
+        addonToLoad: { ...addon, categories: [] },
         variant: VARIANT_SHOW_TOP,
       });
 
@@ -308,7 +308,7 @@ describe(__filename, () => {
       const newSlug = 'some-new-slug';
       const newAddon = {
         ...addon,
-        categories: { firefox: [newCategory] },
+        categories: [newCategory],
         slug: newSlug,
       };
 
@@ -347,7 +347,7 @@ describe(__filename, () => {
       const newSlug = 'some-new-slug';
       const newAddon = {
         ...addon,
-        categories: { firefox: [newCategory] },
+        categories: [newCategory],
         guid: `${addon.guid}-new`,
         slug: newSlug,
       };
@@ -460,7 +460,7 @@ describe(__filename, () => {
         renderWithAddon({
           addonToLoad: {
             ...addon,
-            categories: { firefox: addonCategories },
+            categories: addonCategories,
           },
           variant: VARIANT_SHOW_TOP,
         });

--- a/tests/unit/amo/pages/TestSearchPage.js
+++ b/tests/unit/amo/pages/TestSearchPage.js
@@ -1130,7 +1130,6 @@ describe(__filename, () => {
         results: [
           {
             ...fakeCategory,
-            application: CLIENT_APP_FIREFOX, // Unified categories ignore android applications
             type: ADDON_TYPE_EXTENSION,
             name: categoryName,
             slug: category,

--- a/tests/unit/amo/reducers/test_categories.js
+++ b/tests/unit/amo/reducers/test_categories.js
@@ -110,63 +110,30 @@ describe(__filename, () => {
       const results = [
         {
           ...fakeCategory,
-          application: CLIENT_APP_ANDROID,
           name: 'Alerts & Update',
           slug: 'alert-update',
           type: ADDON_TYPE_EXTENSION,
         },
         {
           ...fakeCategory,
-          application: CLIENT_APP_ANDROID,
-          name: 'Blogging',
-          slug: 'blogging',
-          type: ADDON_TYPE_EXTENSION,
-        },
-        {
-          ...fakeCategory,
-          application: CLIENT_APP_ANDROID,
-          name: 'Games',
-          slug: 'Games',
-          type: ADDON_TYPE_EXTENSION,
-        },
-        {
-          ...fakeCategory,
-          application: CLIENT_APP_FIREFOX,
-          name: 'Alerts & Update',
-          slug: 'alert-update',
-          type: ADDON_TYPE_EXTENSION,
-        },
-        {
-          ...fakeCategory,
-          application: CLIENT_APP_FIREFOX,
           name: 'Security',
           slug: 'security',
           type: ADDON_TYPE_EXTENSION,
         },
         {
           ...fakeCategory,
-          application: CLIENT_APP_FIREFOX,
           name: 'Anime',
           slug: 'anime',
           type: ADDON_TYPE_STATIC_THEME,
         },
         {
           ...fakeCategory,
-          application: CLIENT_APP_FIREFOX,
           name: 'Naturé',
           slug: 'naturé',
           type: ADDON_TYPE_STATIC_THEME,
         },
         {
           ...fakeCategory,
-          application: CLIENT_APP_FIREFOX,
-          name: 'Painting',
-          slug: 'painting',
-          type: ADDON_TYPE_STATIC_THEME,
-        },
-        {
-          ...fakeCategory,
-          application: CLIENT_APP_ANDROID,
           name: 'Painting',
           slug: 'painting',
           type: ADDON_TYPE_STATIC_THEME,
@@ -179,14 +146,12 @@ describe(__filename, () => {
         [ADDON_TYPE_EXTENSION]: {
           'alert-update': {
             ...fakeCategory,
-            application: CLIENT_APP_FIREFOX,
             name: 'Alerts & Update',
             slug: 'alert-update',
             type: ADDON_TYPE_EXTENSION,
           },
           security: {
             ...fakeCategory,
-            application: CLIENT_APP_FIREFOX,
             name: 'Security',
             slug: 'security',
             type: ADDON_TYPE_EXTENSION,
@@ -196,21 +161,18 @@ describe(__filename, () => {
         [ADDON_TYPE_STATIC_THEME]: {
           anime: {
             ...fakeCategory,
-            application: CLIENT_APP_FIREFOX,
             name: 'Anime',
             slug: 'anime',
             type: ADDON_TYPE_STATIC_THEME,
           },
           naturé: {
             ...fakeCategory,
-            application: CLIENT_APP_FIREFOX,
             name: 'Naturé',
             slug: 'naturé',
             type: ADDON_TYPE_STATIC_THEME,
           },
           painting: {
             ...fakeCategory,
-            application: CLIENT_APP_FIREFOX,
             name: 'Painting',
             slug: 'painting',
             type: ADDON_TYPE_STATIC_THEME,

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -145,7 +145,7 @@ export const fakeVersion = Object.freeze({
 export const fakeAddon = Object.freeze({
   authors: [fakeAuthor],
   average_daily_users: 100,
-  categories: { firefox: ['other'] },
+  categories: ['other'],
   contributions_url: null,
   created: '2014-11-22T10:09:01Z',
   current_version: fakeVersion,
@@ -299,7 +299,6 @@ export function createExternalReview({
 }
 
 export const fakeCategory = Object.freeze({
-  application: CLIENT_APP_FIREFOX,
   description: 'I am a cool category for doing things',
   id: 5,
   misc: false,


### PR DESCRIPTION
Fixes mozilla/addons#2195

Since https://github.com/mozilla/addons/issues/4579 the v5 API has stopped returning per-application categories: the application property is gone in the category API, the add-on API returns a list instead of an object.

This should be a transparent change, see https://github.com/mozilla/addons/issues/2195#issuecomment-2328630067 for more details.