### PR TITLE
Adjust rating card layout and show rating breakdown

### DIFF
--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -166,6 +166,7 @@
 
   .AddonReviewCard-confirmDeleteDialog {
     margin-top: 12px;
+    margin-bottom: 6px;
     text-align: center;
     width: 100%;
 
@@ -216,6 +217,7 @@
     background-color: transparentize($blue-50, 0.95);
     border-radius: $border-radius-default;
     padding: 12px;
+    margin-bottom: 6px;
 
     @include respond-to(medium) {
       padding: 12px 24px;

--- a/src/amo/components/Rating/styles.scss
+++ b/src/amo/components/Rating/styles.scss
@@ -29,7 +29,6 @@ $icon-small: 13px;
   @include respond-to(extraExtraLarge) {
     &.Rating--large {
       grid-column-gap: 12px;
-      max-width: none;
     }
   }
 }

--- a/src/amo/components/Rating/styles.scss
+++ b/src/amo/components/Rating/styles.scss
@@ -21,8 +21,8 @@ $icon-small: 13px;
   // The width of large rating stars are controlled by the container.
   &.Rating--large {
     grid-column-gap: 6px;
-    max-width: 300px;
-    min-height: 64px;
+    max-width: 250px;
+    min-height: 32px;
     width: 100%;
   }
 

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -210,7 +210,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
           {/* eslint-enable react/no-danger */}
           <div className="RatingManager-ratingControl">
             {!this.isSignedIn() ? this.renderLogInToRate() : null}
-            Click to rate:
+            {i18n.gettext('Click to rate:')}
             {userReview && onDeleteScreen ? (
               <AddonReviewManagerRating
                 className="RatingManager-AddonReviewManagerRating"

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -16,6 +16,7 @@ import {
 import AddonReviewCard from 'amo/components/AddonReviewCard';
 import AddonReviewManagerRating from 'amo/components/AddonReviewManagerRating';
 import RatingManagerNotice from 'amo/components/RatingManagerNotice';
+import RatingsByStar from 'amo/components/RatingsByStar';
 import { selectLatestUserReview } from 'amo/reducers/reviews';
 import AuthenticateButton from 'amo/components/AuthenticateButton';
 import {
@@ -189,14 +190,14 @@ export class RatingManagerBase extends React.Component<InternalProps> {
           'Are you sure you want to delete your rating of %(addonName)s?',
         );
       }
-    } else {
-      prompt = i18n.gettext('How are you enjoying %(addonName)s?');
     }
 
-    const promptHTML = sanitizeHTML(
-      i18n.sprintf(prompt, { addonName: `<b>${addon.name}</b>` }),
-      ['b'],
-    );
+    const promptHTML = prompt
+      ? sanitizeHTML(
+          i18n.sprintf(prompt, { addonName: `<b>${addon.name}</b>` }),
+          ['b'],
+        )
+      : null;
 
     return (
       <form action="">
@@ -209,6 +210,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
           {/* eslint-enable react/no-danger */}
           <div className="RatingManager-ratingControl">
             {!this.isSignedIn() ? this.renderLogInToRate() : null}
+            Click to rate:
             {userReview && onDeleteScreen ? (
               <AddonReviewManagerRating
                 className="RatingManager-AddonReviewManagerRating"
@@ -267,6 +269,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
             slim
           />
         )}
+        <RatingsByStar addon={addon} />
       </div>
     );
   }

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -3,6 +3,8 @@
 .RatingManager-ratingControl {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
   position: relative;
 }
 

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -3,7 +3,6 @@
 .RatingManager-ratingControl {
   align-items: center;
   display: flex;
-  justify-content: center;
   position: relative;
 }
 

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -18,6 +18,10 @@
 }
 
 .RatingManager {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
   fieldset {
     // Prevent content overflow.
     min-width: 0;
@@ -29,10 +33,6 @@
       $showmorecard-gradient-color
     );
   }
-}
-
-.RatingManager-UserRating {
-  margin: 12px;
 }
 
 .RatingManager-savedRating-withReview {

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -242,11 +242,11 @@ export class AddonBase extends React.Component {
       content = i18n.gettext('No reviews yet');
     }
 
-    let addonAverage;
-    if (addon && addon.ratings) {
+    let header;
+    if (addon && addon.ratings && addon.ratings.count !== undefined) {
       const roundedAverage = roundToOneDigit(addon.ratings.average);
       const ratingCount = addon.ratings.count;
-      addonAverage = i18n.sprintf(
+      header = i18n.sprintf(
         // eslint-disable-next-line max-len
         // L10n: ratingAverage is a number rounded to one digit, such as 4.5 in English or ٤٫٧ in Arabic.
         i18n.ngettext(
@@ -259,6 +259,8 @@ export class AddonBase extends React.Component {
           ratingCount: i18n.formatNumber(ratingCount),
         },
       );
+    } else {
+      header = <LoadingText minWidth={30} />;
     }
 
     const props = {
@@ -266,12 +268,9 @@ export class AddonBase extends React.Component {
         <div className="Addon-read-reviews-footer">{content}</div>
       ),
     };
+
     return (
-      <Card
-        header={addon ? addonAverage : <LoadingText minWidth={30} />}
-        className="Addon-overall-rating"
-        {...props}
-      >
+      <Card header={header} className="Addon-overall-rating" {...props}>
         {ratingManager}
       </Card>
     );

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 
 import { setViewContext } from 'amo/actions/viewContext';
 import AddAddonToCollection from 'amo/components/AddAddonToCollection';
-import AddonBadges from 'amo/components/AddonBadges';
+import AddonBadges, { roundToOneDigit } from 'amo/components/AddonBadges';
 import AddonCompatibilityError from 'amo/components/AddonCompatibilityError';
 import AddonHead from 'amo/components/AddonHead';
 import AddonInstallError from 'amo/components/AddonInstallError';
@@ -242,6 +242,25 @@ export class AddonBase extends React.Component {
       content = i18n.gettext('No reviews yet');
     }
 
+    let addonAverage;
+    if (addon && addon.ratings) {
+      const roundedAverage = roundToOneDigit(addon.ratings.average);
+      const ratingCount = addon.ratings.count;
+      addonAverage = i18n.sprintf(
+        // eslint-disable-next-line max-len
+        // L10n: ratingAverage is a number rounded to one digit, such as 4.5 in English or ٤٫٧ in Arabic.
+        i18n.ngettext(
+          'Rated %(ratingAverage)s by 1 reviewer',
+          'Rated %(ratingAverage)s by %(ratingCount)s reviewers',
+          ratingCount,
+        ),
+        {
+          ratingAverage: i18n.formatNumber(roundedAverage),
+          ratingCount: i18n.formatNumber(ratingCount),
+        },
+      );
+    }
+
     const props = {
       [footerPropName]: (
         <div className="Addon-read-reviews-footer">{content}</div>
@@ -249,7 +268,7 @@ export class AddonBase extends React.Component {
     };
     return (
       <Card
-        header={i18n.gettext('Rate your experience')}
+        header={addon ? addonAverage : <LoadingText minWidth={30} />}
         className="Addon-overall-rating"
         {...props}
       >

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -110,7 +110,7 @@ describe(__filename, () => {
     return { addon, review };
   };
 
-  it('prompts you to rate the add-on by name', () => {
+  it('doesnt show any prompt when not deleting', () => {
     const name = 'Some Add-on';
     render({
       addon: createInternalAddonWithLang({
@@ -119,9 +119,7 @@ describe(__filename, () => {
       }),
     });
 
-    expect(
-      screen.getByTextAcrossTags(`How are you enjoying ${name}?`),
-    ).toBeInTheDocument();
+    expect(screen.queryByText(`of ${name}?`)).not.toBeInTheDocument();
   });
 
   it('dispatches fetchLatestUserReview on construction', () => {
@@ -533,5 +531,16 @@ describe(__filename, () => {
       // When Rating is in readOnly mode, the title for all stars is as below.
       expect(screen.getAllByTitle('Rated 3 out of 5')).toHaveLength(6);
     });
+  });
+
+  it('renders RatingsByStar with an add-on', () => {
+    const addon = fakeAddon;
+    render({ addon });
+
+    // Do a sanity check to make sure the right add-on was used.
+    expect(screen.getByTitle('There are no five-star reviews')).toHaveAttribute(
+      'href',
+      `/en-US/android/addon/${addon.slug}/reviews/?score=5`,
+    );
   });
 });

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -386,7 +386,7 @@ describe(__filename, () => {
   it('renders without an add-on', () => {
     render();
 
-    expect(screen.getAllByRole('alert')).toHaveLength(6);
+    expect(screen.getAllByRole('alert')).toHaveLength(7);
   });
 
   it('renders without a version', () => {
@@ -1019,6 +1019,33 @@ describe(__filename, () => {
     expect(badge).toBeInTheDocument();
     const content = within(badge).getByClassName('Badge-content');
     expect(content).toHaveTextContent('100 Users');
+  });
+
+  describe('ratings count header', () => {
+    const renderWithRatings = (average, count) => {
+      addon.ratings = { ...fakeAddon.ratings, count, average };
+      renderWithAddon();
+    };
+
+    it('mentions a single reviewer when there is only one rating', () => {
+      renderWithRatings(3, 1);
+
+      expect(screen.getByText('Rated 3 by 1 reviewer')).toBeInTheDocument();
+    });
+
+    it('mentions a multiple reviewers when there are many ratings', () => {
+      renderWithRatings(2.4, 5);
+
+      expect(screen.getByText('Rated 2.4 by 5 reviewers')).toBeInTheDocument();
+    });
+
+    it('localizes the review count', () => {
+      renderWithRatings(2.4, 10000);
+
+      expect(
+        screen.getByText('Rated 2.4 by 10,000 reviewers'),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('read reviews footer', () => {


### PR DESCRIPTION

Fixes mozilla/addons#15684

Adjusts the label, header, and stars for the rating card, and includes the breakdown.  I reduced the star size or the "click to rate" label looked tiny in comparison, (and had to add bottom margins to make it look non-terrible), but otherwise left styling changes for phase 2.

I couldn't see anything in particular in the spec about the logged out view; adding review text, or deleting ratings/reviews, so those are as now.

### Before:
![image](https://github.com/user-attachments/assets/9a33373c-11a2-4e3d-a073-902c8f5d95c8)

### After
logged out at 900px:
![Screenshot 2025-07-04 105817](https://github.com/user-attachments/assets/49694afa-ccfb-4227-a9ce-f2f96b7fea47)

logged in at 900px:
![Screenshot 2025-07-04 111728](https://github.com/user-attachments/assets/f0ad7e68-1018-46d4-911c-e02c69f7be77)

card at 500px
![Screenshot 2025-07-04 112054](https://github.com/user-attachments/assets/8a718e8e-8bc2-4c47-98f7-fbbc013de971)

card at 720px (the "click..." text is only wrapped because the card is size-constrained - when we move to single column it won't happen)
![Screenshot 2025-07-04 112104](https://github.com/user-attachments/assets/091cc3c4-a9b1-43da-961f-52b2f5493170)

card at 900px
![Screenshot 2025-07-04 112124](https://github.com/user-attachments/assets/f8aadec2-4c4b-49d1-8921-d1d5b7fa92ad)

card at 1150px:
![Screenshot 2025-07-04 112140](https://github.com/user-attachments/assets/9f97f5a5-9d58-4c0c-97a6-cb83c3a1858e)

video


https://github.com/user-attachments/assets/a12c31ea-16bc-43fc-830a-73980d13d410


