### PR TITLE
Mark block reason as an en-US English paragraph

### DIFF
--- a/src/amo/pages/Block/index.js
+++ b/src/amo/pages/Block/index.js
@@ -76,7 +76,8 @@ export class BlockBase extends React.Component<InternalProps> {
     }
 
     return (
-      <p className="Block-reason">
+      // The reason is provided by the reviewers, and written in en-US English.
+      <p className="Block-reason" lang="en-US">
         {block ? sanitizeHTML(block.reason).__html : <LoadingText />}
       </p>
     );

--- a/tests/unit/amo/pages/TestBlock.js
+++ b/tests/unit/amo/pages/TestBlock.js
@@ -175,6 +175,7 @@ describe(__filename, () => {
     render();
 
     expect(screen.getByText(reason)).toBeInTheDocument();
+    expect(screen.getByText(reason)).toHaveAttribute('lang', 'en-US');
   });
 
   it('does not render a reason if the block does not have one', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15051