### PR TITLE
Update favicon query string to bust cache and reference new Firefox logo favicon

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -72,7 +72,7 @@ module.exports = {
   // The version for the favicon.
   // This should be changed when a new favicon is pushed to the CDN to prevent
   // client caching.
-  faviconVersion: 2,
+  faviconVersion: 3,
 
   // URL patterns of anonymous/stateless pages. These pages won't authenticate
   // the logged in user (if any) and should not contain any non-public data (so

--- a/src/amo/components/ServerHtml/index.js
+++ b/src/amo/components/ServerHtml/index.js
@@ -140,8 +140,9 @@ export default class ServerHtml extends Component {
 
   getFaviconLink() {
     const { _config } = this.props;
-    // /favicon.ico is an alias handled in nginx - the favicon is actually in
-    // addons-server static files.
+    // /favicon.ico is an alias handled in nginx - the favicon actually lives
+    // in addons-server static files, and gets copied to /favicon.ico on the
+    // bucket serving those assets when addons-server assets are deployed.
     return `/favicon.ico?v=${_config.get('faviconVersion')}`;
   }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14951
Needs https://github.com/mozilla/addons-server/pull/22650
