### PR TITLE
Simplify how we list the badges in AddonBadges

### DIFF
--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -6,41 +6,4 @@
   gap: 6px;
   align-items: flex-start;
   align-content: flex-start;
-
-  .Addon-theme & {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  @include respond-to(large) {
-    grid-column: 2;
-    grid-row: 1;
-
-    .Addon-theme & {
-      grid-column: auto;
-      grid-row: auto;
-    }
-  }
-}
-
-.AddonBadges .Badge {
-  @include text-align-start;
-
-  .Addon-theme & {
-    @include margin-end(12px);
-  }
-
-  @include respond-to(large) {
-    @include text-align-end;
-
-    .Addon-theme & {
-      @include margin-start(0);
-    }
-
-    .Icon {
-      .Addon-theme & {
-        margin: 0;
-      }
-    }
-  }
 }


### PR DESCRIPTION
Refs https://github.com/mozilla/addons/issues/15703

~~:warning: Depends on https://github.com/mozilla/addons-frontend/pull/13825~~

---

I am not clear on why this was needed, but removing this code makes the
theme page look a lot better, and more consistent with the extension
page.