### PR TITLE
Fix broken theme thumbnail (quick fix)

### DIFF
--- a/src/amo/components/ThemeImage/styles.scss
+++ b/src/amo/components/ThemeImage/styles.scss
@@ -2,6 +2,8 @@
 
 .ThemeImage {
   height: auto;
+  max-height: $theme-height-legacy;
+  max-width: $theme-width-default;
   order: -1;
   overflow-y: hidden;
   position: relative;

--- a/src/amo/components/ThemeImage/styles.scss
+++ b/src/amo/components/ThemeImage/styles.scss
@@ -2,8 +2,6 @@
 
 .ThemeImage {
   height: auto;
-  max-height: $theme-height-legacy;
-  max-width: $theme-width-default;
   order: -1;
   overflow-y: hidden;
   position: relative;
@@ -13,7 +11,6 @@
 .ThemeImage-image {
   display: block;
   height: auto;
-  max-width: $theme-width-default;
   object-fit: cover;
   object-position: top left;
   width: 100%;

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -170,11 +170,19 @@ export class AddonBase extends React.Component {
     }
   }
 
+  renderThemeThumbnail() {
+    const { addon } = this.props;
+
+    if (!addon || addon.type !== ADDON_TYPE_STATIC_THEME) return null;
+
+    return <ThemeImage addon={addon} roundedCorners />;
+  }
+
   headerImage() {
     const { addon, i18n } = this.props;
 
     if (addon && ADDON_TYPE_STATIC_THEME === addon.type) {
-      return <ThemeImage addon={addon} roundedCorners />;
+      return null;
     }
 
     const label = addon
@@ -184,14 +192,12 @@ export class AddonBase extends React.Component {
       : null;
 
     return (
-      <div key="Addon-icon-header">
-        <div className="Addon-icon-wrapper">
-          <img
-            alt={label}
-            className="Addon-icon-image"
-            src={getAddonIconUrl(addon)}
-          />
-        </div>
+      <div className="Addon-icon-wrapper">
+        <img
+          alt={label}
+          className="Addon-icon-image"
+          src={getAddonIconUrl(addon)}
+        />
       </div>
     );
   }
@@ -484,6 +490,10 @@ export class AddonBase extends React.Component {
                 </Notice>
               ) : null}
 
+              <div className="Addon-theme-thumbnail">
+                {this.renderThemeThumbnail()}
+              </div>
+
               <header className="Addon-header">
                 {this.headerImage()}
 
@@ -491,7 +501,6 @@ export class AddonBase extends React.Component {
                   <AddonTitle addon={addon} />
                   {showSummary ? summary : null}
 
-                  <AddonBadges addon={addon} />
                   {addon && <InstallWarning addon={addon} />}
                   {addon ? (
                     <WrongPlatformWarning
@@ -500,6 +509,7 @@ export class AddonBase extends React.Component {
                     />
                   ) : null}
                 </div>
+                <AddonBadges addon={addon} />
                 <div className="Addon-install">
                   <InstallButtonWrapper addon={addon} />
                 </div>

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -170,19 +170,15 @@ export class AddonBase extends React.Component {
     }
   }
 
-  renderThemeThumbnail() {
-    const { addon } = this.props;
-
-    if (!addon || addon.type !== ADDON_TYPE_STATIC_THEME) return null;
-
-    return <ThemeImage addon={addon} roundedCorners />;
-  }
-
   headerImage() {
     const { addon, i18n } = this.props;
 
     if (addon && ADDON_TYPE_STATIC_THEME === addon.type) {
-      return null;
+      return (
+        <div className="Addon-theme-thumbnail">
+          <ThemeImage addon={addon} roundedCorners />
+        </div>
+      );
     }
 
     const label = addon
@@ -490,9 +486,13 @@ export class AddonBase extends React.Component {
                 </Notice>
               ) : null}
 
-              <div className="Addon-theme-thumbnail">
-                {this.renderThemeThumbnail()}
-              </div>
+              {addon && <InstallWarning addon={addon} />}
+              {addon ? (
+                <WrongPlatformWarning
+                  addon={addon}
+                  className="Addon-WrongPlatformWarning"
+                />
+              ) : null}
 
               <header className="Addon-header">
                 {this.headerImage()}
@@ -500,14 +500,6 @@ export class AddonBase extends React.Component {
                 <div className="Addon-info">
                   <AddonTitle addon={addon} />
                   {showSummary ? summary : null}
-
-                  {addon && <InstallWarning addon={addon} />}
-                  {addon ? (
-                    <WrongPlatformWarning
-                      addon={addon}
-                      className="Addon-WrongPlatformWarning"
-                    />
-                  ) : null}
                 </div>
                 <AddonBadges addon={addon} />
                 <div className="Addon-install">

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -37,19 +37,15 @@
   }
 }
 
-.Addon-theme-thumbnail {
-  margin-bottom: 12px;
-}
-
 .Addon-header {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 6px 0;
+  row-gap: 14px;
 
   @include respond-to(medium) {
     display: grid;
     grid-template:
+      'preview preview' auto
       'icon icon' auto
       'info info' auto
       'badges badges' auto
@@ -57,10 +53,29 @@
   }
 
   @include respond-to(large) {
-    display: grid;
+    column-gap: 14px;
+    grid-template:
+      'preview preview preview preview preview' auto
+      'icon info info button button' auto
+      'badges badges badges badges badges' auto / min-content 1fr 1fr 1fr auto;
+  }
+
+  @include respond-to(extraLarge) {
     grid-template:
       'icon info button' auto
-      'badges badges badges' auto / [icon] min-content [info] 1fr [button] min-content;
+      'preview preview preview' auto
+      'badges badges badges' auto / min-content 1fr auto;
+  }
+
+  @include respond-to(extraExtraLarge) {
+    grid-template:
+      'preview preview preview preview . button' auto
+      'icon info info info . button' auto
+      'badges badges badges badges badges badges' auto / min-content 1fr 1fr 1fr auto;
+  }
+
+  & .Addon-theme-thumbnail {
+    grid-area: preview;
   }
 
   & .Addon-icon-wrapper {
@@ -68,9 +83,6 @@
   }
 
   & .Addon-info {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
     grid-area: info;
   }
 
@@ -80,11 +92,11 @@
 
   & .Addon-install {
     grid-area: button;
-    @include respond-to(medium) {
-      width: 100%;
-    }
     @include respond-to(large) {
-      width: 100%;
+      min-width: 180px;
+    }
+    @include respond-to(extraLarge) {
+      min-width: 200px;
     }
   }
 }
@@ -149,7 +161,6 @@
 }
 
 .Addon-WrongPlatformWarning {
-  margin: 12px 0 0;
   padding-left: 0;
   padding-right: 0;
 }

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -37,30 +37,51 @@
   }
 }
 
