### PR TITLE
Fix push-locales CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,7 @@ jobs:
           event_name: ${{ github.event_name }}
           is_default_branch: ${{ needs.context.outputs.is_default_branch }}
           is_push: ${{ github.event_name == 'push' }}
+          GH_TOKEN: ${{ secrets.L10N_GITHUB_TOKEN || github.token }}
         run: |
 
           # Keep this logic in sync with addons-server


### PR DESCRIPTION
0fdc7b6aa940c8023142c5d8152f8425664d4a74 is not enough: gh cli needs GH_TOKEN to be set in the env to create the pull request.

See also https://github.com/mozilla/addons-server/commit/3c84c20e5417abe3ac9cb216d2cb5f870d32fda8

Hasn't been a problem so far because we haven't had any new strings to extract and push in addons-frontend since moving locales to an external repo...

Follow-up for https://github.com/mozilla/addons-frontend/pull/14411