### PR TITLE
Remove direct dependency on `chalk`

### DIFF
--- a/bin/build-checks.js
+++ b/bin/build-checks.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable global-require, no-console */
 
-const chalk = require('chalk');
+const util = require('node:util');
 require('@babel/register');
 
-console.log(chalk.green(`\n--->  BUILDING app\n`));
+console.log(util.styleText('green', `\n--->  BUILDING app\n`));

--- a/bin/config-check.js
+++ b/bin/config-check.js
@@ -6,8 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
-
-const chalk = require('chalk');
+const util = require('node:util');
 
 const root = path.resolve(path.join(path.dirname(__filename), '..'));
 if (!fs.statSync(root).isDirectory()) {
@@ -33,12 +32,12 @@ const disallowedFiles = fs
 
 if (disallowedFiles.length) {
   console.log(
-    chalk.red(
+    util.styleText('red',
       'These local config files are not allowed because they might pollute ' +
         'the test environment. Prefix them with local-development- or remove ' +
         'them:',
     ),
   );
-  console.log(chalk.red(disallowedFiles.join('\n')));
+  console.log(util.styleText('red', disallowedFiles.join('\n')));
   process.exit(1);
 }

--- a/bin/version-check.js
+++ b/bin/version-check.js
@@ -13,8 +13,9 @@
 // A simple check that node + npm versions
 // meet the expected minimums.
 
-const { exec } = require('shelljs');
 const util = require('node:util');
+
+const { exec } = require('shelljs');
 const semver = require('semver');
 
 const MIN_NODE_VERSION = 22;

--- a/bin/version-check.js
+++ b/bin/version-check.js
@@ -13,25 +13,25 @@
 // A simple check that node + npm versions
 // meet the expected minimums.
 
-var { exec } = require('shelljs');
-var chalk = require('chalk');
-var semver = require('semver');
+const { exec } = require('shelljs');
+const util = require('node:util');
+const semver = require('semver');
 
-var MIN_NODE_VERSION = 6;
-var MIN_NPM_VERSION = 3;
+const MIN_NODE_VERSION = 22;
+const MIN_NPM_VERSION = 10;
 
-var NODE_VERSION = process.versions.node;
-var NPM_VERSION = exec('npm --version', { silent: true }).stdout;
+const NODE_VERSION = process.versions.node;
+const NPM_VERSION = exec('npm --version', { silent: true }).stdout;
 
-var versionCheckPassed = true;
+let versionCheckPassed = true;
 
 if (semver.major(NODE_VERSION) < MIN_NODE_VERSION) {
-  console.log(chalk.red('Node version must be at least: ' + MIN_NODE_VERSION));
+  console.log(util.styleText('red', 'Node version must be at least: ' + MIN_NODE_VERSION));
   versionCheckPassed = false;
 }
 
 if (semver.major(NPM_VERSION) < MIN_NPM_VERSION) {
-  console.log(chalk.red('NPM version must be at least: ' + MIN_NPM_VERSION));
+  console.log(util.styleText('red', 'NPM version must be at least: ' + MIN_NPM_VERSION));
   versionCheckPassed = false;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
         "babel-loader": "^10.1.1",
         "babel-plugin-dynamic-import-node": "^2.2.0",
         "bytes": "^3.1.2",
-        "chalk": "^4.0.0",
         "characterset": "^2.0.0",
         "cheerio": "^1.2.0",
         "chokidar-cli": "^3.0.0",
@@ -3749,9 +3748,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3773,9 +3769,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3797,9 +3790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3821,9 +3811,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3845,9 +3832,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3869,9 +3853,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4662,9 +4643,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4679,9 +4657,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4696,9 +4671,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4713,9 +4685,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4730,9 +4699,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4747,9 +4713,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4764,9 +4727,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4781,9 +4741,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4798,9 +4755,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4815,9 +4769,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -255,7 +255,6 @@
     "babel-loader": "^10.1.1",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "bytes": "^3.1.2",
-    "chalk": "^4.0.0",
     "characterset": "^2.0.0",
     "cheerio": "^1.2.0",
     "chokidar-cli": "^3.0.0",


### PR DESCRIPTION
Other packages we depend on still have it as a dependency but that should make upgrades easier in the future.