### PR TITLE
UTM install time injection & GTM Data Layer push

### DIFF
--- a/src/amo/components/AddonSuggestions/index.js
+++ b/src/amo/components/AddonSuggestions/index.js
@@ -261,7 +261,6 @@ export class AddonSuggestionsBase extends React.Component<Props> {
           pathname: `/collections/${config.get('mozillaUserId')}/${
             category.collection
           }/`,
-          query: { addonInstallSource: INSTALL_SOURCE_SUGGESTIONS },
         }
       : null;
 

--- a/src/amo/components/HeroRecommendation/index.js
+++ b/src/amo/components/HeroRecommendation/index.js
@@ -19,6 +19,7 @@ import {
 } from 'amo/constants';
 import translate from 'amo/i18n/translate';
 import log from 'amo/logger';
+import { setAddonInstallSource } from 'amo/reducers/addonInstallSource';
 import tracking, { getAddonEventParams } from 'amo/tracking';
 import { getPromotedCategory } from 'amo/utils/addons';
 import { addQueryParams } from 'amo/utils/url';
@@ -55,6 +56,7 @@ export type InternalProps = {|
   ...Props,
   ...PropsFromState,
   ...DefaultProps,
+  dispatch: (action: Object) => void,
   i18n: I18nType,
 |};
 
@@ -72,14 +74,14 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
     const { addon, external } = shelfData;
 
     if (addon) {
-      return addQueryParams(getAddonURL(addon.slug), {
-        utm_source: DEFAULT_UTM_SOURCE,
-        utm_medium: DEFAULT_UTM_MEDIUM,
-        utm_content: PRIMARY_HERO_SRC,
-      });
+      // Internal addon link: clean URL without UTM params. The install source
+      // is dispatched to Redux in onHeroClick() and injected into the page URL
+      // at install time. See utils/installAttribution.js.
+      return getAddonURL(addon.slug);
     }
 
     invariant(external, 'Either an addon or an external is required');
