### PR TITLE
Wrap <dl> contents and avoid breaking columns inside

### DIFF
--- a/src/amo/components/DefinitionList/index.js
+++ b/src/amo/components/DefinitionList/index.js
@@ -16,10 +16,10 @@ export const Definition = ({
   term,
 }: DefinitionProps): React.Node => {
   return (
-    <>
+    <div>
       <dt className="Definition-dt">{term}</dt>
       <dd className={makeClassName('Definition-dd', className)}>{children}</dd>
-    </>
+    </div>
   );
 };
 

--- a/src/amo/components/DefinitionList/styles.scss
+++ b/src/amo/components/DefinitionList/styles.scss
@@ -5,7 +5,6 @@
   padding: 0;
 
   ul {
-    break-inside: avoid;
     list-style: none;
     margin: 0;
     padding: 0;

--- a/src/amo/components/DefinitionList/styles.scss
+++ b/src/amo/components/DefinitionList/styles.scss
@@ -5,9 +5,14 @@
   padding: 0;
 
   ul {
+    break-inside: avoid;
     list-style: none;
     margin: 0;
     padding: 0;
+  }
+
+  div {
+    break-inside: avoid;
   }
 }
 


### PR DESCRIPTION
An alternative would have been to set break-after: avoid(-column) on the <dt> but that's not supported by Firefox yet.

Fixes mozilla/addons#15726

### Screenshots
#### Before
<img width="2636" height="444" alt="Screenshot 2025-07-31 at 13-50-17 Promoted requeued-Jul 8 2025 – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/cf154eba-7931-47cc-a177-00144ba9bd1e" />

#### After
<img width="2636" height="486" alt="Screenshot 2025-07-31 at 13-50-25 Promoted requeued-Jul 8 2025 – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/468c6f74-79b4-42d3-beb9-eed6672247d5" />
