### PR TITLE
Render Add-on Summary as Plaintext

### DIFF
--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -160,17 +160,11 @@ export class SearchResultBase extends React.Component<InternalProps> {
       );
     }
 
-    let summary = null;
-    if (showSummary) {
-      const summaryProps = {};
-      if (addon) {
-        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(addon.summary);
-      } else {
-        summaryProps.children = <LoadingText />;
-      }
-
-      summary = <p className="SearchResult-summary" {...summaryProps} />;
-    }
+    const summary = (
+      <p className="SearchResult-summary">
+        {addon ? addon.summary : <LoadingText />}
+      </p>
+    );
 
     const promotedCategory = _getPromotedCategory({
       addon,
@@ -208,7 +202,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
                 />
               ) : null}
             </h2>
-            {summary}
+            {showSummary ? summary : null}
 
             {showMetadata ? (
               <div className="SearchResult-metadata">

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -445,12 +445,9 @@ export class AddonBase extends React.Component {
 
     const addonType = addon ? addon.type : ADDON_TYPE_EXTENSION;
 
-    const showSummary = !addon || addon.summary.length;
-
+    const showSummary = !addon || addon.summary?.length;
     const summary = (
-      <p className="SearchResult-summary">
-        {addon ? addon.summary : <LoadingText />}
-      </p>
+      <p className="Addon-summary">{addon ? addon.summary : <LoadingText />}</p>
     );
 
     const addonPreviews = addon ? addon.previews : [];

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -33,7 +33,7 @@ import {
 } from 'amo/experiments/20221130_amo_detail_category';
 import { getAddonsForSlug } from 'amo/reducers/addonsByAuthors';
 import { reviewListURL } from 'amo/reducers/reviews';
-import { getAddonURL, nl2br, sanitizeHTML, sanitizeUserHTML } from 'amo/utils';
+import { getAddonURL, sanitizeUserHTML } from 'amo/utils';
 import { getVersionById } from 'amo/reducers/versions';
 import {
   fetchAddon,
@@ -445,24 +445,13 @@ export class AddonBase extends React.Component {
 
     const addonType = addon ? addon.type : ADDON_TYPE_EXTENSION;
 
-    const summaryProps = {};
-    let showSummary = false;
-    if (addon) {
-      // Themes lack a summary so we do the inverse :-/
-      // TODO: We should file an API bug about this...
-      const summary = addon.summary ? addon.summary : addon.description;
+    const showSummary = !addon || addon.summary.length;
 
-      if (summary && summary.length) {
-        summaryProps.dangerouslySetInnerHTML = sanitizeHTML(nl2br(summary), [
-          'a',
-          'br',
-        ]);
-        showSummary = true;
-      }
-    } else {
-      summaryProps.children = <LoadingText width={100} />;
-      showSummary = true;
-    }
+    const summary = (
+      <p className="SearchResult-summary">
+        {addon ? addon.summary : <LoadingText />}
+      </p>
+    );
 
     const addonPreviews = addon ? addon.previews : [];
 
@@ -519,9 +508,7 @@ export class AddonBase extends React.Component {
                 {addon && <InstallWarning addon={addon} />}
 
                 <div className="Addon-summary-and-install-button-wrapper">
-                  {showSummary ? (
-                    <p className="Addon-summary" {...summaryProps} />
-                  ) : null}
+                  {showSummary ? summary : null}
 
                   <InstallButtonWrapper addon={addon} />
                 </div>

--- a/src/blog-utils/StaticAddonCard/index.js
+++ b/src/blog-utils/StaticAddonCard/index.js
@@ -4,7 +4,6 @@ import makeClassName from 'classnames';
 
 import { ADDON_TYPE_STATIC_THEME } from 'amo/constants';
 import { getAddonIconUrl } from 'amo/imageUtils';
-import { nl2br, sanitizeHTML } from 'amo/utils';
 import AddonBadges from 'amo/components/AddonBadges';
 import AddonTitle from 'amo/components/AddonTitle';
 import GetFirefoxButton from 'amo/components/GetFirefoxButton';
@@ -33,7 +32,6 @@ export const StaticAddonCardBase = ({
     return null;
   }
 
-  const summary = addon.summary ? addon.summary : addon.description;
   const isTheme = addon.type === ADDON_TYPE_STATIC_THEME;
 
   return (
@@ -64,10 +62,7 @@ export const StaticAddonCardBase = ({
       <AddonBadges addon={addon} />
 
       <div className="StaticAddonCard-summary">
-        <p
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={sanitizeHTML(nl2br(summary), ['a', 'br'])}
-        />
+        <p>{addon.summary}</p>
       </div>
 
       <div className="StaticAddonCard-metadata">

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -661,11 +661,9 @@ describe(__filename, () => {
     ).toBeTruthy();
   });
 
-  it('sanitizes a summary', () => {
-    const summaryText = 'some summary text';
-    addon.summary = createLocalizedString(
-      `${summaryText}<script>alert(document.cookie);</script>`,
-    );
+  it('renders html as plaintext', () => {
+    const summaryText = '<script>alert(document.cookie);</script>';
+    addon.summary = createLocalizedString(summaryText);
     renderWithAddon();
 
     // Verify that the summary text exists without the script tag.
@@ -674,30 +672,6 @@ describe(__filename, () => {
     const addonSummary = screen.getByClassName('Addon-summary');
     expect(
       within(addonSummary).queryByTagName('script'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('adds <br> tags for newlines in a summary', () => {
-    addon.summary = createLocalizedString('Hello\nI am an\n add-on.');
-    renderWithAddon();
-
-    const addonSummary = screen.getByClassName('Addon-summary');
-    expect(within(addonSummary).queryAllByTagName('br')).toHaveLength(2);
-  });
-
-  it('sanitizes bad description HTML', () => {
-    const descriptionText = 'some description text';
-    addon.summary = createLocalizedString(
-      `${descriptionText}<script>alert(document.cookie);</script>`,
-    );
-    renderWithAddon();
-
-    // Verify that the summary text exists without the script tag.
-    expect(screen.getByText(descriptionText)).toBeInTheDocument();
-    // Verify that no script tags exist in the summary.
-    const addonDescription = screen.getByClassName('AddonDescription');
-    expect(
-      within(addonDescription).queryByTagName('script'),
     ).not.toBeInTheDocument();
   });
 
@@ -935,18 +909,16 @@ describe(__filename, () => {
     expect(screen.getByText(summary)).toBeInTheDocument();
   });
 
-  it('renders a summary with links', () => {
-    const summaryText = 'some summary text';
-    const linkText = 'link destination';
-    addon.summary = createLocalizedString(
-      `${summaryText} <a href="http://foo.com/">${linkText}</a>`,
-    );
+  it('does not render links in a summary', () => {
+    const linkText = 'click me!';
+    const summaryText = `blah blah <a href="http://foo.com/">${linkText}</a>`;
+    addon.summary = createLocalizedString(summaryText);
     renderWithAddon();
 
+    expect(screen.getByTextAcrossTags(summaryText)).toBeInTheDocument();
     expect(
-      screen.getByTextAcrossTags(`${summaryText} ${linkText}`),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: linkText })).toBeInTheDocument();
+      screen.queryByRole('link', { name: linkText }),
+    ).not.toBeInTheDocument();
   });
 
   it('renders an amo icon image', () => {

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -86,7 +86,7 @@ describe(__filename, () => {
     ).toBeInTheDocument();
   });
 
-  it('sanitizes the summary', () => {
+  it('renders html as plaintext', () => {
     const plainText = '<script>alert(document.cookie);</script>';
     const scriptHTML = createLocalizedString(plainText);
 

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -87,10 +87,8 @@ describe(__filename, () => {
   });
 
   it('sanitizes the summary', () => {
-    const plainText = 'Some safe text';
-    const scriptHTML = createLocalizedString(
-      `${plainText}<script>alert(document.cookie);</script>`,
-    );
+    const plainText = '<script>alert(document.cookie);</script>';
+    const scriptHTML = createLocalizedString(plainText);
 
     render({
       addon: createInternalAddonWithLang({
@@ -99,13 +97,9 @@ describe(__filename, () => {
       }),
     });
 
+    expect(screen.getByText(plainText)).toBeInTheDocument();
     // Make sure an actual script tag was not created.
     expect(screen.queryByTagName('script')).not.toBeInTheDocument();
-    // Make sure the script has been removed.
-    expect(screen.getByText(plainText)).toBeInTheDocument();
-    expect(
-      screen.getByClassName('StaticAddonCard-summary'),
-    ).not.toHaveTextContent('<script>');
   });
 
   it('displays the number of users', () => {

--- a/tests/unit/blog-utils/TestStaticAddonCard.js
+++ b/tests/unit/blog-utils/TestStaticAddonCard.js
@@ -86,14 +86,6 @@ describe(__filename, () => {
     ).toBeInTheDocument();
   });
 
-  it('displays the description if there is no summary', () => {
-    const addon = createInternalAddonWithLang({ ...fakeAddon, summary: null });
-
-    render({ addon });
-
-    expect(screen.getByText(addon.description)).toBeInTheDocument();
-  });
-
   it('sanitizes the summary', () => {
     const plainText = 'Some safe text';
     const scriptHTML = createLocalizedString(


### PR DESCRIPTION
Relates to mozilla/addons#15254

Changes the add-on summary to render just as plaintext. Linebreaks are not supported.