-.Addon-theme .AddonTitle {
-  margin: $padding-page-l 0;
+.Addon-theme-thumbnail {
+  margin-bottom: 12px;
 }
 
 .Addon-header {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 16px;
   padding: 6px 0;
 
+  @include respond-to(medium) {
+    display: grid;
+    grid-template:
+      'icon icon' auto
+      'info info' auto
+      'badges badges' auto
+      '. button' auto / 1fr 1fr;
+  }
+
   @include respond-to(large) {
-    grid-template-columns: 0.5fr 3fr 1fr;
+    display: grid;
+    grid-template:
+      'icon info button' auto
+      'badges badges badges' auto / [icon] min-content [info] 1fr [button] min-content;
+  }
+
+  & .Addon-icon-wrapper {
+    grid-area: icon;
   }
 
   & .Addon-info {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    grid-area: info;
+  }
+
+  & .AddonBadges {
+    grid-area: badges;
   }
 
   & .Addon-install {
+    grid-area: button;
     @include respond-to(medium) {
-      margin-left: auto;
-      width: 50%;
+      width: 100%;
     }
     @include respond-to(large) {
       width: 100%;


### PR DESCRIPTION
fixes: mozilla/addons#15685

## Description

Fix layout for theme details page switching between inline thumbnail and full row theme preview

## Context

https://github.com/mozilla/addons-frontend/pull/13638 introduced a regression for themes that render a 720px width theme preview. This doesn't fit in our left column thumbnail section.

## Testing

Run dev mode

```bash
yarn amo:dev
```

Check both URLs on various breakpoints, should scale from stacked to grid layout and on theme addons the theme preview should always be above the header content (within the header card)


https://github.com/user-attachments/assets/4f8fac5f-0ea4-4d03-ad50-d5ccdb94623c


https://github.com/user-attachments/assets/c2f1eecd-b824-480c-907b-cb76ea440c42


https://github.com/user-attachments/assets/a69cf162-9623-4075-9a18-983ec8e2064f



