### PR TITLE
Ensure <li>s are wrapped in a <ol> or <ul> after sanitizing HTML

### DIFF
--- a/src/amo/purify.js
+++ b/src/amo/purify.js
@@ -14,13 +14,17 @@ _purify.addHook('uponSanitizeElement', (node, data, config) => {
     _ALLOWED_TAGS.includes('li')
   ) {
     // If we find a <li> with no <ul>/<ol>/<menu> parent, create one for it.
-    // It's not ideal because this might create multiple independent lists for
-    // each item, but it's better than creating invalid HTML that would throw
-    // the virtual DOM off.
+    // Try to use the same <ul> if there are multiple <li> next to each other,
+    // otherwise create a new <ul>, it's better than creating invalid HTML that
+    // would throw the virtual DOM off anyway.
     const oldParent = node.parentNode;
-    const newParent = node.ownerDocument.createElement('ul');
+    const previousElement = node.previousElementSibling;
+    const newParent =
+      previousElement && previousElement.tagName === 'UL'
+        ? previousElement
+        : node.ownerDocument.createElement('ul');
+    oldParent.insertBefore(newParent, node);
     newParent.appendChild(node);
-    oldParent.appendChild(newParent);
   }
 });
 

--- a/src/amo/purify.js
+++ b/src/amo/purify.js
@@ -2,4 +2,26 @@ import createDOMPurify from 'dompurify';
 
 import universalWindow from 'amo/window';
 
-export default createDOMPurify(universalWindow);
+const _purify = createDOMPurify(universalWindow);
+_purify.addHook('uponSanitizeElement', (node, data, config) => {
+  const _ALLOWED_TAGS = config.ALLOWED_TAGS || [];
+  if (
+    node.tagName &&
+    node.parentNode &&
+    node.tagName === 'LI' &&
+    !['MENU', 'OL', 'UL'].includes(node.parentNode.tagName) &&
+    _ALLOWED_TAGS.includes('ul') &&
+    _ALLOWED_TAGS.includes('li')
+  ) {
+    // If we find a <li> with no <ul>/<ol>/<menu> parent, create one for it.
+    // It's not ideal because this might create multiple independent lists for
+    // each item, but it's better than creating invalid HTML that would throw
+    // the virtual DOM off.
+    const oldParent = node.parentNode;
+    const newParent = node.ownerDocument.createElement('ul');
+    newParent.appendChild(node);
+    oldParent.appendChild(newParent);
+  }
+});
+
+export default _purify;

--- a/tests/unit/amo/utils/test_index.js
+++ b/tests/unit/amo/utils/test_index.js
@@ -748,8 +748,44 @@ describe(__filename, () => {
 
       it('doesnt wrap `<li>` inside a `<ul>` if not necessary with menu', () => {
         const html = '<menu><li>witness me!</li></menu>';
-        expect(sanitizeHTML(html, ['li', 'menu'])).toEqual({
+        expect(sanitizeHTML(html, ['li', 'menu', 'ul'])).toEqual({
           __html: '<menu><li>witness me!</li></menu>',
+        });
+      });
+
+      it('handles multiple `<li>`', () => {
+        const html = '<li>foo</li><li>bar</li>';
+        expect(sanitizeHTML(html, ['li', 'ul'])).toEqual({
+          __html: '<ul><li>foo</li><li>bar</li></ul>',
+        });
+      });
+
+      it('handles multiple `<li>` when one does not need fixing', () => {
+        const html = '<li>foo</li><ul><li>bar</li></ul>';
+        expect(sanitizeHTML(html, ['li', 'ul'])).toEqual({
+          __html: '<ul><li>foo</li></ul><ul><li>bar</li></ul>',
+        });
+      });
+
+      it('handles multiple `<li>` in separate lists', () => {
+        const html = '<li>foo</li><code>alice</code><li>bar</li>';
+        expect(sanitizeHTML(html, ['li', 'ul', 'code'])).toEqual({
+          __html:
+            '<ul><li>foo</li></ul><code>alice</code><ul><li>bar</li></ul>',
+        });
+      });
+
+      it('handles no closing `</li>`', () => {
+        const html = '<li>foo<li>bar';
+        expect(sanitizeHTML(html, ['li', 'ul', 'p'])).toEqual({
+          __html: '<ul><li>foo</li><li>bar</li></ul>',
+        });
+      });
+
+      it('does not mess ordering`', () => {
+        const html = 'Before <li>foo</li><li>bar</li> After';
+        expect(sanitizeHTML(html, ['li', 'ul', 'p'])).toEqual({
+          __html: 'Before <ul><li>foo</li><li>bar</li></ul> After',
         });
       });
     });

--- a/tests/unit/amo/utils/test_index.js
+++ b/tests/unit/amo/utils/test_index.js
@@ -698,6 +698,61 @@ describe(__filename, () => {
         __html: '<a href="http://example.org">link</a>',
       });
     });
