### PR TITLE
Add some padding between the content and rating components on large screens

### DIFF
--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -144,6 +144,10 @@
   }
 
   @include respond-to(extraExtraLarge) {
+    .AddonDescription {
+      @include padding-end(24px);
+    }
+
     .AddonDescription,
     .Addon-overall-rating {
       flex-grow: 1;


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15865