### PR TITLE
linkify all user names on ratings list; handle an account response with undefined fields

### DIFF
--- a/src/amo/components/AddonReviewCard/index.js
+++ b/src/amo/components/AddonReviewCard/index.js
@@ -10,7 +10,7 @@ import Link from 'amo/components/Link';
 import AddonReviewManager from 'amo/components/AddonReviewManager';
 import FlagReviewMenu from 'amo/components/FlagReviewMenu';
 import { reviewListURL } from 'amo/reducers/reviews';
-import { ADDONS_EDIT, USERS_EDIT } from 'amo/constants';
+import { ADDONS_EDIT } from 'amo/constants';
 import { withErrorHandler } from 'amo/errorHandler';
 import translate from 'amo/i18n/translate';
 import log from 'amo/logger';
@@ -73,7 +73,6 @@ type PropsFromState = {|
   beginningToDeleteReview: boolean,
   deletingReview: boolean,
   editingReview: boolean,
-  hasUsersEditPermission: boolean,
   replyingToReview: boolean,
   siteUser: UserType | null,
   siteUserCanManageReplies: boolean,
@@ -344,7 +343,6 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
       editingReview,
       errorHandler,
       flaggable,
-      hasUsersEditPermission,
       i18n,
       location,
       replyingToReview,
@@ -359,21 +357,15 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
 
     let byLine;
     const noAuthor = shortByLine || this.isReply();
-    const showUserProfileLink = !noAuthor && hasUsersEditPermission;
 
     if (review) {
       // eslint-disable-next-line no-nested-ternary
       const byLineString = noAuthor
         ? // L10n: Example in English: "posted last week"
           i18n.gettext('posted %(linkStart)s%(timestamp)s%(linkEnd)s')
-        : showUserProfileLink
-        ? // L10n: Example in English: "by UserName123, last week"
-          i18n.gettext(
-            'by %(linkUserProfileStart)s%(authorName)s%(linkUserProfileEnd)s, %(linkStart)s%(timestamp)s%(linkEnd)s',
-          )
         : // L10n: Example in English: "by UserName123, last week"
           i18n.gettext(
-            'by %(authorName)s, %(linkStart)s%(timestamp)s%(linkEnd)s',
+            'by %(linkUserProfileStart)s%(authorName)s%(linkUserProfileEnd)s, %(linkStart)s%(timestamp)s%(linkEnd)s',
           );
 
       // See https://github.com/mozilla/addons-frontend/issues/7322 for why we
@@ -415,7 +407,7 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
         ],
       ];
 
