### PR TITLE
Simplify heartbeat endpoint, don't call API, just return 200

### DIFF
--- a/src/amo/server/base.js
+++ b/src/amo/server/base.js
@@ -26,7 +26,10 @@ import * as middleware from 'amo/middleware';
 import requestId from 'amo/middleware/requestId';
 import { loadErrorPage } from 'amo/reducers/errorPage';
 import { addQueryParamsToHistory, convertBoolean } from 'amo/utils';
-import { viewFrontendVersionHandler } from 'amo/utils/server';
+import {
+  viewFrontendVersionHandler,
+  viewMonitorHandler,
+} from 'amo/utils/server';
 import {
   setAuthToken,
   setClientApp,
@@ -205,6 +208,8 @@ function baseServer(
   app.get('/__version__', viewFrontendVersionHandler());
   // For AMO, this helps differentiate from /__version__ served by addons-server.
   app.get('/__frontend_version__', viewFrontendVersionHandler());
+  // Simple monitor endpoint that proves we can talk to the API.
+  app.get('/frontend_monitor.json', viewMonitorHandler());
   // Also return info for requests to __heartbeat__ and __lbheartbeat__.
   app.get('/__frontend_heartbeat__', (req, res) => {
     return res.status(200).end('ok');

--- a/src/amo/server/base.js
+++ b/src/amo/server/base.js
@@ -26,10 +26,7 @@ import * as middleware from 'amo/middleware';
 import requestId from 'amo/middleware/requestId';
 import { loadErrorPage } from 'amo/reducers/errorPage';
 import { addQueryParamsToHistory, convertBoolean } from 'amo/utils';
-import {
-  viewFrontendVersionHandler,
-  viewHeartbeatHandler,
-} from 'amo/utils/server';
+import { viewFrontendVersionHandler } from 'amo/utils/server';
 import {
   setAuthToken,
   setClientApp,
@@ -209,7 +206,9 @@ function baseServer(
   // For AMO, this helps differentiate from /__version__ served by addons-server.
   app.get('/__frontend_version__', viewFrontendVersionHandler());
   // Also return info for requests to __heartbeat__ and __lbheartbeat__.
-  app.get('/__frontend_heartbeat__', viewHeartbeatHandler());
+  app.get('/__frontend_heartbeat__', (req, res) => {
+    return res.status(200).end('ok');
+  });
   app.get('/__frontend_lbheartbeat__', (req, res) => {
     return res.status(200).end('ok');
   });

--- a/src/amo/utils/server.js
+++ b/src/amo/utils/server.js
@@ -20,6 +20,11 @@ type ViewFrontendVersionHandlerParams = {
   versionFilename?: string,
 };
 
+type ViewMonitorHandlerParams = {
+  _config?: typeof config,
+  _fetch?: typeof fetch,
+};
+
 export const viewFrontendVersionHandler = ({
   _config = config,
   _log = log,
@@ -61,5 +66,35 @@ export const viewFrontendVersionHandler = ({
         });
       }
     });
+  };
+};
+
+export const viewMonitorHandler = ({
+  _config = config,
+  _fetch = fetch,
+}: ViewMonitorHandlerParams = {}): ExpressHandler => {
+  const apiURL = `${_config.get('apiHost')}${_config.get(
+    'apiPath',
+  )}${_config.get('apiVersion')}/site/?disable_caching`;
+
+  return async (req: typeof $Request, res: typeof $Response) => {
+    const monitors = {};
+
+    try {
+      const response = await _fetch(apiURL);
+      monitors.api = {
+        state: response.status === 200,
+        response: await response.json(),
+      };
+    } catch (err) {
+      monitors.api = {
+        state: false,
+        response: err !== undefined ? err.toString() : '?',
+      };
+    }
+    const ok = Object.keys(monitors)
+      .map((key) => monitors[key])
+      .every((item) => item.state);
+    res.status(ok ? 200 : 500).json(monitors);
   };
 };

--- a/src/amo/utils/server.js
+++ b/src/amo/utils/server.js
@@ -20,11 +20,6 @@ type ViewFrontendVersionHandlerParams = {
   versionFilename?: string,
 };
 
-type ViewHeartbeatHandlerParams = {
-  _config?: typeof config,
-  _fetch?: typeof fetch,
-};
-
 export const viewFrontendVersionHandler = ({
   _config = config,
   _log = log,
@@ -66,27 +61,5 @@ export const viewFrontendVersionHandler = ({
         });
       }
     });
-  };
-};
-
-export const viewHeartbeatHandler = ({
-  _config = config,
-  _fetch = fetch,
-}: ViewHeartbeatHandlerParams = {}): ExpressHandler => {
-  const apiURL = `${_config.get('apiHost')}${_config.get(
-    'apiPath',
-  )}${_config.get('apiVersion')}/site/?disable_caching`;
-
-  return async (req: typeof $Request, res: typeof $Response) => {
-    let ok;
-
-    try {
-      const response = await _fetch(apiURL);
-      ok = response.status === 200;
-    } catch (err) {
-      ok = false;
-    }
-
-    res.status(ok ? 200 : 500).end(ok ? 'ok' : 'ko');
   };
 };

