### PR TITLE
l10n - add Saraiki (skr) to languages.js

### DIFF
--- a/src/amo/languages.js
+++ b/src/amo/languages.js
@@ -521,6 +521,10 @@ export const unfilteredLanguages = {
     English: 'Slovenian',
     native: 'Sloven\u0161\u010dina',
   },
+  skr: {
+    English: 'Saraiki',
+    native: '\u0633\u0631\u0627\u0626\u06cc\u06a9\u06cc',
+  },
   son: {
     English: 'Songhai',
     native: 'So\u014bay',


### PR DESCRIPTION
Saraiki locale was added to Firefox starting from 128. The locale needs to be added in order to make the language available in the Language Tools page.

This adds the following:
Locale: skr
English: Saraiki
Native: سرائیکی