### PR TITLE
Show "About this add-on" area if there are developer comments

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -262,9 +262,9 @@ export class AddonBase extends React.Component {
   renderShowMoreCard() {
     const { addon, i18n } = this.props;
 
+    let showAbout;
     let title;
     const descriptionProps = {};
-    let showAbout = true;
 
     if (addon) {
       switch (addon.type) {
@@ -284,14 +284,14 @@ export class AddonBase extends React.Component {
           title = i18n.gettext('About this add-on');
       }
 
-      const description = addon.description ? addon.description : addon.summary;
-      showAbout = description !== addon.summary || addon.developer_comments;
-
-      if (description && description.length) {
-        descriptionProps.dangerouslySetInnerHTML =
-          sanitizeUserHTML(description);
+      if (addon.description && addon.description.length) {
+        descriptionProps.dangerouslySetInnerHTML = sanitizeUserHTML(
+          addon.description,
+        );
       }
+      showAbout = addon.description || addon.developer_comments;
     } else {
+      showAbout = true;
       title = <LoadingText width={40} />;
       descriptionProps.children = <LoadingText width={100} />;
     }
@@ -306,7 +306,9 @@ export class AddonBase extends React.Component {
         id={showMoreCardName}
         maxHeight={300}
       >
-        <div className="AddonDescription-contents" {...descriptionProps} />
+        {descriptionProps && Object.keys(descriptionProps).length ? (
+          <div className="AddonDescription-contents" {...descriptionProps} />
+        ) : null}
         {addon && addon.developer_comments ? (
           /* eslint-disable react/no-danger */
           <div className="Addon-developer-comments">

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -285,12 +285,12 @@ export class AddonBase extends React.Component {
       }
 
       const description = addon.description ? addon.description : addon.summary;
-      showAbout = description !== addon.summary;
+      showAbout = description !== addon.summary || addon.developer_comments;
 
-      if (!description || !description.length) {
-        return null;
+      if (description && description.length) {
+        descriptionProps.dangerouslySetInnerHTML =
+          sanitizeUserHTML(description);
       }
-      descriptionProps.dangerouslySetInnerHTML = sanitizeUserHTML(description);
     } else {
       title = <LoadingText width={40} />;
       descriptionProps.children = <LoadingText width={100} />;

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -194,5 +194,11 @@
 .Addon-developer-comments-header {
   font-size: 15px;
   font-weight: 600;
-  margin: 24px 0 12px;
+  margin-bottom: 12px;
+}
+
+.AddonDescription-contents + .Addon-developer-comments {
+  .Addon-developer-comments-header {
+    margin-top: 24px;
+  }
 }

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -847,6 +847,18 @@ describe(__filename, () => {
     expect(screen.getByText('Developer comments')).toBeInTheDocument();
   });
 
+  it('shows the developer comments if present and description is null without duplicating summary', () => {
+    addon.description = null;
+    addon.summary = createLocalizedString('Bar');
+    addon.developer_comments = createLocalizedString('Foo');
+    renderWithAddon();
+
+    expect(screen.getByText('Developer comments')).toBeInTheDocument();
+    expect(
+      screen.queryByClassName('AddonDescription-contents'),
+    ).not.toBeInTheDocument();
+  });
+
   it('displays developer comments', () => {
     const developerComments = 'some awesome developers comments';
     addon.developer_comments = createLocalizedString(developerComments);

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -829,6 +829,24 @@ describe(__filename, () => {
     expect(screen.queryByText('Developer comments')).not.toBeInTheDocument();
   });
 
+  it('shows the developer comments if present and description and summary are blank', () => {
+    addon.description = createLocalizedString('');
+    addon.summary = createLocalizedString('');
+    addon.developer_comments = createLocalizedString('Foo');
+    renderWithAddon();
+
+    expect(screen.getByText('Developer comments')).toBeInTheDocument();
+  });
+
+  it('shows the developer comments if present and description and summary are null', () => {
+    addon.description = null;
+    addon.summary = null;
+    addon.developer_comments = createLocalizedString('Foo');
+    renderWithAddon();
+
+    expect(screen.getByText('Developer comments')).toBeInTheDocument();
+  });
+
   it('displays developer comments', () => {
     const developerComments = 'some awesome developers comments';
     addon.developer_comments = createLocalizedString(developerComments);


### PR DESCRIPTION
And not just if there is a description, now that the developer comments are part of this area as well.

Follow-up fix for https://github.com/mozilla/addons/issues/15463#issuecomment-2841273057
Fixes mozilla/addons#15592