### PR TITLE
Bump uuid from 11.1.0 to 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "universal-base64url": "1.1.0",
     "universal-cookie-express": "8.1.2",
     "url": "0.11.4",
-    "uuid": "11.1.0",
+    "uuid": "11.1.1",
     "web-vitals": "5.2.0",
     "webpack-isomorphic-tools": "4.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11791,10 +11791,10 @@ utila@~0.4:
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
 
-uuid@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+uuid@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
Avoids the bump to 14.x for now.

https://github.com/uuidjs/uuid/blob/11.x/CHANGELOG.md