### PR TITLE
Migrate sass @ imports and global built-ins

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -21,11 +21,13 @@
           "each",
           "else",
           "for",
+          "forward",
           "function",
           "if",
           "include",
           "mixin",
           "return",
+          "use",
           "warn",
         ],
       }

--- a/src/amo/components/AMInstallButton/styles.scss
+++ b/src/amo/components/AMInstallButton/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AMInstallButton-transition-enter {
   opacity: 0.01;

--- a/src/amo/components/AddonBadges/styles.scss
+++ b/src/amo/components/AddonBadges/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonBadges {
   display: flex;

--- a/src/amo/components/AddonCompatibilityError/style.scss
+++ b/src/amo/components/AddonCompatibilityError/style.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonCompatibilityError {
   margin-top: 12px;

--- a/src/amo/components/AddonFeedbackForm/styles.scss
+++ b/src/amo/components/AddonFeedbackForm/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $icon-size: 32px;
 

--- a/src/amo/components/AddonInstallError/style.scss
+++ b/src/amo/components/AddonInstallError/style.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonInstallError {
   margin-bottom: 12px;

--- a/src/amo/components/AddonRecommendations/styles.scss
+++ b/src/amo/components/AddonRecommendations/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonRecommendations {
   // stylelint-disable max-nesting-depth

--- a/src/amo/components/AddonReportAbuseLink/styles.scss
+++ b/src/amo/components/AddonReportAbuseLink/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonReportAbuseLink {
   margin: 24px auto 0;

--- a/src/amo/components/AddonReviewCard/styles.scss
+++ b/src/amo/components/AddonReviewCard/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 .AddonReviewCard {
   .Rating {
@@ -112,7 +113,7 @@
 }
 
 .AddonReviewCard-reply {
-  background-color: transparentize($blue-50, 0.95);
+  background-color: color.adjust($blue-50, $alpha: -0.95);
   border-radius: $border-radius-default;
   margin-top: 12px;
   padding: 12px;
@@ -214,7 +215,7 @@
       .AddonReviewCard-isReply
     )
     > .AddonReviewCard-container {
-    background-color: transparentize($blue-50, 0.95);
+    background-color: color.adjust($blue-50, $alpha: -0.95);
     border-radius: $border-radius-default;
     padding: 12px;
     margin-bottom: 6px;

--- a/src/amo/components/AddonReviewManager/styles.scss
+++ b/src/amo/components/AddonReviewManager/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonReviewManager {
   font-size: $font-size-default;

--- a/src/amo/components/AddonReviewManagerRating/styles.scss
+++ b/src/amo/components/AddonReviewManagerRating/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonReviewManagerRating {
   align-items: center;

--- a/src/amo/components/AddonSummaryCard/styles.scss
+++ b/src/amo/components/AddonSummaryCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonSummaryCard-overallRatingStars {
   align-items: center;

--- a/src/amo/components/AddonTitle/styles.scss
+++ b/src/amo/components/AddonTitle/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonTitle {
   @include font-regular;

--- a/src/amo/components/AddonVersionCard/styles.scss
+++ b/src/amo/components/AddonVersionCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonVersionCard {
   display: grid;

--- a/src/amo/components/AddonsByAuthorsCard/styles.scss
+++ b/src/amo/components/AddonsByAuthorsCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonsByAuthorsCard {
   margin-top: 0;

--- a/src/amo/components/AddonsCard/styles.scss
+++ b/src/amo/components/AddonsCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonsCard--horizontal {
   @include respond-to(large) {

--- a/src/amo/components/App/styles.scss
+++ b/src/amo/components/App/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 html,
 body {

--- a/src/amo/components/AppBanner/styles.scss
+++ b/src/amo/components/AppBanner/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AppBanner {
   padding: $padding-page;

--- a/src/amo/components/AutoSearchInput/styles.scss
+++ b/src/amo/components/AutoSearchInput/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 .AutoSearchInput-search-box {
   position: relative;
@@ -45,7 +46,7 @@
   background-color: $white;
   border-bottom-left-radius: $border-radius-s;
   border-bottom-right-radius: $border-radius-s;
-  box-shadow: 1px 4px 3px transparentize($black, 0.5);
+  box-shadow: 1px 4px 3px color.adjust($black, $alpha: -0.5);
   color: $black;
   margin: 0;
   padding: 0;

--- a/src/amo/components/Badge/styles.scss
+++ b/src/amo/components/Badge/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $badge-size-large: 16px;
 $badge-size-small: 12px;

--- a/src/amo/components/Button/styles.scss
+++ b/src/amo/components/Button/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 $micro-font-size: $font-size-xs;
 
@@ -128,9 +129,9 @@ $micro-font-size: $font-size-xs;
 
 .Button--neutral {
   @include button(
-    $background: transparentize($grey-90, 0.9),
-    $background-active: transparentize($grey-90, 0.7),
-    $background-hover: transparentize($grey-90, 0.8),
+    $background: color.adjust($grey-90, $alpha: -0.9),
+    $background-active: color.adjust($grey-90, $alpha: -0.7),
+    $background-hover: color.adjust($grey-90, $alpha: -0.8),
     $color: $grey-90
   );
 }

--- a/src/amo/components/Card/styles.scss
+++ b/src/amo/components/Card/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $footer-padding: 10px;
 

--- a/src/amo/components/CardList/styles.scss
+++ b/src/amo/components/CardList/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CardList {
   margin: $padding-page 0;

--- a/src/amo/components/Categories/styles.scss
+++ b/src/amo/components/Categories/styles.scss
@@ -1,4 +1,6 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use 'sass:list';
+@use '~amo/css/styles' as *;
 
 .Categories .Card-contents {
   @include respond-to(large) {
@@ -52,11 +54,14 @@
 
 @for $i from 1 through 12 {
   .Categories--category-color-#{$i} {
-    background: nth($category-colors, $i);
+    background: list.nth($category-colors, $i);
 
     &:focus,
     &:hover {
-      background: darken(nth($category-colors, $i), 20);
+      background: color.adjust(
+        list.nth($category-colors, $i),
+        $lightness: -20%
+      );
     }
   }
 }

--- a/src/amo/components/CategoryIcon/styles.scss
+++ b/src/amo/components/CategoryIcon/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:list';
+@use '~amo/css/styles' as *;
 
 $default-icon-size: 64px;
 
@@ -27,7 +28,7 @@ $default-icon-size: 64px;
 
 @for $i from 1 through 12 {
   .CategoryIcon-#{$i} {
-    background-color: nth($category-colors, $i);
+    background-color: list.nth($category-colors, $i);
   }
 }
 

--- a/src/amo/components/CollectionAddAddon/styles.scss
+++ b/src/amo/components/CollectionAddAddon/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CollectionAddAddon {
   margin: $padding-page 0;

--- a/src/amo/components/CollectionControls/styles.scss
+++ b/src/amo/components/CollectionControls/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CollectionControls {
   margin-top: $padding-page;

--- a/src/amo/components/CollectionDetails/styles.scss
+++ b/src/amo/components/CollectionDetails/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CollectionDetails {
   .MetadataCard {

--- a/src/amo/components/CollectionManager/styles.scss
+++ b/src/amo/components/CollectionManager/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CollectionManager {
   label {

--- a/src/amo/components/CollectionSort/styles.scss
+++ b/src/amo/components/CollectionSort/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CollectionSort-label {
   color: $grey-50;

--- a/src/amo/components/ConfirmationDialog/styles.scss
+++ b/src/amo/components/ConfirmationDialog/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .ConfirmationDialog-buttons {
   align-items: center;

--- a/src/amo/components/ContributeCard/styles.scss
+++ b/src/amo/components/ContributeCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .ContributeCard {
   margin: 0 auto;

--- a/src/amo/components/CopyAddonId/styles.scss
+++ b/src/amo/components/CopyAddonId/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CopyAddonId {
   .Icon {

--- a/src/amo/components/DefinitionList/styles.scss
+++ b/src/amo/components/DefinitionList/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .DefinitionList {
   margin: 0;

--- a/src/amo/components/DismissibleTextForm/styles.scss
+++ b/src/amo/components/DismissibleTextForm/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .DismissibleTextForm-form {
   margin: 6px 0;

--- a/src/amo/components/DropdownMenu/styles.scss
+++ b/src/amo/components/DropdownMenu/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 .DropdownMenu {
   @include text-align-start;
@@ -71,7 +72,7 @@
   background: $white;
   border: 0;
   border-radius: $border-radius-default;
-  box-shadow: 0 0 2px transparentize($black, 0.5);
+  box-shadow: 0 0 2px color.adjust($black, $alpha: -0.5);
   color: $grey-90;
   display: none;
   list-style-type: none;

--- a/src/amo/components/DropdownMenuItem/styles.scss
+++ b/src/amo/components/DropdownMenuItem/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .DropdownMenuItem-section {
   color: $grey-50;

--- a/src/amo/components/EditableCollectionAddon/styles.scss
+++ b/src/amo/components/EditableCollectionAddon/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 $icon-size: 32px;
 
@@ -82,7 +83,7 @@ div.EditableCollectionAddon-leaveNote {
 }
 
 div.EditableCollectionAddon-notes {
-  background-color: transparentize($blue-50, 0.95);
+  background-color: color.adjust($blue-50, $alpha: -0.95);
   border-radius: $border-radius-default;
   grid-column: 1 / 3;
   margin-top: $padding-page;

--- a/src/amo/components/Errors/AuthExpired/styles.scss
+++ b/src/amo/components/Errors/AuthExpired/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .ReloadPageLink {
   color: $link-color;

--- a/src/amo/components/Errors/ErrorComponent/styles.scss
+++ b/src/amo/components/Errors/ErrorComponent/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Errors {
   @include page-padding;

--- a/src/amo/components/ExpandableCard/styles.scss
+++ b/src/amo/components/ExpandableCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .ExpandableCard-ToggleLink {
   display: flex;

--- a/src/amo/components/FeaturedAddonReview/styles.scss
+++ b/src/amo/components/FeaturedAddonReview/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .FeaturedAddonReview-notfound {
   font-size: $font-size-default;

--- a/src/amo/components/FeedbackForm/styles.scss
+++ b/src/amo/components/FeedbackForm/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .FeedbackForm .Card {
   margin-bottom: $padding-page;

--- a/src/amo/components/FlagReview/styles.scss
+++ b/src/amo/components/FlagReview/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .FlagReview-button {
   padding: 0;

--- a/src/amo/components/Footer/styles.scss
+++ b/src/amo/components/Footer/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Footer {
   @include font-regular;

--- a/src/amo/components/GetFirefoxBanner/styles.scss
+++ b/src/amo/components/GetFirefoxBanner/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 .GetFirefoxBanner {
   @include respond-to(extraLarge) {
@@ -11,7 +12,7 @@
   }
 
   border-radius: 0;
-  box-shadow: 0 1px 7px transparentize($black, 0.5);
+  box-shadow: 0 1px 7px color.adjust($black, $alpha: -0.5);
   color: $grey-90;
   font-size: $font-size-s;
   left: 50%;

--- a/src/amo/components/GetFirefoxButton/styles.scss
+++ b/src/amo/components/GetFirefoxButton/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .GetFirefoxButton-button {
   padding: 12px 18px;

--- a/src/amo/components/Header/styles.scss
+++ b/src/amo/components/Header/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Header {
   background: $color-ink-80;

--- a/src/amo/components/HeroRecommendation/styles.scss
+++ b/src/amo/components/HeroRecommendation/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .HeroRecommendation-wrapper {
   margin: 0 auto;

--- a/src/amo/components/Icon/styles.scss
+++ b/src/amo/components/Icon/styles.scss
@@ -1,5 +1,5 @@
-@import '~amo/css/styles';
-@import './vars';
+@use '~amo/css/styles' as *;
+@use 'vars' as *;
 
 @mixin icon($name) {
   background: url('./img/#{$name}.svg') center no-repeat;

--- a/src/amo/components/IconXMark/styles.scss
+++ b/src/amo/components/IconXMark/styles.scss
@@ -1,5 +1,5 @@
-@import '~amo/css/styles';
-@import '~amo/components/Icon/vars';
+@use '~amo/css/styles' as *;
+@use '~amo/components/Icon/vars' as *;
 
 .IconXMark-svg {
   height: $default-icon-size;

--- a/src/amo/components/InstallButtonWrapper/styles.scss
+++ b/src/amo/components/InstallButtonWrapper/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .InstallButtonWrapper-download {
   margin: 12px 0;

--- a/src/amo/components/InstallWarning/styles.scss
+++ b/src/amo/components/InstallWarning/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .InstallWarning {
   grid-column: 1 / span 2;

--- a/src/amo/components/LoadingText/styles.scss
+++ b/src/amo/components/LoadingText/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 @keyframes place-holder-shimmer {
   0% {

--- a/src/amo/components/MetadataCard/styles.scss
+++ b/src/amo/components/MetadataCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .MetadataCard {
   background-color: $grey-10;

--- a/src/amo/components/Notice/styles.scss
+++ b/src/amo/components/Notice/styles.scss
@@ -1,5 +1,5 @@
-@import '~amo/css/styles';
-@import '~amo/components/Button/styles';
+@use '~amo/css/styles' as *;
+@use '~amo/components/Button/styles' as *;
 
 .Notice {
   border-radius: $border-radius-s;

--- a/src/amo/components/Overlay/styles.scss
+++ b/src/amo/components/Overlay/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 $z-index: 1000;
 
@@ -23,7 +24,7 @@ $z-index: 1000;
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1178765
   // http://caniuse.com/#feat=css-backdrop-filter
   backdrop-filter: blur(2px);
-  background: transparentize($grey-90, 0.4);
+  background: color.adjust($grey-90, $alpha: -0.4);
   height: 100%;
   left: 0;
   position: fixed;

--- a/src/amo/components/OverlayCard/styles.scss
+++ b/src/amo/components/OverlayCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .OverlayCard {
   margin: 0 20px;

--- a/src/amo/components/Page/styles.scss
+++ b/src/amo/components/Page/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Page-amo {
   display: flex;

--- a/src/amo/components/Paginate/styles.scss
+++ b/src/amo/components/Paginate/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Paginate {
   padding: $padding-page;

--- a/src/amo/components/PermissionsCard/styles.scss
+++ b/src/amo/components/PermissionsCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .PermissionsCard-header {
   display: flex;

--- a/src/amo/components/QRCard/styles.scss
+++ b/src/amo/components/QRCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .QRCard {
   background-color: rgba($blue-60, 0.1);

--- a/src/amo/components/Rating/styles.scss
+++ b/src/amo/components/Rating/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $icon-large: 64px;
 $icon-medium: 19px;

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .RatingManager-ratingControl {
   align-items: center;

--- a/src/amo/components/RatingManagerNotice/styles.scss
+++ b/src/amo/components/RatingManagerNotice/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .RatingManagerNotice-savedRating.RatingManagerNotice-savedRating-hidden {
   display: none;

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:math';
+@use '~amo/css/styles' as *;
 
 $yellow-40: #ffbd4f;
 
@@ -40,7 +41,7 @@ a.RatingsByStar-row {
   background-color: $yellow-40;
 
   @for $num from 0 through 100 {
-    $pct: percentage($num / 100);
+    $pct: math.percentage($num / 100);
     &.RatingsByStar-barValue--#{$num}pct {
       width: $pct;
     }

--- a/src/amo/components/ScreenShots/styles.scss
+++ b/src/amo/components/ScreenShots/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 /* stylelint-disable selector-class-pattern */
 

--- a/src/amo/components/Search/styles.scss
+++ b/src/amo/components/Search/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Search {
   @include respond-to(large) {

--- a/src/amo/components/SearchContextCard/styles.scss
+++ b/src/amo/components/SearchContextCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .SearchContextCard-header {
   font-size: $font-size-l;

--- a/src/amo/components/SearchFilters/styles.scss
+++ b/src/amo/components/SearchFilters/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .SearchFilters-label {
   color: $grey-50;

--- a/src/amo/components/SearchResult/styles.scss
+++ b/src/amo/components/SearchResult/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 $icon-default-size: 32px;
 
@@ -234,7 +235,7 @@ $icon-default-size: 32px;
 }
 
 .SearchResult-note {
-  background-color: transparentize($blue-50, 0.95);
+  background-color: color.adjust($blue-50, $alpha: -0.95);
   border-radius: $border-radius-default;
   color: $type-black;
   flex-grow: 1;

--- a/src/amo/components/SearchSuggestion/styles.scss
+++ b/src/amo/components/SearchSuggestion/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .SearchSuggestion {
   align-items: center;

--- a/src/amo/components/SecondaryHero/styles.scss
+++ b/src/amo/components/SecondaryHero/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .SecondaryHero {
   color: $black;

--- a/src/amo/components/SectionLinks/styles.scss
+++ b/src/amo/components/SectionLinks/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .SectionLinks {
   display: flex;

--- a/src/amo/components/Select/styles.scss
+++ b/src/amo/components/Select/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Select {
   @include padding-end(24px);

--- a/src/amo/components/ShowMoreCard/styles.scss
+++ b/src/amo/components/ShowMoreCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .ShowMoreCard-contents {
   &::after {

--- a/src/amo/components/SignedInUser/styles.scss
+++ b/src/amo/components/SignedInUser/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .SignedInUser {
   display: inline-flex;

--- a/src/amo/components/StaticPage/styles.scss
+++ b/src/amo/components/StaticPage/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .StaticPage {
   @include page-padding;

--- a/src/amo/components/ThemeImage/styles.scss
+++ b/src/amo/components/ThemeImage/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .ThemeImage {
   height: auto;

--- a/src/amo/components/TooltipMenu/styles.scss
+++ b/src/amo/components/TooltipMenu/styles.scss
@@ -1,4 +1,5 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 .TooltipMenu {
   border: 0;
@@ -24,7 +25,7 @@
 // actually just a tilted square.
 .TooltipMenu-arrow {
   background-color: $white;
-  box-shadow: 0 0 2px transparentize($black, 0.5);
+  box-shadow: 0 0 2px color.adjust($black, $alpha: -0.5);
   display: block;
   height: 8px;
   left: 50%;
@@ -41,7 +42,7 @@
 
 .TooltipMenu-inner {
   border-radius: $border-radius-default;
-  box-shadow: 0 0 2px transparentize($black, 0.5);
+  box-shadow: 0 0 2px color.adjust($black, $alpha: -0.5);
 }
 
 .TooltipMenu-list,

--- a/src/amo/components/UserCollection/styles.scss
+++ b/src/amo/components/UserCollection/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CardList ul > li.UserCollection {
   padding: 4px $padding-page-l;

--- a/src/amo/components/UserProfileEditNotifications/styles.scss
+++ b/src/amo/components/UserProfileEditNotifications/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $input-height: 16px;
 

--- a/src/amo/components/UserProfileEditPicture/styles.scss
+++ b/src/amo/components/UserProfileEditPicture/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $picture-size: 128px;
 

--- a/src/amo/components/UserReview/styles.scss
+++ b/src/amo/components/UserReview/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .UserReview {
   .Rating {

--- a/src/amo/components/VPNPromoBanner/styles.scss
+++ b/src/amo/components/VPNPromoBanner/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $cta-text-color: #1d1133;
 $cta-alternate-color: #f9f7fd;

--- a/src/amo/components/WrongPlatformWarning/styles.scss
+++ b/src/amo/components/WrongPlatformWarning/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .WrongPlatformWarning {
   margin: 0 0 12px;

--- a/src/amo/css/inc/mixins.scss
+++ b/src/amo/css/inc/mixins.scss
@@ -1,4 +1,8 @@
-@import './vars';
+@use 'sass:color';
+@use 'sass:map';
+@use 'vars' as *;
+
+@forward 'vars';
 
 @mixin page-padding() {
   // This adds consistent padding to any top-level page component.
@@ -59,7 +63,7 @@
   box-shadow:
     0 0 0 1px $blue-50 inset,
     0 0 0 1px $blue-50,
-    0 0 0 4px transparentize($blue-50, 0.7);
+    0 0 0 4px color.adjust($blue-50, $alpha: -0.7);
   outline: none;
 }
 
@@ -69,8 +73,8 @@
 }
 
 @mixin respond-to($breakpoint) {
-  @if map-has-key($breakpoints, $breakpoint) {
-    @media #{map-get($breakpoints, $breakpoint)} {
+  @if map.has-key($breakpoints, $breakpoint) {
+    @media #{map.get($breakpoints, $breakpoint)} {
       @content;
     }
   } @else {

--- a/src/amo/css/inc/vars.scss
+++ b/src/amo/css/inc/vars.scss
@@ -1,5 +1,8 @@
-@import '~photon-colors/photon-colors';
-@import '~@mozilla-protocol/tokens/dist/index';
+@use 'sass:color';
+@use '~photon-colors/photon-colors' as *;
+
+@forward '~photon-colors/photon-colors';
+@forward '~@mozilla-protocol/tokens/dist/index';
 
 // Add-on details
 $primary-font-color: #000;
@@ -105,15 +108,15 @@ $neutral-base-color: #adb5bd;
 $neutral-hover-color: #dee2e6;
 $neutral-active-color: #868e96;
 $light-base-color: $white;
-$light-hover-color: darken($white, 15%);
-$light-active-color: darken($white, 5%);
+$light-hover-color: color.adjust($white, $lightness: -15%);
+$light-active-color: color.adjust($white, $lightness: -5%);
 $block-base-white-color: $white;
 $block-hover-white-color: #f8f9fa;
 $background-grey: #e9ecef;
 $background-gray: $background-grey;
 $type-black: $black;
 $header-accent-color: $link-color;
-$header-text-not-active-color: transparentize($white, 0.5);
+$header-text-not-active-color: color.adjust($white, $alpha: -0.5);
 
 // Category Colors
 // There are currently 12 colors and this number must be kept in sync with

--- a/src/amo/css/styles.scss
+++ b/src/amo/css/styles.scss
@@ -1,5 +1,5 @@
-// This import will also import `./inc/vars.scss`.
-@import './inc/mixins';
+// This forward will also import `./inc/vars.scss`.
+@forward 'inc/mixins';
 
 /* Shared CSS lib code. Bear in mind that changes here impacts *everything*. */
 .visually-hidden {

--- a/src/amo/pages/Addon/styles.scss
+++ b/src/amo/pages/Addon/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Addon {
   @include page-padding;

--- a/src/amo/pages/AddonFeedback/styles.scss
+++ b/src/amo/pages/AddonFeedback/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonFeedback-page {
   @include page-padding;

--- a/src/amo/pages/AddonInfo/styles.scss
+++ b/src/amo/pages/AddonInfo/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonInfo {
   @include page-padding;

--- a/src/amo/pages/AddonReviewList/styles.scss
+++ b/src/amo/pages/AddonReviewList/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonReviewList {
   @include page-padding;

--- a/src/amo/pages/AddonVersions/styles.scss
+++ b/src/amo/pages/AddonVersions/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .AddonVersions {
   @include page-padding;

--- a/src/amo/pages/Block/styles.scss
+++ b/src/amo/pages/Block/styles.scss
@@ -1,11 +1,12 @@
-@import '~amo/css/styles';
+@use 'sass:color';
+@use '~amo/css/styles' as *;
 
 .Block-page {
   @include page-padding;
 }
 
 .Block-reason {
-  background-color: transparentize($blue-50, 0.95);
+  background-color: color.adjust($blue-50, $alpha: -0.95);
   border-radius: $border-radius-default;
   margin-top: 8px;
   padding: $padding-page;

--- a/src/amo/pages/CategoriesPage/styles.scss
+++ b/src/amo/pages/CategoriesPage/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CategoriesPage {
   @include page-padding;

--- a/src/amo/pages/Collection/styles.scss
+++ b/src/amo/pages/Collection/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Collection {
   @include page-padding;

--- a/src/amo/pages/CollectionFeedback/styles.scss
+++ b/src/amo/pages/CollectionFeedback/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CollectionFeedback-page {
   @include page-padding;

--- a/src/amo/pages/CollectionList/styles.scss
+++ b/src/amo/pages/CollectionList/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .CollectionList {
   @include page-padding;

--- a/src/amo/pages/Home/styles.scss
+++ b/src/amo/pages/Home/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .Home {
   width: 100%;

--- a/src/amo/pages/LandingPage/styles.scss
+++ b/src/amo/pages/LandingPage/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .LandingPage {
   @include page-padding;

--- a/src/amo/pages/LanguageTools/styles.scss
+++ b/src/amo/pages/LanguageTools/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $cell-padding: 6px;
 

--- a/src/amo/pages/RatingFeedback/styles.scss
+++ b/src/amo/pages/RatingFeedback/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $icon-size: 16px;
 

--- a/src/amo/pages/UserFeedback/styles.scss
+++ b/src/amo/pages/UserFeedback/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $icon-size: 32px;
 

--- a/src/amo/pages/UserProfile/styles.scss
+++ b/src/amo/pages/UserProfile/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $avatar-size: 64px;
 

--- a/src/amo/pages/UserProfileEdit/styles.scss
+++ b/src/amo/pages/UserProfileEdit/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $font-size-aside: $font-size-xs;
 

--- a/src/amo/pages/UsersUnsubscribe/styles.scss
+++ b/src/amo/pages/UsersUnsubscribe/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 .UsersUnsubscribe {
   @include page-padding;

--- a/src/blog-utils/StaticAddonCard/styles.scss
+++ b/src/blog-utils/StaticAddonCard/styles.scss
@@ -1,4 +1,4 @@
-@import '~amo/css/styles';
+@use '~amo/css/styles' as *;
 
 $icon-size: 48px;
 

--- a/webpack-common.js
+++ b/webpack-common.js
@@ -33,8 +33,6 @@ export function getStyleRules({
     sassOptions: {
       quietDeps: true,
       silenceDeprecations: [
-        'import', // https://sass-lang.com/documentation/breaking-changes/import/
-        'global-builtin', // https://sass-lang.com/documentation/breaking-changes/import/
         'mixed-decls', // https://sass-lang.com/documentation/breaking-changes/mixed-decls/
         'color-functions', // https://sass-lang.com/documentation/breaking-changes/color-functions/
         'slash-div', // https://sass-lang.com/documentation/breaking-changes/slash-div/


### PR DESCRIPTION
Relates to mozilla/addons#15367

Adapts sass files to address deprecation warnings for [`@import` and global built-in functions](https://sass-lang.com/documentation/breaking-changes/import/) via `sass-migrator`.