+    // External link: keep UTM params (these go to third-party sites).
     return external.homepage
       ? addQueryParams(external.homepage.url, {
           utm_source: DEFAULT_UTM_SOURCE,
@@ -90,12 +92,17 @@ export class HeroRecommendationBase extends React.Component<InternalProps> {
   };
 
   onHeroClick: () => void = () => {
-    const { _tracking, _getPromotedCategory, clientApp, shelfData } =
+    const { _tracking, _getPromotedCategory, clientApp, dispatch, shelfData } =
       this.props;
 
     invariant(shelfData, 'The shelfData property is required');
 
     const { addon } = shelfData;
+
+    // Store install source in Redux for install-time UTM injection.
+    if (addon) {
+      dispatch(setAddonInstallSource(PRIMARY_HERO_SRC));
+    }
 
     _tracking.sendEvent({
       category: PRIMARY_HERO_CLICK_CATEGORY,

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -8,16 +8,12 @@ import { compose } from 'redux';
 import Link from 'amo/components/Link';
 import { getAddonURL, nl2br, sanitizeHTML } from 'amo/utils';
 import { getPromotedProps } from 'amo/utils/promoted';
-import {
-  ADDON_TYPE_STATIC_THEME,
-  DEFAULT_UTM_SOURCE,
-  DEFAULT_UTM_MEDIUM,
-} from 'amo/constants';
+import { ADDON_TYPE_STATIC_THEME } from 'amo/constants';
 import translate from 'amo/i18n/translate';
 import { getAddonIconUrl, getPreviewImage } from 'amo/imageUtils';
 import { isRecentAddon } from 'amo/reducers/addons';
+import { setAddonInstallSource } from 'amo/reducers/addonInstallSource';
 import { getPromotedCategory } from 'amo/utils/addons';
-import { addQueryParams } from 'amo/utils/url';
 import Icon from 'amo/components/Icon';
 import LoadingText from 'amo/components/LoadingText';
 import Rating from 'amo/components/Rating';
@@ -55,6 +51,7 @@ type InternalProps = {|
   ...Props,
   ...PropsFromState,
   _getPromotedCategory: typeof getPromotedCategory,
+  dispatch: (action: Object) => void,
   history: ReactRouterHistoryType,
   i18n: I18nType,
 |};
@@ -72,21 +69,11 @@ export class SearchResultBase extends React.Component<InternalProps> {
     useThemePlaceholder: false,
   };
 
-  getAddonLink(
-    addon: AddonType | CollectionAddonType,
-    addonInstallSource?: string,
-  ): string {
-    let linkTo = getAddonURL(addon.slug);
-
-    if (addonInstallSource) {
-      linkTo = addQueryParams(linkTo, {
-        utm_source: DEFAULT_UTM_SOURCE,
-        utm_medium: DEFAULT_UTM_MEDIUM,
-        utm_content: addonInstallSource,
-      });
-    }
-
-    return linkTo;
+  // Returns a clean addon URL without UTM params. The install source is
+  // dispatched to Redux on click (see onClickResult) and injected into the
+  // page URL at install time instead. See utils/installAttribution.js.
+  getAddonLink(addon: AddonType | CollectionAddonType): string {
+    return getAddonURL(addon.slug);
   }
 
   onClickAddon: HTMLElementEventHandler = (e: ElementEvent) => {
@@ -129,7 +116,6 @@ export class SearchResultBase extends React.Component<InternalProps> {
   renderResult(): React.Node {
     const {
       addon,
-      addonInstallSource,
       i18n,
       onImpression,
       showFullSizePreview,
@@ -154,7 +140,7 @@ export class SearchResultBase extends React.Component<InternalProps> {
       addonTitle = (
         <Link
           className="SearchResult-link"
-          to={this.getAddonLink(addon, addonInstallSource)}
+          to={this.getAddonLink(addon)}
           onClick={this.onClickAddon}
         >
           {addon.name}
@@ -275,13 +261,25 @@ export class SearchResultBase extends React.Component<InternalProps> {
   }
 
   onClickResult: () => void = () => {
-    const { addon, addonInstallSource, clientApp, history, lang, onClick } =
-      this.props;
+    const {
+      addon,
+      addonInstallSource,
+      clientApp,
+      dispatch,
+      history,
+      lang,
+      onClick,
+    } = this.props;
 
     if (addon) {
-      history.push(
-        `/${lang}/${clientApp}${this.getAddonLink(addon, addonInstallSource)}`,
-      );
+      // Store the install source in Redux so it survives navigation to the
+      // addon detail page. It will be used at install time to inject UTM
+      // params into the URL for Firefox attribution.
+      if (addonInstallSource) {
+        dispatch(setAddonInstallSource(addonInstallSource));
+      }
+
+      history.push(`/${lang}/${clientApp}${this.getAddonLink(addon)}`);
 
       if (onClick) {
         onClick(addon);

--- a/src/amo/components/SearchResult/index.js
+++ b/src/amo/components/SearchResult/index.js
@@ -77,7 +77,11 @@ export class SearchResultBase extends React.Component<InternalProps> {
   }
 
   onClickAddon: HTMLElementEventHandler = (e: ElementEvent) => {
-    const { addon, onClick } = this.props;
+    const { addon, addonInstallSource, dispatch, onClick } = this.props;
+
+    if (addon && addonInstallSource) {
+      dispatch(setAddonInstallSource(addonInstallSource));
+    }
 
     e.stopPropagation();
     if (addon && onClick) {

--- a/src/amo/components/SecondaryHero/index.js
+++ b/src/amo/components/SecondaryHero/index.js
@@ -1,11 +1,14 @@
 /* @flow */
 /* global window */
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
 
 import Link from 'amo/components/Link';
 import { checkInternalURL } from 'amo/utils';
 import tracking from 'amo/tracking';
 import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'amo/constants';
+import { setAddonInstallSource } from 'amo/reducers/addonInstallSource';
 import { addQueryParams } from 'amo/utils/url';
 import LoadingText from 'amo/components/LoadingText';
 import type {
@@ -25,6 +28,7 @@ type InternalProps = {|
   ...Props,
   _checkInternalURL: typeof checkInternalURL,
   _tracking: typeof tracking,
+  dispatch: (action: Object) => void,
 |};
 
 export const makeCallToActionURL = (urlString: string): string => {
@@ -38,6 +42,7 @@ export const makeCallToActionURL = (urlString: string): string => {
 export const SecondaryHeroBase = ({
   _checkInternalURL = checkInternalURL,
   _tracking = tracking,
+  dispatch,
   shelfData,
 }: InternalProps): null | React.Node => {
   if (shelfData === null) {
@@ -65,15 +70,24 @@ export const SecondaryHeroBase = ({
     });
   };
 
+  // Store install source in Redux for install-time UTM injection.
+  const onInternalLinkClick = () => {
+    dispatch(setAddonInstallSource(SECONDARY_HERO_SRC));
+    onHeroClick();
+  };
+
   const getLinkProps = (link: LinkWithTextType | null) => {
-    const props = { onClick: onHeroClick };
     if (link) {
       const urlInfo = _checkInternalURL({ urlString: link.url });
       if (urlInfo.isInternal) {
-        return { ...props, to: makeCallToActionURL(urlInfo.relativeURL) };
+        // Internal link: clean URL without UTM params. Install source is
+        // dispatched to Redux on click and injected at install time.
+        // See utils/installAttribution.js.
+        return { onClick: onInternalLinkClick, to: urlInfo.relativeURL };
       }
+      // External link: keep UTM params (these go to third-party sites).
       return {
-        ...props,
+        onClick: onHeroClick,
         href: makeCallToActionURL(link.url),
         prependClientApp: false,
         prependLang: false,
@@ -155,4 +169,7 @@ export const SecondaryHeroBase = ({
   );
 };
 
-export default SecondaryHeroBase;
+const SecondaryHero: React.ComponentType<Props> =
+  compose(connect())(SecondaryHeroBase);
+
+export default SecondaryHero;

--- a/src/amo/constants.js
+++ b/src/amo/constants.js
@@ -236,6 +236,11 @@ export const CLICK_CATEGORY = 'amo_addon_theme_clicks';
 
 export const SUGGESTIONS_CLICK_CATEGORY = 'amo_suggested_addon_clicks';
 
+export const SET_ADDON_INSTALL_SOURCE: 'SET_ADDON_INSTALL_SOURCE' =
+  'SET_ADDON_INSTALL_SOURCE';
+export const CLEAR_ADDON_INSTALL_SOURCE: 'CLEAR_ADDON_INSTALL_SOURCE' =
+  'CLEAR_ADDON_INSTALL_SOURCE';
+
 // Collection tracking event categories
 export const COLLECTION_CREATE_STARTED_CATEGORY =
   'amo_create_collection_started';

--- a/src/amo/installAddon.js
+++ b/src/amo/installAddon.js
@@ -38,6 +38,10 @@ import * as addonManager from 'amo/addonManager';
 import { getVersionById } from 'amo/reducers/versions';
 import { getDisplayName } from 'amo/utils';
 import { getFileHash, getPromotedCategory } from 'amo/utils/addons';
+import {
+  injectUTMParams as defaultInjectUTMParams,
+  removeUTMParams as defaultRemoveUTMParams,
+} from 'amo/utils/installAttribution';
 import type { AppState } from 'amo/store';
 import type { AddonVersionType } from 'amo/reducers/versions';
 import type { AddonType } from 'amo/types/addons';
@@ -57,6 +61,7 @@ type EventType = {|
 |};
 
 type MakeProgressHandlerParams = {|
+  _removeUTMParams: typeof defaultRemoveUTMParams,
   _tracking: typeof tracking,
   addon: AddonType,
   dispatch: DispatchFunc,
@@ -65,6 +70,7 @@ type MakeProgressHandlerParams = {|
 |};
 
 export function makeProgressHandler({
+  _removeUTMParams,
   _tracking,
   addon,
   dispatch,
@@ -97,6 +103,7 @@ export function makeProgressHandler({
           category: getAddonEventCategory(type, INSTALL_DOWNLOAD_FAILED_ACTION),
           params: getAddonEventParams(addon, window.location.pathname),
         });
+        _removeUTMParams();
       }
     } else if (event.type === 'onInstallCancelled') {
       dispatch({
@@ -108,8 +115,10 @@ export function makeProgressHandler({
         category: getAddonEventCategory(type, INSTALL_CANCELLED_ACTION),
         params: getAddonEventParams(addon, window.location.pathname),
       });
+      _removeUTMParams();
     } else if (event.type === 'onInstallFailed') {
       dispatch(setInstallError({ guid, error: INSTALL_FAILED }));
+      _removeUTMParams();
     }
   };
 }
@@ -123,12 +132,15 @@ type WithInstallHelpersPropsFromState = {|
   WrappedComponent: React.ComponentType<any>,
   clientApp: string,
   currentVersion: AddonVersionType | null,
+  installSource: string | null,
 |};
 
 type WithInstallHelpersDefaultProps = {|
   _addonManager: typeof addonManager,
   _getPromotedCategory: typeof getPromotedCategory,
+  _injectUTMParams: typeof defaultInjectUTMParams,
   _log: typeof log,
+  _removeUTMParams: typeof defaultRemoveUTMParams,
   _tracking: typeof tracking,
 |};
 
@@ -158,7 +170,9 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
   static defaultProps: WithInstallHelpersDefaultProps = {
     _addonManager: addonManager,
     _getPromotedCategory: getPromotedCategory,
+    _injectUTMParams: defaultInjectUTMParams,
     _log: log,
+    _removeUTMParams: defaultRemoveUTMParams,
     _tracking: tracking,
   };
 
@@ -268,12 +282,15 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
     const {
       _addonManager,
       _getPromotedCategory,
+      _injectUTMParams,
       _log,
+      _removeUTMParams,
       _tracking,
       addon,
       clientApp,
       currentVersion,
       dispatch,
+      installSource,
     } = this.props;
 
     invariant(addon, 'need an addon to call install()');
@@ -285,6 +302,12 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
     if (!file) {
       _log.debug('no file found, aborting install().');
       return Promise.resolve();
+    }
+
+    // Inject UTM params into the page URL so Firefox can read them at
+    // install time for attribution.
+    if (installSource) {
+      _injectUTMParams(installSource);
     }
 
     return new Promise((resolve) => {
@@ -311,6 +334,7 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
         return _addonManager.install(
           installURL || '',
           makeProgressHandler({
+            _removeUTMParams,
             _tracking,
             addon,
             dispatch,
@@ -341,10 +365,16 @@ export class WithInstallHelpers extends React.Component<WithInstallHelpersIntern
             },
           });
         }
+
+        // Clean up UTM params injected before install. This is called on
+        // every exit path (success, failure, cancel) to ensure the URL is
+        // always restored. removeUTMParams() is idempotent.
+        _removeUTMParams();
       })
       .catch((error) => {
         _log.error(`Install error: ${error}`);
 
+        _removeUTMParams();
         dispatch(setInstallError({ guid, error: FATAL_INSTALL_ERROR }));
       });
   }
@@ -419,6 +449,7 @@ export const withInstallHelpers = (
       WrappedComponent,
       clientApp: state.api.clientApp,
       currentVersion,
+      installSource: state.addonInstallSource.installSource,
     };
   };
 

--- a/src/amo/installAddon.js
+++ b/src/amo/installAddon.js
@@ -103,8 +103,8 @@ export function makeProgressHandler({
           category: getAddonEventCategory(type, INSTALL_DOWNLOAD_FAILED_ACTION),
           params: getAddonEventParams(addon, window.location.pathname),
         });
-        _removeUTMParams();
       }
+      _removeUTMParams();
     } else if (event.type === 'onInstallCancelled') {
       dispatch({
         type: INSTALL_CANCELLED,

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -38,6 +38,7 @@ import {
   isAddonLoading,
   isRecentAddon,
 } from 'amo/reducers/addons';
+import { clearAddonInstallSource } from 'amo/reducers/addonInstallSource';
 import { sendServerRedirect } from 'amo/reducers/redirectTo';
 import { withFixedErrorHandler } from 'amo/errorHandler';
 import {
@@ -135,6 +136,12 @@ export class AddonBase extends React.Component {
         );
       }
     }
+  }
+
+  componentWillUnmount() {
+    // Clear the install source so stale values from a previous addon page
+    // aren't used for a future install on a different page.
+    this.props.dispatch(clearAddonInstallSource());
   }
 
   componentDidUpdate(prevProps) {

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -57,6 +57,7 @@ import ThemeImage from 'amo/components/ThemeImage';
 import Notice from 'amo/components/Notice';
 import AddonSuggestions from 'amo/components/AddonSuggestions';
 import { withExperiment } from 'amo/withExperiment';
+import tracking from 'amo/tracking';
 
 import './styles.scss';
 
@@ -138,6 +139,18 @@ export class AddonBase extends React.Component {
     }
   }
 
+  componentDidMount() {
+    this.pushPageVariables();
+  }
+
+  pushPageVariables() {
+    const { addon, lang } = this.props;
+    if (addon && addon.type && lang) {
+      const addonType = addon.type === ADDON_TYPE_STATIC_THEME ? 'theme' : 'extension';
+      tracking.setPageVariables({ addon_type: addonType, page_locale: lang });
+    }
+  }
+
   componentWillUnmount() {
     // Clear the install source so stale values from a previous addon page
     // aren't used for a future install on a different page.
@@ -164,6 +177,10 @@ export class AddonBase extends React.Component {
     const oldAddonType = oldAddon ? oldAddon.type : null;
     if (newAddon && newAddon.type !== oldAddonType) {
       dispatch(setViewContext(newAddon.type));
+    }
+
+    if (newAddon && (!oldAddon || oldAddon.slug !== newAddon.slug || prevProps.lang !== this.props.lang)) {
+      this.pushPageVariables();
     }
 
     if (!addonIsLoading && (!newAddon || oldParams.slug !== params.slug)) {

--- a/src/amo/pages/Addon/index.js
+++ b/src/amo/pages/Addon/index.js
@@ -146,7 +146,8 @@ export class AddonBase extends React.Component {
   pushPageVariables() {
     const { addon, lang } = this.props;
     if (addon && addon.type && lang) {
-      const addonType = addon.type === ADDON_TYPE_STATIC_THEME ? 'theme' : 'extension';
+      const addonType =
+        addon.type === ADDON_TYPE_STATIC_THEME ? 'theme' : 'extension';
       tracking.setPageVariables({ addon_type: addonType, page_locale: lang });
     }
   }
@@ -179,7 +180,12 @@ export class AddonBase extends React.Component {
       dispatch(setViewContext(newAddon.type));
     }
 
-    if (newAddon && (!oldAddon || oldAddon.slug !== newAddon.slug || prevProps.lang !== this.props.lang)) {
+    if (
+      newAddon &&
+      (!oldAddon ||
+        oldAddon.slug !== newAddon.slug ||
+        prevProps.lang !== this.props.lang)
+    ) {
       this.pushPageVariables();
     }
 

--- a/src/amo/reducers/addonInstallSource.js
+++ b/src/amo/reducers/addonInstallSource.js
@@ -1,0 +1,56 @@
+/* @flow */
+// Stores the install source (e.g. 'homepage-primary-hero', 'featured') across
+// internal page navigation. When a user clicks an addon link on a listing page,
+// the source is dispatched here. Later, when the user clicks "Install" on the
+// detail page, `installAddon.js` reads this value and injects it as UTM params
+// into the page URL for Firefox attribution. Cleared when leaving the addon
+// detail page. See `utils/installAttribution.js` for the full picture.
+import {
+  SET_ADDON_INSTALL_SOURCE,
+  CLEAR_ADDON_INSTALL_SOURCE,
+} from 'amo/constants';
+
+export type AddonInstallSourceState = {|
+  installSource: string | null,
+|};
+
+export const initialState: AddonInstallSourceState = {
+  installSource: null,
+};
+
+type SetAddonInstallSourceAction = {|
+  type: typeof SET_ADDON_INSTALL_SOURCE,
+  payload: string,
+|};
+
+type ClearAddonInstallSourceAction = {|
+  type: typeof CLEAR_ADDON_INSTALL_SOURCE,
+|};
+
+export const setAddonInstallSource = (
+  installSource: string,
+): SetAddonInstallSourceAction => ({
+  type: SET_ADDON_INSTALL_SOURCE,
+  payload: installSource,
+});
+
+export const clearAddonInstallSource = (): ClearAddonInstallSourceAction => ({
+  type: CLEAR_ADDON_INSTALL_SOURCE,
+});
+
+type Action = SetAddonInstallSourceAction | ClearAddonInstallSourceAction;
+
+export default function addonInstallSourceReducer(
+  // eslint-disable-next-line default-param-last
+  state: AddonInstallSourceState = initialState,
+  action: Action,
+): AddonInstallSourceState {
+  switch (action.type) {
+    case SET_ADDON_INSTALL_SOURCE:
+      return { installSource: action.payload };
+    case CLEAR_ADDON_INSTALL_SOURCE:
+      return { installSource: null };
+    default:
+      return state;
+  }
+}

--- a/src/amo/store.js
+++ b/src/amo/store.js
@@ -8,6 +8,7 @@ import createSagaMiddleware from 'redux-saga';
 import { createLogger } from 'redux-logger';
 import { configureStore } from '@reduxjs/toolkit';
 
+import addonInstallSource from 'amo/reducers/addonInstallSource';
 import addonsByAuthors from 'amo/reducers/addonsByAuthors';
 import collections from 'amo/reducers/collections';
 import collectionAbuseReports from 'amo/reducers/collectionAbuseReports';
@@ -37,6 +38,7 @@ import versions from 'amo/reducers/versions';
 import log from 'amo/logger';
 import suggestions from 'amo/reducers/suggestions';
 import type { AddonsByAuthorsState } from 'amo/reducers/addonsByAuthors';
+import type { AddonInstallSourceState } from 'amo/reducers/addonInstallSource';
 import type { BlocksState } from 'amo/reducers/blocks';
 import type { CollectionsState } from 'amo/reducers/collections';
 import type { CollectionAbuseReportsState } from 'amo/reducers/collectionAbuseReports';
@@ -118,6 +120,7 @@ export function middleware({
 
 type InternalAppState = {|
   abuse: AbuseState,
+  addonInstallSource: AddonInstallSourceState,
   addons: AddonsState,
   addonsByAuthors: AddonsByAuthorsState,
   api: ApiState,
@@ -175,6 +178,7 @@ export const createRootReducer = ({
 
 export const reducers: AppReducersType = {
   abuse,
+  addonInstallSource,
   addons,
   addonsByAuthors,
   api,

--- a/src/amo/tracking.js
+++ b/src/amo/tracking.js
@@ -228,6 +228,16 @@ export class Tracking {
     });
     this.log('setUserProperties', props);
   }
+
+  /*
+   * Push generic key-value pairs into the dataLayer. Useful for background
+   * variables (e.g., page_locale, addon_type) that GTM tags might read.
+   */
+  setPageVariables(variables: { [string]: string }) {
+    // $FlowIgnore
+    this._pushToDataLayer(variables);
+    this.log('setPageVariables', variables);
+  }
 }
 
 // Returns { extension_name: name } or { theme_name: name } based on addon type

--- a/src/amo/utils/installAttribution.js
+++ b/src/amo/utils/installAttribution.js
@@ -1,0 +1,69 @@
+/* @flow */
+/* global window */
+//
+// Install-time UTM attribution for Firefox.
+//
+// Problem: Firefox reads `utm_*` query params from `window.location.href` at
+// addon install time to record where the install originated (e.g. homepage
+// hero, search results, etc.). But having UTM params on every internal link
+// pollutes GA4 data by making internal navigation look like external campaign
+// traffic.
+//
+// Solution: Internal links are kept clean (no query params). Instead, the
+// install source is stored in Redux (see `reducers/addonInstallSource.js`).
+// Right before Firefox's install API is called, we use
+// `history.replaceState()` to temporarily inject UTM params into the page
+// URL. After install completes (or fails/cancels), we remove them.
+//
+// External UTM params (from users arriving via external links) are never
+// touched — they're already in the URL and Firefox reads them directly.
+//
+// See also: `installAddon.js` (where inject/remove are called) and
+// `SearchResult`, `HeroRecommendation`, `SecondaryHero` (where install
+// source is dispatched to Redux on click).
+//
+import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'amo/constants';
+
+// Temporarily add UTM params to the page URL for Firefox install attribution.
+// No-op if UTM params are already present (external attribution).
+export function injectUTMParams(installSource: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+
+  // Don't overwrite UTM params that are already in the URL (from external
+  // sources or previous injection).
+  if (url.searchParams.has('utm_source')) {
+    return;
+  }
+
+  url.searchParams.set('utm_source', DEFAULT_UTM_SOURCE);
+  url.searchParams.set('utm_medium', DEFAULT_UTM_MEDIUM);
+  url.searchParams.set('utm_content', installSource);
+
+  window.history.replaceState(window.history.state, '', url.toString());
+}
+
+// Clean up UTM params we injected. Only removes params whose utm_source
+// matches DEFAULT_UTM_SOURCE — external UTM params are left untouched.
+// Idempotent: safe to call even if no params were injected.
+export function removeUTMParams(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+
+  // Only remove UTM params that we injected (matching our internal source).
+  if (url.searchParams.get('utm_source') !== DEFAULT_UTM_SOURCE) {
+    return;
+  }
+
+  url.searchParams.delete('utm_source');
+  url.searchParams.delete('utm_medium');
+  url.searchParams.delete('utm_content');
+
+  window.history.replaceState(window.history.state, '', url.toString());
+}

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -7,7 +7,6 @@ import AddonsCard from 'amo/components/AddonsCard';
 import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
-  DEFAULT_UTM_SOURCE,
   RECOMMENDED,
 } from 'amo/constants';
 import {
@@ -280,18 +279,12 @@ describe(__filename, () => {
       expect(stopPropagationWatcher).toHaveBeenCalled();
     });
 
-    it('links the heading to the detail page with UTM params', () => {
-      const addonInstallSource = 'home-page-featured';
-      renderWithResult({ props: { addonInstallSource } });
+    it('links the heading to the detail page', () => {
+      renderWithResult();
 
-      const expectedLink = [
-        `/en-US/android/addon/${slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-        'utm_medium=referral',
-        `utm_content=${addonInstallSource}`,
-      ].join('&');
       expect(screen.getByRole('link', { name })).toHaveAttribute(
         'href',
-        expectedLink,
+        `/en-US/android/addon/${slug}/`,
       );
     });
 

--- a/tests/unit/amo/components/TestAddonsCard.js
+++ b/tests/unit/amo/components/TestAddonsCard.js
@@ -394,6 +394,17 @@ describe(__filename, () => {
       expect(onClick).toHaveBeenCalledWith(createAddon());
     });
 
+    it('dispatches the addonInstallSource to Redux store on click', async () => {
+      const addonInstallSource = 'some-custom-install-source';
+      renderWithResult({ props: { addonInstallSource } });
+
+      await userEvent.click(screen.getByRole('listitem'));
+
+      expect(store.getState().addonInstallSource.installSource).toEqual(
+        addonInstallSource,
+      );
+    });
+
     it('does not call the custom onClick handler for the li element without an addon', async () => {
       const onClick = jest.fn();
       render({ loading: true, onAddonClick: onClick, placeholderCount: 1 });

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -78,6 +78,7 @@ import {
 jest.mock('amo/tracking', () => ({
   ...jest.requireActual('amo/tracking'),
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
 }));
 
 const INVALID_TYPE = 'not-a-real-type';

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -944,6 +944,7 @@ describe(__filename, () => {
 
       const createProgressHandler = (props = {}) => {
         return makeProgressHandler({
+          _removeUTMParams: jest.fn(),
           _tracking: createFakeTracking(),
           dispatch: jest.fn(),
           guid: 'some-guid',

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -973,10 +973,12 @@ describe(__filename, () => {
 
       it('sets status to error on onDownloadFailed', () => {
         const _tracking = createFakeTracking();
+        const _removeUTMParams = jest.fn();
         const dispatch = jest.fn();
         const guid = '{my-addon}';
         const type = ADDON_TYPE_EXTENSION;
         const handler = createProgressHandler({
+          _removeUTMParams,
           _tracking,
           dispatch,
           guid,
@@ -996,6 +998,7 @@ describe(__filename, () => {
             window.location.pathname,
           ),
         });
+        expect(_removeUTMParams).toHaveBeenCalled();
       });
 
       it('sets status to installing onDownloadEnded', () => {
@@ -1064,10 +1067,12 @@ describe(__filename, () => {
 
       it('sets status to error when file appears to be corrupt', () => {
         const _tracking = createFakeTracking();
+        const _removeUTMParams = jest.fn();
         const dispatch = jest.fn();
         const guid = '{my-addon}';
         const type = ADDON_TYPE_EXTENSION;
         const handler = createProgressHandler({
+          _removeUTMParams,
           _tracking,
           dispatch,
           guid,
@@ -1084,6 +1089,7 @@ describe(__filename, () => {
           payload: { guid, error: ERROR_CORRUPT_FILE },
         });
         expect(_tracking.sendEvent).not.toHaveBeenCalled();
+        expect(_removeUTMParams).toHaveBeenCalled();
       });
     });
 
@@ -1215,6 +1221,60 @@ describe(__filename, () => {
           expect.any(Function),
           { hash: addon.current_version.file.hash },
         );
+      });
+
+      it('injects and removes UTM parameters during install flow if installSource is present', async () => {
+        const _injectUTMParams = jest.fn();
+        const _removeUTMParams = jest.fn();
+        const installSource = 'some-install-source';
+
+        store.dispatch({
+          type: 'SET_ADDON_INSTALL_SOURCE',
+          payload: installSource,
+        });
+
+        const addonManagerOverrides = {
+          getAddon: Promise.reject(),
+        };
+
+        renderWithCurrentVersion({
+          addonManagerOverrides,
+          _injectUTMParams,
+          _removeUTMParams,
+        });
+
+        const button = screen.getByRole('link', { name: 'Add to Firefox' });
+        await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
+        await userEvent.click(button);
+
+        expect(_injectUTMParams).toHaveBeenCalledWith(installSource);
+        await waitFor(() => {
+          expect(_removeUTMParams).toHaveBeenCalled();
+        });
+      });
+
+      it('does not inject UTM parameters if no installSource is present', async () => {
+        const _injectUTMParams = jest.fn();
+        const _removeUTMParams = jest.fn();
+
+        const addonManagerOverrides = {
+          getAddon: Promise.reject(),
+        };
+
+        renderWithCurrentVersion({
+          addonManagerOverrides,
+          _injectUTMParams,
+          _removeUTMParams,
+        });
+
+        const button = screen.getByRole('link', { name: 'Add to Firefox' });
+        await waitFor(() => expect(button).not.toHaveAttribute('disabled'));
+        await userEvent.click(button);
+
+        expect(_injectUTMParams).not.toHaveBeenCalled();
+        await waitFor(() => {
+          expect(_removeUTMParams).toHaveBeenCalled();
+        });
       });
 
       it('uses a version instead of the currentVersion when one exists in props', async () => {

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import LandingAddonsCard from 'amo/components/LandingAddonsCard';
 import {
   ADDON_TYPE_STATIC_THEME,
-  DEFAULT_UTM_SOURCE,
   LANDING_PAGE_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
 } from 'amo/constants';
@@ -81,14 +80,9 @@ describe(__filename, () => {
     const addons = [createInternalAddonWithLang(fakeAddon)];
     render({ addons, addonInstallSource });
 
-    const expectedLink = [
-      `/en-US/android/addon/${addons[0].slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-      'utm_medium=referral',
-      `utm_content=${addonInstallSource}`,
-    ].join('&');
     expect(screen.getByRole('link', { name: addons[0].name })).toHaveAttribute(
       'href',
-      expectedLink,
+      `/en-US/android/addon/${addons[0].slug}/`,
     );
   });
 

--- a/tests/unit/amo/components/TestLandingAddonsCard.js
+++ b/tests/unit/amo/components/TestLandingAddonsCard.js
@@ -102,6 +102,18 @@ describe(__filename, () => {
     expect(onAddonClick).toHaveBeenCalledWith(addons[0]);
   });
 
+  it('dispatches the addonInstallSource to Redux store on click', async () => {
+    const addonInstallSource = 'some-featured-shelf';
+    const addons = [createInternalAddonWithLang(fakeAddon)];
+    const { store } = render({ addons, addonInstallSource });
+
+    await userEvent.click(screen.getByRole('listitem'));
+
+    expect(store.getState().addonInstallSource.installSource).toEqual(
+      addonInstallSource,
+    );
+  });
+
   it('overrides the default placeholder value when passed in', () => {
     render({
       addons: [],

--- a/tests/unit/amo/components/TestPage-VPNPromoBanner.js
+++ b/tests/unit/amo/components/TestPage-VPNPromoBanner.js
@@ -24,6 +24,7 @@ jest.mock('config');
 // We need this to avoid firing sendEvent during tests, which will throw.
 jest.mock('amo/tracking', () => ({
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
   setUserProperties: jest.fn(),
 }));
 

--- a/tests/unit/amo/components/TestPage.js
+++ b/tests/unit/amo/components/TestPage.js
@@ -53,6 +53,7 @@ jest.mock('config');
 // We are also asserting on the calling of sendEvent in some tests.
 jest.mock('amo/tracking', () => ({
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
 }));
 
 // We need to mock logOutFromServer as it is called directly and we want

--- a/tests/unit/amo/components/TestSearchResults.js
+++ b/tests/unit/amo/components/TestSearchResults.js
@@ -3,13 +3,7 @@ import * as React from 'react';
 import { DEFAULT_API_PAGE_SIZE } from 'amo/api';
 import Paginate from 'amo/components/Paginate';
 import SearchResults from 'amo/components/SearchResults';
-import {
-  ADDON_TYPE_STATIC_THEME,
-  DEFAULT_UTM_SOURCE,
-  INSTALL_SOURCE_FEATURED,
-  INSTALL_SOURCE_SEARCH,
-  RECOMMENDED,
-} from 'amo/constants';
+import { ADDON_TYPE_STATIC_THEME, RECOMMENDED } from 'amo/constants';
 import {
   createInternalAddonWithLang,
   fakeAddon,
@@ -103,7 +97,7 @@ describe(__filename, () => {
     expect(screen.getByClassName('SearchResult-users')).toBeInTheDocument();
   });
 
-  it('sets add-on install source to search by default', () => {
+  it('renders a clean add-on link for search results', () => {
     const results = [createInternalAddonWithLang(fakeAddon)];
     render({
       filters: { query: 'ad blockers' },
@@ -111,18 +105,13 @@ describe(__filename, () => {
       results,
     });
 
-    const expectedLink = [
-      `/en-US/android/addon/${results[0].slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-      'utm_medium=referral',
-      `utm_content=${INSTALL_SOURCE_SEARCH}`,
-    ].join('&');
     expect(screen.getByRole('link', { name: results[0].name })).toHaveAttribute(
       'href',
-      expectedLink,
+      `/en-US/android/addon/${results[0].slug}/`,
     );
   });
 
-  it('sets add-on install source to recommended when approrpriate', () => {
+  it('renders a clean add-on link for recommended search results', () => {
     const results = [createInternalAddonWithLang(fakeAddon)];
     render({
       filters: { query: 'ad blockers', promoted: RECOMMENDED },
@@ -130,14 +119,9 @@ describe(__filename, () => {
       results,
     });
 
-    const expectedLink = [
-      `/en-US/android/addon/${results[0].slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-      'utm_medium=referral',
-      `utm_content=${INSTALL_SOURCE_FEATURED}`,
-    ].join('&');
     expect(screen.getByRole('link', { name: results[0].name })).toHaveAttribute(
       'href',
-      expectedLink,
+      `/en-US/android/addon/${results[0].slug}/`,
     );
   });
 

--- a/tests/unit/amo/components/TestSearchResults.js
+++ b/tests/unit/amo/components/TestSearchResults.js
@@ -1,9 +1,15 @@
 import * as React from 'react';
+import userEvent from '@testing-library/user-event';
 
 import { DEFAULT_API_PAGE_SIZE } from 'amo/api';
 import Paginate from 'amo/components/Paginate';
 import SearchResults from 'amo/components/SearchResults';
-import { ADDON_TYPE_STATIC_THEME, RECOMMENDED } from 'amo/constants';
+import {
+  ADDON_TYPE_STATIC_THEME,
+  INSTALL_SOURCE_FEATURED,
+  INSTALL_SOURCE_SEARCH,
+  RECOMMENDED,
+} from 'amo/constants';
 import {
   createInternalAddonWithLang,
   fakeAddon,
@@ -147,5 +153,35 @@ describe(__filename, () => {
     expect(
       screen.queryByClassName('SearchResult-users'),
     ).not.toBeInTheDocument();
+  });
+
+  it('dispatches INSTALL_SOURCE_SEARCH when clicking on a search result (not promoted)', async () => {
+    const results = [createInternalAddonWithLang(fakeAddon)];
+    const { store } = render({
+      filters: { query: 'test' },
+      loading: false,
+      results,
+    });
+
+    await userEvent.click(screen.getByRole('link', { name: results[0].name }));
+
+    expect(store.getState().addonInstallSource.installSource).toEqual(
+      INSTALL_SOURCE_SEARCH,
+    );
+  });
+
+  it('dispatches INSTALL_SOURCE_FEATURED when clicking on a promoted search result', async () => {
+    const results = [createInternalAddonWithLang(fakeAddon)];
+    const { store } = render({
+      filters: { query: 'test', promoted: RECOMMENDED },
+      loading: false,
+      results,
+    });
+
+    await userEvent.click(screen.getByRole('link', { name: results[0].name }));
+
+    expect(store.getState().addonInstallSource.installSource).toEqual(
+      INSTALL_SOURCE_FEATURED,
+    );
   });
 });

--- a/tests/unit/amo/pages/TestAddon-AddonSuggestions.js
+++ b/tests/unit/amo/pages/TestAddon-AddonSuggestions.js
@@ -8,9 +8,6 @@ import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
-  DEFAULT_UTM_SOURCE,
-  DEFAULT_UTM_MEDIUM,
-  INSTALL_SOURCE_SUGGESTIONS,
   SUGGESTIONS_CLICK_CATEGORY,
 } from 'amo/constants';
 import {
@@ -315,7 +312,7 @@ describe(__filename, () => {
       doLoadSuggestions();
 
       const dispatch = jest.spyOn(store, 'dispatch');
-
+ 
       renderWithAddon({ variant: VARIANT_SHOW_TOP });
 
       dispatch.mockClear();
@@ -443,7 +440,7 @@ describe(__filename, () => {
         'href',
         `/${lang}/${defaultClientApp}/collections/${config.get(
           'mozillaUserId',
-        )}/${collectionForCategory}/?addonInstallSource=${INSTALL_SOURCE_SUGGESTIONS}`,
+        )}/${collectionForCategory}/`,
       );
     });
 
@@ -494,17 +491,11 @@ describe(__filename, () => {
       doLoadSuggestions();
       renderWithAddon({ variant: VARIANT_SHOW_TOP });
 
-      const expectedQuerystring = [
-        `utm_source=${DEFAULT_UTM_SOURCE}`,
-        `utm_medium=${DEFAULT_UTM_MEDIUM}`,
-        `utm_content=${INSTALL_SOURCE_SUGGESTIONS}`,
-      ].join('&');
-
       expect(
         screen.getByRole('link', { name: suggestedAddonName }),
       ).toHaveAttribute(
         'href',
-        `/${lang}/${defaultClientApp}/addon/${suggestedAddonSlug}/?${expectedQuerystring}`,
+        `/${lang}/${defaultClientApp}/addon/${suggestedAddonSlug}/`,
       );
     });
   });

--- a/tests/unit/amo/pages/TestAddon-AddonSuggestions.js
+++ b/tests/unit/amo/pages/TestAddon-AddonSuggestions.js
@@ -46,6 +46,7 @@ jest.mock('config');
 jest.mock('amo/tracking', () => ({
   ...jest.requireActual('amo/tracking'),
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
   setDimension: jest.fn(),
   setUserProperties: jest.fn(),
 }));
@@ -312,7 +313,7 @@ describe(__filename, () => {
       doLoadSuggestions();
 
       const dispatch = jest.spyOn(store, 'dispatch');
- 
+
       renderWithAddon({ variant: VARIANT_SHOW_TOP });
 
       dispatch.mockClear();

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -265,12 +265,17 @@ describe(__filename, () => {
     tracking.setPageVariables.mockClear();
 
     addon.slug = `${defaultSlug}-new`;
+    _loadAddon();
+
     await changeLocation({
       history,
       pathname: getLocation({ slug: addon.slug }),
     });
 
-    expect(tracking.setPageVariables).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(tracking.setPageVariables).toHaveBeenCalledTimes(1);
+    });
+
     expect(tracking.setPageVariables).toHaveBeenCalledWith({
       addon_type: 'extension',
       page_locale: 'en-US',

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -119,6 +119,7 @@ jest.mock('amo/addonManager', () => ({
 jest.mock('amo/tracking', () => ({
   ...jest.requireActual('amo/tracking'),
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
   setUserProperties: jest.fn(),
 }));
 
@@ -243,6 +244,37 @@ describe(__filename, () => {
     renderWithAddon();
 
     expect(dispatch).toHaveBeenCalledWith(setViewContext(addon.type));
+  });
+
+  it('pushes page variables to tracking on mount', () => {
+    tracking.setPageVariables.mockClear();
+    renderWithAddon();
+
+    expect(tracking.setPageVariables).toHaveBeenCalledTimes(1);
+    expect(tracking.setPageVariables).toHaveBeenCalledWith({
+      addon_type: 'extension',
+      page_locale: 'en-US',
+    });
+  });
+
+  it('pushes page variables to tracking on update', async () => {
+    tracking.setPageVariables.mockClear();
+    renderWithAddon();
+
+    expect(tracking.setPageVariables).toHaveBeenCalledTimes(1);
+    tracking.setPageVariables.mockClear();
+
+    addon.slug = `${defaultSlug}-new`;
+    await changeLocation({
+      history,
+      pathname: getLocation({ slug: addon.slug }),
+    });
+
+    expect(tracking.setPageVariables).toHaveBeenCalledTimes(1);
+    expect(tracking.setPageVariables).toHaveBeenCalledWith({
+      addon_type: 'extension',
+      page_locale: 'en-US',
+    });
   });
 
   it('updates the ViewContext on update', async () => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -20,7 +20,6 @@ import {
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
-  DEFAULT_UTM_SOURCE,
   FATAL_ERROR,
   INCOMPATIBLE_UNSUPPORTED_PLATFORM,
   INSTALLING,
@@ -2380,17 +2379,10 @@ describe(__filename, () => {
       });
       renderWithAddon();
 
-      const expectedLink = [
-        `/${lang}/${clientApp}/addon/${slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-        'utm_medium=referral',
-        `utm_content=${outcome}`,
-      ].join('&');
-
-      // This shows that the add-on was passed to AddonsCard, along
-      // with a correct addonInstallSource.
+      // This shows that the add-on was passed to AddonsCard.
       expect(screen.getByRole('link', { name })).toHaveAttribute(
         'href',
-        expectedLink,
+        `/${lang}/${clientApp}/addon/${slug}/`,
       );
       // This shows that the header was passed.
       expect(
@@ -2439,14 +2431,9 @@ describe(__filename, () => {
       });
       renderWithAddon();
 
-      const expectedLink = [
-        `/${lang}/${clientApp}/addon/${slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-        'utm_medium=referral',
-        `utm_content=${outcome}`,
-      ].join('&');
       expect(screen.getByRole('link', { name })).toHaveAttribute(
         'href',
-        expectedLink,
+        `/${lang}/${clientApp}/addon/${slug}/`,
       );
       expect(screen.getByText('Other popular extensions')).toBeInTheDocument();
     });
@@ -2468,14 +2455,9 @@ describe(__filename, () => {
       });
       renderWithAddon();
 
-      const expectedLink = [
-        `/${lang}/${clientApp}/addon/${slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-        'utm_medium=referral',
-        `utm_content=${outcome}`,
-      ].join('&');
       expect(screen.getByRole('link', { name })).toHaveAttribute(
         'href',
-        expectedLink,
+        `/${lang}/${clientApp}/addon/${slug}/`,
       );
       expect(screen.getByText('Other popular extensions')).toBeInTheDocument();
     });

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -90,6 +90,7 @@ jest.mock('config');
 jest.mock('amo/tracking', () => ({
   ...jest.requireActual('amo/tracking'),
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
 }));
 
 describe(__filename, () => {

--- a/tests/unit/amo/pages/TestCollection.js
+++ b/tests/unit/amo/pages/TestCollection.js
@@ -609,15 +609,9 @@ describe(__filename, () => {
       ],
     });
 
-    const expectedQuerystring = [
-      'utm_source=addons.mozilla.org',
-      'utm_medium=referral',
-      'utm_content=collection',
-    ].join('&');
-
     expect(screen.getByRole('link', { name: addonName })).toHaveAttribute(
       'href',
-      `/${lang}/${clientApp}/addon/${fakeAddon.slug}/?${expectedQuerystring}`,
+      `/${lang}/${clientApp}/addon/${fakeAddon.slug}/`,
     );
     expect(screen.getByAltText(addonName)).toHaveAttribute(
       'src',
@@ -639,15 +633,9 @@ describe(__filename, () => {
       location: `${getLocation()}?addonInstallSource=${INSTALL_SOURCE_SUGGESTIONS}`,
     });
 
-    const expectedQuerystring = [
-      'utm_source=addons.mozilla.org',
-      'utm_medium=referral',
-      `utm_content=${INSTALL_SOURCE_SUGGESTIONS}`,
-    ].join('&');
-
     expect(screen.getByRole('link', { name: addonName })).toHaveAttribute(
       'href',
-      `/${lang}/${clientApp}/addon/${fakeAddon.slug}/?${expectedQuerystring}`,
+      `/${lang}/${clientApp}/addon/${fakeAddon.slug}/`,
     );
   });
 

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -69,6 +69,7 @@ jest.mock('amo/utils', () => ({
 jest.mock('amo/tracking', () => ({
   ...jest.requireActual('amo/tracking'),
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
 }));
 
 describe(__filename, () => {

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -28,7 +28,6 @@ import {
   DEFAULT_UTM_SOURCE,
   INSTALL_SOURCE_FEATURED_COLLECTION,
   INSTALL_SOURCE_FEATURED,
-  INSTALL_SOURCE_TAG_SHELF_PREFIX,
   LANDING_PAGE_EXTENSION_COUNT,
   LANDING_PAGE_THEME_COUNT,
   LINE,
@@ -175,11 +174,7 @@ describe(__filename, () => {
       const link = screen.getByRole('link', { name: cta.text });
       expect(link).toHaveAttribute(
         'href',
-        `/${defaultLang}/${defaultClientApp}${addQueryParams(cta.url, {
-          utm_source: DEFAULT_UTM_SOURCE,
-          utm_medium: DEFAULT_UTM_MEDIUM,
-          utm_content: SECONDARY_HERO_SRC,
-        })}`,
+        `/${defaultLang}/${defaultClientApp}${cta.url}`,
       );
       expect(link).not.toHaveAttribute('target');
       expect(checkInternalURL).toHaveBeenCalledWith({ urlString: cta.url });
@@ -335,14 +330,7 @@ describe(__filename, () => {
               // eslint-disable-next-line jest/no-conditional-expect
               expect(link).toHaveAttribute(
                 'href',
-                `/${defaultLang}/${defaultClientApp}${addQueryParams(
-                  moduleData.cta.url,
-                  {
-                    utm_source: DEFAULT_UTM_SOURCE,
-                    utm_medium: DEFAULT_UTM_MEDIUM,
-                    utm_content: SECONDARY_HERO_SRC,
-                  },
-                )}`,
+                `/${defaultLang}/${defaultClientApp}${moduleData.cta.url}`,
               );
               // eslint-disable-next-line jest/no-conditional-expect
               expect(link).not.toHaveAttribute('target');
@@ -494,11 +482,7 @@ describe(__filename, () => {
 
         expect(screen.getByRole('link', { name: addonName })).toHaveAttribute(
           'href',
-          [
-            `/${defaultLang}/${defaultClientApp}/addon/${slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-            `utm_medium=${DEFAULT_UTM_MEDIUM}`,
-            `utm_content=${addonInstallSource}`,
-          ].join('&'),
+          `/${defaultLang}/${defaultClientApp}/addon/${slug}/`,
         );
       },
     );
@@ -523,11 +507,7 @@ describe(__filename, () => {
 
       expect(screen.getByRole('link', { name: addonName })).toHaveAttribute(
         'href',
-        [
-          `/${defaultLang}/${defaultClientApp}/addon/${slug}/?utm_source=${DEFAULT_UTM_SOURCE}`,
-          `utm_medium=${DEFAULT_UTM_MEDIUM}`,
-          `utm_content=${INSTALL_SOURCE_TAG_SHELF_PREFIX}${tagName}`,
-        ].join('&'),
+        `/${defaultLang}/${defaultClientApp}/addon/${slug}/`,
       );
     });
 
@@ -634,11 +614,7 @@ describe(__filename, () => {
           screen.getByRole('link', { name: 'Get the extension' }),
         ).toHaveAttribute(
           'href',
-          addQueryParams(`/${defaultLang}/${defaultClientApp}/addon/${slug}/`, {
-            utm_source: DEFAULT_UTM_SOURCE,
-            utm_medium: DEFAULT_UTM_MEDIUM,
-            utm_content: PRIMARY_HERO_SRC,
-          }),
+          `/${defaultLang}/${defaultClientApp}/addon/${slug}/`,
         );
       });
 
@@ -1207,11 +1183,7 @@ describe(__filename, () => {
     ).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: addonName })).toHaveAttribute(
       'href',
-      `/${defaultLang}/${clientApp}${addQueryParams(`/addon/${addon.slug}/`, {
-        utm_source: DEFAULT_UTM_SOURCE,
-        utm_medium: DEFAULT_UTM_MEDIUM,
-        utm_content: INSTALL_SOURCE_FEATURED,
-      })}`,
+      `/${defaultLang}/${clientApp}/addon/${addon.slug}/`,
     );
   });
 
@@ -1259,11 +1231,7 @@ describe(__filename, () => {
     ).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: addonName })).toHaveAttribute(
       'href',
-      `/${defaultLang}/${clientApp}${addQueryParams(`/addon/${addon.slug}/`, {
-        utm_source: DEFAULT_UTM_SOURCE,
-        utm_medium: DEFAULT_UTM_MEDIUM,
-        utm_content: INSTALL_SOURCE_FEATURED,
-      })}`,
+      `/${defaultLang}/${clientApp}/addon/${addon.slug}/`,
     );
   });
 

--- a/tests/unit/amo/pages/TestHome.js
+++ b/tests/unit/amo/pages/TestHome.js
@@ -229,6 +229,21 @@ describe(__filename, () => {
       });
     });
 
+    it('dispatches the install source when the cta is clicked', async () => {
+      checkInternalURL.mockReturnValue({
+        isInternal: true,
+        relativeURL: '/some/url',
+      });
+      const cta = { text: 'cta text', url: '/some/url', outgoing: '/out/url' };
+      renderWithHomeData({ secondaryProps: { cta } });
+
+      await userEvent.click(screen.getByRole('link', { name: cta.text }));
+
+      expect(store.getState().addonInstallSource.installSource).toEqual(
+        SECONDARY_HERO_SRC,
+      );
+    });
+
     it('sends a tracking event for the impression on mount', () => {
       const cta = { text: 'cta text', url: '/some/url', outgoing: '/out/url' };
       renderWithHomeData({ secondaryProps: { cta } });
@@ -466,7 +481,7 @@ describe(__filename, () => {
       [INSTALL_SOURCE_FEATURED, HOMESHELVES_ENDPOINT_SEARCH],
     ])(
       'passes addonInstallSource as %s when endpoint is %s',
-      (addonInstallSource, endpoint) => {
+      async (addonInstallSource, endpoint) => {
         const addonName = 'Some add-on name';
         const slug = 'some-slug';
         renderWithHomeData({
@@ -485,10 +500,16 @@ describe(__filename, () => {
           'href',
           `/${defaultLang}/${defaultClientApp}/addon/${slug}/`,
         );
+
+        await userEvent.click(screen.getByRole('link', { name: addonName }));
+
+        expect(store.getState().addonInstallSource.installSource).toEqual(
+          addonInstallSource,
+        );
       },
     );
 
-    it('passes addonInstallSource as tag-shelf-{tag} when endpoint is random-tag', () => {
+    it('passes addonInstallSource as tag-shelf-{tag} when endpoint is random-tag', async () => {
       const tagName = 'foo';
       const url = `https://addons-dev.allizom.org/api/v5/addons/search/?sort=rating&tag=${tagName}`;
       const addonName = 'Some add-on name';
@@ -509,6 +530,12 @@ describe(__filename, () => {
       expect(screen.getByRole('link', { name: addonName })).toHaveAttribute(
         'href',
         `/${defaultLang}/${defaultClientApp}/addon/${slug}/`,
+      );
+
+      await userEvent.click(screen.getByRole('link', { name: addonName }));
+
+      expect(store.getState().addonInstallSource.installSource).toEqual(
+        `tag-shelf-${tagName}`,
       );
     });
 
@@ -1003,6 +1030,18 @@ describe(__filename, () => {
             trusted: false,
           }),
         });
+      });
+
+      it('dispatches the install source when clicked for addon', async () => {
+        renderWithHomeData(withAddonShelfData);
+
+        await userEvent.click(
+          screen.getByRole('link', { name: 'Get the extension' }),
+        );
+
+        expect(store.getState().addonInstallSource.installSource).toEqual(
+          PRIMARY_HERO_SRC,
+        );
       });
 
       it('sends a tracking event when the cta is clicked for external', async () => {

--- a/tests/unit/amo/reducers/test_addonInstallSource.js
+++ b/tests/unit/amo/reducers/test_addonInstallSource.js
@@ -1,0 +1,38 @@
+import reducer, {
+  setAddonInstallSource,
+  clearAddonInstallSource,
+  initialState,
+} from 'amo/reducers/addonInstallSource';
+
+describe(__filename, () => {
+  describe('reducer', () => {
+    it('returns the initial state by default', () => {
+      // $FlowIgnore: passing an invalid action to test default path
+      expect(reducer(undefined, { type: '@@INIT' })).toEqual(initialState);
+    });
+
+    it('sets the addon install source', () => {
+      const state = reducer(
+        undefined,
+        setAddonInstallSource('homepage-primary-hero'),
+      );
+
+      expect(state.installSource).toEqual('homepage-primary-hero');
+    });
+
+    it('clears the addon install source', () => {
+      const stateWithSource = { installSource: 'some-source' };
+      const state = reducer(stateWithSource, clearAddonInstallSource());
+
+      expect(state.installSource).toBeNull();
+    });
+
+    it('ignores unrelated actions', () => {
+      const stateWithSource = { installSource: 'some-source' };
+      // $FlowIgnore: passing an invalid action to test default path
+      const state = reducer(stateWithSource, { type: 'SOME_OTHER_ACTION' });
+
+      expect(state).toEqual(stateWithSource);
+    });
+  });
+});

--- a/tests/unit/amo/sagas/test_collections.js
+++ b/tests/unit/amo/sagas/test_collections.js
@@ -42,6 +42,7 @@ import {
 jest.mock('amo/tracking', () => ({
   ...jest.requireActual('amo/tracking'),
   sendEvent: jest.fn(),
+  setPageVariables: jest.fn(),
 }));
 
 describe(__filename, () => {

--- a/tests/unit/amo/test_tracking.js
+++ b/tests/unit/amo/test_tracking.js
@@ -256,6 +256,17 @@ describe(__filename, () => {
         });
       });
     });
+
+    describe('setPageVariables', () => {
+      it('should push page variables to dataLayer', () => {
+        const tracking = createTracking();
+        const variables = { addon_type: 'extension', page_locale: 'en-US' };
+
+        tracking.setPageVariables(variables);
+
+        expect(window.dataLayer).toContainEqual(variables);
+      });
+    });
   });
 
   describe('getAddonNameParam', () => {

--- a/tests/unit/amo/utils/test_installAttribution.js
+++ b/tests/unit/amo/utils/test_installAttribution.js
@@ -1,0 +1,85 @@
+/* global window */
+import { injectUTMParams, removeUTMParams } from 'amo/utils/installAttribution';
+import { DEFAULT_UTM_SOURCE, DEFAULT_UTM_MEDIUM } from 'amo/constants';
+
+describe(__filename, () => {
+  let replaceStateSpy;
+
+  beforeEach(() => {
+    replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+  });
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore();
+    // Return window.location to a clean root path.
+    window.history.replaceState(null, '', 'http://localhost/');
+  });
+
+  describe('injectUTMParams', () => {
+    it('injects UTM parameters when none are present', () => {
+      window.history.replaceState(
+        null,
+        '',
+        'http://localhost/en-US/firefox/addon/some-slug/',
+      );
+      replaceStateSpy.mockClear();
+
+      injectUTMParams('featured-shelf');
+
+      expect(replaceStateSpy).toHaveBeenCalled();
+      const lastCallUrl =
+        replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1][2];
+      const url = new URL(lastCallUrl);
+      expect(url.searchParams.get('utm_source')).toEqual(DEFAULT_UTM_SOURCE);
+      expect(url.searchParams.get('utm_medium')).toEqual(DEFAULT_UTM_MEDIUM);
+      expect(url.searchParams.get('utm_content')).toEqual('featured-shelf');
+    });
+
+    it('does not overwrite existing external UTM parameters', () => {
+      window.history.replaceState(
+        null,
+        '',
+        'http://localhost/en-US/firefox/addon/some-slug/?utm_source=external-source&utm_medium=external-medium',
+      );
+      replaceStateSpy.mockClear();
+
+      injectUTMParams('featured-shelf');
+
+      expect(replaceStateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeUTMParams', () => {
+    it('removes injected UTM parameters when utm_source matches DEFAULT_UTM_SOURCE', () => {
+      window.history.replaceState(
+        null,
+        '',
+        `http://localhost/en-US/firefox/addon/some-slug/?utm_source=${DEFAULT_UTM_SOURCE}&utm_medium=${DEFAULT_UTM_MEDIUM}&utm_content=featured-shelf`,
+      );
+      replaceStateSpy.mockClear();
+
+      removeUTMParams();
+
+      expect(replaceStateSpy).toHaveBeenCalled();
+      const lastCallUrl =
+        replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1][2];
+      const url = new URL(lastCallUrl);
+      expect(url.searchParams.has('utm_source')).toBe(false);
+      expect(url.searchParams.has('utm_medium')).toBe(false);
+      expect(url.searchParams.has('utm_content')).toBe(false);
+    });
+
+    it('does not remove external UTM parameters', () => {
+      window.history.replaceState(
+        null,
+        '',
+        'http://localhost/en-US/firefox/addon/some-slug/?utm_source=external-source&utm_medium=external-medium&utm_content=external-content',
+      );
+      replaceStateSpy.mockClear();
+
+      removeUTMParams();
+
+      expect(replaceStateSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1548,7 +1548,7 @@ export const render = (ui, options = {}) => {
   };
 
   const result = libraryRender(ui, { wrapper });
-  return { ...result, history, root: result.container.firstChild };
+  return { ...result, history, store, root: result.container.firstChild };
 };
 /* eslint-enable testing-library/no-node-access */
 


### PR DESCRIPTION
Fixes [#16178](https://github.com/mozilla/addons/issues/16178)

**Remove utm_* query parameters from internal AMO links while browsing to stop pollution of GA4 data**
> - Clean URL during browsing
> - Remember where the click came from - Store the reference in redux
> - Inject UTM at install time only - you click "Add to Firefox", right before Firefox's install API is called, we silently update the URL using history.replaceState(). Firefox reads this and records the attribution.
> - Clean up after install — Once the install completes (or fails/cancels), we silently remove the UTM params from the URL again.
> - External UTM params are untouched — If someone arrives from an external link like ?utm_source=blog.example.com, we never overwrite those. Firefox reads them directly.


**Push page variables to GTM datalayer**
> On Addon Detail page, push the following variables to GTM datalayer for analytics reporting and dashboard
> - Addon Type
> - Page Locale
