### PR TITLE
Correctly capitalize 'YouTube' in footer

### DIFF
--- a/src/amo/components/Footer/index.js
+++ b/src/amo/components/Footer/index.js
@@ -291,7 +291,7 @@ export class FooterBase extends React.Component<InternalProps> {
                   className="Footer-link"
                   href={`https://www.youtube.com/user/firefoxchannel`}
                 >
-                  Youtube
+                  YouTube
                 </a>
               </li>
 

--- a/tests/unit/amo/components/TestPage.js
+++ b/tests/unit/amo/components/TestPage.js
@@ -950,7 +950,7 @@ describe(__filename, () => {
         'href',
         `https://www.instagram.com/firefox`,
       );
-      expect(screen.getByRole('link', { name: 'Youtube' })).toHaveAttribute(
+      expect(screen.getByRole('link', { name: 'YouTube' })).toHaveAttribute(
         'href',
         `https://www.youtube.com/user/firefoxchannel`,
       );


### PR DESCRIPTION
Relates to mozilla/addons#15925

Fixes capitalization of YouTube.