### PR TITLE
Hide QR Code on smaller viewports

### DIFF
--- a/src/amo/components/QRCard/styles.scss
+++ b/src/amo/components/QRCard/styles.scss
@@ -1,14 +1,17 @@
 @use '~amo/css/styles' as *;
 
 .QRCard {
-  background-color: rgba($blue-60, 0.1);
-  border-radius: $border-radius-default;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px 20px;
-  margin: 24px 0 0;
-  gap: 10px;
+  display: none;
+  @include respond-to(large) {
+    background-color: rgba($blue-60, 0.1);
+    border-radius: $border-radius-default;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px 20px;
+    margin: 24px 0 0;
+    gap: 10px;
+  }
 }
 
 .QRCard-label {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons/issues/16316

Hides the QR code on smaller viewports.

<img width="748" height="632" alt="image" src="https://github.com/user-attachments/assets/94a09e46-dcb6-4524-8fc1-e3dbbcf0b7c6" />
<img width="523" height="388" alt="image" src="https://github.com/user-attachments/assets/9766e233-f998-4bbe-bcaf-184a052050a1" />

