### PR TITLE
Combine overall ratings with about card at extraExtraLarge breakpoint

### DIFF
--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -209,8 +209,7 @@ export class RatingManagerBase extends React.Component<InternalProps> {
           />
           {/* eslint-enable react/no-danger */}
           <div className="RatingManager-ratingControl">
-            {!this.isSignedIn() ? this.renderLogInToRate() : null}
-            {i18n.gettext('Click to rate:')}
+            {this.isSignedIn() ? i18n.gettext('Click to rate:') : this.renderLogInToRate()}
             {userReview && onDeleteScreen ? (
               <AddonReviewManagerRating
                 className="RatingManager-AddonReviewManagerRating"

--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -209,7 +209,9 @@ export class RatingManagerBase extends React.Component<InternalProps> {
           />
           {/* eslint-enable react/no-danger */}
           <div className="RatingManager-ratingControl">
-            {this.isSignedIn() ? i18n.gettext('Click to rate:') : this.renderLogInToRate()}
+            {this.isSignedIn()
+              ? i18n.gettext('Click to rate:')
+              : this.renderLogInToRate()}
             {userReview && onDeleteScreen ? (
               <AddonReviewManagerRating
                 className="RatingManager-AddonReviewManagerRating"

--- a/src/amo/components/ShowMoreCard/styles.scss
+++ b/src/amo/components/ShowMoreCard/styles.scss
@@ -27,16 +27,26 @@
   }
 }
 
+.AddonDescription {
+  .ShowMoreCard-contents {
+    // Keep in sync with `maxHeight` passed to the `ShowMoreCard` component in
+    // `Addon/index.js`
+    max-height: 230px;
+  }
+}
+
+.PermissionsCard {
+  .ShowMoreCard-contents {
+    // Keep in sync with `maxHeight` passed to the `ShowMoreCard` component in
+    // `PermissionCard/index.js`.
+    max-height: 300px;
+  }
+}
+
 .AddonDescription,
 .PermissionsCard {
   .Card-contents {
     border-radius: 0;
-  }
-
-  .ShowMoreCard-contents {
-    // Keep in sync with `maxHeight` passed to the `ShowMoreCard` component in
-    // `Addon/index.js` and `PermissionCard/index.js`.
-    max-height: 300px;
   }
 
   &.ShowMoreCard--expanded .ShowMoreCard-contents {

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -322,7 +322,7 @@ export class AddonBase extends React.Component {
         className={showMoreCardName}
         header={title}
         id={showMoreCardName}
-        maxHeight={300}
+        maxHeight={230}
       >
         {descriptionProps && Object.keys(descriptionProps).length ? (
           <div className="AddonDescription-contents" {...descriptionProps} />
@@ -547,9 +547,10 @@ export class AddonBase extends React.Component {
                 </Card>
               ) : null}
 
-              {this.renderAboutThisCard()}
-
-              {this.renderRatingsCard()}
+              <Card className="Addon-description-rating-card">
+                {this.renderAboutThisCard()}
+                {this.renderRatingsCard()}
+              </Card>
             </div>
 
             <PermissionsCard version={currentVersion} />

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -6,10 +6,6 @@
 
 .Addon .Card {
   margin-bottom: $padding-page;
-
-  @include respond-to(large) {
-    margin-bottom: $padding-page-l;
-  }
 }
 
 .Addon-icon-wrapper {
@@ -117,6 +113,32 @@
   width: 100%;
 }
 
+.Addon-description-rating-card > .Card-contents {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+.Addon-description-rating-card {
+  .AddonDescription {
+    max-width: 760px;
+  }
+
+  .Addon-overall-rating {
+    margin-bottom: 0;
+
+    @include respond-to(medium) {
+      min-width: 380px;
+      max-width: 520px;
+      flex-grow: 1;
+    }
+
+    .Card-contents {
+      border-radius: 0;
+    }
+  }
+}
+
 // Details section with lots of grid stuff, on larger displays.
 @include respond-to(large) {
   .Addon-screenshots {
@@ -142,6 +164,23 @@
 @include respond-to(extraExtraLarge) {
   .AddonMoreInfo dl {
     column-count: 3;
+  }
+
+  .Addon-description-rating-card > .Card-contents {
+    flex-direction: row;
+  }
+
+  .Addon-description-rating-card {
+    .AddonDescription,
+    .Addon-overall-rating {
+      margin-bottom: 0;
+
+      .Card-contents,
+      .Card-header,
+      .Card-footer {
+        border-radius: 0;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15733

### Description of changes

- Stopped displaying "Click to rate" text if not logged in (it was overlapping with the "Log in to rate this extension" in some sizes, and obviously redundant)
- Reduced margin between cards overall in larger breakpoint to reduce wasted vertical space since the card layout is going away soon anyway
- Added some min/max widths where appropriate
- Moved overall ratings and description in a wrapper card, and let both be displayed side by side are higher resolutions
  - Overrode the rounded corners on both cards as a result, the rounded corners are coming from the wrapper now
- Tweaked description area height before triggering "Read more"

### Context & notes

Because the final design doesn't have the card-style layout with rounded corners etc I had to improvise a bit, and ultimately chose to wrap the cards in another card. This makes the design kinda inconsistent, because the grey border around card headers & footers is normally provided by the grey background, but here the background of the inner cards is white from the wrapper card instead, so you don't see those borders. I feel like this is a good compromise before getting rid of that style in phase 2.

### Screenshots

#### Before
<details><summary>Extra Extra Large</summary><img width="2640" height="1816" alt="Screenshot 2025-08-01 at 14-39-06 Tree Style Tab – Holen Sie sich diese Erweiterung für 🦊 Firefox (de)" src="https://github.com/user-attachments/assets/6d388a8e-23c5-411a-acfb-bf350c9335ea" /></details>

<details><summary>Large</summary>
<img width="1650" height="1790" alt="Screenshot 2025-08-01 at 14-39-38 Tree Style Tab – Holen Sie sich diese Erweiterung für 🦊 Firefox (de)" src="https://github.com/user-attachments/assets/771712bd-fc8c-4178-97a4-88dffb3e1e32" /></details>

<details><summary>"Small"</summary>
<img width="948" height="1504" alt="Screenshot 2025-08-01 at 14-40-14 Tree Style Tab – Holen Sie sich diese Erweiterung für 🦊 Firefox (de)" src="https://github.com/user-attachments/assets/a9f5ee59-baf0-443f-b4f5-8725e089a83c" /></details>

#### After
<details><summary>Extra Extra Large</summary>
<img width="2642" height="862" alt="Screenshot 2025-08-01 at 14-44-36 Tree Style Tab – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/6f905484-87a5-4b85-8a04-3155f8facaf8" /></details>

<details><summary>Large</summary>
<img width="1650" height="1520" alt="Screenshot 2025-08-01 at 14-46-25 Tree Style Tab – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/028821c4-72b3-4f59-9d51-95e5ab7f381f" /></details>

<details><summary>"Small"</summary>
<img width="948" height="1338" alt="Screenshot 2025-08-01 at 14-50-26 Tree Style Tab – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/566829bf-0a47-4360-8121-8ea3f9f7106b" /></details>

<details><summary>Bonus Extra Extra Large with short description</summary>
<img width="2704" height="766" alt="Screenshot 2025-08-01 at 14-56-50 SearchbyImageSearchbyImageSearchbyImageSearchbyIma – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/43389ac6-f5a5-4f9a-8667-359e8a67e5bb" /></details>

<details><summary>Bonus Extra Extra Large logged in</summary>
<img width="2642" height="892" alt="Screenshot 2025-08-01 at 15-01-50 Tree Style Tab – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/a4a9e8b3-f7b6-42e9-97b2-aeb0c1d8ab93" /></details>


