### PR TITLE
Remove tooltip (callout) on the install button

### DIFF
--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -154,18 +154,6 @@ export const GetFirefoxButtonBase = ({
   const buttonText = supportsRTAMO
     ? downloadTextForRTAMO
     : i18n.gettext('Download Firefox');
-  let calloutText =
-    addon.type === ADDON_TYPE_STATIC_THEME
-      ? i18n.gettext(`You'll need Firefox to use this theme`)
-      : i18n.gettext(`You'll need Firefox to use this extension`);
-  if (forIncompatibleAddon) {
-    calloutText =
-      addon.type === ADDON_TYPE_STATIC_THEME
-        ? i18n.gettext('You need an updated version of Firefox for this theme')
-        : i18n.gettext(
-            'You need an updated version of Firefox for this extension',
-          );
-  }
 
   const buttonContent = (
     <Button
@@ -181,10 +169,6 @@ export const GetFirefoxButtonBase = ({
 
   return (
     <div className={makeClassName('GetFirefoxButton', className)}>
-      <div className="GetFirefoxButton-callout">
-        <div className="GetFirefoxButton-callout-icon" />
-        <div className="GetFirefoxButton-callout-text">{calloutText}</div>
-      </div>
       {buttonContent}
     </div>
   );

--- a/src/amo/components/GetFirefoxButton/styles.scss
+++ b/src/amo/components/GetFirefoxButton/styles.scss
@@ -1,57 +1,12 @@
 @import '~amo/css/styles';
 
-$callout-color: $yellow-50;
-
 .GetFirefoxButton-button {
-  display: flex;
-  margin: auto;
-  white-space: nowrap;
-  width: 100%;
-
-  @include respond-to(medium) {
-    align-self: flex-end;
-    margin-bottom: 12px;
-    margin-top: 0;
-    width: fit-content;
-  }
-}
-
-.GetFirefoxButton-callout {
-  background-color: $callout-color;
-  border: 1px solid $callout-color;
-  border-radius: 4px;
-  color: $grey-90;
-  display: flex;
-  justify-content: center;
-  margin: 16px 0;
-  padding: 10px;
-  position: relative;
+  padding: 12px 18px;
   text-align: center;
+  text-wrap: wrap;
   width: 100%;
 
-  @include respond-to(medium) {
-    margin: 16px auto;
-    width: fit-content;
+  @include respond-to(extraLarge) {
+    text-wrap: nowrap;
   }
-
-  &::before {
-    border: 0.8em solid transparent;
-    border-top: 10px solid $callout-color;
-    bottom: -20px;
-    content: '';
-    height: 0;
-    left: 45%;
-    position: absolute;
-    width: 0;
-  }
-}
-
-.GetFirefoxButton-callout-icon {
-  @include margin-end(4px);
-
-  background-image: url('../Notice/img/generic-info-mark.svg');
-  height: 16px;
-  margin: 2px 0 0;
-  min-width: 16px;
-  width: 16px;
 }

--- a/src/amo/components/InstallButtonWrapper/styles.scss
+++ b/src/amo/components/InstallButtonWrapper/styles.scss
@@ -1,29 +1,5 @@
 @import '~amo/css/styles';
 
-.InstallButtonWrapper {
-  display: flex;
-  flex-direction: column;
-
-  .GetFirefoxButton {
-    display: flex;
-    flex-direction: column;
-
-    .GetFirefoxButton-button,
-    .GetFirefoxButton-callout {
-      max-width: 100%;
-      text-align: center;
-      white-space: initial;
-      width: 100%;
-    }
-
-    @include respond-to(extraLarge) {
-      .GetFirefoxButton-button {
-        white-space: nowrap;
-      }
-    }
-  }
-}
-
 .InstallButtonWrapper-download {
   margin: 12px 0;
 

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -94,17 +94,12 @@ $icon-size: 48px;
   width: 100%;
 
   &,
-  .GetFirefoxButton-button,
-  .GetFirefoxButton-callout {
+  .GetFirefoxButton-button {
     box-sizing: border-box;
   }
 
   .GetFirefoxButton-button {
     margin-bottom: 0;
-  }
-
-  .GetFirefoxButton-callout {
-    margin-top: 0;
   }
 
   @include respond-to(medium) {

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -635,46 +635,6 @@ describe(__filename, () => {
         ).toBeInTheDocument();
       });
 
-      it('has the expected callout text for an extension', () => {
-        render();
-
-        expect(
-          screen.getByText(`You'll need Firefox to use this extension`),
-        ).toBeInTheDocument();
-      });
-
-      it('has the expected callout text for an extension, which is incompatible', () => {
-        renderAsIncompatible();
-
-        expect(
-          screen.getByText(
-            'You need an updated version of Firefox for this extension',
-          ),
-        ).toBeInTheDocument();
-      });
-
-      it('has the expected callout text for a theme', () => {
-        addon.type = ADDON_TYPE_STATIC_THEME;
-
-        render();
-
-        expect(
-          screen.getByText(`You'll need Firefox to use this theme`),
-        ).toBeInTheDocument();
-      });
-
-      it('has the expected callout text for a theme, which is incompatible', () => {
-        addon.type = ADDON_TYPE_STATIC_THEME;
-
-        renderAsIncompatible();
-
-        expect(
-          screen.getByText(
-            'You need an updated version of Firefox for this theme',
-          ),
-        ).toBeInTheDocument();
-      });
-
       it('sends a tracking event when the button is clicked', async () => {
         render();
 

--- a/tests/unit/blog-utils/test_index.js
+++ b/tests/unit/blog-utils/test_index.js
@@ -50,7 +50,6 @@ describe(__filename, () => {
       expect(html('.StaticAddonCard')).toHaveLength(1);
       expect(html('.GetFirefoxButton')).toHaveLength(1);
       expect(html('.GetFirefoxButton-button')).toHaveLength(1);
-      expect(html('.GetFirefoxButton-callout')).toHaveLength(1);
     });
 
     it('lets the caller catch and handle errors', async () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15710

---

Per UX guidance, we should remove the yellow callout component. This, in turn, fixes https://github.com/mozilla/addons/issues/15710 and it wontfixes https://github.com/mozilla/addons/issues/15712, yay.

## Before

<img width="1624" height="1001" alt="Screenshot 2025-09-26 at 11 28 41" src="https://github.com/user-attachments/assets/1ba4b6ce-eb25-4635-a785-650145133641" />
<img width="1624" height="1001" alt="Screenshot 2025-09-26 at 11 28 37" src="https://github.com/user-attachments/assets/1bd9f938-59c3-4e2e-8877-c31a2cddaa73" />
<img width="1624" height="1001" alt="Screenshot 2025-09-26 at 11 28 35" src="https://github.com/user-attachments/assets/7a9feda9-7883-4d7d-a956-3b96973b12f8" />

## After

<img width="1624" height="1001" alt="Screenshot 2025-09-26 at 11 28 17" src="https://github.com/user-attachments/assets/b7571642-c472-4874-8ae2-d5c7b318a0e5" />
<img width="1624" height="1001" alt="Screenshot 2025-09-26 at 11 28 12" src="https://github.com/user-attachments/assets/42f4cc04-8c5d-4baa-9688-58f8cc3df0f1" />
<img width="1624" height="1001" alt="Screenshot 2025-09-26 at 11 28 10" src="https://github.com/user-attachments/assets/4f2c1a3e-582c-4dc8-981a-02ee4666f4c6" />
