### PR TITLE
Update Install Button RTAMO Restrictions

### DIFF
--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -7,8 +7,8 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { encode } from 'universal-base64url';
 
-import Button from 'amo/components/Button';
 import {
+  ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
@@ -17,6 +17,7 @@ import {
   DOWNLOAD_FIREFOX_UTM_CAMPAIGN,
   GET_FIREFOX_BANNER_UTM_CONTENT,
 } from 'amo/constants';
+import Button from 'amo/components/Button';
 import translate from 'amo/i18n/translate';
 import tracking, { getAddonEventParams } from 'amo/tracking';
 import { makeQueryStringWithUTM } from 'amo/utils';
@@ -144,7 +145,9 @@ export const GetFirefoxButtonBase = ({
     });
   };
 
-  const supportsRTAMO = clientApp === CLIENT_APP_FIREFOX;
+  const supportsRTAMO =
+    clientApp === CLIENT_APP_FIREFOX ||
+    (clientApp === CLIENT_APP_ANDROID && addon.type === ADDON_TYPE_EXTENSION);
 
   let downloadTextForRTAMO =
     addon.type === ADDON_TYPE_STATIC_THEME

--- a/src/amo/components/GetFirefoxButton/index.js
+++ b/src/amo/components/GetFirefoxButton/index.js
@@ -8,7 +8,6 @@ import { compose } from 'redux';
 import { encode } from 'universal-base64url';
 
 import {
-  ADDON_TYPE_EXTENSION,
   ADDON_TYPE_STATIC_THEME,
   CLIENT_APP_ANDROID,
   CLIENT_APP_FIREFOX,
@@ -147,7 +146,7 @@ export const GetFirefoxButtonBase = ({
 
   const supportsRTAMO =
     clientApp === CLIENT_APP_FIREFOX ||
-    (clientApp === CLIENT_APP_ANDROID && addon.type === ADDON_TYPE_EXTENSION);
+    (clientApp === CLIENT_APP_ANDROID && addon.isAndroidCompatible);
 
   let downloadTextForRTAMO =
     addon.type === ADDON_TYPE_STATIC_THEME

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -597,7 +597,7 @@ describe(__filename, () => {
         ).toBeInTheDocument();
       });
 
-      it('has the expected button text when client is an Android theme', () => {
+      it('has the expected button text when client is an non-compatible Android theme', () => {
         // The default clientApp is `CLIENT_APP_ANDROID`.
         _dispatchClientMetadata({ userAgent: userAgents.chrome[0] });
         addon.type = ADDON_TYPE_STATIC_THEME;
@@ -606,6 +606,24 @@ describe(__filename, () => {
         expect(
           screen.getByRole('link', {
             name: 'Download Firefox',
+          }),
+        ).toBeInTheDocument();
+      });
+
+      it('has the expected button text when client is a compatible Android theme', () => {
+        // The default clientApp is `CLIENT_APP_ANDROID`.
+        _dispatchClientMetadata({ userAgent: userAgents.chrome[0] });
+        addon.type = ADDON_TYPE_STATIC_THEME;
+        render({
+          addon: {
+            ...createInternalAddonWithLang(addon),
+            isAndroidCompatible: true,
+          },
+        });
+
+        expect(
+          screen.getByRole('link', {
+            name: 'Download Firefox and get the theme',
           }),
         ).toBeInTheDocument();
       });

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -380,7 +380,9 @@ describe(__filename, () => {
     render();
 
     expect(
-      screen.getByRole('link', { name: 'Download Firefox' }),
+      screen.getByRole('link', {
+        name: 'Download Firefox and get the extension',
+      }),
     ).toHaveAttribute('href', expectedHref);
   });
 
@@ -539,7 +541,9 @@ describe(__filename, () => {
         render();
 
         expect(
-          screen.queryByRole('link', { name: 'Download Firefox' }),
+          screen.queryByRole('link', {
+            name: 'Download Firefox and get the extension',
+          }),
         ).not.toBeInTheDocument();
       });
 
@@ -548,7 +552,9 @@ describe(__filename, () => {
         render();
 
         expect(
-          screen.queryByRole('link', { name: 'Download Firefox' }),
+          screen.queryByRole('link', {
+            name: 'Download Firefox and get the extension',
+          }),
         ).not.toBeInTheDocument();
       });
 
@@ -579,13 +585,28 @@ describe(__filename, () => {
         expect(getFirefoxButton()).toBeInTheDocument();
       });
 
-      it('has the expected button text when client is Android', () => {
+      it('has the expected button text when client is an Android extension', () => {
         // The default clientApp is `CLIENT_APP_ANDROID`.
         _dispatchClientMetadata({ userAgent: userAgents.chrome[0] });
         render();
 
         expect(
-          screen.getByRole('link', { name: 'Download Firefox' }),
+          screen.getByRole('link', {
+            name: 'Download Firefox and get the extension',
+          }),
+        ).toBeInTheDocument();
+      });
+
+      it('has the expected button text when client is an Android theme', () => {
+        // The default clientApp is `CLIENT_APP_ANDROID`.
+        _dispatchClientMetadata({ userAgent: userAgents.chrome[0] });
+        addon.type = ADDON_TYPE_STATIC_THEME;
+        render();
+
+        expect(
+          screen.getByRole('link', {
+            name: 'Download Firefox',
+          }),
         ).toBeInTheDocument();
       });
 

--- a/tests/unit/amo/components/TestInstallButtonWrapper.js
+++ b/tests/unit/amo/components/TestInstallButtonWrapper.js
@@ -585,7 +585,7 @@ describe(__filename, () => {
         expect(getFirefoxButton()).toBeInTheDocument();
       });
 
-      it('has the expected button text when client is an Android extension', () => {
+      it('has the expected button text when client is Android and add-on type is extension', () => {
         // The default clientApp is `CLIENT_APP_ANDROID`.
         _dispatchClientMetadata({ userAgent: userAgents.chrome[0] });
         render();
@@ -597,7 +597,7 @@ describe(__filename, () => {
         ).toBeInTheDocument();
       });
 
-      it('has the expected button text when client is an non-compatible Android theme', () => {
+      it('has the expected button text when client is Android but add-on is not an extension', () => {
         // The default clientApp is `CLIENT_APP_ANDROID`.
         _dispatchClientMetadata({ userAgent: userAgents.chrome[0] });
         addon.type = ADDON_TYPE_STATIC_THEME;
@@ -610,20 +610,19 @@ describe(__filename, () => {
         ).toBeInTheDocument();
       });
 
-      it('has the expected button text when client is a compatible Android theme', () => {
+      it('has the expected button text when add-on is not Android compatible', () => {
         // The default clientApp is `CLIENT_APP_ANDROID`.
         _dispatchClientMetadata({ userAgent: userAgents.chrome[0] });
-        addon.type = ADDON_TYPE_STATIC_THEME;
         render({
           addon: {
             ...createInternalAddonWithLang(addon),
-            isAndroidCompatible: true,
+            isAndroidCompatible: false,
           },
         });
 
         expect(
           screen.getByRole('link', {
-            name: 'Download Firefox and get the theme',
+            name: 'Download Firefox',
           }),
         ).toBeInTheDocument();
       });


### PR DESCRIPTION
Closes mozilla/addons#16281

Updates install button to display, on a different browser --

1. `Download Firefox and get the extension` on `/firefox/` on a different browser
2. `Download Firefox and get the extension`on `/android/` if the addon is Android compatible (i.e has the badge)
3. 'Download Firefox' otherwise.

Firefox:
<img width="548" height="506" alt="image" src="https://github.com/user-attachments/assets/fc4e6989-acfc-4977-8d49-3feda228f7b4" />
Android and compatible:
<img width="541" height="508" alt="image" src="https://github.com/user-attachments/assets/77d23c6d-db95-45eb-b477-6232caae74fe" />
Android and incompatible:
<img width="546" height="604" alt="image" src="https://github.com/user-attachments/assets/cd807e85-4fdf-4d55-bb2a-a3549d77d0f9" />
