### PR TITLE
fix(create-locales): shell command built from environment values

### DIFF
--- a/bin/create-locales
+++ b/bin/create-locales
@@ -12,7 +12,7 @@ require('@babel/register');
 const config = require('config');
 const fs = require('fs');
 const path = require('path');
-const shell = require('shelljs');
+const { execFileSync } = require('child_process');
 
 const supportedLangs = config.get('langs');
 const localeDir = path.join(__dirname, '../locale');
@@ -34,8 +34,12 @@ for (lang of supportedLangs) {
     console.log(`${outputFile} already exists skipping`);
   } catch (e) {
     if (e.code === 'ENOENT') {
-      shell.exec(`msginit --no-translator --input=${templateDir}/amo.pot
-                  --output-file=${outputFile} -l ${locale}`.replace('\n', ' '));
+      execFileSync('msginit', [
+        '--no-translator',
+        `--input=${path.join(templateDir, 'amo.pot')}`,
+        `--output-file=${outputFile}`,
+        `-l`, `${locale}`
+      ]);
     } else {
       throw e;
     }


### PR DESCRIPTION
https://github.com/mozilla/addons-frontend/blob/1cd93c99caaf3bb1c6228b3d63c3b62755d323ac/bin/create-locales#L15-L15
https://github.com/mozilla/addons-frontend/blob/1cd93c99caaf3bb1c6228b3d63c3b62755d323ac/bin/create-locales#L37-L38

Fix the issue, we will replace the use of `shell.exec` with a safer alternative that avoids shell interpretation of dynamic values. Specifically, we will use `child_process.execFileSync`, which allows us to pass arguments to the command as an array, ensuring that special characters in the arguments are not interpreted by the shell.

1. Replace the `shell.exec` call on line 37 with a call to `child_process.execFileSync`.
2. Import the `child_process` module at the top of the file if it is not already imported.
3. Construct the command and its arguments separately, passing the arguments as an array to `execFileSync`.

---


