### PR TITLE
Fallback to github.token if secrets.L10N_GITHUB_TOKEN is not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: mozilla-l10n/addons-frontend-l10n
-          token: ${{ secrets.L10N_GITHUB_TOKEN }}
+          token: ${{ secrets.L10N_GITHUB_TOKEN || github.token }}
           persist-credentials: ${{ needs.context.outputs.is_default_branch }}
           path: locale
 


### PR DESCRIPTION
Follow-up for https://github.com/mozilla/addons-frontend/pull/14411

Forks won't have `secrets.L10N_GITHUB_TOKEN` set ; they should still be able to check out the locale repo in CI.
