### PR TITLE
Fix dark mode text contrast - addon details

### DIFF
--- a/src/amo/components/DefinitionList/styles.scss
+++ b/src/amo/components/DefinitionList/styles.scss
@@ -18,7 +18,7 @@
 .Definition-dt {
   @include font-regular;
 
-  color: $grey-50;
+  color: var(--sub-text-color);
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes https://github.com/mozilla/addons/issues/16314

Modify addon details grey color, to a css variable which switches on theme change.

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
<img width="1314" height="347" alt="Screenshot 2026-07-23 at 14 08 05" src="https://github.com/user-attachments/assets/7c97d104-bf32-43d2-a28f-d3cd172d8c73" />

