### PR TITLE
Set screenshots list overflow to auto

### DIFF
--- a/src/amo/components/ScreenShots/styles.scss
+++ b/src/amo/components/ScreenShots/styles.scss
@@ -23,7 +23,7 @@ $screenshot-width: 320px;
   height: $screenshot-height;
   list-style-type: none;
   margin: 0;
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
   padding: 0;
   width: auto;


### PR DESCRIPTION
Fixes #15319

Change `overflow-x` from `scroll` to `auto`.