--- a/tests/unit/amo/server/test_base.js
+++ b/tests/unit/amo/server/test_base.js
@@ -749,4 +749,16 @@ describe(__filename, () => {
       expect(history).toHaveProperty('location.query');
     });
   });
+
+  describe('heartbeat', () => {
+    it('returns a 200 for the __frontend_heartbeat__ endpoint', async () => {
+      const response = await testClient().get('/__frontend_heartbeat__/');
+      expect(response.statusCode).toEqual(200);
+    });
+
+    it('returns a 200 for the __frontend_lbheartbeat__ endpoint', async () => {
+      const response = await testClient().get('/__frontend_lbheartbeat__/');
+      expect(response.statusCode).toEqual(200);
+    });
+  });
 });

--- a/tests/unit/amo/utils/test_server.js
+++ b/tests/unit/amo/utils/test_server.js
@@ -4,10 +4,7 @@ import EventEmitter from 'events';
 import fs from 'fs-extra';
 import httpMocks from 'node-mocks-http';
 
-import {
-  viewFrontendVersionHandler,
-  viewHeartbeatHandler,
-} from 'amo/utils/server';
+import { viewFrontendVersionHandler } from 'amo/utils/server';
 import { getFakeConfig, getFakeLogger } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -88,45 +85,6 @@ describe(__filename, () => {
 
         done();
       });
-    });
-  });
-
-  describe('viewHeartbeatHandler', () => {
-    it('calls the site API and returns 200 if successful', async () => {
-      const apiHost = 'https://somehost/';
-      const apiPath = 'some/path/';
-      const apiVersion = 'someVersion';
-      const _config = getFakeConfig({ apiHost, apiPath, apiVersion });
-      const _fetch = jest.fn().mockResolvedValue({ status: 200 });
-      const handler = viewHeartbeatHandler({ _config, _fetch });
-
-      const res = httpMocks.createResponse();
-      await handler(null, res);
-
-      expect(_fetch).toHaveBeenCalledWith(
-        `${apiHost}${apiPath}${apiVersion}/site/?disable_caching`,
-      );
-      expect(res.statusCode).toEqual(200);
-    });
-
-    it('returns a 500 if there is an API error', async () => {
-      const _fetch = jest.fn().mockResolvedValue({ status: 400 });
-      const handler = viewHeartbeatHandler({ _fetch });
-
-      const res = httpMocks.createResponse();
-      await handler(null, res);
-
-      expect(res.statusCode).toEqual(500);
-    });
-
-    it('returns a 500 if fetch fails', async () => {
-      const _fetch = jest.fn().mockRejectedValue();
-      const handler = viewHeartbeatHandler({ _fetch });
-
-      const res = httpMocks.createResponse();
-      await handler(null, res);
-
-      expect(res.statusCode).toEqual(500);
     });
   });
 });

--- a/tests/unit/amo/utils/test_server.js
+++ b/tests/unit/amo/utils/test_server.js
@@ -4,7 +4,10 @@ import EventEmitter from 'events';
 import fs from 'fs-extra';
 import httpMocks from 'node-mocks-http';
 
-import { viewFrontendVersionHandler } from 'amo/utils/server';
+import {
+  viewFrontendVersionHandler,
+  viewMonitorHandler,
+} from 'amo/utils/server';
 import { getFakeConfig, getFakeLogger } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -85,6 +88,52 @@ describe(__filename, () => {
 
         done();
       });
+    });
+  });
+
+  describe('viewMonitorHandler', () => {
+    it('calls the site API and returns 200 if successful', async () => {
+      const apiHost = 'https://somehost/';
+      const apiPath = 'some/path/';
+      const apiVersion = 'someVersion';
+      const _config = getFakeConfig({ apiHost, apiPath, apiVersion });
+      const apiJsonData = { some: 'thing' };
+      const _fetch = jest.fn().mockResolvedValue({
+        status: 200,
+        json: jest.fn().mockResolvedValue(apiJsonData),
+      });
+      const handler = viewMonitorHandler({ _config, _fetch });
+
+      const res = httpMocks.createResponse();
+      await handler(null, res);
+
+      expect(_fetch).toHaveBeenCalledWith(
+        `${apiHost}${apiPath}${apiVersion}/site/?disable_caching`,
+      );
+      expect(res.statusCode).toEqual(200);
+      expect(res._getJSONData()).toMatchObject({
+        api: { state: true, response: apiJsonData },
+      });
+    });
+
+    it('returns a 500 if there is an API error', async () => {
+      const _fetch = jest.fn().mockResolvedValue({ status: 400 });
+      const handler = viewMonitorHandler({ _fetch });
+
+      const res = httpMocks.createResponse();
+      await handler(null, res);
+
+      expect(res.statusCode).toEqual(500);
+    });
+
+    it('returns a 500 if fetch fails', async () => {
+      const _fetch = jest.fn().mockRejectedValue();
+      const handler = viewMonitorHandler({ _fetch });
+
+      const res = httpMocks.createResponse();
+      await handler(null, res);
+
+      expect(res.statusCode).toEqual(500);
     });
   });
 });


### PR DESCRIPTION
Calling the API here would just cause us to needlessly spawn new pods if the API is erroring... but the frontend itself is fine.

Second half of mozilla/addons#16297
See also https://github.com/mozilla/addons-server/pull/25074