### PR TITLE
Pass updated/created threshold query parameters to search API

### DIFF
--- a/src/amo/searchUtils.js
+++ b/src/amo/searchUtils.js
@@ -26,6 +26,7 @@ export const paramsToFilter = {
   author: 'author',
   category: 'category',
   color: 'color',
+  ...generateThresholdParams('created'),
   exclude_addons: 'exclude_addons',
   guid: 'guid',
   page: 'page',
@@ -37,6 +38,7 @@ export const paramsToFilter = {
   sort: 'sort',
   tag: 'tag',
   type: 'addonType',
+  ...generateThresholdParams('updated'),
   ...generateThresholdParams('users'),
 };
 

--- a/tests/unit/amo/test_searchUtils.js
+++ b/tests/unit/amo/test_searchUtils.js
@@ -261,7 +261,9 @@ describe(__filename, () => {
 
   describe('paramsToFilter', () => {
     it('generates all the required threshold parameters for ratings and users', () => {
+      expect(paramsToFilter).toMatchObject({ created__gte: 'created__gte' });
       expect(paramsToFilter).toMatchObject({ ratings__gt: 'ratings__gt' });
+      expect(paramsToFilter).toMatchObject({ updated__lt: 'updated__lt' });
       expect(paramsToFilter).toMatchObject({ users__lte: 'users__lte' });
       expect(paramsToFilter).toMatchObject({ users: 'users' });
     });


### PR DESCRIPTION
Companion to https://github.com/mozilla/addons/issues/15814

Allows using `created` and `updated` threshold parameters in the search page by modifying the URL.

`http://localhost:3000/en-US/firefox/search/?created__gte=2025-01-01` for instance locally should only return add-ons created in 2025.