### PR TITLE
Unify most detail page components in a single card

### DIFF
--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -454,53 +454,49 @@ export class AddonBase extends React.Component {
 
           {this.renderCategorySuggestions(VARIANT_SHOW_TOP)}
 
-          <div>
-            <Card className="Addon-header-info-card" photonStyle>
-              <div className="Addon-warnings">
-                <AddonInstallError error={this.props.installError} />
+          <Card className="Addon-content" photonStyle>
+            <div className="Addon-warnings">
+              <AddonInstallError error={this.props.installError} />
 
-                <AddonCompatibilityError addon={addon} />
+              <AddonCompatibilityError addon={addon} />
 
-                {addon &&
-                (addon.status !== STATUS_PUBLIC || addon.is_disabled) ? (
-                  <Notice type="error" className="Addon-non-public-notice">
-                    {i18n.gettext(
-                      'This is not a public listing. You are only seeing it because of elevated permissions.',
-                    )}
-                  </Notice>
-                ) : null}
+              {addon &&
+              (addon.status !== STATUS_PUBLIC || addon.is_disabled) ? (
+                <Notice type="error" className="Addon-non-public-notice">
+                  {i18n.gettext(
+                    'This is not a public listing. You are only seeing it because of elevated permissions.',
+                  )}
+                </Notice>
+              ) : null}
 
-                {addon && <InstallWarning addon={addon} />}
-                {addon ? (
-                  <WrongPlatformWarning
-                    addon={addon}
-                    className="Addon-WrongPlatformWarning"
-                  />
-                ) : null}
+              {addon && <InstallWarning addon={addon} />}
+              {addon ? (
+                <WrongPlatformWarning
+                  addon={addon}
+                  className="Addon-WrongPlatformWarning"
+                />
+              ) : null}
+            </div>
+
+            <header className="Addon-header">
+              {this.headerImage()}
+
+              <div className="Addon-info">
+                <AddonTitle addon={addon} />
+                {showSummary ? summary : null}
+              </div>
+              <AddonBadges addon={addon} />
+              <div className="Addon-install">
+                <InstallButtonWrapper addon={addon} />
               </div>
 
-              <header className="Addon-header">
-                {this.headerImage()}
+              <h2 className="visually-hidden">
+                {i18n.gettext('Extension Metadata')}
+              </h2>
+            </header>
 
-                <div className="Addon-info">
-                  <AddonTitle addon={addon} />
-                  {showSummary ? summary : null}
-                </div>
-                <AddonBadges addon={addon} />
-                <div className="Addon-install">
-                  <InstallButtonWrapper addon={addon} />
-                </div>
+            {this.renderCategorySuggestions(VARIANT_SHOW_MIDDLE)}
 
-                <h2 className="visually-hidden">
-                  {i18n.gettext('Extension Metadata')}
-                </h2>
-              </header>
-            </Card>
-          </div>
-
-          {this.renderCategorySuggestions(VARIANT_SHOW_MIDDLE)}
-
-          <div className="Addon-details">
             <div className="Addon-main-content">
               {addonPreviews.length > 0 && !isThemeType ? (
                 <Card
@@ -511,16 +507,18 @@ export class AddonBase extends React.Component {
                 </Card>
               ) : null}
 
-              <Card className="Addon-description-rating-card">
+              <div className="Addon-description-and-ratings">
                 {this.renderAboutThisCard()}
                 {this.renderRatingsCard()}
-              </Card>
+              </div>
             </div>
 
             <PermissionsCard version={currentVersion} />
 
             <AddonMoreInfo addon={addon} />
+          </Card>
 
+          <div>
             <ContributeCard addon={addon} />
 
             {this.renderVersionReleaseNotes()}

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -25,17 +25,25 @@
   width: 100%;
 }
 
-.Addon-header-info-card {
-  .AddonCompatibilityError,
-  .Addon-non-public-notice {
-    margin: 0;
-    margin-bottom: 12px;
-  }
+.Addon-warnings {
+  margin-bottom: 16px;
+}
 
-  .Card-contents {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+.Addon-screenshots,
+.PermissionsCard,
+.AddonMoreInfo,
+.Addon-description-and-ratings {
+  border-top: 1px solid $grey-30;
+  margin-top: 32px;
+  padding-top: 16px;
+}
+
+.Addon-content {
+  * > .Card-header,
+  * > .Card-contents {
+    border-radius: 0;
+    margin: 0;
+    padding: 0;
   }
 }
 
@@ -114,13 +122,10 @@
   width: 100%;
 }
 
-.Addon-description-rating-card > .Card-contents {
+.Addon-description-and-ratings {
   display: flex;
   flex-direction: column;
-  padding: 0;
-}
 
-.Addon-description-rating-card {
   .AddonDescription {
     max-width: 760px;
   }
@@ -135,6 +140,19 @@
 
     .Card-contents {
       border-radius: 0;
+    }
+  }
+
+  @include respond-to(extraExtraLarge) {
+    .AddonDescription,
+    .Addon-overall-rating {
+      flex-grow: 1;
+
+      .Card-contents,
+      .Card-header,
+      .Card-footer {
+        border-radius: 0;
+      }
     }
   }
 }
@@ -166,22 +184,8 @@
     column-count: 3;
   }
 
-  .Addon-description-rating-card > .Card-contents {
+  .Addon-description-and-ratings {
     flex-direction: row;
-  }
-
-  .Addon-description-rating-card {
-    .AddonDescription,
-    .Addon-overall-rating {
-      flex-grow: 1;
-      margin-bottom: 0;
-
-      .Card-contents,
-      .Card-header,
-      .Card-footer {
-        border-radius: 0;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15862

---

This is the first step to have a unified body. We'll figure out the exact spacing/sizes in a different patch.


### Screenshots

(1) Before: https://addons-dev.allizom.org/fa/firefox/addon/cas-current-theme-1/

After:

<img width="3024" height="3438" alt="Screenshot 2025-09-29 at 10-14-02 cas-current-theme-1 – Get this Theme for 🦊 Firefox (fa)" src="https://github.com/user-attachments/assets/336cc01d-2b8f-44ee-b343-27cf49546a96" />

---

(2) Before: https://addons-dev.allizom.org/en-US/firefox/addon/release-lang-pack777/

After:

<img width="3024" height="3236" alt="Screenshot 2025-09-29 at 10-14-11 Langpack - en-US – Get this Language Pack for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/8e5ddc3e-3658-4b1c-973d-294154e4d7ec" />

---

(3) Before: https://addons-dev.allizom.org/en-US/firefox/addon/just-recommended-for-firefox/

After:

<img width="3024" height="4040" alt="Screenshot 2025-09-29 at 10-14-17 Just recommended for firefox – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/d6a5b564-59ab-4746-b7a3-3150570b4623" />

---

(4) Before: https://addons-dev.allizom.org/en-US/android/addon/mixed-unlisted-pending-rej/

After:

<img width="3024" height="3618" alt="Screenshot 2025-09-29 at 10-14-30 mixed - listed unlisted – Get this Extension for 🦊 Firefox Android (en-US)" src="https://github.com/user-attachments/assets/7acd2d5b-7757-4c92-9d88-4b1ffaf586f1" />

---

(5). Before: https://addons-dev.allizom.org/en-US/firefox/addon/dark22reader/

After:

<img width="3024" height="4768" alt="Screenshot 2025-09-29 at 10-20-32 AUTOMATION Addon versions page – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/8b278918-12e4-440e-a1b8-535afa1b54a9" />
