### PR TITLE
Remove GetFirefoxCallout as it totally breaks the layout and is absolutely not worth it.

### DIFF
--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -154,18 +154,6 @@ export const GetFirefoxButtonBase = ({
   const buttonText = supportsRTAMO
     ? downloadTextForRTAMO
     : i18n.gettext('Download Firefox');
-  let calloutText =
-    addon.type === ADDON_TYPE_STATIC_THEME
-      ? i18n.gettext(`You'll need Firefox to use this theme`)
-      : i18n.gettext(`You'll need Firefox to use this extension`);
-  if (forIncompatibleAddon) {
-    calloutText =
-      addon.type === ADDON_TYPE_STATIC_THEME
-        ? i18n.gettext('You need an updated version of Firefox for this theme')
-        : i18n.gettext(
-            'You need an updated version of Firefox for this extension',
-          );
-  }
 
   const buttonContent = (
     <Button
@@ -181,10 +169,6 @@ export const GetFirefoxButtonBase = ({
 
   return (
     <div className={makeClassName('GetFirefoxButton', className)}>
-      <div className="GetFirefoxButton-callout">
-        <div className="GetFirefoxButton-callout-icon" />
-        <div className="GetFirefoxButton-callout-text">{calloutText}</div>
-      </div>
       {buttonContent}
     </div>
   );

--- a/src/amo/components/GetFirefoxButton/styles.scss
+++ b/src/amo/components/GetFirefoxButton/styles.scss
@@ -1,57 +1,16 @@
 @import '~amo/css/styles';
 
-$callout-color: $yellow-50;
-
 .GetFirefoxButton-button {
-  display: flex;
-  margin: auto;
-  white-space: nowrap;
-  width: 100%;
+  background: #ffe900;
+  // Button.tsx defines classes that override this color, so we need to use !important
+  color: black !important;
 
-  @include respond-to(medium) {
-    align-self: flex-end;
-    margin-bottom: 12px;
-    margin-top: 0;
-    width: fit-content;
+  @include respond-to(extraLarge) {
+    text-wrap: nowrap;
   }
-}
 
-.GetFirefoxButton-callout {
-  background-color: $callout-color;
-  border: 1px solid $callout-color;
-  border-radius: 4px;
-  color: $grey-90;
-  display: flex;
-  justify-content: center;
-  margin: 16px 0;
-  padding: 10px;
-  position: relative;
+  width: 100%;
+  text-wrap: wrap;
   text-align: center;
-  width: 100%;
-
-  @include respond-to(medium) {
-    margin: 16px auto;
-    width: fit-content;
-  }
-
-  &::before {
-    border: 0.8em solid transparent;
-    border-top: 10px solid $callout-color;
-    bottom: -20px;
-    content: '';
-    height: 0;
-    left: 45%;
-    position: absolute;
-    width: 0;
-  }
-}
-
-.GetFirefoxButton-callout-icon {
-  @include margin-end(4px);
-
-  background-image: url('../Notice/img/generic-info-mark.svg');
-  height: 16px;
-  margin: 2px 0 0;
-  min-width: 16px;
-  width: 16px;
+  padding: 12px 18px;
 }

--- a/src/amo/components/InstallButtonWrapper/styles.scss
+++ b/src/amo/components/InstallButtonWrapper/styles.scss
@@ -1,29 +1,5 @@
 @import '~amo/css/styles';
 
-.InstallButtonWrapper {
-  display: flex;
-  flex-direction: column;
-
-  .GetFirefoxButton {
-    display: flex;
-    flex-direction: column;
-
-    .GetFirefoxButton-button,
-    .GetFirefoxButton-callout {
-      max-width: 100%;
-      text-align: center;
-      white-space: initial;
-      width: 100%;
-    }
-
-    @include respond-to(extraLarge) {
-      .GetFirefoxButton-button {
-        white-space: nowrap;
-      }
-    }
-  }
-}
-
 .InstallButtonWrapper-download {
   margin: 12px 0;
 

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -93,18 +93,8 @@ $icon-size: 48px;
   text-align: center;
   width: 100%;
 
-  &,
-  .GetFirefoxButton-button,
-  .GetFirefoxButton-callout {
-    box-sizing: border-box;
-  }
-
   .GetFirefoxButton-button {
     margin-bottom: 0;
-  }
-
-  .GetFirefoxButton-callout {
-    margin-top: 0;
   }
 
   @include respond-to(medium) {

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -635,46 +635,6 @@ describe(__filename, () => {
         ).toBeInTheDocument();
       });
 
-      it('has the expected callout text for an extension', () => {
-        render();
-
-        expect(
-          screen.getByText(`You'll need Firefox to use this extension`),
-        ).toBeInTheDocument();
-      });
-
-      it('has the expected callout text for an extension, which is incompatible', () => {
-        renderAsIncompatible();
-
-        expect(
-          screen.getByText(
-            'You need an updated version of Firefox for this extension',
-          ),
-        ).toBeInTheDocument();
-      });
-
-      it('has the expected callout text for a theme', () => {
-        addon.type = ADDON_TYPE_STATIC_THEME;
-
-        render();
-
-        expect(
-          screen.getByText(`You'll need Firefox to use this theme`),
-        ).toBeInTheDocument();
-      });
-
-      it('has the expected callout text for a theme, which is incompatible', () => {
-        addon.type = ADDON_TYPE_STATIC_THEME;
-
-        renderAsIncompatible();
-
-        expect(
-          screen.getByText(
-            'You need an updated version of Firefox for this theme',
-          ),
-        ).toBeInTheDocument();
-      });
-
       it('sends a tracking event when the button is clicked', async () => {
         render();
 

--- a/tests/unit/blog-utils/test_index.js
+++ b/tests/unit/blog-utils/test_index.js
@@ -50,7 +50,6 @@ describe(__filename, () => {
       expect(html('.StaticAddonCard')).toHaveLength(1);
       expect(html('.GetFirefoxButton')).toHaveLength(1);
       expect(html('.GetFirefoxButton-button')).toHaveLength(1);
-      expect(html('.GetFirefoxButton-callout')).toHaveLength(1);
     });
 
     it('lets the caller catch and handle errors', async () => {


### PR DESCRIPTION

Fixes #15710

## Description

This PR removes the persistent tooltip "you'll need firefox.." positioned above the download/install button on non-firefox browsers.

## Context

As noted in the ticket, the tooltip adds significant height to the download button, causing empty space on certain screen widths.

Additionally, the content of the tooltip is not particularly enlightening for the user as the text of the button already says a variation of "download firefox" or "download firefox and install X" dependning on RTAMO availability.

So rather than trying to finese this text into the layout, removing it removes the original problem with much lower effort.

## Testing

### Standard flow

- Open an extension details page on a non-firefox browser
- expect not to see the persistent tooltip
- expect to see a yellow download fgirefox button that redirects to firefox download page

### RTAMO flow

TBD (how to enable RTAMO locally)

## Screenshots

### Small screen

<img width="486" height="518" alt="Screenshot 2025-08-11 at 12 51 32" src="https://github.com/user-attachments/assets/6f52b628-9411-4e9f-bd1d-58112fb6501b" />

<img width="483" height="589" alt="Screenshot 2025-08-11 at 13 42 46" src="https://github.com/user-attachments/assets/527bf099-e4d3-4182-9cb2-cfa12ed3d061" />

### Medium screen
<img width="752" height="467" alt="Screenshot 2025-08-11 at 12 51 09" src="https://github.com/user-attachments/assets/63d74da7-ed97-47c1-9523-27002cbe6e25" />

<img width="783" height="582" alt="Screenshot 2025-08-11 at 13 41 38" src="https://github.com/user-attachments/assets/6507f500-0623-405f-b869-e3485d952d64" />

### Large screen
<img width="1074" height="382" alt="Screenshot 2025-08-11 at 13 41 46" src="https://github.com/user-attachments/assets/9381022f-8fcf-4bbf-bce5-ecae8dde4f26" />

<img width="1352" height="310" alt="Screenshot 2025-08-11 at 12 50 33" src="https://github.com/user-attachments/assets/a24cf291-23df-4018-a9cd-d6154569b2d7" />