-      if (showUserProfileLink) {
+      if (!noAuthor) {
         replacements.push([
           'linkUserProfileStart',
           'linkUserProfileEnd',
@@ -438,12 +430,10 @@ export class AddonReviewCardBase extends React.Component<InternalProps> {
           // `<Link />` using `replaceStringsWithJSX`.
           linkEnd: '%(linkEnd)s',
           linkStart: '%(linkStart)s',
-          linkUserProfileStart: showUserProfileLink
+          linkUserProfileStart: !noAuthor
             ? '%(linkUserProfileStart)s'
             : undefined,
-          linkUserProfileEnd: showUserProfileLink
-            ? '%(linkUserProfileEnd)s'
-            : undefined,
+          linkUserProfileEnd: !noAuthor ? '%(linkUserProfileEnd)s' : undefined,
         }),
         replacements,
       });
@@ -625,7 +615,6 @@ function mapStateToProps(state: AppState, ownProps: Props): PropsFromState {
     beginningToDeleteReview,
     deletingReview,
     editingReview,
-    hasUsersEditPermission: hasPermission(state, USERS_EDIT),
     replyingToReview,
     siteUser: getCurrentUser(state.users),
     siteUserCanManageReplies: ownProps.siteUserCanReply || siteUserHasReplyPerm,

--- a/src/amo/pages/UserFeedback/index.js
+++ b/src/amo/pages/UserFeedback/index.js
@@ -141,7 +141,7 @@ export class UserFeedbackBase extends React.Component<InternalProps> {
 
                 <div className="UserFeedback-header-metadata">
                   <span>{i18n.gettext('User since')}</span>
-                  {user ? (
+                  {user && user.created ? (
                     i18n.moment(user.created).format('ll')
                   ) : (
                     <LoadingText />

--- a/src/amo/pages/UserProfile/index.js
+++ b/src/amo/pages/UserProfile/index.js
@@ -337,6 +337,11 @@ export class UserProfileBase extends React.Component<InternalProps> {
         })
       : i18n.gettext('User Profile');
 
+    const userCreatedDate =
+      user && user.created !== undefined
+        ? i18n.moment(user.created).format('ll')
+        : null;
+
     return (
       <Page errorHandler={errorHandler}>
         <div className="UserProfile">
@@ -376,36 +381,34 @@ export class UserProfileBase extends React.Component<InternalProps> {
                     {user.occupation}
                   </Definition>
                 ) : null}
-                <Definition
-                  className="UserProfile-user-since"
-                  term={i18n.gettext('User since')}
-                >
-                  {user ? (
-                    i18n.moment(user.created).format('ll')
-                  ) : (
-                    <LoadingText />
-                  )}
-                </Definition>
-                <Definition
-                  className="UserProfile-number-of-addons"
-                  term={i18n.gettext('Number of add-ons')}
-                >
-                  {user ? user.num_addons_listed : <LoadingText />}
-                </Definition>
-                <Definition
-                  className="UserProfile-rating-average"
-                  term={i18n.gettext('Average rating of developer’s add-ons')}
-                >
-                  {user ? (
+                {userCreatedDate ? (
+                  <Definition
+                    className="UserProfile-user-since"
+                    term={i18n.gettext('User since')}
+                  >
+                    {userCreatedDate}
+                  </Definition>
+                ) : null}
+                {user && user.num_addons_listed !== undefined ? (
+                  <Definition
+                    className="UserProfile-number-of-addons"
+                    term={i18n.gettext('Number of add-ons')}
+                  >
+                    {user.num_addons_listed}
+                  </Definition>
+                ) : null}
+                {user && user.average_addon_rating ? (
+                  <Definition
+                    className="UserProfile-rating-average"
+                    term={i18n.gettext('Average rating of developer’s add-ons')}
+                  >
                     <Rating
                       rating={user.average_addon_rating}
                       readOnly
                       styleSize="small"
                     />
-                  ) : (
-                    <LoadingText />
-                  )}
-                </Definition>
+                  </Definition>
+                ) : null}
                 {user && user.biography && user.biography.length ? (
                   <Definition
                     className="UserProfile-biography"

--- a/src/amo/pages/UserProfileEdit/index.js
+++ b/src/amo/pages/UserProfileEdit/index.js
@@ -410,11 +410,11 @@ export class UserProfileEditBase extends React.Component<InternalProps, State> {
     }
 
     const {
-      biography,
+      biography = defaultFormValues.biography,
       display_name: displayName,
-      homepage,
-      location,
-      occupation,
+      homepage = defaultFormValues.homepage,
+      location = defaultFormValues.location,
+      occupation = defaultFormValues.occupation,
     } = user;
 
     return {

--- a/src/amo/reducers/users.js
+++ b/src/amo/reducers/users.js
@@ -52,23 +52,24 @@ export type NotificationsType = Array<NotificationType>;
 export type NotificationsUpdateType = { [name: string]: boolean };
 
 export type BaseExternalUserType = {|
-  average_addon_rating: number,
-  biography: string | null,
-  created: string,
-  has_anonymous_display_name: boolean,
-  has_anonymous_username: boolean,
-  homepage: string | null,
   id: number,
-  is_addon_developer: boolean,
-  is_artist: boolean,
-  location: string | null,
   name: string,
-  num_addons_listed: number,
-  occupation: string | null,
-  picture_type: string | null,
-  picture_url: string | null,
   username: string,
-  // Properties returned if we are accessing our own profile or the current
+  // Properties returned for a developer
+  average_addon_rating?: number,
+  biography?: string | null,
+  created?: string,
+  has_anonymous_display_name?: boolean,
+  has_anonymous_username?: boolean,
+  homepage?: string | null,
+  is_addon_developer?: boolean,
+  is_artist?: boolean,
+  location?: string | null,
+  num_addons_listed?: number,
+  occupation?: string | null,
+  picture_type?: string | null,
+  picture_url?: string | null,
+  // Further Properties returned if we are accessing our own profile or the current
   // user has the `Users:Edit` permission.
   deleted?: boolean,
   display_name: string | null,
@@ -453,7 +454,7 @@ export const isDeveloper = (user: UserType | null): boolean => {
     return false;
   }
 
-  return user.is_addon_developer || user.is_artist;
+  return user.is_addon_developer || user.is_artist || false;
 };
 
 export const hasPermission = (state: AppState, permission: string): boolean => {

--- a/tests/unit/amo/components/TestAddonReviewCard.js
+++ b/tests/unit/amo/components/TestAddonReviewCard.js
@@ -1116,14 +1116,16 @@ describe(__filename, () => {
       ).toHaveTextContent(i18n.moment(review.created).fromNow());
     });
 
-    it('renders a byLine with an author by default', () => {
+    it('renders a linkified byLine with an author by default', () => {
       const name = 'some_user';
       const review = signInAndDispatchSavedReview({
         reviewUserProps: { name },
       });
       render({ review });
 
-      expect(screen.getByText(`by ${name},`)).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: review.userName }),
+      ).toHaveAttribute('href', `/en-US/android/user/${review.userId}/`);
     });
 
     it('renders a short byLine for replies by default', () => {
@@ -1145,29 +1147,6 @@ describe(__filename, () => {
           `posted ${i18n.moment(review.created).fromNow()}`,
         ),
       ).toBeInTheDocument();
-    });
-
-    it('linkifies username if current user is an admin', () => {
-      dispatchSignInActionsWithStore({
-        store,
-        userProps: { permissions: [ALL_SUPER_POWERS] },
-      });
-
-      const review = _setReview(fakeReview);
-      render({ review });
-
-      expect(
-        screen.getByRole('link', { name: review.userName }),
-      ).toHaveAttribute('href', `/en-US/android/user/${review.userId}/`);
-    });
-
-    it('does not linkify username if current user is not an admin', () => {
-      const review = _setReview(fakeReview);
-      render({ review });
-
-      expect(
-        screen.queryByRole('link', { name: review.userName }),
-      ).not.toBeInTheDocument();
     });
   });
 
@@ -1232,10 +1211,13 @@ describe(__filename, () => {
     it('does not include a user name in the byline', () => {
       const replyUserName = 'Bob';
       const reviewUserName = 'Daniel';
+      const reviewUserId = 123;
 
-      renderNestedReply({ replyUserName, reviewUserName });
+      renderNestedReply({ replyUserName, reviewUserName, reviewUserId });
 
-      expect(screen.getByText(`by ${reviewUserName},`)).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: reviewUserName }),
+      ).toHaveAttribute('href', `/en-US/android/user/${reviewUserId}/`);
       expect(screen.queryByText(replyUserName)).not.toBeInTheDocument();
     });
 

--- a/tests/unit/amo/pages/TestUserProfile.js
+++ b/tests/unit/amo/pages/TestUserProfile.js
@@ -261,21 +261,6 @@ describe(__filename, () => {
     expect(
       within(screen.getByClassName('UserProfile-name')).getByRole('alert'),
     ).toBeInTheDocument();
-    expect(
-      within(screen.getByClassName('UserProfile-user-since')).getByRole(
-        'alert',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      within(screen.getByClassName('UserProfile-number-of-addons')).getByRole(
-        'alert',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      within(screen.getByClassName(`UserProfile-rating-average`)).getByRole(
-        'alert',
-      ),
-    ).toBeInTheDocument();
   });
 
   it("renders the user's homepage", () => {
@@ -334,11 +319,29 @@ describe(__filename, () => {
     expect(screen.getByText('Aug 15, 2000')).toBeInTheDocument();
   });
 
+  it("omits the user's account creation date if undefined", () => {
+    const user = createUserAccountResponse({ id: defaultUserId });
+    user.created = undefined;
+    store.dispatch(loadUserAccount({ user }));
+    renderUserProfile();
+
+    expect(screen.queryByText('User since')).not.toBeInTheDocument();
+  });
+
   it("renders the user's number of add-ons", () => {
     signInUserAndRenderUserProfile({ num_addons_listed: 70 });
 
     expect(screen.getByText('Number of add-ons')).toBeInTheDocument();
     expect(screen.getByText('70')).toBeInTheDocument();
+  });
+
+  it("omits the user's number of add-ons if undefined", () => {
+    const user = createUserAccountResponse({ id: defaultUserId });
+    user.num_addons_listed = undefined;
+    store.dispatch(loadUserAccount({ user }));
+    renderUserProfile();
+
+    expect(screen.queryByText('Number of add-ons')).not.toBeInTheDocument();
   });
 
   it("renders the user's average add-on rating", () => {
@@ -350,6 +353,17 @@ describe(__filename, () => {
       screen.getByText('Average rating of developer’s add-ons'),
     ).toBeInTheDocument();
     expect(screen.getAllByTitle('Rated 3.1 out of 5')).toHaveLength(6);
+  });
+
+  it("omits the user's average add-on rating if undefined", () => {
+    const user = createUserAccountResponse({ id: defaultUserId });
+    user.average_addon_rating = undefined;
+    store.dispatch(loadUserAccount({ user }));
+    renderUserProfile();
+
+    expect(
+      screen.queryByText('Average rating of developer’s add-ons'),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the user's biography", () => {

--- a/tests/unit/amo/pages/TestUserProfileEdit.js
+++ b/tests/unit/amo/pages/TestUserProfileEdit.js
@@ -11,6 +11,7 @@ import {
   USERS_EDIT,
   VIEW_CONTEXT_HOME,
 } from 'amo/constants';
+import { setAuthToken } from 'amo/reducers/api';
 import { clearError } from 'amo/reducers/errors';
 import {
   FETCH_USER_ACCOUNT,
@@ -23,6 +24,7 @@ import {
   finishUpdateUserAccount,
   getCurrentUser,
   getUserById,
+  loadCurrentUserAccount,
   loadUserAccount,
   loadUserNotifications,
   logOutUser,
@@ -42,6 +44,7 @@ import {
   getElement,
   renderPage as defaultRender,
   screen,
+  userAuthSessionId,
   within,
 } from 'tests/unit/helpers';
 
@@ -422,6 +425,45 @@ describe(__filename, () => {
           occupation: user.occupation,
         },
         userId: user.id,
+      }),
+    );
+  });
+
+  it('dispatches updateUserAccount action with default values if undefined beforehand', async () => {
+    const dispatch = jest.spyOn(store, 'dispatch');
+    const displayName = 'Name';
+    const userId = defaultUserId;
+
+    store.dispatch(setAuthToken(userAuthSessionId()));
+    store.dispatch(
+      loadCurrentUserAccount({
+        user: {
+          id: userId,
+          display_name: displayName,
+          username: 'username-123',
+        },
+      }),
+    );
+    render({ userId });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Update My Profile' }),
+    );
+
+    expect(dispatch).toHaveBeenCalledWith(
+      updateUserAccount({
+        errorHandlerId: getErrorHandlerId(userId),
+        notifications: {},
+        picture: null,
+        pictureData: null,
+        userFields: {
+          biography: '',
+          display_name: displayName,
+          homepage: '',
+          location: '',
+          occupation: '',
+        },
+        userId,
       }),
     );
   });


### PR DESCRIPTION
Fixes mozilla/addons#15403

Shows user account links for all ratings, and hides the fields that won't be present on the user profile page.

### profile page
before
![Screenshot 2025-03-19 121902](https://github.com/user-attachments/assets/26a90137-ac67-4330-8593-4f4bb22abab5)
(before https://github.com/mozilla/addons/issues/15402 changed the API it would have been a 404)

after
![Screenshot 2025-03-19 121846](https://github.com/user-attachments/assets/8a642ba1-3af6-43bc-902a-f4d8c291569c)

### ratings
before
![Screenshot 2025-03-19 122209](https://github.com/user-attachments/assets/55fd7b7f-d6d7-4e6e-8e9d-c9682516a9b1)
after
![Screenshot 2025-03-19 122229](https://github.com/user-attachments/assets/a7cee46d-224a-41b2-ab11-7d09f598b6c2)
