### PR TITLE
Add a default color to dropdown menu items so that the ellipsis shows up

### DIFF
--- a/src/amo/components/DropdownMenu/styles.scss
+++ b/src/amo/components/DropdownMenu/styles.scss
@@ -72,6 +72,7 @@
   border: 0;
   border-radius: $border-radius-default;
   box-shadow: 0 0 2px transparentize($black, 0.5);
+  color: $grey-90;
   display: none;
   list-style-type: none;
   margin: 0;


### PR DESCRIPTION
.DropdownMenu-items sets a white background, so setting a contrasting color as well ensures text is shown correctly even when the parent would set a white color.

This didn't affect links and section headers which sets their own color but was affecting the '...' ellipsis text that is triggered when the menu item is too long, which happens in some locales.

Fixes https://github.com/mozilla/addons/issues/2182

### Testing

- Visit http://localhost:3000/it/firefox/
- Log in
- Check the contents of the dropdown menus (Altro..., <Your name> ▼): you should see ellipsis text (...) on some items that overflow inside the menu.