### PR TITLE
Update QRCard qr's z-index to be less arbitrary

### DIFF
--- a/src/amo/components/QRCard/styles.scss
+++ b/src/amo/components/QRCard/styles.scss
@@ -34,7 +34,7 @@
 
 .QRCard-qr-wrapper {
   position: absolute;
-  z-index: 10;
+  z-index: 2;
   width: 35%;
   min-width: 76px;
   transform: translate(-2.5px, -8px);


### PR DESCRIPTION

Fixes mozilla/addons#16304

Lowers the QR's z-index so it doesn't conflict with (namely) the search bar results.

<img width="529" height="543" alt="image" src="https://github.com/user-attachments/assets/91e1154f-694c-43d2-bec2-22aa4ded4d30" />