### PR TITLE
Make /firefox/ act like /android/ on Android devices

### DIFF
--- a/src/amo/components/GetFirefoxBanner/index.js
+++ b/src/amo/components/GetFirefoxBanner/index.js
@@ -13,7 +13,6 @@ import {
 import Button from 'amo/components/Button';
 import { getDownloadLink } from 'amo/components/GetFirefoxButton';
 import Notice from 'amo/components/Notice';
-import Link from 'amo/components/Link';
 import tracking from 'amo/tracking';
 import { isFirefox } from 'amo/utils/compatibility';
 import translate from 'amo/i18n/translate';
@@ -102,27 +101,13 @@ export const GetFirefoxBannerBase = ({
     ],
   ];
 
-  if (clientApp === CLIENT_APP_ANDROID) {
-    replacements.push([
-      'linkStart',
-      'linkEnd',
-      (text) => (
-        <Link to={`/${CLIENT_APP_FIREFOX}/`} prependClientApp={false}>
-          {text}
-        </Link>
-      ),
-    ]);
-  }
-
   const bannerContent = replaceStringsWithJSX({
     text:
       clientApp === CLIENT_APP_FIREFOX
         ? i18n.gettext(`To use these add-ons, you'll need to
             %(downloadLinkStart)sdownload Firefox%(downloadLinkEnd)s.`)
         : i18n.gettext(`To use Android extensions, you'll need
-            %(downloadLinkStart)sFirefox for Android%(downloadLinkEnd)s. To
-            explore Firefox for desktop add-ons, please %(linkStart)svisit our
-            desktop site%(linkEnd)s.`),
+            %(downloadLinkStart)sFirefox for Android%(downloadLinkEnd)s.`),
     replacements,
   });
 

--- a/src/amo/components/WrongPlatformWarning/index.js
+++ b/src/amo/components/WrongPlatformWarning/index.js
@@ -122,12 +122,9 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
         utm_campaign: location.query.utm_campaign || undefined,
       };
 
-      // Redirecting to new page on the desktop site.
       message = replaceStringsWithJSX({
         text: i18n.gettext(`To use Android extensions, you'll need
-          %(downloadLinkStart)sFirefox for Android%(downloadLinkEnd)s. To
-          explore Firefox for desktop add-ons, please %(linkStart)svisit our
-          desktop site%(linkEnd)s.`),
+          %(downloadLinkStart)sFirefox for Android%(downloadLinkEnd)s.`),
         replacements: [
           [
             'downloadLinkStart',
@@ -135,19 +132,6 @@ export class WrongPlatformWarningBase extends React.Component<InternalProps> {
             (text) => (
               <Link
                 href={getDownloadLink({ clientApp, overrideQueryParams })}
-                prependClientApp={false}
-                prependLang={false}
-              >
-                {text}
-              </Link>
-            ),
-          ],
-          [
-            'linkStart',
-            'linkEnd',
-            (text) => (
-              <Link
-                to={newLocation}
                 prependClientApp={false}
                 prependLang={false}
               >

--- a/src/amo/reducers/api.js
+++ b/src/amo/reducers/api.js
@@ -2,6 +2,8 @@
 import invariant from 'invariant';
 import UAParser from 'ua-parser-js';
 
+import { CLIENT_APP_FIREFOX } from 'amo/constants';
+import { getClientApp } from 'amo/utils/getClientApp';
 import { LOG_OUT_USER } from 'amo/reducers/users';
 import type { LogOutUserAction } from 'amo/reducers/users';
 import type { Exact } from 'amo/types/util';
@@ -141,6 +143,19 @@ type Action =
   | SetUserAgentAction
   | LogOutUserAction;
 
+// If it's a `firefox` clientApp - i.e. `/firefox/` - pages behave like `/android/` on
+// Android devices. It only, effectively, turns `firefox` into  `android`, never the reverse.
+export const getEffectiveClientApp = (
+  clientApp: string,
+  userAgent: ?string,
+): string => {
+  if (clientApp === CLIENT_APP_FIREFOX) {
+    return getClientApp(userAgent || '');
+  }
+
+  return clientApp;
+};
+
 export default function api(
   // eslint-disable-next-line default-param-last
   state: Exact<ApiState> = initialApiState,
@@ -155,7 +170,13 @@ export default function api(
     case SET_LANG:
       return { ...state, lang: action.payload.lang };
     case SET_CLIENT_APP:
-      return { ...state, clientApp: action.payload.clientApp };
+      return {
+        ...state,
+        clientApp: getEffectiveClientApp(
+          action.payload.clientApp,
+          state.userAgent,
+        ),
+      };
     case SET_REGION_CODE:
       return { ...state, regionCode: action.payload.regionCode };
     case SET_REQUEST_ID:
@@ -165,6 +186,10 @@ export default function api(
 
       return {
         ...state,
+        clientApp: getEffectiveClientApp(
+          state.clientApp,
+          action.payload.userAgent,
+        ),
         userAgent: action.payload.userAgent,
         userAgentInfo: { browser, device, os },
       };

--- a/src/amo/utils/getClientApp.js
+++ b/src/amo/utils/getClientApp.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+/*
+ * This is a very simplistic check of the user-agent string in order to redirect to
+ * the right set of AMO data.
+ *
+ * More complete UA detection for compatibility will take place elsewhere.
+ *
+ */
+export function getClientApp(userAgentString: string): string {
+  // We are going to return android as the application if it's *any* android browser.
+  // whereas the previous behaviour was to only return 'android' for FF Android.
+  // This way we are showing more relevant content, and if we prompt for the user to download
+  // firefox we can prompt them to download Firefox for Android.
+  if (/android/i.test(userAgentString)) {
+    return 'android';
+  }
+  return 'firefox';
+}

--- a/src/amo/utils/index.js
+++ b/src/amo/utils/index.js
@@ -185,23 +185,8 @@ export function convertBoolean(value: mixed): boolean {
   }
 }
 
-/*
- * This is a very simplistic check of the user-agent string in order to redirect to
- * the right set of AMO data.
- *
- * More complete UA detection for compatibility will take place elsewhere.
- *
- */
-export function getClientApp(userAgentString: string): string {
-  // We are going to return android as the application if it's *any* android browser.
-  // whereas the previous behaviour was to only return 'android' for FF Android.
-  // This way we are showing more relevant content, and if we prompt for the user to download
-  // firefox we can prompt them to download Firefox for Android.
-  if (/android/i.test(userAgentString)) {
-    return 'android';
-  }
-  return 'firefox';
-}
+// Re-exported from its own module to avoid a circular dependency
+export { getClientApp } from 'amo/utils/getClientApp';
 
 export function isValidClientApp(
   value: string,

--- a/tests/unit/amo/components/TestPage.js
+++ b/tests/unit/amo/components/TestPage.js
@@ -122,8 +122,9 @@ describe(__filename, () => {
     render({ isHomePage: true, showWrongPlatformWarning: true });
 
     expect(
-      screen.getByRole('link', { name: 'visit our desktop site' }),
-    ).toHaveAttribute('href', '/');
+      screen.getByRole('link', { name: 'Firefox for Android' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/To use Android extensions/)).toBeInTheDocument();
   });
 
   it('assigns a className to a page other than the home page', () => {
@@ -317,6 +318,17 @@ describe(__filename, () => {
         expect(
           screen.getByText(/To use Android extensions, you'll need/),
         ).toBeInTheDocument();
+      });
+
+      it('does not link to the desktop site', () => {
+        render(props);
+
+        expect(
+          screen.queryByRole('link', { name: 'visit our desktop site' }),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(/explore Firefox for desktop add-ons/),
+        ).not.toBeInTheDocument();
       });
 
       it('sets the href on the button with the expected utm params', () => {
@@ -766,6 +778,23 @@ describe(__filename, () => {
           screen.getByText('Dictionaries & Language Packs'),
         ).toHaveAttribute('href', '/en-US/firefox/language-tools/');
         expect(screen.getByText('Add-ons for Android')).toBeInTheDocument();
+      });
+
+      it('hides the Firefox-only section links for a mobile user agent on the Firefox site', () => {
+        // A mobile user agent switches the clientApp to Android, which hides
+        // the Themes and Language Packs links.
+        _dispatchClientMetadata({
+          clientApp: CLIENT_APP_FIREFOX,
+          userAgent: userAgents.firefoxAndroid[0],
+        });
+        render();
+
+        expect(
+          screen.queryByRole('link', { name: 'Themes' }),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText('Dictionaries & Language Packs'),
+        ).not.toBeInTheDocument();
       });
 
       it('renders a DropdownMenu for the "More" section', () => {

--- a/tests/unit/amo/components/TestWrongPlatformWarning.js
+++ b/tests/unit/amo/components/TestWrongPlatformWarning.js
@@ -197,13 +197,13 @@ describe(__filename, () => {
     expect(screen.getByText(/To use Android extensions/)).toBeInTheDocument();
 
     expect(
-      screen.getByRole('link', {
+      screen.queryByRole('link', {
         name: 'visit our desktop site',
       }),
-    ).toHaveAttribute('href', newLocation);
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/To explore Firefox for desktop add-ons, please/),
-    ).toBeInTheDocument();
+      screen.queryByText(/To explore Firefox for desktop add-ons, please/),
+    ).not.toBeInTheDocument();
   });
 
   it('generates the expected message when being directed to other than the mobile home page, from other pages', () => {
@@ -232,13 +232,13 @@ describe(__filename, () => {
     expect(screen.getByText(/To use Android extensions/)).toBeInTheDocument();
 
     expect(
-      screen.getByRole('link', {
+      screen.queryByRole('link', {
         name: 'visit our desktop site',
       }),
-    ).toHaveAttribute('href', newLocation);
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(/To explore Firefox for desktop add-ons, please/),
-    ).toBeInTheDocument();
+      screen.queryByText(/To explore Firefox for desktop add-ons, please/),
+    ).not.toBeInTheDocument();
   });
 
   it('passes the utm_campaign value to the Play Store link when available', () => {

--- a/tests/unit/amo/pages/TestAddon.js
+++ b/tests/unit/amo/pages/TestAddon.js
@@ -484,14 +484,12 @@ describe(__filename, () => {
     expect(
       screen.getByClassName('Addon-WrongPlatformWarning'),
     ).toBeInTheDocument();
+    expect(screen.getByText(/To use Android extensions/)).toBeInTheDocument();
     expect(
-      screen.getByRole('link', {
+      screen.queryByRole('link', {
         name: 'visit our desktop site',
       }),
-    ).toHaveAttribute('href', '/a/different/location/');
-    expect(
-      screen.getByText(/To explore Firefox for desktop add-ons, please/),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
   });
 
   it('does not render a WrongPlatformWarning component without an addon', () => {

--- a/tests/unit/amo/reducers/test_api.js
+++ b/tests/unit/amo/reducers/test_api.js
@@ -1,8 +1,9 @@
 import UAParser from 'ua-parser-js';
 
 import * as actions from 'amo/reducers/api';
+import { CLIENT_APP_ANDROID, CLIENT_APP_FIREFOX } from 'amo/constants';
 import { logOutUser } from 'amo/reducers/users';
-import api, { initialApiState } from 'amo/reducers/api';
+import api, { getEffectiveClientApp, initialApiState } from 'amo/reducers/api';
 import { userAgents, userAuthSessionId } from 'tests/unit/helpers';
 
 describe(__filename, () => {
@@ -168,6 +169,85 @@ describe(__filename, () => {
   describe('setAuthToken', () => {
     it('requires a token', () => {
       expect(() => actions.setAuthToken()).toThrow(/token cannot be falsey/);
+    });
+  });
+
+  describe('getEffectiveClientApp', () => {
+    it('returns android when clientApp is firefox and UA is Android', () => {
+      expect(
+        getEffectiveClientApp(CLIENT_APP_FIREFOX, userAgents.firefoxAndroid[0]),
+      ).toEqual(CLIENT_APP_ANDROID);
+    });
+
+    it('returns android for a non-Firefox Android UA', () => {
+      expect(
+        getEffectiveClientApp(CLIENT_APP_FIREFOX, userAgents.chromeAndroid[0]),
+      ).toEqual(CLIENT_APP_ANDROID);
+    });
+
+    it('keeps firefox when clientApp is firefox and UA is desktop', () => {
+      expect(
+        getEffectiveClientApp(CLIENT_APP_FIREFOX, userAgents.firefox[5]),
+      ).toEqual(CLIENT_APP_FIREFOX);
+    });
+
+    it('keeps firefox when clientApp is firefox and UA is Firefox for iOS', () => {
+      expect(
+        getEffectiveClientApp(CLIENT_APP_FIREFOX, userAgents.firefoxIOS[1]),
+      ).toEqual(CLIENT_APP_FIREFOX);
+    });
+
+    it('keeps firefox when clientApp is firefox and there is no userAgent', () => {
+      expect(getEffectiveClientApp(CLIENT_APP_FIREFOX, null)).toEqual(
+        CLIENT_APP_FIREFOX,
+      );
+    });
+
+    it('keeps android when clientApp is android and UA is desktop', () => {
+      // A desktop user who explicitly chose the Android site keeps it.
+      expect(
+        getEffectiveClientApp(CLIENT_APP_ANDROID, userAgents.firefox[5]),
+      ).toEqual(CLIENT_APP_ANDROID);
+    });
+  });
+
+  describe('deriving clientApp from a mobile user agent', () => {
+    it('turns a firefox clientApp into android for a mobile UA', () => {
+      const userAgent = userAgents.firefoxAndroid[0];
+      let state = api(undefined, actions.setClientApp(CLIENT_APP_FIREFOX));
+      state = api(state, actions.setUserAgent(userAgent));
+
+      expect(state.clientApp).toEqual(CLIENT_APP_ANDROID);
+    });
+
+    it('derives android regardless of the order of the actions', () => {
+      // On the server the userAgent may be set before the clientApp.
+      const userAgent = userAgents.firefoxAndroid[0];
+      let state = api(undefined, actions.setUserAgent(userAgent));
+      state = api(state, actions.setClientApp(CLIENT_APP_FIREFOX));
+
+      expect(state.clientApp).toEqual(CLIENT_APP_ANDROID);
+    });
+
+    it('keeps a firefox clientApp for a desktop UA', () => {
+      let state = api(undefined, actions.setClientApp(CLIENT_APP_FIREFOX));
+      state = api(state, actions.setUserAgent(userAgents.firefox[5]));
+
+      expect(state.clientApp).toEqual(CLIENT_APP_FIREFOX);
+    });
+
+    it('keeps a firefox clientApp for a Firefox for iOS UA', () => {
+      let state = api(undefined, actions.setClientApp(CLIENT_APP_FIREFOX));
+      state = api(state, actions.setUserAgent(userAgents.firefoxIOS[1]));
+
+      expect(state.clientApp).toEqual(CLIENT_APP_FIREFOX);
+    });
+
+    it('does not turn android back into firefox for a desktop UA', () => {
+      let state = api(undefined, actions.setClientApp(CLIENT_APP_ANDROID));
+      state = api(state, actions.setUserAgent(userAgents.firefox[5]));
+
+      expect(state.clientApp).toEqual(CLIENT_APP_ANDROID);
     });
   });
 });


### PR DESCRIPTION
<!--
    Thanks for opening a pull request (PR). Please read through
    these instructions to help us review and merge your change quicker.

    Replace ISSUE_NUMBER with the number of the issue related to what
    you're fixing followed by a description of your change. For example:

    Fixes #3588

    This patch adds a margin on the logout button to correct the layout.
-->

Fixes mozilla/addons#16397

Makes a /firefox/ url work the same as /android/ while the UA is Android, so users who navigate to the desktop url don't have a confusing landing.

## http://127.0.0.1:3333/en-GB/firefox/
### Before
<img width="1081" height="2401" alt="Screen Shot 2026-09-07 at 15 00 01" src="https://github.com/user-attachments/assets/bba71690-b0e5-4493-bb32-6a5accdb9451" />

### After
<img width="1081" height="2401" alt="Screen Shot 2026-09-07 at 14 59 41" src="https://github.com/user-attachments/assets/81cc6362-b4c0-443a-8c16-92693767722f" />

## http://127.0.0.1:3333/en-GB/firefox/addon/private-relay/ (add-on compatible with both desktop and android)
### Before
<img width="1081" height="2401" alt="Screen Shot 2026-09-07 at 15 00 14" src="https://github.com/user-attachments/assets/5c9bff86-27fc-46de-a7f9-8d5e8e8579e2" />

### After
<img width="1081" height="2401" alt="Screen Shot 2026-09-07 at 15 15 07" src="https://github.com/user-attachments/assets/2a0962e3-7672-4b0a-9ef4-b7d0af0f3090" />

