### PR TITLE
`langs` not `lang`

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -3,7 +3,7 @@ import {
   apiDevHost,
   baseUrlDev,
   devDomain,
-  devLang,
+  devLangs,
   ga4AdditionalAnalyticsHost,
   ga4AnalyticsHost,
   ga4TagManagerHost,
@@ -56,6 +56,5 @@ module.exports = {
 
   extensionWorkshopUrl: 'https://extensionworkshop.allizom.org',
 
-  lang: devLang,
+  langs: devLangs,
 };
-

--- a/config/development.js
+++ b/config/development.js
@@ -2,7 +2,7 @@
 import {
   apiDevHost,
   baseUrlDev,
-  devLang,
+  devLangs,
   ga4AdditionalAnalyticsHost,
   ga4AnalyticsHost,
   ga4TagManagerHost,
@@ -90,5 +90,5 @@ module.exports = {
 
   extensionWorkshopUrl: 'https://extensionworkshop.allizom.org',
 
-  lang: devLang,
+  langs: devLangs,
 };

--- a/config/lib/shared.js
+++ b/config/lib/shared.js
@@ -21,7 +21,7 @@ export const serverStaticPath = '/static-server/';  // addons-server statics.
 export const mediaPath = '/user-media/';  // addons-server user-uploaded media.
 
 // These are all the locales in pontoon
-export const devLang = [
+export const devLangs = [
     'af',
     'ar',
     'ast',


### PR DESCRIPTION
Fixes mozilla/addons#15687 again

I stupidly changed the name of the `langs` config to `lang` while refactoring
