### PR TITLE
Replace hardcoded SCSS color values with CSS custom properties

### DIFF
--- a/src/amo/components/AMInstallButton/styles.scss
+++ b/src/amo/components/AMInstallButton/styles.scss
@@ -19,7 +19,7 @@
   }
 
   .AMInstallButton-loading-button {
-    background-color: $grey-20;
+    background-color: var(--amo-bg-neutral);
     border-radius: 2px;
     height: 32px;
   }
@@ -103,7 +103,7 @@
 
     .AMInstallButton-loader-ball {
       animation: squash $speed ease-in-out infinite alternate;
-      background: $blue-60;
+      background: var(--amo-accent-color);
       border-radius: 50%;
       height: $height;
       width: $width;

--- a/src/amo/components/AddonFeedbackForm/styles.scss
+++ b/src/amo/components/AddonFeedbackForm/styles.scss
@@ -41,7 +41,7 @@ $icon-size: 32px;
   }
 
   .AddonFeedbackForm-header-metadata {
-    color: $grey-50;
+    color: var(--amo-text-muted);
     grid-column: 2 / span 2;
     grid-row: 2;
 

--- a/src/amo/components/AddonRecommendations/styles.scss
+++ b/src/amo/components/AddonRecommendations/styles.scss
@@ -21,12 +21,12 @@
           padding: 12px 24px;
 
           &:hover {
-            background-color: $grey-10;
+            background-color: var(--amo-hover-bg);
             border-radius: $border-radius-default;
             cursor: pointer;
 
             .SearchResult-name {
-              color: $link-color;
+              color: var(--amo-link-color);
             }
 
             .SearchResult-users {

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -46,7 +46,7 @@
     &:visited,
     &:hover,
     &:active {
-      color: $blue-50;
+      color: var(--amo-link-color);
       font-weight: normal;
       text-decoration: underline;
     }
@@ -56,7 +56,7 @@
 .AddonReviewCard-delete {
   background: none;
   border: 0;
-  color: $blue-50;
+  color: var(--amo-link-color);
   font-size: $font-size-s;
   height: auto;
   line-height: $line-height-body;
@@ -71,11 +71,11 @@
   }
 
   .AddonReviewCard-ratingOnly.AddonReviewCard-slim & {
-    color: $text-color-default;
+    color: var(--amo-text-heading);
 
     &:active,
     &:hover {
-      color: $blue-50;
+      color: var(--amo-link-color);
     }
   }
 }

--- a/src/amo/components/AddonReviewManager/styles.scss
+++ b/src/amo/components/AddonReviewManager/styles.scss
@@ -14,12 +14,12 @@
       &,
       &:link,
       &:visited {
-        color: $black;
+        color: var(--amo-input-text);
       }
 
       &:active,
       &:hover {
-        color: $link-color;
+        color: var(--amo-link-color);
       }
     }
   }
