### PR TITLE
Fix margin bottom on some pages

### DIFF
--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -4,10 +4,6 @@
   @include page-padding;
 }
 
-.Addon .Card {
-  margin-bottom: $padding-page;
-}
-
 .Addon-icon-wrapper {
   height: 40px;
   overflow: hidden;
@@ -230,4 +226,10 @@
 
 .ContributeCard {
   margin: 32px auto;
+}
+
+.AddonRecommendations {
+  // This is the last card in the page, and it doesn't need a `margin-bottom`,
+  // which `.CardList` adds by default.
+  margin-bottom: 0;
 }

--- a/src/amo/pages/LandingPage/styles.scss
+++ b/src/amo/pages/LandingPage/styles.scss
@@ -2,6 +2,11 @@
 
 .LandingPage {
   @include page-padding;
+
+  & > .LandingAddonsCard:last-child {
+    // The last `.CardList` doesn't need a `margin-bottom`.
+    margin-bottom: 0;
+  }
 }
 
 .LandingPage-header {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15871

---

Before:

<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 16-00-22 GhostText 🧬 – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/2c806883-5b21-483d-8cd3-9e614caf6e54" />
<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 16-00-44 Extensions – Add-ons for Firefox (en-US)" src="https://github.com/user-attachments/assets/c484ed87-50fd-41d2-af62-ba3173e2c3f1" />
<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 16-02-16 Theme gets recommended – Get this Theme for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/1f7f338f-2a54-49e1-b326-3d2618881d6f" />


After:

<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 16-00-27 GhostText 🧬 – Get this Extension for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/28702a61-a2c1-4d9c-a191-a362f673340d" />
<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 16-00-36 Extensions – Add-ons for Firefox (en-US)" src="https://github.com/user-attachments/assets/ccf8e230-60ae-491d-8321-3556a3079cc0" />
<img width="3024" height="1610" alt="Screenshot 2025-10-01 at 16-02-03 Theme gets recommended – Get this Theme for 🦊 Firefox (en-US)" src="https://github.com/user-attachments/assets/641525a2-3462-40f0-8a44-d574fe19892b" />
