### PR TITLE
Add cooldown period to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7      
     open-pull-requests-limit: 99
     ignore:
       - dependency-name: "ua-parser-js"
@@ -16,3 +20,5 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7      


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15842

Makes dependabot wait for 7 days before suggesting an update.