### PR TITLE
Update style of the add-on header in the detail page

### DIFF
--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -103,6 +103,10 @@
 
     & .Addon-install {
       justify-self: end;
+
+      .InstallButtonWrapper {
+        width: 320px;
+      }
     }
   }
 

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -45,6 +45,10 @@
     margin: 0;
     padding: 0;
   }
+
+  & > .Card-contents {
+    padding: 32px 24px;
+  }
 }
 
 .Addon-header {

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -48,46 +48,10 @@
 }
 
 .Addon-header {
+  column-gap: 0;
   display: flex;
   flex-direction: column;
-  row-gap: 14px;
-  column-gap: 0;
-
-  @include respond-to(medium) {
-    display: grid;
-
-    // stylelint-disable-next-line named-grid-areas-no-invalid
-    grid-template:
-      'theme theme theme' auto
-      'icon info info' auto
-      '.   badge badge' auto
-      '.   .   install' auto / auto 1fr 1fr;
-  }
-
-  @include respond-to(large) {
-    grid-template:
-      'theme theme theme theme theme' auto
-      'icon info info info info' auto
-      '. badge badge  .   . ' auto
-      '. badge badge  .  install' auto / min-content 1fr 1fr 1fr 1fr;
-  }
-
-  @include respond-to(extraLarge) {
-    grid-template:
-      'theme theme theme theme theme  .  install' auto
-      'icon info info info info  .  install' auto
-      '. badge badge badge badge badge badge' auto / min-content 1fr 1fr 1fr 1fr 1fr 1fr;
-  }
-
-  @include respond-to(extraExtraLarge) {
-    column-gap: 0;
-    // stylelint-disable named-grid-areas-no-invalid
-    grid-template:
-      'theme theme theme theme install install' auto
-      'icon info info info  .  install' auto
-      '. badge badge badge badge badge' auto / min-content 1fr 1fr 1fr 1fr 1fr;
-    // stylelint-enable named-grid-areas-no-invalid
-  }
+  row-gap: 8px;
 
   & .Addon-theme-thumbnail {
     grid-area: theme;
@@ -108,6 +72,48 @@
 
   & .Addon-install {
     grid-area: install;
+    margin-top: 16px;
+  }
+
+  @include respond-to(large) {
+    column-gap: 16px;
+    display: grid;
+    grid-template:
+      'icon  info' auto
+      '.     badge' auto
+      '.     install' auto
+      / 48px auto;
+    row-gap: 16px;
+
+    .Addon-theme & {
+      grid-template:
+        'theme' auto
+        'info' auto
+        'badge' auto
+        'install' auto;
+    }
+
+    & .Addon-install {
+      justify-self: end;
+    }
+  }
+
+  @include respond-to(extraLarge) {
+    grid-template:
+      'icon info  install' auto
+      '.    badge .' auto
+      / 64px auto;
+
+    .Addon-theme & {
+      grid-template:
+        'theme install' auto
+        'info  .' auto
+        'badge .' auto;
+    }
+
+    & .Addon-install {
+      margin-top: 0;
+    }
   }
 }
 

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -9,13 +9,17 @@
 }
 
 .Addon-icon-wrapper {
-  height: 48px;
+  height: 40px;
   overflow: hidden;
-  width: 48px;
+  width: 40px;
 
-  @include respond-to(medium) {
+  @include respond-to(large) {
+    height: 48px;
+    width: 48px;
+  }
+
+  @include respond-to(extraLarge) {
     height: 64px;
-    overflow: hidden;
     width: 64px;
   }
 }

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -25,7 +25,7 @@
   width: 100%;
 }
 
-.Addon-warnings {
+.Addon-warnings *:last-child {
   margin-bottom: 16px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15866

---

Each commit does something a bit different. The biggest one is probably the "simplify grid" one, which simplifies the grid and make things a bit better overall.

### Before

<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 12-05-50 Check the override decision – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/1b442c8f-aa5b-4629-b809-97e242c75c2a" />
<img width="1624" height="1001" alt="Screenshot 2025-10-01 at 12 07 00" src="https://github.com/user-attachments/assets/98e8efb2-e7dc-4bbf-8c55-e3b2e5b7865f" />


### After

<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 12-04-22 Check the override decision – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/c25a1c1a-1c58-429d-9905-36e5d6bb555b" />
<img width="1624" height="1001" alt="Screenshot 2025-10-01 at 12 06 52" src="https://github.com/user-attachments/assets/a679a07c-f59b-4da1-a1b6-5e82084d7012" />