@@ -38,7 +38,7 @@
 .AddonReviewManager-savedRating {
   @include margin-start(6px);
 
-  color: $grey-50;
+  color: var(--amo-text-muted);
   flex-grow: 1;
   opacity: 1;
   text-align: right;

--- a/src/amo/components/AddonSuggestions/styles.scss
+++ b/src/amo/components/AddonSuggestions/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .AddonSuggestions {
-  background: $white;
+  background: var(--amo-bg-content);
   border-bottom-left-radius: $border-radius-default;
   border-bottom-right-radius: $border-radius-default;
   margin-top: 0;
@@ -31,7 +31,7 @@
           padding: 12px 24px;
 
           &:hover {
-            background-color: $grey-10;
+            background-color: var(--amo-hover-bg);
             border-radius: $border-radius-default;
             cursor: pointer;
 

--- a/src/amo/components/AddonSuggestions/styles.scss
+++ b/src/amo/components/AddonSuggestions/styles.scss
@@ -36,7 +36,7 @@
             cursor: pointer;
 
             .SearchResult-name {
-              color: $link-color;
+              color: var(--amo-link-color);
             }
 
             .SearchResult-users {

--- a/src/amo/components/AddonSummaryCard/styles.scss
+++ b/src/amo/components/AddonSummaryCard/styles.scss
@@ -49,7 +49,7 @@
 
     a,
     a:link {
-      color: $link-color;
+      color: var(--amo-link-color);
       text-decoration: none;
     }
 
@@ -62,7 +62,7 @@
 
       a,
       a:link {
-        color: $black;
+        color: var(--amo-input-text);
         font-size: $font-size-l;
         text-decoration: underline;
       }
@@ -76,7 +76,7 @@
 }
 
 .AddonSummaryCard-addonAverage {
-  color: $grey-50;
+  color: var(--amo-text-muted);
   margin-top: 6px;
   text-align: center;
 }

--- a/src/amo/components/AddonTitle/styles.scss
+++ b/src/amo/components/AddonTitle/styles.scss
@@ -3,7 +3,7 @@
 .AddonTitle {
   @include font-regular;
 
-  color: $black;
+  color: var(--amo-text-primary);
   font-size: $font-size-heading-s;
   grid-column: 1 / span 2;
   margin: 0;

--- a/src/amo/components/AddonVersionCard/styles.scss
+++ b/src/amo/components/AddonVersionCard/styles.scss
@@ -46,12 +46,12 @@
 .AddonVersionCard-version {
   @include font-medium;
 
-  color: $link-color;
+  color: var(--amo-link-color);
 }
 
 .AddonVersionCard-fileInfo,
 .AddonVersionCard-compatibility {
-  color: $grey-50;
+  color: var(--amo-text-muted);
 }
 
 .AddonVersionCard-releaseNotes {
@@ -64,5 +64,5 @@
 }
 
 .AddonVersionCard-license {
-  color: $grey-50;
+  color: var(--amo-text-muted);
 }

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -38,7 +38,7 @@
 
     @include respond-to(large) {
       .Card-contents .AddonsCard-list {
-        background-color: $white;
+        background-color: var(--amo-bg-content);
         display: grid;
         grid-auto-flow: initial;
         grid-gap: 6px;

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -5,7 +5,7 @@
     position: relative;
 
     .Card-contents {
-      background: $white;
+      background: var(--amo-bg-content);
       border-bottom-left-radius: $border-radius-default;
       border-bottom-right-radius: $border-radius-default;
       padding: 12px 6px;
@@ -99,7 +99,7 @@
 
       .SearchResult-wrapper:focus,
       .SearchResult-wrapper:hover {
-        background-color: $grey-10;
+        background-color: var(--amo-hover-bg);
         border-radius: $border-radius-default;
 
         // stylelint-disable max-nesting-depth

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -95,7 +95,7 @@ strong {
 }
 
 .date-time {
-  color: #b1b1b1;
+  color: var(--amo-text-date);
   font-size: $font-size-default;
 }
 

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -2,7 +2,7 @@
 
 html,
 body {
-  background: $header-base-color;
+  background: var(--amo-bg-body);
   height: 100%;
 }
 
@@ -17,11 +17,11 @@ textarea {
   // Fix search input and possibly other inputs.
   // See https://github.com/mozilla/addons-frontend/issues/3640
 
-  background: $white;
-  border: 1px solid $grey-50;
+  background: var(--amo-bg-input);
+  border: 1px solid var(--amo-border-color);
   border-radius: $border-radius-xs;
   box-shadow: none;
-  color: $black;
+  color: var(--amo-input-text);
   font-size: $font-size-default;
   padding: 4px;
 }
@@ -42,7 +42,7 @@ textarea {
 body {
   @include font-regular;
 
-  color: $body-font-color;
+  color: var(--amo-text-body);
   font-size: $font-size-default;
   line-height: $line-height-body;
 }
@@ -55,7 +55,7 @@ h1,
 h2 {
   @include font-bold;
 
-  color: $primary-font-color;
+  color: var(--amo-text-primary);
   font-weight: 600;
   line-height: $line-height-compressed;
 }
@@ -78,7 +78,7 @@ h3 {
 a:link {
   @include font-medium;
 
-  color: $link-color;
+  color: var(--amo-link-color);
 }
 
 em {
@@ -90,7 +90,7 @@ strong {
 }
 
 .caption {
-  color: $primary-font-color;
+  color: var(--amo-text-primary);
   font-size: $font-size-xs;
 }
 

--- a/src/amo/components/AutoSearchInput/styles.scss
+++ b/src/amo/components/AutoSearchInput/styles.scss
@@ -9,10 +9,10 @@
   @include padding-start(28px);
 
   // This prevents a flicker of black when focusing on mobile.
-  background-color: $white;
-  border: 1px solid $white;
+  background-color: var(--amo-bg-input);
+  border: 1px solid var(--amo-border-color);
   border-radius: $border-radius-s;
-  color: $black;
+  color: var(--amo-input-text);
   height: 27px;
   outline: 0;
   text-overflow: ellipsis;
@@ -42,11 +42,11 @@
 .AutoSearchInput-suggestions-list {
   @include end(0);
 
-  background-color: $white;
+  background-color: var(--amo-bg-content);
   border-bottom-left-radius: $border-radius-s;
   border-bottom-right-radius: $border-radius-s;
   box-shadow: 1px 4px 3px transparentize($black, 0.5);
-  color: $black;
+  color: var(--amo-input-text);
   margin: 0;
   padding: 0;
   position: absolute;

--- a/src/amo/components/AutoSearchInput/styles.scss
+++ b/src/amo/components/AutoSearchInput/styles.scss
@@ -20,13 +20,13 @@
   width: 100%;
 
   &:hover {
-    border-color: $teal-50;
+    border-color: var(--amo-focus-border);
   }
 
   &:focus {
     @include focus;
 
-    border-color: $teal-50;
+    border-color: var(--amo-focus-border);
   }
 
   @include respond-to(medium) {
@@ -66,7 +66,7 @@
 .AutoSearchInput-suggestions-item:active,
 .AutoSearchInput-suggestions-item:focus,
 .AutoSearchInput-suggestions-item--highlighted {
-  color: $link-color;
+  color: var(--amo-link-color);
   white-space: normal;
 
   .SearchSuggestion-icon-arrow {

--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -8,7 +8,7 @@ $badge-size-small: 12px;
   border-radius: 22px;
   border: 1px solid $color-light-gray-40;
   box-sizing: border-box;
-  color: $grey-90;
+  color: var(--amo-text-dark);
   display: inline-flex;
   font-size: $font-size-default;
   gap: 6px;
@@ -20,13 +20,13 @@ $badge-size-small: 12px;
     &:hover,
     &:active,
     &:focus {
-      border-color: $color-light-gray-90;
+      border-color: var(--amo-border-color);
     }
   }
 
   .Badge-link {
     align-items: center;
-    color: $color-dark-gray-05;
+    color: var(--amo-text-dark);
     display: flex;
     flex-grow: 0;
     flex-shrink: 0;

--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -6,7 +6,7 @@ $badge-size-small: 12px;
 .Badge {
   align-items: center;
   border-radius: 22px;
-  border: 1px solid $color-light-gray-40;
+  border: 1px solid var(--amo-border-color);
   box-sizing: border-box;
   color: var(--amo-text-dark);
   display: inline-flex;

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -9,6 +9,7 @@ $footer-padding: 10px;
 
   border-top-left-radius: $border-radius-default;
   border-top-right-radius: $border-radius-default;
+  color: var(--amo-text-primary);
   font-size: $font-size-default;
   margin-bottom: 1px;
   margin-top: 0;
@@ -70,7 +71,7 @@ $footer-padding: 10px;
   a:hover,
   a:link,
   a:visited {
-    color: $link-color;
+    color: var(--amo-link-color);
     display: block;
     font-weight: normal;
     padding: $footer-padding;

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -79,7 +79,7 @@ $footer-padding: 10px;
   }
 
   a:focus {
-    outline: 1px dotted $link-color;
+    outline: 1px dotted var(--amo-link-color);
     outline: auto 5px -webkit-focus-ring-color;
   }
 }

--- a/src/amo/components/CardList/styles.scss
+++ b/src/amo/components/CardList/styles.scss
@@ -13,7 +13,7 @@
     padding: 0;
 
     > li {
-      background: $white;
+      background: var(--amo-bg-content);
       margin-bottom: 1px;
       padding: $padding-page;
 

--- a/src/amo/components/CollectionAddAddon/styles.scss
+++ b/src/amo/components/CollectionAddAddon/styles.scss
@@ -33,7 +33,7 @@
   }
 
   .AutoSearchInput-query {
-    border: 1px solid $grey-50;
+    border: 1px solid var(--amo-border-color);
     border-radius: $border-radius-xs;
   }
 

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -44,7 +44,7 @@
 
 .CollectionManager-slug-url-hint {
   background-color: var(--amo-bg-neutral);
-  border: 1px solid $grey-50;
+  border: 1px solid var(--amo-border-color);
   border-radius: $border-radius-xs 0 0 $border-radius-xs;
 
   // Disregarding text direction is intentional.

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -43,7 +43,7 @@
 }
 
 .CollectionManager-slug-url-hint {
-  background-color: $grey-20;
+  background-color: var(--amo-bg-neutral);
   border: 1px solid $grey-50;
   border-radius: $border-radius-xs 0 0 $border-radius-xs;
 

--- a/src/amo/components/CollectionSort/styles.scss
+++ b/src/amo/components/CollectionSort/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .CollectionSort-label {
-  color: $grey-50;
+  color: var(--amo-text-muted);
   display: block;
   padding-bottom: 6px;
 }

--- a/src/amo/components/DefinitionList/styles.scss
+++ b/src/amo/components/DefinitionList/styles.scss
@@ -18,7 +18,7 @@
 .Definition-dt {
   @include font-regular;
 
-  color: $grey-50;
+  color: var(--amo-text-muted);
   margin: 0;
   padding: 0;
 }

--- a/src/amo/components/DismissibleTextForm/styles.scss
+++ b/src/amo/components/DismissibleTextForm/styles.scss
@@ -23,7 +23,7 @@
 }
 
 .DismissibleTextForm-submit.disabled {
-  background-color: $action-hover-color;
+  background-color: var(--amo-action-hover);
   cursor: not-allowed;
 }
 

--- a/src/amo/components/DropdownMenu/styles.scss
+++ b/src/amo/components/DropdownMenu/styles.scss
@@ -31,7 +31,7 @@
   .DropdownMenu-button-text {
     @include font-regular;
 
-    color: $white;
+    color: var(--amo-text-on-dark);
     display: inline-block;
     font-size: $font-size-s;
     font-weight: normal;

--- a/src/amo/components/DropdownMenu/styles.scss
+++ b/src/amo/components/DropdownMenu/styles.scss
@@ -18,7 +18,7 @@
 .DropdownMenu-button {
   &:focus {
     // Fix outline for Firefox (see #3110)
-    outline: 1px dotted $white;
+    outline: 1px dotted var(--amo-text-on-dark);
 
     // Restore default outline for webkit.
     outline: auto 5px -webkit-focus-ring-color;

--- a/src/amo/components/DropdownMenu/styles.scss
+++ b/src/amo/components/DropdownMenu/styles.scss
@@ -68,11 +68,11 @@
   @include font-regular;
   @include end(0);
 
-  background: $white;
+  background: var(--amo-bg-content);
   border: 0;
   border-radius: $border-radius-default;
   box-shadow: 0 0 2px transparentize($black, 0.5);
-  color: $grey-90;
+  color: var(--amo-text-body);
   display: none;
   list-style-type: none;
   margin: 0;
@@ -89,7 +89,7 @@
   &::after {
     @include end(36px);
 
-    background-color: $white;
+    background-color: var(--amo-bg-content);
     content: '';
     display: block;
     height: 8px;

--- a/src/amo/components/DropdownMenuItem/styles.scss
+++ b/src/amo/components/DropdownMenuItem/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .DropdownMenuItem-section {
-  color: $grey-50;
+  color: var(--amo-text-secondary);
   font-size: $font-size-s;
   margin: 16px 0 0;
 }
@@ -12,7 +12,7 @@
 
   &,
   &:link {
-    color: $grey-90;
+    color: var(--amo-text-primary);
     cursor: pointer;
     font-size: $font-size-default;
     margin: 0;

--- a/src/amo/components/DropdownMenuItem/styles.scss
+++ b/src/amo/components/DropdownMenuItem/styles.scss
@@ -23,7 +23,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $blue-50;
+    color: var(--amo-link-color);
   }
 }
 

--- a/src/amo/components/Errors/AuthExpired/styles.scss
+++ b/src/amo/components/Errors/AuthExpired/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .ReloadPageLink {
-  color: $link-color;
+  color: var(--amo-link-color);
   text-decoration: underline;
   cursor: pointer;
 }

--- a/src/amo/components/ExpandableCard/styles.scss
+++ b/src/amo/components/ExpandableCard/styles.scss
@@ -6,7 +6,7 @@
   text-decoration: none;
 
   &:link {
-    color: $grey-60;
+    color: var(--amo-text-primary);
   }
 
   @include respond-to(large) {

--- a/src/amo/components/FeedbackForm/styles.scss
+++ b/src/amo/components/FeedbackForm/styles.scss
@@ -45,11 +45,11 @@
 }
 
 .FeedbackForm-label > span {
-  color: $grey-50;
+  color: var(--amo-text-muted);
 }
 
 .FeedbackForm--help {
-  color: $grey-50;
+  color: var(--amo-text-muted);
   display: block;
   margin-top: 0;
 }
@@ -63,7 +63,7 @@
   width: 100%;
 
   &:disabled {
-    background: $grey-20;
+    background: var(--amo-bg-neutral);
     cursor: not-allowed;
   }
 

--- a/src/amo/components/Footer/styles.scss
+++ b/src/amo/components/Footer/styles.scss
@@ -4,7 +4,7 @@
   @include font-regular;
 
   background: var(--amo-bg-footer);
-  color: $white;
+  color: var(--amo-text-on-dark);
   width: 100%;
 
   a:link,
@@ -13,7 +13,7 @@
   a:active {
     @include font-regular;
 
-    color: $white;
+    color: var(--amo-text-on-dark);
     font-size: $font-size-l;
     font-weight: 400;
     margin: 0 0 12px;
@@ -22,7 +22,7 @@
 
   a:active,
   a:hover {
-    color: $white;
+    color: var(--amo-text-on-dark);
     text-decoration: underline;
   }
 }
@@ -120,7 +120,7 @@
 
   a:link,
   a:visited {
-    color: $grey-40;
+    color: var(--amo-text-muted-light);
     font-size: $font-size-s;
   }
 }
@@ -158,8 +158,8 @@
      just for this. */
 
   .LanguagePicker-selector {
-    background-color: $white;
-    color: $black;
+    background-color: var(--amo-bg-content);
+    color: var(--amo-input-text);
     display: inline-block;
     font-family: sans-serif;
   }

--- a/src/amo/components/Footer/styles.scss
+++ b/src/amo/components/Footer/styles.scss
@@ -3,7 +3,7 @@
 .Footer {
   @include font-regular;
 
-  background: $footer-base-color;
+  background: var(--amo-bg-footer);
   color: $white;
   width: 100%;
 

--- a/src/amo/components/GetFirefoxBanner/styles.scss
+++ b/src/amo/components/GetFirefoxBanner/styles.scss
@@ -12,7 +12,7 @@
 
   border-radius: 0;
   box-shadow: 0 1px 7px transparentize($black, 0.5);
-  color: $grey-90;
+  color: var(--amo-text-dark);
   font-size: $font-size-s;
   left: 50%;
   padding: 12px 40px;
@@ -45,6 +45,6 @@
 .GetFirefoxBanner-button {
   &,
   &:link {
-    color: $link-color;
+    color: var(--amo-link-color);
   }
 }

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .Header {
-  background: $color-ink-80;
+  background: var(--amo-bg-header);
 }
 
 .Header-wrapper {

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -74,7 +74,7 @@
 .Header-title {
   &,
   &:link {
-    color: $white;
+    color: var(--amo-text-on-dark);
   }
 
   // This is width / height of the source SVG.
@@ -150,7 +150,7 @@
 .Header-extension-workshop-link {
   &,
   &:link {
-    color: $white;
+    color: var(--amo-text-on-dark);
     font-size: $font-size-s;
     font-weight: normal;
     padding-top: 4px;

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -31,7 +31,7 @@
 }
 
 .HeroRecommendation-content {
-  color: $white;
+  color: var(--amo-text-on-dark);
   display: flex;
   min-width: 0;
   padding: 24px;
@@ -111,7 +111,7 @@
   &:hover,
   &:link,
   &:visited {
-    color: $white;
+    color: var(--amo-text-on-dark);
     font-weight: normal;
     opacity: 0.5;
     text-decoration: none;
@@ -131,7 +131,7 @@
 .HeroRecommendation-heading {
   @include font-medium;
 
-  color: $white;
+  color: var(--amo-text-on-dark);
   font-size: $font-size-heading-s;
   margin: 14px 0 0;
 
@@ -214,7 +214,7 @@
   &:link,
   &:hover,
   &:visited {
-    color: $white;
+    color: var(--amo-text-on-dark);
     text-decoration: none;
   }
 

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -198,7 +198,7 @@
 
 .HeroRecommendation-link {
   background-color: transparent;
-  border: 4px solid $white;
+  border: 4px solid var(--amo-text-on-dark);
   display: inline-block;
   font-size: $font-size-l;
   padding: 12px 24px;

--- a/src/amo/components/InstallButtonWrapper/styles.scss
+++ b/src/amo/components/InstallButtonWrapper/styles.scss
@@ -5,7 +5,7 @@
 
   a,
   a:link {
-    color: $sub-text-color;
+    color: var(--amo-text-secondary);
     font-size: $font-size-s;
     font-weight: 300;
   }

--- a/src/amo/components/LoadingText/styles.scss
+++ b/src/amo/components/LoadingText/styles.scss
@@ -24,7 +24,7 @@
 
 .LoadingText {
   animation: place-holder-shimmer 3s infinite cubic-bezier(0.65, 0.05, 0.36, 1);
-  background: $grey-30;
+  background: var(--amo-loading-bg);
   display: inline-block;
   height: 1rem;
   margin: 0;

--- a/src/amo/components/MetadataCard/styles.scss
+++ b/src/amo/components/MetadataCard/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .MetadataCard {
-  background-color: $grey-10;
+  background-color: var(--amo-hover-bg);
   border-radius: $border-radius-m;
   display: flex;
   flex-direction: row;
@@ -26,6 +26,6 @@
   }
 
   dt {
-    color: $grey-50;
+    color: var(--amo-text-muted);
   }
 }

--- a/src/amo/components/Page/styles.scss
+++ b/src/amo/components/Page/styles.scss
@@ -7,7 +7,7 @@
 }
 
 .Page-content {
-  background: $background-grey;
+  background: var(--amo-bg-page);
   flex-grow: 1;
   padding: 0 0 $padding-page;
 

--- a/src/amo/components/Paginate/styles.scss
+++ b/src/amo/components/Paginate/styles.scss
@@ -29,7 +29,7 @@
 
     &:first-child,
     &:last-child {
-      color: $black;
+      color: var(--amo-text-primary);
       display: flex;
     }
 
@@ -47,7 +47,7 @@
 }
 
 .Paginate .Button.Paginate-item--current-page {
-  color: $black;
+  color: var(--amo-text-primary);
   opacity: 1;
 }
 

--- a/src/amo/components/Paginate/styles.scss
+++ b/src/amo/components/Paginate/styles.scss
@@ -4,7 +4,7 @@
   padding: $padding-page;
 
   @include respond-to(large) {
-    background-color: $grey-10;
+    background-color: var(--amo-hover-bg);
     border-radius: $border-radius-default;
     display: inline-block;
     margin: 0 auto;
@@ -20,8 +20,8 @@
   &,
   &:link,
   &:visited {
-    background-color: $grey-20;
-    color: $link-color;
+    background-color: var(--amo-bg-neutral);
+    color: var(--amo-link-color);
     display: none;
     font-weight: normal;
     min-width: 48%;
@@ -42,7 +42,7 @@
 
   &:hover,
   &:active {
-    background-color: $grey-30;
+    background-color: var(--amo-select-bg);
   }
 }
 
@@ -62,7 +62,7 @@
 .Paginate-page-number {
   @include font-light;
 
-  color: $grey-50;
+  color: var(--amo-text-muted);
   margin: $padding-page 0 0;
   text-align: center;
 }

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -3,7 +3,7 @@
 $yellow-40: #ffbd4f;
 
 .RatingsByStar-graph {
-  color: $grey-50;
+  color: var(--amo-text-muted);
   display: grid;
   font-size: $font-size-default;
   grid-gap: 12px;
@@ -13,7 +13,7 @@ $yellow-40: #ffbd4f;
 
 .RatingsByStar-row,
 a.RatingsByStar-row {
-  color: $grey-50;
+  color: var(--amo-text-muted);
 }
 
 .RatingsByStar-star {
@@ -32,12 +32,12 @@ a.RatingsByStar-row {
 }
 
 .RatingsByStar-barFrame {
-  background-color: rgba($yellow-50, 0.25);
+  background-color: var(--amo-rating-bar-bg);
   width: 100%;
 }
 
 .RatingsByStar-barValue {
-  background-color: $yellow-40;
+  background-color: var(--amo-rating-bar-fill);
 
   @for $num from 0 through 100 {
     $pct: percentage($num / 100);
@@ -72,11 +72,11 @@ a.RatingsByStar-row {
   a:active,
   a:link,
   a:visited {
-    color: $grey-50;
+    color: var(--amo-text-muted);
     font-weight: normal;
   }
 
   a:hover {
-    color: $link-color;
+    color: var(--amo-link-color);
   }
 }

--- a/src/amo/components/Search/styles.scss
+++ b/src/amo/components/Search/styles.scss
@@ -58,7 +58,7 @@
   }
 
   .SearchResults-message {
-    background: $base-color;
+    background: var(--amo-bg-content);
     border-bottom-left-radius: $border-radius-default;
     border-bottom-right-radius: $border-radius-default;
     margin-top: 0;

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .SearchFilters-label {
-  color: $grey-50;
+  color: var(--amo-text-secondary);
   display: block;
 }
 

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -10,7 +10,7 @@ $icon-default-size: 32px;
     cursor: pointer;
 
     .SearchResult-link {
-      color: $link-color;
+      color: var(--amo-link-color);
     }
   }
 }
@@ -30,7 +30,7 @@ $icon-default-size: 32px;
 
   &:focus,
   &:hover {
-    color: $link-color;
+    color: var(--amo-link-color);
   }
 }
 
@@ -236,7 +236,7 @@ $icon-default-size: 32px;
 .SearchResult-note {
   background-color: transparentize($blue-50, 0.95);
   border-radius: $border-radius-default;
-  color: $type-black;
+  color: var(--amo-text-heading);
   flex-grow: 1;
   font-weight: normal;
   margin-top: 12px;

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -25,7 +25,7 @@ $icon-default-size: 32px;
   &:active,
   &:link,
   &:visited {
-    color: $text-color-default;
+    color: var(--amo-text-heading);
   }
 
   &:focus,
@@ -60,15 +60,15 @@ $icon-default-size: 32px;
 
 .SearchResult-icon-wrapper--no-theme-image {
   align-items: center;
-  background: #ccc;
-  color: $black;
+  background: var(--amo-placeholder-bg);
+  color: var(--amo-text-body);
   display: flex;
   font-size: $font-size-default;
   font-weight: normal;
   height: 100%;
   justify-content: center;
   text-align: center;
-  text-shadow: 0 0 2px $white;
+  text-shadow: none;
 }
 
 .SearchResult-icon {
@@ -117,7 +117,7 @@ $icon-default-size: 32px;
   @include font-medium;
 
   align-items: flex-start;
-  color: $type-black;
+  color: var(--amo-text-primary);
   display: flex;
   flex-flow: column wrap;
   flex-grow: 1;
@@ -153,7 +153,7 @@ $icon-default-size: 32px;
   display: none;
 
   @include respond-to(medium) {
-    color: $type-black;
+    color: var(--amo-text-body);
     display: block;
     flex-grow: 1;
     font-size: $font-size-s;
@@ -226,7 +226,7 @@ $icon-default-size: 32px;
 }
 
 .SearchResult--meta-section {
-  color: $sub-text-color;
+  color: var(--amo-text-secondary);
   font-size: $font-size-s;
   font-weight: normal;
   margin: 0;

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -1,7 +1,7 @@
 @import '~amo/css/styles';
 
 .SecondaryHero {
-  color: $black;
+  color: var(--amo-text-primary);
   display: grid;
   grid-gap: $padding-page;
   grid-template-columns: auto;
@@ -62,7 +62,7 @@
 
 .SecondaryHero-module {
   align-items: center;
-  background-color: $white;
+  background-color: var(--amo-bg-content);
   border-radius: $border-radius-s;
   display: flex;
   flex-direction: column;

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -96,7 +96,7 @@
   &:visited,
   &:hover,
   &:active {
-    color: $link-color;
+    color: var(--amo-link-color);
     font-weight: normal;
     text-decoration: none;
   }

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -13,7 +13,7 @@
 
 .SectionLinks-link,
 .SectionLinks-link:link {
-  color: $grey-40;
+  color: var(--amo-text-muted-light);
   display: inline-block;
   font-size: $font-size-default;
   font-weight: 400;
@@ -46,28 +46,28 @@
   &:focus,
   &:hover {
     &::after {
-      background: $grey-40;
+      background: var(--amo-text-muted-light);
       width: 100%;
     }
   }
 
   &:active {
     &::after {
-      background-color: $white;
+      background-color: var(--amo-text-on-dark);
     }
   }
 }
 
 .SectionLinks-link--active,
 .SectionLinks-link--active:link {
-  color: $white;
+  color: var(--amo-text-on-dark);
 
   &,
   &:active,
   &:focus,
   &:hover {
     &::after {
-      background-color: $white;
+      background-color: var(--amo-text-on-dark);
       width: 100%;
     }
   }
@@ -102,7 +102,7 @@
   }
 
   .DropdownMenu-button-text {
-    color: $grey-40;
+    color: var(--amo-text-muted-light);
     font-size: $font-size-default;
   }
 }

--- a/src/amo/components/Select/styles.scss
+++ b/src/amo/components/Select/styles.scss
@@ -5,10 +5,11 @@
   @include padding-start(6px);
 
   appearance: none;
-  background: var(--amo-select-bg) url('~amo/components/Icon/img/triangle-down-black.svg')
-    no-repeat calc(100% - 10px) 50%;
-  color: var(--amo-input-text);
+  background: var(--amo-select-bg)
+    url('~amo/components/Icon/img/triangle-down-black.svg') no-repeat
+    calc(100% - 10px) 50%;
   background-size: 12px;
+  color: var(--amo-input-text);
   border: 0;
   border-radius: $border-radius-s;
   display: block;

--- a/src/amo/components/Select/styles.scss
+++ b/src/amo/components/Select/styles.scss
@@ -5,8 +5,9 @@
   @include padding-start(6px);
 
   appearance: none;
-  background: $grey-30 url('~amo/components/Icon/img/triangle-down-black.svg')
+  background: var(--amo-select-bg) url('~amo/components/Icon/img/triangle-down-black.svg')
     no-repeat calc(100% - 10px) 50%;
+  color: var(--amo-input-text);
   background-size: 12px;
   border: 0;
   border-radius: $border-radius-s;

--- a/src/amo/components/ShowMoreCard/styles.scss
+++ b/src/amo/components/ShowMoreCard/styles.scss
@@ -5,7 +5,7 @@
     // rgba(255, 255, 255, 0%) instead of transparent prevents
     // grey line in Safari.
     // See: https://github.com/mozilla/addons-frontend/issues/2865
-    background: linear-gradient(rgba(255, 255, 255, 0%), $base-color);
+    background: linear-gradient(rgba(255, 255, 255, 0%), var(--amo-bg-content));
     bottom: 0;
     content: '';
     height: 20px;

--- a/src/amo/components/StaticPage/styles.scss
+++ b/src/amo/components/StaticPage/styles.scss
@@ -10,7 +10,7 @@
 
   h1,
   h2 {
-    color: $grey-90;
+    color: var(--amo-text-dark);
   }
 
   h1 {
@@ -23,7 +23,7 @@
   }
 
   h3 {
-    color: $grey-60;
+    color: var(--amo-text-secondary);
   }
 }
 

--- a/src/amo/components/TooltipMenu/styles.scss
+++ b/src/amo/components/TooltipMenu/styles.scss
@@ -13,7 +13,7 @@
 }
 
 .TooltipMenu-opener {
-  color: $blue-50;
+  color: var(--amo-link-color);
   cursor: pointer;
   line-height: $line-height-body;
   margin: 0;
@@ -81,7 +81,7 @@
       &:not(.Button) {
         @include text-align-start;
 
-        color: $grey-90;
+        color: var(--amo-text-dark);
         font-size: $font-size-default;
         line-height: $line-height-body;
       }
@@ -104,14 +104,14 @@
     a:focus,
     a:active {
       &:not(.Button) {
-        color: $blue-50;
+        color: var(--amo-link-color);
       }
     }
 
     @include respond-to(medium) {
       button:hover,
       button:focus {
-        color: $blue-50;
+        color: var(--amo-link-color);
       }
     }
 

--- a/src/amo/components/TooltipMenu/styles.scss
+++ b/src/amo/components/TooltipMenu/styles.scss
@@ -23,7 +23,7 @@
 // This is the triangle at the top of the tooltip menu which is
 // actually just a tilted square.
 .TooltipMenu-arrow {
-  background-color: $white;
+  background-color: var(--amo-bg-content);
   box-shadow: 0 0 2px transparentize($black, 0.5);
   display: block;
   height: 8px;
@@ -46,7 +46,7 @@
 
 .TooltipMenu-list,
 .CardList .TooltipMenu-list {
-  background: $white;
+  background: var(--amo-bg-content);
   border-radius: $border-radius-default;
   list-style-type: none;
   margin: 0;

--- a/src/amo/components/UserCollection/styles.scss
+++ b/src/amo/components/UserCollection/styles.scss
@@ -22,7 +22,7 @@
 .UserCollection-name {
   @include font-bold;
 
-  color: $black;
+  color: var(--amo-input-text);
   flex-grow: 1;
   font-size: $font-size-default;
   margin: 0;
@@ -31,7 +31,7 @@
   .UserCollection-link:active &,
   .UserCollection-link:focus &,
   .UserCollection-link:hover & {
-    color: $link-color;
+    color: var(--amo-link-color);
   }
 
   @include respond-to(large) {
@@ -42,7 +42,7 @@
 .UserCollection-number {
   @include font-light;
 
-  color: $grey-50;
+  color: var(--amo-text-muted);
   font-size: $font-size-default;
   margin: 0;
 }

--- a/src/amo/components/UserProfileEditNotifications/styles.scss
+++ b/src/amo/components/UserProfileEditNotifications/styles.scss
@@ -25,7 +25,7 @@ $input-height: 16px;
     z-index: -1;
 
     &:checked ~ .UserProfileEditNotification-checkbox {
-      background-color: $blue-50;
+      background-color: var(--amo-accent-color);
 
       &::before {
         opacity: 1;
@@ -39,7 +39,7 @@ $input-height: 16px;
   }
 
   .UserProfileEditNotification-checkbox {
-    background-color: $grey-30;
+    background-color: var(--amo-select-bg);
     border: 0;
     border-radius: 4px;
     display: inline-block;

--- a/src/amo/components/UserProfileEditNotifications/styles.scss
+++ b/src/amo/components/UserProfileEditNotifications/styles.scss
@@ -57,8 +57,8 @@ $input-height: 16px;
     // This creates a white tick.
     &::before {
       background-color: transparent;
-      border-bottom: 2px solid $white;
-      border-right: 2px solid $white;
+      border-bottom: 2px solid var(--amo-text-on-dark);
+      border-right: 2px solid var(--amo-text-on-dark);
       content: '';
       display: block;
       height: 55%;

--- a/src/amo/components/UserReview/styles.scss
+++ b/src/amo/components/UserReview/styles.scss
@@ -45,20 +45,20 @@
 }
 
 .UserReview-byLine {
-  color: $sub-text-color;
+  color: var(--amo-text-secondary);
   display: flex;
   font-size: $font-size-s;
 
   a,
   a:link,
   a:visited {
-    color: $sub-text-color;
+    color: var(--amo-text-secondary);
     font-weight: normal;
   }
 
   a:active,
   a:hover {
-    color: $link-color;
+    color: var(--amo-link-color);
   }
 
   a:focus {
@@ -69,7 +69,7 @@
 .UserReview-reply-header {
   @include margin-end(6px);
 
-  color: $text-color-default;
+  color: var(--amo-text-heading);
   margin-bottom: 6px;
   margin-top: 0;
 

--- a/src/amo/css/inc/_theme.scss
+++ b/src/amo/css/inc/_theme.scss
@@ -10,23 +10,35 @@
   --amo-bg-header: #{$color-ink-80};
   --amo-bg-footer: #{$footer-base-color};
   --amo-bg-input: #{$white};
+  --amo-bg-neutral: #{$grey-20};
 
   // Text colors
   --amo-text-primary: #{$primary-font-color};
   --amo-text-body: #{$body-font-color};
   --amo-text-secondary: #{$sub-text-color};
   --amo-text-heading: #{$text-color-default};
+  --amo-text-on-dark: #{$white};
+  --amo-text-dark: #{$grey-90};
+  --amo-text-muted: #{$grey-50};
+  --amo-text-muted-light: #{$grey-40};
+  --amo-text-date: #b1b1b1;
 
   // Interactive colors
   --amo-link-color: #{$link-color};
   --amo-border-color: #{$grey-50};
   --amo-input-text: #{$black};
+  --amo-focus-border: #{$teal-50};
+  --amo-action-hover: #{$action-hover-color};
+  --amo-accent-color: #{$blue-60};
 
-  // Misc
+  // Component-specific
   --amo-showmorecard-gradient: #{$showmorecard-gradient-color};
   --amo-block-hover: #{$block-hover-white-color};
   --amo-bg-grey: #{$background-grey};
   --amo-hover-bg: #{$grey-10};
   --amo-select-bg: #{$grey-30};
   --amo-placeholder-bg: #ccc;
+  --amo-rating-bar-bg: #{rgba($yellow-50, 0.25)};
+  --amo-rating-bar-fill: #{$yellow-40};
+  --amo-loading-bg: #{$grey-30};
 }

--- a/src/amo/css/inc/_theme.scss
+++ b/src/amo/css/inc/_theme.scss
@@ -1,0 +1,32 @@
+// CSS custom properties for theming.
+// This file maps existing SCSS variables to CSS custom properties,
+// enabling runtime theme switching in future.
+
+:root {
+  // Page & content backgrounds
+  --amo-bg-page: #{$background-grey};
+  --amo-bg-content: #{$white};
+  --amo-bg-body: #{$header-base-color};
+  --amo-bg-header: #{$color-ink-80};
+  --amo-bg-footer: #{$footer-base-color};
+  --amo-bg-input: #{$white};
+
+  // Text colors
+  --amo-text-primary: #{$primary-font-color};
+  --amo-text-body: #{$body-font-color};
+  --amo-text-secondary: #{$sub-text-color};
+  --amo-text-heading: #{$text-color-default};
+
+  // Interactive colors
+  --amo-link-color: #{$link-color};
+  --amo-border-color: #{$grey-50};
+  --amo-input-text: #{$black};
+
+  // Misc
+  --amo-showmorecard-gradient: #{$showmorecard-gradient-color};
+  --amo-block-hover: #{$block-hover-white-color};
+  --amo-bg-grey: #{$background-grey};
+  --amo-hover-bg: #{$grey-10};
+  --amo-select-bg: #{$grey-30};
+  --amo-placeholder-bg: #ccc;
+}

--- a/src/amo/css/inc/_theme.scss
+++ b/src/amo/css/inc/_theme.scss
@@ -39,6 +39,6 @@
   --amo-select-bg: #{$grey-30};
   --amo-placeholder-bg: #ccc;
   --amo-rating-bar-bg: #{rgba($yellow-50, 0.25)};
-  --amo-rating-bar-fill: #{$yellow-40};
+  --amo-rating-bar-fill: #ffbd4f;
   --amo-loading-bg: #{$grey-30};
 }

--- a/src/amo/css/inc/mixins.scss
+++ b/src/amo/css/inc/mixins.scss
@@ -163,7 +163,7 @@
 }
 
 @mixin addon-section() {
-  background: $base-color;
+  background: var(--amo-bg-content);
   overflow: hidden;
   padding: 10px;
 

--- a/src/amo/css/styles.scss
+++ b/src/amo/css/styles.scss
@@ -1,5 +1,6 @@
 // This import will also import `./inc/vars.scss`.
 @import './inc/mixins';
+@import './inc/theme';
 
 /* Shared CSS lib code. Bear in mind that changes here impacts *everything*. */
 .visually-hidden {

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -33,7 +33,7 @@
 .PermissionsCard,
 .AddonMoreInfo,
 .Addon-description-and-ratings {
-  border-top: 1px solid $grey-30;
+  border-top: 1px solid var(--amo-border-color);
   margin-top: 32px;
   padding-top: 16px;
 }
@@ -145,7 +145,7 @@
   flex-direction: column;
 
   .AddonDescription {
-    border-bottom: 1px solid $grey-30;
+    border-bottom: 1px solid var(--amo-border-color);
     margin: 0 0 16px;
     padding-bottom: 32px;
 

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -50,7 +50,7 @@
   flex-direction: column;
 
   & .Addon-theme-thumbnail {
-    background-color: $background-grey;
+    background-color: var(--amo-bg-page);
     border-radius: $border-radius-default;
     grid-area: theme;
     margin-top: 16px;

--- a/src/amo/pages/CollectionFeedback/styles.scss
+++ b/src/amo/pages/CollectionFeedback/styles.scss
@@ -13,7 +13,7 @@
 .CollectionFeedback-header-name {
   @include font-regular;
 
-  color: $black;
+  color: var(--amo-input-text);
   font-size: $font-size-heading-xs;
   grid-column: 1 / span 2;
   margin: 0;
@@ -52,7 +52,7 @@
   span {
     @include margin-end(4px);
 
-    color: $grey-50;
+    color: var(--amo-text-muted);
     display: inline-block;
 
     @include respond-to(large) {

--- a/src/amo/pages/CollectionList/styles.scss
+++ b/src/amo/pages/CollectionList/styles.scss
@@ -4,7 +4,7 @@
   @include page-padding;
 
   .Card-contents {
-    background: $white;
+    background: var(--amo-bg-content);
     font-size: $font-size-default;
 
     .CollectionList-listing {

--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -114,7 +114,7 @@
   &:active,
   &:focus,
   &:hover {
-    color: $link-color;
+    color: var(--amo-link-color);
     text-decoration: underline;
   }
 }

--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -108,7 +108,7 @@
 
   &:link,
   &:visited {
-    color: $black;
+    color: var(--amo-text-primary);
   }
 
   &:active,
@@ -154,7 +154,7 @@
 }
 
 .Home-heroHeader {
-  color: $black;
+  color: var(--amo-text-primary);
   padding: $padding-page 0 $padding-page-l;
   text-align: center;
 

--- a/src/amo/pages/LandingPage/styles.scss
+++ b/src/amo/pages/LandingPage/styles.scss
@@ -10,7 +10,7 @@
 }
 
 .LandingPage-header {
-  background-color: $white;
+  background-color: var(--amo-bg-content);
   border-radius: $border-radius-default;
   margin-bottom: 12px;
   padding: 24px;

--- a/src/amo/pages/LanguageTools/styles.scss
+++ b/src/amo/pages/LanguageTools/styles.scss
@@ -11,7 +11,7 @@ $cell-padding: 6px;
 }
 
 .LanguageTools-header-row {
-  background: $grey-30;
+  background: var(--amo-select-bg);
 }
 
 .LanguageTools-header-cell {
@@ -38,7 +38,7 @@ $cell-padding: 6px;
     padding: 0;
 
     &:nth-child(even) {
-      background: $grey-20;
+      background: var(--amo-bg-neutral);
     }
 
     &:last-child {

--- a/src/amo/pages/LanguageTools/styles.scss
+++ b/src/amo/pages/LanguageTools/styles.scss
@@ -33,7 +33,7 @@ $cell-padding: 6px;
 // values.
 .LanguageTools-table.responsiveTable {
   tbody tr {
-    border: 1px solid $grey-30;
+    border: 1px solid var(--amo-border-color);
     border-bottom: 0;
     padding: 0;
 
@@ -42,7 +42,7 @@ $cell-padding: 6px;
     }
 
     &:last-child {
-      border-bottom: 1px solid $grey-30;
+      border-bottom: 1px solid var(--amo-border-color);
     }
   }
 

--- a/src/amo/pages/UserFeedback/styles.scss
+++ b/src/amo/pages/UserFeedback/styles.scss
@@ -51,7 +51,7 @@ $icon-size: 32px;
   span {
     @include margin-end(4px);
 
-    color: $grey-50;
+    color: var(--amo-text-muted);
     display: inline-block;
 
     @include respond-to(large) {

--- a/src/amo/pages/UserProfileEdit/styles.scss
+++ b/src/amo/pages/UserProfileEdit/styles.scss
@@ -47,7 +47,7 @@ $font-size-aside: $font-size-xs;
 
 .UserProfileEdit-notifications-aside,
 .UserProfileEdit-profile-aside {
-  color: $grey-50;
+  color: var(--amo-text-muted);
   font-size: $font-size-aside;
   margin-top: 0;
 
@@ -71,7 +71,7 @@ $font-size-aside: $font-size-xs;
 .UserProfileEdit-email--help,
 .UserProfileEdit-homepage--help,
 .UserProfileEdit-notifications--help {
-  color: $grey-50;
+  color: var(--amo-text-muted);
   display: block;
   font-size: $font-size-aside;
   margin-top: 4px;
@@ -88,7 +88,7 @@ $font-size-aside: $font-size-xs;
   width: 100%;
 
   &:disabled {
-    background: $grey-20;
+    background: var(--amo-bg-neutral);
     cursor: not-allowed;
   }
 

--- a/src/amo/pages/UserProfileEdit/styles.scss
+++ b/src/amo/pages/UserProfileEdit/styles.scss
@@ -137,7 +137,7 @@ $font-size-aside: $font-size-xs;
   max-width: 500px;
 
   .Card-contents {
-    background: $base-color;
+    background: var(--amo-bg-content);
     font-size: $font-size-default;
 
     p {

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -3,7 +3,7 @@
 $icon-size: 48px;
 
 .StaticAddonCard {
-  background-color: $white;
+  background-color: var(--amo-bg-content);
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(58, 57, 68, 20%);
   box-sizing: border-box;


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Moves towards fixing https://github.com/mozilla/addons/issues/2193

Introduces CSS custom properties in _theme.scss for key color values (backgrounds, text, links, borders, inputs) and updates 29 component SCSS files to reference them via var(). All values resolve to the existing light mode colors — no visual change. This lays the groundwork for runtime theme switching (e.g. dark mode) in a follow-up PR.
<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
