### PR TITLE
Update RatingManager to account for the read-only mode

### DIFF
--- a/src/amo/components/RatingManager/index.js
+++ b/src/amo/components/RatingManager/index.js
@@ -30,7 +30,7 @@ import { withRenderedErrorHandler } from 'amo/errorHandler';
 import translate from 'amo/i18n/translate';
 import log from 'amo/logger';
 import { sanitizeHTML } from 'amo/utils';
-import { genericType, successType } from 'amo/components/Notice';
+import Notice, { genericType, successType } from 'amo/components/Notice';
 import UserRating from 'amo/components/UserRating';
 import type { FlashMessageType, UserReviewType } from 'amo/actions/reviews';
 import type { UserId } from 'amo/reducers/users';
@@ -53,6 +53,7 @@ type PropsFromState = {|
   deletingReview: boolean,
   editingReview: boolean,
   flashMessage?: FlashMessageType | void,
+  siteIsReadOnly: boolean,
   userId: UserId | null,
   userReview?: UserReviewType | null,
 |};
@@ -167,17 +168,61 @@ export class RatingManagerBase extends React.Component<InternalProps> {
     return [STARTED_SAVE_RATING, SAVED_RATING].includes(flashMessage);
   }
 
+  renderRatingControl(): React.Node {
+    const {
+      beginningToDeleteReview,
+      deletingReview,
+      i18n,
+      siteIsReadOnly,
+      userReview,
+    } = this.props;
+
+    if (siteIsReadOnly) {
+      return (
+        <Notice type="warningInfo" light>
+          {
+            // l10n: This is shown on the rating manager of an add-on detail page when the site is put in read-only mode (for maintenance), which prevents users from rating said add-on.
+            i18n.gettext('Add-on ratings are temporarily disabled.')
+          }
+        </Notice>
+      );
+    }
+
+    const onDeleteScreen = beginningToDeleteReview || deletingReview;
+
+    return [
+      this.isSignedIn()
+        ? i18n.gettext('Click to rate:')
+        : this.renderLogInToRate(),
+      userReview && onDeleteScreen ? (
+        <AddonReviewManagerRating
+          className="RatingManager-AddonReviewManagerRating"
+          onSelectRating={undefined}
+          rating={userReview.score}
+        />
+      ) : (
+        <UserRating
+          className="RatingManager-UserRating"
+          readOnly={!this.isSignedIn()}
+          onSelectRating={this.onSelectRating}
+          review={!this.isSignedIn() ? null : userReview}
+        />
+      ),
+    ];
+  }
+
   renderUserRatingForm(): React.Node {
     const {
       addon,
       beginningToDeleteReview,
       deletingReview,
-      i18n,
       flashMessage,
+      i18n,
       userReview,
     } = this.props;
 
     const onDeleteScreen = beginningToDeleteReview || deletingReview;
+
     let prompt;
     if (userReview && onDeleteScreen) {
       if (userReview.body) {
@@ -208,25 +253,11 @@ export class RatingManagerBase extends React.Component<InternalProps> {
             dangerouslySetInnerHTML={promptHTML}
           />
           {/* eslint-enable react/no-danger */}
+
           <div className="RatingManager-ratingControl">
-            {this.isSignedIn()
-              ? i18n.gettext('Click to rate:')
-              : this.renderLogInToRate()}
-            {userReview && onDeleteScreen ? (
-              <AddonReviewManagerRating
-                className="RatingManager-AddonReviewManagerRating"
-                onSelectRating={undefined}
-                rating={userReview.score}
-              />
-            ) : (
-              <UserRating
-                className="RatingManager-UserRating"
-                readOnly={!this.isSignedIn()}
-                onSelectRating={this.onSelectRating}
-                review={!this.isSignedIn() ? null : userReview}
-              />
-            )}
+            {this.renderRatingControl()}
           </div>
+
           <RatingManagerNotice
             className={
               userReview && userReview.body
@@ -312,8 +343,9 @@ export const mapStateToProps = (
     deletingReview,
     editingReview,
     flashMessage: state.reviews.flashMessage,
-    userReview,
+    siteIsReadOnly: state.site.readOnly,
     userId,
+    userReview,
   };
 };
 

--- a/src/amo/components/RatingManager/styles.scss
+++ b/src/amo/components/RatingManager/styles.scss
@@ -27,6 +27,10 @@
   fieldset {
     // Prevent content overflow.
     min-width: 0;
+
+    .Notice {
+      width: 100%;
+    }
   }
 
   .ShowMoreCard-contents::after {

--- a/tests/unit/amo/components/TestRatingManager.js
+++ b/tests/unit/amo/components/TestRatingManager.js
@@ -20,6 +20,7 @@ import {
   setReview,
   updateAddonReview,
 } from 'amo/actions/reviews';
+import { loadSiteStatus } from 'amo/reducers/site';
 import RatingManager from 'amo/components/RatingManager';
 import {
   createFailedErrorHandler,
@@ -531,6 +532,32 @@ describe(__filename, () => {
       // When Rating is in readOnly mode, the title for all stars is as below.
       expect(screen.getAllByTitle('Rated 3 out of 5')).toHaveLength(6);
     });
+  });
+
+  it('renders a notice instead of the rating control when the site is in read-only mode', () => {
+    store.dispatch(loadSiteStatus({ readOnly: true, notice: null }));
+    renderWithReview();
+
+    expect(
+      screen.getByText('Add-on ratings are temporarily disabled.'),
+    ).toBeInTheDocument();
+
+    // The rating control should not be rendered.
+    expect(
+      screen.queryByClassName('RatingManager-UserRating'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the rating control when the site is not in read-only mode', () => {
+    store.dispatch(loadSiteStatus({ readOnly: false, notice: null }));
+    renderWithReview();
+
+    expect(
+      screen.queryByText('Add-on ratings are temporarily disabled.'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByClassName('RatingManager-UserRating'),
+    ).toBeInTheDocument();
   });
 
   it('renders RatingsByStar with an add-on', () => {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16302

---

Since the component didn't check the `readOnly` state, I opted to
display a `Notice` unconditionally. There isn't much a user can do
anyway (no matter if they are logged in or not).

As for simulating this locally, this is the local change I applied:

```
diff --git a/src/amo/reducers/site.js b/src/amo/reducers/site.js
index e941573e5..a68eb888a 100644
--- a/src/amo/reducers/site.js
+++ b/src/amo/reducers/site.js
@@ -79,7 +79,7 @@ export default function siteReducer(
     case LOAD_SITE_STATUS:
       return {
         ...state,
-        readOnly: action.payload.readOnly,
+        readOnly: true, // action.payload.readOnly,
         notice: action.payload.notice,
       };
     case LOADED_PAGE_IS_ANONYMOUS:
```

The string is fairly generic on purpose. Read-only mode is exceptional.

### Screenshot

<img width="1014" height="582" alt="Screenshot 2026-07-01 at 10 21 24" src="https://github.com/user-attachments/assets/14295e2c-1c66-4c4c-af42-1e5b62034800" />

