### PR TITLE
Prevent dependabot from offering us to upgrade to UAParser 2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 99
+    ignore:
+      - dependency-name: "ua-parser-js"
+        versions: ["2.x"]


### PR DESCRIPTION
Fixes mozilla/addons#15203

addons-frontend uses https://github.com/faisalman/ua-parser-js and version 2.x of that library is still under development, but it [has breaking changes](https://github.com/faisalman/ua-parser-js/blob/master/CHANGELOG.md), including a license change that might be an issue for us. Let's make sure we don't accidentally upgrade yet.