+
+    describe('custom `<li>` handling through hook', () => {
+      it('removes `<li>` if not allowed', () => {
+        const html = '<li>witness me!</li>';
+        expect(sanitizeHTML(html, [])).toEqual({
+          __html: 'witness me!',
+        });
+
+        expect(sanitizeHTML(html)).toEqual({
+          __html: 'witness me!',
+        });
+      });
+
+      it('does not wrap `<li>` inside a `<ul>` if not allowed', () => {
+        const html = '<li>witness me!</li>';
+        expect(sanitizeHTML(html, ['li'])).toEqual({
+          __html: '<li>witness me!</li>',
+        });
+      });
+
+      it('wraps `<li>` inside a `<ul>` if they dont already', () => {
+        const html = '<li>witness me!</li>';
+        expect(sanitizeHTML(html, ['li', 'ul'])).toEqual({
+          __html: '<ul><li>witness me!</li></ul>',
+        });
+      });
+
+      it('wraps `<li>` inside a `<ul>` if their parent was not allowed', () => {
+        const html = '<ol><li>witness me!</li></ol>';
+        expect(sanitizeHTML(html, ['li', 'ul'])).toEqual({
+          __html: '<ul><li>witness me!</li></ul>',
+        });
+      });
+
+      it('doesnt wrap `<li>` inside a `<ul>` if not necessary', () => {
+        const html = '<ul><li>witness me!</li></ul>';
+        expect(sanitizeHTML(html, ['li', 'ul'])).toEqual({
+          __html: '<ul><li>witness me!</li></ul>',
+        });
+      });
+
+      it('doesnt wrap `<li>` inside a `<ul>` if not necessary with ol', () => {
+        const html = '<ol><li>witness me!</li></ol>';
+        expect(sanitizeHTML(html, ['li', 'ol', 'ul'])).toEqual({
+          __html: '<ol><li>witness me!</li></ol>',
+        });
+      });
+
+      it('doesnt wrap `<li>` inside a `<ul>` if not necessary with menu', () => {
+        const html = '<menu><li>witness me!</li></menu>';
+        expect(sanitizeHTML(html, ['li', 'menu'])).toEqual({
+          __html: '<menu><li>witness me!</li></menu>',
+        });
+      });
+    });
   });
 
   describe('removeProtocolFromURL', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/14989

### Context

This matters when displaying the versions page, where each version is in a `<li>` already, and developers can have release notes containing `<li>` of their own. This can be seen:
- On dev: https://addons-dev.allizom.org/en-US/firefox/addon/ratopuse-weasp-vulturkal/versions/
- On prod: https://addons.mozilla.org/en-US/firefox/addon/bitwarden-password-manager/versions/

(Look at the output carefully, the HTML from the footer is duplicated, the "clone" appearing either in the sidebar or on top of the existing footer)

### Testing

You have to manually craft HTML with `<li>` and no parent `<ul>` and get it passed to our sanitize functions to test this. That is harder to achieve now that we have markdown, so best to modify the entry in the database, or pick one that was already broken, or test with https://localhost:3000/en-US/firefox/addon/ratopuse-weasp-vulturkal/versions/ with the patch applied and unapplied to see the difference. Or look at the unit tests.