### PR TITLE
Align badges with summary (info)

### DIFF
--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -52,7 +52,7 @@
     grid-template:
       'theme theme theme' auto
       'icon info info' auto
-      'badge badge badge' auto
+      '.   badge badge' auto
       '.   .   install' auto / auto 1fr 1fr;
   }
 
@@ -60,15 +60,15 @@
     grid-template:
       'theme theme theme theme theme' auto
       'icon info info info info' auto
-      'badge badge badge  .   . ' auto
-      'badge badge badge  .  install' auto / min-content 1fr 1fr 1fr 1fr;
+      '. badge badge  .   . ' auto
+      '. badge badge  .  install' auto / min-content 1fr 1fr 1fr 1fr;
   }
 
   @include respond-to(extraLarge) {
     grid-template:
       'theme theme theme theme theme  .  install' auto
       'icon info info info info  .  install' auto
-      'badge badge badge badge badge badge badge' auto / min-content 1fr 1fr 1fr 1fr 1fr 1fr;
+      '. badge badge badge badge badge badge' auto / min-content 1fr 1fr 1fr 1fr 1fr 1fr;
   }
 
   @include respond-to(extraExtraLarge) {
@@ -77,7 +77,7 @@
     grid-template:
       'theme theme theme theme install install' auto
       'icon info info info  .  install' auto
-      'badge badge badge badge badge badge' auto / min-content 1fr 1fr 1fr 1fr 1fr;
+      '. badge badge badge badge badge' auto / min-content 1fr 1fr 1fr 1fr 1fr;
     // stylelint-enable named-grid-areas-no-invalid
   }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15860

---

Before:

<img width="1410" height="351" alt="Screenshot 2025-09-26 at 17 57 34" src="https://github.com/user-attachments/assets/ef0f2a99-d61f-4bd7-a4c4-741cb5058be6" />

After:

<img width="1394" height="341" alt="Screenshot 2025-09-26 at 17 57 23" src="https://github.com/user-attachments/assets/0445bb1f-13b3-46a2-8f40-6a7617666369" />