### PR TITLE
move Recommendations and Permissions cards; set to 3 columns

### DIFF
--- a/src/amo/components/AddonRecommendations/styles.scss
+++ b/src/amo/components/AddonRecommendations/styles.scss
@@ -8,7 +8,12 @@
       // overriding default Search Results styles
       @include respond-to(large) {
         grid-auto-flow: initial;
-        grid-template-columns: repeat(2, 50%);
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      @include respond-to(extraLarge) {
+        grid-auto-flow: initial;
+        grid-template-columns: repeat(3, 1fr);
       }
 
       .SearchResult {

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -62,11 +62,11 @@
 .AddonsByAuthorsCard:not(.AddonsByAuthorsCard--theme) {
   .Card-contents .AddonsCard-list {
     @include respond-to(large) {
-      grid-template-columns: repeat(1, 1fr);
+      grid-template-columns: repeat(2, 1fr);
     }
 
-    @include respond-to(extraExtraLarge) {
-      grid-template-columns: repeat(2, 1fr);
+    @include respond-to(extraLarge) {
+      grid-template-columns: repeat(3, 1fr);
     }
   }
 }

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -277,7 +277,7 @@ export class AddonBase extends React.Component {
     );
   }
 
-  renderShowMoreCard() {
+  renderAboutThisCard() {
     const { addon, i18n } = this.props;
 
     let showAbout;
@@ -547,20 +547,20 @@ export class AddonBase extends React.Component {
                 </Card>
               ) : null}
 
-              {this.renderShowMoreCard()}
+              {this.renderAboutThisCard()}
 
               {this.renderRatingsCard()}
-
-              {this.renderRecommendations()}
             </div>
-
-            <ContributeCard addon={addon} />
 
             <PermissionsCard version={currentVersion} />
 
             <AddonMoreInfo addon={addon} />
 
+            <ContributeCard addon={addon} />
+
             {this.renderVersionReleaseNotes()}
+
+            {this.renderRecommendations()}
 
             {this.renderAddonsByAuthorsCard({ isForTheme: false })}
           </div>


### PR DESCRIPTION
Fixes mozilla/addons#15631 and fixes mozilla/addons#15627

Moves Recommendations (aka Other popular extensions) and Permissions cards to their eventual final position in the new detail page layout.  

Also adjusts the number of columns to match figma (2 at large, 3 at extraLarge) - and repeats that style adjustment for the extensions by author card for consistency (author card is not shown on the figma, so it remains at it's old position, at the bottom of the page)

## medium/500px

<img width="600" height="auto" alt="Screen Shot 2025-07-18 at 17 26 03-fullpage" src="https://github.com/user-attachments/assets/1ab84106-5967-456f-a23c-749ad11a5d53" />

## large/720px

<img width="600" height="auto" alt="Screen Shot 2025-07-18 at 17 25 57-fullpage" src="https://github.com/user-attachments/assets/22ff36a7-0dba-464e-9e0b-9e94ed065a12" />

## extraLarge

<img width="600" height="auto" alt="Screen Shot 2025-07-18 at 17 25 49-fullpage" src="https://github.com/user-attachments/assets/406e70fa-de4d-4000-ac74-8e8b34e03ef8" />

## extraExtraLarge

<img width="600" height="auto" alt="Screen Shot 2025-07-18 at 17 25 36-fullpage" src="https://github.com/user-attachments/assets/57f67063-8f00-4aad-bd80-0796b51487a7" />
