### PR TITLE
Fix spacing and sizing of Badge and Badge Content

### DIFF
--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -20,6 +20,7 @@ $badge-size-small: 16px;
     flex-grow: 0;
     flex-shrink: 0;
     text-decoration: none;
+    gap: 6px;
 
     &,
     &:link,

--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -8,9 +8,10 @@ $badge-size-small: 16px;
   font-size: $font-size-default;
   line-height: $line-height-compressed;
   display: flex;
+  gap: 6px;
   align-items: center;
   white-space: nowrap;
-  padding: 3px 6px 3px 3px;
+  padding: 4px 6px;
 
   .Badge-link {
     color: inherit;
@@ -40,6 +41,7 @@ $badge-size-small: 16px;
     border: 1px solid $color-light-gray-40;
     border-radius: 20px;
     display: inline-flex;
+    gap: 6px;
     box-sizing: border-box;
 
     &:hover,
@@ -63,16 +65,12 @@ $badge-size-small: 16px;
   }
 }
 
-.Badge-icon + .Badge-content {
-  @include margin-start(6px);
-}
-
 .Badge-content--small {
   font-size: 12px;
 }
 
 .Badge-content--large {
-  font-size: $badge-size-large;
+  font-size: 16px;
 }
 
 .Badge-icon {


### PR DESCRIPTION
Fixes: mozilla/addons#15679

# Testing
- badge font size should be 12px or 16px for small/large badges
- there should be a appropriate padding on badge content
- there should be a 6px gap between badge content and icon.

# Screenshots

## Small

### Before

<img width="387" alt="image" src="https://github.com/user-attachments/assets/54e6a02e-bfe1-43ad-b719-f50b42ef991f" />

### After

<img width="386" alt="image" src="https://github.com/user-attachments/assets/7bdbac84-9119-4da8-aab7-3ef29753d494" />

## Medium

### Before

<img width="516" alt="image" src="https://github.com/user-attachments/assets/85ea7697-8d8b-42f3-9cd1-15a93621e039" />

### After

<img width="508" alt="image" src="https://github.com/user-attachments/assets/40722a8f-46e2-4943-953a-17e0c63e6c77" />

## Large

### Before

<img width="732" alt="image" src="https://github.com/user-attachments/assets/b5a61b41-40cf-47d1-8a30-707b9edae67a" />

### After

<img width="738" alt="image" src="https://github.com/user-attachments/assets/fb962737-792e-4f23-9e8c-987c2a12bcc6" />

## ExtraLarge

### Before

<img width="924" alt="image" src="https://github.com/user-attachments/assets/ecedea5c-be59-4e91-9f1b-894553487a9f" />

### After

<img width="946" alt="image" src="https://github.com/user-attachments/assets/e51fe8f7-a5b2-4105-a190-b72e0919546b" />

## ExtraExtraLarge

### Before

<img width="1169" alt="image" src="https://github.com/user-attachments/assets/94888d6f-84fe-40f8-88de-f1c7023c540c" />

### After

<img width="1176" alt="image" src="https://github.com/user-attachments/assets/130919aa-7dae-4362-915c-b196d482ebfb" />

TBD
- [ ] depending on outcome of UX discussions we might be making all badges bordered.
- [ ] even if we don't we should probably make badge rendering semantically consistent and render either an `<a>` or `<div>` tag instead of rendering the `<a>` within the `<div>`. This would simplify the styling definition as we don't need to define flex within the link and within the parent div.