### PR TITLE
Revert "Bump uuid from 11.1.1 to 14.0.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "universal-base64url": "1.1.0",
         "universal-cookie-express": "8.1.2",
         "url": "0.11.4",
-        "uuid": "14.0.1",
+        "uuid": "11.1.1",
         "web-vitals": "5.3.0",
         "webpack-isomorphic-tools": "4.0.0"
       },
@@ -18329,16 +18329,14 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "version": "11.1.1",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "universal-base64url": "1.1.0",
     "universal-cookie-express": "8.1.2",
     "url": "0.11.4",
-    "uuid": "14.0.1",
+    "uuid": "11.1.1",
     "web-vitals": "5.3.0",
     "webpack-isomorphic-tools": "4.0.0"
   },


### PR DESCRIPTION
Reverts mozilla/addons-frontend#14264

For some reason, CI passed in the PR but it broke on the main branch. `uuid` is now a pure ESM package so I am not entirely surprised. Let's revert for now.