### PR TITLE
Fix star rating spacing change

### DIFF
--- a/src/amo/components/RatingManagerNotice/styles.scss
+++ b/src/amo/components/RatingManagerNotice/styles.scss
@@ -1,8 +1,6 @@
 @use '~amo/css/styles' as *;
 
 .RatingManagerNotice-savedRating {
-  margin: 11px 0 -17px; // TODO: Magic numbers, to make the confirmation message appear in the same place as the delete button
-
   &.RatingManagerNotice-savedRating-hidden {
     display: none;
   }


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes https://github.com/mozilla/addons/issues/16313

Reverted a previous tweak made in https://github.com/mozilla/addons-frontend/pull/14270 to attempt to improve the jump on the user star review flow when changing the star rating given, as it had the opposite effect for a first time review

Before:
<img width="1670" height="442" alt="Image" src="https://github.com/user-attachments/assets/7be8760e-13a6-47b3-a679-fab7ec6e610f" />

After (technically the same as before the before):
<img width="1094" height="740" alt="output" src="https://github.com/user-attachments/assets/c90eafbc-2592-4585-aa17-c603d64c2c45" />

<!--
    Read through this checklist to make sure your patch is ready for review.

    - Add a PR title that summarizes your patch
    - Make sure this PR relates to an existing open issue and there are no existing PRs open for the same issue.
    - Add tests to cover the changes added in this PR.
    - Check that the change works locally.
    - Add before and after screenshots (Only for changes that impact the UI).

    Thanks for your contribution!
-->
