### PR TITLE
Migrate sass colour functions, slash division

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -26,6 +26,7 @@
           "include",
           "mixin",
           "return",
+          "use",
           "warn",
         ],
       }

--- a/src/amo/components/AppBanner/styles.scss
+++ b/src/amo/components/AppBanner/styles.scss
@@ -10,16 +10,16 @@
   }
 
   & > *:not(:last-child) {
-    margin-bottom: $padding-page / 2;
+    margin-bottom: $padding-page * 0.5;
   }
 
   @include respond-to(large) {
     padding: $padding-page-l;
-    padding-bottom: $padding-page-l / 2;
-    padding-top: $padding-page-l / 2;
+    padding-bottom: $padding-page-l * 0.5;
+    padding-top: $padding-page-l * 0.5;
 
     & > *:not(:last-child) {
-      margin-bottom: $padding-page-l / 2;
+      margin-bottom: $padding-page-l * 0.5;
     }
   }
 }

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import '~amo/css/styles';
 
 $yellow-40: #ffbd4f;

--- a/src/amo/components/RatingsByStar/styles.scss
+++ b/src/amo/components/RatingsByStar/styles.scss
@@ -40,7 +40,7 @@ a.RatingsByStar-row {
   background-color: $yellow-40;
 
   @for $num from 0 through 100 {
-    $pct: percentage($num / 100);
+    $pct: math.percentage($num * 0.01);
     &.RatingsByStar-barValue--#{$num}pct {
       width: $pct;
     }

--- a/webpack-common.js
+++ b/webpack-common.js
@@ -36,8 +36,6 @@ export function getStyleRules({
         'import', // https://sass-lang.com/documentation/breaking-changes/import/
         'global-builtin', // https://sass-lang.com/documentation/breaking-changes/import/
         'mixed-decls', // https://sass-lang.com/documentation/breaking-changes/mixed-decls/
-        'color-functions', // https://sass-lang.com/documentation/breaking-changes/color-functions/
-        'slash-div', // https://sass-lang.com/documentation/breaking-changes/slash-div/
       ],
     },
   };


### PR DESCRIPTION
Relates to mozilla/addons#15367

Adapts sass files to address deprecation warnings for:
- [Slash as Division](https://sass-lang.com/documentation/breaking-changes/slash-div/)
- [Color Functions](https://sass-lang.com/documentation/breaking-changes/color-functions/) -- Nothing to migrate was found.

Via `sass-migrator`.