### PR TITLE
Add some padding between warnings in the add-on header

### DIFF
--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -29,7 +29,7 @@
   width: 100%;
 }
 
-.Addon-warnings *:last-child {
+.Addon-warnings > * {
   margin-bottom: 16px;
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/15872

---

Before:
<img width="3024" height="1608" alt="Screenshot 2025-10-03 at 11-06-00 apeckey-buttleah-reine – Get this Extension for 🦊 Firefox Android (en-US)" src="https://github.com/user-attachments/assets/6f9d3d2c-8c71-4436-8aa2-884443686254" />

After:
<img width="3024" height="3880" alt="Screenshot 2025-10-03 at 11-06-15 apeckey-buttleah-reine – Get this Extension for 🦊 Firefox Android (en-US)" src="https://github.com/user-attachments/assets/163909bb-4eba-483e-8a52-70f15c43f3e0" />