### PR TITLE
Move Developer Comments to "About this add-on" area & tweak "Read More" behavior

### DIFF
--- a/src/amo/components/ShowMoreCard/styles.scss
+++ b/src/amo/components/ShowMoreCard/styles.scss
@@ -1,13 +1,5 @@
 @import '~amo/css/styles';
 
-.ShowMoreCard {
-  @include respond-to(large) {
-    .Card-contents {
-      border-radius: 0 0 $border-radius-default $border-radius-default;
-    }
-  }
-}
-
 .ShowMoreCard-contents {
   &::after {
     // rgba(255, 255, 255, 0%) instead of transparent prevents
@@ -26,10 +18,6 @@
   overflow: hidden;
   position: relative;
 
-  @include respond-to(large) {
-    max-height: 780px;
-  }
-
   .ShowMoreCard--expanded & {
     &::after {
       display: none;
@@ -39,12 +27,15 @@
   }
 }
 
+.AddonDescription,
 .PermissionsCard {
   .Card-contents {
     border-radius: 0;
   }
 
   .ShowMoreCard-contents {
+    // Keep in sync with `maxHeight` passed to the `ShowMoreCard` component in
+    // `Addon/index.js` and `PermissionCard/index.js`.
     max-height: 300px;
   }
 
@@ -53,6 +44,7 @@
   }
 }
 
+.AddonDescription.ShowMoreCard--expanded,
 .PermissionsCard.ShowMoreCard--expanded {
   .Card-contents {
     border-bottom-left-radius: $border-radius-default;

--- a/src/amo/components/ShowMoreCard/styles.scss
+++ b/src/amo/components/ShowMoreCard/styles.scss
@@ -34,22 +34,14 @@
     max-height: none;
   }
 }
-
-.AddonDescription,
-.Addon-developer-comments {
-  .ShowMoreCard-contents {
-    @include respond-to(large) {
-      &::after {
-        height: 0;
-      }
-
-      max-height: none;
-    }
+.ShowMoreCard-contents {
+  @include respond-to(large) {
+    max-height: 780px;
   }
 
-  .Card-footer-link {
+  .ShowMoreCard--expanded & {
     @include respond-to(large) {
-      display: none;
+      max-height: none;
     }
   }
 }

--- a/src/amo/components/ShowMoreCard/styles.scss
+++ b/src/amo/components/ShowMoreCard/styles.scss
@@ -26,23 +26,16 @@
   overflow: hidden;
   position: relative;
 
+  @include respond-to(large) {
+    max-height: 780px;
+  }
+
   .ShowMoreCard--expanded & {
     &::after {
       display: none;
     }
 
     max-height: none;
-  }
-}
-.ShowMoreCard-contents {
-  @include respond-to(large) {
-    max-height: 780px;
-  }
-
-  .ShowMoreCard--expanded & {
-    @include respond-to(large) {
-      max-height: none;
-    }
   }
 }
 

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -304,6 +304,7 @@ export class AddonBase extends React.Component {
         className={showMoreCardName}
         header={title}
         id={showMoreCardName}
+        maxHeight={300}
       >
         <div className="AddonDescription-contents" {...descriptionProps} />
         {addon && addon.developer_comments ? (

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -307,9 +307,17 @@ export class AddonBase extends React.Component {
       >
         <div className="AddonDescription-contents" {...descriptionProps} />
         {addon && addon.developer_comments ? (
+          /* eslint-disable react/no-danger */
           <div className="Addon-developer-comments">
-            <header className="Addon-developer-comments-header">{i18n.gettext('Developer comments')}</header>
-            <div className="Addon-developer-comments-contents" dangerouslySetInnerHTML={sanitizeUserHTML(addon.developer_comments)} />
+            <header className="Addon-developer-comments-header">
+              {i18n.gettext('Developer comments')}
+            </header>
+            <div
+              className="Addon-developer-comments-contents"
+              dangerouslySetInnerHTML={sanitizeUserHTML(
+                addon.developer_comments,
+              )}
+            />
           </div>
         ) : null}
       </ShowMoreCard>

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -306,36 +306,15 @@ export class AddonBase extends React.Component {
         id={showMoreCardName}
       >
         <div className="AddonDescription-contents" {...descriptionProps} />
+        {addon && addon.developer_comments ? (
+          <div className="Addon-developer-comments">
+            <header className="Addon-developer-comments-header">{i18n.gettext('Developer comments')}</header>
+            <div className="Addon-developer-comments-contents" dangerouslySetInnerHTML={sanitizeUserHTML(addon.developer_comments)} />
+          </div>
+        ) : null}
       </ShowMoreCard>
     ) : null;
   }
-
-  renderDevCommentsCard = () => {
-    const { addon, i18n } = this.props;
-
-    if (!addon || !addon.developer_comments) {
-      return null;
-    }
-
-    const devComments = sanitizeUserHTML(addon.developer_comments);
-    const showMoreCardName = 'Addon-developer-comments';
-
-    /* eslint-disable react/no-danger */
-    return (
-      <ShowMoreCard
-        contentId={addon.id}
-        className={showMoreCardName}
-        header={i18n.gettext('Developer comments')}
-        id={showMoreCardName}
-      >
-        <div
-          className="Addon-developer-comments-contents"
-          dangerouslySetInnerHTML={devComments}
-        />
-      </ShowMoreCard>
-    );
-    /* eslint-enable react/no-danger */
-  };
 
   renderVersionReleaseNotes() {
     const { addon, i18n, currentVersion } = this.props;
@@ -543,8 +522,6 @@ export class AddonBase extends React.Component {
               ) : null}
 
               {this.renderShowMoreCard()}
-
-              {this.renderDevCommentsCard()}
 
               {this.renderRecommendations()}
             </div>

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -194,5 +194,5 @@
 .Addon-developer-comments-header {
   font-size: 15px;
   font-weight: 600;
-  margin: 24px 0 12px 0;
+  margin: 24px 0 12px;
 }

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -112,8 +112,6 @@
 
   @include respond-to(medium) {
     @include margin-end(24px);
-
-    max-width: 550px;
   }
 }
 
@@ -165,11 +163,6 @@
         margin-top: 0;
       }
     }
-
-    .AddonDescription-contents,
-    .Addon-developer-comments-contents {
-      max-width: 550px;
-    }
   }
 
   .Addon-screenshots {
@@ -196,4 +189,10 @@
   @include respond-to(medium) {
     margin-top: 0;
   }
+}
+
+.Addon-developer-comments-header {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 24px 0 12px 0;
 }

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -838,19 +838,6 @@ describe(__filename, () => {
     expect(screen.getByText(developerComments)).toBeInTheDocument();
   });
 
-  it('passes the expected contentId to ShowMoreCard for developer comments', async () => {
-    addon.developer_comments = createLocalizedString(
-      'some awesome developers comments',
-    );
-    expect(
-      await testContentId({
-        addonProp: 'id',
-        addonPropValue: addon.id + 1,
-        cardClassName: 'Addon-developer-comments',
-      }),
-    ).toBeTruthy();
-  });
-
   it('allows some HTML tags in the developer comments', () => {
     addon.developer_comments = createLocalizedString(
       '<b>super</b> <i>cool</i> <blink>comments</blink>',


### PR DESCRIPTION
Change the logic around when to show the "Read More" link for the Description area when it's over 300px like permissions, instead of always showing the full content.

Fixes https://github.com/mozilla/addons/issues/15463

### Testing

- Try navigating to an add-on detail page with a small description: it should be fully displayed without "Read More"
- Try navigating to an add-on detail page with a large enough description to be more than 300px height: it should be displayed behind "Read More" regardless of screen size
- Repeat with developer comments added into the mix, note that they no longer have their own card but instead are shown inside "About this add-on" after the description.
- The other uses of `ShowMoreCard`, like permissions, shouldn't regress.

On a local env with dev data (`yarn amo:dev`), can try with:
- http://localhost:3000/en-US/firefox/addon/larebirra-buffala-chidger/ (short description)
- http://localhost:3000/en-US/firefox/addon/dark22reader/ (medium description + developer comments)
- http://localhost:3000/en-US/firefox/addon/long-description/ (long description)
- http://localhost:3000/en-US/firefox/addon/permissions/ (lots of permissions)
- More... create your own!