### PR TITLE
add trivial padding in between h1 and summary in header

### DIFF
--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -111,6 +111,7 @@
   font-size: $font-size-default;
   overflow-x: auto;
   margin: 0;
+  margin-top: 14px;
 }
 
 .Addon .AMInstallButton-button {


### PR DESCRIPTION
Fixes mozilla/addons#15714

Adds a 14px top margin to the summary text box in the header

### Before
<img width="2931" height="651" alt="Screenshot 2025-07-28 180527" src="https://github.com/user-attachments/assets/af434cfb-9f38-4489-b75e-b27d027dcdc9" />

### After
<img width="2929" height="667" alt="Screenshot 2025-07-28 180504" src="https://github.com/user-attachments/assets/e663b7bb-a1a2-49c6-9fb3-2d9459fbe58c" />
