### PR TITLE
When fetching add-ons by author, sort by popularity by default instead of trending

### DIFF
--- a/src/amo/sagas/addonsByAuthors.js
+++ b/src/amo/sagas/addonsByAuthors.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { call, put, select, takeEvery } from 'redux-saga/effects';
 
-import { SEARCH_SORT_TRENDING } from 'amo/constants';
+import { SEARCH_SORT_POPULAR } from 'amo/constants';
 import {
   FETCH_ADDONS_BY_AUTHORS,
   loadAddonsByAuthors,
@@ -41,7 +41,7 @@ export function* fetchAddonsByAuthors({
         exclude_addons: forAddonSlug,
         page: page || '1',
         page_size: pageSize,
-        sort: sort || SEARCH_SORT_TRENDING,
+        sort: sort || SEARCH_SORT_POPULAR,
       },
     };
     const response = yield call(searchApi, params);

--- a/tests/unit/amo/sagas/test_addonsByAuthors.js
+++ b/tests/unit/amo/sagas/test_addonsByAuthors.js
@@ -66,7 +66,7 @@ describe(__filename, () => {
           exclude_addons: undefined, // `callApi` will internally unset this
           page: '1',
           page_size: pageSize,
-          sort: SEARCH_SORT_TRENDING,
+          sort: SEARCH_SORT_POPULAR,
         },
       })
       .once()
@@ -111,7 +111,7 @@ describe(__filename, () => {
           exclude_addons: slug,
           page: '1',
           page_size: pageSize,
-          sort: SEARCH_SORT_TRENDING,
+          sort: SEARCH_SORT_POPULAR,
         },
       })
       .once()
@@ -183,7 +183,7 @@ describe(__filename, () => {
           exclude_addons: slug,
           page: '1',
           page_size: pageSize,
-          sort: SEARCH_SORT_TRENDING,
+          sort: SEARCH_SORT_POPULAR,
         },
       })
       .once()
@@ -227,7 +227,7 @@ describe(__filename, () => {
           exclude_addons: undefined, // `callApi` will internally unset this
           page,
           page_size: pageSize,
-          sort: SEARCH_SORT_TRENDING,
+          sort: SEARCH_SORT_POPULAR,
         },
       })
       .once()
@@ -256,7 +256,7 @@ describe(__filename, () => {
     const addons = [fakeAddon];
     const authorIds = [123, 456];
     const pageSize = EXTENSIONS_BY_AUTHORS_PAGE_SIZE;
-    const sort = SEARCH_SORT_POPULAR;
+    const sort = SEARCH_SORT_TRENDING;
 
     const state = sagaTester.getState();
 


### PR DESCRIPTION
Fixes mozilla/addons#15287

## Context

We were not customizing the `sort` when calling that saga from the card, and it doesn't make sense to default to trending anyway (it's not a really useful sort outside of the home/landing page) for fetching add-ons by author, so I changed the default in the saga.

## Testing

To test, alter the `hotness` and `average_daily_users` values for add-ons that would show up and wait for reindex (+ caching to expire, if logged out). Then load an add-on and look at the "More extensions by..." box on the left.

## Screenshots

Example right now with https://addons-dev.allizom.org/en-US/firefox/addon/ublock-origin_testdev/ (both values for each add-on will be overridden tomorrow though):

### Using local addons-frontend instance with that branch, hitting dev
![Screenshot 2025-02-12 at 15-12-35 uBlock Origin_testdev – Get this Extension for 🦊 Firefox (en-US)](https://github.com/user-attachments/assets/8a55fd28-1e02-44e5-96fd-deec731f0059)

### Using dev directly, without those changes
![Screenshot 2025-02-12 at 15-12-53 uBlock Origin_testdev – Get this Extension for 🦊 Firefox (en-US)](https://github.com/user-attachments/assets/0fbce82a-c41d-46ce-8010-a0b13f6aa705)
