### PR TITLE
Fix dependabot config since docker/github-actions support for cooldown is unreliable

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default-days: 7      
+      default-days: 7
     open-pull-requests-limit: 99
     ignore:
       - dependency-name: "ua-parser-js"
@@ -18,5 +18,3 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    cooldown:
-      default-days: 7      


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15855