### PR TITLE
Bump main bundle max size (368 -> 369kB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
   "bundlewatch": [
     {
       "path": "./dist/static/amo-!(i18n-)*.js",
-      "maxSize": "368 kB"
+      "maxSize": "369 kB"
     },
     {
       "path": "./dist/static/amo-i18n-*.js",


### PR DESCRIPTION
This is needed for https://github.com/mozilla/addons-frontend/pull/13746 at least.