### PR TITLE
Add info to README for Silicon Macs and Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you would like to run tests without Eslint checks, set an environment variabl
 
 There is limited support for using [Flow](https://flowtype.org/) to validate the intention of our program.
 
-> [!Note] The current version of Flow does not have default support for Silicon Macs. To allow Flow to run on Silicon Macs, first install Rosetta 2 using `sudo softwareupdate --install-rosetta --agree-to-license`
+> The current version of Flow does not have default support for Silicon Macs. To allow Flow to run on Silicon Macs, first install Rosetta 2 using `sudo softwareupdate --install-rosetta --agree-to-license`
 
 As you run tests you will see a report of Flow errors at the end of the test output:
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ If you would like to run tests without Eslint checks, set an environment variabl
 
 There is limited support for using [Flow](https://flowtype.org/) to validate the intention of our program.
 
+> [!Note]
+> The current version of Flow does not have default support for Silicon Macs. To allow Flow to run on Silicon Macs, first install Rosetta 2 using `sudo softwareupdate --install-rosetta --agree-to-license`
+
 As you run tests you will see a report of Flow errors at the end of the test output:
 
     yarn test

--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ If you would like to run tests without Eslint checks, set an environment variabl
 
 There is limited support for using [Flow](https://flowtype.org/) to validate the intention of our program.
 
-> [!Note]
-> The current version of Flow does not have default support for Silicon Macs. To allow Flow to run on Silicon Macs, first install Rosetta 2 using `sudo softwareupdate --install-rosetta --agree-to-license`
+> [!Note] The current version of Flow does not have default support for Silicon Macs. To allow Flow to run on Silicon Macs, first install Rosetta 2 using `sudo softwareupdate --install-rosetta --agree-to-license`
 
 As you run tests you will see a report of Flow errors at the end of the test output:
 


### PR DESCRIPTION
Adds a note to the Flow section of the README, specifically for running this version on Silicon Macs.